### PR TITLE
fix(hybrid-cloud): Fix client config for superuser

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -16,7 +16,7 @@ from packaging.version import parse as parse_version
 import sentry
 from sentry import features, options
 from sentry.api.utils import generate_organization_url, generate_region_url
-from sentry.auth import staff, superuser
+from sentry.auth import superuser
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.user import User
@@ -149,10 +149,7 @@ def _resolve_last_org(
     has_org_access = bool(org_context and org_context.member)
 
     if not has_org_access and user_is_authenticated:
-        has_staff = features.has("auth:enterprise-staff-cookie", actor=user)
-        is_active_staff = has_staff and staff.is_active_staff(request)
-        is_active_superuser = not has_staff and superuser.is_active_superuser(request)
-        has_org_access = is_active_staff or is_active_superuser
+        has_org_access = superuser.is_active_superuser(request)
 
     if org_context and has_org_access:
         return org_context.organization

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -8,19 +8,26 @@ import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages import get_messages
+from django.contrib.sessions.backends.base import SessionBase
 from django.core.cache import cache
+from django.http import HttpRequest
 from packaging.version import parse as parse_version
 
 import sentry
 from sentry import features, options
 from sentry.api.utils import generate_organization_url, generate_region_url
-from sentry.auth import superuser
+from sentry.auth import staff, superuser
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.organizationmapping import OrganizationMapping
+from sentry.models.user import User
 from sentry.services.hybrid_cloud.auth import AuthenticatedToken, AuthenticationContext
-from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.organization import (
+    RpcUserOrganizationContext,
+    organization_service,
+)
 from sentry.services.hybrid_cloud.project_key import ProjectKeyRole, project_key_service
 from sentry.services.hybrid_cloud.user import UserSerializeType
+from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.silo.base import SiloMode
@@ -115,13 +122,22 @@ def _delete_activeorg(session):
         del session["activeorg"]
 
 
-def _resolve_last_org(session, user, org_context=None):
+def _resolve_last_org(
+    request: HttpRequest | None,
+    session: SessionBase | None,
+    user: RpcUser | User | None,
+    org_context: RpcUserOrganizationContext | None = None,
+):
+    user_is_authenticated = (
+        user is not None and not isinstance(user, AnonymousUser) and user.is_authenticated
+    )
+
     if org_context is None:
         last_org_slug = session["activeorg"] if session and "activeorg" in session else None
         if not last_org_slug:
             return None
 
-        if user is not None and not isinstance(user, AnonymousUser):
+        if user_is_authenticated:
             org_context = organization_service.get_organization_by_slug(
                 slug=last_org_slug,
                 only_visible=False,
@@ -130,14 +146,26 @@ def _resolve_last_org(session, user, org_context=None):
                 include_teams=False,
             )
 
-    if org_context and org_context.member:
+    has_org_access = bool(org_context and org_context.member)
+
+    if not has_org_access and user_is_authenticated:
+        has_staff = features.has("auth:enterprise-staff-cookie", actor=user)
+        is_active_staff = has_staff and staff.is_active_staff(request)
+        is_active_superuser = not has_staff and superuser.is_active_superuser(request)
+        has_org_access = is_active_staff or is_active_superuser
+
+    if org_context and has_org_access:
         return org_context.organization
 
     return None
 
 
 class _ClientConfig:
-    def __init__(self, request=None, org_context=None) -> None:
+    def __init__(
+        self,
+        request: HttpRequest | None = None,
+        org_context: RpcUserOrganizationContext | None = None,
+    ) -> None:
         self.request = request
         if request is not None:
             self.user = getattr(request, "user", None) or AnonymousUser()
@@ -146,7 +174,7 @@ class _ClientConfig:
             self.user = None
             self.session = None
 
-        self.last_org = _resolve_last_org(self.session, self.user, org_context)
+        self.last_org = _resolve_last_org(request, self.session, self.user, org_context)
 
     @property
     def last_org_slug(self) -> str | None:
@@ -374,7 +402,9 @@ class _ClientConfig:
         }
 
 
-def get_client_config(request=None, org_context=None) -> MutableMapping[str, Any]:
+def get_client_config(
+    request=None, org_context: RpcUserOrganizationContext | None = None
+) -> MutableMapping[str, Any]:
     """
     Provides initial bootstrap data needed to boot the frontend application.
     """

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -301,11 +301,12 @@ class ReactPageViewTest(TestCase):
                 assert response.redirect_chain == [
                     (f"http://{other_org.slug}.testserver/issues/", 302)
                 ]
+                assert self.client.session["activeorg"] == other_org.slug
             else:
                 assert response.redirect_chain == [
                     (f"http://{other_org.slug}.testserver/auth/login/{other_org.slug}/", 302)
                 ]
