### PR TITLE
feat: add support for `name` on api token endpoints

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -3,6 +3,7 @@ from django.db import router, transaction
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from rest_framework import serializers
+from rest_framework.fields import CharField
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -21,6 +22,7 @@ from sentry.security.utils import capture_security_activity
 
 
 class ApiTokenSerializer(serializers.Serializer):
+    name = CharField(max_length=255, allow_blank=True, required=False)
     scopes = MultipleChoiceField(required=True, choices=settings.SENTRY_SCOPES)
 
 
@@ -62,6 +64,7 @@ class ApiTokensEndpoint(Endpoint):
 
             token = ApiToken.objects.create(
                 user_id=request.user.id,
+                name=result.get("name", None),
                 scope_list=result["scopes"],
                 refresh_token=None,
                 expires_at=None,

--- a/src/sentry/api/serializers/models/apitoken.py
+++ b/src/sentry/api/serializers/models/apitoken.py
@@ -21,6 +21,7 @@ class ApiTokenSerializer(Serializer):
         data = {
             "id": str(obj.id),
             "scopes": obj.get_scopes(),
+            "name": obj.name,
             "application": attrs["application"],
             "expiresAt": obj.expires_at,
             "dateCreated": obj.date_added,

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -81,6 +81,42 @@ class ApiTokensCreateTest(APITestCase):
         assert response.status_code == 400
         assert not ApiToken.objects.filter(user=self.user).exists()
 
+    def test_with_name(self):
+        self.login_as(self.user)
+        url = reverse("sentry-api-0-api-tokens")
+        response = self.client.post(
+            url,
+            data={"name": "testname1", "scopes": ["event:read"]},
+        )
+        assert response.status_code == 201
+
+        token = ApiToken.objects.get(user=self.user)
+        assert token.name == "testname1"
+
+        response = self.client.get(url)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+
+        assert response.data[0]["name"] == "testname1"
+
+    def test_without_name(self):
+        self.login_as(self.user)
+        url = reverse("sentry-api-0-api-tokens")
+        response = self.client.post(
+            url,
+            data={"scopes": ["event:read"]},
+        )
+        assert response.status_code == 201
+
+        token = ApiToken.objects.get(user=self.user)
+        assert token.name is None
+
+        response = self.client.get(url)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+
+        assert response.data[0]["name"] is None
+
 
 @control_silo_test
 class ApiTokensDeleteTest(APITestCase):


### PR DESCRIPTION
Adds backend support for naming API tokens.

- see issue #9600 and https://github.com/getsentry/customer-feedback/issues/22
- https://github.com/getsentry/sentry/issues/58918
- [RFC #32](https://github.com/getsentry/rfcs/pull/32)