### PR TITLE
fix(hybrid-cloud): Fix disabling of GitLab integration

### DIFF
--- a/src/sentry/integrations/notify_disable.py
+++ b/src/sentry/integrations/notify_disable.py
@@ -1,5 +1,6 @@
 from sentry import analytics
 from sentry.models.organization import Organization
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.utils.email import MessageBuilder
 
 provider_types = {
@@ -9,7 +10,7 @@ provider_types = {
 }
 
 
-def get_url(organization: Organization, provider_type: str, name: str) -> str:
+def get_url(organization: Organization | RpcOrganization, provider_type: str, name: str) -> str:
     if provider_type:
         type_name = provider_types.get(provider_type, "")
         if type_name:
@@ -39,7 +40,7 @@ def get_sentry_app_subject(integration_name: str) -> str:
 
 
 def notify_disable(
-    organization: Organization,
+    organization: RpcOrganization | Organization,
     integration_name: str,
     redis_key: str,
     integration_slug: str | None = None,
@@ -62,32 +63,38 @@ def notify_disable(
     for user in organization.get_owners():
 
         msg = MessageBuilder(
-            subject=get_sentry_app_subject(integration_name.title())
-            if "sentry-app" in redis_key
-            else get_subject(integration_name.title()),
+            subject=(
+                get_sentry_app_subject(integration_name.title())
+                if "sentry-app" in redis_key
+                else get_subject(integration_name.title())
+            ),
             context={
                 "integration_name": integration_name.title(),
                 "integration_link": f"{integration_link}{referrer}",
                 "webhook_url": webhook_url if "sentry-app" in redis_key and webhook_url else "",
-                "dashboard_link": f"{integration_link}dashboard/{referrer}"
-                if "sentry-app" in redis_key
-                else "",
+                "dashboard_link": (
+                    f"{integration_link}dashboard/{referrer}" if "sentry-app" in redis_key else ""
+                ),
             },
-            html_template="sentry/integrations/sentry-app-notify-disable.html"
-            if "sentry-app" in redis_key and integration_slug
-            else "sentry/integrations/notify-disable.html",
-            template="sentry/integrations/sentry-app-notify-disable.txt"
-            if "sentry-app" in redis_key and integration_slug
-            else "sentry/integrations/notify-disable.txt",
+            html_template=(
+                "sentry/integrations/sentry-app-notify-disable.html"
+                if "sentry-app" in redis_key and integration_slug
+                else "sentry/integrations/notify-disable.html"
+            ),
+            template=(
+                "sentry/integrations/sentry-app-notify-disable.txt"
+                if "sentry-app" in redis_key and integration_slug
+                else "sentry/integrations/notify-disable.txt"
+            ),
         )
         msg.send_async([user.email])
 
     analytics.record(
         "integration.disabled.notified",
         organization_id=organization.id,
-        provider=integration_slug
-        if integration_slug and "sentry-app" in redis_key
-        else integration_name,  # integration_name is the provider for first party integrations
+        provider=(
+            integration_slug if integration_slug and "sentry-app" in redis_key else integration_name
+        ),  # integration_name is the provider for first party integrations
         integration_type=("sentry_app" if "sentry-app" in redis_key else "first-party"),
         integration_id=redis_key[redis_key.find(":") + 1 :],
         user_id=organization.default_owner_id,

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -17,9 +17,9 @@ from sentry.http import build_session
 from sentry.integrations.notify_disable import notify_disable
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.models.integrations.utils import is_response_error, is_response_success
-from sentry.models.organization import Organization
 from sentry.net.http import SafeSession
 from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.utils import json, metrics
 from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.hashlib import md5_text
@@ -145,8 +145,7 @@ class BaseApiClient(TrackResponseMixin):
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: Literal[True] = ...,
-    ) -> Response:
-        ...
+    ) -> Response: ...
 
     @overload
     def _request(
@@ -164,8 +163,7 @@ class BaseApiClient(TrackResponseMixin):
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: bool = ...,
-    ) -> BaseApiResponseX:
-        ...
+    ) -> BaseApiResponseX: ...
 
     def _request(
         self,
@@ -442,7 +440,7 @@ class BaseApiClient(TrackResponseMixin):
         if buffer.is_integration_broken():
             self.disable_integration(buffer)
 
-    def disable_integration(self, buffer) -> None:
+    def disable_integration(self, buffer: IntegrationRequestBuffer) -> None:
         rpc_integration, rpc_org_integrations = integration_service.get_organization_contexts(
             integration_id=self.integration_id
         )
@@ -451,7 +449,13 @@ class BaseApiClient(TrackResponseMixin):
 
         org = None
         if len(rpc_org_integrations) > 0:
-            org = Organization.objects.filter(id=rpc_org_integrations[0].organization_id).first()
+            org_context = organization_service.get_organization_by_id(
+                id=rpc_org_integrations[0].organization_id,
+                include_projects=False,
+                include_teams=False,
+            )
+            if org_context:
+                org = org_context.organization
 
         extra = {
             "integration_id": self.integration_id,
@@ -489,7 +493,7 @@ class BaseApiClient(TrackResponseMixin):
             notify_disable(org, rpc_integration.provider, self._get_redis_key())
             buffer.clear()
             create_system_audit_entry(
-                organization=org,
+                organization_id=org.id,
                 target_object=org.id,
                 event=audit_log.get_event_id("INTEGRATION_DISABLED"),
                 data={"provider": rpc_integration.provider},

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -145,7 +145,8 @@ class BaseApiClient(TrackResponseMixin):
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: Literal[True] = ...,
-    ) -> Response: ...
+    ) -> Response:
+        ...
 
     @overload
     def _request(
@@ -163,7 +164,8 @@ class BaseApiClient(TrackResponseMixin):
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: bool = ...,
-    ) -> BaseApiResponseX: ...
+    ) -> BaseApiResponseX:
+        ...
 
     def _request(
         self,

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -14,7 +14,11 @@ from sentry.features.base import OrganizationFeature, ProjectFeature
 from sentry.features.exceptions import FeatureNotRegistered
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
+from sentry.services.hybrid_cloud.organization import (
+    RpcOrganization,
+    RpcOrganizationSummary,
+    RpcUserOrganizationContext,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +73,15 @@ def Feature(names):
 
             if isinstance(feature, OrganizationFeature):
                 org = args[0] if len(args) > 0 else kwargs.get("organization", None)
-                if not isinstance(org, (Organization, RpcOrganizationSummary)):
+                if not isinstance(
+                    org,
+                    (
+                        Organization,
+                        RpcOrganizationSummary,
+                        RpcOrganization,
+                        RpcUserOrganizationContext,
+                    ),
+                ):
                     raise ValueError("Must provide organization to check feature")
                 return resolve_feature_name_value_for_org(org, names[name])
 

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -3,18 +3,24 @@ from __future__ import annotations
 from dataclasses import asdict
 from datetime import datetime, timezone
 from unittest import mock
+from unittest.mock import patch
 from urllib.parse import quote
 
 import pytest
 import responses
+from requests.exceptions import ConnectionError
 
 from fixtures.gitlab import GET_COMMIT_RESPONSE, GitLabTestCase
 from sentry.auth.exceptions import IdentityNotValid
+from sentry.constants import ObjectStatus
 from sentry.integrations.gitlab.blame import GitLabCommitResponse, GitLabFileBlameResponseItem
 from sentry.integrations.gitlab.utils import get_rate_limit_info_from_response
 from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
+from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.models.identity import Identity
-from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+from sentry.models.integrations import Integration
+from sentry.shared_integrations.exceptions import ApiError, ApiHostError, ApiRateLimitedError
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 from sentry.utils.cache import cache
@@ -601,3 +607,30 @@ class GitLabBlameForFilesTest(GitLabClientTest):
         )
 
         assert resp == []
+
+
+@control_silo_test
+class GitLabUnhappyPathTest(GitLabClientTest):
+
+    @responses.activate
+    @patch.object(IntegrationRequestBuffer, "is_integration_broken", return_value=True)
+    def test_unreachable_host(self, mock_is_integration_broken):
+
+        integration = Integration.objects.get(id=self.integration.id)
+        assert integration.status == ObjectStatus.ACTIVE
+
+        path = "src/file.py"
+        ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
+        responses.add(
+            responses.HEAD,
+            f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/src%2Ffile.py?ref={ref}",
+            body=ConnectionError("Unable to reach host: https://example.gitlab.com"),
+        )
+        with self.feature(
+            {"organizations:gitlab-disable-on-broken": True}
+        ), outbox_runner(), pytest.raises(ApiHostError):
+            self.gitlab_client.check_file(self.repo, path, ref)
+
+        # Assert integration is disabled.
+        integration = Integration.objects.get(id=self.integration.id)
+        assert integration.status == ObjectStatus.DISABLED

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -611,7 +611,6 @@ class GitLabBlameForFilesTest(GitLabClientTest):
 
 @control_silo_test
 class GitLabUnhappyPathTest(GitLabClientTest):
-
     @responses.activate
     @patch.object(IntegrationRequestBuffer, "is_integration_broken", return_value=True)
     def test_unreachable_host(self, mock_is_integration_broken):


### PR DESCRIPTION
Fixes SENTRY-2J66

The disabling of the GitLab integration may occur on the control silo, especially when integration requests are proxied from the region to the control silo.