-            assert self.client.session["activeorg"] == other_org.slug
+                assert "activeorg" not in self.client.session
 
             # Accessing org on non-customer domain with superuser and/or staff.
             response = self.client.get(

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -1,9 +1,11 @@
 from fnmatch import fnmatch
 
+from django.test import override_settings
 from django.urls import URLResolver, get_resolver, reverse
 
 from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -114,7 +116,6 @@ class ReactPageViewTest(TestCase):
             assert self.client.session["activeorg"]
 
         with self.feature({"organizations:customer-domains": True}):
-
             # Redirect to customer domain
             response = self.client.get(
                 reverse("sentry-organization-issue-list", args=[org.slug]), follow=True
@@ -182,7 +183,6 @@ class ReactPageViewTest(TestCase):
         self.login_as(user)
 
         with self.feature({"organizations:customer-domains": True}):
-
             url_name = "sentry-organization-create"
             url_name_is_non_customer_domain = any(
                 fnmatch(url_name, p) for p in NON_CUSTOMER_DOMAIN_URL_NAMES
@@ -261,30 +261,70 @@ class ReactPageViewTest(TestCase):
         assert response.status_code == 200
         self.assertTemplateUsed(response, "sentry/base-react.html")
 
-    def test_customer_domain_non_member_org_superuser(self):
-        org = self.create_organization(owner=self.user)
+    def test_customer_domain_non_member(self):
+        self.create_organization(owner=self.user)
         other_org = self.create_organization()
 
-        self.login_as(self.user, superuser=True)
-
-        with self.feature({"organizations:customer-domains": [org.slug]}):
-            # Induce activeorg
+        self.login_as(self.user)
+        with override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True), self.feature(
+            {"organizations:customer-domains": [other_org.slug]}
+        ):
+            # Should not be able to induce activeorg
+            assert "activeorg" not in self.client.session
             response = self.client.get(
                 "/",
-                HTTP_HOST=f"{org.slug}.testserver",
+                HTTP_HOST=f"{other_org.slug}.testserver",
                 follow=True,
             )
             assert response.status_code == 200
-            assert response.redirect_chain == [(f"http://{org.slug}.testserver/issues/", 302)]
-            assert self.client.session["activeorg"] == org.slug
+            assert response.redirect_chain == [(f"http://{other_org.slug}.testserver/issues/", 302)]
+            assert "activeorg" not in self.client.session
+
+    def _run_customer_domain_elevated_privileges(self, is_superuser: bool, is_staff: bool):
+        user = self.create_user("foo@example.com", is_superuser=is_superuser, is_staff=is_staff)
+        org = self.create_organization(owner=user)
+        other_org = self.create_organization()
+
+        self.login_as(user, superuser=is_superuser, staff=is_staff)
+        with override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True), self.feature(
+            {"organizations:customer-domains": [other_org.slug]}
+        ):
+            # Induce activeorg
+            assert "activeorg" not in self.client.session
+            response = self.client.get(
+                "/",
+                HTTP_HOST=f"{other_org.slug}.testserver",
+                follow=True,
+            )
+            assert response.status_code == 200
+            if is_superuser:
+                assert response.redirect_chain == [
+                    (f"http://{other_org.slug}.testserver/issues/", 302)
+                ]
+            else:
+                assert response.redirect_chain == [
+                    (f"http://{other_org.slug}.testserver/auth/login/{other_org.slug}/", 302)
+                ]
+            assert self.client.session["activeorg"] == other_org.slug
 
             # Access another org as superuser on non-customer domain
             response = self.client.get(
-                reverse("sentry-organization-issue-list", args=[other_org.slug]),
+                reverse("sentry-organization-issue-list", args=[org.slug]),
                 follow=True,
             )
             assert response.status_code == 200
             assert response.redirect_chain == []
+
+    def test_customer_domain_non_member_org_superuser(self):
+        self._run_customer_domain_elevated_privileges(is_superuser=True, is_staff=False)
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_customer_domain_non_member_org_staff(self):
+        self._run_customer_domain_elevated_privileges(is_superuser=False, is_staff=True)
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_customer_domain_non_member_org_superuser_and_staff(self):
+        self._run_customer_domain_elevated_privileges(is_superuser=True, is_staff=True)
 
     def test_customer_domain_superuser(self):
         org = self.create_organization(owner=self.user)

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -307,7 +307,7 @@ class ReactPageViewTest(TestCase):
                 ]
             assert self.client.session["activeorg"] == other_org.slug
 
