### PR TITLE
chore(codeowners): replace enterprise with core product foundations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,11 +54,11 @@
 
 ## Security
 /src/sentry/net/                                         @getsentry/security
-/src/sentry/auth/                                        @getsentry/security @getsentry/enterprise
-/src/sentry/api/permissions.py                           @getsentry/security @getsentry/enterprise
-/src/sentry/api/authentication.py                        @getsentry/security @getsentry/enterprise
-/src/sentry/api/endpoints/auth*                          @getsentry/security @getsentry/enterprise
-/src/sentry/api/endpoints/user_permission*               @getsentry/security @getsentry/enterprise
+/src/sentry/auth/                                        @getsentry/security @getsentry/core-product-foundations
+/src/sentry/api/permissions.py                           @getsentry/security @getsentry/core-product-foundations
+/src/sentry/api/authentication.py                        @getsentry/security @getsentry/core-product-foundations
+/src/sentry/api/endpoints/auth*                          @getsentry/security @getsentry/core-product-foundations
+/src/sentry/api/endpoints/user_permission*               @getsentry/security @getsentry/core-product-foundations
 /src/sentry/web/frontend/auth_close.py                   @getsentry/security
 /src/sentry/web/frontend/auth_login.py                   @getsentry/security
 /src/sentry/web/frontend/auth_logout.py                  @getsentry/security
@@ -398,36 +398,34 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 ## End of Data
 
 
-## Enterprise
-/src/sentry/api/endpoints/oauth_userinfo.py                             @getsentry/enterprise
-/src/sentry/api/endpoints/organization_auditlogs.py                     @getsentry/enterprise
-/src/sentry/api/endpoints/organization_projects_experiment.py           @getsentry/enterprise
-/src/sentry/api/endpoints/organization_stats*.py                        @getsentry/enterprise
-/src/sentry/api/endpoints/release_threshold*.py                         @getsentry/enterprise
-/src/sentry/api/endpoints/user_social_identity*                         @getsentry/enterprise
-/src/sentry/auth/staff.py                                               @getsentry/enterprise
-/src/sentry/auth/superuser.py                                           @getsentry/enterprise
-/src/sentry/middleware/staff.py                                         @getsentry/enterprise
-/src/sentry/middleware/superuser.py                                     @getsentry/enterprise
-/src/sentry/models/release_threshold                                    @getsentry/enterprise
-/src/sentry/scim/                                                       @getsentry/enterprise
-/src/sentry/tasks/integrations/github/                                  @getsentry/enterprise
-/src/sentry/web/frontend/auth_login.py                                  @getsentry/enterprise
-/static/app/components/superuserStaffAccessForm.tsx                     @getsentry/enterprise
-/static/app/constants/superuserAccessErrors.tsx                         @getsentry/enterprise
-/static/app/views/organizationStats                                     @getsentry/enterprise
-/static/app/views/releases/thresholdsList/                              @getsentry/enterprise
-/static/app/views/settings/organizationAuth/                            @getsentry/enterprise
-/static/app/views/settings/organizationMembers/inviteBanner.tsx         @getsentry/enterprise
-/tests/sentry/api/endpoints/test_auth*.py                               @getsentry/enterprise
-/tests/sentry/api/endpoints/test_organization_projects_experiment.py    @getsentry/enterprise
-/tests/sentry/api/test_data_secrecy.py                                  @getsentry/enterprise
-/tests/sentry/api/test_scim*.py                                         @getsentry/enterprise
-/tests/sentry/auth/test_staff.py                                        @getsentry/enterprise
-/tests/sentry/auth/test_superuser.py                                    @getsentry/enterprise
-/tests/sentry/middleware/test_staff.py                                  @getsentry/enterprise
-/tests/sentry/tasks/integrations/github/                                @getsentry/enterprise
-## End of Enterprise
+## Core Product Foundations
+/src/sentry/api/endpoints/oauth_userinfo.py                             @getsentry/core-product-foundations
+/src/sentry/api/endpoints/organization_auditlogs.py                     @getsentry/core-product-foundations
+/src/sentry/api/endpoints/organization_projects_experiment.py           @getsentry/core-product-foundations
+/src/sentry/api/endpoints/organization_stats*.py                        @getsentry/core-product-foundations
+/src/sentry/api/endpoints/release_threshold*.py                         @getsentry/core-product-foundations
+/src/sentry/api/endpoints/user_social_identity*                         @getsentry/core-product-foundations
+/src/sentry/auth/staff.py                                               @getsentry/core-product-foundations
+/src/sentry/auth/superuser.py                                           @getsentry/core-product-foundations
+/src/sentry/middleware/staff.py                                         @getsentry/core-product-foundations
+/src/sentry/middleware/superuser.py                                     @getsentry/core-product-foundations
+/src/sentry/models/release_threshold                                    @getsentry/core-product-foundations
+/src/sentry/scim/                                                       @getsentry/core-product-foundations
+/src/sentry/web/frontend/auth_login.py                                  @getsentry/core-product-foundations
+/static/app/components/superuserStaffAccessForm.tsx                     @getsentry/core-product-foundations
+/static/app/constants/superuserAccessErrors.tsx                         @getsentry/core-product-foundations
+/static/app/views/organizationStats                                     @getsentry/core-product-foundations
+/static/app/views/releases/thresholdsList/                              @getsentry/core-product-foundations
+/static/app/views/settings/organizationAuth/                            @getsentry/core-product-foundations
+/static/app/views/settings/organizationMembers/inviteBanner.tsx         @getsentry/core-product-foundations
+/tests/sentry/api/endpoints/test_auth*.py                               @getsentry/core-product-foundations
+/tests/sentry/api/endpoints/test_organization_projects_experiment.py    @getsentry/core-product-foundations
+/tests/sentry/api/test_data_secrecy.py                                  @getsentry/core-product-foundations
+/tests/sentry/api/test_scim*.py                                         @getsentry/core-product-foundations
+/tests/sentry/auth/test_staff.py                                        @getsentry/core-product-foundations
+/tests/sentry/auth/test_superuser.py                                    @getsentry/core-product-foundations
+/tests/sentry/middleware/test_staff.py                                  @getsentry/core-product-foundations
+## End of Core Product Foundations
 
 
 ## Native
