### PR TITLE
fix(superuser): allow superusers to invite members in other orgs

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -48,25 +48,17 @@ function InviteMembersModal({
     source,
   });
 
-  let member = memberResult.data;
-
   if (memberResult.isLoading) {
     return <LoadingIndicator />;
   }
 
-  if (memberResult.isError) {
-    if (!isActiveSuperuser()) {
-      return (
-        <LoadingError
-          message={t('Failed to load members')}
-          onRetry={memberResult.refetch}
-        />
-      );
-    }
-    // superuser may not be a member of the organization
-    // setting member to undefined allows superuser to
-    // invite all roles in InviteMembersModalView
-    member = undefined;
+  if (memberResult.isError && !isActiveSuperuser()) {
+    return (
+      <LoadingError
+        message={t('Failed to load members')}
+        onRetry={memberResult.refetch}
+      />
+    );
   }
 
   return (
@@ -93,7 +85,7 @@ function InviteMembersModal({
               headerInfo={headerInfo}
               invites={invites}
               inviteStatus={inviteStatus}
-              member={member}
+              member={memberResult.data}
               pendingInvites={pendingInvites}
               removeInviteRow={removeInviteRow}
               reset={reset}

--- a/static/app/components/modals/inviteMembersModal/inviteMembersModalview.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteMembersModalview.tsx
@@ -30,7 +30,7 @@ interface Props {
   headerInfo: ReactNode;
   inviteStatus: InviteStatus;
   invites: NormalizedInvite[];
-  member: Member;
+  member: Member | undefined;
   pendingInvites: InviteRow[];
   removeInviteRow: (index: number) => void;
   reset: () => void;


### PR DESCRIPTION
We recently did some work to refactor the invite members modal to a functional component (#63681).

Before this change, we were handling the case where superusers attempting to invite members on behalf of another organization (in which they weren't a member). This calls an endpoint that returns a 404 if the user is not a member of the organization. `DeprecatedAsyncComponent` handled this by setting the response value to `undefined`, thus setting the state variable that represents the API call to `undefined`. The new change always returns an error message if the status code of the response is some kind of error code.

We can fix the superuser case by checking for active superuser. If there is an error response (e.g. 404) from this particular endpoint and the user hitting it is active superuser, we can set the state variable to `undefined`.