-            # Access another org as superuser on non-customer domain
+            # Accessing org on non-customer domain with superuser and/or staff.
             response = self.client.get(
                 reverse("sentry-organization-issue-list", args=[org.slug]),
                 follow=True,

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -15,6 +15,7 @@ from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.scheduled import run_deletion
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, create_test_regions, region_silo_test
 from sentry.utils import json
 
@@ -188,9 +189,12 @@ class ClientConfigViewTest(TestCase):
         assert data["features"] == ["organizations:create"]
         assert data["customerDomain"] is None
 
-    def test_superuser(self):
-        user = self.create_user("foo@example.com", is_superuser=True)
-        self.login_as(user, superuser=True)
+    def _run_test_with_privileges(self, is_superuser: bool, is_staff: bool):
+        user = self.create_user("foo@example.com", is_superuser=is_superuser, is_staff=is_staff)
+        self.create_organization(owner=user)
+        self.login_as(user, superuser=is_superuser, staff=is_staff)
+
+        other_org = self.create_organization()
 
         with mock.patch("sentry.auth.superuser.ORG_ID", self.organization.id):
             resp = self.client.get(self.path)
@@ -202,32 +206,75 @@ class ClientConfigViewTest(TestCase):
         assert data["isAuthenticated"]
         assert data["user"]
         assert data["user"]["email"] == user.email
-        assert data["user"]["isSuperuser"] is True
+        assert data["user"]["isSuperuser"] is is_superuser
         assert data["lastOrganization"] is None
-        assert data["links"] == {
-            "organizationUrl": None,
-            "regionUrl": None,
-            "sentryUrl": "http://testserver",
-            "superuserUrl": f"http://{self.organization.slug}.testserver",
-        }
+        if is_superuser:
+            assert data["links"] == {
+                "organizationUrl": None,
+                "regionUrl": None,
+                "sentryUrl": "http://testserver",
+                "superuserUrl": f"http://{self.organization.slug}.testserver",
+            }
+        else:
+            assert data["links"] == {
+                "organizationUrl": None,
+                "regionUrl": None,
+                "sentryUrl": "http://testserver",
+            }
         assert "activeorg" not in self.client.session
 
         # Induce last active organization
-        resp = self.client.get(
-            reverse("sentry-api-0-organization-projects", args=[self.organization.slug])
-        )
-        assert resp.status_code == 200
-        assert resp["Content-Type"] == "application/json"
-        assert "activeorg" not in self.client.session
+        with override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True), self.feature(
+            {"organizations:customer-domains": [other_org.slug]}
+        ), assume_test_silo_mode(SiloMode.MONOLITH):
+            response = self.client.get(
+                "/",
+                HTTP_HOST=f"{other_org.slug}.testserver",
+                follow=True,
+            )
+            assert response.status_code == 200
+            if is_superuser:
+                assert response.redirect_chain == [
+                    (f"http://{other_org.slug}.testserver/issues/", 302)
+                ]
+            else:
+                assert response.redirect_chain == [
+                    (f"http://{other_org.slug}.testserver/auth/login/{other_org.slug}/", 302)
+                ]
+            assert self.client.session["activeorg"] == other_org.slug
 
-        # lastOrganization is not set
-        resp = self.client.get(self.path)
+        # lastOrganization is set
+        with mock.patch("sentry.auth.superuser.ORG_ID", self.organization.id):
+            resp = self.client.get(self.path)
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"
 
         data = json.loads(resp.content)
-        assert data["lastOrganization"] is None
-        assert "activeorg" not in self.client.session
+        assert data["lastOrganization"] == other_org.slug
+        if is_superuser:
+            assert data["links"] == {
+                "organizationUrl": f"http://{other_org.slug}.testserver",
+                "regionUrl": generate_region_url(),
+                "sentryUrl": "http://testserver",
+                "superuserUrl": f"http://{self.organization.slug}.testserver",
+            }
+        else:
+            assert data["links"] == {
+                "organizationUrl": f"http://{other_org.slug}.testserver",
+                "regionUrl": generate_region_url(),
+                "sentryUrl": "http://testserver",
+            }
+
+    def test_superuser(self):
+        self._run_test_with_privileges(is_superuser=True, is_staff=False)
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff(self):
+        self._run_test_with_privileges(is_superuser=False, is_staff=True)
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_superuser_and_staff(self):
+        self._run_test_with_privileges(is_superuser=True, is_staff=True)
 
     def test_superuser_cookie_domain(self):
         # Cannot set the superuser cookie domain using override_settings().

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -206,7 +206,6 @@ def test_client_config_links_regionurl():
 @multiregion_client_config_test
 @django_db_all
 def test_client_config_links_with_priority_org():
-    # request, user = make_user_request_from_non_existant_org()
     request, user = make_user_request_from_org()
     request.user = user
 


### PR DESCRIPTION
I noticed the client config is deleting the `activeorg` from the request session object when the current user is in superuser mode. A side effect of this that we're not properly propagating the accessed org in `links`. This pull request patches this.

I've also included tests for staff privileges as part of the upcoming superuser/staff split work.