### PR TITLE
chore(integrations): Remove project creation instructions

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -65,7 +65,6 @@ external_install = {
 
 
 configure_integration = {"title": _("Connect Your Projects")}
-create_project_instruction = _("Don't have a project yet? Click [here]({}) to create one.")
 install_source_code_integration = _(
     "Install a [source code integration]({}) and configure your repositories."
 )
@@ -98,11 +97,9 @@ class VercelIntegration(IntegrationInstallation):
     def get_dynamic_display_information(self):
         qs = urlencode({"category": "source code management"})
         source_code_link = absolute_uri(f"/settings/{self.organization.slug}/integrations/?{qs}")
-        add_project_link = absolute_uri(f"/organizations/{self.organization.slug}/projects/new/")
         return {
             "configure_integration": {
                 "instructions": [
-                    create_project_instruction.format(add_project_link),
                     install_source_code_integration.format(source_code_link),
                 ]
             }

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -398,7 +398,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         installation = integration.get_installation(self.organization.id)
         dynamic_display_info = installation.get_dynamic_display_information()
         instructions = dynamic_display_info["configure_integration"]["instructions"]
-        assert len(instructions) == 2
+        assert len(instructions) == 1
         assert "configure your repositories." in instructions[0]
 
     @responses.activate

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -399,8 +399,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         dynamic_display_info = installation.get_dynamic_display_information()
         instructions = dynamic_display_info["configure_integration"]["instructions"]
         assert len(instructions) == 2
-        assert "Don't have a project yet?" in instructions[0]
-        assert "configure your repositories." in instructions[1]
+        assert "configure your repositories." in instructions[0]
 
     @responses.activate
     def test_uninstall(self):


### PR DESCRIPTION
this pr removes the instruction to create a new project now that we have the project creation modal 

closes https://github.com/getsentry/sentry/issues/64297