### PR TITLE
ref(relay): Stop exposing relay cardinality limiter feature flag

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -58,7 +58,6 @@ EXPOSABLE_FEATURES = [
     "organizations:custom-metrics",
     "organizations:metric-meta",
     "organizations:standalone-span-ingestion",
-    "organizations:relay-cardinality-limiter",
 ]
 
 EXTRACT_METRICS_VERSION = 1


### PR DESCRIPTION
Cardinality Limits will only be added to the project config when the feature flag is enabled, we don't need to additionally send the feature flag.

Relay PR: https://github.com/getsentry/relay/pull/3068