### PR TITLE
fix(ddm): sample tooltip value

### DIFF
--- a/static/app/views/ddm/chart.tsx
+++ b/static/app/views/ddm/chart.tsx
@@ -103,6 +103,7 @@ export const MetricChart = forwardRef<ReactEchartsRef, ChartProps>(
       highlightedSampleId: scatter?.higlightedId,
       operation,
       timeseries: series,
+      valueFormatter,
     });
 
     // TODO(ddm): This assumes that all series have the same bucket size

--- a/static/app/views/ddm/useChartSamples.tsx
+++ b/static/app/views/ddm/useChartSamples.tsx
@@ -5,7 +5,6 @@ import type {XAXisOption} from 'echarts/types/dist/shared';
 import moment from 'moment';
 
 import type {ReactEchartsRef, Series} from 'sentry/types/echarts';
-import {getDuration} from 'sentry/utils/formatters';
 import {isCumulativeOp} from 'sentry/utils/metrics';
 import type {MetricCorrelation, MetricSummary} from 'sentry/utils/metrics/types';
 import {fitToValueRect, getValueRect} from 'sentry/views/ddm/chartUtils';
@@ -20,6 +19,7 @@ type UseChartSamplesProps = {
   onMouseOut?: (sample: Sample) => void;
   onMouseOver?: (sample: Sample) => void;
   operation?: string;
+  valueFormatter?: (value: number) => string;
 };
 
 // TODO: remove this once we have a stabilized type for this
@@ -42,6 +42,7 @@ export function useChartSamples({
   chartRef,
   operation,
   timeseries,
+  valueFormatter,
 }: UseChartSamplesProps) {
   const theme = useTheme();
 
@@ -188,10 +189,14 @@ export function useChartSamples({
       },
       valueFormatter: (_, label?: string) => {
         const sample = samples[label ?? ''];
-        return getDuration(sample.duration / 1000, 2, true);
+        const yValue = ((sample.min ?? 0) + (sample.max ?? 0)) / 2;
+        if (!valueFormatter) {
+          return yValue.toPrecision(5);
+        }
+        return valueFormatter(yValue);
       },
     };
-  }, [samples]);
+  }, [samples, valueFormatter]);
 
   return {
     handleClick,


### PR DESCRIPTION
Uses value from metric summaries in sample tooltip
<img width="728" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/3a39cbcb-6c3b-403b-b137-16f89e3dae36">
