### PR TITLE
feat(issues): Remove trace timeline from behind user flag

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -39,7 +39,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {useUser} from 'sentry/utils/useUser';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import EventCreatedTooltip from 'sentry/views/issueDetails/eventCreatedTooltip';
 import {TraceLink} from 'sentry/views/issueDetails/traceTimeline/traceLink';
@@ -363,7 +362,6 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
 export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarouselProps) {
   const organization = useOrganization();
   const location = useLocation();
-  const user = useUser();
 
   const latencyThreshold = 30 * 60 * 1000; // 30 minutes
   const isOverLatencyThreshold =
@@ -379,7 +377,7 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
     text: event.id,
   });
 
-  const hasTraceTimeline = hasTraceTimelineFeature(organization, user);
+  const hasTraceTimeline = hasTraceTimelineFeature(organization);
 
   return (
     <CarouselAndButtonsWrapper>

--- a/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
@@ -1,11 +1,9 @@
 import {EventFixture} from 'sentry-fixture/event';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import ConfigStore from 'sentry/stores/configStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
 import {TraceLink} from './traceLink';
@@ -55,17 +53,7 @@ describe('TraceLink', () => {
   };
 
   beforeEach(() => {
-    // Can be removed with issueDetailsNewExperienceQ42023
     ProjectsStore.loadInitialData([project]);
-    ConfigStore.set(
-      'user',
-      UserFixture({
-        options: {
-          ...UserFixture().options,
-          issueDetailsNewExperienceQ42023: true,
-        },
-      })
-    );
   });
 
   it('renders the number of issues', async () => {

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
@@ -1,11 +1,9 @@
 import {EventFixture} from 'sentry-fixture/event';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import ConfigStore from 'sentry/stores/configStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
 import {TraceTimeline} from './traceTimeline';
@@ -56,17 +54,7 @@ describe('TraceTimeline', () => {
   };
 
   beforeEach(() => {
-    // Can be removed with issueDetailsNewExperienceQ42023
     ProjectsStore.loadInitialData([project]);
-    ConfigStore.set(
-      'user',
-      UserFixture({
-        options: {
-          ...UserFixture().options,
-          issueDetailsNewExperienceQ42023: true,
-        },
-      })
-    );
   });
 
   it('renders items and highlights the current event', async () => {

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -7,7 +7,6 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import {hasTraceTimelineFeature} from 'sentry/views/issueDetails/traceTimeline/utils';
 
 import {TraceTimelineEvents} from './traceTimelineEvents';
@@ -20,11 +19,10 @@ interface TraceTimelineProps {
 }
 
 export function TraceTimeline({event}: TraceTimelineProps) {
-  const user = useUser();
   const organization = useOrganization({allowNull: true});
   const timelineRef = useRef<HTMLDivElement>(null);
   const {width} = useDimensions({elementRef: timelineRef});
-  const hasFeature = hasTraceTimelineFeature(organization, user);
+  const hasFeature = hasTraceTimelineFeature(organization);
   const {isError, isLoading, data} = useTraceTimelineEvents({event}, hasFeature);
 
   if (!hasFeature || !event.contexts?.trace?.trace_id) {

--- a/static/app/views/issueDetails/traceTimeline/utils.tsx
+++ b/static/app/views/issueDetails/traceTimeline/utils.tsx
@@ -1,4 +1,4 @@
-import type {Organization, User} from 'sentry/types';
+import type {Organization} from 'sentry/types';
 
 import type {TimelineEvent} from './useTraceTimelineEvents';
 
@@ -48,12 +48,6 @@ export function getChunkTimeRange(
   return [Math.floor(chunkStartTimestamp), Math.floor(chunkEndTimestamp) + 1];
 }
 
-export function hasTraceTimelineFeature(
-  organization: Organization | null,
-  user: User | undefined
-) {
-  const newIssueExperienceEnabled = user?.options?.issueDetailsNewExperienceQ42023;
-  const hasFeature = organization?.features?.includes('issues-trace-timeline');
-
-  return !!(newIssueExperienceEnabled && hasFeature);
+export function hasTraceTimelineFeature(organization: Organization | null) {
+  return organization?.features?.includes('issues-trace-timeline');
 }


### PR DESCRIPTION
Stops checking for the new experience user flag, still behind a flagr flag
