### PR TITLE
ref(tests): Remove usage of slack utils in favour of fixtures

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -125,7 +125,6 @@ from sentry.tagstore.snuba.backend import SnubaTagStorage
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.pytest.selenium import Browser
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.utils import json
@@ -2761,7 +2760,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
                     **base_params,
                 )
             UserOption.objects.create(user=self.user, key="self_notifications", value="1")
-            self.integration = install_slack(self.organization)
+            self.integration = self.create_slack_integration(self.organization)
             self.idp = IdentityProvider.objects.create(
                 type="slack", external_id="TXXXXXXX1", config={}
             )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1570,8 +1570,8 @@ class Factories:
     @assume_test_silo_mode(SiloMode.CONTROL)
     def create_slack_integration(
         organization: Organization,
+        user: User | RpcUser | None = None,
         external_id: str = "TXXXXXXX1",
-        user: User | None = None,
     ) -> Integration:
         integration_params = {
             "provider": "slack",
@@ -1582,19 +1582,12 @@ class Factories:
                 "installation_type": "born_as_bot",
             },
         }
-        if user:
-            integration, _, _, _ = Factories.create_identity_integration(
-                user=user,
-                organization=organization,
-                integration_params=integration_params,
-                identity_params={"external_id": "UXXXXXXX1"},
-            )
-        else:
-            integration, _ = Factories.create_provider_integration_for(
-                user=user,
-                organization=organization,
-                **integration_params,
-            )
+        integration, _, _, _ = Factories.create_identity_integration(
+            user=user,
+            organization=organization,
+            integration_params=integration_params,
+            identity_params={"external_id": "UXXXXXXX1"},
+        )
         return integration
 
     @staticmethod

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1569,18 +1569,32 @@ class Factories:
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)
     def create_slack_integration(
-        organization: Organization, external_id: str, **kwargs: Any
+        organization: Organization,
+        external_id: str = "TXXXXXXX1",
+        user: User | None = None,
     ) -> Integration:
