### PR TITLE
ref: upgrade pyyaml to 6.0.1

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -50,7 +50,7 @@ pymemcache
 python-u2flib-server>=5.0.0
 fido2>=0.9.2
 python3-saml>=1.15.0
-PyYAML>=5.4
+PyYAML>=6.0.1
 rb>=1.9.0
 redis-py-cluster>=2.1.0
 redis>=3.4.1

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -156,7 +156,7 @@ pytz==2018.9
 pyupgrade==3.15.0
 pyuwsgi==2.0.23
 pyvat==1.3.15
-pyyaml==5.4
+pyyaml==6.0.1
 rb==1.10.0
 redis==3.4.1
 redis-py-cluster==2.1.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -103,7 +103,7 @@ python3-saml==1.15.0
 pytz==2018.9
 pyuwsgi==2.0.23
 pyvat==1.3.15
-pyyaml==5.4
+pyyaml==6.0.1
 rb==1.10.0
 redis==3.4.1
 redis-py-cluster==2.1.0


### PR DESCRIPTION
our current version does not build for python 3.12

<!-- Describe your PR here. -->