### PR TITLE
fix(issue-alerts): Fix issue alert options on small screens

### DIFF
--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -136,7 +136,7 @@ class IssueAlertOptions extends DeprecatedAsyncComponent<Props, State> {
   ): [string, string | React.ReactElement][] {
     const customizedAlertOption: [string, React.ReactNode] = [
       RuleAction.CUSTOMIZED_ALERTS.toString(),
-      <CustomizeAlertsGrid
+      <CustomizeAlert
         key={RuleAction.CUSTOMIZED_ALERTS}
         onClick={e => {
           // XXX(epurkhiser): The `e.preventDefault` here is needed to stop
@@ -173,7 +173,7 @@ class IssueAlertOptions extends DeprecatedAsyncComponent<Props, State> {
           }))}
           onChange={interval => this.setStateAndUpdateParents({interval: interval.value})}
         />
-      </CustomizeAlertsGrid>,
+      </CustomizeAlert>,
     ];
 
     const default_label = this.shouldUseNewDefaultSetting()
@@ -331,10 +331,10 @@ const Content = styled('div')`
   padding-bottom: ${space(4)};
 `;
 
-const CustomizeAlertsGrid = styled('div')`
-  display: grid;
-  grid-template-columns: repeat(5, max-content);
+const CustomizeAlert = styled('div')`
+  display: flex;
   gap: ${space(1)};
+  flex-wrap: wrap;
   align-items: center;
 `;
 


### PR DESCRIPTION
this pr updates the issue alert options shown on project creation to look better on small screens. previously, you wouldn't be able to see the boxes on small screen sizes.

before: 
![Screenshot 2024-02-05 at 10 24 52 AM](https://github.com/getsentry/sentry/assets/46740234/dcaca98c-c1d0-4d41-a125-ff26ece17887)


after: 
![Screenshot 2024-02-05 at 10 40 13 AM](https://github.com/getsentry/sentry/assets/46740234/c4aa1885-2ed6-48bd-875b-7a37f127bd12)
