### PR TITLE
feat(app-start): Add change column to overview table

### DIFF
--- a/static/app/views/starfish/views/appStartup/breakdown.tsx
+++ b/static/app/views/starfish/views/appStartup/breakdown.tsx
@@ -33,6 +33,7 @@ export function TooltipContents({
             <StartupDot style={{backgroundColor: color}} />
             <StartupName>{name}</StartupName>
           </StartupNameContainer>
+          <StartupCount>{row[key] ?? 0}</StartupCount>
           {toRoundedPercent((row[key] ?? 0) / total)}
         </StartupType>
       ))}
@@ -115,7 +116,11 @@ const StartupNameContainer = styled(OpsContent)`
 const StartupType = styled('div')`
   display: flex;
   justify-content: space-between;
-  gap: ${space(4)};
+  gap: ${space(2)};
+`;
+
+const StartupCount = styled('div')`
+  color: ${p => p.theme.gray300};
 `;
 
 const StartupName = styled('div')`

--- a/static/app/views/starfish/views/appStartup/index.tsx
+++ b/static/app/views/starfish/views/appStartup/index.tsx
@@ -192,13 +192,18 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
     MAX_CHART_RELEASE_CHARS
   );
 
+  const countTopScreens = Math.min(TOP_SCREENS, topTransactions.length);
+
   return (
     <div data-test-id="starfish-mobile-app-startup-view">
       <ChartContainer>
         <ScreensBarChart
           chartOptions={[
             {
-              title: t('Top Cold Starts'),
+              title:
+                countTopScreens > 1
+                  ? t('Top %s Screen Cold Starts', countTopScreens)
+                  : t('Top Screen Cold Start'),
               yAxis: YAXIS_COLUMNS[YAxis.COLD_START],
               xAxisLabel: topTransactions,
               series: Object.values(
@@ -220,7 +225,10 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
         <ScreensBarChart
           chartOptions={[
             {
-              title: t('Top Warm Starts'),
+              title:
+                countTopScreens > 1
+                  ? t('Top %s Screen Warm Starts', countTopScreens)
+                  : t('Top Screen Warm Start'),
               yAxis: YAXIS_COLUMNS[YAxis.WARM_START],
               xAxisLabel: topTransactions,
               series: Object.values(

--- a/static/app/views/starfish/views/appStartup/index.tsx
+++ b/static/app/views/starfish/views/appStartup/index.tsx
@@ -86,6 +86,8 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
       `avg_if(measurements.app_start_cold,release,${secondaryRelease})`,
       `avg_if(measurements.app_start_warm,release,${primaryRelease})`,
       `avg_if(measurements.app_start_warm,release,${secondaryRelease})`,
+      `avg_compare(measurements.app_start_cold,release,${primaryRelease},${secondaryRelease})`,
+      `avg_compare(measurements.app_start_warm,release,${primaryRelease},${secondaryRelease})`,
       'count_starts(measurements.app_start_cold)',
       'count_starts(measurements.app_start_warm)',
       'count()',
@@ -196,7 +198,7 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
         <ScreensBarChart
           chartOptions={[
             {
-              title: t('Cold Start by Top Screen'),
+              title: t('Top Cold Starts'),
               yAxis: YAXIS_COLUMNS[YAxis.COLD_START],
               xAxisLabel: topTransactions,
               series: Object.values(
@@ -218,7 +220,7 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
         <ScreensBarChart
           chartOptions={[
             {
-              title: t('Warm Start by Top Screen'),
+              title: t('Top Warm Starts'),
               yAxis: YAXIS_COLUMNS[YAxis.WARM_START],
               xAxisLabel: topTransactions,
               series: Object.values(
@@ -252,7 +254,7 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
         }}
         organization={organization}
         query={getFreeTextFromQuery(derivedQuery)}
-        placeholder={t('Search for Screens')}
+        placeholder={t('Search for Screen')}
         additionalConditions={
           new MutableSearch(
             appendReleaseFilters(tableSearchFilters, primaryRelease, secondaryRelease)

--- a/static/app/views/starfish/views/appStartup/screenSummary/systemApplicationBreakdown.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/systemApplicationBreakdown.spec.tsx
@@ -106,7 +106,7 @@ describe('SystemApplicationBreakdown', function () {
 
     await userEvent.hover(await screen.findByTestId('primary-release-breakdown'));
     expect(await screen.findByTestId('breakdown-tooltip-content')).toHaveTextContent(
-      'System70%Application30%'
+      'System7070%Application3030%'
     );
 
     await userEvent.unhover(screen.getByTestId('primary-release-breakdown'));

--- a/static/app/views/starfish/views/appStartup/screenSummary/systemApplicationBreakdown.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/systemApplicationBreakdown.spec.tsx
@@ -116,7 +116,7 @@ describe('SystemApplicationBreakdown', function () {
 
     await userEvent.hover(screen.getByTestId('secondary-release-breakdown'));
     expect(await screen.findByTestId('breakdown-tooltip-content')).toHaveTextContent(
-      'System100%'
+      'System70100%Application00%'
     );
   });
 });

--- a/static/app/views/starfish/views/appStartup/screensTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screensTable.tsx
@@ -56,7 +56,11 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
       'Warm Start (%s)',
       SECONDARY_RELEASE_ALIAS
     ),
-    app_start_breakdown: t('App Start Breakdown'),
+    [`avg_compare(measurements.app_start_cold,release,${primaryRelease},${secondaryRelease})`]:
+      t('Change'),
+    [`avg_compare(measurements.app_start_warm,release,${primaryRelease},${secondaryRelease})`]:
+      t('Change'),
+    app_start_breakdown: t('Type Breakdown'),
     'count()': t('Total Count'),
   };
 
@@ -171,8 +175,10 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
           'transaction',
           `avg_if(measurements.app_start_cold,release,${primaryRelease})`,
           `avg_if(measurements.app_start_cold,release,${secondaryRelease})`,
+          `avg_compare(measurements.app_start_cold,release,${primaryRelease},${secondaryRelease})`,
           `avg_if(measurements.app_start_warm,release,${primaryRelease})`,
           `avg_if(measurements.app_start_warm,release,${secondaryRelease})`,
+          `avg_compare(measurements.app_start_warm,release,${primaryRelease},${secondaryRelease})`,
           `app_start_breakdown`,
           'count()',
         ].map(columnKey => {


### PR DESCRIPTION
Adds the change column by using `avg_compare` as well as updates the tooltip for the type breakdown to show the count of the start breakdown

My tooltip change was also picked up by the system v. application breakdown and instead of deleting the files, I've updated the test because it provides additional coverage for the tooltip change.

I'm also aware that this is still metrics data, but the conversion to span metrics is slightly more difficult to aggregate cold + warm start data since spans and will require custom functions in `datasets/spans_metrics.py`. For now this is okay because if there is start data, the event count is still a decent proxy for "top screens" in the meantime.