### PR TITLE
feat(replays): Add replay issue type config

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -302,6 +302,7 @@ function BaseGroupRow({
     [IssueCategory.PERFORMANCE]: t('Transaction Events'),
     [IssueCategory.PROFILE]: t('Profile Events'),
     [IssueCategory.CRON]: t('Cron Events'),
+    [IssueCategory.REPLAY]: t('Replay Events'),
   };
 
   const groupCount = !defined(primaryCount) ? (

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -61,6 +61,7 @@ export enum IssueCategory {
   ERROR = 'error',
   CRON = 'cron',
   PROFILE = 'profile',
+  REPLAY = 'replay',
 }
 
 export enum IssueType {
@@ -91,6 +92,9 @@ export enum IssueType {
   PROFILE_FRAME_DROP_EXPERIMENTAL = 'profile_frame_drop_experimental',
   PROFILE_FUNCTION_REGRESSION = 'profile_function_regression',
   PROFILE_FUNCTION_REGRESSION_EXPERIMENTAL = 'profile_function_regression_exp',
+
+  // Replay
+  REPLAY_RAGE_CLICK = 'replay_click_rage',
 }
 
 export enum IssueTitle {

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -7,6 +7,7 @@ import {
   getErrorHelpResource,
 } from 'sentry/utils/issueTypeConfig/errorConfig';
 import performanceConfig from 'sentry/utils/issueTypeConfig/performanceConfig';
+import replayConfig from 'sentry/utils/issueTypeConfig/replayConfig';
 import type {
   IssueCategoryConfigMapping,
   IssueTypeConfig,
@@ -52,6 +53,7 @@ const issueTypeConfig: Config = {
   [IssueCategory.PERFORMANCE]: performanceConfig,
   [IssueCategory.PROFILE]: performanceConfig,
   [IssueCategory.CRON]: cronConfig,
+  [IssueCategory.REPLAY]: replayConfig,
 };
 
 /**

--- a/static/app/utils/issueTypeConfig/replayConfig.tsx
+++ b/static/app/utils/issueTypeConfig/replayConfig.tsx
@@ -1,0 +1,31 @@
+import {t} from 'sentry/locale';
+import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+
+const replayConfig: IssueCategoryConfigMapping = {
+  _categoryDefaults: {
+    actions: {
+      archiveUntilOccurrence: {enabled: true},
+      delete: {enabled: false},
+      deleteAndDiscard: {enabled: false},
+      merge: {enabled: false},
+      ignore: {enabled: true},
+      resolveInRelease: {enabled: true},
+      share: {enabled: true},
+    },
+    attachments: {enabled: false},
+    events: {enabled: true},
+    mergedIssues: {enabled: false},
+    regression: {enabled: false},
+    replays: {enabled: true},
+    stats: {enabled: true},
+    similarIssues: {enabled: false},
+    tags: {enabled: true},
+    userFeedback: {enabled: true},
+    discover: {enabled: true},
+    evidence: {title: t('Evidence')},
+    resources: null,
+    usesIssuePlatform: true,
+  },
+};
+
+export default replayConfig;


### PR DESCRIPTION
Adds issue config for Replay Issues, the first being rage click. Main difference from base config is we're enabling the replays tab.