### PR TITLE
feat(replay): Split /replay-count/ data source by issue category

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -81,7 +81,7 @@ function EventOrGroupExtraDetails({data, showAssignee, organization}: Props) {
           <span>{numComments}</span>
         </CommentsLink>
       )}
-      {showReplayCount && <IssueReplayCount groupId={id} />}
+      {showReplayCount && <IssueReplayCount group={data as Group} />}
       {logger && (
         <LoggerAnnotation>
           <GlobalSelectionLink

--- a/static/app/components/group/issueReplayCount.spec.tsx
+++ b/static/app/components/group/issueReplayCount.spec.tsx
@@ -1,3 +1,5 @@
+import {GroupFixture} from 'sentry-fixture/group';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -19,36 +21,37 @@ function mockCount(count: undefined | number) {
 
 describe('IssueReplayCount', function () {
   const groupId = '3363325111';
+  const group = GroupFixture({id: groupId});
   const {organization, routerContext} = initializeOrg();
 
   it('does not render when a group has undefined count', async function () {
     const mockGetReplayCountForIssue = mockCount(undefined);
 
-    const {container} = render(<IssueReplayCount groupId={groupId} />);
+    const {container} = render(<IssueReplayCount group={group} />);
 
     await waitFor(() => {
       expect(container).toBeEmptyDOMElement();
     });
 
-    expect(mockGetReplayCountForIssue).toHaveBeenCalledWith(groupId);
+    expect(mockGetReplayCountForIssue).toHaveBeenCalledWith(groupId, 'error');
   });
 
   it('does not render when a group has a count of zero', async function () {
     const mockGetReplayCountForIssue = mockCount(0);
 
-    const {container} = render(<IssueReplayCount groupId={groupId} />);
+    const {container} = render(<IssueReplayCount group={group} />);
 
     await waitFor(() => {
       expect(container).toBeEmptyDOMElement();
     });
 
-    expect(mockGetReplayCountForIssue).toHaveBeenCalledWith(groupId);
+    expect(mockGetReplayCountForIssue).toHaveBeenCalledWith(groupId, 'error');
   });
 
   it('renders the correct replay count', async function () {
     const mockGetReplayCountForIssue = mockCount(2);
 
-    const {container} = render(<IssueReplayCount groupId={groupId} />, {
+    const {container} = render(<IssueReplayCount group={group} />, {
       context: routerContext,
     });
 
@@ -62,6 +65,6 @@ describe('IssueReplayCount', function () {
       'href',
       `/organizations/${organization.slug}/issues/${groupId}/replays/`
     );
-    expect(mockGetReplayCountForIssue).toHaveBeenCalledWith(groupId);
+    expect(mockGetReplayCountForIssue).toHaveBeenCalledWith(groupId, 'error');
   });
 });

--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -10,11 +10,9 @@ import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForI
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
-type NewType = {
+interface Props {
   group: Group;
-};
-
-type Props = NewType;
+}
 
 /**
  * Show the count of how many replays are associated to an issue.

--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -5,21 +5,24 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconPlay} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {Group} from 'sentry/types';
 import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
-type Props = {
-  groupId: string;
+type NewType = {
+  group: Group;
 };
+
+type Props = NewType;
 
 /**
  * Show the count of how many replays are associated to an issue.
  */
-function IssueReplayCount({groupId}: Props) {
+function IssueReplayCount({group}: Props) {
   const organization = useOrganization();
   const {getReplayCountForIssue} = useReplayCountForIssues();
-  const count = getReplayCountForIssue(groupId);
+  const count = getReplayCountForIssue(group.id, group.issueCategory);
 
   if (count === undefined || count === 0) {
     return null;
@@ -37,7 +40,7 @@ function IssueReplayCount({groupId}: Props) {
     <Tooltip title={count > 50 ? titleOver50 : title50OrLess}>
       <ReplayCountLink
         to={normalizeUrl(
-          `/organizations/${organization.slug}/issues/${groupId}/replays/`
+          `/organizations/${organization.slug}/issues/${group.id}/replays/`
         )}
         aria-label="replay-count"
       >

--- a/static/app/utils/replayCount/useReplayCountForIssues.tsx
+++ b/static/app/utils/replayCount/useReplayCountForIssues.tsx
@@ -1,3 +1,4 @@
+import {IssueCategory} from 'sentry/types';
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -6,18 +7,39 @@ import useOrganization from 'sentry/utils/useOrganization';
  */
 export default function useReplayCountForIssues() {
   const organization = useOrganization();
-  const {getOne, getMany, hasOne, hasMany} = useReplayCount({
+  const {
+    getOne: getOneError,
+    getMany: getManyError,
+    hasOne: hasOneError,
+    hasMany: hasManyError,
+  } = useReplayCount({
     bufferLimit: 25,
     dataSource: 'discover',
     fieldName: 'issue.id',
     organization,
     statsPeriod: '14d',
   });
+  const {
+    getOne: getOneIssue,
+    getMany: getManyIssue,
+    hasOne: hasOneIssue,
+    hasMany: hasManyIssue,
+  } = useReplayCount({
+    bufferLimit: 25,
+    dataSource: 'search_issues',
+    fieldName: 'issue.id',
+    organization,
+    statsPeriod: '14d',
+  });
 
   return {
-    getReplayCountForIssue: getOne,
-    getReplayCountForIssues: getMany,
-    issueHasReplay: hasOne,
-    issuesHaveReplay: hasMany,
+    getReplayCountForIssue: (id: string, category: IssueCategory) =>
+      category === IssueCategory.ERROR ? getOneError(id) : getOneIssue(id),
+    getReplayCountForIssues: (id: readonly string[], category: IssueCategory) =>
+      category === IssueCategory.ERROR ? getManyError(id) : getManyIssue(id),
+    issueHasReplay: (id: string, category: IssueCategory) =>
+      category === IssueCategory.ERROR ? hasOneError(id) : hasOneIssue(id),
+    issuesHaveReplay: (id: readonly string[], category: IssueCategory) =>
+      category === IssueCategory.ERROR ? hasManyError(id) : hasManyIssue(id),
   };
 }

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -59,7 +59,7 @@ function GroupHeaderTabs({
   const organization = useOrganization();
 
   const {getReplayCountForIssue} = useReplayCountForIssues();
-  const replaysCount = getReplayCountForIssue(group.id);
+  const replaysCount = getReplayCountForIssue(group.id, group.issueCategory);
 
   const projectFeatures = new Set(project ? project.features : []);
   const organizationFeatures = new Set(organization ? organization.features : []);


### PR DESCRIPTION
TypeScript makes this kind of thing easy. But I also stuck some console.log statements in there to double-check: the Issue Stream and Issue Details pages are the ones that run this code, and they still make the requests we expect.

Fixes https://github.com/getsentry/team-replay/issues/380