### PR TITLE
nit(superuser): add comments for not replacing is_active_superuser with superuser_has_permission

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -383,6 +383,8 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         Remove an organization member.
         """
 
+        # with superuser read write separation, superuser read cannot hit this endpoint
+        # so we can keep this as is_active_superuser
         if request.user.is_authenticated and not is_active_superuser(request):
             try:
                 acting_member = OrganizationMember.objects.get(

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -196,6 +196,8 @@ class UserDetailsEndpoint(UserEndpoint):
 
         if request.access.has_permission("users.admin"):
             serializer_cls = PrivilegedUserSerializer
+        # with superuser read write separation, superuser read cannot hit this endpoint
+        # so we can keep this as is_active_superuser
         elif is_active_superuser(request):
             serializer_cls = SuperuserUserSerializer
         else:

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -1,3 +1,5 @@
+from django.test import override_settings
+
 from sentry.models.deletedorganization import DeletedOrganization
 from sentry.models.options.user_option import UserOption
 from sentry.models.organization import Organization, OrganizationStatus
@@ -8,6 +10,7 @@ from sentry.models.userrole import UserRole
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -188,6 +191,39 @@ class UserDetailsSuperuserUpdateTest(UserDetailsTest):
 
         user = User.objects.get(id=self.user.id)
         assert not user.is_active
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_read_cannot_change_is_active(self):
+        self.user.update(is_active=True)
+        superuser = self.create_user(email="b@example.com", is_superuser=True)
+        self.login_as(user=superuser, superuser=True)
+
+        self.get_error_response(
+            self.user.id,
+            isActive="false",
+            status_code=403,
+        )
+
+        self.user.refresh_from_db()
+        assert self.user.is_active
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_write_can_change_is_active(self):
+        self.user.update(is_active=True)
+        superuser = self.create_user(email="b@example.com", is_superuser=True)
+        self.add_user_permission(superuser, "superuser.write")
+        self.login_as(user=superuser, superuser=True)
+
+        resp = self.get_success_response(
+            self.user.id,
+            isActive="false",
+        )
+        assert resp.data["id"] == str(self.user.id)
+
+        self.user.refresh_from_db()
+        assert not self.user.is_active
 
     def test_superuser_cannot_add_superuser(self):
         self.user.update(is_superuser=False)


### PR DESCRIPTION
(1) `OrganizationMemberDetailsEndpoint` DELETE and (2) `UserDetailsEndpoint` PUT include `is_active_superuser` calls, but we don't need to replace them with `superuser_has_permission`.

Superuser read-only will not be able to hit these endpoints because (1) read-only superuser will not have sufficient scopes to hit the endpoint and (2) this is covered by `UserPermission` which checks for `superuser.write`.

For https://github.com/getsentry/team-enterprise/issues/40