### PR TITLE
feat(issue-priority): Add priority column to issue stream

### DIFF
--- a/fixtures/page_objects/issue_list.py
+++ b/fixtures/page_objects/issue_list.py
@@ -47,8 +47,21 @@ class IssueListPage(BasePage):
         self.browser.click('[data-test-id="confirm-button"]')
 
     def merge_issues(self):
-        self.browser.click('[aria-label="Merge Selected Issues"]')
-        self.browser.click('[data-test-id="confirm-button"]')
+        # Merge button gets put into an overflow menu for small viewports
+        if self.browser.element_exists('[aria-label="Merge Selected Issues"]'):
+            self.browser.click('[aria-label="Merge Selected Issues"]')
+            self.browser.click('[data-test-id="confirm-button"]')
+        else:
+            self.browser.click('[aria-label="More issue actions"]')
+            self.browser.wait_until('[data-test-id="merge"]')
+            self.browser.click('[data-test-id="merge"]')
+            self.browser.click('[data-test-id="confirm-button"]')
 
     def mark_reviewed_issues(self):
-        self.browser.click('[aria-label="Mark Reviewed"]')
+        # Marked reviewed button gets put into an overflow menu for small viewports
+        if self.browser.element_exists('[aria-label="Mark Reviewed"]'):
+            self.browser.click('[aria-label="Mark Reviewed"]')
+        else:
+            self.browser.click('[aria-label="More issue actions"]')
+            self.browser.wait_until('[data-test-id="mark-reviewed"]')
+            self.browser.click('[data-test-id="mark-reviewed"]')

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -41,7 +41,13 @@ const defaultProps = {
   withColumns: ['graph', 'event', 'users', 'assignee'] satisfies GroupListColumn[],
 };
 
