### PR TITLE
frontend: Add support for naming user auth tokens

### DIFF
--- a/fixtures/js-stubs/apiToken.tsx
+++ b/fixtures/js-stubs/apiToken.tsx
@@ -5,6 +5,7 @@ export function ApiTokenFixture(
 ): NewInternalAppApiToken {
   return {
     id: '1',
+    name: 'token_name1',
     token: 'apitoken123',
     dateCreated: new Date('Thu Jan 11 2018 18:01:41 GMT-0800 (PST)').toISOString(),
     scopes: ['project:read', 'project:write'],

--- a/fixtures/js-stubs/sentryAppToken.tsx
+++ b/fixtures/js-stubs/sentryAppToken.tsx
@@ -5,6 +5,7 @@ export function SentryAppTokenFixture(
 ): NewInternalAppApiToken {
   return {
     token: '123456123456123456123456-token',
+    name: 'apptokenname-1',
     dateCreated: '2019-03-02T18:30:26Z',
     scopes: [],
     refreshToken: '123456123456123456123456-refreshtoken',

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -72,6 +72,7 @@ interface BaseApiToken {
   dateCreated: string;
   expiresAt: string;
   id: string;
+  name: string;
   scopes: Scope[];
   state: string;
 }

--- a/static/app/views/settings/account/apiNewToken.spec.tsx
+++ b/static/app/views/settings/account/apiNewToken.spec.tsx
@@ -74,4 +74,82 @@ describe('ApiNewToken', function () {
       )
     );
   });
+
+  it('creates token with optional name', async function () {
+    MockApiClient.clearMockResponses();
+    const assignMock = MockApiClient.addMockResponse({
+      method: 'POST',
+      url: `/api-tokens/`,
+    });
+
+    render(<ApiNewToken />, {
+      context: RouterContextFixture(),
+    });
+    const createButton = await screen.getByRole('button', {name: 'Create Token'});
+
+    const selectByValue = (name, value) =>
+      selectEvent.select(screen.getByRole('textbox', {name}), value);
+
+    await selectByValue('Project', 'Admin');
+    await selectByValue('Release', 'Admin');
+
+    await userEvent.type(screen.getByLabelText('Name'), 'My Token');
+
+    await userEvent.click(createButton);
+
+    await waitFor(() =>
+      expect(assignMock).toHaveBeenCalledWith(
+        '/api-tokens/',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            name: 'My Token',
+            scopes: expect.arrayContaining([
+              'project:read',
+              'project:write',
+              'project:admin',
+              'project:releases',
+            ]),
+          }),
+        })
+      )
+    );
+  });
+
+  it('creates token without name', async function () {
+    MockApiClient.clearMockResponses();
+    const assignMock = MockApiClient.addMockResponse({
+      method: 'POST',
+      url: `/api-tokens/`,
+    });
+
+    render(<ApiNewToken />, {
+      context: RouterContextFixture(),
+    });
+    const createButton = await screen.getByRole('button', {name: 'Create Token'});
+
+    const selectByValue = (name, value) =>
+      selectEvent.select(screen.getByRole('textbox', {name}), value);
+
+    await selectByValue('Project', 'Admin');
+    await selectByValue('Release', 'Admin');
+
+    await userEvent.click(createButton);
+
+    await waitFor(() =>
+      expect(assignMock).toHaveBeenCalledWith(
+        '/api-tokens/',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            name: '', // expect a blank name
+            scopes: expect.arrayContaining([
+              'project:read',
+              'project:write',
+              'project:admin',
+              'project:releases',
+            ]),
+          }),
+        })
+      )
+    );
+  });
 });

