### PR TITLE
ref(superuser): only allow superuser write to set team role

### DIFF
--- a/src/sentry/api/endpoints/organization_member/__init__.py
+++ b/src/sentry/api/endpoints/organization_member/__init__.py
@@ -9,7 +9,7 @@ from rest_framework.request import Request
 from sentry import roles
 from sentry.api.exceptions import SentryAPIException
 from sentry.auth.access import Access
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.superuser import is_active_superuser, superuser_has_permission
 from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
@@ -69,7 +69,7 @@ def can_set_team_role(request: Request, team: Team, new_role: TeamRole) -> bool:
     * If they are an org owner/manager/admin
     * If they are a team admin on the team
     """
-    if is_active_superuser(request):
+    if superuser_has_permission(request):
         return True
 
     access: Access = request.access

--- a/src/sentry/api/endpoints/organization_member/__init__.py
+++ b/src/sentry/api/endpoints/organization_member/__init__.py
@@ -65,7 +65,7 @@ def can_set_team_role(request: Request, team: Team, new_role: TeamRole) -> bool:
     """
     User can set a team role:
 
-    * If they are an active superuser
+    * If they are an active superuser (with the feature flag, they must be superuser write)
     * If they are an org owner/manager/admin
     * If they are a team admin on the team
     """


### PR DESCRIPTION
Replace `is_active_superuser` in `can_set_team_role` with `superuser_has_permission`. Active superusers with the `auth:enterprise-superuser-read-write` feature flag must be a superuser with write permission in order to set the team role of an org member.

For https://github.com/getsentry/team-enterprise/issues/40