### PR TITLE
ref: Remove `start_transaction` from `auto_ongoing_issues.py`

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -68,25 +68,24 @@ def schedule_auto_transition_to_ongoing() -> None:
     that transition Issues to Ongoing according to their specific
     criteria.
     """
-    with sentry_sdk.start_transaction(op="task", name="schedule_auto_transition_to_ongoing"):
-        now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=timezone.utc)
 
-        seven_days_ago = now - timedelta(days=TRANSITION_AFTER_DAYS)
+    seven_days_ago = now - timedelta(days=TRANSITION_AFTER_DAYS)
 
-        schedule_auto_transition_issues_new_to_ongoing.delay(
-            first_seen_lte=int(seven_days_ago.timestamp()),
-            expires=now + timedelta(hours=1),
-        )
+    schedule_auto_transition_issues_new_to_ongoing.delay(
+        first_seen_lte=int(seven_days_ago.timestamp()),
+        expires=now + timedelta(hours=1),
+    )
 
-        schedule_auto_transition_issues_regressed_to_ongoing.delay(
-            date_added_lte=int(seven_days_ago.timestamp()),
-            expires=now + timedelta(hours=1),
-        )
+    schedule_auto_transition_issues_regressed_to_ongoing.delay(
+        date_added_lte=int(seven_days_ago.timestamp()),
+        expires=now + timedelta(hours=1),
+    )
 
-        schedule_auto_transition_issues_escalating_to_ongoing.delay(
-            date_added_lte=int(seven_days_ago.timestamp()),
-            expires=now + timedelta(hours=1),
-        )
+    schedule_auto_transition_issues_escalating_to_ongoing.delay(
+        date_added_lte=int(seven_days_ago.timestamp()),
+        expires=now + timedelta(hours=1),
+    )
 
 
 @instrumented_task(


### PR DESCRIPTION
This `start_transaction` call is unnecessary and it leads to undefined behavior, since it occurs within a Celery task that is already automatically instrumented by the Python SDK's Celery integration. The auto-instrumented transaction can be viewed [here](https://sentry.sentry.io/performance/summary/?project=1&query=&referrer=performance-transaction-summary&statsPeriod=24h&transaction=sentry.tasks.schedule_auto_transition_to_ongoing&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29).

Ref GH-63590