### PR TITLE
ref(notification-actions): Remove trigger registration entirely

### DIFF
--- a/src/sentry/api/endpoints/notifications/notification_actions.md
+++ b/src/sentry/api/endpoints/notifications/notification_actions.md
@@ -25,11 +25,9 @@ Notification Actions all rely on a few things:
 
 ## Setting up new triggers, services, or targets
 
-If you need to setup new types of triggers, services or targets, you can do so by extending the relevant enums in the `notificationaction.py`.
-Services and Targets can only be extended by modifying these enums. There are a few triggers that exist in getsentry, which require modifying the
-`GetsentryTriggerAction` enum in that repository.
+If you need to setup new types of triggers, services or targets, you can do so by extending the relevant enums in the `notificationaction.py`. These enums are used by Django when validating new Notification Actions before saving, meaning this step cannot be skipped.
 
-## Setting up new registrations
+## Setting up new action registrations
 
 The registration classes can be set up via the decorator:
 

--- a/tests/sentry/models/test_notificationaction.py
+++ b/tests/sentry/models/test_notificationaction.py
@@ -21,7 +21,7 @@ class NotificationActionTest(TestCase):
             organization=self.organization, projects=self.projects
         )
         # Need to use a mock new trigger to avoid tests conflicting with current registered actions
-        self.new_trigger = (-1, "sandevistan")
+        self.test_trigger = (-1, "sandevistan")
 
     @patch.object(NotificationActionLogger, "error")
     def test_register_action_for_fire(self, mock_error_logger):
@@ -36,32 +36,25 @@ class NotificationActionTest(TestCase):
         assert not mock_error_logger.called
         assert mock_handler.called
 
-    def test_register_action_for_overlap(self):
-        NotificationAction._trigger_types += (self.new_trigger,)
+    @patch("sentry.models.notificationaction.ActionTrigger")
+    def test_register_action_for_overlap(self, mock_action_trigger):
+        mock_action_trigger.as_choices.return_value = (self.test_trigger,)
         mock_handler = MagicMock()
         NotificationAction.register_action(
-            trigger_type=self.new_trigger[0],
+            trigger_type=self.test_trigger[0],
             service_type=ActionService.EMAIL.value,
             target_type=ActionTarget.SPECIFIC.value,
         )(mock_handler)
         with pytest.raises(AttributeError):
             NotificationAction.register_action(
-                trigger_type=self.new_trigger[0],
+                trigger_type=self.test_trigger[0],
                 service_type=ActionService.EMAIL.value,
                 target_type=ActionTarget.SPECIFIC.value,
             )(mock_handler)
 
-    @pytest.mark.skip(reason="deprecated: will be removed once callers are removed")
-    def test_register_trigger_type(self):
-        self.notif_action.trigger_type = self.new_trigger[0]
-        self.notif_action.save()
-        self.notif_action.full_clean()
-        NotificationAction.register_trigger_type(*self.new_trigger)
-        self.notif_action.full_clean()
-
     @patch.object(NotificationActionLogger, "error")
     def test_fire_fails_silently(self, mock_error_logger):
-        self.notif_action.trigger_type = self.new_trigger[0]
+        self.notif_action.trigger_type = self.test_trigger[0]
         self.notif_action.save()
         # Misconfigured/missing handlers shouldn't raise errors, but should log errors
         self.notif_action.fire()


### PR DESCRIPTION
With this PR, the notification action triggers will only be registered by directly modifying the enum. The `ActionRegistration`s themselves can still be registered dynamically (as is done for spike-protection in getsentry). This should be the last to remove trigger registration

First PR: https://github.com/getsentry/sentry/pull/64459/
Second PR: https://github.com/getsentry/getsentry/pull/12817/
