### PR TITLE
fix(projects): Fix session metrics not rendering when period is 45+ days

### DIFF
--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -72,6 +72,12 @@ const useCrashFreeRate = (props: Props) => {
     {staleTime: 0, enabled: isEnabled}
   );
 
+  const isPreviousPeriodEnabled = shouldFetchPreviousPeriod({
+    start: datetime.start,
+    end: datetime.end,
+    period: datetime.period,
+  });
+
   const previousQuery = useApiQuery<SessionApiResponse>(
     [
       `/organizations/${organization.slug}/sessions/`,
@@ -85,20 +91,15 @@ const useCrashFreeRate = (props: Props) => {
     ],
     {
       staleTime: 0,
-      enabled:
-        isEnabled &&
-        shouldFetchPreviousPeriod({
-          start: datetime.start,
-          end: datetime.end,
-          period: datetime.period,
-        }),
+      enabled: isEnabled && isPreviousPeriodEnabled,
     }
   );
 
   return {
     crashFreeRate: currentQuery.data,
     previousCrashFreeRate: previousQuery.data,
-    isLoading: currentQuery.isLoading || previousQuery.isLoading,
+    isLoading:
+      currentQuery.isLoading || (previousQuery.isLoading && isPreviousPeriodEnabled),
     error: currentQuery.error || previousQuery.error,
     refetch: () => {
       currentQuery.refetch();


### PR DESCRIPTION
Session metrics don't render on 45+ days because the previous period query `isLoading` state is always true. Fix this by updating `isLoading` to check to see if the query is enabled.

![image](https://github.com/getsentry/sentry/assets/83961295/8f2c80e1-7480-47b1-afb9-a868734ae96f)
