### PR TITLE
ref(slack): Use helper function for testing assign action

### DIFF
--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -22,6 +22,7 @@ from sentry.models.groupsnooze import GroupSnooze
 from sentry.models.identity import Identity
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.release import Release
+from sentry.models.team import Team
 from sentry.silo import SiloMode, unguarded_write
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
@@ -192,6 +193,26 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             )
 
         assert resp.status_code == 200, resp.content
+
+    def assign_issue_block_kit(self, original_message, selected_option, payload_data=None):
+        if isinstance(selected_option, Team):
+            status_action = self.get_assign_status_action(
+                "team", selected_option.slug, selected_option.id
+            )
+        else:
+            status_action = self.get_assign_status_action(
+                "user", selected_option.get_display_name(), selected_option.id
+            )
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook_block_kit(
+                action_data=[status_action], original_message=original_message
+            )
+
+        assert resp.status_code == 200, resp.content
+        # Unlike the other action helper functions, this doesn't involve opening and submitting a
+        # a modal so we don't use the responses wrapper on the assignment tests; we need to return
+        # resp so that the tests can assert the response blocks looked as expected
+        return resp
 
     def resolve_issue_block_kit(self, original_message, selected_option, payload_data=None):
         status_action = self.get_resolve_status_action()
@@ -633,17 +654,11 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
     def test_assign_issue_block_kit(self):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
-        status_action = self.get_assign_status_action("user", user2.email, user2.id)
         original_message = self.get_original_message_block_kit(self.group.id)
+
         # Assign to user
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message
-            )
-
-        assert resp.status_code == 200, resp.content
+        resp = self.assign_issue_block_kit(original_message, user2)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
-
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert (
             resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
@@ -651,43 +666,38 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
         # Assign to team
-        status_action = self.get_assign_status_action("team", self.team.slug, self.team.id)
-        original_message = self.get_original_message_block_kit(self.group.id)
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message
-            )
-
-        assert resp.status_code == 200, resp.content
+        resp = self.assign_issue_block_kit(original_message, self.team)
         assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
-        activity = Activity.objects.filter(group=self.group).first()
-        assert activity.data == {
-            "assignee": str(user2.id),
-            "assigneeEmail": user2.email,
-            "assigneeType": "user",
-            "integration": ActivityIntegration.SLACK.value,
-        }
-
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
         assert (
             resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
         )
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+
+        # Assert group assignment activity recorded
+        group_activity = Activity.objects.filter(group=self.group)
+        assert group_activity.first().data == {
+            "assignee": str(user2.id),
+            "assigneeEmail": user2.email,
+            "assigneeType": "user",
+            "integration": ActivityIntegration.SLACK.value,
+        }
+        assert group_activity.last().data == {
+            "assignee": str(self.team.id),
+            "assigneeEmail": None,
+            "assigneeType": "team",
+            "integration": ActivityIntegration.SLACK.value,
+        }
 
     def test_assign_issue_block_kit_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
-        status_action = self.get_assign_status_action("user", user2.email, user2.id)
         original_message = self.get_original_message_block_kit(self.group.id)
