### PR TITLE
fix(hybridcloud) Add retries to integration proxy requests

### DIFF
--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -147,12 +147,12 @@ class BlacklistAdapter(HTTPAdapter):
     is_ipaddress_permitted: IsIpAddressPermitted = None
 
     def __init__(
-        self, is_ipaddress_permitted: IsIpAddressPermitted = None, *args, **kwargs
+        self, is_ipaddress_permitted: IsIpAddressPermitted = None, max_retries: Retry | None = None
     ) -> None:
-        super().__init__(*args, **kwargs)
         # If is_ipaddress_permitted is defined, then we pass it as an additional parameter to freshly created
         # `urllib3.connectionpool.ConnectionPool` instances managed by `SafePoolManager`.
         self.is_ipaddress_permitted = is_ipaddress_permitted
+        super().__init__(max_retries=max_retries)
 
     def init_poolmanager(self, connections, maxsize, block=DEFAULT_POOLBLOCK, **pool_kwargs):
         self._pool_connections = connections

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -8,7 +8,7 @@ from socket import timeout as SocketTimeout
 from typing import Optional
 
 from requests import Session as _Session
-from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter, Retry
+from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_RETRIES, HTTPAdapter, Retry
 from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.connectionpool import connection_from_url as _connection_from_url
@@ -147,7 +147,9 @@ class BlacklistAdapter(HTTPAdapter):
     is_ipaddress_permitted: IsIpAddressPermitted = None
 
     def __init__(
-        self, is_ipaddress_permitted: IsIpAddressPermitted = None, max_retries: Retry | None = None
+        self,
+        is_ipaddress_permitted: IsIpAddressPermitted = None,
+        max_retries: Retry | int = DEFAULT_RETRIES,
     ) -> None:
         # If is_ipaddress_permitted is defined, then we pass it as an additional parameter to freshly created
         # `urllib3.connectionpool.ConnectionPool` instances managed by `SafePoolManager`.

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -8,7 +8,7 @@ from socket import timeout as SocketTimeout
 from typing import Optional
 
 from requests import Session as _Session
-from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
+from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter, Retry
 from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.connectionpool import connection_from_url as _connection_from_url
@@ -146,11 +146,13 @@ class BlacklistAdapter(HTTPAdapter):
 
     is_ipaddress_permitted: IsIpAddressPermitted = None
 
-    def __init__(self, is_ipaddress_permitted: IsIpAddressPermitted = None) -> None:
+    def __init__(
+        self, is_ipaddress_permitted: IsIpAddressPermitted = None, *args, **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
         # If is_ipaddress_permitted is defined, then we pass it as an additional parameter to freshly created
         # `urllib3.connectionpool.ConnectionPool` instances managed by `SafePoolManager`.
         self.is_ipaddress_permitted = is_ipaddress_permitted
-        super().__init__()
 
     def init_poolmanager(self, connections, maxsize, block=DEFAULT_POOLBLOCK, **pool_kwargs):
         self._pool_connections = connections
@@ -196,10 +198,14 @@ class Session(_Session):
 
 
 class SafeSession(Session):
-    def __init__(self, is_ipaddress_permitted: IsIpAddressPermitted = None) -> None:
+    def __init__(
+        self, is_ipaddress_permitted: IsIpAddressPermitted = None, max_retries: Retry | None = None
+    ) -> None:
         Session.__init__(self)
         self.headers.update({"User-Agent": USER_AGENT})
-        adapter = BlacklistAdapter(is_ipaddress_permitted=is_ipaddress_permitted)
+        adapter = BlacklistAdapter(
+            is_ipaddress_permitted=is_ipaddress_permitted, max_retries=max_retries
+        )
         self.mount("https://", adapter)
         self.mount("http://", adapter)
 

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -156,7 +156,7 @@ class IntegrationProxyClient(ApiClient):
                     total=5,
                     backoff_factor=0.1,
                     status_forcelist=[503],
-                    allowed_methods=["PUT", "GET", "DELETE", "POST"],
+                    allowed_methods=["PATCH", "HEAD", "PUT", "GET", "DELETE", "POST"],
                 ),
             )
         return build_session()

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -13,6 +13,7 @@ import urllib3
 from django.conf import settings
 from django.utils.encoding import force_str
 from requests import PreparedRequest
+from requests.adapters import Retry
 
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.http import build_session
@@ -144,11 +145,20 @@ class IntegrationProxyClient(ApiClient):
         """
         Generates a safe Requests session for the API client to use.
         This injects a custom is_ipaddress_permitted function to allow only connections to the IP address of the Control Silo.
+
         We only validate the IP address from within the Region Silo.
         For all other silo modes, we use the default is_ipaddress_permitted function, which tests against SENTRY_DISALLOWED_IPS.
         """
         if SiloMode.get_current_mode() == SiloMode.REGION:
-            return build_session(is_ipaddress_permitted=is_control_silo_ip_address)
+            return build_session(
+                is_ipaddress_permitted=is_control_silo_ip_address,
+                max_retries=Retry(
+                    total=5,
+                    backoff_factor=0.1,
+                    status_forcelist=[503],
+                    allowed_methods=["PUT", "GET", "DELETE", "POST"],
+                ),
+            )
         return build_session()
 
     @staticmethod

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup
 from requests import Response
+from requests.adapters import RetryError
 from requests.exceptions import RequestException
 
 from sentry.utils import json
@@ -107,6 +108,15 @@ class ApiHostError(ApiError):
     def from_request(cls, request: _RequestHasUrl) -> ApiHostError:
         host = urlparse(request.url).netloc
         return cls(f"Unable to reach host: {host}", url=request.url)
+
+
+class ApiRetryError(ApiError):
+    code = 503
+
+    @classmethod
+    def from_exception(cls, exception: RetryError) -> ApiRetryError:
+        msg = str(exception)
+        return cls(msg)
 
 
 class ApiTimeoutError(ApiError):


### PR DESCRIPTION
We've seen an increasing number of 503 errors when proxying to control. Try using a retry strategy as that helped with other RPC pod traffic.

