### PR TITLE
chore(webvitals0: Add firefox to lcp support

### DIFF
--- a/static/app/views/performance/vitalDetail/utils.tsx
+++ b/static/app/views/performance/vitalDetail/utils.tsx
@@ -168,7 +168,7 @@ export function getMaxOfSeries(series: Series[]) {
 }
 
 export const vitalSupportedBrowsers: Partial<Record<WebVital, Browser[]>> = {
-  [WebVital.LCP]: [Browser.CHROME, Browser.EDGE, Browser.OPERA],
+  [WebVital.LCP]: [Browser.CHROME, Browser.EDGE, Browser.OPERA, Browser.FIREFOX],
   [WebVital.FID]: [
     Browser.CHROME,
     Browser.EDGE,


### PR DESCRIPTION
Firefox supports LCP as of version 122.