### PR TITLE
fix(api): Stop making a default auth token

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/index.py
@@ -128,7 +128,8 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
                     overview=data["overview"],
                     allowed_origins=data["allowedOrigins"],
                     popularity=data["popularity"],
-                ).run(user=request.user, request=request)
+                ).run(user=request.user, request=request, skip_default_auth_token=True)
+                # We want to stop creating the default auth token for new apps and installations through the API
             except ValidationError as e:
                 # we generate and validate the slug here instead of the serializer since the slug never changes
                 return Response(e.detail, status=400)

--- a/tests/sentry/sentry_apps/test_sentry_app_creator.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_creator.py
@@ -217,6 +217,24 @@ class TestInternalCreator(TestCase):
 
         assert install.api_token
 
+    def test_skips_creating_auth_token_when_flag_is_true(self) -> None:
+        app = SentryAppCreator(
+            is_internal=True,
+            verify_install=False,
+            author=self.org.name,
+            name="nulldb",
+            organization_id=self.org.id,
+            scopes=[
+                "project:read",
+            ],
+            webhook_url="http://example.com",
+            schema={"elements": [self.create_issue_link_schema()]},
+        ).run(user=self.user, request=None, skip_default_auth_token=True)
+
+        install = SentryAppInstallation.objects.get(organization_id=self.org.id, sentry_app=app)
+
+        assert install.api_token is None
+
     @patch("sentry.utils.audit.create_audit_entry")
     def test_audits(self, create_audit_entry):
         SentryAppCreator(


### PR DESCRIPTION
We no longer expose auth token values, so there's no point in creating a default auth token if the user can't read the value. The default token is also an increased security risk if the integration is not used or users are not aware of the side effects. Instead, incentivize the user to create the token when they are comfortable, and in the future, push them towards OAuth 2.0 instead of the long lived tokens.

https://github.com/getsentry/sentry/assets/5581484/dc43d44b-01f6-4254-a63a-b54c48b71b63


Resolves: https://github.com/getsentry/sentry/issues/64798