### PR TITLE
fix(ui): Fix alignment of ListItem

### DIFF
--- a/static/app/components/list/listItem.tsx
+++ b/static/app/components/list/listItem.tsx
@@ -19,16 +19,15 @@ const ListItem = styled(
   )
 )`
   position: relative;
-  ${p => p.symbol && `padding-left: ${p.padding ?? space(4)};`}
+  display: flex;
+  align-items: center;
+  gap: ${space(2)};
 `;
 
 const Symbol = styled('div')`
-  display: flex;
-  align-items: center;
-  position: absolute;
-  top: 0;
-  left: 0;
-  min-height: 22.5px;
+display: flex;
+align-items: center;
+left: 0;
 `;
 
 export default ListItem;


### PR DESCRIPTION
this pr attempts to fix a problem with the ListItem component where the symbol was weirdly aligned. 

before: 
<img width="1182" alt="Screenshot 2024-02-05 at 3 32 37 PM" src="https://github.com/getsentry/sentry/assets/46740234/d71616e2-6acb-4341-af52-115f48c375b5">


after: 
<img width="848" alt="Screenshot 2024-02-05 at 3 34 14 PM" src="https://github.com/getsentry/sentry/assets/46740234/d069d855-ebb4-451b-93c1-0fca8af1a80a">