--- a/static/app/views/settings/account/apiNewToken.spec.tsx
+++ b/static/app/views/settings/account/apiNewToken.spec.tsx
@@ -85,7 +85,7 @@ describe('ApiNewToken', function () {
     render(<ApiNewToken />, {
       context: RouterContextFixture(),
     });
-    const createButton = await screen.getByRole('button', {name: 'Create Token'});
+    const createButton = screen.getByRole('button', {name: 'Create Token'});
 
     const selectByValue = (name, value) =>
       selectEvent.select(screen.getByRole('textbox', {name}), value);
@@ -125,7 +125,7 @@ describe('ApiNewToken', function () {
     render(<ApiNewToken />, {
       context: RouterContextFixture(),
     });
-    const createButton = await screen.getByRole('button', {name: 'Create Token'});
+    const createButton = screen.getByRole('button', {name: 'Create Token'});
 
     const selectByValue = (name, value) =>
       selectEvent.select(screen.getByRole('textbox', {name}), value);

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -2,6 +2,7 @@ import {Component} from 'react';
 import {browserHistory} from 'react-router';
 
 import ApiForm from 'sentry/components/forms/apiForm';
+import TextField from 'sentry/components/forms/fields/textField';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -18,6 +19,7 @@ import PermissionSelection from 'sentry/views/settings/organizationDeveloperSett
 
 const API_INDEX_ROUTE = '/settings/account/api/auth-tokens/';
 type State = {
+  name: string | null;
   newToken: NewInternalAppApiToken | null;
   permissions: Permissions;
 };
@@ -26,6 +28,7 @@ export default class ApiNewToken extends Component<{}, State> {
   constructor(props: {}) {
     super(props);
     this.state = {
+      name: null,
       permissions: {
         Event: 'no-access',
         Team: 'no-access',
@@ -75,12 +78,11 @@ export default class ApiNewToken extends Component<{}, State> {
               handleGoBack={this.handleGoBack}
             />
           ) : (
-            <Panel>
-              <PanelHeader>{t('Permissions')}</PanelHeader>
+            <div>
               <ApiForm
                 apiMethod="POST"
                 apiEndpoint="/api-tokens/"
-                initialData={{scopes: []}}
+                initialData={{scopes: [], name: ''}}
                 onSubmitSuccess={response => {
                   this.setState({newToken: response});
                 }}
@@ -94,17 +96,33 @@ export default class ApiNewToken extends Component<{}, State> {
                 )}
                 submitLabel={t('Create Token')}
               >
-                <PanelBody>
-                  <PermissionSelection
-                    appPublished={false}
-                    permissions={permissions}
-                    onChange={value => {
-                      this.setState({permissions: value});
-                    }}
-                  />
-                </PanelBody>
+                <Panel>
+                  <PanelHeader>{t('General')}</PanelHeader>
+                  <PanelBody>
+                    <TextField
+                      name="name"
+                      label={t('Name')}
+                      help={t('A name to help you identify this token.')}
+                      onChange={value => {
+                        this.setState({name: value});
+                      }}
+                    />
+                  </PanelBody>
+                </Panel>
+                <Panel>
+                  <PanelHeader>{t('Permissions')}</PanelHeader>
+                  <PanelBody>
+                    <PermissionSelection
+                      appPublished={false}
+                      permissions={permissions}
+                      onChange={value => {
+                        this.setState({permissions: value});
+                      }}
+                    />
+                  </PanelBody>
+                </Panel>
               </ApiForm>
-            </Panel>
+            </div>
           )}
         </div>
       </SentryDocumentTitle>

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -20,15 +20,10 @@ function ApiTokenRow({token, onRemove, tokenPrefix = ''}: Props) {
   return (
     <StyledPanelItem>
       <Controls>
-        <TokenPreview aria-label={t('Token preview')}>
-          {tokenPreview(
-            getDynamicText({
-              value: token.tokenLastCharacters,
-              fixed: 'ABCD',
-            }),
-            tokenPrefix
-          )}
-        </TokenPreview>
+        {getDynamicText({
+          value: token.name ? token.name : '<no name>',
+          fixed: 'TokenName_1234',
+        })}
         <ButtonWrapper>
           <Button
             data-test-id="token-delete"
@@ -41,6 +36,18 @@ function ApiTokenRow({token, onRemove, tokenPrefix = ''}: Props) {
       </Controls>
 
       <Details>
+        <TokenWrapper>
+          <Heading>{t('Token')}</Heading>
+          <TokenPreview aria-label={t('Token preview')}>
+            {tokenPreview(
+              getDynamicText({
+                value: token.tokenLastCharacters,
+                fixed: 'ABCD',
+              }),
+              tokenPrefix
+            )}
+          </TokenPreview>
+        </TokenWrapper>
         <ScopesWrapper>
           <Heading>{t('Scopes')}</Heading>
           <ScopeList>{token.scopes.join(', ')}</ScopeList>
@@ -77,8 +84,14 @@ const Details = styled('div')`
   margin-top: ${space(1)};
 `;
 
-const ScopesWrapper = styled('div')`
+const TokenWrapper = styled('div')`
   flex: 1;
+  margin-right: ${space(1)};
+`;
+
+const ScopesWrapper = styled('div')`
+  flex: 2;
+  margin-right: ${space(4)};
 `;
 
 const ScopeList = styled('div')`

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -20,10 +20,7 @@ function ApiTokenRow({token, onRemove, tokenPrefix = ''}: Props) {
   return (
     <StyledPanelItem>
       <Controls>
-        {getDynamicText({
-          value: token.name ? token.name : '<no name>',
-          fixed: 'TokenName_1234',
-        })}
+        {token.name ? token.name : ''}
         <ButtonWrapper>
           <Button
             data-test-id="token-delete"


### PR DESCRIPTION
Add support for naming tokens when creating them. I've broken the form out into two panels, _General_ and _Permissions_. We have future plans to add an expiry duration in the _general_ panel. If there's a better way to design this form, I'm open to the critique and feedback. 🙂 

**Token Creation Before**
![image](https://github.com/getsentry/sentry/assets/20070360/cd5e2f0d-3abb-4977-901a-f6781c0a9e4a)

**Token Creation After**
![image](https://github.com/getsentry/sentry/assets/20070360/e1983df2-2f4b-494a-bb1e-6fef401351ab)

---

**Token List Before**
![image](https://github.com/getsentry/sentry/assets/20070360/271d2f35-76e4-4466-b2e8-9f308454b95f)

**Token List After**
![image](https://github.com/getsentry/sentry/assets/20070360/b9b0f3b3-5908-4353-96f0-c6e8ba4aaa0e)


