### PR TITLE
fix(security): do not allow team-level access for certain org roles

### DIFF
--- a/src/sentry/conf/types/role_dict.py
+++ b/src/sentry/conf/types/role_dict.py
@@ -13,3 +13,4 @@ class RoleDict(TypedDict):
     is_retired: NotRequired[bool]
     is_global: NotRequired[bool]
     is_minimum_role_for: NotRequired[str]
+    is_team_roles_allowed: NotRequired[bool]

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -25,6 +25,7 @@ class Role(abc.ABC):
     desc: str
     scopes: frozenset[str]
     is_retired: bool = False
+    is_team_roles_allowed: bool = True
 
     def __post_init__(self) -> None:
         assert len(self.id) <= 32, "Role id must be no more than 32 characters"

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -145,8 +145,11 @@ class TeamMembers extends DeprecatedAsyncView<Props, State> {
           });
           addSuccessMessage(t('Successfully added member to team.'));
         },
-        error: () => {
-          addErrorMessage(t('Unable to add team member.'));
+        error: resp => {
+          const errorMessage =
+            (resp && resp.responseJSON && resp.responseJSON.detail) ||
+            t('Unable to add team member.');
+          addErrorMessage(errorMessage);
         },
       }
     );

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -13,12 +13,16 @@ from sentry.models.options.user_option import UserOption
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.roles import organization_roles
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from tests.sentry.api.endpoints.test_organization_member_index import (
+    mock_organization_roles_get_factory,
+)
 
 
 class OrganizationMemberTestBase(APITestCase):
@@ -550,6 +554,86 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         )
 
         self.get_error_response(self.organization.slug, member_om.id, status_code=403)
+
+    @patch(
+        "sentry.roles.organization_roles.get",
+        wraps=mock_organization_roles_get_factory(organization_roles.get),
+    )
+    def test_cannot_add_to_team_when_team_roles_disabled(self, mock_get):
+        team = self.create_team(organization=self.organization, name="Team Foo")
+
+        self.member = self.create_user()
+        self.member_om = self.create_member(
+            organization=self.organization, user=self.member, role="member", teams=[]
+        )
+
+        owner_user = self.create_user("owner@localhost")
+        self.owner = self.create_member(
+            user=owner_user, organization=self.organization, role="owner"
+        )
+        self.login_as(user=owner_user)
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.member_om.id,
+            teamRoles=[{"teamSlug": team.slug, "role": None}],
+            status_code=400,
+        )
+        assert (
+            response.data["detail"]
+            == "The user with a 'member' role cannot have team-level permissions."
+        )
+
+    @patch(
+        "sentry.roles.organization_roles.get",
+        wraps=mock_organization_roles_get_factory(organization_roles.get),
+    )
+    def test_cannot_demote_team_member_to_role_where_team_roles_disabled(self, mock_get):
+        team = self.create_team(organization=self.organization, name="Team Foo")
+
+        self.manager = self.create_user()
+        self.manager_om = self.create_member(
+            organization=self.organization, user=self.manager, role="manager", teams=[team]
+        )
+
+        owner_user = self.create_user("owner@localhost")
+        self.owner = self.create_member(
+            user=owner_user, organization=self.organization, role="owner"
+        )
+        self.login_as(user=owner_user)
+
+        response = self.get_error_response(
+            self.organization.slug, self.manager_om.id, orgRole="member", status_code=400
+        )
+        assert (
+            response.data["detail"]
+            == "The user with a 'member' role cannot have team-level permissions."
+        )
+
+    @patch(
+        "sentry.roles.organization_roles.get",
+        wraps=mock_organization_roles_get_factory(organization_roles.get),
+    )
+    def test_can_promote_team_member_to_role_where_team_roles_enabled(self, mock_get):
+        team = self.create_team(organization=self.organization, name="Team Foo")
+
+        self.member = self.create_user()
+        self.member_om = self.create_member(
+            organization=self.organization, user=self.member, role="member", teams=[]
+        )
+
+        owner_user = self.create_user("owner@localhost")
+        self.owner = self.create_member(
+            user=owner_user, organization=self.organization, role="owner"
+        )
+        self.login_as(user=owner_user)
+
+        self.get_success_response(
+            self.organization.slug,
+            self.member_om.id,
+            teamRoles=[{"teamSlug": team.slug, "role": None}],
+            orgRole="manager",
+        )
 
 
 @region_silo_test

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from unittest.mock import patch
 
 from django.core import mail
@@ -10,12 +11,24 @@ from sentry.models.authenticator import Authenticator
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.useremail import UserEmail
+from sentry.roles import organization_roles
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+
+
+def mock_organization_roles_get_factory(original_organization_roles_get):
+    def wrapped_method(role):
+        # emulate the 'member' role not having team-level permissions
+        role_obj = original_organization_roles_get(role)
+        if role == "member":
+            return replace(role_obj, is_team_roles_allowed=False)
+        return role_obj
+
+    return wrapped_method
 
 
 @region_silo_test
@@ -728,3 +741,25 @@ class OrganizationMemberListPostTest(OrganizationMemberListTestBase, HybridCloud
         data = {"email": "jane@gmail.com", "role": "member"}
         self.get_error_response(self.organization.slug, **data, status_code=429)
         assert not OrganizationMember.objects.filter(email="jane@gmail.com").exists()
+
+    @patch(
+        "sentry.roles.organization_roles.get",
+        wraps=mock_organization_roles_get_factory(organization_roles.get),
+    )
+    def test_cannot_add_to_team_when_team_roles_disabled(self, mock_get):
+        owner_user = self.create_user("owner@localhost")
+        self.owner = self.create_member(
+            user=owner_user, organization=self.organization, role="owner"
+        )
+        self.login_as(user=owner_user)
+
+        data = {
+            "email": "eric@localhost",
+            "orgRole": "member",
+            "teamRoles": [{"teamSlug": self.team.slug, "role": None}],
+        }
+        response = self.get_error_response(self.organization.slug, **data, status_code=400)
+        assert (
+            response.data["email"]
+            == "The user with a 'member' role cannot have team-level permissions."
+        )


### PR DESCRIPTION
Check if team-level roles are allowed for certain roles, on specific pages:
* invitation page
* team members page
* member settings page

Related: https://github.com/getsentry/getsentry/pull/12844