### PR TITLE
chore(api): make certain group endpoints private

### DIFF
--- a/src/sentry/api/endpoints/group_hashes.py
+++ b/src/sentry/api/endpoints/group_hashes.py
@@ -18,8 +18,8 @@ from sentry.utils.snuba import raw_query
 @region_silo_endpoint
 class GroupHashesEndpoint(GroupEndpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, group) -> Response:

--- a/src/sentry/api/endpoints/group_hashes_split.py
+++ b/src/sentry/api/endpoints/group_hashes_split.py
@@ -25,9 +25,9 @@ from sentry.utils import snuba
 @region_silo_endpoint
 class GroupHashesSplitEndpoint(GroupEndpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, group) -> Response:

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -19,8 +19,8 @@ from sentry.types.activity import ActivityType
 @region_silo_endpoint
 class GroupNotesDetailsEndpoint(GroupEndpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
 
     # We explicitly don't allow a request with an ApiKey

--- a/src/sentry/api/endpoints/group_reprocessing.py
+++ b/src/sentry/api/endpoints/group_reprocessing.py
@@ -11,7 +11,7 @@ from sentry.tasks.reprocessing2 import reprocess_group
 @region_silo_endpoint
 class GroupReprocessingEndpoint(GroupEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
     def post(self, request: Request, group) -> Response:

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -22,7 +22,7 @@ def _fix_label(label):
 @region_silo_endpoint
 class GroupSimilarIssuesEndpoint(GroupEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, group) -> Response:

--- a/src/sentry/api/endpoints/group_tombstone.py
+++ b/src/sentry/api/endpoints/group_tombstone.py
@@ -14,7 +14,7 @@ from sentry.models.grouptombstone import GroupTombstone
 class GroupTombstoneEndpoint(ProjectEndpoint):
     owner = ApiOwner.ISSUES
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/api/endpoints/group_tombstone_details.py
+++ b/src/sentry/api/endpoints/group_tombstone_details.py
@@ -14,7 +14,7 @@ from sentry.models.grouptombstone import GroupTombstone
 class GroupTombstoneDetailsEndpoint(ProjectEndpoint):
     owner = ApiOwner.ISSUES
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
     }
 
     def delete(self, request: Request, project, tombstone_id) -> Response:

--- a/src/sentry/api/endpoints/group_user_reports.py
+++ b/src/sentry/api/endpoints/group_user_reports.py
@@ -13,7 +13,7 @@ from sentry.models.userreport import UserReport
 @region_silo_endpoint
 class GroupUserReportsEndpoint(GroupEndpoint, EnvironmentMixin):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, group) -> Response:

--- a/src/sentry/api/endpoints/group_user_reports.py
+++ b/src/sentry/api/endpoints/group_user_reports.py
@@ -13,7 +13,7 @@ from sentry.models.userreport import UserReport
 @region_silo_endpoint
 class GroupUserReportsEndpoint(GroupEndpoint, EnvironmentMixin):
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.UNKNOWN,
     }
 
     def get(self, request: Request, group) -> Response:

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -30,8 +30,8 @@ from sentry.utils.safe import safe_execute
 @region_silo_endpoint
 class IssueGroupActionEndpoint(PluginGroupEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     view_method_name = None
     plugin = None


### PR DESCRIPTION
As a part of https://github.com/getsentry/sentry/issues/61487, this pr makes the following endpoints private
- GroupNotesDetailsEndpoint
- GroupReprocessingEndpoint
- GroupTombstoneDetailsEndpoint
- GroupTombstoneEndpoint
- IssueGroupActionEndpoint
- GroupHashesEndpoint
- GroupHashesSplitEndpoint
- GroupSimilarIssuesEndpoint