### PR TITLE
fix(clippedbox): Correctly clear max height when window is maximized

### DIFF
--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -50,7 +50,7 @@ function calculateAddedHeight({
   }
 }
 
-function clearMaxHeight(element?: HTMLElement | null) {
+function clearMaxHeight(element: HTMLElement | null) {
   if (element) {
     element.style.maxHeight = 'none';
   }
@@ -91,7 +91,7 @@ function revealAndDisconnectObserver({
     wrapperRef.current.addEventListener('transitionend', onTransitionEnd);
     wrapperRef.current.style.maxHeight = `${revealedWrapperHeight}px`;
   } else {
-    clearMaxHeight();
+    clearMaxHeight(wrapperRef.current);
   }
 
   revealRef.current = true;


### PR DESCRIPTION
When maximizing a window, the reveal function would be called, but the content height would be the same as the revealed height which means that it would skip the reveal animation. I had erroneously not provided the element as an argument to `clearMaxHeight()` in this scenario. Adding that fixes the behavior, and I also modified the signature to require the argument.