### PR TITLE
fix(security): Ensure project permissions are checked for code mappings endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/api/endpoints/organization_code_mapping_details.py
@@ -59,6 +59,8 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
         :param string default_branch:
         :auth: required
         """
+        if not request.access.has_project_access(config.project):
+            return self.respond(status=status.HTTP_403_FORBIDDEN)
 
         try:
             # We expect there to exist an org_integration
@@ -92,6 +94,10 @@ class OrganizationCodeMappingDetailsEndpoint(OrganizationEndpoint, OrganizationI
 
         :auth: required
         """
+
+        if not request.access.has_project_access(config.project):
+            return self.respond(status=status.HTTP_403_FORBIDDEN)
+
         try:
             config.delete()
             return self.respond(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/organization_derive_code_mappings.py
+++ b/src/sentry/api/endpoints/organization_derive_code_mappings.py
@@ -94,6 +94,9 @@ class OrganizationDeriveCodeMappingsEndpoint(OrganizationEndpoint):
                 {"text": "Could not find project"}, status=status.HTTP_404_NOT_FOUND
             )
 
+        if not request.access.has_project_access(project):
+            return self.respond(status=status.HTTP_403_FORBIDDEN)
+
         repo_name = request.data.get("repoName")
         stack_root = request.data.get("stackRoot")
         source_root = request.data.get("sourceRoot")

--- a/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
@@ -22,6 +22,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
         self.organization.flags.allow_joinleave = False
         self.organization.save()
         self.team = self.create_team(organization=self.organization, name="night-springs")
+        self.create_team_membership(team=self.team, user=self.user)
         self.project = self.create_project(organization=self.organization, teams=[self.team])
         self.url = reverse(
             "sentry-api-0-organization-derive-code-mappings",

--- a/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from django.db import router
 from django.urls import reverse
+from rest_framework import status
 
 from sentry.integrations.utils.code_mapping import FrameFilename, _get_code_mapping_source_path
 from sentry.models.integrations.integration import Integration
@@ -17,7 +18,11 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.project = self.create_project(organization=self.organization)
+        self.organization = self.create_organization("federal-bureau-of-control")
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+        self.team = self.create_team(organization=self.organization, name="night-springs")
+        self.project = self.create_project(organization=self.organization, teams=[self.team])
         self.url = reverse(
             "sentry-api-0-organization-derive-code-mappings",
             args=[self.organization.slug],
@@ -117,6 +122,26 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
             Integration.objects.all().delete()
         response = self.client.get(self.url, data=config_data, format="json")
         assert response.status_code == 404, response.content
+
+    def test_non_project_member_permissions(self):
+        config_data = {
+            "projectId": self.project.id,
+            "stackRoot": "/stack/root",
+            "sourceRoot": "/source/root",
+            "defaultBranch": "master",
+            "repoName": "getsentry/codemap",
+        }
+        non_member = self.create_user()
+        non_member_om = self.create_member(organization=self.organization, user=non_member)
+        self.login_as(user=non_member)
+
+        response = self.client.post(self.url, data=config_data, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        self.create_team_membership(team=self.team, member=non_member_om)
+
+        response = self.client.post(self.url, data=config_data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
 
     def test_post_simple(self):
         config_data = {


### PR DESCRIPTION
Addresses https://github.com/getsentry/sentry/issues/55871

Will now use the request context for projects to enforce membership for organizations without open enrollment in teams. Added tests to double check this behaviour.