### PR TITLE
feat(crons): Allow max_workers to be configured for consumer

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -102,6 +102,12 @@ def ingest_monitors_options() -> list[click.Option]:
             default=10,
             help="Maximum time spent batching check-ins to batch before processing in parallel.",
         ),
+        click.Option(
+            ["--max-workers", "max_workers"],
+            type=int,
+            default=None,
+            help="The maximum number of threads to spawn in parallel mode.",
+        ),
     ]
     return options
 

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -770,7 +770,7 @@ def process_checkin_group(items: list[CheckinItem]):
         process_checkin(item)
 
 
-def process_batch(worker: Executor, message: Message[ValuesBatch[KafkaPayload]]):
+def process_batch(message: Message[ValuesBatch[KafkaPayload]], worker: Executor):
     """
     Receives batches of check-in messages. This function will take the batch
     and group them together by monitor ID (ensuring order is preserved) and

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -4,8 +4,9 @@ import logging
 import uuid
 from collections import defaultdict
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import Executor, ThreadPoolExecutor, wait
 from datetime import datetime, timedelta
+from functools import partial
 from typing import Literal
 
 import msgpack
@@ -746,9 +747,6 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span):
         logger.exception("Failed to process check-in")
 
 
-_checkin_worker = ThreadPoolExecutor()
-
-
 def process_checkin(item: CheckinItem):
     """
     Process an individual check-in
@@ -772,7 +770,7 @@ def process_checkin_group(items: list[CheckinItem]):
         process_checkin(item)
 
 
-def process_batch(message: Message[ValuesBatch[KafkaPayload]]):
+def process_batch(worker: Executor, message: Message[ValuesBatch[KafkaPayload]]):
     """
     Receives batches of check-in messages. This function will take the batch
     and group them together by monitor ID (ensuring order is preserved) and
@@ -820,8 +818,7 @@ def process_batch(message: Message[ValuesBatch[KafkaPayload]]):
     # Submit check-in groups for processing
     with sentry_sdk.start_transaction(op="process_batch", name="monitors.monitor_consumer"):
         futures = [
-            _checkin_worker.submit(process_checkin_group, group)
-            for group in checkin_mapping.values()
+            worker.submit(process_checkin_group, group) for group in checkin_mapping.values()
         ]
         wait(futures)
 
@@ -866,6 +863,11 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
     Does the consumer process unrelated check-ins in parallel?
     """
 
+    max_workers: int | None = None
+    """
+    Number of Executor workers to use when running in parallel
+    """
+
     max_batch_size = 500
     """
     How many messages will be batched at once when in parallel mode.
@@ -881,6 +883,7 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
         mode: Literal["parallel", "serial"] | None = None,
         max_batch_size: int | None = None,
         max_batch_time: int | None = None,
+        max_workers: int | None = None,
     ) -> None:
         if mode == "parallel":
             self.parallel = True
@@ -889,10 +892,14 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
             self.max_batch_size = max_batch_size
         if max_batch_time is not None:
             self.max_batch_time = max_batch_time
+        if max_workers is not None:
+            self.max_workers = max_workers
 
-    def create_paralell_worker(self, commit: Commit) -> ProcessingStrategy[KafkaPayload]:
+    def create_parallel_worker(self, commit: Commit) -> ProcessingStrategy[KafkaPayload]:
+        worker = ThreadPoolExecutor(max_workers=self.max_workers)
+
         batch_processor = RunTask(
-            function=process_batch,
+            function=partial(process_batch, worker=worker),
             next_step=CommitOffsets(commit),
         )
         return BatchStep(
@@ -913,6 +920,6 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
         if self.parallel:
-            return self.create_paralell_worker(commit)
+            return self.create_parallel_worker(commit)
         else:
             return self.create_synchronous_worker(commit)

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 
 CHECKIN_QUOTA_LIMIT = 6
 CHECKIN_QUOTA_WINDOW = 60
+StrategyMode = Literal["parallel", "serial"]
 
 
 def _ensure_monitor_with_config(
@@ -880,7 +881,7 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
 
     def __init__(
         self,
-        mode: Literal["parallel", "serial"] | None = None,
+        mode: StrategyMode | None = None,
         max_batch_size: int | None = None,
         max_batch_time: int | None = None,
         max_workers: int | None = None,

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -13,7 +13,10 @@ from sentry import killswitches
 from sentry.constants import ObjectStatus
 from sentry.db.models import BoundedPositiveIntegerField
 from sentry.monitors.constants import TIMEOUT, PermitCheckInStatus
-from sentry.monitors.consumers.monitor_consumer import StoreMonitorCheckInStrategyFactory
+from sentry.monitors.consumers.monitor_consumer import (
+    StoreMonitorCheckInStrategyFactory,
+    StrategyMode,
+)
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -23,7 +26,7 @@ from sentry.monitors.models import (
     MonitorType,
     ScheduleType,
 )
-from sentry.testutils.cases import TestCase, TransactionTestCase
+from sentry.testutils.cases import BaseTestCase, TestCase, TransactionTestCase
 from sentry.utils import json
 from sentry.utils.locking.manager import LockManager
 from sentry.utils.outcomes import Outcome
@@ -32,8 +35,8 @@ from sentry.utils.services import build_instance_from_options
 locks = LockManager(build_instance_from_options(settings.SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS))
 
 
-class MonitorConsumerTest:
-    mode = "serial"
+class MonitorConsumerTest(BaseTestCase):
+    mode: StrategyMode = "serial"
 
     def _create_monitor(self, **kwargs):
         return Monitor.objects.create(
@@ -99,7 +102,7 @@ class MonitorConsumerTest:
 
 
 class ParallelMonitorConsumerTest(TransactionTestCase, MonitorConsumerTest):
-    mode = "parallel"
+    mode: StrategyMode = "parallel"
 
     def test(self) -> None:
         monitor = self._create_monitor(slug="my-monitor")


### PR DESCRIPTION
Try 3 of this. Reverts the revert of https://github.com/getsentry/sentry/pull/64432. This time we have a test in place that uses the parallel code, so we shouldn't have any further breakages.

Using a threadpool means that the thread will use a different db connection, and so to see the results of the threadpool we have to use `TransactionTestCase`. I wanted to apply this to all tests, but they started taking 50s to run instead of 10, so I settled for just the one test.