### PR TITLE
fix(issues): Hide codecov in frame stacktrace prompt

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -423,7 +423,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
             event={event}
             hasInFrameFeature={hasInFrameFeature}
           />
-        ) : shouldShowCodecovPrompt(organization, match) ? (
+        ) : shouldShowCodecovPrompt(organization, match) && !hasInFrameFeature ? (
           <HookCodecovStacktraceLink organization={organization} />
         ) : null}
       </StacktraceLinkWrapper>
@@ -469,7 +469,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
             event={event}
             hasInFrameFeature={hasInFrameFeature}
           />
-        ) : shouldShowCodecovPrompt(organization, match) ? (
+        ) : shouldShowCodecovPrompt(organization, match) && !hasInFrameFeature ? (
           <HookCodecovStacktraceLink organization={organization} />
         ) : null}
       </StacktraceLinkWrapper>


### PR DESCRIPTION
hides the in frame codecov prompt
<img width="417" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/cc806942-ffdc-4bdc-a33f-550639b618cf">
