### PR TITLE
feat(issue-priority): Register option to enable issue priority

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -773,6 +773,15 @@ register(
 )
 
 
+# Killswitch for issue priority
+register(
+    "issues.priority.enabled",
+    default=False,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+
 # ## sentry.killswitches
 #
 # The following options are documented in sentry.killswitches in more detail


### PR DESCRIPTION
We will use this to enable/disable the feature during today's GA rollout. The project-based option will be removed in a followup.