-        data = self.get_block_kit_unfurl_data(original_message["blocks"])
+        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
 
         # Assign to user
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(action_data=[status_action], data=data)
-
-        assert resp.status_code == 200, resp.content
+        resp = self.assign_issue_block_kit(original_message, user2, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
-
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
         assert (
             resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
@@ -695,26 +705,28 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
         # Assign to team
-        status_action = self.get_assign_status_action("team", self.team.slug, self.team.id)
-        original_message = self.get_original_message_block_kit(self.group.id)
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(action_data=[status_action], data=data)
-
-        assert resp.status_code == 200, resp.content
+        resp = self.assign_issue_block_kit(original_message, self.team, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
-        activity = Activity.objects.filter(group=self.group).first()
-        assert activity.data == {
-            "assignee": str(user2.id),
-            "assigneeEmail": user2.email,
-            "assigneeType": "user",
-            "integration": ActivityIntegration.SLACK.value,
-        }
-
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
         assert (
             resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
         )
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
+
+        # Assert group assignment activity recorded
+        group_activity = Activity.objects.filter(group=self.group)
+        assert group_activity.first().data == {
+            "assignee": str(user2.id),
+            "assigneeEmail": user2.email,
+            "assigneeType": "user",
+            "integration": ActivityIntegration.SLACK.value,
+        }
+        assert group_activity.last().data == {
+            "assignee": str(self.team.id),
+            "assigneeEmail": None,
+            "assigneeType": "team",
+            "integration": ActivityIntegration.SLACK.value,
+        }
 
     def test_assign_issue_where_team_not_in_project(self):
         user2 = self.create_user(is_superuser=False)
@@ -753,12 +765,8 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         self.create_member(user=user2, organization=self.organization, teams=[team2])
         self.create_project(name="hellboy", organization=self.organization, teams=[team2])
         # Assign to team
-        status_action = self.get_assign_status_action("team", team2.slug, team2.id)
         original_message = self.get_original_message_block_kit(self.group.id)
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook(action_data=[status_action], original_message=original_message)
-
-        assert resp.status_code == 200, resp.content
+        resp = self.assign_issue_block_kit(original_message, team2)
         assert resp.data["text"].endswith("Cannot assign to a team without access to the project")
         assert not GroupAssignee.objects.filter(group=self.group).exists()
 
@@ -770,14 +778,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         self.create_member(user=user2, organization=self.organization, teams=[team2])
         self.create_project(name="hellboy", organization=self.organization, teams=[team2])
         # Assign to team
-        status_action = self.get_assign_status_action("team", team2.slug, team2.id)
         original_message = self.get_original_message_block_kit(self.group.id)
-        data = self.get_block_kit_unfurl_data(original_message["blocks"])
-
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook(action_data=[status_action], data=data)
-
-        assert resp.status_code == 200, resp.content
+        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
+        resp = self.assign_issue_block_kit(original_message, team2, payload_data)
         assert resp.data["text"].endswith("Cannot assign to a team without access to the project")
         assert not GroupAssignee.objects.filter(group=self.group).exists()
 
@@ -820,20 +823,13 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
     def test_assign_issue_user_has_identity_block_kit(self):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
-
         user2_identity = self.create_identity(
             external_id="slack_id2",
             identity_provider=self.idp,
             user=user2,
         )
-        status_action = self.get_assign_status_action("user", user2.email, user2.id)
         original_message = self.get_original_message_block_kit(self.group.id)
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message
-            )
-
-        assert resp.status_code == 200, resp.content
+        resp = self.assign_issue_block_kit(original_message, user2)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
 
         expect_status = (
@@ -853,13 +849,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             identity_provider=self.idp,
             user=user2,
         )
-        status_action = self.get_assign_status_action("user", user2.email, user2.id)
         original_message = self.get_original_message_block_kit(self.group.id)
-        data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(action_data=[status_action], data=data)
-
-        assert resp.status_code == 200, resp.content
+        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
+        resp = self.assign_issue_block_kit(original_message, user2, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
 
         expect_status = (
@@ -869,91 +861,6 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
         )
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-
-    def test_response_differs_on_bot_message(self):
-        status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
-        original_message = {"type": "message"}
-
-        resp = self.post_webhook(action_data=[status_action], original_message=original_message)
-        self.group = Group.objects.get(id=self.group.id)
-
-        assert self.group.get_status() == GroupStatus.IGNORED
-        assert self.group.substatus == GroupSubStatus.FOREVER
-        assert resp.status_code == 200, resp.content
-        assert "attachments" in resp.data
-        assert resp.data["attachments"][0]["title"] in self.group.title
-
-        with self.feature("organizations:slack-block-kit"):
-            # test backwards compatibility
-            resp = self.post_webhook(action_data=[status_action], original_message=original_message)
-            self.group = Group.objects.get(id=self.group.id)
-            assert self.group.get_status() == GroupStatus.IGNORED
-            assert self.group.substatus == GroupSubStatus.FOREVER
-            assert resp.status_code == 200, resp.content
-            assert "blocks" in resp.data
-            assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] in self.group.title
-
-    @responses.activate
-    def test_response_differs_on_bot_message_block_kit(self):
-        status_action = self.get_archive_status_action()
-        original_message = self.get_original_message_block_kit(self.group.id)
-
-        # Expect request to open dialog on slack
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/views.open",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action],
-                original_message=original_message,
-            )
-        assert resp.status_code == 200, resp.content
-
-        # Opening dialog should *not* cause the current message to be updated
-        assert resp.content == b""
-
-        data = json.loads(responses.calls[0].request.body)
-        assert data["trigger_id"] == self.trigger_id
-        assert "view" in data
-
-        view = json.loads(data["view"])
-        private_metadata = json.loads(view["private_metadata"])
-        assert int(private_metadata["issue"]) == self.group.id
-        assert private_metadata["orig_response_url"] == self.response_url
-
-        # Completing the dialog will update the message
-        responses.add(
-            method=responses.POST,
-            url=self.response_url,
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                type="view_submission",
-                private_metadata=json.dumps(private_metadata),
-                selected_option="ignored:archived_forever",
-            )
-        assert resp.status_code == 200, resp.content
-        self.group = Group.objects.get(id=self.group.id)
-
-        assert self.group.get_status() == GroupStatus.IGNORED
-        assert self.group.substatus == GroupSubStatus.FOREVER
-
-        update_data = json.loads(responses.calls[1].request.body)
-
-        expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
-        assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     def test_assign_user_with_multiple_identities(self):
         org2 = self.create_organization(owner=None)
@@ -1010,14 +917,8 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             identity_provider=idp2,
             user=self.user,
         )
