### PR TITLE
feat(app-start): Show more spans in span table

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
@@ -12,7 +12,17 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
+import {TTID_CONTRIBUTING_SPAN_OPS} from 'sentry/views/starfish/views/screens/screenLoadSpans/spanOpSelector';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+
+export const APP_START_SPANS = [
+  ...TTID_CONTRIBUTING_SPAN_OPS,
+  'app.start.cold',
+  'app.start.warm',
+  'contentprovider.load',
+  'application.load',
+  'activity.load',
+];
 
 type Props = {
   primaryRelease?: string;
@@ -36,6 +46,7 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
     'transaction.op:ui.load',
     `transaction:${transaction}`,
     `has:ttid`,
+    `span.op:[${APP_START_SPANS.join(',')}]`,
   ]);
   const queryStringPrimary = appendReleaseFilters(
     searchQuery,

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
@@ -11,7 +11,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
-import {STARTUP_SPANS} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOperationTable';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
@@ -28,12 +27,15 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
   const value = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
 
   const searchQuery = new MutableSearch([
-    'transaction.op:ui.load',
-    `transaction:${transaction}`,
-    `span.op:[${[...STARTUP_SPANS].join(',')}]`,
-    'has:span.description',
+    // Exclude root level spans because they're comprised of nested operations
     '!span.description:"Cold Start"',
     '!span.description:"Warm Start"',
+    // Exclude this span because we can get TTID contributing spans instead
+    '!span.description:"Initial Frame Render"',
+    'has:span.description',
+    'transaction.op:ui.load',
+    `transaction:${transaction}`,
+    `has:ttid`,
   ]);
   const queryStringPrimary = appendReleaseFilters(
     searchQuery,

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -32,6 +32,7 @@ import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/te
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {APP_START_SPANS} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOpSelector';
 import {
   COLD_START_TYPE,
   WARM_START_TYPE,
@@ -82,6 +83,7 @@ export function SpanOperationTable({
     `${SpanMetricsField.APP_START_TYPE}:${
       startType || `[${COLD_START_TYPE},${WARM_START_TYPE}]`
     }`,
+    `${SpanMetricsField.SPAN_OP}:${spanOp ? spanOp : `[${APP_START_SPANS.join(',')}]`}`,
     ...(spanOp ? [`${SpanMetricsField.SPAN_OP}:${spanOp}`] : []),
     ...(deviceClass ? [`${SpanMetricsField.DEVICE_CLASS}:${deviceClass}`] : []),
   ]);

--- a/static/app/views/starfish/views/screens/screenLoadSpans/spanOpSelector.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/spanOpSelector.tsx
@@ -16,6 +16,17 @@ import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseCompariso
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
+export const TTID_CONTRIBUTING_SPAN_OPS = [
+  'file.read',
+  'file.write',
+  'ui.load',
+  'http.client',
+  'db',
+  'db.sql.room',
+  'db.sql.query',
+  'db.sql.transaction',
+];
+
 type Props = {
   primaryRelease?: string;
   secondaryRelease?: string;
@@ -31,7 +42,7 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
   const searchQuery = new MutableSearch([
     'transaction.op:ui.load',
     `transaction:${transaction}`,
-    'span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction]',
+    `span.op:[${TTID_CONTRIBUTING_SPAN_OPS.join(',')}]`,
     'has:span.description',
   ]);
   const queryStringPrimary = appendReleaseFilters(

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -43,7 +43,10 @@ import {
   PLATFORM_LOCAL_STORAGE_KEY,
   PLATFORM_QUERY_PARAM,
 } from 'sentry/views/starfish/views/screens/platformSelector';
-import {SpanOpSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/spanOpSelector';
+import {
+  SpanOpSelector,
+  TTID_CONTRIBUTING_SPAN_OPS,
+} from 'sentry/views/starfish/views/screens/screenLoadSpans/spanOpSelector';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 import {isCrossPlatform} from 'sentry/views/starfish/views/screens/utils';
 
@@ -88,9 +91,7 @@ export function ScreenLoadSpansTable({
       'has:span.description',
       ...(spanOp
         ? [`${SpanMetricsField.SPAN_OP}:${spanOp}`]
-        : [
-            'span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction]',
-          ]),
+        : [`span.op:[${TTID_CONTRIBUTING_SPAN_OPS.join(',')}]`]),
     ]);
 
     if (project && isCrossPlatform(project) && hasPlatformSelectFeature) {


### PR DESCRIPTION
Surface more span ops in the operations table and selector.

Since app start is everything up to TTID, we can show the other spans that contribute to a delayed start time. We have to ignore a span with the description "Initial Frame Render" in this case because iOS creates that to encompass the time to run the application code to get TTID and if we showed it, we'd essentially be duplicating the results in the table.