### PR TITLE
ref: move the warnings carevout for migrations to pytest init

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -140,7 +140,7 @@ jobs:
       - name: run tests
         run: |
           # historic migrations trigger some warnings
-          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations -W ignore" make test-python-ci
+          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations" make test-python-ci
 
       # Upload coverage data even if running the tests step fails since
       # it reduces large coverage fluctuations

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -91,6 +91,10 @@ def pytest_configure(config: pytest.Config) -> None:
 
     config.addinivalue_line("markers", "migrations: requires --migrations")
 
+    if not config.getvalue("nomigrations"):
+        # XXX: ignore warnings in historic migrations
+        config.addinivalue_line("filterwarnings", "ignore:.*index_together.*")
+
     if sys.platform == "darwin" and shutil.which("colima"):
         # This is the only way other than pytest --basetemp to change
         # the temproot. We'd like to keep invocations to just "pytest".


### PR DESCRIPTION
<!-- Describe your PR here. -->

since django 4.2 raises warnings on legacy usage of `index_together` -- until we squash we'll need this to make it easier to run locally