### PR TITLE
feat(issue-priority): Add new `GroupType.default_priority` field 

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -54,7 +54,6 @@ from sentry.grouping.ingest import (
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.issues.priority import PriorityLevel
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.killswitches import killswitch_matches_context
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL, convert_crashreport_count
@@ -97,7 +96,7 @@ from sentry.tasks.process_buffer import buffer_incr
 from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.tsdb.base import TSDBModel
 from sentry.types.activity import ActivityType
-from sentry.types.group import GroupSubStatus
+from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.usage_accountant import record
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache_key_for_event

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -11,6 +11,7 @@ import sentry_sdk
 from sentry import features
 from sentry.features.base import OrganizationFeature
 from sentry.ratelimits.sliding_windows import Quota
+from sentry.types.group import PriorityLevel
 from sentry.utils import metrics
 
 if TYPE_CHECKING:
@@ -116,6 +117,7 @@ class GroupType:
     description: str
     category: int
     noise_config: NoiseConfig | None = None
+    default_priority: int = PriorityLevel.MEDIUM
     # If True this group type should be released everywhere. If False, fall back to features to
     # decide if this is released.
     released: bool = False
@@ -217,6 +219,7 @@ class ErrorGroupType(GroupType):
     slug = "error"
     description = "Error"
     category = GroupCategory.ERROR.value
+    default_priority = PriorityLevel.MEDIUM
     released = True
 
 
@@ -232,6 +235,7 @@ class PerformanceSlowDBQueryGroupType(PerformanceGroupTypeDefaults, GroupType):
     description = "Slow DB Query"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=100)
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -241,6 +245,7 @@ class PerformanceRenderBlockingAssetSpanGroupType(PerformanceGroupTypeDefaults, 
     slug = "performance_render_blocking_asset_span"
     description = "Large Render Blocking Asset"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -250,6 +255,7 @@ class PerformanceNPlusOneGroupType(PerformanceGroupTypeDefaults, GroupType):
     slug = "performance_n_plus_one_db_queries"
     description = "N+1 Query"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -260,6 +266,7 @@ class PerformanceConsecutiveDBQueriesGroupType(PerformanceGroupTypeDefaults, Gro
     description = "Consecutive DB Queries"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=15)
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -269,6 +276,7 @@ class PerformanceFileIOMainThreadGroupType(PerformanceGroupTypeDefaults, GroupTy
     slug = "performance_file_io_main_thread"
     description = "File IO on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -279,6 +287,7 @@ class PerformanceConsecutiveHTTPQueriesGroupType(PerformanceGroupTypeDefaults, G
     description = "Consecutive HTTP"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=5)
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -288,6 +297,7 @@ class PerformanceNPlusOneAPICallsGroupType(GroupType):
     slug = "performance_n_plus_one_api_calls"
     description = "N+1 API Call"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -297,6 +307,7 @@ class PerformanceMNPlusOneDBQueriesGroupType(PerformanceGroupTypeDefaults, Group
     slug = "performance_m_n_plus_one_db_queries"
     description = "MN+1 Query"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -307,6 +318,7 @@ class PerformanceUncompressedAssetsGroupType(PerformanceGroupTypeDefaults, Group
     description = "Uncompressed Asset"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=100)
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -316,6 +328,7 @@ class PerformanceDBMainThreadGroupType(PerformanceGroupTypeDefaults, GroupType):
     slug = "performance_db_main_thread"
     description = "DB on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -325,6 +338,7 @@ class PerformanceLargeHTTPPayloadGroupType(PerformanceGroupTypeDefaults, GroupTy
     slug = "performance_large_http_payload"
     description = "Large HTTP payload"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -335,6 +349,7 @@ class PerformanceHTTPOverheadGroupType(PerformanceGroupTypeDefaults, GroupType):
     description = "HTTP/1.1 Overhead"
     noise_config = NoiseConfig(ignore_limit=20)
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 # experimental
@@ -346,6 +361,7 @@ class PerformanceDurationRegressionGroupType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
     enable_escalation_detection = False
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -356,6 +372,7 @@ class PerformanceP95EndpointRegressionGroupType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
     enable_escalation_detection = False
+    default_priority = PriorityLevel.MEDIUM
     released = True
 
 
@@ -366,6 +383,7 @@ class ProfileFileIOGroupType(GroupType):
     slug = "profile_file_io_main_thread"
     description = "File I/O on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -374,6 +392,7 @@ class ProfileImageDecodeGroupType(GroupType):
     slug = "profile_image_decode_main_thread"
     description = "Image Decoding on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -382,6 +401,7 @@ class ProfileJSONDecodeType(GroupType):
     slug = "profile_json_decode_main_thread"
     description = "JSON Decoding on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -390,17 +410,17 @@ class ProfileCoreDataExperimentalType(GroupType):
     slug = "profile_core_data_main_exp"
     description = "Core Data on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 # 2005 was ProfileRegexExperimentalType
-
-
 @dataclass(frozen=True)
 class ProfileViewIsSlowExperimentalType(GroupType):
     type_id = 2006
     slug = "profile_view_is_slow_experimental"
     description = "View Render/Layout/Update is slow"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -410,6 +430,7 @@ class ProfileRegexType(GroupType):
     description = "Regex on Main Thread"
     category = GroupCategory.PERFORMANCE.value
     released = True
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -418,6 +439,7 @@ class ProfileFrameDropExperimentalType(GroupType):
     slug = "profile_frame_drop_experimental"
     description = "Frame Drop"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -428,6 +450,7 @@ class ProfileFrameDropType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=2000)
     released = True
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -437,6 +460,7 @@ class ProfileFunctionRegressionExperimentalType(GroupType):
     description = "Function Duration Regression (Experimental)"
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -447,6 +471,7 @@ class ProfileFunctionRegressionType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
     released = True
+    default_priority = PriorityLevel.MEDIUM
 
 
 @dataclass(frozen=True)
@@ -457,6 +482,7 @@ class MonitorCheckInFailure(GroupType):
     category = GroupCategory.CRON.value
     released = True
     creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.HIGH
 
 
 @dataclass(frozen=True)
@@ -467,6 +493,7 @@ class MonitorCheckInTimeout(GroupType):
     category = GroupCategory.CRON.value
     released = True
     creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.HIGH
 
 
 @dataclass(frozen=True)
@@ -477,6 +504,7 @@ class MonitorCheckInMissed(GroupType):
     category = GroupCategory.CRON.value
     released = True
     creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.HIGH
 
 
 @dataclass(frozen=True)
@@ -486,6 +514,7 @@ class ReplayDeadClickType(GroupType):
     slug = "replay_click_dead"
     description = "Dead Click Detected"
     category = GroupCategory.REPLAY.value
+    default_priority = PriorityLevel.MEDIUM
 
 
 @dataclass(frozen=True)
@@ -494,6 +523,7 @@ class ReplayRageClickType(GroupType):
     slug = "replay_click_rage"
     description = "Rage Click Detected"
     category = GroupCategory.REPLAY.value
+    default_priority = PriorityLevel.MEDIUM
 
 
 @dataclass(frozen=True)
@@ -503,6 +533,7 @@ class FeedbackGroup(GroupType):
     description = "Feedback"
     category = GroupCategory.FEEDBACK.value
     creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.MEDIUM
 
 
 @metrics.wraps("noise_reduction.should_create_group", sample_rate=1.0)

--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from enum import Enum, IntEnum
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from sentry import features
@@ -10,15 +10,10 @@ from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus, record_
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.types.activity import ActivityType
+from sentry.types.group import PriorityLevel
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
-
-
-class PriorityLevel(IntEnum):
-    LOW = 25
-    MEDIUM = 50
-    HIGH = 75
 
 
 PRIORITY_LEVEL_TO_STR: dict[int, str] = {

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from enum import IntEnum
 
 
 class GroupSubStatus:
@@ -65,3 +66,9 @@ GROUP_SUBSTATUS_TO_GROUP_HISTORY_STATUS = {
     GroupSubStatus.FOREVER: "archived_forever",
     GroupSubStatus.UNTIL_CONDITION_MET: "archived_until_condition_met",
 }
+
+
+class PriorityLevel(IntEnum):
+    LOW = 25
+    MEDIUM = 50
+    HIGH = 75

--- a/tests/sentry/event_manager/test_priority.py
+++ b/tests/sentry/event_manager/test_priority.py
@@ -4,11 +4,11 @@ import logging
 from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
-from sentry.issues.priority import PriorityLevel
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
+from sentry.types.group import PriorityLevel
 from tests.sentry.event_manager.test_severity import make_event
 
 pytestmark = [requires_snuba]

--- a/tests/sentry/issues/test_priority.py
+++ b/tests/sentry/issues/test_priority.py
@@ -4,7 +4,6 @@ from sentry.issues.priority import (
     PRIORITY_LEVEL_TO_STR,
     PRIORITY_TO_GROUP_HISTORY_STATUS,
     PriorityChangeReason,
-    PriorityLevel,
     auto_update_priority,
 )
 from sentry.models.activity import Activity
@@ -14,6 +13,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.types.activity import ActivityType
+from sentry.types.group import PriorityLevel
 
 
 @apply_feature_flag_on_cls("projects:issue-priority")

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -1,12 +1,13 @@
 import logging
 
 from sentry.event_manager import EventManager
-from sentry.issues.priority import PRIORITY_LEVEL_TO_STR, PriorityLevel
+from sentry.issues.priority import PRIORITY_LEVEL_TO_STR
 from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
+from sentry.types.group import PriorityLevel
 from sentry.utils.iterators import chunked
 from tests.sentry.event_manager.test_event_manager import make_event
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -29,7 +29,6 @@ from sentry.issues.grouptype import (
     ProfileFileIOGroupType,
 )
 from sentry.issues.ingest import save_issue_occurrence
-from sentry.issues.priority import PriorityLevel
 from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
@@ -72,7 +71,7 @@ from sentry.testutils.performance_issues.store_transaction import PerfIssueTrans
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
-from sentry.types.group import GroupSubStatus
+from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.utils import json
 from sentry.utils.cache import cache
 from sentry.utils.sdk_crashes.sdk_crash_detection_config import SdkName

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -4,7 +4,6 @@ from rest_framework.exceptions import ErrorDetail
 
 from sentry import tsdb
 from sentry.issues.forecasts import generate_and_save_forecasts
-from sentry.issues.priority import PriorityLevel
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.group import GroupStatus
@@ -16,6 +15,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
+from sentry.types.group import PriorityLevel
 
 
 @region_silo_test

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -7,7 +7,6 @@ from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializerSnuba
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileFileIOGroupType
-from sentry.issues.priority import PriorityLevel
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.grouplink import GroupLink
@@ -23,6 +22,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.performance_issues.store_transaction import PerfIssueTransactionTestMixin
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.types.group import PriorityLevel
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 


### PR DESCRIPTION
Pre-work for https://github.com/getsentry/sentry/pull/64231

We're adding GroupType.default_priority, which will be used in the case where an occurrence is created without providing initial_issue_priority.

