### PR TITLE
fix(crons): Don't show expected date for first check-in

### DIFF
--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -184,19 +184,23 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                 )}
                 {!hasMultiEnv ? null : <div>{checkIn.environment}</div>}
                 <div>
-                  <Tooltip
-                    disabled={!customTimezone}
-                    title={
-                      <DateTime
-                        date={checkIn.expectedTime}
-                        forcedTimezone={monitor.config.timezone ?? 'UTC'}
-                        timeZone
-                        seconds
-                      />
-                    }
-                  >
-                    <Timestamp date={checkIn.expectedTime} timeZone seconds />
-                  </Tooltip>
+                  {checkIn.expectedTime ? (
+                    <Tooltip
+                      disabled={!customTimezone}
+                      title={
+                        <DateTime
+                          date={checkIn.expectedTime}
+                          forcedTimezone={monitor.config.timezone ?? 'UTC'}
+                          timeZone
+                          seconds
+                        />
+                      }
+                    >
+                      <Timestamp date={checkIn.expectedTime} timeZone seconds />
+                    </Tooltip>
+                  ) : (
+                    emptyCell
+                  )}
                 </div>
               </Fragment>
             ))}


### PR DESCRIPTION
to avoid situations like this:

<img width="960" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/04b3d0a6-b6d4-497f-b8b7-5797fa2c94a3">
