### PR TITLE
fix(group-attributes): Fix redis cluster usage

### DIFF
--- a/src/sentry/migrations/0641_backfill_group_attributes.py
+++ b/src/sentry/migrations/0641_backfill_group_attributes.py
@@ -3,6 +3,7 @@ import dataclasses
 from datetime import datetime
 from enum import Enum
 
+from django.conf import settings
 from django.db import migrations
 from django.db.models import F, Window
 from django.db.models.functions import Rank
@@ -124,7 +125,7 @@ def backfill_group_attributes_to_snuba(apps, schema_editor):
     GroupOwner = apps.get_model("sentry", "GroupOwner")
 
     backfill_key = "backfill_group_attributes_to_snuba_progress"
-    redis_client = redis.redis_clusters.get("default")
+    redis_client = redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
 
     progress_id = int(redis_client.get(backfill_key) or 0)
 


### PR DESCRIPTION
I need to use a setting to define the cluster in use. Since we're using just one key, I'm just piggybacking off of an existing system's redis cluster