@@ -544,5 +542,5 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/api/endpoints/organization_missing_org_members.py           @getsentry/ecosystem
 /src/sentry/tasks/invite_missing_org_members.py                         @getsentry/ecosystem
 /static/app/components/modals/inviteMissingMembersModal/                @getsentry/ecosystem
-/src/sentry/tasks/integrations/github/pr_comment.py                     @getsentry/ecosystem
+/tests/sentry/tasks/integrations/github/                                @getsentry/ecosystem
 ## End of Ecosystem

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -11,7 +11,6 @@ class ApiOwner(Enum):
     CRONS = "crons"
     DISCOVER_N_DASHBOARDS = "discover-n-dashboards"
     ECOSYSTEM = "ecosystem"
-    ENTERPRISE = "enterprise"
     CORE_PRODUCT_FOUNDATIONS = "core-product-foundations"
     FEEDBACK = "feedback-backend"
     HYBRID_CLOUD = "hybrid-cloud"

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -11,7 +11,7 @@ class ApiOwner(Enum):
     CRONS = "crons"
     DISCOVER_N_DASHBOARDS = "discover-n-dashboards"
     ECOSYSTEM = "ecosystem"
-    ENTERPRISE = "enterprise"
+    CORE_PRODUCT_FOUNDATIONS = "core-product-foundations"
     FEEDBACK = "feedback-backend"
     HYBRID_CLOUD = "hybrid-cloud"
     INTEGRATIONS = "product-owners-settings-integrations"

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -11,6 +11,7 @@ class ApiOwner(Enum):
     CRONS = "crons"
     DISCOVER_N_DASHBOARDS = "discover-n-dashboards"
     ECOSYSTEM = "ecosystem"
+    ENTERPRISE = "enterprise"
     CORE_PRODUCT_FOUNDATIONS = "core-product-foundations"
     FEEDBACK = "feedback-backend"
     HYBRID_CLOUD = "hybrid-cloud"

