### PR TITLE
fix(issues): Render one "you are here" node in timeline

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -167,20 +167,20 @@ function NodeGroup({
           const isCurrentNode = groupEvents.some(e => e.id === currentEventId);
           return (
             <EventColumn key={column} style={{gridColumn: Math.floor(column)}}>
-              {groupEvents.map(groupEvent => (
-                <Fragment key={groupEvent.id}>
-                  {isCurrentNode ? (
-                    <CurrentNodeContainer aria-label={t('Current Event')}>
-                      <CurrentNodeRing />
-                      <CurrentIconNode />
-                    </CurrentNodeContainer>
-                  ) : !('event.type' in groupEvent) ? (
-                    <PerformanceIconNode />
+              {isCurrentNode && (
+                <CurrentNodeContainer aria-label={t('Current Event')}>
+                  <CurrentNodeRing />
+                  <CurrentIconNode />
+                </CurrentNodeContainer>
+              )}
+              {!isCurrentNode &&
+                groupEvents.map(groupEvent =>
+                  'event.type' in groupEvent ? (
+                    <IconNode key={groupEvent.id} />
                   ) : (
-                    <IconNode />
-                  )}
-                </Fragment>
-              ))}
+                    <PerformanceIconNode key={groupEvent.id} />
+                  )
+                )}
             </EventColumn>
           );
         })}


### PR DESCRIPTION
We were rendering too many "you are here" nodes - example https://sentry.sentry.io/issues/4930495536/events/27a2d0a6abbc4caa838fcf08bf7b998a/
