### PR TITLE
fix(metrics-extraction): Remove isExtrapolatedData from legend

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -636,7 +636,7 @@ async function doOnDemandMetricsRequest(
       generatePathname: isEditing ? fetchEstimatedStats : undefined,
     });
 
-    response[0] = {...response[0], isMetricsData: true, isExtrapolatedData: isEditing};
+    response[0] = {...response[0]};
 
     return [response[0], response[1], response[2]];
   } catch (err) {


### PR DESCRIPTION
This keys shouldn't be part of the data body as it's not data, and for dashboards it automatically shows up in legends, if they are needed elsewhere they can be added to `ResponseMeta`. It looks like this is used in alerts but I don't see instances of this used in dashboards. 

![Screenshot 2024-02-06 at 7 47 45 AM](https://github.com/getsentry/sentry/assets/6111995/55f6abc9-51bf-485a-ab5e-060c7a1654b0)




Closes https://github.com/orgs/getsentry/projects/156/views/2\?pane\=issue\&itemId\=39293709
