### PR TITLE
fix(feedback): Get feedback integration using `getIntegrationByName`

### DIFF
--- a/static/app/components/feedback/widget/useFeedbackWidget.tsx
+++ b/static/app/components/feedback/widget/useFeedbackWidget.tsx
@@ -13,6 +13,7 @@ interface Props {
 export default function useFeedbackWidget({buttonRef}: Props) {
   const config = useLegacyStore(ConfigStore);
   const client = getClient();
+  // Note that this is only defined in environments where Feedback is enabled (getsentry)
   const feedback = client?.getIntegrationByName?.<Feedback>('Feedback');
 
   useEffect(() => {

--- a/static/app/components/feedback/widget/useFeedbackWidget.tsx
+++ b/static/app/components/feedback/widget/useFeedbackWidget.tsx
@@ -1,6 +1,6 @@
 import type {RefObject} from 'react';
 import {useEffect} from 'react';
-import {Feedback, getCurrentHub} from '@sentry/react';
+import {feedbackIntegration} from '@sentry/react';
 
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -12,8 +12,7 @@ interface Props {
 
 export default function useFeedbackWidget({buttonRef}: Props) {
   const config = useLegacyStore(ConfigStore);
-  const hub = getCurrentHub();
-  const feedback = hub.getIntegration(Feedback);
+  const feedback = feedbackIntegration();
 
   useEffect(() => {
     if (!feedback) {

--- a/static/app/components/feedback/widget/useFeedbackWidget.tsx
+++ b/static/app/components/feedback/widget/useFeedbackWidget.tsx
@@ -1,6 +1,6 @@
 import type {RefObject} from 'react';
 import {useEffect} from 'react';
-import {feedbackIntegration} from '@sentry/react';
+import {type Feedback, getClient} from '@sentry/react';
 
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
@@ -12,7 +12,8 @@ interface Props {
 
 export default function useFeedbackWidget({buttonRef}: Props) {
   const config = useLegacyStore(ConfigStore);
-  const feedback = feedbackIntegration();
+  const client = getClient();
+  const feedback = client?.getIntegrationByName?.<Feedback>('Feedback');
 
   useEffect(() => {
     if (!feedback) {

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -109,6 +109,7 @@ jest.mock('@sentry/react', function sentryReact() {
     startSpan: jest.spyOn(SentryReact, 'startSpan'),
     finishSpan: jest.fn(),
     lastEventId: jest.fn(),
+    getClient: jest.spyOn(SentryReact, 'getClient'),
     getCurrentHub: jest.spyOn(SentryReact, 'getCurrentHub'),
     withScope: jest.spyOn(SentryReact, 'withScope'),
     Hub: SentryReact.Hub,


### PR DESCRIPTION
Gets the feedback integration via the newer function as described in the deprecation notice