### PR TITLE
ref(metrics-extraction): Fix logging for exception

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -705,9 +705,8 @@ def _convert_aggregate_and_query_to_metrics(
             logger.exception("Invalid on-demand metric spec", extra=extra)
         except Exception:
             # Since prefilling might include several non-ondemand-compatible alerts, we want to not trigger errors in the
-            # Sentry console.
-            if not prefilling:
-                logger.exception("Failed on-demand metric spec creation.", extra=extra)
+            metrics.incr("on_demand_metrics.invalid_metric_spec.other")
+            logger.exception("Failed on-demand metric spec creation.", extra=extra)
 
     return metric_specs_and_hashes
 


### PR DESCRIPTION
### Summary
We are potentially hiding exceptions in metrics-extraction.