-        integration = Integration.objects.create(
-            provider="slack",
-            name="Team A",
-            external_id=external_id,
-            metadata={
+        integration_params = {
+            "provider": "slack",
+            "name": "Team A",
+            "external_id": external_id,
+            "metadata": {
                 "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
                 "installation_type": "born_as_bot",
             },
-        )
-        integration.add_organization(organization)
+        }
+        if user:
+            integration, _, _, _ = Factories.create_identity_integration(
+                user=user,
+                organization=organization,
+                integration_params=integration_params,
+                identity_params={"external_id": "UXXXXXXX1"},
+            )
+        else:
+            integration, _ = Factories.create_provider_integration_for(
+                user=user,
+                organization=organization,
+                **integration_params,
+            )
         return integration
 
     @staticmethod

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -460,22 +460,18 @@ class Fixtures:
     def create_slack_integration(
         self,
         organization: Organization,
-        external_id: str = "TXXXXXXX1",
         user: RpcUser | None = None,
-        identity_external_id: str = "UXXXXXXX1",
-        **kwargs: Any,
+        external_id: str = "TXXXXXXX1",
     ):
         if user is None:
             with assume_test_silo_mode(SiloMode.REGION):
                 user = organization.get_default_owner()
 
-        integration = Factories.create_slack_integration(
-            organization=organization, external_id=external_id, **kwargs
+        return Factories.create_slack_integration(
+            organization=organization,
+            user=user,
+            external_id=external_id,
         )
-        idp = Factories.create_identity_provider(integration=integration)
-        Factories.create_identity(user, idp, identity_external_id)
-
-        return integration
 
     def create_integration(
         self,

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
@@ -16,7 +16,6 @@ from sentry.models.notificationaction import (
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
@@ -223,7 +222,7 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
         channel_name = "journal"
         channel_id = "CABC123"
 
-        integration = install_slack(organization=self.organization)
+        integration = self.create_slack_integration(organization=self.organization)
         data = {
             "triggerType": "audit-log",
             "targetType": "specific",

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
@@ -16,7 +16,6 @@ from sentry.models.notificationaction import (
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
@@ -271,7 +270,7 @@ class NotificationActionsIndexEndpointTest(APITestCase):
         channel_name = "journal"
         channel_id = "CABC123"
 
-        integration = install_slack(organization=self.organization)
+        integration = self.create_slack_integration(organization=self.organization)
         data = {
             "triggerType": "audit-log",
             "targetType": "specific",

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -16,7 +16,6 @@ from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityTy
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
@@ -78,7 +77,7 @@ class ProjectRuleDetailsBaseTestCase(APITestCase):
     def setUp(self):
         self.rule = self.create_project_rule(project=self.project)
         self.environment = self.create_environment(self.project, name="production")
-        self.slack_integration = install_slack(organization=self.organization)
+        self.slack_integration = self.create_slack_integration(organization=self.organization)
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.jira_integration = self.create_provider_integration(
                 provider="jira", name="Jira", external_id="jira:1"

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -17,7 +17,7 @@ from sentry.models.user import User
 from sentry.silo import SiloMode
 from sentry.tasks.integrations.slack.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import install_slack, with_feature
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
@@ -27,7 +27,7 @@ class ProjectRuleBaseTestCase(APITestCase):
 
     def setUp(self):
         self.rule = self.create_project_rule(project=self.project)
-        self.slack_integration = install_slack(organization=self.organization)
+        self.slack_integration = self.create_slack_integration(organization=self.organization)
         self.sentry_app = self.create_sentry_app(
             name="Pied Piper",
             organization=self.organization,

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -4,7 +4,7 @@ from sentry.integrations.slack.views.link_identity import build_linking_url
 from sentry.integrations.slack.views.unlink_identity import build_unlinking_url
 from sentry.models.identity import Identity, IdentityStatus
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import add_identity, install_slack
+from sentry.testutils.helpers import add_identity
 from sentry.testutils.silo import control_silo_test
 
 
@@ -17,7 +17,7 @@ class SlackIntegrationLinkIdentityTestBase(TestCase):
         self.channel_id = "my-channel"
         self.response_url = "http://example.slack.com/response_url"
 
-        self.integration = install_slack(self.organization)
+        self.integration = self.create_slack_integration(self.organization)
         self.idp = add_identity(self.integration, self.user, self.external_id)
 
         responses.add(

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -15,7 +15,7 @@ from sentry.models.organization import Organization
 from sentry.models.team import Team
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import add_identity, get_response_text, install_slack, link_team
+from sentry.testutils.helpers import add_identity, get_response_text, link_team
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
@@ -34,7 +34,7 @@ class SlackIntegrationLinkTeamTestBase(TestCase):
         self.channel_id = "my-channel_id"
         self.response_url = "http://example.slack.com/response_url"
 
-        self.integration = install_slack(self.organization)
+        self.integration = self.create_slack_integration(self.organization)
         self.idp = add_identity(self.integration, self.user, self.external_id)
 
         responses.add(

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -16,7 +16,6 @@ from sentry.tasks.integrations.slack import (
     post_message,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import install_slack
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
@@ -27,7 +26,7 @@ pytestmark = [requires_snuba]
 @region_silo_test
 class SlackTasksTest(TestCase):
     def setUp(self):
-        self.integration = install_slack(self.organization)
+        self.integration = self.create_slack_integration(organization=self.organization)
         self.uuid = uuid4().hex
 
     @pytest.fixture(autouse=True)

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -16,7 +16,6 @@ from sentry.integrations.slack.unfurl import LinkType, UnfurlableUrl, link_handl
 from sentry.services.hybrid_cloud.integration.serial import serialize_integration
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
@@ -177,7 +176,7 @@ class UnfurlTest(TestCase):
         # We're redefining project to ensure that the individual tests have unique project ids.
         # Sharing project ids across tests could result in some race conditions
         self.project = self.create_project()
-        self._integration = install_slack(self.organization)
+        self._integration = self.create_slack_integration(organization=self.organization)
         self.integration = serialize_integration(self._integration)
 
         self.request = RequestFactory().get("slack/event")

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -5,7 +5,6 @@ from sentry.integrations.slack.utils import get_channel_id
 from sentry.integrations.slack.utils.channel import CHANNEL_PREFIX, MEMBER_PREFIX
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, DuplicateDisplayNameError
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import install_slack
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
 
@@ -17,7 +16,9 @@ class GetChannelIdTest(TestCase):
         self.resp = responses.mock
         self.resp.__enter__()
 
-        self.integration = install_slack(self.event.project.organization)
+        self.integration = self.create_slack_integration(
+            organization=self.event.project.organization
+        )
 
     def tearDown(self):
         self.resp.__exit__(None, None, None)

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import add_identity, install_slack
+from sentry.testutils.helpers import add_identity
 from sentry.utils import json
 
 
@@ -9,7 +9,7 @@ class BaseEventTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.external_id = "slack:1"
-        self.integration = install_slack(self.organization)
+        self.integration = self.create_slack_integration(organization=self.organization)
         self.idp = add_identity(self.integration, self.user, self.external_id)
 
         self.trigger_id = "13345224609.738474920.8088930838d88f008e0"

--- a/tests/sentry/integrations/slack/webhooks/commands/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/__init__.py
@@ -14,7 +14,7 @@ from sentry.models.identity import Identity
 from sentry.models.team import Team
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase, TestCase
-from sentry.testutils.helpers import find_identity, install_slack, link_team, link_user
+from sentry.testutils.helpers import find_identity, link_team, link_user
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json
@@ -33,7 +33,9 @@ class SlackCommandsTest(APITestCase, TestCase):
         self.channel_id = "my-channel_id"
         self.response_url = "http://example.slack.com/response_url"
 
-        self.integration = install_slack(self.organization, self.external_id)
+        self.integration = self.create_slack_integration(
+            organization=self.organization, external_id=self.external_id
+        )
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.idp = self.create_identity_provider(
                 type=EXTERNAL_PROVIDERS[ExternalProviders.SLACK],

--- a/tests/sentry/integrations/slack/webhooks/events/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/events/__init__.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import install_slack
 from sentry.utils import json
 
 UNSET = object()
@@ -49,7 +48,7 @@ def build_test_block(link):
 class BaseEventTest(APITestCase):
     def setUp(self):
         super().setUp()
-        self.integration = install_slack(self.organization)
+        self.integration = self.create_slack_integration(organization=self.organization)
 
     @patch(
         "sentry.integrations.slack.requests.SlackRequest._check_signing_secret", return_value=True

--- a/tests/sentry/integrations/slack/webhooks/options_load/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/options_load/__init__.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.slack import install_slack
 from sentry.utils import json
 
 
@@ -9,7 +8,7 @@ class BaseEventTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.external_id = "slack:1"
-        self.integration = install_slack(self.organization)
+        self.integration = self.create_slack_integration(organization=self.organization)
         self.channel = {"channel_id": "C065W1189", "name": "workflow"}
 
     @patch(

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -19,7 +19,6 @@ from sentry.rules.conditions import EventCondition
 from sentry.rules.filters.base import EventFilter
 from sentry.rules.processor import RuleProcessor
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import install_slack
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
@@ -147,7 +146,7 @@ class RuleProcessorTest(TestCase):
 
     def test_muted_slack_rule(self):
         """Test that we don't sent a notification for a muted Slack rule"""
-        integration = install_slack(self.organization)
+        integration = self.create_slack_integration(organization=self.organization)
         action_data = [
             {
                 "channel": "#my-channel",
@@ -673,7 +672,7 @@ class RuleProcessorTestFilters(TestCase):
     @patch("sentry.shared_integrations.client.base.BaseApiClient.post")
     def test_slack_title_link_notification_uuid(self, mock_post):
         """Test that the slack title link includes the notification uuid from apply function"""
-        integration = install_slack(self.organization)
+        integration = self.create_slack_integration(organization=self.organization)
         action_data = [
             {
                 "channel": "#my-channel",


### PR DESCRIPTION
This may be an opinionated PR that we don't necessarily need, but in the long term I don't think it makes sense to have utils be scoped so heavily per integration for tests when they're just creating DB models. They become hard to find and obscure some details that may be helpful being surfaced in the test. We're not adding more util files for other integrations, so I would like to bring slack testutil usage over to fixtures as a drop in alternative.

Additionally, it has the benefit of auto-completion with any tests inheriting from `TestCase` and will hopefully increase the visibility that these methods exist.