### PR TITLE
chore(ui): Improve error handling for search input parse errors

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1051,7 +1051,13 @@ function tryParseSearch<T extends {config: SearchConfig}>(
   try {
     return grammar.parse(query, config);
   } catch (e) {
-    Sentry.captureException(e);
+    Sentry.withScope(scope => {
+      scope.setFingerprint(['search-syntax-parse-error']);
+      scope.setExtra('message', e.message?.slice(-100));
+      scope.setExtra('found', e.found);
+      Sentry.captureException(e);
+    });
+
     return null;
   }
 }


### PR DESCRIPTION
We're getting blasted with issues right now!

- capture `found` so we know what string caused the error
- capture `message` for convenience
- force same fingerprint so they're grouped
