### PR TITLE
feat(issues): Cleanup timeline loading state

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -12,8 +12,6 @@ import {hasTraceTimelineFeature} from 'sentry/views/issueDetails/traceTimeline/u
 import {TraceTimelineEvents} from './traceTimelineEvents';
 import {useTraceTimelineEvents} from './useTraceTimelineEvents';
 
-const PLACEHOLDER_SIZE = '45px';
-
 interface TraceTimelineProps {
   event: Event;
 }
@@ -35,14 +33,17 @@ export function TraceTimeline({event}: TraceTimelineProps) {
     !isLoading && data.length > 0 && data.every(item => item.id === event.id);
   if (isError || noEvents || onlySelfEvent) {
     // display empty placeholder to reduce layout shift
-    return <div style={{height: PLACEHOLDER_SIZE}} data-test-id="trace-timeline-empty" />;
+    return <div style={{height: 34}} data-test-id="trace-timeline-empty" />;
   }
 
   return (
     <ErrorBoundary mini>
       <Stacked ref={timelineRef}>
         {isLoading ? (
-          <Placeholder height={PLACEHOLDER_SIZE} />
+          <LoadingSkeleton>
+            <Placeholder height="12px" />
+            <Placeholder height="8px" />
+          </LoadingSkeleton>
         ) : (
           <TimelineEventsContainer>
             <TimelineOutline />
@@ -84,11 +85,19 @@ const Stacked = styled('div')`
   > * {
     grid-area: 1 / 1;
   }
-  margin-top: ${space(1)};
+  margin-top: ${space(0.5)};
 `;
 
 const TimelineEventsContainer = styled('div')`
   position: relative;
-  height: 45px;
+  height: 34px;
   padding-top: 10px;
+`;
+
+const LoadingSkeleton = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.25)};
+  padding: ${space(0.75)} 0 ${space(1)};
+  height: 34px;
 `;


### PR DESCRIPTION
Loading state is a bit big and the empty state is a bit big too. Shrink everything and add a loading state that more closely resembles the loaded state.

before
![Screenshot 2024-02-06 at 11 44 43 AM](https://github.com/getsentry/sentry/assets/1400464/d8c21a29-ebc6-4c04-8ae6-29188408a790)

after
![Screenshot 2024-02-06 at 11 45 14 AM](https://github.com/getsentry/sentry/assets/1400464/f78d9c13-e173-45da-9924-e59789d6fcd2)

video

https://github.com/getsentry/sentry/assets/1400464/ad889ff8-0780-46a0-a738-730e1b03214f

