### PR TITLE
fix(replays): remove page URL from rage click issue evidence

### DIFF
--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -70,7 +70,6 @@ def report_rage_click_issue(project_id: int, replay_id: str, event: SentryEvent)
         evidence_display=[
             IssueEvidence(name="Clicked Element", value=clicked_element, important=True),
             IssueEvidence(name="Selector Path", value=selector, important=True),
-            IssueEvidence(name="Page URL", value=payload["data"]["url"], important=True),
         ],
         extra_event_data={
             "contexts": {"replay": {"replay_id": replay_id}},

--- a/tests/sentry/replays/unit/test_rage_click_issue.py
+++ b/tests/sentry/replays/unit/test_rage_click_issue.py
@@ -83,10 +83,6 @@ def test_report_rage_click_issue_a_tag(mock_new_issue_occurrence, default_projec
         issue_occurence_call["evidence_display"][1].to_dict()
         == IssueEvidence(name="Selector Path", value="div.xyz > a", important=True).to_dict()
     )
-    assert (
-        issue_occurence_call["evidence_display"][2].to_dict()
-        == IssueEvidence(name="Page URL", value="https://www.sentry.io", important=True).to_dict()
-    )
 
     assert issue_occurence_call["extra_event_data"] == {
         "contexts": {"replay": {"replay_id": "b58a67446c914f44a4e329763420047b"}},


### PR DESCRIPTION
- URL is already a tag, so no need to include it in evidence
