### PR TITLE
ref(superuser): only allow superuser write to add/delete internal app tokens

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -429,7 +429,7 @@ class SentryInternalAppTokenPermission(SentryPermission):
         )
         self.determine_access(request, owner_app)
 
-        if is_active_superuser(request):
+        if superuser_has_permission(request):
             return True
 
         return ensure_scoped_permission(request, self.scope_map.get(request.method))

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
@@ -1,12 +1,17 @@
-from django.urls import reverse
+from django.test import override_settings
+from rest_framework import status
 
 from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 
 
 @control_silo_test
 class SentryInternalAppTokenCreationTest(APITestCase):
+    endpoint = "sentry-api-0-sentry-internal-app-token-details"
+    method = "delete"
+
     def setUp(self):
         self.user = self.create_user(email="boop@example.com")
         self.org = self.create_organization(owner=self.user, name="My Org")
@@ -18,41 +23,36 @@ class SentryInternalAppTokenCreationTest(APITestCase):
 
         self.api_token = ApiToken.objects.get(application=self.internal_sentry_app.application)
 
-        self.url = reverse(
-            "sentry-api-0-sentry-internal-app-token-details",
-            args=[self.internal_sentry_app.slug, self.api_token.id],
-        )
+        self.superuser = self.create_user(is_superuser=True)
 
     def test_delete_token(self):
         self.login_as(user=self.user)
-        response = self.client.delete(self.url, format="json")
-        assert response.status_code == 204
+        self.get_success_response(
+            self.internal_sentry_app.slug,
+            self.api_token.id,
+            status_code=status.HTTP_204_NO_CONTENT,
+        )
         assert not ApiToken.objects.filter(pk=self.api_token.id).exists()
 
     def test_delete_invalid_token(self):
         self.login_as(user=self.user)
 
