### PR TITLE
feat(app-start): Update module names

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -270,7 +270,7 @@ function Sidebar() {
               <Feature features="performance-screens-view" organization={organization}>
                 <SidebarItem
                   {...sidebarItemProps}
-                  label={t('Mobile')}
+                  label={t('Screen Load')}
                   to={`/organizations/${organization.slug}/performance/mobile/screens/`}
                   id="performance-mobile-screens"
                   icon={<SubitemDot collapsed />}
@@ -279,7 +279,7 @@ function Sidebar() {
               <Feature features="starfish-mobile-appstart" organization={organization}>
                 <SidebarItem
                   {...sidebarItemProps}
-                  label={t('App Startup')}
+                  label={t('App Start')}
                   to={`/organizations/${organization.slug}/performance/mobile/app-startup`}
                   id="performance-mobile-app-startup"
                   icon={<SubitemDot collapsed />}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -270,7 +270,7 @@ function Sidebar() {
               <Feature features="performance-screens-view" organization={organization}>
                 <SidebarItem
                   {...sidebarItemProps}
-                  label={t('Screen Load')}
+                  label={t('Screen Loads')}
                   to={`/organizations/${organization.slug}/performance/mobile/screens/`}
                   id="performance-mobile-screens"
                   icon={<SubitemDot collapsed />}
@@ -279,7 +279,7 @@ function Sidebar() {
               <Feature features="starfish-mobile-appstart" organization={organization}>
                 <SidebarItem
                   {...sidebarItemProps}
-                  label={t('App Start')}
+                  label={t('App Starts')}
                   to={`/organizations/${organization.slug}/performance/mobile/app-startup`}
                   id="performance-mobile-app-startup"
                   icon={<SubitemDot collapsed />}

--- a/static/app/views/starfish/modules/mobile/pageload.tsx
+++ b/static/app/views/starfish/modules/mobile/pageload.tsx
@@ -37,13 +37,13 @@ export default function PageloadModule() {
   }, [projects, selection.projects]);
 
   return (
-    <SentryDocumentTitle title={t('Mobile')} orgSlug={organization.slug}>
+    <SentryDocumentTitle title={t('Screen Load')} orgSlug={organization.slug}>
       <Layout.Page>
         <PageAlertProvider>
           <Layout.Header>
             <Layout.HeaderContent>
               <HeaderWrapper>
-                <Layout.Title>{t('Mobile')}</Layout.Title>
+                <Layout.Title>{t('Screen Load')}</Layout.Title>
                 {organization.features.includes(
                   'performance-screens-platform-selector'
                 ) &&

--- a/static/app/views/starfish/modules/mobile/pageload.tsx
+++ b/static/app/views/starfish/modules/mobile/pageload.tsx
@@ -37,13 +37,13 @@ export default function PageloadModule() {
   }, [projects, selection.projects]);
 
   return (
-    <SentryDocumentTitle title={t('Screen Load')} orgSlug={organization.slug}>
+    <SentryDocumentTitle title={t('Screen Loads')} orgSlug={organization.slug}>
       <Layout.Page>
         <PageAlertProvider>
           <Layout.Header>
             <Layout.HeaderContent>
               <HeaderWrapper>
-                <Layout.Title>{t('Screen Load')}</Layout.Title>
+                <Layout.Title>{t('Screen Loads')}</Layout.Title>
                 {organization.features.includes(
                   'performance-screens-platform-selector'
                 ) &&

--- a/static/app/views/starfish/utils/routeNames.tsx
+++ b/static/app/views/starfish/utils/routeNames.tsx
@@ -7,6 +7,6 @@ export const ROUTE_NAMES = {
   'span-summary': t('Span Summary'),
   'web-service': t('Web Service'),
   'app-startup': t('App Startup'),
-  pageload: t('Mobile'),
+  pageload: t('Screen Load'),
   responsiveness: t('Responsiveness'),
 };

--- a/static/app/views/starfish/utils/routeNames.tsx
+++ b/static/app/views/starfish/utils/routeNames.tsx
@@ -6,7 +6,7 @@ export const ROUTE_NAMES = {
   'endpoint-overview': t('Endpoint Overview'),
   'span-summary': t('Span Summary'),
   'web-service': t('Web Service'),
-  'app-startup': t('App Startup'),
-  pageload: t('Screen Load'),
+  'app-startup': t('App Starts'),
+  pageload: t('Screen Loads'),
   responsiveness: t('Responsiveness'),
 };

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -68,7 +68,7 @@ function ScreenSummary() {
   const crumbs: Crumb[] = [
     {
       to: startupModule,
-      label: t('App Startup'),
+      label: t('App Starts'),
       preservePageFilters: true,
     },
     {

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -76,7 +76,7 @@ function ScreenLoadSpans() {
   const crumbs: Crumb[] = [
     {
       to: screenLoadModule,
-      label: t('Mobile'),
+      label: t('Screen Load'),
       preservePageFilters: true,
     },
     {

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -76,7 +76,7 @@ function ScreenLoadSpans() {
   const crumbs: Crumb[] = [
     {
       to: screenLoadModule,
-      label: t('Screen Load'),
+      label: t('Screen Loads'),
       preservePageFilters: true,
     },
     {


### PR DESCRIPTION
Since the App Start module is also a mobile module, we need to be more specific for the screens module.

Also renamed App Startup to App Start because that's the language we use in docs (see [here](https://docs.sentry.io/platforms/android/performance/instrumentation/automatic-instrumentation/#app-start-instrumentation))

The title changes are:
- Mobile --> Screen Load
- App Startup --> App Start