### PR TITLE
chore(roles): remove UI to set team org role

### DIFF
--- a/static/app/data/forms/teamSettingsFields.tsx
+++ b/static/app/data/forms/teamSettingsFields.tsx
@@ -1,6 +1,5 @@
 import type {JsonFormObject} from 'sentry/components/forms/types';
 import {t} from 'sentry/locale';
-import type {MemberRole} from 'sentry/types';
 import slugify from 'sentry/utils/slugify';
 
 // Export route to make these forms searchable by label/help
@@ -23,32 +22,6 @@ const formGroups: JsonFormObject[] = [
         saveOnBlur: false,
         saveMessageAlertType: 'info',
         saveMessage: t('You will be redirected to the new team slug after saving'),
-      },
-    ],
-  },
-  {
-    title: 'Team Organization Role',
-    fields: [
-      {
-        name: 'orgRole',
-        type: 'select',
-        choices: ({orgRoleList}) => {
-          const choices = orgRoleList.map((r: MemberRole) => [r.id, r.name]) ?? [];
-          choices.unshift(['', 'None']);
-          return choices;
-        },
-        required: false,
-        label: t('Organization Role'),
-        help: t(
-          'Organization owners can bulk assign an org-role for all the members in this team'
-        ),
-        disabled: ({hasOrgAdmin, idpProvisioned}) => !hasOrgAdmin || idpProvisioned,
-        visible: ({hasOrgRoleFlag}) => hasOrgRoleFlag,
-        saveOnBlur: false,
-        saveMessageAlertType: 'info',
-        saveMessage: t(
-          'You are giving all team members the permissions of this organization role'
-        ),
       },
     ],
   },

--- a/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
@@ -1,5 +1,4 @@
 import {browserHistory} from 'react-router';
-import selectEvent from 'react-select-event';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TeamFixture} from 'sentry-fixture/team';
 
@@ -63,55 +62,6 @@ describe('TeamSettings', function () {
     );
   });
 
-  it('can set team org-role', async function () {
-    const team = TeamFixture({orgRole: ''});
-    const putMock = MockApiClient.addMockResponse({
-      url: `/teams/org-slug/${team.slug}/`,
-      method: 'PUT',
-      body: {
-        slug: 'new-slug',
-        orgRole: 'owner',
-      },
-    });
-    const organization = OrganizationFixture({
-      access: ['org:admin'],
-      features: ['org-roles-for-teams'],
-    });
-
-    render(<TeamSettings {...routerProps} team={team} params={{teamId: team.slug}} />, {
-      organization,
-    });
-
-    // set org role
-    const unsetDropdown = await screen.findByText('None');
-    await selectEvent.select(unsetDropdown, 'Owner');
-
-    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
-    expect(putMock).toHaveBeenCalledWith(
-      `/teams/org-slug/${team.slug}/`,
-      expect.objectContaining({
-        data: {
-          orgRole: 'owner',
-        },
-      })
-    );
-
-    // unset org role
-    const setDropdown = await screen.findByText('Owner');
-    await selectEvent.select(setDropdown, 'None');
-
-    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
-
-    expect(putMock).toHaveBeenCalledWith(
-      `/teams/org-slug/${team.slug}/`,
-      expect.objectContaining({
-        data: {
-          orgRole: '',
-        },
-      })
-    );
-  });
-
   it('needs team:admin in order to see an enabled Remove Team button', function () {
     const team = TeamFixture();
     const organization = OrganizationFixture({access: []});
@@ -121,34 +71,6 @@ describe('TeamSettings', function () {
     });
 
     expect(screen.getByTestId('button-remove-team')).toBeDisabled();
-  });
-
-  it('needs org:admin in order to set team org-role', function () {
-    const team = TeamFixture();
-    const organization = OrganizationFixture({
-      access: [],
-      features: ['org-roles-for-teams'],
-    });
-
-    render(<TeamSettings {...routerProps} team={team} params={{teamId: team.slug}} />, {
-      organization,
-    });
-
-    expect(screen.getByRole('textbox', {name: 'Organization Role'})).toBeDisabled();
-  });
-
-  it('cannot set team org-role for idp:provisioned team', function () {
-    const team = TeamFixture({flags: {'idp:provisioned': true}});
-    const organization = OrganizationFixture({
-      access: ['org:admin'],
-      features: ['org-roles-for-teams'],
-    });
-
-    render(<TeamSettings {...routerProps} team={team} params={{teamId: team.slug}} />, {
-      organization,
-    });
-
-    expect(screen.getByRole('textbox', {name: 'Organization Role'})).toBeDisabled();
   });
 
   it('can remove team', async function () {

--- a/static/app/views/settings/organizationTeams/teamSettings/index.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.tsx
@@ -52,13 +52,8 @@ function TeamSettings({team, params}: TeamSettingsProps) {
     }
   };
 
-  const idpProvisioned = team.flags['idp:provisioned'];
-  const orgRoleList = organization.orgRoleList;
-  const hasOrgRoleFlag = organization.features.includes('org-roles-for-teams');
-
   const hasTeamWrite = hasEveryAccess(['team:write'], {organization, team});
   const hasTeamAdmin = hasEveryAccess(['team:admin'], {organization, team});
-  const hasOrgAdmin = hasEveryAccess(['org:admin'], {organization});
 
   return (
     <Fragment>
@@ -81,11 +76,7 @@ function TeamSettings({team, params}: TeamSettingsProps) {
       >
         <JsonForm
           additionalFieldProps={{
-            idpProvisioned,
-            hasOrgRoleFlag,
             hasTeamWrite,
-            hasOrgAdmin,
-            orgRoleList,
           }}
           forms={teamSettingsFields}
         />

--- a/static/app/views/settings/organizationTeams/teamSettings/index.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.tsx
@@ -71,7 +71,6 @@ function TeamSettings({team, params}: TeamSettingsProps) {
         initialData={{
           name: team.name,
           slug: team.slug,
-          orgRole: team.orgRole,
         }}
       >
         <JsonForm


### PR DESCRIPTION
I implemented a feature last year to be able to set the organization role for all members of a team, but that feature will not be released so I'm removing all references to it.

This PR essentially reverts the FE changes made in #45064.

For https://github.com/getsentry/team-enterprise/issues/51