### PR TITLE
fix(ddm): Skip unnecessary segment details query

### DIFF
--- a/src/sentry/sentry_metrics/querying/metadata/metrics_correlations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_correlations.py
@@ -371,13 +371,17 @@ class MetricsSummariesCorrelationsSource(CorrelationsSource):
         )
 
         # Third, we fetch the segments details together with aggregates
-        segments = _get_segments(
-            where=[Condition(Column("transaction_id"), Op.IN, list(segments_spans.keys()))],
-            start=start,
-            end=end,
-            organization=self.organization,
-            projects=self.projects,
-        )
+        if segments_spans:
+            segments = _get_segments(
+                where=[Condition(Column("transaction_id"), Op.IN, list(segments_spans.keys()))],
+                start=start,
+                end=end,
+                organization=self.organization,
+                projects=self.projects,
+            )
+        else:
+            # If there are no segment spans, we can safely skip fetching segment details
+            segments = []
 
         # Fourth, we merge span details with the fetched segments.
         extended_segments = []


### PR DESCRIPTION
In the event that the metrics summary query returns no span ids, or if the segment ids could not be found, we can safely skip the segment details query as it will always return no results.