### PR TITLE
ref(open-pr-comments): cap number of recent unresolved issues to filter through

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -91,6 +91,8 @@ OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE = """\
 
 OPEN_PR_ISSUE_DESCRIPTION_LENGTH = 52
 
+MAX_RECENT_ISSUES = 10000
+
 
 def format_open_pr_comment(issue_tables: list[str]) -> str:
     return OPEN_PR_COMMENT_BODY_TEMPLATE.format(issue_tables="\n".join(issue_tables))
@@ -303,8 +305,10 @@ def get_top_5_issues_by_count_for_file(
             last_seen__gte=datetime.now() - timedelta(days=14),
             status=GroupStatus.UNRESOLVED,
             project__in=projects,
-        ).values_list("id", flat=True)
-    )
+        )
+        .order_by("-times_seen")
+        .values_list("id", flat=True)
+    )[:MAX_RECENT_ISSUES]
     project_ids = [p.id for p in projects]
 
     multi_if = language_parser.generate_multi_if(function_names)

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -49,6 +49,8 @@ This pull request was deployed and Sentry observed the following issues:
 
 MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
 
+MAX_SUSPECT_COMMITS = 1000
+
 
 def format_comment_subtitle(subtitle):
     return subtitle[:47] + "..." if len(subtitle) > 50 else subtitle
@@ -138,7 +140,7 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
     gh_repo_id, pr_key, org_id, issue_list = pr_to_issue_query(pullrequest_id)[0]
 
     # cap to 1000 issues in which the merge commit is the suspect commit
-    issue_list = issue_list[:1000]
+    issue_list = issue_list[:MAX_SUSPECT_COMMITS]
 
     try:
         organization = Organization.objects.get_from_cache(id=org_id)


### PR DESCRIPTION
[This error](https://sentry.sentry.io/issues/4929543284/) is still happening because we are passing too many issue ids to the Snuba query, and the query isn't being processed because it's too big. This results is no comment being made on a newly opened pull request.

In Open PR Comments we fetch recent unresolved issues and pass those into the Snuba query to determine if the functions + files being modified in a pull request can be found in the stack trace of those issues. We can cap this to something big (because Snuba can handle a pretty big number, but not a HUGE number) and order the issues by how many times they have occurred (`times_seen`) so that we can match functions + files to the most common issues.