### PR TITLE
fix(mobile-starfish): Broken links to profiles

### DIFF
--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -143,7 +143,7 @@ export function SpanSamplesTable({
             <Tooltip title={t('View Profile')}>
               <LinkButton
                 to={normalizeUrl(
-                  `/organizations/${organization.slug}/profiling/profile/${row.project}/${row.profile_id}/flamechart/`
+                  `/organizations/${organization.slug}/profiling/profile/${row.project}/${row.profile_id}/flamegraph/`
                 )}
                 size="xs"
               >

--- a/static/app/views/starfish/components/samplesTable/transactionSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/transactionSamplesTable.tsx
@@ -195,7 +195,7 @@ export function TransactionSamplesTable({
         <Link
           {...commonProps}
           to={normalizeUrl(
-            `/organizations/${organization.slug}/profiling/profile/${row['project.name']}/${row.profile_id}/flamechart/`
+            `/organizations/${organization.slug}/profiling/profile/${row['project.name']}/${row.profile_id}/flamegraph/`
           )}
         >
           {row.profile_id.slice(0, 8)}


### PR DESCRIPTION
The URL incorrectly uses `/flamechart` instead of `/flamegraph`