### PR TITLE
ref(superuser): only allow superuser write to remove team members

### DIFF
--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -26,7 +26,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.examples.team_examples import TeamExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.auth.access import Access
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.superuser import superuser_has_permission
 from sentry.models.organization import Organization
 from sentry.models.organizationaccessrequest import OrganizationAccessRequest
 from sentry.models.organizationmember import OrganizationMember
@@ -135,7 +135,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         * If they are removing their own membership
         * If they are a team admin or have global write access
         """
-        if is_active_superuser(request):
+        if superuser_has_permission(request):
             return True
 
         if not request.user.is_authenticated:


### PR DESCRIPTION
Replace `is_active_superuser` in `_can_delete` (for a team member) with `superuser_has_permission`. Active superusers with the `auth:enterprise-superuser-read-write` feature flag must be a superuser with write permission in order to remove a member from a team.

For https://github.com/getsentry/team-enterprise/issues/40