-        status_action = self.get_assign_status_action("user", self.user.email, self.user.id)
         original_message = self.get_original_message_block_kit(self.group.id)
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(
-                action_data=[status_action], original_message=original_message
-            )
-
-        assert resp.status_code == 200, resp.content
+        resp = self.assign_issue_block_kit(original_message, self.user)
         assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
 
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
@@ -1042,13 +943,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             identity_provider=idp2,
             user=self.user,
         )
-        status_action = self.get_assign_status_action("user", self.user.email, self.user.id)
         original_message = self.get_original_message_block_kit(self.group.id)
-        data = self.get_block_kit_unfurl_data(original_message["blocks"])
-        with self.feature("organizations:slack-block-kit"):
-            resp = self.post_webhook_block_kit(action_data=[status_action], data=data)
-
-        assert resp.status_code == 200, resp.content
+        payload_data = self.get_block_kit_unfurl_data(original_message["blocks"])
+        resp = self.assign_issue_block_kit(original_message, self.user, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
 
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
@@ -1420,6 +1317,91 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
+        assert (
+            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
+        )
+        assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
+
+    def test_response_differs_on_bot_message(self):
+        status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
+        original_message = {"type": "message"}
+
+        resp = self.post_webhook(action_data=[status_action], original_message=original_message)
+        self.group = Group.objects.get(id=self.group.id)
+
+        assert self.group.get_status() == GroupStatus.IGNORED
+        assert self.group.substatus == GroupSubStatus.FOREVER
+        assert resp.status_code == 200, resp.content
+        assert "attachments" in resp.data
+        assert resp.data["attachments"][0]["title"] in self.group.title
+
+        with self.feature("organizations:slack-block-kit"):
+            # test backwards compatibility
+            resp = self.post_webhook(action_data=[status_action], original_message=original_message)
+            self.group = Group.objects.get(id=self.group.id)
+            assert self.group.get_status() == GroupStatus.IGNORED
+            assert self.group.substatus == GroupSubStatus.FOREVER
+            assert resp.status_code == 200, resp.content
+            assert "blocks" in resp.data
+            assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] in self.group.title
+
+    @responses.activate
+    def test_response_differs_on_bot_message_block_kit(self):
+        status_action = self.get_archive_status_action()
+        original_message = self.get_original_message_block_kit(self.group.id)
+
+        # Expect request to open dialog on slack
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/views.open",
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook_block_kit(
+                action_data=[status_action],
+                original_message=original_message,
+            )
+        assert resp.status_code == 200, resp.content
+
+        # Opening dialog should *not* cause the current message to be updated
+        assert resp.content == b""
+
+        data = json.loads(responses.calls[0].request.body)
+        assert data["trigger_id"] == self.trigger_id
+        assert "view" in data
+
+        view = json.loads(data["view"])
+        private_metadata = json.loads(view["private_metadata"])
+        assert int(private_metadata["issue"]) == self.group.id
+        assert private_metadata["orig_response_url"] == self.response_url
+
+        # Completing the dialog will update the message
+        responses.add(
+            method=responses.POST,
+            url=self.response_url,
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook_block_kit(
+                type="view_submission",
+                private_metadata=json.dumps(private_metadata),
+                selected_option="ignored:archived_forever",
+            )
+        assert resp.status_code == 200, resp.content
+        self.group = Group.objects.get(id=self.group.id)
+
+        assert self.group.get_status() == GroupStatus.IGNORED
+        assert self.group.substatus == GroupSubStatus.FOREVER
+
+        update_data = json.loads(responses.calls[1].request.body)
+
+        expect_status = f"*Issue archived by <@{self.external_id}>*"
         assert (
             update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
         )


### PR DESCRIPTION
making the tests a little nicer by introducing a helper function for testing the assignment status action :)

this was done for the archive and resolve actions in #63925 and #64067 respectively