### PR TITLE
feat(snuba): Switch to materialized user and release columns for Events queries

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -167,20 +167,18 @@ class SnubaTSDB(BaseTSDB):
     non_outcomes_snql_query_settings = {
         TSDBModel.project: SnubaModelQuerySettings(Dataset.Events, "project_id", None, []),
         TSDBModel.group: SnubaModelQuerySettings(Dataset.Events, "group_id", None, []),
-        TSDBModel.release: SnubaModelQuerySettings(
-            Dataset.Events, "tags[sentry:release]", None, []
-        ),
+        TSDBModel.release: SnubaModelQuerySettings(Dataset.Events, "release", None, []),
         TSDBModel.users_affected_by_group: SnubaModelQuerySettings(
             Dataset.Events, "group_id", "tags[sentry:user]", []
         ),
         TSDBModel.users_affected_by_project: SnubaModelQuerySettings(
-            Dataset.Events, "project_id", "tags[sentry:user]", []
+            Dataset.Events, "project_id", "user", []
         ),
         TSDBModel.frequent_environments_by_group: SnubaModelQuerySettings(
             Dataset.Events, "group_id", "environment", []
         ),
         TSDBModel.frequent_releases_by_group: SnubaModelQuerySettings(
-            Dataset.Events, "group_id", "tags[sentry:release]", []
+            Dataset.Events, "group_id", "release", []
         ),
         TSDBModel.frequent_issues_by_project: SnubaModelQuerySettings(
             Dataset.Events, "project_id", "group_id", []


### PR DESCRIPTION
Switched to using the USER or RELEASE columns in the Events dataset instead of querying those tags for issue alert conditions. 

The modified conditions have tests in `tests/sentry/event_manager/test_event_manager.py` to confirm the queried column counts are accurate. I ran the tests with SENTRY_SNUBA_INFO=1 and the generated query also reflects the change from `tags[sentry:user]` to the user column (and the same for `tags[sentry:release]`.


Fixes https://github.com/getsentry/sentry/issues/64322