### PR TITLE
ref(deps): Remove old component annotate plugin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@emotion/css": "^11.10.5",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@fullstory/babel-plugin-annotate-react": "^2.3.0",
     "@monaco-editor/react": "^4.4.5",
     "@popperjs/core": "^2.11.5",
     "@react-aria/button": "^3.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,11 +1643,6 @@
   dependencies:
     tslib "^2.4.0"
 
-"@fullstory/babel-plugin-annotate-react@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@fullstory/babel-plugin-annotate-react/-/babel-plugin-annotate-react-2.3.0.tgz#ab4df27dbecaa3771a1b353b898ccf887876e9fb"
-  integrity sha512-gYLUL6Tu0exbvTIhK9nSCaztmqBlQAm07Fvtl/nKTc+lxwFkcX9vR8RrdTbyjJZKbPaA5EMlExQ6GeLCXkfm5g==
-
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.11.tgz#88a04c570dbbc7dd943e4712429c3df09bc32844"


### PR DESCRIPTION
Removes this dependency, as it is being replaced with our own plugin. The replacement plugin to be added in a followup PR

getsentry PR: https://github.com/getsentry/getsentry/pull/12838