### PR TITLE
fix(metrics-extraction): Remove condition in on-demand task

### DIFF
--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -116,9 +116,9 @@ def schedule_on_demand_check() -> None:
     dashboard_widget_count = 0
 
     for (widget_query_id,) in RangeQuerySetWrapper(
-        DashboardWidgetQuery.objects.filter(widget__widget_type=DashboardWidgetTypes.DISCOVER)
-        .exclude(conditions__contains="event.type:error")
-        .values_list("id"),
+        DashboardWidgetQuery.objects.filter(
+            widget__widget_type=DashboardWidgetTypes.DISCOVER
+        ).values_list("id"),
         result_value_getter=lambda item: item[0],
     ):
         dashboard_widget_pre_rollout_count += 1


### PR DESCRIPTION
### Summary
This removes the event.type:error condition in the on-demand task, that should be handled by the spec creation (and shouldn't generate specs)
