### PR TITLE
fix(integrations): Project creation modal shows browser platforms for Vercel

### DIFF
--- a/static/app/components/forms/fields/projectMapperField.tsx
+++ b/static/app/components/forms/fields/projectMapperField.tsx
@@ -130,7 +130,9 @@ export class RenderField extends Component<RenderProps, State> {
 
     const handleSelectProject = ({value}: {value: number}) => {
       if (value === -1) {
-        openProjectCreationModal({defaultCategory: 'popular'});
+        openProjectCreationModal({
+          defaultCategory: iconType === 'vercel' ? 'browser' : 'popular',
+        });
       } else {
         this.setState({selectedSentryProjectId: value});
       }


### PR DESCRIPTION
this pr changes the project creation modal so that it shows the browser platform page first for the Vercel integration page. 