### PR TITLE
feat(issues): Add no trace available to trace timeline

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.spec.tsx
@@ -72,4 +72,9 @@ describe('TraceLink', () => {
       await screen.findByRole('link', {name: 'View Full Trace (2 issues)'})
     ).toBeInTheDocument();
   });
+
+  it('renders no trace available', async () => {
+    render(<TraceLink event={EventFixture({})} />, {organization});
+    expect(await screen.findByText('No Trace Available')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/issueDetails/traceTimeline/traceLink.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceLink.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import Link from 'sentry/components/links/link';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
@@ -21,7 +22,18 @@ export function TraceLink({event}: TraceLinkProps) {
   const traceTarget = generateTraceTarget(event, organization);
 
   if (!event.contexts?.trace?.trace_id) {
-    return null;
+    return (
+      <NoTraceAvailable>
+        {t('No Trace Available')}
+        <QuestionTooltip
+          position="bottom"
+          size="sm"
+          title={t(
+            'Traces help you understand if there are any issues with other services connected to this event'
+          )}
+        />
+      </NoTraceAvailable>
+    );
   }
 
   return (
@@ -49,4 +61,21 @@ const StyledLink = styled(Link)`
   gap: ${space(0.25)};
   line-height: 1.2;
   font-size: ${p => p.theme.fontSizeMedium};
+
+  svg {
+    margin-top: 1px;
+  }
+`;
+
+const NoTraceAvailable = styled('span')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.25)};
+  line-height: 1.2;
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+
+  svg {
+    margin-top: 1px;
+  }
 `;


### PR DESCRIPTION
Displays a message when no trace is available
![Screenshot 2024-02-06 at 11 22 54 AM](https://github.com/getsentry/sentry/assets/1400464/a9b308d7-77bf-4006-ab41-a8b5805e5f66)