-export type GroupListColumn = 'graph' | 'event' | 'users' | 'assignee' | 'lastTriggered';
+export type GroupListColumn =
+  | 'graph'
+  | 'event'
+  | 'users'
+  | 'priority'
+  | 'assignee'
+  | 'lastTriggered';
 
 type Props = WithRouterProps & {
   api: Client;

--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import type {GroupListColumn} from './groupList';
 
@@ -17,6 +18,8 @@ function GroupListHeader({
   narrowGroups = false,
   withColumns = ['graph', 'event', 'users', 'assignee', 'lastTriggered'],
 }: Props) {
+  const organization = useOrganization();
+
   return (
     <PanelHeader disablePadding>
       <IssueWrapper>{t('Issue')}</IssueWrapper>
@@ -27,6 +30,10 @@ function GroupListHeader({
         <EventUserWrapper>{t('events')}</EventUserWrapper>
       )}
       {withColumns.includes('users') && <EventUserWrapper>{t('users')}</EventUserWrapper>}
+      {withColumns.includes('priority') &&
+        organization.features.includes('issue-priority-ui') && (
+          <PriorityWrapper narrowGroups={narrowGroups}>{t('Priority')}</PriorityWrapper>
+        )}
       {withColumns.includes('assignee') && (
         <AssigneeWrapper narrowGroups={narrowGroups}>{t('Assignee')}</AssigneeWrapper>
       )}
@@ -70,14 +77,24 @@ const ChartWrapper = styled(Heading)<{narrowGroups: boolean}>`
   width: 160px;
 
   @media (max-width: ${p =>
-    p.narrowGroups ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
+    p.narrowGroups ? p.theme.breakpoints.xxlarge : p.theme.breakpoints.xlarge}) {
+    display: none;
+  }
+`;
+
+const PriorityWrapper = styled(Heading)<{narrowGroups: boolean}>`
+  justify-content: flex-end;
+  width: 85px;
+
+  @media (max-width: ${p =>
+    p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
     display: none;
   }
 `;
 
 const AssigneeWrapper = styled(Heading)<{narrowGroups: boolean}>`
   justify-content: flex-end;
-  width: 80px;
+  width: 60px;
 
   @media (max-width: ${p =>
     p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {

--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -1,14 +1,15 @@
 import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import StreamGroup from 'sentry/components/stream/group';
 import GroupStore from 'sentry/stores/groupStore';
 import GuideStore from 'sentry/stores/guideStore';
 import type {GroupStatusResolution, MarkReviewed} from 'sentry/types';
-import {EventOrGroupType, GroupStatus} from 'sentry/types';
+import {EventOrGroupType, GroupStatus, PriorityLevel} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
 jest.mock('sentry/utils/analytics');
@@ -87,6 +88,32 @@ describe('StreamGroup', function () {
     act(() => GroupStore.onUpdate('1337', undefined, data));
     act(() => GroupStore.onUpdateSuccess('1337', undefined, data));
     expect(screen.getByTestId('resolved-issue')).toBeInTheDocument();
+  });
+
+  it('can change priority', async function () {
+    const mockModifyGroup = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/foo-project/issues/',
+      method: 'PUT',
+      body: {priority: PriorityLevel.HIGH},
+    });
+
+    render(<StreamGroup id="1337" query="is:unresolved" />, {
+      organization: OrganizationFixture({features: ['issue-priority-ui']}),
+    });
+
+    const priorityDropdown = screen.getByRole('button', {name: 'Modify issue priority'});
+    expect(within(priorityDropdown).getByText('Medium')).toBeInTheDocument();
+    await userEvent.click(priorityDropdown);
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'High'}));
+    expect(within(priorityDropdown).getByText('High')).toBeInTheDocument();
+    expect(mockModifyGroup).toHaveBeenCalledWith(
+      '/projects/org-slug/foo-project/issues/',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          priority: 'high',
+        }),
+      })
+    );
   });
 
   it('tracks clicks from issues stream', async function () {

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -44,6 +44,7 @@ import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import withOrganization from 'sentry/utils/withOrganization';
 import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
+import GroupPriority from 'sentry/views/issueDetails/groupPriority';
 import {
   DISCOVER_EXCLUSION_FIELDS,
   getTabs,
@@ -87,7 +88,7 @@ function BaseGroupRow({
   statsPeriod = DEFAULT_STREAM_GROUP_STATS_PERIOD,
   canSelect = true,
   withChart = true,
-  withColumns = ['graph', 'event', 'users', 'assignee', 'lastTriggered'],
+  withColumns = ['graph', 'event', 'users', 'priority', 'assignee', 'lastTriggered'],
   useFilteredStats = false,
   useTintRow = true,
   narrowGroups = false,
@@ -454,6 +455,12 @@ function BaseGroupRow({
           {withColumns.includes('users') && issueTypeConfig.stats.enabled && (
             <EventCountsWrapper>{groupUsersCount}</EventCountsWrapper>
           )}
+          {organization.features.includes('issue-priority-ui') &&
+          withColumns.includes('priority') ? (
+            <PriorityWrapper narrowGroups={narrowGroups}>
+              {group.priority ? <GroupPriority group={group} /> : null}
+            </PriorityWrapper>
+          ) : null}
           {withColumns.includes('assignee') && (
             <AssigneeWrapper narrowGroups={narrowGroups}>
               <AssigneeSelector
@@ -585,8 +592,7 @@ const ChartWrapper = styled('div')<{narrowGroups: boolean}>`
   width: 200px;
   align-self: center;
 
-  @media (max-width: ${p =>
-    p.narrowGroups ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
+  @media (max-width: ${p => (p.narrowGroups ? '1600px' : p.theme.breakpoints.xlarge)}) {
     display: none;
   }
 `;
@@ -603,8 +609,21 @@ const EventCountsWrapper = styled('div')`
   }
 `;
 
+const PriorityWrapper = styled('div')<{narrowGroups: boolean}>`
+  width: 85px;
+  margin: 0 ${space(2)};
+  align-self: center;
+  display: flex;
+  justify-content: flex-end;
+
+  @media (max-width: ${p =>
+    p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+    display: none;
+  }
+`;
+
 const AssigneeWrapper = styled('div')<{narrowGroups: boolean}>`
-  width: 80px;
+  width: 60px;
   margin: 0 ${space(2)};
   align-self: center;
 

--- a/static/app/views/alerts/rules/issue/previewTable.tsx
+++ b/static/app/views/alerts/rules/issue/previewTable.tsx
@@ -70,6 +70,7 @@ function PreviewTable({
           withChart={false}
           canSelect={false}
           showLastTriggered
+          withColumns={['assignee', 'event', 'lastTriggered', 'users']}
         />
       );
     });

--- a/static/app/views/issueDetails/groupPriority.tsx
+++ b/static/app/views/issueDetails/groupPriority.tsx
@@ -30,6 +30,7 @@ function GroupPriority({group}: GroupDetailsPriorityProps) {
     });
 
     addLoadingMessage(t('Saving changes\u2026'));
+    IssueListCacheStore.reset();
 
     bulkUpdate(
       api,
@@ -41,8 +42,6 @@ function GroupPriority({group}: GroupDetailsPriorityProps) {
       },
       {complete: clearIndicators}
     );
-
-    IssueListCacheStore.reset();
   };
 
   return (

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import {useTheme} from '@emotion/react';
 
 import ActionLink from 'sentry/components/actions/actionLink';
 import ArchiveActions from 'sentry/components/actions/archive';
@@ -103,8 +102,7 @@ function ActionSet({
 
   // Determine whether to nest "Merge" and "Mark as Reviewed" buttons inside
   // the dropdown menu based on the current screen size
-  const theme = useTheme();
-  const nestMergeAndReview = useMedia(`(max-width: ${theme.breakpoints.xlarge})`);
+  const nestMergeAndReview = useMedia(`(max-width: 1700px`);
 
   const menuItems: MenuItemProps[] = [
     {

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -52,9 +52,12 @@ function Headers({
           </GraphHeaderWrapper>
           <EventsOrUsersLabel>{t('Events')}</EventsOrUsersLabel>
           <EventsOrUsersLabel>{t('Users')}</EventsOrUsersLabel>
-          <AssigneesLabel isSavedSearchesOpen={isSavedSearchesOpen}>
+          <PriorityLabel isSavedSearchesOpen={isSavedSearchesOpen}>
+            <ToolbarHeader>{t('Priority')}</ToolbarHeader>
+          </PriorityLabel>
+          <AssigneeLabel isSavedSearchesOpen={isSavedSearchesOpen}>
             <ToolbarHeader>{t('Assignee')}</ToolbarHeader>
-          </AssigneesLabel>
+          </AssigneeLabel>
         </Fragment>
       )}
     </Fragment>
@@ -70,7 +73,7 @@ const GraphHeaderWrapper = styled('div')<{isSavedSearchesOpen?: boolean}>`
   animation: 0.25s FadeIn linear forwards;
 
   @media (max-width: ${p =>
-    p.isSavedSearchesOpen ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
+    p.isSavedSearchesOpen ? '1600px' : p.theme.breakpoints.xlarge}) {
     display: none;
   }
 
@@ -117,10 +120,22 @@ const EventsOrUsersLabel = styled(ToolbarHeader)`
   }
 `;
 
-const AssigneesLabel = styled('div')<{isSavedSearchesOpen?: boolean}>`
+const PriorityLabel = styled('div')<{isSavedSearchesOpen?: boolean}>`
   justify-content: flex-end;
   text-align: right;
-  width: 80px;
+  width: 85px;
+  margin: 0 ${space(2)};
+
+  @media (max-width: ${p =>
+    p.isSavedSearchesOpen ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+    display: none;
+  }
+`;
+
+const AssigneeLabel = styled('div')<{isSavedSearchesOpen?: boolean}>`
+  justify-content: flex-end;
+  text-align: right;
+  width: 60px;
   margin-left: ${space(2)};
   margin-right: ${space(2)};
 

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -5,6 +5,7 @@ import ToolbarHeader from 'sentry/components/toolbarHeader';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
   isReprocessingQuery: boolean;
@@ -21,6 +22,8 @@ function Headers({
   isReprocessingQuery,
   isSavedSearchesOpen,
 }: Props) {
+  const organization = useOrganization();
+
   return (
     <Fragment>
       {isReprocessingQuery ? (
@@ -52,9 +55,11 @@ function Headers({
           </GraphHeaderWrapper>
           <EventsOrUsersLabel>{t('Events')}</EventsOrUsersLabel>
           <EventsOrUsersLabel>{t('Users')}</EventsOrUsersLabel>
-          <PriorityLabel isSavedSearchesOpen={isSavedSearchesOpen}>
-            <ToolbarHeader>{t('Priority')}</ToolbarHeader>
-          </PriorityLabel>
+          {organization.features.includes('issue-priority-ui') && (
+            <PriorityLabel isSavedSearchesOpen={isSavedSearchesOpen}>
+              <ToolbarHeader>{t('Priority')}</ToolbarHeader>
+            </PriorityLabel>
+          )}
           <AssigneeLabel isSavedSearchesOpen={isSavedSearchesOpen}>
             <ToolbarHeader>{t('Assignee')}</ToolbarHeader>
           </AssigneeLabel>

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -75,7 +75,7 @@ function IssueListActions({
 
   const disableActions = useMedia(
     `(max-width: ${
-      isSavedSearchesOpen ? theme.breakpoints.large : theme.breakpoints.small
+      isSavedSearchesOpen ? theme.breakpoints.xlarge : theme.breakpoints.medium
     })`
   );
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/64423

- Add priority column
- Adjust assignee column to have take up less space (tested this even with 3 suggested assignees, still looks good)
- Adjust responsive elements to hide columns and actions sooner because of the extra required space. (I decided to make these changes without the feature flag because it works fine without it and it was already a bit crowded at smaller screen sizes)

Note that priority is only shown for issues that have a priority, which won't always be the case until we run the backfill.

![CleanShot 2024-02-07 at 13 22 01](https://github.com/getsentry/sentry/assets/10888943/bdabfa51-0d90-4c6e-b9ed-c1e434644897)
