### PR TITLE
chore(staff): Let staff access user index endpoint

### DIFF
--- a/src/sentry/api/endpoints/user_index.py
+++ b/src/sentry/api/endpoints/user_index.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.paginator import DateTimePaginator
-from sentry.api.permissions import SuperuserPermission
+from sentry.api.permissions import SuperuserOrStaffFeatureFlaggedPermission
 from sentry.api.serializers import serialize
 from sentry.db.models.query import in_iexact
 from sentry.models.user import User
@@ -15,9 +15,9 @@ from sentry.search.utils import tokenize_query
 @control_silo_endpoint
 class UserIndexEndpoint(Endpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
-    permission_classes = (SuperuserPermission,)
+    permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def get(self, request: Request) -> Response:
         queryset = User.objects.distinct()


### PR DESCRIPTION
I believe this is only used in the _admin portal, so once the feature flag is removed we'll only let staff access this and not superuser

After this PR, the users tab in _admin should be complete!
On reflection, I actually needed far more stuff 🤥