### PR TITLE
feat(app-start): Merge samples tables

### DIFF
--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -35,6 +35,8 @@ export enum SpanMetricsField {
   HTTP_RESPONSE_TRANSFER_SIZE = 'http.response_transfer_size',
   FILE_EXTENSION = 'file_extension',
   OS_NAME = 'os.name',
+  APP_START_TYPE = 'app_start_type',
+  DEVICE_CLASS = 'device.class',
 }
 
 export type SpanNumberFields =

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -42,6 +42,8 @@ export function EventSamples({
   const {selection} = usePageFilters();
   const {primaryRelease} = useReleaseSelection();
   const cursor = decodeScalar(location.query?.[cursorName]);
+
+  const deviceClass = decodeScalar(location.query[SpanMetricsField.DEVICE_CLASS]) ?? '';
   const startType = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
 
   const searchQuery = new MutableSearch([
@@ -55,8 +57,6 @@ export function EventSamples({
     ')',
     `${SpanMetricsField.APP_START_TYPE}:${startType || '[cold,warm]'}`,
   ]);
-
-  const deviceClass = decodeScalar(location.query['device.class']);
 
   if (deviceClass) {
     if (deviceClass === 'Unknown') {

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -12,6 +12,7 @@ import {
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/starfish/components/releaseSelector';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {EventSamplesTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamplesTable';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
@@ -41,6 +42,7 @@ export function EventSamples({
   const {selection} = usePageFilters();
   const {primaryRelease} = useReleaseSelection();
   const cursor = decodeScalar(location.query?.[cursorName]);
+  const startType = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
 
   const searchQuery = new MutableSearch([
     `transaction:${transaction}`,
@@ -51,6 +53,7 @@ export function EventSamples({
     'OR',
     'span.description:"Warm Start"',
     ')',
+    `${SpanMetricsField.APP_START_TYPE}:${startType || '[cold,warm]'}`,
   ]);
 
   const deviceClass = decodeScalar(location.query['device.class']);

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -13,6 +13,10 @@ import {
 } from 'sentry/views/starfish/components/releaseSelector';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {
+  COLD_START_TYPE,
+  WARM_START_TYPE,
+} from 'sentry/views/starfish/views/appStartup/screenSummary/startTypeSelector';
 import {EventSamplesTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamplesTable';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
@@ -55,7 +59,9 @@ export function EventSamples({
     'OR',
     'span.description:"Warm Start"',
     ')',
-    `${SpanMetricsField.APP_START_TYPE}:${startType || '[cold,warm]'}`,
+    `${SpanMetricsField.APP_START_TYPE}:${
+      startType || `[${COLD_START_TYPE},${WARM_START_TYPE}]`
+    }`,
   ]);
 
   if (deviceClass) {

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -25,6 +25,7 @@ type Props = {
   release: string;
   sortKey: string;
   transaction: string;
+  footerAlignedPagination?: boolean;
   showDeviceClassSelector?: boolean;
 };
 
@@ -34,6 +35,7 @@ export function EventSamples({
   release,
   sortKey,
   showDeviceClassSelector,
+  footerAlignedPagination,
 }: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
@@ -112,6 +114,7 @@ export function EventSamples({
       showDeviceClassSelector={showDeviceClassSelector}
       columnNameMap={columnNameMap}
       sort={sort}
+      footerAlignedPagination={footerAlignedPagination}
     />
   );
 }

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -23,13 +23,8 @@ import {
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/starfish/components/releaseSelector';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {EventSamples} from 'sentry/views/starfish/views/appStartup/screenSummary/eventSamples';
-import {SpanOperationTable} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOperationTable';
+import {SamplesTables} from 'sentry/views/starfish/views/appStartup/screenSummary/samples';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
-import {
-  MobileCursors,
-  MobileSortKeys,
-} from 'sentry/views/starfish/views/screens/constants';
 import {MetricsRibbon} from 'sentry/views/starfish/views/screens/screenLoadSpans/metricsRibbon';
 import {ScreenLoadSpanSamples} from 'sentry/views/starfish/views/screens/screenLoadSpans/samples';
 
@@ -194,36 +189,9 @@ function ScreenSummary() {
               <ErrorBoundary mini>
                 <AppStartWidgets additionalFilters={[`transaction:${transactionName}`]} />
               </ErrorBoundary>
-              <EventSamplesContainer>
-                <ErrorBoundary mini>
-                  <div>
-                    <EventSamples
-                      cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
-                      sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
-                      release={primaryRelease}
-                      transaction={transactionName}
-                      showDeviceClassSelector
-                    />
-                  </div>
-                </ErrorBoundary>
-                <ErrorBoundary mini>
-                  <div>
-                    <EventSamples
-                      cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
-                      sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
-                      release={secondaryRelease}
-                      transaction={transactionName}
-                    />
-                  </div>
-                </ErrorBoundary>
-              </EventSamplesContainer>
-              <ErrorBoundary mini>
-                <SpanOperationTable
-                  transaction={transactionName}
-                  primaryRelease={primaryRelease}
-                  secondaryRelease={secondaryRelease}
-                />
-              </ErrorBoundary>
+              <SamplesContainer>
+                <SamplesTables transactionName={transactionName} />
+              </SamplesContainer>
               {spanGroup && spanOp && (
                 <ScreenLoadSpanSamples
                   groupId={spanGroup}
@@ -265,9 +233,6 @@ const Container = styled('div')`
   }
 `;
 
-const EventSamplesContainer = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+const SamplesContainer = styled('div')`
   margin-top: ${space(2)};
-  gap: ${space(2)};
 `;

--- a/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
@@ -80,7 +80,7 @@ export function SamplesTables({transactionName}) {
             />
           )}
           <StartTypeSelector />
-          <DeviceClassSelector size="md" />
+          <DeviceClassSelector size="md" clearSpansTableCursor />
         </FiltersContainer>
         <SegmentedControl onChange={value => setSampleType(value)} defaultValue={SPANS}>
           <SegmentedControl.Item key={SPANS}>{t('By Spans')}</SegmentedControl.Item>

--- a/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
@@ -72,11 +72,13 @@ export function SamplesTables({transactionName}) {
     <div>
       <Controls>
         <FiltersContainer>
-          <SpanOpSelector
-            primaryRelease={primaryRelease}
-            transaction={transactionName}
-            secondaryRelease={secondaryRelease}
-          />
+          {sampleType === SPANS && (
+            <SpanOpSelector
+              primaryRelease={primaryRelease}
+              transaction={transactionName}
+              secondaryRelease={secondaryRelease}
+            />
+          )}
           <StartTypeSelector />
           <DeviceClassSelector size="md" />
         </FiltersContainer>

--- a/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
@@ -1,4 +1,4 @@
-import {type ReactNode, useState} from 'react';
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -23,41 +23,41 @@ export function SamplesTables({transactionName}) {
   const [sampleType, setSampleType] = useState<typeof EVENT | typeof SPANS>(SPANS);
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
 
-  let content: null | ReactNode = null;
+  const content = useMemo(() => {
+    if (sampleType === EVENT) {
+      return (
+        <EventSplitContainer>
+          <ErrorBoundary mini>
+            {primaryRelease && (
+              <div>
+                <EventSamples
+                  cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
+                  sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
+                  release={primaryRelease}
+                  transaction={transactionName}
+                  footerAlignedPagination
+                />
+              </div>
+            )}
+          </ErrorBoundary>
+          <ErrorBoundary mini>
+            {secondaryRelease && (
+              <div>
+                <EventSamples
+                  cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
+                  sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
+                  release={secondaryRelease}
+                  transaction={transactionName}
+                  footerAlignedPagination
+                />
+              </div>
+            )}
+          </ErrorBoundary>
+        </EventSplitContainer>
+      );
+    }
 
-  if (sampleType === EVENT) {
-    content = (
-      <EventSplitContainer>
-        <ErrorBoundary mini>
-          {primaryRelease && (
-            <div>
-              <EventSamples
-                cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
-                sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
-                release={primaryRelease}
-                transaction={transactionName}
-                footerAlignedPagination
-              />
-            </div>
-          )}
-        </ErrorBoundary>
-        <ErrorBoundary mini>
-          {secondaryRelease && (
-            <div>
-              <EventSamples
-                cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
-                sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
-                release={secondaryRelease}
-                transaction={transactionName}
-                footerAlignedPagination
-              />
-            </div>
-          )}
-        </ErrorBoundary>
-      </EventSplitContainer>
-    );
-  } else {
-    content = (
+    return (
       <ErrorBoundary mini>
         <SpanOperationTable
           transaction={transactionName}
@@ -66,7 +66,7 @@ export function SamplesTables({transactionName}) {
         />
       </ErrorBoundary>
     );
-  }
+  }, [primaryRelease, sampleType, secondaryRelease, transactionName]);
 
   return (
     <div>

--- a/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
@@ -77,7 +77,7 @@ export function SamplesTables({transactionName}) {
             secondaryRelease={secondaryRelease}
           />
           <StartTypeSelector />
-          <DeviceClassSelector />
+          <DeviceClassSelector size="md" />
         </FiltersContainer>
         <SegmentedControl onChange={value => setSampleType(value)} defaultValue={SPANS}>
           <SegmentedControl.Item key={SPANS}>By Spans</SegmentedControl.Item>

--- a/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {EventSamples} from 'sentry/views/starfish/views/appStartup/screenSummary/eventSamples';
@@ -80,8 +81,8 @@ export function SamplesTables({transactionName}) {
           <DeviceClassSelector size="md" />
         </FiltersContainer>
         <SegmentedControl onChange={value => setSampleType(value)} defaultValue={SPANS}>
-          <SegmentedControl.Item key={SPANS}>By Spans</SegmentedControl.Item>
-          <SegmentedControl.Item key={EVENT}>By Event</SegmentedControl.Item>
+          <SegmentedControl.Item key={SPANS}>{t('By Spans')}</SegmentedControl.Item>
+          <SegmentedControl.Item key={EVENT}>{t('By Event')}</SegmentedControl.Item>
         </SegmentedControl>
       </Controls>
       {content}

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
@@ -1,9 +1,7 @@
 import {browserHistory} from 'react-router';
-import styled from '@emotion/styled';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {NewQuery} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -73,7 +71,7 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
   ];
 
   return (
-    <StyledCompactSelect
+    <CompactSelect
       triggerProps={{prefix: t('Operation'), size: 'xs'}}
       value={value}
       options={options ?? []}
@@ -90,7 +88,3 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
     />
   );
 }
-
-const StyledCompactSelect = styled(CompactSelect)`
-  margin-bottom: ${space(1)};
-`;

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
@@ -72,7 +72,7 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
 
   return (
     <CompactSelect
-      triggerProps={{prefix: t('Operation'), size: 'xs'}}
+      triggerProps={{prefix: t('Operation')}}
       value={value}
       options={options ?? []}
       onChange={newValue => {

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
@@ -48,7 +48,7 @@ describe('SpanOpSelector', function () {
             'span.description': 'string',
             'span.group': 'string',
             'avg_if(span.self_time,release,release1)': 'duration',
-            'time_spent_percentage()': 'percentage',
+            'avg_compare(span.self_time,release,release1,release2)': 'percent_change',
             'count()': 'integer',
             'avg_if(span.self_time,release,release2)': 'duration',
             'sum(span.self_time)': 'duration',
@@ -61,7 +61,7 @@ describe('SpanOpSelector', function () {
             'span.description': 'Application Init',
             'span.group': '7f4be68f08c0455f',
             'avg_if(span.self_time,release,release1)': 22.549867,
-            'time_spent_percentage()': 0.003017625053431528,
+            'avg_compare(span.self_time,release,release1,release2)': 0.5,
             'count()': 14,
             'avg_if(span.self_time,release,release2)': 12504.931908384617,
             'sum(span.self_time)': 162586.66467600001,
@@ -84,15 +84,15 @@ describe('SpanOpSelector', function () {
     expect(screen.getByRole('link', {name: 'Span Description'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Duration (R1)'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Duration (R2)'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Change'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Total Count'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Total Time Spent'})).toBeInTheDocument();
 
     expect(await screen.findByRole('cell', {name: 'app.start.warm'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: 'Application Init'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '22.55ms'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '12.50s'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '+50%'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '14'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '2.71min'})).toBeInTheDocument();
 
     expect(screen.getByRole('link', {name: 'Application Init'})).toHaveAttribute(
       'href',

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
@@ -82,17 +82,15 @@ describe('SpanOpSelector', function () {
 
     expect(await screen.findByRole('link', {name: 'Operation'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Span Description'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Duration (R1)'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Duration (R2)'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Avg Duration (R1)'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Avg Duration (R2)'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Change'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Total Count'})).toBeInTheDocument();
 
     expect(await screen.findByRole('cell', {name: 'app.start.warm'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: 'Application Init'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '22.55ms'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '12.50s'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '+50%'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '14'})).toBeInTheDocument();
 
     expect(screen.getByRole('link', {name: 'Application Init'})).toHaveAttribute(
       'href',

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -68,6 +68,8 @@ export function SpanOperationTable({
   const cursor = decodeScalar(location.query?.[MobileCursors.SPANS_TABLE]);
 
   const spanOp = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
+  const startType = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+  const deviceClass = decodeScalar(location.query[SpanMetricsField.DEVICE_CLASS]) ?? '';
 
   const searchQuery = new MutableSearch([
     'transaction.op:ui.load',
@@ -76,10 +78,9 @@ export function SpanOperationTable({
     // Exclude root level spans because they're comprised of nested operations
     '!span.description:"Cold Start"',
     '!span.description:"Warm Start"',
-    `app_start_type:[cold,warm]`,
-    ...(spanOp
-      ? [`${SpanMetricsField.SPAN_OP}:${spanOp}`]
-      : [`span.op:[${[...STARTUP_SPANS].join(',')}]`]),
+    `${SpanMetricsField.APP_START_TYPE}:${startType || '[cold,warm]'}`,
+    `${SpanMetricsField.SPAN_OP}:${spanOp || `[${[...STARTUP_SPANS].join(',')}]`}`,
+    ...(deviceClass ? [`${SpanMetricsField.DEVICE_CLASS}:${deviceClass}`] : []),
   ]);
   const queryStringPrimary = appendReleaseFilters(
     searchQuery,

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import {browserHistory} from 'react-router';
-import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
 import {getInterval} from 'sentry/components/charts/utils';
@@ -10,7 +9,6 @@ import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
-import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
@@ -38,8 +36,14 @@ import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
-const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
-  SpanMetricsField;
+const {
+  SPAN_SELF_TIME,
+  SPAN_DESCRIPTION,
+  SPAN_GROUP,
+  SPAN_OP,
+  PROJECT_ID,
+  APP_START_TYPE,
+} = SpanMetricsField;
 
 type Props = {
   primaryRelease?: string;
@@ -105,7 +109,7 @@ export function SpanOperationTable({
       `avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`,
       `avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`,
       `avg_compare(${SPAN_SELF_TIME},release,${primaryRelease},${secondaryRelease})`,
-      `app_start_type`,
+      SpanMetricsField.APP_START_TYPE,
       `sum(${SPAN_SELF_TIME})`,
     ],
     query: queryStringPrimary,
@@ -138,7 +142,7 @@ export function SpanOperationTable({
     ),
     [`avg_compare(${SPAN_SELF_TIME},release,${primaryRelease},${secondaryRelease})`]:
       t('Change'),
-    app_start_type: t('Start Type'),
+    [APP_START_TYPE]: t('Start Type'),
   };
 
   function renderBodyCell(column, row): React.ReactNode {
@@ -164,17 +168,6 @@ export function SpanOperationTable({
         <Link to={`${pathname}?${qs.stringify(query)}`}>
           <OverflowEllipsisTextContainer>{label}</OverflowEllipsisTextContainer>
         </Link>
-      );
-    }
-
-    if (column.key === 'app_start_type' && row.app_start_type === '') {
-      return (
-        <Tooltip
-          title={t('The start type is unknown until we collect more recent data.')}
-          showUnderline
-        >
-          <UnknownValue>{t('Unknown')}</UnknownValue>
-        </Tooltip>
       );
     }
 
@@ -250,7 +243,7 @@ export function SpanOperationTable({
         isLoading={isLoading}
         data={data?.data as TableDataRow[]}
         columnOrder={[
-          `app_start_type`,
+          APP_START_TYPE,
           String(SPAN_OP),
           String(SPAN_DESCRIPTION),
           `avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`,
@@ -270,7 +263,3 @@ export function SpanOperationTable({
     </Fragment>
   );
 }
-
-const UnknownValue = styled('div')`
-  color: ${p => p.theme.gray300};
-`;

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -34,7 +34,6 @@ import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/te
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
-import {SpanOpSelector} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOpSelector';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
@@ -77,8 +76,7 @@ export function SpanOperationTable({
     // Exclude root level spans because they're comprised of nested operations
     '!span.description:"Cold Start"',
     '!span.description:"Warm Start"',
-    // TODO: Add this back when we have the data
-    // `app_start_type:[cold,warm]`,
+    `app_start_type:[cold,warm]`,
     ...(spanOp
       ? [`${SpanMetricsField.SPAN_OP}:${spanOp}`]
       : [`span.op:[${[...STARTUP_SPANS].join(',')}]`]),
@@ -130,11 +128,11 @@ export function SpanOperationTable({
     [SPAN_OP]: t('Operation'),
     [SPAN_DESCRIPTION]: t('Span Description'),
     [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t(
-      'Duration (%s)',
+      'Avg Duration (%s)',
       PRIMARY_RELEASE_ALIAS
     ),
     [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t(
-      'Duration (%s)',
+      'Avg Duration (%s)',
       SECONDARY_RELEASE_ALIAS
     ),
     [`avg_compare(${SPAN_SELF_TIME},release,${primaryRelease},${secondaryRelease})`]:
@@ -247,11 +245,6 @@ export function SpanOperationTable({
 
   return (
     <Fragment>
-      <SpanOpSelector
-        primaryRelease={primaryRelease}
-        transaction={transaction}
-        secondaryRelease={secondaryRelease}
-      />
       <GridEditable
         isLoading={isLoading}
         data={data?.data as TableDataRow[]}

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -77,6 +77,8 @@ export function SpanOperationTable({
     // Exclude root level spans because they're comprised of nested operations
     '!span.description:"Cold Start"',
     '!span.description:"Warm Start"',
+    // TODO: Add this back when we have the data
+    // `app_start_type:[cold,warm]`,
     ...(spanOp
       ? [`${SpanMetricsField.SPAN_OP}:${spanOp}`]
       : [`span.op:[${[...STARTUP_SPANS].join(',')}]`]),

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -32,6 +32,10 @@ import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/te
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {
+  COLD_START_TYPE,
+  WARM_START_TYPE,
+} from 'sentry/views/starfish/views/appStartup/screenSummary/startTypeSelector';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
@@ -82,7 +86,9 @@ export function SpanOperationTable({
     // Exclude root level spans because they're comprised of nested operations
     '!span.description:"Cold Start"',
     '!span.description:"Warm Start"',
-    `${SpanMetricsField.APP_START_TYPE}:${startType || '[cold,warm]'}`,
+    `${SpanMetricsField.APP_START_TYPE}:${
+      startType || `[${COLD_START_TYPE},${WARM_START_TYPE}]`
+    }`,
     `${SpanMetricsField.SPAN_OP}:${spanOp || `[${[...STARTUP_SPANS].join(',')}]`}`,
     ...(deviceClass ? [`${SpanMetricsField.DEVICE_CLASS}:${deviceClass}`] : []),
   ]);

--- a/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
@@ -4,12 +4,13 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 
 export function StartTypeSelector() {
   const location = useLocation();
 
-  const value = decodeScalar(location.query.app_start_type) ?? '';
+  const value = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
 
   const options = [
     {value: '', label: t('All')},
@@ -27,7 +28,7 @@ export function StartTypeSelector() {
           ...location,
           query: {
             ...location.query,
-            ['app_start_type']: newValue.value,
+            [SpanMetricsField.APP_START_TYPE]: newValue.value,
             [MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE]: undefined,
             [MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE]: undefined,
           },

--- a/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
@@ -7,6 +7,9 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 
+export const COLD_START_TYPE = 'cold';
+export const WARM_START_TYPE = 'warm';
+
 export function StartTypeSelector() {
   const location = useLocation();
 
@@ -14,8 +17,8 @@ export function StartTypeSelector() {
 
   const options = [
     {value: '', label: t('All')},
-    {value: 'cold', label: t('Cold')},
-    {value: 'warm', label: t('Warm')},
+    {value: COLD_START_TYPE, label: t('Cold')},
+    {value: WARM_START_TYPE, label: t('Warm')},
   ];
 
   return (

--- a/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
@@ -1,0 +1,38 @@
+import {browserHistory} from 'react-router';
+
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
+
+export function StartTypeSelector() {
+  const location = useLocation();
+
+  const value = decodeScalar(location.query.app_start_type) ?? '';
+
+  const options = [
+    {value: '', label: t('All')},
+    {value: 'cold', label: t('Cold')},
+    {value: 'warm', label: t('Warm')},
+  ];
+
+  return (
+    <CompactSelect
+      triggerProps={{prefix: t('Start Type'), size: 'xs'}}
+      value={value}
+      options={options ?? []}
+      onChange={newValue => {
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            ['app_start_type']: newValue.value,
+            [MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE]: undefined,
+            [MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE]: undefined,
+          },
+        });
+      }}
+    />
+  );
+}

--- a/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
@@ -31,6 +31,7 @@ export function StartTypeSelector() {
             [SpanMetricsField.APP_START_TYPE]: newValue.value,
             [MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE]: undefined,
             [MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE]: undefined,
+            [MobileCursors.SPANS_TABLE]: undefined,
           },
         });
       }}

--- a/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
@@ -19,7 +19,7 @@ export function StartTypeSelector() {
 
   return (
     <CompactSelect
-      triggerProps={{prefix: t('Start Type'), size: 'xs'}}
+      triggerProps={{prefix: t('Start Type')}}
       value={value}
       options={options ?? []}
       onChange={newValue => {

--- a/static/app/views/starfish/views/screens/screenLoadSpans/deviceClassSelector.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/deviceClassSelector.tsx
@@ -8,10 +8,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 
 interface Props {
+  clearSpansTableCursor?: boolean;
   size?: ComponentProps<typeof CompactSelect>['size'];
 }
 
-export function DeviceClassSelector({size = 'xs'}: Props) {
+export function DeviceClassSelector({size = 'xs', clearSpansTableCursor}: Props) {
   const location = useLocation();
 
   const value = decodeScalar(location.query['device.class']) ?? '';
@@ -38,6 +39,7 @@ export function DeviceClassSelector({size = 'xs'}: Props) {
             ['device.class']: newValue.value,
             [MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE]: undefined,
             [MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE]: undefined,
+            ...(clearSpansTableCursor ? {[MobileCursors.SPANS_TABLE]: undefined} : {}),
           },
         });
       }}

--- a/static/app/views/starfish/views/screens/screenLoadSpans/deviceClassSelector.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/deviceClassSelector.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import {browserHistory} from 'react-router';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -6,7 +7,11 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 
-export function DeviceClassSelector() {
+interface Props {
+  size?: ComponentProps<typeof CompactSelect>['size'];
+}
+
+export function DeviceClassSelector({size = 'xs'}: Props) {
   const location = useLocation();
 
   const value = decodeScalar(location.query['device.class']) ?? '';
@@ -21,7 +26,8 @@ export function DeviceClassSelector() {
 
   return (
     <CompactSelect
-      triggerProps={{prefix: t('Device Class'), size: 'xs'}}
+      size={size}
+      triggerProps={{prefix: t('Device Class')}}
       value={value}
       options={options ?? []}
       onChange={newValue => {

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.tsx
@@ -38,6 +38,7 @@ type Props = {
   sort: Sort;
   sortKey: string;
   data?: TableData;
+  footerAlignedPagination?: boolean;
   pageLinks?: string;
   showDeviceClassSelector?: boolean;
 };
@@ -56,6 +57,7 @@ export function EventSamplesTable({
   profileIdKey,
   columnNameMap,
   sort,
+  footerAlignedPagination = false,
 }: Props) {
   const location = useLocation();
   const organization = useOrganization();
@@ -169,10 +171,13 @@ export function EventSamplesTable({
 
   return (
     <Fragment>
-      <Header>
-        {showDeviceClassSelector && <DeviceClassSelector />}
-        <StyledPagination size="xs" pageLinks={pageLinks} onCursor={handleCursor} />
-      </Header>
+      {!footerAlignedPagination && (
+        <Header>
+          {showDeviceClassSelector && <DeviceClassSelector />}
+
+          <StyledPagination size="xs" pageLinks={pageLinks} onCursor={handleCursor} />
+        </Header>
+      )}
       <GridContainer>
         <GridEditable
           isLoading={isLoading}
@@ -190,6 +195,11 @@ export function EventSamplesTable({
           }}
         />
       </GridContainer>
+      <div>
+        {footerAlignedPagination && (
+          <StyledPagination size="xs" pageLinks={pageLinks} onCursor={handleCursor} />
+        )}
+      </div>
     </Fragment>
   );
 }


### PR DESCRIPTION
This PR merges the span ops table with the event samples table.

Before:
<img width="1464" alt="Screenshot 2024-02-06 at 3 36 12 PM" src="https://github.com/getsentry/sentry/assets/22846452/f6787c67-100a-4252-81e7-355eadad54c7">

After:

https://github.com/getsentry/sentry/assets/22846452/e1fb8d1a-9f4c-43e5-a1aa-92b9503e378a

 In doing so I've also made the following changes:
 - Add a change column for comparing cold/warm start durations in the span op table
 - Apply the span op, start type, and device class filters to the span op table and start type and device class for the event samples
     -  I had to leave out the span op filter from the event samples table because it's going to be more difficult to implement and I felt like this PR was big enough
- Add props to shared components so we can style them differently before the new style is propagated to the screens module (since it's in prod currently)

Upcoming PRs for these tables:
- Surface more span ops in the span ops table
- Allow for the span op filter in the event samples table and expose the span op filter
    - There's a way forward by making multiple queries (one to indexed spans to get the events with that span op and one to get the app start duration for those transactions)