### PR TITLE
chore(hybrid-cloud): Fix region by default errors for relay tests

### DIFF
--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -10,11 +10,13 @@ from sentry.tasks.relay import invalidate_project_config
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
 from sentry.testutils.relay import RelayStoreHelper
+from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_kafka
 
 pytestmark = [requires_kafka]
 
 
+@region_silo_test
 class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
     # used to be test_ungzipped_data
     def test_simple_data(self):

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -67,8 +67,8 @@ def post_event_with_sdk(settings, relay_server, wait_for_ingest_consumer):
 
 
 @no_silo_test
-@django_db_all
 @override_settings(SENTRY_PROJECT=1)
+@django_db_all
 def test_simple(settings, post_event_with_sdk):
     event = post_event_with_sdk({"message": "internal client test"})
 

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -9,10 +9,11 @@ from sentry import eventstore
 from sentry.eventstore.models import Event
 from sentry.models.userrole import manage_default_super_admin_role
 from sentry.receivers import create_default_projects
+from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.pytest.relay import adjust_settings_for_relay_tests
-from sentry.testutils.silo import no_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_kafka
 from sentry.utils.sdk import bind_organization_context, configure_sdk
 
@@ -21,7 +22,8 @@ pytestmark = [requires_kafka]
 
 @pytest.fixture(autouse=True)
 def setup_fixtures():
-    manage_default_super_admin_role()
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        manage_default_super_admin_role()
     create_default_projects()
 
 
@@ -64,9 +66,9 @@ def post_event_with_sdk(settings, relay_server, wait_for_ingest_consumer):
         yield inner
 
 
-@no_silo_test
-@override_settings(SENTRY_PROJECT=1)
+@region_silo_test
 @django_db_all
+@override_settings(SENTRY_PROJECT=1)
 def test_simple(settings, post_event_with_sdk):
     event = post_event_with_sdk({"message": "internal client test"})
 
@@ -75,7 +77,7 @@ def test_simple(settings, post_event_with_sdk):
     assert event.data["logentry"]["formatted"] == "internal client test"
 
 
-@no_silo_test
+@region_silo_test
 @override_settings(SENTRY_PROJECT=1)
 @django_db_all
 def test_recursion_breaker(settings, post_event_with_sdk):
@@ -93,7 +95,7 @@ def test_recursion_breaker(settings, post_event_with_sdk):
     assert_mock_called_once_with_partial(save, settings.SENTRY_PROJECT, cache_key=f"e:{event_id}:1")
 
 
-@no_silo_test
+@region_silo_test
 @django_db_all
 @override_settings(SENTRY_PROJECT=1)
 def test_encoding(settings, post_event_with_sdk):
@@ -109,7 +111,7 @@ def test_encoding(settings, post_event_with_sdk):
     assert "NotJSONSerializable" in event.data["extra"]["request"]
 
 
-@no_silo_test
+@region_silo_test
 @override_settings(SENTRY_PROJECT=1)
 @django_db_all
 def test_bind_organization_context(default_organization):
@@ -125,7 +127,7 @@ def test_bind_organization_context(default_organization):
     }
 
 
-@no_silo_test
+@region_silo_test
 @override_settings(SENTRY_PROJECT=1)
 @django_db_all
 def test_bind_organization_context_with_callback(settings, default_organization):
@@ -141,7 +143,7 @@ def test_bind_organization_context_with_callback(settings, default_organization)
     assert Hub.current.scope._tags["organization.test"] == "1"
 
 
-@no_silo_test
+@region_silo_test
 @override_settings(SENTRY_PROJECT=1)
 @django_db_all
 def test_bind_organization_context_with_callback_error(settings, default_organization):

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -13,7 +13,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.pytest.relay import adjust_settings_for_relay_tests
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, no_silo_test
 from sentry.testutils.skips import requires_kafka
 from sentry.utils.sdk import bind_organization_context, configure_sdk
 
@@ -66,7 +66,7 @@ def post_event_with_sdk(settings, relay_server, wait_for_ingest_consumer):
         yield inner
 
 
-@region_silo_test
+@no_silo_test
 @django_db_all
 @override_settings(SENTRY_PROJECT=1)
 def test_simple(settings, post_event_with_sdk):
@@ -77,7 +77,7 @@ def test_simple(settings, post_event_with_sdk):
     assert event.data["logentry"]["formatted"] == "internal client test"
 
 
-@region_silo_test
+@no_silo_test
 @override_settings(SENTRY_PROJECT=1)
 @django_db_all
 def test_recursion_breaker(settings, post_event_with_sdk):
@@ -95,7 +95,7 @@ def test_recursion_breaker(settings, post_event_with_sdk):
     assert_mock_called_once_with_partial(save, settings.SENTRY_PROJECT, cache_key=f"e:{event_id}:1")
 
 
-@region_silo_test
+@no_silo_test
 @django_db_all
 @override_settings(SENTRY_PROJECT=1)
 def test_encoding(settings, post_event_with_sdk):
@@ -111,7 +111,7 @@ def test_encoding(settings, post_event_with_sdk):
     assert "NotJSONSerializable" in event.data["extra"]["request"]
 
 
-@region_silo_test
+@no_silo_test
 @override_settings(SENTRY_PROJECT=1)
 @django_db_all
 def test_bind_organization_context(default_organization):
@@ -127,7 +127,7 @@ def test_bind_organization_context(default_organization):
     }
 
 
-@region_silo_test
+@no_silo_test
 @override_settings(SENTRY_PROJECT=1)
 @django_db_all
 def test_bind_organization_context_with_callback(settings, default_organization):
@@ -143,7 +143,7 @@ def test_bind_organization_context_with_callback(settings, default_organization)
     assert Hub.current.scope._tags["organization.test"] == "1"
 
 
-@region_silo_test
+@no_silo_test
 @override_settings(SENTRY_PROJECT=1)
 @django_db_all
 def test_bind_organization_context_with_callback_error(settings, default_organization):


### PR DESCRIPTION
Small fixes for tests to allow them to run in region-mode by default.