### PR TITLE
ref(metrics-extraction): Modify metric for 0 on demand rows

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, TypedDict
 
 import sentry_sdk
 from celery.exceptions import SoftTimeLimitExceeded
+from django.utils import timezone
 from sentry_relay.processing import validate_sampling_condition
 
 from sentry import features, options

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -1,9 +1,9 @@
 import logging
 import random
-from datetime import timedelta
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, Literal, TypedDict
 
 import sentry_sdk


### PR DESCRIPTION
### Summary
This splits up the metric to check we're skipped recently modified or not
