### PR TITLE
chore(staff): Let staff access user identities

### DIFF
--- a/src/sentry/api/endpoints/user_identity_config.py
+++ b/src/sentry/api/endpoints/user_identity_config.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
-from sentry.api.bases.user import UserEndpoint
+from sentry.api.bases.user import UserAndStaffPermission, UserEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user_identity_config import (
     Status,
@@ -83,6 +83,8 @@ class UserIdentityConfigEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.UNKNOWN,
     }
 
+    permission_classes = (UserAndStaffPermission,)
+
     def get(self, request: Request, user) -> Response:
         """
         Retrieve all of a user's SocialIdentity, Identity, and AuthIdentity values
@@ -102,6 +104,8 @@ class UserIdentityConfigDetailsEndpoint(UserEndpoint):
         "DELETE": ApiPublishStatus.UNKNOWN,
         "GET": ApiPublishStatus.UNKNOWN,
     }
+
+    permission_classes = (UserAndStaffPermission,)
 
     @staticmethod
     def _get_identity(user, category, identity_id) -> UserIdentityConfig | None:

--- a/tests/sentry/api/endpoints/test_user_identity_config.py
+++ b/tests/sentry/api/endpoints/test_user_identity_config.py
@@ -199,9 +199,9 @@ class UserIdentityConfigDetailsEndpointGetTest(UserIdentityConfigTest):
 
     def _verify_identities(
         self,
-        social_ident: UserSocialAuth,
-        global_ident: Identity,
-        org_ident: AuthIdentity,
+        social_ident,
+        global_ident,
+        org_ident,
     ) -> None:
         # Verify social identity
         assert social_ident["category"] == "social-identity"

--- a/tests/sentry/api/endpoints/test_user_identity_config.py
+++ b/tests/sentry/api/endpoints/test_user_identity_config.py
@@ -197,32 +197,44 @@ class UserIdentityConfigDetailsEndpointGetTest(UserIdentityConfigTest):
     endpoint = "sentry-api-0-user-identity-config-details"
     method = "get"
 
+    def _verify_identities(
+        self,
+        social_ident: UserSocialAuth,
+        global_ident: Identity,
+        org_ident: AuthIdentity,
+    ) -> None:
+        # Verify social identity
+        assert social_ident["category"] == "social-identity"
+        assert social_ident["status"] == "can_disconnect"
+        assert social_ident["organization"] is None
+
+        # Verify global identity
+        assert global_ident["category"] == "global-identity"
+        assert global_ident["status"] == "can_disconnect"
+        assert global_ident["organization"] is None
+
+        # Verify org identity
+        assert org_ident["category"] == "org-identity"
+        assert org_ident["status"] == "needed_for_org_auth"
+        assert org_ident["organization"]["id"] == str(self.organization.id)
+
     def test_get(self):
         social_obj, global_obj, org_obj = self._setup_identities()
 
         social_ident = self.get_success_response(
             self.user.id, "social-identity", str(social_obj.id), status_code=200
         ).data
-        assert social_ident["id"] == str(social_obj.id)
-        assert social_ident["category"] == "social-identity"
-        assert social_ident["status"] == "can_disconnect"
-        assert social_ident["organization"] is None
-
         global_ident = self.get_success_response(
             self.user.id, "global-identity", str(global_obj.id), status_code=200
         ).data
-        assert global_ident["id"] == str(global_obj.id)
-        assert global_ident["category"] == "global-identity"
-        assert global_ident["status"] == "can_disconnect"
-        assert global_ident["organization"] is None
-
         org_ident = self.get_success_response(
             self.user.id, "org-identity", str(org_obj.id), status_code=200
         ).data
+
+        assert social_ident["id"] == str(social_obj.id)
+        assert global_ident["id"] == str(global_obj.id)
         assert org_ident["id"] == str(org_obj.id)
-        assert org_ident["category"] == "org-identity"
-        assert org_ident["status"] == "needed_for_org_auth"
-        assert org_ident["organization"]["id"] == str(self.organization.id)
+        self._verify_identities(social_ident, global_ident, org_ident)
 
     def test_superuser_can_fetch_other_users_identity(self):
         self.login_as(self.superuser, superuser=True)
@@ -231,26 +243,17 @@ class UserIdentityConfigDetailsEndpointGetTest(UserIdentityConfigTest):
         social_ident = self.get_success_response(
             self.user.id, "social-identity", str(social_obj.id), status_code=200
         ).data
-        assert social_ident["id"] == str(social_obj.id)
-        assert social_ident["category"] == "social-identity"
-        assert social_ident["status"] == "can_disconnect"
-        assert social_ident["organization"] is None
-
         global_ident = self.get_success_response(
             self.user.id, "global-identity", str(global_obj.id), status_code=200
         ).data
-        assert global_ident["id"] == str(global_obj.id)
-        assert global_ident["category"] == "global-identity"
-        assert global_ident["status"] == "can_disconnect"
-        assert global_ident["organization"] is None
-
         org_ident = self.get_success_response(
             self.user.id, "org-identity", str(org_obj.id), status_code=200
         ).data
+
+        assert social_ident["id"] == str(social_obj.id)
+        assert global_ident["id"] == str(global_obj.id)
         assert org_ident["id"] == str(org_obj.id)
-        assert org_ident["category"] == "org-identity"
-        assert org_ident["status"] == "needed_for_org_auth"
-        assert org_ident["organization"]["id"] == str(self.organization.id)
+        self._verify_identities(social_ident, global_ident, org_ident)
 
     def test_staff_can_fetch_other_users_identity(self):
         self.login_as(self.staff_user, staff=True)
@@ -259,26 +262,17 @@ class UserIdentityConfigDetailsEndpointGetTest(UserIdentityConfigTest):
         social_ident = self.get_success_response(
             self.user.id, "social-identity", str(social_obj.id), status_code=200
         ).data
-        assert social_ident["id"] == str(social_obj.id)
-        assert social_ident["category"] == "social-identity"
-        assert social_ident["status"] == "can_disconnect"
-        assert social_ident["organization"] is None
-
         global_ident = self.get_success_response(
             self.user.id, "global-identity", str(global_obj.id), status_code=200
         ).data
-        assert global_ident["id"] == str(global_obj.id)
-        assert global_ident["category"] == "global-identity"
-        assert global_ident["status"] == "can_disconnect"
-        assert global_ident["organization"] is None
-
         org_ident = self.get_success_response(
             self.user.id, "org-identity", str(org_obj.id), status_code=200
         ).data
+
+        assert social_ident["id"] == str(social_obj.id)
+        assert global_ident["id"] == str(global_obj.id)
         assert org_ident["id"] == str(org_obj.id)
-        assert org_ident["category"] == "org-identity"
-        assert org_ident["status"] == "needed_for_org_auth"
-        assert org_ident["organization"]["id"] == str(self.organization.id)
+        self._verify_identities(social_ident, global_ident, org_ident)
 
     def test_enforces_ownership_by_user(self):
         another_user = self.create_user()

--- a/tests/sentry/api/endpoints/test_user_identity_config.py
+++ b/tests/sentry/api/endpoints/test_user_identity_config.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest.mock import patch
 
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
@@ -11,6 +11,9 @@ from social_auth.models import UserSocialAuth
 class UserIdentityConfigTest(APITestCase):
     def setUp(self):
         super().setUp()
+
+        self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
 
         self.slack_idp = self.create_identity_provider(type="slack", external_id="A")
         self.github_idp = self.create_identity_provider(type="github", external_id="B")
@@ -33,10 +36,11 @@ class UserIdentityConfigEndpointTest(UserIdentityConfigTest):
     endpoint = "sentry-api-0-user-identity-config"
     method = "get"
 
-    @mock.patch("sentry.api.serializers.models.user_identity_config.is_login_provider")
+    @patch(
+        "sentry.api.serializers.models.user_identity_config.is_login_provider",
+        side_effect=mock_is_login_provider_effect,
+    )
     def test_simple(self, mock_is_login_provider):
-        mock_is_login_provider.side_effect = mock_is_login_provider_effect
-
         UserSocialAuth.objects.create(provider="github", user=self.user)
         Identity.objects.create(user=self.user, idp=self.github_idp)
         Identity.objects.create(user=self.user, idp=self.slack_idp)
@@ -67,10 +71,45 @@ class UserIdentityConfigEndpointTest(UserIdentityConfigTest):
         assert org_ident["isLogin"] is True
         assert org_ident["organization"]["id"] == str(self.organization.id)
 
-    @mock.patch("sentry.api.serializers.models.user_identity_config.is_login_provider")
-    def test_identity_needed_for_global_auth(self, mock_is_login_provider):
-        mock_is_login_provider.side_effect = mock_is_login_provider_effect
+    @patch(
+        "sentry.api.serializers.models.user_identity_config.is_login_provider",
+        side_effect=mock_is_login_provider_effect,
+    )
+    def test_superuser_can_fetch_other_users_identities(self, mock_is_login_provider):
+        self.login_as(self.superuser, superuser=True)
 
+        UserSocialAuth.objects.create(provider="github", user=self.user)
+        Identity.objects.create(user=self.user, idp=self.github_idp)
+        Identity.objects.create(user=self.user, idp=self.slack_idp)
+        AuthIdentity.objects.create(user=self.user, auth_provider=self.org_provider)
+
+        response = self.get_success_response(self.user.id, status_code=200)
+
+        identities = {(obj["category"], obj["provider"]["key"]): obj for obj in response.data}
+        assert len(identities) == 4
+
+    @patch(
+        "sentry.api.serializers.models.user_identity_config.is_login_provider",
+        side_effect=mock_is_login_provider_effect,
+    )
+    def test_staff_can_fetch_other_users_identities(self, mock_is_login_provider):
+        self.login_as(self.staff_user, staff=True)
+
+        UserSocialAuth.objects.create(provider="github", user=self.user)
+        Identity.objects.create(user=self.user, idp=self.github_idp)
+        Identity.objects.create(user=self.user, idp=self.slack_idp)
+        AuthIdentity.objects.create(user=self.user, auth_provider=self.org_provider)
+
+        response = self.get_success_response(self.user.id, status_code=200)
+
+        identities = {(obj["category"], obj["provider"]["key"]): obj for obj in response.data}
+        assert len(identities) == 4
+
+    @patch(
+        "sentry.api.serializers.models.user_identity_config.is_login_provider",
+        side_effect=mock_is_login_provider_effect,
+    )
+    def test_identity_needed_for_global_auth(self, mock_is_login_provider):
         self.user.update(password="")
         identity = Identity.objects.create(user=self.user, idp=self.github_idp)
         self.login_as(self.user)
@@ -186,6 +225,66 @@ class UserIdentityConfigDetailsEndpointGetTest(UserIdentityConfigTest):
         assert org_ident["status"] == "needed_for_org_auth"
         assert org_ident["organization"]["id"] == str(self.organization.id)
 
+    def test_superuser_can_fetch_other_users_identity(self):
+        self.login_as(self.superuser, superuser=True)
+        social_obj = UserSocialAuth.objects.create(provider="github", user=self.user)
+        global_obj = Identity.objects.create(user=self.user, idp=self.github_idp)
+        org_obj = AuthIdentity.objects.create(user=self.user, auth_provider=self.org_provider)
+
+        social_ident = self.get_success_response(
+            self.user.id, "social-identity", str(social_obj.id), status_code=200
+        ).data
+        assert social_ident["id"] == str(social_obj.id)
+        assert social_ident["category"] == "social-identity"
+        assert social_ident["status"] == "can_disconnect"
+        assert social_ident["organization"] is None
+
+        global_ident = self.get_success_response(
+            self.user.id, "global-identity", str(global_obj.id), status_code=200
+        ).data
+        assert global_ident["id"] == str(global_obj.id)
+        assert global_ident["category"] == "global-identity"
+        assert global_ident["status"] == "can_disconnect"
+        assert global_ident["organization"] is None
+
+        org_ident = self.get_success_response(
+            self.user.id, "org-identity", str(org_obj.id), status_code=200
+        ).data
+        assert org_ident["id"] == str(org_obj.id)
+        assert org_ident["category"] == "org-identity"
+        assert org_ident["status"] == "needed_for_org_auth"
+        assert org_ident["organization"]["id"] == str(self.organization.id)
+
+    def test_staff_can_fetch_other_users_identity(self):
+        self.login_as(self.staff_user, staff=True)
+        social_obj = UserSocialAuth.objects.create(provider="github", user=self.user)
+        global_obj = Identity.objects.create(user=self.user, idp=self.github_idp)
+        org_obj = AuthIdentity.objects.create(user=self.user, auth_provider=self.org_provider)
+
+        social_ident = self.get_success_response(
+            self.user.id, "social-identity", str(social_obj.id), status_code=200
+        ).data
+        assert social_ident["id"] == str(social_obj.id)
+        assert social_ident["category"] == "social-identity"
+        assert social_ident["status"] == "can_disconnect"
+        assert social_ident["organization"] is None
+
+        global_ident = self.get_success_response(
+            self.user.id, "global-identity", str(global_obj.id), status_code=200
+        ).data
+        assert global_ident["id"] == str(global_obj.id)
+        assert global_ident["category"] == "global-identity"
+        assert global_ident["status"] == "can_disconnect"
+        assert global_ident["organization"] is None
+
+        org_ident = self.get_success_response(
+            self.user.id, "org-identity", str(org_obj.id), status_code=200
+        ).data
+        assert org_ident["id"] == str(org_obj.id)
+        assert org_ident["category"] == "org-identity"
+        assert org_ident["status"] == "needed_for_org_auth"
+        assert org_ident["organization"]["id"] == str(self.organization.id)
+
     def test_enforces_ownership_by_user(self):
         another_user = self.create_user()
         their_identity = Identity.objects.create(user=another_user, idp=self.github_idp)
@@ -221,6 +320,50 @@ class UserIdentityConfigDetailsEndpointDeleteTest(UserIdentityConfigTest):
         self.get_success_response(self.user.id, "org-identity", str(org_obj.id), status_code=204)
         assert not AuthIdentity.objects.filter(id=org_obj.id).exists()
 
+    def test_superuser_can_delete_other_users_identity(self):
+        self.login_as(self.superuser, superuser=True)
+        self.org_provider.flags.allow_unlinked = True
+        self.org_provider.save()
+
+        social_obj = UserSocialAuth.objects.create(provider="github", user=self.user)
+        global_obj = Identity.objects.create(user=self.user, idp=self.github_idp)
+        org_obj = AuthIdentity.objects.create(user=self.user, auth_provider=self.org_provider)
+
+        self.get_success_response(
+            self.user.id, "social-identity", str(social_obj.id), status_code=204
+        )
+        assert not UserSocialAuth.objects.filter(id=social_obj.id).exists()
+
+        self.get_success_response(
+            self.user.id, "global-identity", str(global_obj.id), status_code=204
+        )
+        assert not Identity.objects.filter(id=global_obj.id).exists()
+
+        self.get_success_response(self.user.id, "org-identity", str(org_obj.id), status_code=204)
+        assert not AuthIdentity.objects.filter(id=org_obj.id).exists()
+
+    def test_staff_can_delete_other_users_identity(self):
+        self.login_as(self.staff_user, staff=True)
+        self.org_provider.flags.allow_unlinked = True
+        self.org_provider.save()
+
+        social_obj = UserSocialAuth.objects.create(provider="github", user=self.user)
+        global_obj = Identity.objects.create(user=self.user, idp=self.github_idp)
+        org_obj = AuthIdentity.objects.create(user=self.user, auth_provider=self.org_provider)
+
+        self.get_success_response(
+            self.user.id, "social-identity", str(social_obj.id), status_code=204
+        )
+        assert not UserSocialAuth.objects.filter(id=social_obj.id).exists()
+
+        self.get_success_response(
+            self.user.id, "global-identity", str(global_obj.id), status_code=204
+        )
+        assert not Identity.objects.filter(id=global_obj.id).exists()
+
+        self.get_success_response(self.user.id, "org-identity", str(org_obj.id), status_code=204)
+        assert not AuthIdentity.objects.filter(id=org_obj.id).exists()
+
     def test_enforces_ownership_by_user(self):
         another_user = self.create_user()
         their_identity = Identity.objects.create(user=another_user, idp=self.github_idp)
@@ -235,10 +378,11 @@ class UserIdentityConfigDetailsEndpointDeleteTest(UserIdentityConfigTest):
         self.get_error_response(self.user.id, "org-identity", str(ident_obj.id), status_code=403)
         assert AuthIdentity.objects.get(id=ident_obj.id)
 
-    @mock.patch("sentry.api.serializers.models.user_identity_config.is_login_provider")
+    @patch(
+        "sentry.api.serializers.models.user_identity_config.is_login_provider",
+        side_effect=mock_is_login_provider_effect,
+    )
     def test_enforces_global_ident_needed_for_login(self, mock_is_login_provider):
-        mock_is_login_provider.side_effect = mock_is_login_provider_effect
-
         self.user.update(password="")
         self.login_as(self.user)
 


### PR DESCRIPTION
Needed for _admin. I noticed that _admin doesn't use the single item GET, but it doesn't seem to be a big deal to give it access to that when it uses the collection GET.

Kinda sad I had to delete my actual test gitlab integration for the demo, will be sad when I eventually add it back 😢

https://github.com/getsentry/sentry/assets/67301797/76923399-7a3f-4f39-8b97-f74d2cfc4653
