### PR TITLE
test(hc): Disable silo test case inheritance validation

### DIFF
--- a/tests/sentry/api/endpoints/test_user_permission_details.py
+++ b/tests/sentry/api/endpoints/test_user_permission_details.py
@@ -37,6 +37,7 @@ class UserDetailsTest(APITestCase):
         assert response.status_code == 403
 
 
+@control_silo_test
 class UserPermissionDetailsGetTest(UserDetailsTest):
     method = "GET"
 
@@ -69,6 +70,7 @@ class UserPermissionDetailsGetTest(UserDetailsTest):
         assert mock_has_permission.call_count == 1
 
 
+@control_silo_test
 class UserPermissionDetailsPostTest(UserDetailsTest):
     method = "POST"
 
@@ -115,6 +117,7 @@ class UserPermissionDetailsPostTest(UserDetailsTest):
         assert mock_has_permission.call_count == 1
 
 
+@control_silo_test
 class UserPermissionDetailsDeleteTest(UserDetailsTest):
     method = "DELETE"
 

--- a/tests/sentry/api/endpoints/test_user_role_details.py
+++ b/tests/sentry/api/endpoints/test_user_role_details.py
@@ -32,6 +32,7 @@ class UserUserRolesTest(APITestCase):
         assert resp.status_code == 403
 
 
+@control_silo_test
 class UserUserRolesDetailsTest(UserUserRolesTest):
     def test_lookup_self(self):
         role = UserRole.objects.create(name="support", permissions=["broadcasts.admin"])
@@ -43,6 +44,7 @@ class UserUserRolesDetailsTest(UserUserRolesTest):
         assert resp.data["name"] == "support"
 
 
+@control_silo_test
 class UserUserRolesCreateTest(UserUserRolesTest):
     method = "POST"
 
@@ -66,6 +68,7 @@ class UserUserRolesCreateTest(UserUserRolesTest):
         assert resp.status_code == 410
 
 
+@control_silo_test
 class UserUserRolesDeleteTest(UserUserRolesTest):
     method = "DELETE"
 

--- a/tests/sentry/api/endpoints/test_user_roles.py
+++ b/tests/sentry/api/endpoints/test_user_roles.py
@@ -32,6 +32,7 @@ class UserUserRolesTest(APITestCase):
         assert resp.status_code == 403
 
 
+@control_silo_test
 class UserUserRolesGetTest(UserUserRolesTest):
     def test_lookup_self(self):
         role = UserRole.objects.create(name="support", permissions=["broadcasts.admin"])

--- a/tests/sentry/api/endpoints/test_userroles_index.py
+++ b/tests/sentry/api/endpoints/test_userroles_index.py
@@ -32,6 +32,7 @@ class UserRolesTest(APITestCase):
         assert resp.status_code == 403
 
 
+@control_silo_test
 class UserRolesGetTest(UserRolesTest):
     def test_simple(self):
         UserRole.objects.create(name="test-role")
@@ -41,6 +42,7 @@ class UserRolesGetTest(UserRolesTest):
         assert "test-role" in [r["name"] for r in resp.data]
 
 
+@control_silo_test
 class UserRolesPostTest(UserRolesTest):
     method = "POST"
 

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -55,10 +55,12 @@ class RangeQuerySetWrapperTest(TestCase):
         assert len(list(self.range_wrapper(qs, step=2))) == 0
 
 
+@no_silo_test
 class RangeQuerySetWrapperWithProgressBarTest(RangeQuerySetWrapperTest):
     range_wrapper = RangeQuerySetWrapperWithProgressBar
 
 
+@no_silo_test
 class RangeQuerySetWrapperWithProgressBarApproxTest(RangeQuerySetWrapperTest):
     range_wrapper = RangeQuerySetWrapperWithProgressBarApprox
 


### PR DESCRIPTION
Remove call to `_validate_that_no_ancestor_is_silo_decorated` and add a deprecation comment.

As far as we can tell, the check was originally motivated by trouble with swapped environment variables when changing into and out of the region silo mode. Those swaps were simplified in #61331 and related PRs, and hopefully having multiple silo decorators in the inheritance tree is no longer a problem.

Decorating the base class will in fact be necessary when tests are run in region mode by default, as some base classes should properly be tagged as `@control_silo_test` and would raise spurious errors otherwise.