### PR TITLE
ref(slack): Only rm user and event count context for some specific issue types

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -72,6 +72,11 @@ SUPPORTED_COMMIT_PROVIDERS = (
     "integrations:bitbucket",
 )
 
+REGRESSION_PERFORMANCE_ISSUE_TYPES = [
+    PerformanceP95EndpointRegressionGroupType,
+    ProfileFunctionRegressionType,
+]
+
 logger = logging.getLogger(__name__)
 
 
@@ -167,6 +172,7 @@ def format_release_tag(value: str, event: GroupEvent | Group):
 
 
 def get_tags(
+    group: Group,
     event_for_tags: Any,
     tags: set[str] | None = None,
 ) -> Sequence[Mapping[str, str | bool]]:
@@ -180,7 +186,23 @@ def get_tags(
     if tags and isinstance(tags, list):
         tags = set(tags[0])
 
-    tags = tags | {"level", "release", "handled", "environment"}
+    default_tags = {"level", "release", "handled", "environment"}
+    # for performance issues we want to have the default tags _except_ level
+    if (
+        group.issue_category == GroupCategory.PERFORMANCE
+        and group.issue_type not in REGRESSION_PERFORMANCE_ISSUE_TYPES
+    ):
+        default_tags.remove("level")
+
+    # XXX(CEO): in the short term we're not adding these to all issue types (e.g. crons, user feedback)
+    # but in the future we'll read some config from the grouptype
+    if group.issue_category not in [GroupCategory.ERROR, GroupCategory.PERFORMANCE] or (
+        group.issue_category == GroupCategory.PERFORMANCE
+        and group.issue_type in REGRESSION_PERFORMANCE_ISSUE_TYPES
+    ):
+        default_tags = set()
+
+    tags = tags | default_tags
     if tags:
         event_tags = event_for_tags.tags if event_for_tags else []
         for key, value in event_tags:
@@ -197,6 +219,26 @@ def get_tags(
                 }
             )
     return fields
+
+
+def get_context(group: Group) -> str:
+    context_text = ""
+    context = {
+        "Events": get_group_global_count(group),
+        "Users Affected": group.count_users_seen(),
+        "State": SUBSTATUS_TO_STR.get(group.substatus, "").replace("_", " ").title(),
+        "First Seen": time_since(group.first_seen),
+    }
+    if group.issue_type in REGRESSION_PERFORMANCE_ISSUE_TYPES:
+        # another short term solution for non-error issues notification content
+        del context["Events"]
+        del context["Users Affected"]
+
+    if group.issue_category in [GroupCategory.ERROR, GroupCategory.PERFORMANCE]:
+        for k, v in context.items():
+            if k and v:
+                context_text += f"{k}: *{v}*   "
+    return context_text
 
 
 def get_option_groups(group: Group) -> Sequence[Mapping[str, Any]]:
@@ -594,35 +636,15 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if self.actions:
             blocks.append(self.get_markdown_block(action_text))
 
-        if self.group.issue_category == GroupCategory.ERROR:
-            # XXX(CEO): in the short term we're not adding these to non-error issues (e.g. crons)
-            # since they don't make sense, but in the future we'll read some config from the grouptype
-
-            # build tags block
-            tags = get_tags(event_for_tags, self.tags)
-            if tags:
-                blocks.append(self.get_tags_block(tags))
+        # build tags block
+        tags = get_tags(self.group, event_for_tags, self.tags)
+        if tags:
+            blocks.append(self.get_tags_block(tags))
 
         # add event count, user count, substate, first seen
-        context = {
-            "Events": get_group_global_count(self.group),
-            "Users Affected": self.group.count_users_seen(),
-            "State": SUBSTATUS_TO_STR.get(self.group.substatus, "").replace("_", " ").title(),
-            "First Seen": time_since(self.group.first_seen),
-        }
-        if self.group.issue_type in [
-            PerformanceP95EndpointRegressionGroupType,
-            ProfileFunctionRegressionType,
-        ]:
-            # another short term solution for non-error issues notification content
-            del context["Events"]
-            del context["Users Affected"]
-
-        context_text = ""
-        for k, v in context.items():
-            if k and v:
-                context_text += f"{k}: *{v}*   "
-        blocks.append(self.get_context_block(context_text[:-3]))
+        context = get_context(self.group)
+        if context:
+            blocks.append(self.get_context_block(context[:-3]))
 
         # build actions
         actions = []

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -231,8 +231,7 @@ def get_context(group: Group) -> str:
     }
     if group.issue_type in REGRESSION_PERFORMANCE_ISSUE_TYPES:
         # another short term solution for non-error issues notification content
-        del context["Events"]
-        del context["Users Affected"]
+        return context_text
 
     if group.issue_category in [GroupCategory.ERROR, GroupCategory.PERFORMANCE]:
         for k, v in context.items():

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2820,10 +2820,6 @@ class SlackActivityNotificationTest(ActivityTestCase):
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
         )
         assert (
-            blocks[3]["text"]["text"]
-            == "environment: `production`  release: `<http://testserver/releases/0.1/|0.1>`  "
-        )
-        assert (
             blocks[4]["elements"][0]["text"]
             == "Events: *1*   State: *Ongoing*   First Seen: *10\xa0minutes ago*"
         )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2820,7 +2820,15 @@ class SlackActivityNotificationTest(ActivityTestCase):
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
         )
         assert (
-            blocks[3]["elements"][0]["text"]
+            blocks[3]["text"]["text"]
+            == "environment: `production`  release: `<http://testserver/releases/0.1/|0.1>`  "
+        )
+        assert (
+            blocks[4]["elements"][0]["text"]
+            == "Events: *1*   State: *Ongoing*   First Seen: *10\xa0minutes ago*"
+        )
+        assert (
+            blocks[5]["elements"][0]["text"]
             == f"{project_slug} | production | <http://testserver/settings/account/notifications/{alert_type}/?referrer={referrer}-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2820,6 +2820,10 @@ class SlackActivityNotificationTest(ActivityTestCase):
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
         )
         assert (
+            blocks[3]["text"]["text"]
+            == "environment: `production`  release: `<http://testserver/releases/0.1/|0.1>`  "
+        )
+        assert (
             blocks[4]["elements"][0]["text"]
             == "Events: *1*   State: *Ongoing*   First Seen: *10\xa0minutes ago*"
         )

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -45,7 +45,7 @@ old_get_tags = get_tags
 
 
 def fake_get_tags(group, event_for_tags, tags):
-    return old_get_tags(group, event_for_tags, [])
+    return old_get_tags(group, event_for_tags, None)
 
 
 @region_silo_test


### PR DESCRIPTION
Initially in https://github.com/getsentry/sentry/pull/64328 I'd removed tags and context for all non-error issues, but it turns out we only want to remove tags and context in some specific cases. Note that this is a short term solution, there is a longer term solution proposed [here](https://www.notion.so/sentry/Rich-Slack-Notifications-Tech-Spec-867736397b4f4ef29b1d0251f5ae98c8?pvs=4#8c9a43bdc6224fcc8df7007189b268a7). 