### PR TITLE
WIP - feedback includes trace navigator

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
@@ -12,6 +12,7 @@ import TimeSince from 'sentry/components/timeSince';
 import {space} from 'sentry/styles/space';
 import type {Event, Group} from 'sentry/types';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
+import {TraceTimeline} from 'sentry/views/issueDetails/traceTimeline/traceTimeline';
 
 interface Props {
   eventData: Event | undefined;
@@ -29,6 +30,7 @@ const fixIssueLinkSpacing = css`
 export default function FeedbackItemHeader({eventData, feedbackItem}: Props) {
   return (
     <VerticalSpacing>
+      {eventData ? <TraceTimeline event={eventData} /> : null}
       <Flex wrap="wrap" flex="1 1 auto" gap={space(1)} justify="space-between">
         <FeedbackItemUsername feedbackIssue={feedbackItem} detailDisplay />
 


### PR DESCRIPTION
Here's what the page looks like while this is loading, then when nothing is found.
There's also an earlier state where we don't know if we should even try to load the trace view (we need to look at the feedback itself to see if there's a trace id), in that case nothing is rendered at all, layout shift happens afterwards.

**Loading**
<img width="1254" alt="SCR-20240206-iqbn" src="https://github.com/getsentry/sentry/assets/187460/04ba187a-19cd-4d86-b4e3-2144e44f8a40">

**Loaded, no trace found**
<img width="1254" alt="SCR-20240206-ipzz" src="https://github.com/getsentry/sentry/assets/187460/653dbb12-e0d7-4f3e-b320-847c3dd5d415">
