### PR TITLE
feat(crons): Allow monitors to be sorted by `name`

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -69,6 +69,14 @@ MONITOR_ENVIRONMENT_ORDERING = Case(
 )
 
 
+def flip_sort_direction(sort_field: str) -> str:
+    if sort_field[0] == "-":
+        sort_field = sort_field[1:]
+    else:
+        sort_field = "-" + sort_field
+    return sort_field
+
+
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
 class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
@@ -113,6 +121,8 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
             ]
         )
         query = request.GET.get("query")
+        is_asc = request.GET.get("asc", "1") == "1"
+        sort = request.GET.get("sort", "status")
 
         environments = None
         if "environment" in filter_params:
@@ -133,29 +143,37 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
         monitor_environments_query = MonitorEnvironment.objects.filter(
             monitor__id=OuterRef("id"), environment__in=environments
         )
+        sort_fields = []
 
-        queryset = queryset.annotate(
-            environment_status_ordering=Case(
-                # Sort DISABLED and is_muted monitors to the bottom of the list
-                When(status=ObjectStatus.DISABLED, then=Value(len(DEFAULT_ORDERING) + 1)),
-                When(is_muted=True, then=Value(len(DEFAULT_ORDERING))),
-                default=Subquery(
-                    monitor_environments_query.annotate(
-                        status_ordering=MONITOR_ENVIRONMENT_ORDERING
-                    )
-                    .order_by("status_ordering")
-                    .values("status_ordering")[:1],
-                    output_field=IntegerField(),
-                ),
+        if sort == "status":
+            queryset = queryset.annotate(
+                environment_status_ordering=Case(
+                    # Sort DISABLED and is_muted monitors to the bottom of the list
+                    When(status=ObjectStatus.DISABLED, then=Value(len(DEFAULT_ORDERING) + 1)),
+                    When(is_muted=True, then=Value(len(DEFAULT_ORDERING))),
+                    default=Subquery(
+                        monitor_environments_query.annotate(
+                            status_ordering=MONITOR_ENVIRONMENT_ORDERING
+                        )
+                        .order_by("status_ordering")
+                        .values("status_ordering")[:1],
+                        output_field=IntegerField(),
+                    ),
+                )
             )
-        )
 
-        queryset = queryset.annotate(
-            last_checkin_monitorenvironment=Subquery(
-                monitor_environments_query.order_by("-last_checkin").values("last_checkin")[:1],
-                output_field=DateTimeField(),
+            queryset = queryset.annotate(
+                last_checkin_monitorenvironment=Subquery(
+                    monitor_environments_query.order_by("-last_checkin").values("last_checkin")[:1],
+                    output_field=DateTimeField(),
+                )
             )
-        )
+            sort_fields = ["environment_status_ordering", "-last_checkin_monitorenvironment"]
+        elif sort == "name":
+            sort_fields = ["name"]
+
+        if not is_asc:
+            sort_fields = [flip_sort_direction(sort_field) for sort_field in sort_fields]
 
         if query:
             tokens = tokenize_query(query)
@@ -191,7 +209,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
         return self.paginate(
             request=request,
             queryset=queryset,
-            order_by=("environment_status_ordering", "-last_checkin_monitorenvironment"),
+            order_by=sort_fields,
             on_results=lambda x: serialize(
                 x, request.user, MonitorSerializer(environments=environments)
             ),

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -43,7 +43,7 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         response = self.get_success_response(self.organization.slug)
         self.check_valid_response(response, [monitor])
 
-    def test_sort(self):
+    def test_sort_status(self):
         last_checkin = datetime.now() - timedelta(minutes=1)
         last_checkin_older = datetime.now() - timedelta(minutes=5)
 
@@ -101,6 +101,38 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
                 monitor_disabled,
             ],
         )
+
+        response = self.get_success_response(
+            self.organization.slug, asc="0", params={"environment": "jungle"}
+        )
+        self.check_valid_response(
+            response,
+            [
+                monitor_disabled,
+                monitor_muted,
+                monitor_active,
+                monitor_ok,
+                monitor_missed_checkin,
+                monitor_timed_out,
+                monitor_error_older_checkin,
+                monitor_error,
+            ],
+        )
+
+    def test_sort_name(self):
+        monitors = [
+            self._create_monitor(name="Some Monitor"),
+            self._create_monitor(name="A monitor"),
+            self._create_monitor(name="ZA monitor"),
+        ]
+        monitors.sort(key=lambda m: m.name)
+
+        response = self.get_success_response(self.organization.slug, sort="name")
+        self.check_valid_response(response, monitors)
+
+        monitors.reverse()
+        response = self.get_success_response(self.organization.slug, sort="name", asc="0")
+        self.check_valid_response(response, monitors)
 
     def test_all_monitor_environments(self):
         monitor = self._create_monitor()


### PR DESCRIPTION
This adds the ability to sort by `Monitor.name` on the cron monitors endpoint. We also add in `asc` as a param to allow the order to be reversed.