### PR TITLE
fix: redirect to login when confirming email if user is not authenticated

### DIFF
--- a/src/sentry/web/decorators.py
+++ b/src/sentry/web/decorators.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 from functools import wraps
 from typing import Any
 
-from django.contrib import messages
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -16,26 +15,21 @@ ERR_BAD_SIGNATURE = _("The link you followed is invalid or expired.")
 EndpointFunc = Callable[..., HttpResponse]
 
 
-def login_required(message: str | None = None, level: int | None = None):
-    def real_decorator(func: EndpointFunc) -> EndpointFunc:
-        @wraps(func)
-        def wrapped(request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-            if not request.user.is_authenticated:
-                if message and level:
-                    messages.add_message(request, level, message)
-                auth.initiate_login(request, next_url=request.get_full_path())
-                if "organization_slug" in kwargs:
-                    redirect_uri = reverse(
-                        "sentry-auth-organization", args=[kwargs["organization_slug"]]
-                    )
-                else:
-                    redirect_uri = auth.get_login_url()
-                return HttpResponseRedirect(redirect_uri)
-            return func(request, *args, **kwargs)
+def login_required(func: EndpointFunc) -> EndpointFunc:
+    @wraps(func)
+    def wrapped(request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        if not request.user.is_authenticated:
+            auth.initiate_login(request, next_url=request.get_full_path())
+            if "organization_slug" in kwargs:
+                redirect_uri = reverse(
+                    "sentry-auth-organization", args=[kwargs["organization_slug"]]
+                )
+            else:
+                redirect_uri = auth.get_login_url()
+            return HttpResponseRedirect(redirect_uri)
+        return func(request, *args, **kwargs)
 
-        return wrapped
-
-    return real_decorator
+    return wrapped
 
 
 def set_referrer_policy(policy: str) -> Callable[[EndpointFunc], EndpointFunc]:

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -241,6 +241,7 @@ def start_confirm_email(request):
 
 
 @set_referrer_policy("strict-origin-when-cross-origin")
+@login_required
 @control_silo_function
 def confirm_email(request, user_id, hash):
     msg = _("Thanks for confirming your email")
@@ -261,7 +262,7 @@ def confirm_email(request, user_id, hash):
     else:
         email.is_verified = True
         email.validation_hash = ""
-        email.save()
+        email.save(update_fields=["is_verified", "validation_hash"])
         email_verified.send(email=email.email, sender=email)
         logger.info(
             "user.email.confirm",

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -241,7 +241,10 @@ def start_confirm_email(request):
 
 
 @set_referrer_policy("strict-origin-when-cross-origin")
-@login_required
+@login_required(
+    message="Please login to complete confirmation of your email.",
+    level=messages.WARNING,
+)
 @control_silo_function
 def confirm_email(request, user_id, hash):
     msg = _("Thanks for confirming your email")

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -241,10 +241,7 @@ def start_confirm_email(request):
 
 
 @set_referrer_policy("strict-origin-when-cross-origin")
-@login_required(
-    message="Please login to complete confirmation of your email.",
-    level=messages.WARNING,
-)
+@login_required
 @control_silo_function
 def confirm_email(request, user_id, hash):
     msg = _("Thanks for confirming your email")

--- a/tests/sentry/web/frontend/test_accounts.py
+++ b/tests/sentry/web/frontend/test_accounts.py
@@ -357,3 +357,20 @@ class TestAccounts(TestCase):
             messages[0].message
             == "There was an error confirming your email. Please try again or visit your Account Settings to resend the verification email."
         )
+
+    def test_confirm_email_unauthenticated(self):
+        useremail = UserEmail(user=self.user, email="new@example.com")
+        useremail.save()
+
+        assert not useremail.is_verified
+
+        url = reverse(
+            "sentry-account-confirm-email",
+            kwargs={"user_id": self.user.id, "hash": useremail.validation_hash},
+        )
+
+        resp = self.client.get(url)
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/auth/login/"
+        assert self.client.session["_next"] == url


### PR DESCRIPTION
Fixes an issue where users receive an error when trying to confirm their emails if they are not already logged in. This redirects the user to login and then to the email confirmation. 