### PR TITLE
chore(hybrid-cloud): Remove deprecated testutil

### DIFF
--- a/src/sentry/testutils/outbox.py
+++ b/src/sentry/testutils/outbox.py
@@ -8,13 +8,7 @@ from typing import Any
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
 
-from sentry.models.outbox import (
-    ControlOutbox,
-    OutboxBase,
-    OutboxCategory,
-    OutboxScope,
-    WebhookProviderIdentifier,
-)
+from sentry.models.outbox import ControlOutbox, OutboxBase, OutboxCategory, OutboxScope
 from sentry.silo import SiloMode
 from sentry.tasks.deliver_from_outbox import enqueue_outbox_jobs, enqueue_outbox_jobs_control
 from sentry.testutils.silo import assume_test_silo_mode
@@ -62,19 +56,6 @@ def outbox_runner(wrapped: Any | None = None) -> Any:
 def assert_no_webhook_outboxes():
     outboxes = ControlOutbox.objects.filter(category=OutboxCategory.WEBHOOK_PROXY).count()
     assert outboxes == 0, "No outboxes should be created"
-
-
-# DEPRECATED: use assert_webhook_outboxes_for_integration instead
-def assert_webhook_outboxes(
-    factory_request: WSGIRequest,
-    webhook_identifier: WebhookProviderIdentifier,
-    region_names: list[str],
-):
-    assert_webhook_outboxes_with_shard_id(
-        factory_request=factory_request,
-        expected_shard_id=webhook_identifier.value,
-        region_names=region_names,
-    )
 
 
 def assert_webhook_outboxes_with_shard_id(


### PR DESCRIPTION
All instances have already been replaced with `assert_webhook_outboxes_with_shard_id` cc @GabeVillalobos 