### PR TITLE
feat(charts): Avoid overflowing tooltips

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -51,7 +51,7 @@ import {defined} from 'sentry/utils';
 import Grid from './components/grid';
 import Legend from './components/legend';
 import type {TooltipSubLabel} from './components/tooltip';
-import {computeChartTooltip} from './components/tooltip';
+import {CHART_TOOLTIP_VIEWPORT_OFFSET, computeChartTooltip} from './components/tooltip';
 import XAxis from './components/xAxis';
 import YAxis from './components/yAxis';
 import LineSeries from './series/lineSeries';
@@ -676,12 +676,14 @@ const getTooltipStyles = (p: {theme: Theme}) => css`
   }
   .tooltip-series {
     border-bottom: none;
+    max-width: calc(100vw - 2 * ${CHART_TOOLTIP_VIEWPORT_OFFSET}px);
   }
   .tooltip-series-solo {
     border-radius: ${p.theme.borderRadius};
   }
   .tooltip-label {
     margin-right: ${space(1)};
+    ${p.theme.overflowEllipsis};
   }
   .tooltip-label strong {
     font-weight: normal;


### PR DESCRIPTION
### Problem
1. The current tooltip can exit the viewport on top.
2. Labels are never truncated -> tooltip can exit the viewport on the side

<img width="540" alt="Screenshot 2024-02-07 at 08 09 12" src="https://github.com/getsentry/sentry/assets/7033940/5ed507f8-1a8a-4c92-a43c-3fd572d57e4e">

### Solution
1. Add a minimum "top" distance to the position calculation
2. Add `max-width` to the tooltip and an ellipsis to its labels.

<img width="540" alt="Screenshot 2024-02-07 at 08 09 40" src="https://github.com/getsentry/sentry/assets/7033940/87798730-aee5-4cf5-a093-f87b0228c410">


- closes https://github.com/getsentry/sentry/issues/63577
- closes https://github.com/getsentry/sentry/issues/64021