### PR TITLE
fix(issues): Increase trace timeline tooltip target

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -68,6 +68,7 @@ const TimelineOutline = styled('div')`
   height: 8px;
   border: 1px solid ${p => p.theme.innerBorder};
   border-radius: ${p => p.theme.borderRadius};
+  background-color: ${p => p.theme.backgroundSecondary};
 `;
 
 /**

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -209,6 +209,7 @@ function NodeGroup({
 }
 
 const EventColumn = styled('div')`
+  place-items: stretch;
   display: grid;
   align-items: center;
   position: relative;
@@ -229,7 +230,7 @@ const IconNode = styled('div')`
   box-shadow: ${p => p.theme.dropShadowLight};
   user-select: none;
   background-color: ${p => color(p.theme.red200).alpha(0.3).string()};
-  margin-left: -4px;
+  margin-left: -8px;
 `;
 
 const PerformanceIconNode = styled(IconNode)`
@@ -252,7 +253,7 @@ const CurrentNodeRing = styled('div')`
   border-radius: 100%;
   position: absolute;
   top: -4px;
-  left: -8px;
+  left: -12px;
   animation: pulse 1s ease-out infinite;
 
   @keyframes pulse {
@@ -278,10 +279,7 @@ const CurrentIconNode = styled(IconNode)`
 
 const TooltipHelper = styled('span')`
   height: 12px;
-  padding-left: 2px;
-  padding-right: 2px;
-  margin-left: -4px;
+  margin-left: -8px;
   margin-top: -6px;
   z-index: 1;
-  border: 1px solid blue;
 `;

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -184,6 +184,8 @@ function NodeGroup({
             </EventColumn>
           );
         })}
+      </TimelineColumns>
+      <TimelineColumns style={{gridTemplateColumns: `repeat(${totalSubColumns}, 1fr)`}}>
         <Tooltip
           title={<TraceTimelineTooltip event={event} timelineEvents={colEvents} />}
           overlayStyle={{
@@ -196,6 +198,7 @@ function NodeGroup({
           <TooltipHelper
             style={{
               gridColumn: columns.length > 1 ? `${minColumn} / ${maxColumn}` : columns[0],
+              width: 8 * columns.length,
             }}
             data-test-id={`trace-timeline-tooltip-${currentColumn}`}
           />
@@ -206,7 +209,6 @@ function NodeGroup({
 }
 
 const EventColumn = styled('div')`
-  place-items: stretch;
   display: grid;
   align-items: center;
   position: relative;
@@ -276,10 +278,10 @@ const CurrentIconNode = styled(IconNode)`
 
 const TooltipHelper = styled('span')`
   height: 12px;
-  padding-left: 4px;
-  padding-right: 4px;
+  padding-left: 2px;
+  padding-right: 2px;
+  margin-left: -2px;
   margin-top: -6px;
-  margin-left: -4px;
-  min-width: 8px;
   z-index: 1;
+  border: 1px solid blue;
 `;

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -280,7 +280,7 @@ const TooltipHelper = styled('span')`
   height: 12px;
   padding-left: 2px;
   padding-right: 2px;
-  margin-left: -2px;
+  margin-left: -4px;
   margin-top: -6px;
   z-index: 1;
   border: 1px solid blue;

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -227,6 +227,7 @@ const IconNode = styled('div')`
   box-shadow: ${p => p.theme.dropShadowLight};
   user-select: none;
   background-color: ${p => color(p.theme.red200).alpha(0.3).string()};
+  margin-left: -4px;
 `;
 
 const PerformanceIconNode = styled(IconNode)`
@@ -249,7 +250,7 @@ const CurrentNodeRing = styled('div')`
   border-radius: 100%;
   position: absolute;
   top: -4px;
-  left: -4px;
+  left: -8px;
   animation: pulse 1s ease-out infinite;
 
   @keyframes pulse {
@@ -275,10 +276,10 @@ const CurrentIconNode = styled(IconNode)`
 
 const TooltipHelper = styled('span')`
   height: 12px;
-  padding-left: 1px;
-  padding-right: 1px;
+  padding-left: 4px;
+  padding-right: 4px;
   margin-top: -6px;
-  margin-right: -1px;
+  margin-left: -4px;
   min-width: 8px;
   z-index: 1;
 `;

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -50,7 +50,7 @@ export function TraceTimelineEvents({event, width}: TraceTimelineEventsProps) {
   return (
     <Fragment>
       {/* Add padding to the total columns, 1 column of padding on each side */}
-      <TimelineColumns totalColumns={totalColumns + 2}>
+      <TimelineColumns style={{gridTemplateColumns: `repeat(${totalColumns + 2}, 1fr)`}}>
         {Array.from(eventsByColumn.entries()).map(([column, colEvents]) => {
           // Calculate the timestamp range that this column represents
           const timeRange = getChunkTimeRange(
@@ -105,7 +105,7 @@ export function TraceTimelineEvents({event, width}: TraceTimelineEventsProps) {
  *   <Col>...</Col>
  * </Columns>
  */
-const TimelineColumns = styled('ul')<{totalColumns: number}>`
+const TimelineColumns = styled('div')`
   /* Reset defaults for <ul> */
   list-style: none;
   margin: 0;
@@ -113,7 +113,6 @@ const TimelineColumns = styled('ul')<{totalColumns: number}>`
 
   /* Layout of the lines */
   display: grid;
-  grid-template-columns: repeat(${p => p.totalColumns}, 1fr);
   margin-top: -1px;
   height: 0;
 `;
@@ -163,7 +162,7 @@ function NodeGroup({
 
   return (
     <Fragment>
-      <TimelineColumns totalColumns={totalSubColumns}>
+      <TimelineColumns style={{gridTemplateColumns: `repeat(${totalSubColumns}, 1fr)`}}>
         {Array.from(eventsByColumn.entries()).map(([column, groupEvents]) => {
           const isCurrentNode = groupEvents.some(e => e.id === currentEventId);
           return (
@@ -185,8 +184,6 @@ function NodeGroup({
             </EventColumn>
           );
         })}
-      </TimelineColumns>
-      <TimelineColumns totalColumns={totalSubColumns}>
         <Tooltip
           title={<TraceTimelineTooltip event={event} timelineEvents={colEvents} />}
           overlayStyle={{
@@ -208,7 +205,7 @@ function NodeGroup({
   );
 }
 
-const EventColumn = styled('li')`
+const EventColumn = styled('div')`
   place-items: stretch;
   display: grid;
   align-items: center;
@@ -277,9 +274,11 @@ const CurrentIconNode = styled(IconNode)`
 `;
 
 const TooltipHelper = styled('span')`
-  height: 8px;
-  margin-top: -4px;
-  margin-right: -2px;
+  height: 12px;
+  padding-left: 1px;
+  padding-right: 1px;
+  margin-top: -6px;
+  margin-right: -1px;
   min-width: 8px;
   z-index: 1;
 `;


### PR DESCRIPTION
- Increases the size of the tooltip timeline
- Removes the inline styles from emotion to reduce unique styles
- sneak in a background color change

current tooltip area
![image](https://github.com/getsentry/sentry/assets/1400464/31188260-f764-48f5-b44a-d0a0ab306eec)

new tooltip area
![image](https://github.com/getsentry/sentry/assets/1400464/aa20a607-0978-4078-a26e-006bf1d5af8d)
