### PR TITLE
fix(ai-autofix): Fix autofix json serialization

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -89,15 +89,17 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
     ):
         requests.post(
             f"{settings.SEER_AUTOFIX_URL}/v0/automation/autofix",
-            json={
-                "base_commit_sha": base_commit_sha,
-                "issue": {
-                    "id": group.id,
-                    "title": group.title,
-                    "events": [{"entries": event_entries}],
-                },
-                "additional_context": additional_context,
-            },
+            data=json.dumps(
+                {
+                    "base_commit_sha": base_commit_sha,
+                    "issue": {
+                        "id": group.id,
+                        "title": group.title,
+                        "events": [{"entries": event_entries}],
+                    },
+                    "additional_context": additional_context,
+                }
+            ),
             headers={"content-type": "application/json;charset=utf-8"},
         )
 


### PR DESCRIPTION
Fixes SENTRY-2J35

by using the Sentry util json dumps which should serialize datetime values