### PR TITLE
fix(on-demand): Add escaping of glob patterns for meta chars supported by Relay

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1527,6 +1527,29 @@ def _get_satisfactory_threshold_and_metric(project: Project) -> tuple[int, str]:
     return threshold, metric_field
 
 
+def _escape_wildcard(value: str) -> str:
+    """
+    Escapes all characters in the wildcard which are considered as meta characters in the glob
+    implementation in Relay, which can be found at: https://docs.rs/globset/latest/globset/#syntax.
+
+    The goal of this function is to only preserve the `*` character as it is the only character that Sentry's
+    product offers to users to perform wildcard matching.
+    """
+    i, n = 0, len(value)
+    escaped = ""
+
+    while i < n:
+        c = value[i]
+        i = i + 1
+
+        if c in "[]{}?":
+            escaped += "\\" + c
+        else:
+            escaped += c
+
+    return escaped
+
+
 T = TypeVar("T")
 
 
@@ -1629,7 +1652,7 @@ class SearchQueryConverter:
             condition: RuleCondition = {
                 "op": "glob",
                 "name": _map_field_name(key),
-                "value": [value],
+                "value": [_escape_wildcard(value)],
             }
         else:
             # Special case for the `has` and `!has` operators which are parsed as follows:

--- a/tests/sentry/snuba/metrics/test_extraction.py
+++ b/tests/sentry/snuba/metrics/test_extraction.py
@@ -482,7 +482,11 @@ def test_spec_wildcard_escaping(query, expected_pattern) -> None:
     assert spec._metric_type == "c"
     assert spec.field_to_extract is None
     assert spec.op == "sum"
-    assert spec.condition["value"] == [expected_pattern]
+    assert spec.condition == {
+        "name": "event.transaction",
+        "op": "glob",
+        "value": [expected_pattern],
+    }
 
 
 def test_spec_count_if() -> None:

--- a/tests/sentry/snuba/metrics/test_extraction.py
+++ b/tests/sentry/snuba/metrics/test_extraction.py
@@ -466,6 +466,25 @@ def test_spec_wildcard() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    "query,expected_pattern",
+    [
+        ("title:*[dispatch:*", "*\\[dispatch:*"),
+        ("title:*{dispatch:*", "*\\{dispatch:*"),
+        ("title:*dispatch]:*", "*dispatch\\]:*"),
+        ("title:*dispatch}:*", "*dispatch\\}:*"),
+        ("title:*?dispatch:*", "*\\?dispatch:*"),
+    ],
+)
+def test_spec_wildcard_escaping(query, expected_pattern) -> None:
+    spec = OnDemandMetricSpec("count()", query)
+
+    assert spec._metric_type == "c"
+    assert spec.field_to_extract is None
+    assert spec.op == "sum"
+    assert spec.condition["value"] == [expected_pattern]
+
+
 def test_spec_count_if() -> None:
     spec = OnDemandMetricSpec("count_if(transaction.duration,equals,300)", "")
 


### PR DESCRIPTION
This PR adds escaping for the chars `[` `]` `{` `}` `?` which are used in Relay's globs implementation but that are not exposed to our users. Our users can exclusively use the `*` for wildcard matches.

For reference, this is the globs implementation used in Relay: https://docs.rs/globset/latest/globset/#syntax