### PR TITLE
fix(self-hosted): Fix CSRF issue for clean installs

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -407,6 +407,9 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
         system_url_prefix = options.get("system.url-prefix")
         if system_url_prefix:
             settings.CSRF_TRUSTED_ORIGINS = [system_url_prefix]
+        else:
+            # For first time users that have not yet set system url prefix, let's default to localhost url
+            settings.CSRF_TRUSTED_ORIGINS = ["http://localhost:9000"]
 
     env.data["config"] = get_sentry_conf()
     env.data["start_date"] = timezone.now()


### PR DESCRIPTION
For clean installs, `system.url-prefix` is not yet set, so let's default to the localhost url