--- a/src/sentry/api/endpoints/api_application_rotate_secret.py
+++ b/src/sentry/api/endpoints/api_application_rotate_secret.py
@@ -16,7 +16,7 @@ class ApiApplicationRotateSecretEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 

--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -21,7 +21,7 @@ class ApiAuthorizationsEndpoint(Endpoint):
         "DELETE": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 

--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -26,7 +26,7 @@ class AuthConfigEndpoint(Endpoint, OrganizationMixin):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     # Disable authentication and permission requirements.
     permission_classes = ()
 

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -45,7 +45,7 @@ class BaseAuthIndexEndpoint(Endpoint):
     AuthIndexEndpoint and StaffAuthIndexEndpoint (in getsentry)
     """
 
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     authentication_classes = (QuietBasicAuthentication, SessionAuthentication)
 
     permission_classes = ()

--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -19,7 +19,7 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     # Disable authentication and permission requirements.
     permission_classes = ()
 

--- a/src/sentry/api/endpoints/authenticator_index.py
+++ b/src/sentry/api/endpoints/authenticator_index.py
@@ -15,7 +15,7 @@ class AuthenticatorIndexEndpoint(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (IsAuthenticated,)
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/codeowners/external_actor/team_details.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/team_details.py
@@ -23,7 +23,7 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         "DELETE": ApiPublishStatus.UNKNOWN,
         "PUT": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def convert_args(
         self,

--- a/src/sentry/api/endpoints/codeowners/external_actor/team_index.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/team_index.py
@@ -20,7 +20,7 @@ class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
     publish_status = {
         "POST": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def post(self, request: Request, team: Team) -> Response:
         """

