### PR TITLE
fix(issues): Adjust timeline animation, container size

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -41,7 +41,7 @@ export function TraceTimeline({event}: TraceTimelineProps) {
       <Stacked ref={timelineRef}>
         {isLoading ? (
           <LoadingSkeleton>
-            <Placeholder height="12px" />
+            <Placeholder height="14px" />
             <Placeholder height="8px" />
           </LoadingSkeleton>
         ) : (
@@ -62,9 +62,9 @@ export function TraceTimeline({event}: TraceTimelineProps) {
 const TimelineOutline = styled('div')`
   position: absolute;
   left: 0;
-  top: 5px;
+  top: 3px;
   width: 100%;
-  height: 8px;
+  height: 10px;
   border: 1px solid ${p => p.theme.innerBorder};
   border-radius: ${p => p.theme.borderRadius};
   background-color: ${p => p.theme.backgroundSecondary};

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -254,14 +254,18 @@ const CurrentNodeRing = styled('div')`
   position: absolute;
   top: -4px;
   left: -12px;
-  animation: pulse 1s ease-out infinite;
+  animation: pulse 4s ease-out infinite;
 
   @keyframes pulse {
     0% {
       transform: scale(0.1, 0.1);
       opacity: 0.0;
     }
-    50% {
+    80% {
+      transform: scale(0.1, 0.1);
+      opacity: 0.0;
+    }
+    90% {
       opacity: 1.0;
     }
     100% {


### PR DESCRIPTION
- Slows down the animation by adding time when its doing nothing, pulses less frequently
- Increases the size of the timeline outline container thing