-        url = reverse(
-            "sentry-api-0-sentry-internal-app-token-details",
-            args=[self.internal_sentry_app.slug, "random"],
+        self.get_error_response(
+            self.internal_sentry_app.slug,
+            "random",
+            status_code=status.HTTP_404_NOT_FOUND,
         )
 
-        response = self.client.delete(url, format="json")
-        assert response.status_code == 404
-
     def test_delete_token_another_app(self):
-
         another_app = self.create_internal_integration(name="Another app", organization=self.org)
         api_token = ApiToken.objects.get(application=another_app.application)
 
-        url = reverse(
-            "sentry-api-0-sentry-internal-app-token-details",
-            args=[self.internal_sentry_app.slug, api_token.id],
-        )
-
         self.login_as(user=self.user)
-        response = self.client.delete(url, format="json")
-        assert response.status_code == 404
+        self.get_error_response(
+            self.internal_sentry_app.slug,
+            api_token.id,
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
 
     def test_non_internal_app(self):
         sentry_app = self.create_sentry_app(name="My External App", organization=self.org)
@@ -61,56 +61,61 @@ class SentryInternalAppTokenCreationTest(APITestCase):
             slug=sentry_app.slug, organization=self.org, user=self.user
         )
 
-        url = reverse(
-            "sentry-api-0-sentry-internal-app-token-details",
-            args=[install.sentry_app.slug, install.api_token.id],
-        )
-
         self.login_as(user=self.user)
-        response = self.client.delete(url, format="json")
 
-        assert response.status_code == 403
+        response = self.get_error_response(
+            install.sentry_app.slug,
+            install.api_token.id,
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
         assert response.data == "This route is limited to internal integrations only"
 
     def test_sentry_app_not_found(self):
-
-        url = reverse(
-            "sentry-api-0-sentry-internal-app-token-details",
-            args=["not_a_slug", self.api_token.id],
-        )
-
         self.login_as(user=self.user)
-        response = self.client.delete(url, format="json")
 
-        assert response.status_code == 404
+        self.get_error_response(
+            "not_a_slug",
+            self.api_token.id,
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
 
     def test_cannot_delete_partner_app_token(self):
         self.login_as(user=self.user)
         self.internal_sentry_app.update(metadata={"partnership_restricted": True})
-        response = self.client.delete(self.url)
-        assert response.status_code == 403
-
-
-@control_silo_test
-class NewSentryInternalAppTokenCreationTest(APITestCase):
-    def setUp(self):
-        self.user = self.create_user(email="boop@example.com")
-        self.org = self.create_organization(owner=self.user, name="My Org")
-        self.project = self.create_project(organization=self.org)
-
-        self.internal_sentry_app = self.create_internal_integration(
-            name="My Internal App", organization=self.org
+        self.get_error_response(
+            self.internal_sentry_app.slug,
+            self.api_token.id,
+            status_code=status.HTTP_403_FORBIDDEN,
         )
 
-        self.api_token = ApiToken.objects.get(application=self.internal_sentry_app.application)
-
-        self.url = reverse(
-            "sentry-api-0-sentry-internal-app-token-details",
-            args=[self.internal_sentry_app.slug, self.api_token.id],
+    def test_superuser_can_delete(self):
+        self.login_as(self.superuser, superuser=True)
+        self.get_success_response(
+            self.internal_sentry_app.slug,
+            self.api_token.id,
+            status_code=status.HTTP_204_NO_CONTENT,
         )
+        assert not ApiToken.objects.filter(pk=self.api_token.id).exists()
 
-    def test_delete_token(self):
-        self.login_as(user=self.user)
-        response = self.client.delete(self.url, format="json")
-        assert response.status_code == 204
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_read_write_delete(self):
+        self.login_as(self.superuser, superuser=True)
+
+        # superuser read cannot delete
+        self.get_error_response(
+            self.internal_sentry_app.slug,
+            self.api_token.id,
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+        assert ApiToken.objects.filter(pk=self.api_token.id).exists()
+
+        # superuser write can delete
+        self.add_user_permission(self.superuser, "superuser.write")
+
+        self.get_success_response(
+            self.internal_sentry_app.slug,
+            self.api_token.id,
+            status_code=status.HTTP_204_NO_CONTENT,
+        )
         assert not ApiToken.objects.filter(pk=self.api_token.id).exists()

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
@@ -1,13 +1,16 @@
-from django.urls import reverse
+from django.test import override_settings
+from rest_framework import status
 
 from sentry.models.apitoken import ApiToken
 from sentry.models.integrations.sentry_app import MASKED_VALUE
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
-from sentry.utils import json
 
 
 class SentryInternalAppTokenTest(APITestCase):
+    endpoint = "sentry-api-0-sentry-internal-app-tokens"
+
     def setUp(self):
         self.user = self.create_user(email="boop@example.com")
         self.org = self.create_organization(owner=self.user, name="My Org")
@@ -16,62 +19,80 @@ class SentryInternalAppTokenTest(APITestCase):
         self.internal_sentry_app = self.create_internal_integration(
             name="My Internal App", organization=self.org
         )
-
-        self.url = reverse(
-            "sentry-api-0-sentry-internal-app-tokens", args=[self.internal_sentry_app.slug]
-        )
+        self.superuser = self.create_user(is_superuser=True)
 
 
 @control_silo_test
 class PostSentryInternalAppTokenTest(SentryInternalAppTokenTest):
+    method = "post"
+
     def test_create_token(self):
         self.login_as(user=self.user)
-        response = self.client.post(self.url, format="json")
-        assert response.status_code == 201
+        response = self.get_success_response(
+            self.internal_sentry_app.slug, status_code=status.HTTP_201_CREATED
+        )
 
         assert ApiToken.objects.get(token=response.data["token"])
 
     def test_non_internal_app(self):
         sentry_app = self.create_sentry_app(name="My External App", organization=self.org)
 
-        url = reverse("sentry-api-0-sentry-internal-app-tokens", args=[sentry_app.slug])
-
         self.login_as(user=self.user)
-        response = self.client.post(url, format="json")
+        response = self.get_error_response(sentry_app.slug, status_code=status.HTTP_403_FORBIDDEN)
 
-        assert response.status_code == 403
         assert response.data == "This route is limited to internal integrations only"
 
     def test_sentry_app_not_found(self):
-
-        url = reverse("sentry-api-0-sentry-internal-app-tokens", args=["not_a_slug"])
-
         self.login_as(user=self.user)
-        response = self.client.post(url, format="json")
-
-        assert response.status_code == 404
+        self.get_error_response("not_a_slug", status_code=status.HTTP_404_NOT_FOUND)
 
     def test_token_limit(self):
         self.login_as(user=self.user)
 
         # we already have one token created so just need to make 19 more first
-        for i in range(19):
-            response = self.client.post(self.url, format="json")
-            assert response.status_code == 201
+        for _ in range(19):
+            self.get_success_response(
+                self.internal_sentry_app.slug, status_code=status.HTTP_201_CREATED
+            )
 
-        response = self.client.post(self.url, format="json")
-        assert response.status_code == 403
+        response = self.get_error_response(
+            self.internal_sentry_app.slug, status_code=status.HTTP_403_FORBIDDEN
+        )
         assert response.data == "Cannot generate more than 20 tokens for a single integration"
 
     def test_cannot_create_partner_app_token(self):
         self.login_as(user=self.user)
         self.internal_sentry_app.update(metadata={"partnership_restricted": True})
-        response = self.client.post(self.url, format="json")
-        assert response.status_code == 403
+
+        self.get_error_response(
+            self.internal_sentry_app.slug, status_code=status.HTTP_403_FORBIDDEN
+        )
+
+    def test_superuser_post(self):
+        self.login_as(self.superuser, superuser=True)
+        self.get_success_response(
+            self.internal_sentry_app.slug, status_code=status.HTTP_201_CREATED
+        )
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_read_write_post(self):
+        # only superuser write can hit post
+        self.login_as(self.superuser, superuser=True)
+        self.get_error_response(
+            self.internal_sentry_app.slug, status_code=status.HTTP_403_FORBIDDEN
+        )
+
+        self.add_user_permission(self.superuser, "superuser.write")
+        self.get_success_response(
+            self.internal_sentry_app.slug, status_code=status.HTTP_201_CREATED
+        )
 
 
 @control_silo_test
 class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
+    method = "get"
+
     def test_get_tokens(self):
         self.login_as(self.user)
 
@@ -79,23 +100,20 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
 
         token = ApiToken.objects.get(application_id=self.internal_sentry_app.application_id)
 
-        response = self.client.get(self.url, format="json")
-
-        assert response.status_code == 200
-        response_content = json.loads(response.content)
+        response = self.get_success_response(self.internal_sentry_app.slug)
 
         # should not include tokens from other internal app
-        assert len(response_content) == 1
-
-        assert response_content[0]["id"] == str(token.id)
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(token.id)
 
     def no_access_for_members(self):
         user = self.create_user(email="meep@example.com")
         self.create_member(organization=self.org, user=user)
         self.login_as(user)
 
-        response = self.client.get(self.url, format="json")
-        assert response.status_code == 403
+        self.get_error_response(
+            self.internal_sentry_app.slug, status_code=status.HTTP_403_FORBIDDEN
+        )
 
     def test_token_is_masked(self):
         user = self.create_user(email="meep@example.com")
@@ -107,12 +125,10 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
 
         self.login_as(user)
 
-        url = reverse("sentry-api-0-sentry-internal-app-tokens", args=[sentry_app.slug])
-        response = self.client.get(url, format="json")
-        response_content = json.loads(response.content)
+        response = self.get_success_response(sentry_app.slug)
 
-        assert response_content[0]["token"] == MASKED_VALUE
-        assert response_content[0]["refreshToken"] == MASKED_VALUE
+        assert response.data[0]["token"] == MASKED_VALUE
+        assert response.data[0]["refreshToken"] == MASKED_VALUE
 
     def test_deny_token_access(self):
         self.login_as(self.user)
@@ -120,6 +136,21 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
 
         sentry_app = self.create_internal_integration(name="OtherInternal", organization=self.org)
 
-        url = reverse("sentry-api-0-sentry-internal-app-tokens", args=[sentry_app.slug])
-        response = self.client.get(url, format="json", HTTP_AUTHORIZATION=f"Bearer {token.token}")
-        assert response.status_code == 403, response.content
+        self.get_error_response(
+            sentry_app.slug,
+            status_code=status.HTTP_403_FORBIDDEN,
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {token.token}"},
+        )
+
+    def test_superuser_get(self):
+        self.login_as(self.superuser, superuser=True)
+        self.get_success_response(self.internal_sentry_app.slug)
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_read_write_get(self):
+        self.login_as(self.superuser, superuser=True)
+        self.get_success_response(self.internal_sentry_app.slug)
+
+        self.add_user_permission(self.superuser, "superuser.write")
+        self.get_success_response(self.internal_sentry_app.slug)


### PR DESCRIPTION
Replace `is_active_superuser` in `SentryInternalAppTokenPermission` with `superuser_has_permission`. Active superusers with the `auth:enterprise-superuser-read-write` feature flag must be a superuser with write permission in order to add or delete internal app tokens.

This PR also includes a refactor for the two old test files.

For https://github.com/getsentry/team-enterprise/issues/40