### PR TITLE
fix(menulistitem): Change item container element from p to div

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -358,7 +358,7 @@ const LabelWrap = styled('div')`
   min-width: 0;
 `;
 
-const Label = styled('p')`
+const Label = styled('div')`
   margin-bottom: 0;
   line-height: 1.4;
   white-space: nowrap;
@@ -366,7 +366,7 @@ const Label = styled('p')`
   ${p => p.theme.overflowEllipsis}
 `;
 
-const Details = styled('p')<{disabled: boolean; priority: Priority}>`
+const Details = styled('div')<{disabled: boolean; priority: Priority}>`
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.subText};
   line-height: 1.2;


### PR DESCRIPTION
`DropdownMenu` items can contain either a string or JSX: 


https://github.com/getsentry/sentry/blob/bae5a52add60b741c58c23da6d002701f77946ee/static/app/components/menuListItem.tsx#L40-L44

When passing a label with a `div`, this will cause an error because `div`s cannot be children of paragraph tags. The label and details containers don't need to be `p` tags so I switched them to `div`s to avoid this.