### PR TITLE
feat: move `noNodejsModules` to biome

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,4 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
 
 const isRelaxed = !!process.env.SENTRY_ESLINT_RELAXED;
 const isCi = !!process.env.CI;
@@ -32,6 +31,9 @@ module.exports = {
       {additionalHooks: ADDITIONAL_HOOKS_TO_CHECK_DEPS_FOR},
     ],
     ...(!isRelaxed && !isCi ? strictRulesNotCi : {}),
+
+    // TODO(@anonrig): Remove these rules from eslint-sentry-config.
+    'import/no-nodejs-modules': 'off',
   },
   // JSON file formatting is handled by Biome. ESLint should not be linting
   // and formatting these files.
@@ -40,6 +42,10 @@ module.exports = {
     {
       files: ['tests/js/**/*.{ts,js}'],
       extends: ['plugin:testing-library/react', 'sentry-app/strict'],
+      rules: {
+        // TODO(@anonrig): Remove these rules from eslint-sentry-config.
+        'import/no-nodejs-modules': 'off',
+      },
     },
     {
       files: ['*.ts', '*.tsx'],

--- a/api-docs/index.ts
+++ b/api-docs/index.ts
@@ -1,9 +1,8 @@
 /* global process */
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
 /* eslint import/no-unresolved:0 */
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import yaml from 'js-yaml';
 import JsonRefs from 'json-refs';

--- a/api-docs/openapi-diff.ts
+++ b/api-docs/openapi-diff.ts
@@ -1,9 +1,8 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
 /* eslint import/no-unresolved:0 */
 
-import fs from 'fs';
-import https from 'https';
+import fs from 'node:fs';
+import https from 'node:https';
 
 import yaml from 'js-yaml';
 import jsonDiff from 'json-diff';

--- a/api-docs/watch.ts
+++ b/api-docs/watch.ts
@@ -1,8 +1,8 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0, import/no-unresolved:0, no-console:0 */
-import {spawn} from 'child_process';
-import {join} from 'path';
-import {stderr, stdout} from 'process';
+/* eslint import/no-unresolved:0, no-console:0 */
+import {spawn} from 'node:child_process';
+import {join} from 'node:path';
+import {stderr, stdout} from 'node:process';
 
 import sane from 'sane';
 

--- a/biome.json
+++ b/biome.json
@@ -15,6 +15,7 @@
       "recommended": false,
       "nursery": {
         "noDuplicateJsonKeys": "error",
+        "noNodejsModules": "error",
         "useExportType": "error",
         "useImportType": "error"
       }
@@ -60,5 +61,27 @@
       "allowComments": true,
       "allowTrailingCommas": true
     }
-  }
+  },
+  "overrides": [
+    {
+      "include": [
+        "api-docs/*.ts",
+        "build-utils/*.ts",
+        "config/webpack.chartcuterie.config.ts",
+        "scripts",
+        "tests/js/sentry-test/loadFixtures.ts",
+        "tests/js/jest-pegjs-transform.js",
+        "tests/js/setup.ts",
+        "tests/js/test-balancer/index.js",
+        "*.config.ts"
+      ],
+      "linter": {
+        "rules": {
+          "nursery": {
+            "noNodejsModules": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/build-utils/last-built-plugin.ts
+++ b/build-utils/last-built-plugin.ts
@@ -1,8 +1,7 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import type webpack from 'webpack';
 

--- a/build-utils/sentry-instrumentation.ts
+++ b/build-utils/sentry-instrumentation.ts
@@ -1,9 +1,7 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
-
-import crypto from 'crypto';
-import https from 'https';
-import os from 'os';
+import crypto from 'node:crypto';
+import https from 'node:https';
+import os from 'node:os';
 
 import type Sentry from '@sentry/node';
 import type {Transaction} from '@sentry/types';

--- a/config/webpack.chartcuterie.config.ts
+++ b/config/webpack.chartcuterie.config.ts
@@ -1,8 +1,7 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
 
-import childProcess from 'child_process';
-import path from 'path';
+import childProcess from 'node:child_process';
+import path from 'node:path';
 
 import webpack from 'webpack';
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,4 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
 import type {Config} from '@jest/types';
 import path from 'node:path';
 import process from 'node:process';

--- a/scripts/build-js-loader.ts
+++ b/scripts/build-js-loader.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-console */
-/* eslint import/no-nodejs-modules:0 */
-
 import fs from 'node:fs';
 import {minify} from 'terser';
 import * as ts from 'typescript';

--- a/scripts/extract-android-device-names.js
+++ b/scripts/extract-android-device-names.js
@@ -1,5 +1,5 @@
 const csv = require('csv-parser');
-const fs = require('fs');
+const fs = require('node:fs');
 
 const transformResults = res => {
   const deviceMapping = {};

--- a/scripts/extract-ios-device-names.ts
+++ b/scripts/extract-ios-device-names.ts
@@ -1,7 +1,6 @@
-/* eslint-disable import/no-nodejs-modules */
 /* eslint-env node */
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import prettier from 'prettier';
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,5 +1,4 @@
 /* global process */
-/* eslint import/no-nodejs-modules:0 */
 
 // Do this as the first thing so that any code reading it knows the right env.
 // process.env.BABEL_ENV = 'test';

--- a/tests/js/jest-pegjs-transform.js
+++ b/tests/js/jest-pegjs-transform.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 
-// eslint-disable-next-line import/no-nodejs-modules
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 const peg = require('pegjs');
 
 function getCacheKey(fileData, _filePath, config, _options) {

--- a/tests/js/sentry-test/loadFixtures.ts
+++ b/tests/js/sentry-test/loadFixtures.ts
@@ -1,8 +1,6 @@
 /* global __dirname */
-/* eslint import/no-nodejs-modules:0 */
-
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const FIXTURES_ROOT = path.join(__dirname, '../../../fixtures');
 

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -1,10 +1,8 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
-import {TextDecoder, TextEncoder} from 'util';
-
 import type {ReactElement} from 'react';
 import {configure as configureRtl} from '@testing-library/react'; // eslint-disable-line no-restricted-imports
 import MockDate from 'mockdate';
+import {TextDecoder, TextEncoder} from 'node:util';
 import {ConfigFixture} from 'sentry-fixture/config';
 
 // eslint-disable-next-line jest/no-mocks-import

--- a/tests/js/test-balancer/index.js
+++ b/tests/js/test-balancer/index.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 module.exports = results => {
   if (!results.success) {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,5 +1,4 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
 
 import {WebpackReactSourcemapsPlugin} from '@acemarke/react-prod-sourcemaps';
 import {RsdoctorWebpackPlugin} from '@rsdoctor/webpack-plugin';


### PR DESCRIPTION
Since Biome supports `no-nodejs-modules`, we can move it to Biome and saving 1.5 seconds in the process.