### PR TITLE
ref(superuser): switch UserPermission to use superuser_has_permission

### DIFF
--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -30,11 +30,19 @@ class UserPermission(SentryPermission):
 
         # populate request.access for SaaS superuser
         SUPERUSER_ORG_ID = getattr(settings, "SUPERUSER_ORG_ID", None)
-        if SUPERUSER_ORG_ID and is_active_superuser(request):
-            org = organization_service.get_organization_by_id(id=SUPERUSER_ORG_ID)
-            self.determine_access(request, org)
+        if is_active_superuser(request):
+            if SUPERUSER_ORG_ID:
+                org = organization_service.get_organization_by_id(id=SUPERUSER_ORG_ID)
+                if not org:
+                    return False
 
-            if superuser_has_permission(request):
+                self.determine_access(request, org)
+
+                if superuser_has_permission(request):
+                    return True
+
+            else:
+                # org is self hosted
                 return True
 
         return False

--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import SentryPermission, StaffPermissionMixin
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.superuser import superuser_has_permission
 from sentry.auth.system import is_system_auth
 from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
@@ -26,7 +26,7 @@ class UserPermission(SentryPermission):
             return True
         if request.auth:
             return False
-        if is_active_superuser(request):
+        if superuser_has_permission(request):
             return True
         return False
 

--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -29,6 +29,7 @@ class UserPermission(SentryPermission):
             return False
 
         if is_active_superuser(request):
+            # collect admin level permissions (only used when a user is active superuser)
             permissions = access_service.get_permissions_for_user(request.user.id)
 
             if superuser_has_permission(request, permissions):

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -88,7 +88,7 @@ def get_superuser_scopes(auth_state: RpcAuthState, user: Any):
 
 
 def superuser_has_permission(
-    request: HttpRequest | Request, permissions: FrozenSet[str] | None = None
+    request: HttpRequest | Request, permissions: frozenset[str] | None = None
 ) -> bool:
     """
     This is used in place of is_active_superuser() in APIs / permission classes.

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -109,11 +109,14 @@ def superuser_has_permission(
     if not features.has("auth:enterprise-superuser-read-write", actor=request.user):
         return True
 
+    # either request.access or permissions must exist
+    assert getattr(request, "access", None) or permissions is not None
+
     # superuser write can access all requests
     if getattr(request, "access", None) and request.access.has_permission("superuser.write"):
         return True
 
-    elif permissions and "superuser.write" in permissions:
+    elif permissions is not None and "superuser.write" in permissions:
         return True
 
     # superuser read-only can only hit GET and OPTIONS (pre-flight) requests

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import ipaddress
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, FrozenSet
+from typing import Any
 
 from django.conf import settings
 from django.core.signing import BadSignature

--- a/tests/sentry/api/bases/test_user.py
+++ b/tests/sentry/api/bases/test_user.py
@@ -34,9 +34,11 @@ class UserPermissionTest(DRFPermissionTestCase):
             self.make_request(self.normal_user), None, self.normal_user
         )
 
+    @override_settings(SUPERUSER_ORG_ID=1000)
     def test_allows_active_superuser(self):
         # The user passed in and the user on the request must be different to
         # check superuser.
+        self.create_organization(owner=self.superuser_user, id=1000)
         assert self.user_permission.has_object_permission(
             self.superuser_request, None, self.normal_user
         )

--- a/tests/sentry/api/bases/test_user.py
+++ b/tests/sentry/api/bases/test_user.py
@@ -46,24 +46,26 @@ class UserPermissionTest(DRFPermissionTestCase):
                 self.superuser_request, None, self.normal_user
             )
 
-    @override_settings(SENTRY_SELF_HOSTED=False)
+    @override_settings(SENTRY_SELF_HOSTED=False, SUPERUSER_ORG_ID=1000)
     @with_feature("auth:enterprise-superuser-read-write")
     def test_active_superuser_read(self):
         # superuser read can hit GET
         request = self.make_request(user=self.superuser_user, is_superuser=True, method="GET")
-        request.access = self.create_request_access()
+        self.create_organization(owner=self.superuser_user, id=1000)
         assert self.user_permission.has_object_permission(request, None, self.normal_user)
 
         # superuser read cannot hit POST
         request.method = "POST"
         assert not self.user_permission.has_object_permission(request, None, self.normal_user)
 
-    @override_settings(SENTRY_SELF_HOSTED=False)
+    @override_settings(SENTRY_SELF_HOSTED=False, SUPERUSER_ORG_ID=1000)
     @with_feature("auth:enterprise-superuser-read-write")
     def test_active_superuser_write(self):
         # superuser write can hit GET
+        self.add_user_permission(self.superuser_user, "superuser.write")
+        self.create_organization(owner=self.superuser_user, id=1000)
+
         request = self.make_request(user=self.superuser_user, is_superuser=True, method="GET")
-        request.access = self.create_request_access(permissions=["superuser.write"])
         assert self.user_permission.has_object_permission(request, None, self.normal_user)
 
         # superuser write can hit POST


### PR DESCRIPTION
Replace `is_active_superuser` calls in UserPermission with `superuser_has_permission`.

`UserPermission` overwrites the `has_object_permission` function from its superclass `SentryPermission`, which sets `request.access`. We need to be able to look at the permissions the request's user has. We can do this by calling `access_service.get_permissions_for_user` and pass it into the `superuser_has_permission` function (and add some logic to check the permissions list if request.access is not set.

For https://github.com/getsentry/team-enterprise/issues/40