### PR TITLE
Add a `payload_size` metric to the ingest consumer

### DIFF
--- a/src/sentry/ingest/consumer/attachment_event.py
+++ b/src/sentry/ingest/consumer/attachment_event.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def decode_and_process_chunks(
-    raw_message: Message[KafkaPayload],
+    raw_message: Message[KafkaPayload], consumer_type: str
 ) -> IngestMessage | None:
     """
     The first pass for the `attachments` topic:
@@ -31,6 +31,12 @@ def decode_and_process_chunks(
     - Process and save `attachment_chunk`s.
     """
     raw_payload = raw_message.payload.value
+    metrics.distribution(
+        "ingest_consumer.payload_size",
+        len(raw_payload),
+        tags={"consumer": consumer_type},
+        unit="byte",
+    )
     message: IngestMessage = msgpack.unpackb(raw_payload, use_list=False)
 
     if message["type"] == "attachment_chunk":

--- a/src/sentry/ingest/consumer/factory.py
+++ b/src/sentry/ingest/consumer/factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, MutableMapping
+from functools import partial
 from typing import Any, NamedTuple, TypeVar
 
 from arroyo import Topic
@@ -102,9 +103,8 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         final_step = CommitOffsets(commit)
 
         if not self.is_attachment_topic:
-            next_step = maybe_multiprocess_step(
-                mp, process_simple_event_message, final_step, self._pool
-            )
+            function = partial(process_simple_event_message, consumer_type=self.consumer_type)
+            next_step = maybe_multiprocess_step(mp, function, final_step, self._pool)
             return create_backpressure_step(health_checker=self.health_checker, next_step=next_step)
 
         # The `attachments` topic is a bit different, as it allows multiple event types:
@@ -129,8 +129,9 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         # As the steps are defined (and types inferred) in reverse order, we would get a type error here,
         # as `step_1` outputs an `| None`, but the `filter_step` does not mention that in its type,
         # as it is inferred from the `step_2` input type which does not mention `| None`.
+        function = partial(decode_and_process_chunks, consumer_type=self.consumer_type)
         step_1 = maybe_multiprocess_step(
-            mp, decode_and_process_chunks, filter_step, self._pool  # type:ignore
+            mp, function, filter_step, self._pool  # type:ignore
         )
 
         return create_backpressure_step(health_checker=self.health_checker, next_step=step_1)

--- a/src/sentry/ingest/consumer/simple_event.py
+++ b/src/sentry/ingest/consumer/simple_event.py
@@ -12,7 +12,7 @@ from .processors import IngestMessage, process_event
 logger = logging.getLogger(__name__)
 
 
-def process_simple_event_message(raw_message: Message[KafkaPayload]) -> None:
+def process_simple_event_message(raw_message: Message[KafkaPayload], consumer_type: str) -> None:
     """
     Processes a single Kafka Message containing a "simple" Event payload.
 
@@ -28,6 +28,12 @@ def process_simple_event_message(raw_message: Message[KafkaPayload]) -> None:
     """
 
     raw_payload = raw_message.payload.value
+    metrics.distribution(
+        "ingest_consumer.payload_size",
+        len(raw_payload),
+        tags={"consumer": consumer_type},
+        unit="byte",
+    )
     message: IngestMessage = msgpack.unpackb(raw_payload, use_list=False)
 
     message_type = message["type"]


### PR DESCRIPTION
In order to have better insights into the pipeline following INC-626, we would like to have a metric for the payload size that the ingest consumers receive from Kafka, because the existing metrics showed an increased read traffic.