### PR TITLE
feat(beacon): Add type of events accepted in beacon last 24h

### DIFF
--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from hashlib import sha1
 from uuid import uuid4
 
-import sentry_sdk
 from django.conf import settings
 from django.utils import timezone
 
@@ -90,11 +89,9 @@ def get_category_event_count_24h() -> int:
             outcome=["accepted"],
         )
         tenant_ids = {"organization_id": organization_id}
-        with sentry_sdk.start_span(op="outcomes.endpoint", description="run_outcomes_query"):
-            result_totals = run_outcomes_query_totals(query, tenant_ids=tenant_ids)
-            result_timeseries = run_outcomes_query_timeseries(query, tenant_ids=tenant_ids)
-        with sentry_sdk.start_span(op="outcomes.endpoint", description="massage_outcomes_result"):
-            result = massage_outcomes_result(query, result_totals, result_timeseries)
+        result_totals = run_outcomes_query_totals(query, tenant_ids=tenant_ids)
+        result_timeseries = run_outcomes_query_timeseries(query, tenant_ids=tenant_ids)
+        result = massage_outcomes_result(query, result_totals, result_timeseries)
         for group in result["groups"]:
             if group["by"]["category"] in event_categories_count.keys():
                 event_categories_count[group["by"]["category"]] += group["totals"]["sum(quantity)"]

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -74,7 +74,7 @@ def get_events_24h() -> int:
     return sum_events
 
 
-def get_category_event_count_24h() -> int:
+def get_category_event_count_24h() -> dict[str, int]:
     from sentry.models.organization import Organization
 
     organization_ids = list(Organization.objects.all().values_list("id", flat=True))

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from hashlib import sha1
 from uuid import uuid4
 
+import sentry_sdk
 from django.conf import settings
 from django.utils import timezone
 
@@ -13,6 +14,12 @@ from sentry.debug.utils.packages import get_all_package_versions
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.locks import locks
 from sentry.silo.base import SiloMode
+from sentry.snuba.outcomes import (
+    QueryDefinition,
+    massage_outcomes_result,
+    run_outcomes_query_timeseries,
+    run_outcomes_query_totals,
+)
 from sentry.tasks.base import instrumented_task
 from sentry.tsdb.base import TSDBModel
 from sentry.utils import json
@@ -68,6 +75,32 @@ def get_events_24h() -> int:
     return sum_events
 
 
+def get_category_event_count_24h() -> int:
+    from sentry.models.organization import Organization
+
+    organization_ids = list(Organization.objects.all().values_list("id", flat=True))
+    event_categories_count = {"error": 0, "replay": 0, "transaction": 0, "profile": 0, "monitor": 0}
+    for organization_id in organization_ids:
+        # Utilize the outcomes dataset to send snql queries for event stats
+        query = QueryDefinition(
+            fields=["sum(quantity)"],
+            organization_id=organization_id,
+            stats_period="24h",
+            group_by=["category"],
+            outcome=["accepted"],
+        )
+        tenant_ids = {"organization_id": organization_id}
+        with sentry_sdk.start_span(op="outcomes.endpoint", description="run_outcomes_query"):
+            result_totals = run_outcomes_query_totals(query, tenant_ids=tenant_ids)
+            result_timeseries = run_outcomes_query_timeseries(query, tenant_ids=tenant_ids)
+        with sentry_sdk.start_span(op="outcomes.endpoint", description="massage_outcomes_result"):
+            result = massage_outcomes_result(query, result_totals, result_timeseries)
+        for group in result["groups"]:
+            if group["by"]["category"] in event_categories_count.keys():
+                event_categories_count[group["by"]["category"]] += group["totals"]["sum(quantity)"]
+    return event_categories_count
+
+
 @instrumented_task(name="sentry.tasks.send_beacon", queue="update")
 def send_beacon():
     """
@@ -90,6 +123,7 @@ def send_beacon():
     # we need this to be explicitly configured and it defaults to None,
     # which is the same as False
     anonymous = options.get("beacon.anonymous") is not False
+    event_categories_count = get_category_event_count_24h()
 
     payload = {
         "install_id": install_id,
@@ -102,6 +136,11 @@ def send_beacon():
             "teams": Team.objects.count(),
             "organizations": Organization.objects.count(),
             "events.24h": get_events_24h(),
+            "errors.24h": event_categories_count["error"],
+            "transactions.24h": event_categories_count["transaction"],
+            "replays.24h": event_categories_count["replay"],
+            "profiles.24h": event_categories_count["profile"],
+            "monitors.24h": event_categories_count["monitor"],
         },
         "packages": get_all_package_versions(),
         "anonymous": anonymous,

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -33,6 +33,39 @@ class SendBeaconTest(OutcomesSnubaTest):
             },
             5,  # Num of outcomes to be stored
         )
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "timestamp": timezone.now() - timedelta(hours=1),
+                "project_id": self.project.id,
+                "outcome": Outcome.ACCEPTED,
+                "reason": "none",
+                "category": DataCategory.REPLAY,
+                "quantity": 1,
+            },
+        )
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "timestamp": timezone.now() - timedelta(hours=1),
+                "project_id": self.project.id,
+                "outcome": Outcome.ACCEPTED,
+                "reason": "none",
+                "category": DataCategory.TRANSACTION,
+                "quantity": 2,
+            },
+        )
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "timestamp": timezone.now() - timedelta(hours=1),
+                "project_id": self.project.id,
+                "outcome": Outcome.ACCEPTED,
+                "reason": "none",
+                "category": DataCategory.PROFILE,
+                "quantity": 3,
+            },
+        )
         self.org2 = self.create_organization()
         self.project2 = self.create_project(
             name="bar", teams=[self.create_team(organization=self.org2, members=[self.user])]
@@ -81,6 +114,11 @@ class SendBeaconTest(OutcomesSnubaTest):
                     "projects": 2,
                     "teams": 2,
                     "events.24h": 8,  # We expect the number of events to be the sum of events from two orgs. First org has 5 events while the second org has 3 events.
+                    "errors.24h": 8,
+                    "transactions.24h": 2,
+                    "replays.24h": 1,
+                    "profiles.24h": 3,
+                    "monitors.24h": 0,
                 },
                 "anonymous": False,
                 "admin_email": "foo@example.com",
@@ -123,6 +161,11 @@ class SendBeaconTest(OutcomesSnubaTest):
                     "projects": 2,
                     "teams": 2,
                     "events.24h": 8,  # We expect the number of events to be the sum of events from two orgs. First org has 5 events while the second org has 3 events.
+                    "errors.24h": 8,
+                    "transactions.24h": 2,
+                    "replays.24h": 1,
+                    "profiles.24h": 3,
+                    "monitors.24h": 0,
                 },
                 "anonymous": True,
                 "packages": mock_get_all_package_versions.return_value,


### PR DESCRIPTION
This adds functionality to start sending self hosted beacon statistics for types of events that are accepted per sentry instance