### PR TITLE
feat(metrics-extraction): Add condition to update on-demand row

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1702,6 +1702,12 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Overrides modified date and always updates the row. Can be removed if not needed later.
+register(
+    "on_demand.update_on_demand_modified",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "delightful_metrics.minimetrics_sample_rate",

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from datetime import timezone
 from typing import Any
 
 import sentry_sdk
 from celery.exceptions import SoftTimeLimitExceeded
+from django.utils import timezone
 
 from sentry import options
 from sentry.api.utils import get_date_range_from_params

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from datetime import timezone
 from typing import Any
 
 import sentry_sdk
@@ -294,6 +295,11 @@ def _set_widget_on_demand_state(
 
         if on_demand.can_extraction_be_auto_overridden():
             on_demand.extraction_state = extraction_state
+
+        if options.get("on_demand.update_on_demand_modified"):
+            # Only temporarily required to check we've updated data on rows the task has passed
+            # Or updated to pass the check against widget query date_modified.
+            on_demand.date_modified = timezone.now()
 
         on_demand.spec_hashes = spec_hashes
         on_demand.save()


### PR DESCRIPTION
### Summary
This will cause the row to always be updated, which fixes the trouble with all the widget queries date modified being set to when the migration ran (Feb 5th) despite them likely being older than an on demand row
