### PR TITLE
fix(ai-autofix): Fix Autofix timeout check + add unit tests for them

### DIFF
--- a/src/sentry/tasks/ai_autofix.py
+++ b/src/sentry/tasks/ai_autofix.py
@@ -15,7 +15,7 @@ def ai_autofix_check_for_timeout(group_id: int, created_at: str):
     metadata = group.data.get("metadata", {})
     autofix_data = metadata.get("autofix", {})
     # created_at is checked to make sure that the correct run is being marked as completed
-    if autofix_data.get("status") == "PROCESSING" and autofix_data.get("createdAt") == created_at:
+    if autofix_data.get("status") == "PROCESSING" and autofix_data.get("created_at") == created_at:
         steps = autofix_data.get("steps", [])
 
         for step in steps:
@@ -28,7 +28,7 @@ def ai_autofix_check_for_timeout(group_id: int, created_at: str):
             **autofix_data,
             "fix": None,
             "status": "ERROR",
-            "completedAt": datetime.now().isoformat(),
+            "completed_at": datetime.now().isoformat(),
             "steps": steps,
         }
         group.data["metadata"] = metadata

--- a/tests/sentry/tasks/test_ai_autofix.py
+++ b/tests/sentry/tasks/test_ai_autofix.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from unittest.mock import patch
 
 from sentry.models.group import Group
 from sentry.tasks.ai_autofix import ai_autofix_check_for_timeout
@@ -19,9 +18,7 @@ class TestAIAutofixCheckForTimeout(TestCase):
         }
         group.save()
 
-        with patch("sentry.models.Group.objects.get") as mock_group_get:
-            mock_group_get.return_value = group
-            ai_autofix_check_for_timeout(group_id=group.id, created_at=created_at)
+        ai_autofix_check_for_timeout(group_id=group.id, created_at=created_at)
 
         updated_group = Group.objects.get(id=group.id)
         updated_autofix_data = updated_group.data["metadata"]["autofix"]
@@ -50,9 +47,7 @@ class TestAIAutofixCheckForTimeout(TestCase):
         }
         group.save()
 
-        with patch("sentry.models.Group.objects.get") as mock_group_get:
-            mock_group_get.return_value = group
-            ai_autofix_check_for_timeout(group_id=group.id, created_at=created_at)
+        ai_autofix_check_for_timeout(group_id=group.id, created_at=created_at)
 
         updated_group = Group.objects.get(id=group.id)
         assert updated_group.data["metadata"]["autofix"]["status"] == "COMPLETED"
@@ -70,9 +65,7 @@ class TestAIAutofixCheckForTimeout(TestCase):
         }
         group.save()
 
-        with patch("sentry.models.Group.objects.get") as mock_group_get:
-            mock_group_get.return_value = group
-            ai_autofix_check_for_timeout(group_id=group.id, created_at=old_created_at)
+        ai_autofix_check_for_timeout(group_id=group.id, created_at=old_created_at)
 
         updated_group = Group.objects.get(id=group.id)
         updated_autofix_data = updated_group.data["metadata"]["autofix"]

--- a/tests/sentry/tasks/test_ai_autofix.py
+++ b/tests/sentry/tasks/test_ai_autofix.py
@@ -1,0 +1,92 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from sentry.models.group import Group
+from sentry.tasks.ai_autofix import ai_autofix_check_for_timeout
+from sentry.testutils.cases import TestCase
+
+
+class TestAIAutofixCheckForTimeout(TestCase):
+    def test_ai_autofix_check_for_timeout(self):
+        created_at = datetime.now().isoformat()
+        group = self.create_group()
+        group.data["metadata"] = {
+            "autofix": {
+                "status": "PROCESSING",
+                "created_at": created_at,
+                "steps": [{"status": "PROCESSING"}, {"status": "PENDING"}],
+            }
+        }
+        group.save()
+
+        with patch("sentry.models.Group.objects.get") as mock_group_get:
+            mock_group_get.return_value = group
+            ai_autofix_check_for_timeout(group_id=group.id, created_at=created_at)
+
+        updated_group = Group.objects.get(id=group.id)
+        updated_autofix_data = updated_group.data["metadata"]["autofix"]
+        assert updated_autofix_data["status"] == "ERROR"
+        assert all(
+            step["status"] == "ERROR"
+            for step in updated_autofix_data["steps"]
+            if step["status"] == "PROCESSING"
+        )
+        assert all(
+            step["status"] == "CANCELLED"
+            for step in updated_autofix_data["steps"]
+            if step["status"] == "PENDING"
+        )
+        assert "completed_at" in updated_autofix_data
+
+    def test_ai_autofix_check_for_timeout_no_change(self):
+        created_at = datetime.now().isoformat()
+        group = self.create_group()
+        group.data["metadata"] = {
+            "autofix": {
+                "status": "COMPLETED",
+                "created_at": created_at,
+                "steps": [{"status": "COMPLETED"}],
+            }
+        }
+        group.save()
+
+        with patch("sentry.models.Group.objects.get") as mock_group_get:
+            mock_group_get.return_value = group
+            ai_autofix_check_for_timeout(group_id=group.id, created_at=created_at)
+
+        updated_group = Group.objects.get(id=group.id)
+        assert updated_group.data["metadata"]["autofix"]["status"] == "COMPLETED"
+
+    def test_ai_autofix_check_for_newer_autofix(self):
+        old_created_at = datetime.now().isoformat()
+        newer_created_at = (datetime.now() + timedelta(minutes=1)).isoformat()
+        group = self.create_group()
+        group.data["metadata"] = {
+            "autofix": {
+                "status": "PROCESSING",
+                "created_at": newer_created_at,
+                "steps": [{"status": "PROCESSING"}, {"status": "PENDING"}],
+            }
+        }
+        group.save()
+
+        with patch("sentry.models.Group.objects.get") as mock_group_get:
+            mock_group_get.return_value = group
+            ai_autofix_check_for_timeout(group_id=group.id, created_at=old_created_at)
+
+        updated_group = Group.objects.get(id=group.id)
+        updated_autofix_data = updated_group.data["metadata"]["autofix"]
+        # The status and steps should not change since a newer autofix has been created
+        assert updated_autofix_data["status"] == "PROCESSING"
+        assert updated_autofix_data["created_at"] == newer_created_at
+        assert "completed_at" not in updated_autofix_data
+        assert all(
+            step["status"] == "PROCESSING"
+            for step in updated_autofix_data["steps"]
+            if step["status"] == "PROCESSING"
+        )
+        assert all(
+            step["status"] == "PENDING"
+            for step in updated_autofix_data["steps"]
+            if step["status"] == "PENDING"
+        )


### PR DESCRIPTION
The created at field was renamed to snake case `created_at` and the check wasn't correctly running