### PR TITLE
fix(ai-autofix): Go through the list of releases to find sentry repo

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -15,6 +15,7 @@ from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.models.commit import Commit
 from sentry.models.group import Group
+from sentry.models.grouprelease import GroupRelease
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
@@ -47,6 +48,42 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
             RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
         }
     }
+
+    def _get_base_commit(self, group: Group) -> Commit | None:
+        # Using `id__in()` because there is no foreign key relationship.
+        releases: list[Release] = Release.objects.filter(
+            id__in=GroupRelease.objects.filter(group_id=group.id)
+            .order_by("-last_seen")
+            .values("release_id")
+        )
+
+        if not releases:
+            return None
+
+        commits: list[Commit] = Commit.objects.filter(
+            id__in=ReleaseCommit.objects.filter(release__in=releases).values("commit")
+        )
+        base_commit: Commit | None = None
+
+        # Hardcoded to only accept getsentry/sentry repo for now, when autofix on the seer side
+        # supports more than just getsentry/sentry, we will just send the latest commit.
+        try:
+            sentry_repo: Repository = Repository.objects.get(
+                organization_id=group.organization.id, name="getsentry/sentry"
+            )
+
+            for commit in commits:
+                if commit.repository_id == sentry_repo.id:
+                    base_commit = commit
+                    break
+        except Repository.DoesNotExist:
+            logger.exception(
+                "No getsentry/sentry repo found for organization",
+                extra={"group.id": group.id, "group.organization.id": group.organization.id},
+            )
+            pass
+
+        return base_commit
 
     def _get_event_entries(self, group: Group, user: User) -> list | None:
         latest_event = group.get_latest_event()
@@ -136,40 +173,13 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
                 group, metadata, "Cannot fix issues without a stacktrace.", 400
             )
 
-        release_version = group.get_last_release()
-        if not release_version:
-            return self._respond_with_error(group, metadata, "Event has no release.", 400)
-
-        try:
-            release: Release = Release.objects.get(
-                organization_id=group.organization.id,
-                projects=group.project,
-                version=release_version,
-            )
-        except Release.DoesNotExist:
-            return self._respond_with_error(
-                group, metadata, "Release not found for the issue.", 400
-            )
-        release_commits: list[ReleaseCommit] = ReleaseCommit.objects.filter(release=release)
-
-        commits: list[Commit] = [release_commit.commit for release_commit in release_commits]
-        base_commit: Commit | None = None
-        for commit in commits:
-            repo: Repository = Repository.objects.get(id=commit.repository_id)
-            provider = repo.get_provider()
-            if provider:
-                external_slug = provider.repository_external_slug(repo)
-                # Hardcoded to only accept getsentry/sentry repo for now, when autofix on the seer side
-                # supports more than just getsentry/sentry, we can remove this, and instead feature flag by project
-                if external_slug == "getsentry/sentry":
-                    base_commit = commit
-                    break
+        base_commit = self._get_base_commit(group)
 
         if not base_commit:
             return self._respond_with_error(
                 group,
                 metadata,
-                "No valid base commit found for release; only getsentry/sentry repo is supported right now.",
+                "No valid base commit from the public sentry repo found associated through issue's releases; only the public sentry repo is supported right now.",
                 400,
             )
 

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -49,7 +49,9 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         release = self.create_release(project=self.project, version="1.0.0")
 
         repo = self.create_repo(
-            project=self.project, name="getsentry/sentry", provider="integrations:github"
+            project=self.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
         )
         repo.save()
 

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -134,7 +134,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         group = Group.objects.get(id=group.id)
 
-        error_msg = "No valid base commit found for release; only getsentry/sentry repo is supported right now."
+        error_msg = "No valid base commit from the public sentry repo found associated through issue's releases; only the public sentry repo is supported right now."
 
         assert response.status_code == 400  # Expecting a Bad Request response for invalid repo
         assert response.data["detail"] == error_msg


### PR DESCRIPTION
## Problem
Often times the latest release does not contain a commit linked to the public `getsentry/sentry` repo and only the private repo

## Fix
Traverse through the list from most recently seen release to find a valid commit. This logic is only used for the current POC stage that only supports the sentry repo; in the near future will be removed and will not need this logic.