### PR TITLE
ref(similarity-embedding): Use in app frames

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -40,20 +40,21 @@ def get_stacktrace_string(exception: Mapping[Any, Any], event: GroupEvent) -> st
             choices = [event.platform, "default"] if event.platform else ["default"]
             templates = [f"sentry/partial/frames/{choice}.txt" for choice in choices]
             for frame in exc["stacktrace"]["frames"]:
-                output.append(
-                    render_to_string(
-                        templates,
-                        {
-                            "abs_path": frame.get("abs_path"),
-                            "filename": frame.get("filename"),
-                            "function": frame.get("function"),
-                            "module": frame.get("module"),
-                            "lineno": frame.get("lineno"),
-                            "colno": frame.get("colno"),
-                            "context_line": frame.get("context_line"),
-                        },
-                    ).strip("\n")
-                )
+                if frame["in_app"]:
+                    output.append(
+                        render_to_string(
+                            templates,
+                            {
+                                "abs_path": frame.get("abs_path"),
+                                "filename": frame.get("filename"),
+                                "function": frame.get("function"),
+                                "module": frame.get("module"),
+                                "lineno": frame.get("lineno"),
+                                "colno": frame.get("colno"),
+                                "context_line": frame.get("context_line"),
+                            },
+                        ).strip("\n")
+                    )
 
     return "\n".join(output)
 

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -40,7 +40,18 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                                     "abs_path": "/Users/jodi/python_onboarding/python_onboarding.py",
                                     "lineno": 20,
                                     "context_line": " divide_by_zero_another()",
-                                }
+                                    "in_app": True,
+                                },
+                                # The non-in-app frame should not be included in the stacktrace
+                                {
+                                    "function": "another_function",
+                                    "module": "__main__",
+                                    "filename": "python_onboarding.py",
+                                    "abs_path": "/Users/jodi/python_onboarding/python_onboarding.py",
+                                    "lineno": 40,
+                                    "context_line": " another_function()",
+                                    "in_app": False,
+                                },
                             ]
                         },
                         "type": "ZeroDivisionError",


### PR DESCRIPTION
Change similarity embeddings to only use in app frames of the stacktrace