### PR TITLE
ref(notification-actions): Prevent dynamic trigger types from being added in getsentry

### DIFF
--- a/src/sentry/models/notificationaction.py
+++ b/src/sentry/models/notificationaction.py
@@ -134,14 +134,18 @@ class AbstractNotificationAction(Model):
 class ActionTrigger(FlexibleIntEnum):
     """
     The possible sources of action notifications.
-    Use values less than 100 here to avoid conflicts with getsentry's trigger values.
+    Items prefixed with 'GS_' are have registrations in getsentry.
     """
 
     AUDIT_LOG = 0
+    GS_SPIKE_PROTECTION = 100
 
     @classmethod
     def as_choices(cls) -> tuple[tuple[int, str], ...]:
-        return ((cls.AUDIT_LOG.value, "audit-log"),)
+        return (
+            (cls.AUDIT_LOG.value, "audit-log"),
+            (cls.GS_SPIKE_PROTECTION.value, "spike-protection"),
+        )
 
 
 class TriggerGenerator:
@@ -220,8 +224,8 @@ class NotificationAction(AbstractNotificationAction):
     organization = FlexibleForeignKey("sentry.Organization")
     projects = models.ManyToManyField("sentry.Project", through=NotificationActionProject)
 
-    # The type of trigger which controls when the actions will go off (e.g. spike-protection)
-    trigger_type = models.SmallIntegerField(choices=TriggerGenerator())
+    # The type of trigger which controls when the actions will go off (e.g. 'spike-protection')
+    trigger_type = models.SmallIntegerField(choices=_trigger_types)
 
     class Meta:
         app_label = "sentry"
@@ -234,10 +238,9 @@ class NotificationAction(AbstractNotificationAction):
         display_text: str,
     ) -> None:
         """
-        This method is used for adding trigger types to this model from getsentry.
-        If the trigger is relevant to sentry as well, directly modify ActionTrigger.
+        Deprecated: Will be removed once removed from getsentry;
         """
-        cls._trigger_types += ((value, display_text),)
+        pass
 
     @classmethod
     def register_action(

--- a/src/sentry/models/notificationaction.py
+++ b/src/sentry/models/notificationaction.py
@@ -148,16 +148,6 @@ class ActionTrigger(FlexibleIntEnum):
         )
 
 
-class TriggerGenerator:
-    """
-    Allows NotificationAction.trigger_type to enforce extra triggers via
-    NotificationAction.register_trigger_type
-    """
-
-    def __iter__(self):
-        yield from NotificationAction._trigger_types
-
-
 @region_silo_only_model
 class NotificationActionProject(Model):
     __relocation_scope__ = {RelocationScope.Global, RelocationScope.Organization}
@@ -232,23 +222,14 @@ class NotificationAction(AbstractNotificationAction):
         db_table = "sentry_notificationaction"
 
     @classmethod
-    def register_trigger_type(
-        cls,
-        value: int,
-        display_text: str,
-    ) -> None:
+    def register_trigger_type(cls, value: int, display_text: str) -> None:
         """
-        Deprecated: Will be removed once removed from getsentry;
+        Deprecated: Will be removed once removed from getsentry.
         """
         pass
 
     @classmethod
-    def register_action(
-        cls,
-        trigger_type: int,
-        service_type: int,
-        target_type: int,
-    ):
+    def register_action(cls, trigger_type: int, service_type: int, target_type: int):
         """
         Register a new trigger/service/target combination for NotificationActions.
         For example, allowing audit-logs (trigger) to fire actions to slack (service) channels (target)

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_available.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_available.py
@@ -40,7 +40,7 @@ class NotificationActionsAvailableEndpointTest(APITestCase):
             serialize_available = MagicMock(return_value=[trigger_available_response])
 
         registration = MockActionRegistration
-        NotificationAction.register_trigger_type(*trigger)
+        NotificationAction._trigger_types += (trigger,)
         NotificationAction.register_action(
             trigger_type=trigger[0],
             service_type=ActionService.SENTRY_NOTIFICATION.value,

--- a/tests/sentry/models/test_notificationaction.py
+++ b/tests/sentry/models/test_notificationaction.py
@@ -20,7 +20,8 @@ class NotificationActionTest(TestCase):
         self.notif_action = self.create_notification_action(
             organization=self.organization, projects=self.projects
         )
-        self.illegal_trigger = (-1, "sandevistan")
+        # Need to use a mock new trigger to avoid tests conflicting with current registered actions
+        self.new_trigger = (-1, "sandevistan")
 
     @patch.object(NotificationActionLogger, "error")
     def test_register_action_for_fire(self, mock_error_logger):
@@ -36,30 +37,31 @@ class NotificationActionTest(TestCase):
         assert mock_handler.called
 
     def test_register_action_for_overlap(self):
-        NotificationAction.register_trigger_type(*self.illegal_trigger)
+        NotificationAction._trigger_types += (self.new_trigger,)
         mock_handler = MagicMock()
         NotificationAction.register_action(
-            trigger_type=self.illegal_trigger[0],
+            trigger_type=self.new_trigger[0],
             service_type=ActionService.EMAIL.value,
             target_type=ActionTarget.SPECIFIC.value,
         )(mock_handler)
         with pytest.raises(AttributeError):
             NotificationAction.register_action(
-                trigger_type=self.illegal_trigger[0],
+                trigger_type=self.new_trigger[0],
                 service_type=ActionService.EMAIL.value,
                 target_type=ActionTarget.SPECIFIC.value,
             )(mock_handler)
 
+    @pytest.mark.skip(reason="deprecated: will be removed once callers are removed")
     def test_register_trigger_type(self):
-        self.notif_action.trigger_type = self.illegal_trigger[0]
+        self.notif_action.trigger_type = self.new_trigger[0]
         self.notif_action.save()
         self.notif_action.full_clean()
-        NotificationAction.register_trigger_type(*self.illegal_trigger)
+        NotificationAction.register_trigger_type(*self.new_trigger)
         self.notif_action.full_clean()
 
     @patch.object(NotificationActionLogger, "error")
     def test_fire_fails_silently(self, mock_error_logger):
-        self.notif_action.trigger_type = self.illegal_trigger[0]
+        self.notif_action.trigger_type = self.new_trigger[0]
         self.notif_action.save()
         # Misconfigured/missing handlers shouldn't raise errors, but should log errors
         self.notif_action.fire()


### PR DESCRIPTION
This PR will prevent new trigger types from being registered dynamically in getsentry to unblock an upgrade to Django 5.x, as choices are no longer lazily evaluated.

