### PR TITLE
fix(ci): Bumping action-github-app-token to use node20

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     steps:
-      - uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
+      - uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         id: token
         continue-on-error: true
         with:
@@ -290,7 +290,7 @@ jobs:
       - run: mypy
         id: run
 
-      - uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
+      - uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         id: token
         continue-on-error: true
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Internal github app token
         id: token
-        uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         continue-on-error: true
         with:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}

--- a/.github/workflows/getsentry-dispatch.yml
+++ b/.github/workflows/getsentry-dispatch.yml
@@ -49,7 +49,7 @@ jobs:
           filters: .github/file-filters.yml
 
       - name: getsentry token
-        uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         id: getsentry
         with:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Getsentry Token
         id: getsentry
-        uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         with:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - # get a non-default github token so that any changes are verified by CI
         if: env.SECRET_ACCESS == 'true'
-        uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         id: token
         with:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}

--- a/.github/workflows/sentry-pull-request-bot.yml
+++ b/.github/workflows/sentry-pull-request-bot.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Fetch getsentry token
         if: steps.org.outputs.result == 'true'
         id: getsentry
-        uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         with:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Bumping action-github-app-token in order to move off of node16 which is now deprecated. 