### PR TITLE
chore(staff): Let staff access doc integrations endpoints

### DIFF
--- a/src/sentry/api/bases/doc_integrations.py
+++ b/src/sentry/api/bases/doc_integrations.py
@@ -5,7 +5,7 @@ from rest_framework.request import Request
 
 from sentry.api.base import Endpoint
 from sentry.api.bases.integration import PARANOID_GET
-from sentry.api.permissions import SentryPermission
+from sentry.api.permissions import SentryPermission, StaffPermissionMixin
 from sentry.api.validators.doc_integration import METADATA_PROPERTIES
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.integrations.doc_integration import DocIntegration
@@ -17,9 +17,15 @@ class DocIntegrationsPermission(SentryPermission):
     scope_map = {"GET": PARANOID_GET}
 
     def has_permission(self, request: Request, view: object) -> bool:
+        """
+        We only want non-sentry employees to be able to access GET. PUT + DEL
+        should only be accessible through _admin.
+        """
         if not super().has_permission(request, view):
             return False
 
+        # TODO(schew2381): Remove superuser check once staff feature flag is rolled out
+        # We want to limit POST + DEL to staff only through the mixin
         if is_active_superuser(request) or request.method == "GET":
             return True
 
@@ -28,9 +34,15 @@ class DocIntegrationsPermission(SentryPermission):
     def has_object_permission(
         self, request: Request, view: object, doc_integration: DocIntegration
     ) -> bool:
+        """
+        We only want non-sentry employees to be able to access GET, and only for
+        published integrations. PUT + DEL should only be accessible through _admin.
+        """
         if not hasattr(request, "user") or not request.user:
             return False
 
+        # TODO(schew2381): Remove superuser check once staff feature flag is rolled out
+        # We want to limit POST + DEL to staff only through the mixin
         if is_active_superuser(request):
             return True
 
@@ -40,14 +52,26 @@ class DocIntegrationsPermission(SentryPermission):
         return False
 
 
+class DocIntegrationsAndStaffPermission(StaffPermissionMixin, DocIntegrationsPermission):
+    pass
+
+
 class DocIntegrationsBaseEndpoint(Endpoint):
-    permission_classes = (DocIntegrationsPermission,)
+    """
+    Base endpoint used for doc integration collection endpoints.
+    """
+
+    permission_classes = (DocIntegrationsAndStaffPermission,)
 
     def generate_incoming_metadata(self, request: Request) -> JSONData:
         return {k: v for k, v in request.json_body.items() if k in METADATA_PROPERTIES}
 
 
 class DocIntegrationBaseEndpoint(DocIntegrationsBaseEndpoint):
+    """
+    Base endpoint used for doc integration item endpoints.
+    """
+
     def convert_args(self, request: Request, doc_integration_slug: str, *args, **kwargs):
         try:
             doc_integration = DocIntegration.objects.get(slug=doc_integration_slug)

--- a/src/sentry/api/endpoints/integrations/doc_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/doc_integrations/index.py
@@ -11,7 +11,7 @@ from sentry.api.bases.doc_integrations import DocIntegrationsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import DocIntegrationSerializer
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.elevated_mode import has_elevated_mode
 from sentry.models.integrations.doc_integration import DocIntegration
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,8 @@ class DocIntegrationsEndpoint(DocIntegrationsBaseEndpoint):
     }
 
     def get(self, request: Request):
-        if is_active_superuser(request):
+        # TODO(schew2381): Change to is_active_staff once the feature flag is rolled out.
+        if has_elevated_mode(request):
             queryset = DocIntegration.objects.all()
         else:
             queryset = DocIntegration.objects.filter(is_draft=False)

--- a/tests/sentry/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/api/endpoints/test_doc_integrations.py
@@ -9,6 +9,7 @@ from sentry.api.serializers.base import serialize
 from sentry.models.integrations.doc_integration import DocIntegration
 from sentry.models.integrations.integration_feature import IntegrationFeature, IntegrationTypes
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.json import JSONData
 
