### PR TITLE
Revert "build: update corejs to v3.35.1 (#64695)"

### DIFF
--- a/babel.config.ts
+++ b/babel.config.ts
@@ -15,7 +15,7 @@ const config: TransformOptions = {
       '@babel/preset-env',
       {
         useBuiltIns: 'usage',
-        corejs: '3.35.1',
+        corejs: '3.27',
       },
     ],
     '@babel/preset-typescript',

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "color": "^4.2.3",
     "compression-webpack-plugin": "10.0.0",
     "copy-webpack-plugin": "^11.0.0",
-    "core-js": "^3.35.1",
+    "core-js": "^3.33.0",
     "cronstrue": "^2.26.0",
     "crypto-browserify": "^3.12.0",
     "crypto-js": "4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5131,10 +5131,10 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^3.35.1:
-  version "3.35.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.35.1.tgz#9c28f8b7ccee482796f8590cc8d15739eaaf980c"
-  integrity sha512-IgdsbxNyMskrTFxa9lWHyMwAJU5gXOPP+1yO+K59d50VLVAIDAbs7gIv705KzALModfK3ZrSZTPNpC0PQgIZuw==
+core-js@^3.33.0:
+  version "3.33.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.33.0.tgz#70366dbf737134761edb017990cf5ce6c6369c40"
+  integrity sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==
 
 core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
This reverts commit 24dd87cc46b75a064457904548c3e21a992a6d91.
This update changed the compiled output of the config [file](https://sentry.io/_chartcuterie-config.js) we serve to chartcuterie - it now includes some URLSearchParam references that charcuterie can't seem to handle causing new pods to crash loop