### PR TITLE
feat(alerts): Add give feedback button for alerts page

### DIFF
--- a/static/app/views/alerts/list/header.tsx
+++ b/static/app/views/alerts/list/header.tsx
@@ -4,6 +4,7 @@ import {navigateTo} from 'sentry/actionCreators/navigation';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import CreateAlertButton from 'sentry/components/createAlertButton';
+import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
@@ -68,6 +69,7 @@ function AlertHeader({router, activeTab}: Props) {
           >
             {t('Create Alert')}
           </CreateAlertButton>
+          <FeedbackWidgetButton />
           <Button
             size="sm"
             onClick={handleNavigateToSettings}


### PR DESCRIPTION
Addresses https://github.com/getsentry/getsentry/issues/12289

Pretty sure this should work, but I'm not sure what flag I need to enable in the UI for it to appear, right now none of the feedback buttons appear on my devserver 🤷 

I'll look into it a bit more and add a test when I trace why that is.

<img width="1141" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/829c26f0-cf12-472d-9a28-6dac78f72922">