### PR TITLE
Update `ophio`

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,7 +62,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.0
 sentry-kafka-schemas>=0.1.38
-sentry-ophio==0.1.4
+sentry-ophio==0.1.5
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.45
 sentry-sdk>=1.39.2

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -178,7 +178,7 @@ sentry-devenv==1.2.2
 sentry-forked-django-stubs==4.2.7.post1
 sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.38
-sentry-ophio==0.1.4
+sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.45
 sentry-sdk==1.39.2

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -119,7 +119,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.0
 sentry-kafka-schemas==0.1.38
-sentry-ophio==0.1.4
+sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.45
 sentry-sdk==1.39.2


### PR DESCRIPTION
This will now silently accept invalid in_app matchers