@@ -19,6 +20,7 @@ class DocIntegrationsTest(APITestCase):
     def setUp(self):
         self.user = self.create_user(email="jinx@lol.com")
         self.superuser = self.create_user(email="vi@lol.com", is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
         self.doc_1 = self.create_doc_integration(name="test_1", is_draft=False, has_avatar=True)
         self.doc_2 = self.create_doc_integration(name="test_2", is_draft=True, has_avatar=True)
         self.doc_3 = self.create_doc_integration(
@@ -36,6 +38,29 @@ class DocIntegrationsTest(APITestCase):
 class GetDocIntegrationsTest(DocIntegrationsTest):
     method = "GET"
 
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_read_docs_for_staff(self):
+        """
+        Tests that all DocIntegrations are returned for staff users,
+        along with serialized versions of their avatars and IntegrationFeatures
+        """
+        self.login_as(user=self.staff_user, staff=True)
+        response = self.get_success_response(status_code=status.HTTP_200_OK)
+        assert len(response.data) == 3
+        for doc in [self.doc_1, self.doc_2, self.doc_3]:
+            assert serialize(doc) in response.data
+        # Check that DocIntegrationAvatars were serialized
+        for doc in [self.doc_1, self.doc_2]:
+            assert doc.avatar.exists()
+            assert serialize(doc.avatar.get()) in self.get_avatars(response)
+        # Check that IntegrationFeatures were also serialized
+        features = IntegrationFeature.objects.filter(
+            target_id=self.doc_3.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        for feature in features:
+            assert serialize(feature) in serialize(self.doc_3)["features"]
+
+    # TODO(schew2381): Change test to check superuser can only fetch non-draft DocIntegrations
     def test_read_docs_for_superuser(self):
         """
         Tests that all DocIntegrations are returned for super users,
@@ -93,12 +118,37 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
     }
     ignored_keys = ["is_draft", "metadata"]
 
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.staff_user, staff=True)
+
+    # TODO(schew2381): Change test to check superuser can't access POST
     def test_create_doc_for_superuser(self):
         """
         Tests that a draft DocIntegration is created for superuser requests along
         with all the appropriate IntegrationFeatures
         """
         self.login_as(user=self.superuser, superuser=True)
+        response = self.get_success_response(status_code=status.HTTP_201_CREATED, **self.payload)
+        doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])
+        assert serialize(doc) == response.data
+        assert doc.is_draft
+        features = IntegrationFeature.objects.filter(
+            target_id=doc.id, target_type=IntegrationTypes.DOC_INTEGRATION.value
+        )
+        assert features.exists()
+        assert len(features) == 3
+        for feature in features:
+            # Ensure payload features are in the database
+            assert feature.feature in self.payload["features"]
+            # Ensure they are also serialized in the response
+            assert serialize(feature) in response.data["features"]
+
+    def test_create_doc_for_staff(self):
+        """
+        Tests that a draft DocIntegration is created for superuser requests along
+        with all the appropriate IntegrationFeatures
+        """
         response = self.get_success_response(status_code=status.HTTP_201_CREATED, **self.payload)
         doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])
         assert serialize(doc) == response.data
@@ -125,7 +175,6 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         """
         Tests that repeated names throw errors when generating slugs
         """
-        self.login_as(user=self.superuser, superuser=True)
         payload = {**self.payload, "name": self.doc_1.name}
         response = self.get_error_response(status_code=status.HTTP_400_BAD_REQUEST, **payload)
         assert "name" in response.data.keys()
@@ -134,7 +183,6 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         """
         Tests that generated slug based on name is not entirely numeric
         """
-        self.login_as(user=self.superuser, superuser=True)
         payload = {**self.payload, "name": "1234"}
         response = self.get_success_response(status_code=status.HTTP_201_CREATED, **payload)
 
@@ -146,7 +194,6 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         """
         Tests that incorrectly structured metadata throws an error
         """
-        self.login_as(user=self.superuser, superuser=True)
         invalid_resources = {
             "not_an_array": {},
             "extra_keys": [{**self.payload["resources"][0], "extra": "key"}],
@@ -162,7 +209,6 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         Tests that sending no metadata keys does not trigger any
         server/database errors
         """
-        self.login_as(user=self.superuser, superuser=True)
         payload = {**self.payload}
         del payload["resources"]
         response = self.get_success_response(status_code=status.HTTP_201_CREATED, **payload)
@@ -173,7 +219,6 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         Tests that certain reserved keys cannot be overridden by the
         request payload. They must be created by the API.
         """
-        self.login_as(user=self.superuser, superuser=True)
         payload = {**self.payload, "is_draft": False, "metadata": {"should": "not override"}}
         self.get_success_response(status_code=status.HTTP_201_CREATED, **payload)
         doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])
@@ -186,7 +231,6 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         Tests that providing duplicate keys do not result in a server
         error; instead, the excess are ignored.
         """
-        self.login_as(user=self.superuser, superuser=True)
         payload = {**self.payload, "features": [0, 0, 0, 0, 1, 1, 1, 2]}
         self.get_success_response(status_code=status.HTTP_201_CREATED, **payload)
         doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])

--- a/tests/sentry/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/api/endpoints/test_doc_integrations.py
@@ -39,7 +39,7 @@ class GetDocIntegrationsTest(DocIntegrationsTest):
     method = "GET"
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_read_docs_for_staff(self):
+    def test_staff_read_docs(self):
         """
         Tests that all DocIntegrations are returned for staff users,
         along with serialized versions of their avatars and IntegrationFeatures
@@ -61,7 +61,7 @@ class GetDocIntegrationsTest(DocIntegrationsTest):
             assert serialize(feature) in serialize(self.doc_3)["features"]
 
     # TODO(schew2381): Change test to check superuser can only fetch non-draft DocIntegrations
-    def test_read_docs_for_superuser(self):
+    def test_superuser_read_docs(self):
         """
         Tests that all DocIntegrations are returned for super users,
         along with serialized versions of their avatars and IntegrationFeatures
@@ -122,13 +122,11 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         super().setUp()
         self.login_as(user=self.staff_user, staff=True)
 
-    # TODO(schew2381): Change test to check superuser can't access POST
-    def test_create_doc_for_superuser(self):
+    def test_staff_create_doc(self):
         """
         Tests that a draft DocIntegration is created for superuser requests along
         with all the appropriate IntegrationFeatures
         """
-        self.login_as(user=self.superuser, superuser=True)
         response = self.get_success_response(status_code=status.HTTP_201_CREATED, **self.payload)
         doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])
         assert serialize(doc) == response.data
