### PR TITLE
chore(login): update the login banners

### DIFF
--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -78,7 +78,7 @@
   <div class="alert-banner">
     <div class="alert-message">
       {% if banner_choice == 0 %}
-      Join us Feb. 6th at 11AM PT to learn how to identify, resolve and prevent crashes in your mobile app. &nbsp<a target="_blank" href="https://sentry.io/resources/mobile-crash-reporting-and-debugging-best-practices/?utm_source=pendo&utm_medium=site&utm_campaign=mobile-fy25q1-mobiledebuggingworkshop&utm_content=workshop-loginbannermobiledebuggingworkshop-saveyourseat">Learn more.</a>
+      Hitting API rate limits in your project? Learn why API rate limits happen and how to address them.  &nbsp<a target="_blank" href="https://blog.sentry.io/how-to-deal-with-api-rate-limits/?utm_source=pendo&utm_medium=site&utm_campaign=general-fy25q1-jtbd1&utm_content=blog-loginbannerapiratelimits-learnmore">Learn more.</a>
       {% elif banner_choice == 1 %}
       Managing a Python monolith? Join us Feb. 27th at 2AM PT to learn how Kraken Technologies debugs their's with Sentry. &nbsp<a target="_blank" href="https://sentry.io/resources/workshop-managing-a-python-monolith-with-sentry/?utm_source=pendo&utm_medium=site&utm_campaign=backend-fy25q1-backend&utm_content=workshop-loginbannerkrakenworkshop-saveyourseat">Learn more.</a>
       {% endif %}


### PR DESCRIPTION
Update login banners to replace the mobile performance workshop with the API rate limit blog.