--- a/src/sentry/api/endpoints/codeowners/external_actor/user_details.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/user_details.py
@@ -25,7 +25,7 @@ class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMix
         "DELETE": ApiPublishStatus.UNKNOWN,
         "PUT": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def convert_args(  # type: ignore[override]
         self,

--- a/src/sentry/api/endpoints/codeowners/external_actor/user_index.py
+++ b/src/sentry/api/endpoints/codeowners/external_actor/user_index.py
@@ -20,7 +20,7 @@ class ExternalUserEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
     publish_status = {
         "POST": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def post(self, request: Request, organization: Organization) -> Response:
         """

--- a/src/sentry/api/endpoints/integrations/organization_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/index.py
@@ -55,7 +55,7 @@ def filter_by_features(
 @control_silo_endpoint
 @extend_schema(tags=["Integrations"])
 class OrganizationIntegrationsEndpoint(OrganizationIntegrationBaseEndpoint):
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.ECOSYSTEM
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }

--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -22,7 +22,7 @@ class OAuthUserInfoEndpoint(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     authentication_classes = ()
     permission_classes = ()
 

--- a/src/sentry/api/endpoints/org_auth_token_details.py
+++ b/src/sentry/api/endpoints/org_auth_token_details.py
@@ -23,7 +23,7 @@ class OrgAuthTokenDetailsEndpoint(ControlSiloOrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (OrgAuthTokenPermission,)
 
     def get(

--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -38,7 +38,7 @@ class OrgAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (OrgAuthTokenPermission,)
 
     @method_decorator(never_cache)

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -50,7 +50,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (AccessRequestPermission,)
 
     # TODO(dcramer): this should go onto AccessRequestPermission

--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -36,7 +36,7 @@ class OrganizationAuditLogsEndpoint(ControlSiloOrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (OrganizationAuditPermission,)
 
     def get(

--- a/src/sentry/api/endpoints/organization_auth_provider_details.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_details.py
@@ -17,7 +17,7 @@ class OrganizationAuthProviderDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (OrganizationAuthProviderPermission,)
 
     def get(self, request: Request, organization: Organization) -> Response:

--- a/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
@@ -20,7 +20,7 @@ class OrganizationAuthProviderSendRemindersEndpoint(OrganizationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (OrganizationAdminPermission,)
 
     def post(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -14,7 +14,7 @@ class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (OrganizationAuthProviderPermission,)
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_integration_migrate_opsgenie.py
+++ b/src/sentry/api/endpoints/organization_integration_migrate_opsgenie.py
@@ -17,7 +17,7 @@ class OrganizationIntegrationMigrateOpsgenieEndpoint(RegionOrganizationIntegrati
     publish_status = {
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.ECOSYSTEM
 
     def put(
         self,

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -111,7 +111,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (RelaxedMemberPermission,)
 
     def _get_member(

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -130,7 +130,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
         "POST": ApiPublishStatus.UNKNOWN,
     }
     permission_classes = (MemberPermission,)
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def get(self, request: Request, organization) -> Response:
         queryset = OrganizationMember.objects.filter(
@@ -341,9 +341,11 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             organization_id=organization.id,
             target_object=om.id,
             data=om.get_audit_log_data(),
-            event=audit_log.get_event_id("MEMBER_INVITE")
-            if settings.SENTRY_ENABLE_INVITES
-            else audit_log.get_event_id("MEMBER_ADD"),
+            event=(
+                audit_log.get_event_id("MEMBER_INVITE")
+                if settings.SENTRY_ENABLE_INVITES
+                else audit_log.get_event_id("MEMBER_ADD")
+            ),
         )
 
         return Response(serialize(om), status=201)

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -102,7 +102,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         "PUT": ApiPublishStatus.UNKNOWN,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (OrganizationTeamMemberPermission,)
 
     def _can_create_team_member(self, request: Request, team: Team) -> bool:

--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -56,7 +56,7 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrgProjectPermission,)
     logger = logging.getLogger("team-project.create")
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def should_add_creator_to_team(self, request: Request):
         return request.user.is_authenticated

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -19,7 +19,7 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
         # Deprecated APIs remain private until removed
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def get(self, request: Request, organization) -> Response:
         """

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -122,7 +122,7 @@ class StatsSummaryApiResponse(TypedDict):
 @region_silo_endpoint
 class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
     publish_status = {"GET": ApiPublishStatus.PUBLIC}
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     @extend_schema(
         operation_id="Retrieve an Organization's Events Count by Project",

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -137,7 +137,7 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/organization_user_teams.py
+++ b/src/sentry/api/endpoints/organization_user_teams.py
@@ -16,7 +16,7 @@ class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def get(self, request: Request, organization) -> Response:
         """

--- a/src/sentry/api/endpoints/project_member_index.py
+++ b/src/sentry/api/endpoints/project_member_index.py
@@ -15,7 +15,7 @@ class ProjectMemberIndexEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def get(self, request: Request, project) -> Response:
         queryset = OrganizationMember.objects.filter(

--- a/src/sentry/api/endpoints/project_team_details.py
+++ b/src/sentry/api/endpoints/project_team_details.py
@@ -32,7 +32,7 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
         "DELETE": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (ProjectTeamsPermission,)
 
     @extend_schema(

--- a/src/sentry/api/endpoints/project_teams.py
+++ b/src/sentry/api/endpoints/project_teams.py
@@ -15,7 +15,7 @@ class ProjectTeamsEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def get(self, request: Request, project) -> Response:
         """

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold.py
@@ -40,7 +40,7 @@ class ReleaseThresholdPOSTSerializer(serializers.Serializer):
 @region_silo_endpoint
 class ReleaseThresholdEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
-    owner: ApiOwner = ApiOwner.ENTERPRISE
+    owner: ApiOwner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "POST": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_details.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_details.py
@@ -44,7 +44,7 @@ class ReleaseThresholdPUTSerializer(serializers.Serializer):
 @region_silo_endpoint
 class ReleaseThresholdDetailsEndpoint(ProjectEndpoint):
     permission_classes = (ProjectReleasePermission,)
-    owner: ApiOwner = ApiOwner.ENTERPRISE
+    owner: ApiOwner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     publish_status = {
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
         "GET": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
@@ -25,7 +25,7 @@ class ReleaseThresholdIndexGETValidator(serializers.Serializer):
 
 @region_silo_endpoint
 class ReleaseThresholdIndexEndpoint(OrganizationEndpoint):
-    owner: ApiOwner = ApiOwner.ENTERPRISE
+    owner: ApiOwner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -84,7 +84,7 @@ class ReleaseThresholdStatusIndexSerializer(serializers.Serializer):
 
 @region_silo_endpoint
 class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
-    owner: ApiOwner = ApiOwner.ENTERPRISE
+    owner: ApiOwner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }

--- a/src/sentry/api/endpoints/team_members.py
+++ b/src/sentry/api/endpoints/team_members.py
@@ -49,7 +49,7 @@ class TeamMembersEndpoint(TeamEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def get(self, request: Request, team) -> Response:
         queryset = OrganizationMemberTeam.objects.filter(

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -82,7 +82,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
         "POST": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (TeamProjectPermission,)
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     @extend_schema(
         operation_id="List a Team's Projects",

--- a/src/sentry/api/endpoints/team_stats.py
+++ b/src/sentry/api/endpoints/team_stats.py
@@ -17,7 +17,7 @@ class TeamStatsEndpoint(TeamEndpoint, EnvironmentMixin, StatsMixin):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def get(self, request: Request, team) -> Response:
         """

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -27,7 +27,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "PUT": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (OrganizationUserPermission,)
 
     def _get_device_for_rename(self, authenticator, interface_device_id):

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -113,7 +113,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     @sudo_required
     def get(self, request: Request, user, interface_id) -> HttpResponse:

--- a/src/sentry/api/endpoints/user_authenticator_index.py
+++ b/src/sentry/api/endpoints/user_authenticator_index.py
@@ -14,7 +14,7 @@ class UserAuthenticatorIndexEndpoint(UserEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def get(self, request: Request, user) -> Response:
         """Returns all interface for a user (un-enrolled ones), otherwise an empty array"""

--- a/src/sentry/api/endpoints/user_permission_details.py
+++ b/src/sentry/api/endpoints/user_permission_details.py
@@ -24,7 +24,7 @@ class UserPermissionDetailsEndpoint(UserEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     authentication_classes = (SessionAuthentication,)
     permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 

--- a/src/sentry/api/endpoints/user_permissions.py
+++ b/src/sentry/api/endpoints/user_permissions.py
@@ -14,7 +14,7 @@ class UserPermissionsEndpoint(UserEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def get(self, request: Request, user) -> Response:

--- a/src/sentry/api/endpoints/user_permissions_config.py
+++ b/src/sentry/api/endpoints/user_permissions_config.py
@@ -14,7 +14,7 @@ class UserPermissionsConfigEndpoint(UserEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def get(self, request: Request, user) -> Response:

--- a/src/sentry/api/endpoints/user_social_identities_index.py
+++ b/src/sentry/api/endpoints/user_social_identities_index.py
@@ -14,7 +14,7 @@ class UserSocialIdentitiesIndexEndpoint(UserEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def get(self, request: Request, user) -> Response:
         """

--- a/src/sentry/api/endpoints/user_social_identity_details.py
+++ b/src/sentry/api/endpoints/user_social_identity_details.py
@@ -18,7 +18,7 @@ class UserSocialIdentityDetailsEndpoint(UserEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
 
     def delete(self, request: Request, user, identity_id) -> Response:
         """

--- a/src/sentry/integrations/github/installation.py
+++ b/src/sentry/integrations/github/installation.py
@@ -25,7 +25,7 @@ class GitHubIntegrationsInstallationEndpoint(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.ECOSYSTEM
 
     permission_classes = (IsAuthenticated,)
 

--- a/src/sentry/scim/endpoints/utils.py
+++ b/src/sentry/scim/endpoints/utils.py
@@ -126,7 +126,7 @@ class SCIMListBaseResponse(TypedDict):
 
 @extend_schema(tags=["SCIM"])
 class SCIMEndpoint(OrganizationEndpoint):
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.CORE_PRODUCT_FOUNDATIONS
     content_negotiation_class = SCIMClientNegotiation
     cursor_name = "startIndex"
 


### PR DESCRIPTION
Correct version of #64792

Updates codeowners to remove Enterprise entirely and replaces Enterprise ApiOwners with Core Product Foundations.