### PR TITLE
fix(open-pr-comments): skip files that don't have a patch

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -208,7 +208,7 @@ def safe_for_comment(
 
     for file in pr_files:
         filename = file["filename"]
-        # don't count the file if it was anything but modified or is not in the list of supported file extensions
+        # we only count the file if it's modified and if the file extension is in the list of supported file extensions
         # we cannot look at deleted or newly added files because we cannot extract functions from the diffs
         if file["status"] != "modified" or filename.split(".")[-1] not in patch_parsers:
             continue

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -208,7 +208,7 @@ def safe_for_comment(
 
     for file in pr_files:
         filename = file["filename"]
-        # don't count the file if it was anything but modified or is not a Python file
+        # don't count the file if it was anything but modified or is not in the list of supported file extensions
         # we cannot look at deleted or newly added files because we cannot extract functions from the diffs
         if file["status"] != "modified" or filename.split(".")[-1] not in patch_parsers:
             continue

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -208,7 +208,8 @@ def safe_for_comment(
 
     for file in pr_files:
         filename = file["filename"]
-        # don't count the file if it was added or is not a Python file
+        # don't count the file if it was anything but modified or is not a Python file
+        # we cannot look at deleted files because we cannot extract functions from them
         if file["status"] != "modified" or filename.split(".")[-1] not in patch_parsers:
             continue
 

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -209,11 +209,7 @@ def safe_for_comment(
     for file in pr_files:
         filename = file["filename"]
         # don't count the file if it was added or is not a Python file
-        if (
-            file["status"] == "added"
-            or file["status"] == "renamed"
-            or filename.split(".")[-1] not in patch_parsers
-        ):
+        if file["status"] != "modified" or filename.split(".")[-1] not in patch_parsers:
             continue
 
         changed_file_count += 1
@@ -240,7 +236,9 @@ def get_pr_files(pr_files: list[dict[str, str]]) -> list[PullRequestFile]:
     # new files will not have sentry issues associated with them
     # only fetch Python files
     pullrequest_files = [
-        PullRequestFile(filename=file["filename"], patch=file["patch"]) for file in pr_files
+        PullRequestFile(filename=file["filename"], patch=file["patch"])
+        for file in pr_files
+        if "patch" in file
     ]
 
     logger.info("github.open_pr_comment.pr_filenames", extra={"count": len(pullrequest_files)})

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -209,7 +209,7 @@ def safe_for_comment(
     for file in pr_files:
         filename = file["filename"]
         # don't count the file if it was anything but modified or is not a Python file
-        # we cannot look at deleted files because we cannot extract functions from them
+        # we cannot look at deleted or newly added files because we cannot extract functions from the diffs
         if file["status"] != "modified" or filename.split(".")[-1] not in patch_parsers:
             continue
 

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -102,6 +102,7 @@ class TestSafeForComment(GithubCommentTestCase):
             {"filename": "bar.js", "changes": 100, "status": "modified"},
             {"filename": "baz.py", "changes": 100, "status": "added"},
             {"filename": "bee.py", "changes": 100, "status": "deleted"},
+            {"filename": "hi.py", "changes": 100, "status": "removed"},
             {"filename": "boo.py", "changes": 0, "status": "renamed"},
         ]
         responses.add(

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -115,7 +115,6 @@ class TestSafeForComment(GithubCommentTestCase):
         pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
         assert pr_files == [
             {"filename": "foo.py", "changes": 100, "status": "modified"},
-            {"filename": "bee.py", "changes": 100, "status": "deleted"},
         ]
 
     @responses.activate
@@ -139,7 +138,6 @@ class TestSafeForComment(GithubCommentTestCase):
         assert pr_files == [
             {"filename": "foo.py", "changes": 100, "status": "modified"},
             {"filename": "bar.js", "changes": 100, "status": "modified"},
-            {"filename": "bee.py", "changes": 100, "status": "deleted"},
         ]
 
     @responses.activate
@@ -175,7 +173,7 @@ class TestSafeForComment(GithubCommentTestCase):
             status=200,
             json=[
                 {"filename": "foo.py", "changes": 300, "status": "modified"},
-                {"filename": "bar.py", "changes": 300, "status": "deleted"},
+                {"filename": "bar.py", "changes": 300, "status": "modified"},
             ],
         )
 
@@ -268,14 +266,15 @@ class TestGetFilenames(GithubCommentTestCase):
     def test_get_pr_files(self):
         data: JSONData = [
             {"filename": "bar.py", "status": "modified", "patch": "b"},
-            {"filename": "baz.py", "status": "deleted", "patch": "c"},
+            {"filename": "baz.py", "status": "modified"},
         ]
 
         pr_files = get_pr_files(data)
-        for i, pr_file in enumerate(pr_files):
-            file = data[i]
-            assert pr_file.filename == file["filename"]
-            assert pr_file.patch == file["patch"]
+        assert len(pr_files) == 1
+
+        pr_file = pr_files[0]
+        assert pr_file.filename == data[0]["filename"]
+        assert pr_file.patch == data[0]["patch"]
 
     def test_get_projects_and_filenames_from_source_file(self):
         projects = [self.create_project() for _ in range(4)]


### PR DESCRIPTION
It seems like sometimes Github returns pull request file information as `deleted` OR `removed` if the file has been deleted.

Deciding to stop checking whether or not a file's status is in a list of statuses we want to skip (added, removed, deleted, etc) and instead check if the file is `modified` instead. We won't be able to find functions changed in deleted files since the whole file is removed, or in added files since it's new. I'm also skipping the file if the `patch` doesn't exist.

Fixes [SENTRY-2D2J](https://sentry.sentry.io/issues/4817645187/?)