@@ -144,11 +142,13 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
             # Ensure they are also serialized in the response
             assert serialize(feature) in response.data["features"]
 
-    def test_create_doc_for_staff(self):
+    # TODO(schew2381): Change test to check superuser can't access POST
+    def test_superuser_create_doc(self):
         """
         Tests that a draft DocIntegration is created for superuser requests along
         with all the appropriate IntegrationFeatures
         """
+        self.login_as(user=self.superuser, superuser=True)
         response = self.get_success_response(status_code=status.HTTP_201_CREATED, **self.payload)
         doc = DocIntegration.objects.get(name=self.payload["name"], author=self.payload["author"])
         assert serialize(doc) == response.data


### PR DESCRIPTION
After this PR, the doc integrations _admin tab should be complete :)

---
### Summary

The following applies to:
1. `DocIntegrationsEndpoint` - GET, POST
2. `DocIntegrationDetailsEndpoint` - GET, PUT, DELETE
3. `DocIntegrationAvatarEndpoint` - GET, PUT

GET - allows everyone with scopes, superuser can fetch unpublished doc integration(s)
PUT, POST, DEL - Limited to superuser. Because these are only used in _admin, we will eventually prevent superuser entirely and allow only staff once the staff feature flag is rolled out

---

### Video Using Staff

https://github.com/getsentry/sentry/assets/67301797/bc7adab2-46b2-4678-a34d-4d49d83fa1ab
