### PR TITLE
[Hack] add experimental topic variable

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3427,6 +3427,7 @@ KAFKA_PROFILES = "profiles"
 KAFKA_INGEST_PERFORMANCE_METRICS = "ingest-performance-metrics"
 KAFKA_INGEST_GENERIC_METRICS_DLQ = "ingest-generic-metrics-dlq"
 KAFKA_SNUBA_GENERIC_METRICS = "snuba-generic-metrics"
+KAFKA_SNUBA_GENERIC_METRICS_EXPERIMENTAL = "snuba-generic-metrics-experimental"
 KAFKA_INGEST_REPLAY_EVENTS = "ingest-replay-events"
 KAFKA_INGEST_REPLAYS_RECORDINGS = "ingest-replay-recordings"
 KAFKA_INGEST_OCCURRENCES = "ingest-occurrences"
@@ -3479,6 +3480,7 @@ KAFKA_TOPICS: Mapping[str, TopicDefinition | None] = {
     KAFKA_PROFILES: {"cluster": "default"},
     KAFKA_INGEST_PERFORMANCE_METRICS: {"cluster": "default"},
     KAFKA_SNUBA_GENERIC_METRICS: {"cluster": "default"},
+    KAFKA_SNUBA_GENERIC_METRICS_EXPERIMENTAL: {"cluster": "default"},
     KAFKA_INGEST_GENERIC_METRICS_DLQ: {"cluster": "default"},
     KAFKA_INGEST_REPLAY_EVENTS: {"cluster": "default"},
     KAFKA_INGEST_REPLAYS_RECORDINGS: {"cluster": "default"},


### PR DESCRIPTION
This is a follow up to #63641 

We are testing an experimental indexer. This PR add the the experimental indexer output topic name to the kafka topics map. This change will be reverted after running the experiment.