### PR TITLE
ref(superuser): only allow superuser write to delete API tokens

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -15,7 +15,7 @@ from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.fields import MultipleChoiceField
 from sentry.api.serializers import serialize
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.superuser import superuser_has_permission
 from sentry.models.apitoken import ApiToken
 from sentry.models.outbox import outbox_context
 from sentry.security.utils import capture_security_activity
@@ -50,7 +50,7 @@ class ApiTokensEndpoint(Endpoint):
         """
         # Get the user id for the user that made the current request as a baseline default
         user_id = request.user.id
-        if is_active_superuser(request):
+        if superuser_has_permission(request):
             datastore = request.GET if request.GET else request.data
             # If a userId override is not found, use the id for the user who made the request
             user_id = datastore.get("userId", user_id)

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -36,7 +36,6 @@ class ApiTokensListTest(APITestCase):
         token = ApiToken.objects.create(user=self.user, scope_list=[])
 
         self.get_error_response(
-            format="json",
             extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"},
             status_code=status.HTTP_403_FORBIDDEN,
         )


### PR DESCRIPTION
Replace `is_active_superuser` in `_get_appropriate_user_id` in `ApiTokensEndpoint` with `superuser_has_permission`. Active superusers with the `auth:enterprise-superuser-read-write` feature flag must be a superuser with write permission in order to delete other users' API tokens.

`_get_appropriate_user_id` is called in the GET and DELETE methods. `superuser_has_permission` will allow all superusers to fetch API tokens for other users, but only superuser write will be able to delete API tokens for other users.

For https://github.com/getsentry/team-enterprise/issues/40