### PR TITLE
feat(issue-priority): Only show activity when UI flag is enabled

### DIFF
--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -75,6 +75,13 @@ function ActivitySection(props: Props) {
           );
         }
 
+        if (
+          item.type === GroupActivityType.SET_PRIORITY &&
+          !organization.features.includes('issue-priority-ui')
+        ) {
+          return null;
+        }
+
         return (
           <ErrorBoundary mini key={`item-${item.id}`}>
             <ActivityItem

--- a/static/app/views/issueDetails/groupActivity.spec.tsx
+++ b/static/app/views/issueDetails/groupActivity.spec.tsx
@@ -737,6 +737,7 @@ describe('GroupActivity', function () {
             dateCreated,
           },
         ],
+        organization: OrganizationFixture({features: ['issue-priority-ui']}),
       });
       expect(screen.getAllByTestId('activity-item').at(-1)).toHaveTextContent(
         'Sentry updated the priority value of this issue to be high after it escalated'
@@ -756,6 +757,7 @@ describe('GroupActivity', function () {
             dateCreated,
           },
         ],
+        organization: OrganizationFixture({features: ['issue-priority-ui']}),
       });
       expect(screen.getAllByTestId('activity-item').at(-1)).toHaveTextContent(
         'Sentry updated the priority value of this issue to be low after it was marked as ongoing'

--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -518,6 +518,16 @@ function GroupActivityItem({
         );
       }
       case GroupActivityType.FIRST_SEEN:
+        if (
+          organization.features.includes('issue-priority-ui') &&
+          activity.data.priority
+        ) {
+          return tct(
+            '[author] first saw this issue and marked it as [priority] priority',
+            {author, priority: activity.data.priority}
+          );
+        }
+
         return tct('[author] first saw this issue', {author});
       case GroupActivityType.ASSIGNED: {
         return (


### PR DESCRIPTION
This will allow us to enable the backend flag to set priority data without displaying activity entries to the user.

Also updates the FIRST_SEEN entry to display priority when available.