### PR TITLE
Fix invalid `app` matcher regression

### DIFF
--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -234,10 +234,11 @@ class FamilyMatch(FrameMatch):
 class InAppMatch(FrameMatch):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._ref_val = bool(get_rule_bool(self.pattern))
+        self._ref_val = get_rule_bool(self.pattern)
 
     def _positive_frame_match(self, match_frame, exception_data, cache):
-        return self._ref_val == bool(match_frame["in_app"])
+        ref_val = self._ref_val
+        return ref_val is not None and ref_val == match_frame["in_app"]
 
 
 class FrameFieldMatch(FrameMatch):

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -238,7 +238,7 @@ class InAppMatch(FrameMatch):
 
     def _positive_frame_match(self, match_frame, exception_data, cache):
         ref_val = self._ref_val
-        return ref_val is not None and ref_val == match_frame["in_app"]
+        return ref_val is not None and ref_val == bool(match_frame["in_app"])
 
 
 class FrameFieldMatch(FrameMatch):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2009,10 +2009,17 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Rate at which to run the Rust implementation of `apply_modifications_to_frames
-# and compare the results`
+# Rate at which to run the Rust implementation of `apply_modifications_to_frames`
+# and compare the results
 register(
     "grouping.rust_enhancers.modify_frames_rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Rate at which to prefer the `apply_modifications_to_frames` result of the Rust implementation.
+register(
+    "grouping.rust_enhancers.prefer_rust_result",
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -32,7 +32,6 @@ def dump_obj(obj):
 
 @pytest.mark.parametrize("version", [1, 2])
 @django_db_all
-@override_options({"grouping.rust_enhancers.parse_rate": 1.0})
 def test_basic_parsing(insta_snapshot, version):
     enhancement = Enhancements.from_config_string(
         """
@@ -54,21 +53,25 @@ family:native                                   max-frames=3
 
     insta_snapshot(dump_obj(enhancement))
 
-    dumped = enhancement.dumps()
-    assert Enhancements.loads(dumped).dumps() == dumped
-    assert Enhancements.loads(dumped)._to_config_structure() == enhancement._to_config_structure()
-    assert isinstance(dumped, str)
-
-    with override_options({"enhancers.use-zstd": True}):
-        dumped_zstd = enhancement.dumps()
-
-        assert dumped_zstd is not dumped
-        assert Enhancements.loads(dumped_zstd).dumps() == dumped_zstd
+    rust_parsing = 1.0 if version == 2 else 0.0
+    with override_options({"grouping.rust_enhancers.parse_rate": rust_parsing}):
+        dumped = enhancement.dumps()
+        assert Enhancements.loads(dumped).dumps() == dumped
         assert (
-            Enhancements.loads(dumped_zstd)._to_config_structure()
-            == enhancement._to_config_structure()
+            Enhancements.loads(dumped)._to_config_structure() == enhancement._to_config_structure()
         )
-        assert isinstance(dumped_zstd, str)
+        assert isinstance(dumped, str)
+
+        with override_options({"enhancers.use-zstd": True}):
+            dumped_zstd = enhancement.dumps()
+
+            assert dumped_zstd is not dumped
+            assert Enhancements.loads(dumped_zstd).dumps() == dumped_zstd
+            assert (
+                Enhancements.loads(dumped_zstd)._to_config_structure()
+                == enhancement._to_config_structure()
+            )
+            assert isinstance(dumped_zstd, str)
 
 
 def test_parsing_errors():
@@ -242,6 +245,15 @@ def test_app_matching():
             app_no_rule, [{"abs_path": "/test.c", "in_app": True}], "native"
         )
     )
+
+
+def test_invalid_app_matcher():
+    enhancements = Enhancements.from_config_string("app://../../src/some-file.ts -app")
+    (rule,) = enhancements.rules
+
+    assert not bool(_get_matching_frame_actions(rule, [{}], "javascript"))
+    assert not bool(_get_matching_frame_actions(rule, [{"in_app": True}], "javascript"))
+    assert not bool(_get_matching_frame_actions(rule, [{"in_app": False}], "javascript"))
 
 
 def test_package_matching():


### PR DESCRIPTION
In #63202 I regressed the behavior of invalid `app` matchers. If an `app` matcher is not parsable as `bool`, it should *never* match, instead of defaulting to `false`.

This also has some more driveby fixes to the Rust Enhancements error, and paving the way to prefer the Rust result later on.