### PR TITLE
fix(replays): use issue platform for rage click issues

### DIFF
--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -26,8 +26,9 @@ export default function useReplayFromIssue({
 
   const [fetchError, setFetchError] = useState();
 
+  // use Discover for errors and Issue Platform for everything else
   const dataSource =
-    group.issueCategory === IssueCategory.PERFORMANCE ? 'search_issues' : 'discover';
+    group.issueCategory === IssueCategory.ERROR ? 'discover' : 'search_issues';
 
   const fetchReplayIds = useCallback(async () => {
     try {


### PR DESCRIPTION
WIthin the replay counts logic, changes this conditional so we only use discover for error issue types and issue platform for everything else