### PR TITLE
bug(replay): Add useMemo to add the replay-count hook helpers

### DIFF
--- a/static/app/utils/replayCount/useReplayCountForFeedbacks.tsx
+++ b/static/app/utils/replayCount/useReplayCountForFeedbacks.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from 'react';
+
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -14,8 +16,11 @@ export default function useReplayCountForFeedbacks() {
     statsPeriod: '90d',
   });
 
-  return {
-    feedbackHasReplay: hasOne,
-    feedbacksHaveReplay: hasMany,
-  };
+  return useMemo(
+    () => ({
+      feedbackHasReplay: hasOne,
+      feedbacksHaveReplay: hasMany,
+    }),
+    [hasMany, hasOne]
+  );
 }

--- a/static/app/utils/replayCount/useReplayCountForIssues.tsx
+++ b/static/app/utils/replayCount/useReplayCountForIssues.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from 'react';
+
 import {IssueCategory} from 'sentry/types';
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -32,14 +34,26 @@ export default function useReplayCountForIssues() {
     statsPeriod: '14d',
   });
 
-  return {
-    getReplayCountForIssue: (id: string, category: IssueCategory) =>
-      category === IssueCategory.ERROR ? getOneError(id) : getOneIssue(id),
-    getReplayCountForIssues: (id: readonly string[], category: IssueCategory) =>
-      category === IssueCategory.ERROR ? getManyError(id) : getManyIssue(id),
-    issueHasReplay: (id: string, category: IssueCategory) =>
-      category === IssueCategory.ERROR ? hasOneError(id) : hasOneIssue(id),
-    issuesHaveReplay: (id: readonly string[], category: IssueCategory) =>
-      category === IssueCategory.ERROR ? hasManyError(id) : hasManyIssue(id),
-  };
+  return useMemo(
+    () => ({
+      getReplayCountForIssue: (id: string, category: IssueCategory) =>
+        category === IssueCategory.ERROR ? getOneError(id) : getOneIssue(id),
+      getReplayCountForIssues: (id: readonly string[], category: IssueCategory) =>
+        category === IssueCategory.ERROR ? getManyError(id) : getManyIssue(id),
+      issueHasReplay: (id: string, category: IssueCategory) =>
+        category === IssueCategory.ERROR ? hasOneError(id) : hasOneIssue(id),
+      issuesHaveReplay: (id: readonly string[], category: IssueCategory) =>
+        category === IssueCategory.ERROR ? hasManyError(id) : hasManyIssue(id),
+    }),
+    [
+      getManyError,
+      getManyIssue,
+      getOneError,
+      getOneIssue,
+      hasManyError,
+      hasManyIssue,
+      hasOneError,
+      hasOneIssue,
+    ]
+  );
 }

--- a/static/app/utils/replayCount/useReplayCountForTransactions.tsx
+++ b/static/app/utils/replayCount/useReplayCountForTransactions.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from 'react';
+
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -14,10 +16,13 @@ export default function useReplayCountForTransactions() {
     statsPeriod: '90d',
   });
 
-  return {
-    getReplayCountForTransaction: getOne,
-    getReplayCountForTransactions: getMany,
-    transactionHasReplay: hasOne,
-    transactionsHaveReplay: hasMany,
-  };
+  return useMemo(
+    () => ({
+      getReplayCountForTransaction: getOne,
+      getReplayCountForTransactions: getMany,
+      transactionHasReplay: hasOne,
+      transactionsHaveReplay: hasMany,
+    }),
+    [getMany, getOne, hasMany, hasOne]
+  );
 }

--- a/static/app/utils/replayCount/useReplayExists.tsx
+++ b/static/app/utils/replayCount/useReplayExists.tsx
@@ -1,3 +1,5 @@
+import {useMemo} from 'react';
+
 import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -14,8 +16,11 @@ export default function useReplayExists() {
     statsPeriod: '90d',
   });
 
-  return {
-    replayExists: hasOne,
-    replaysExist: hasMany,
-  };
+  return useMemo(
+    () => ({
+      replayExists: hasOne,
+      replaysExist: hasMany,
+    }),
+    [hasMany, hasOne]
+  );
 }


### PR DESCRIPTION
Adding useMemo so that we're not returning new objects & new anon-functions each time. I think the assumption is that hooks return stable references whenever possible, so conforming to that will make it easier for callsites to prevent excess re-renders. 