### PR TITLE
limit env's to only selected projects, or my projects

### DIFF
--- a/static/app/views/releases/thresholdsList/index.tsx
+++ b/static/app/views/releases/thresholdsList/index.tsx
@@ -86,16 +86,22 @@ function ReleaseThresholdList({}: Props) {
       projects.flatMap(project => {
         /**
          * Include environments from:
+         * all projects I can access if -1 is the only selected project.
+         * all member projects if 'my projects' (empty list) is selected.
          * all projects if the user is a superuser
          * the requested projects
-         * all member projects if 'my projects' (empty list) is selected.
-         * all projects if -1 is the only selected project.
          */
+        const allProjectsSelectedICanAccess =
+          selectedProjectIds.length === 1 &&
+          selectedProjectIds[0] === String(ALL_ACCESS_PROJECTS) &&
+          project.hasAccess;
+        const myProjectsSelected = selectedProjectIds.length === 0 && project.isMember;
+        const allMemberProjectsIfSuperuser =
+          selectedProjectIds.length === 0 && user.isSuperuser;
         if (
-          (selectedProjectIds.length === 1 &&
-            selectedProjectIds[0] === String(ALL_ACCESS_PROJECTS) &&
-            project.hasAccess) ||
-          (selectedProjectIds.length === 0 && (project.isMember || user.isSuperuser)) ||
+          allProjectsSelectedICanAccess ||
+          myProjectsSelected ||
+          allMemberProjectsIfSuperuser ||
           selectedProjectIds.includes(project.id)
         ) {
           return project.environments;
@@ -120,15 +126,18 @@ function ReleaseThresholdList({}: Props) {
       projects.flatMap(project => {
         /**
          * Include environments from:
-         * the requested projects
-         * all member projects if 'my projects' (empty list) is selected.
          * all projects if -1 is the only selected project.
+         * all member projects if 'my projects' (empty list) is selected.
+         * the requested projects
          */
+        const allProjectsSelected =
+          selectedProjectIds.length === 1 &&
+          selectedProjectIds[0] === String(ALL_ACCESS_PROJECTS) &&
+          project.hasAccess;
+        const myProjectsSelected = selectedProjectIds.length === 0 && project.isMember;
         if (
-          (selectedProjectIds.length === 1 &&
-            selectedProjectIds[0] === String(ALL_ACCESS_PROJECTS) &&
-            project.hasAccess) ||
-          (selectedProjectIds.length === 0 && project.isMember) ||
+          allProjectsSelected ||
+          myProjectsSelected ||
           selectedProjectIds.includes(project.id)
         ) {
           return project.environments;

--- a/static/app/views/releases/thresholdsList/index.tsx
+++ b/static/app/views/releases/thresholdsList/index.tsx
@@ -112,6 +112,39 @@ function ReleaseThresholdList({}: Props) {
       .concat([...envDiff].sort());
   }, [projects, selection.projects]);
 
+  const getEnvironmentsAvailableToProject = useMemo((): string[] => {
+    const selectedProjectIds = selection.projects.map(id => String(id));
+    const allEnvSet = new Set(projects.flatMap(project => project.environments));
+    // NOTE: mostly taken from environmentSelector.tsx
+    const unSortedEnvs = new Set(
+      projects.flatMap(project => {
+        /**
+         * Include environments from:
+         * the requested projects
+         * all member projects if 'my projects' (empty list) is selected.
+         * all projects if -1 is the only selected project.
+         */
+        if (
+          (selectedProjectIds.length === 1 &&
+            selectedProjectIds[0] === String(ALL_ACCESS_PROJECTS) &&
+            project.hasAccess) ||
+          (selectedProjectIds.length === 0 && project.isMember) ||
+          selectedProjectIds.includes(project.id)
+        ) {
+          return project.environments;
+        }
+
+        return [];
+      })
+    );
+    const envDiff = new Set([...allEnvSet].filter(x => !unSortedEnvs.has(x)));
+
+    // bubble the selected projects envs first, then concat the rest of the envs
+    return Array.from(unSortedEnvs)
+      .sort()
+      .concat([...envDiff].sort());
+  }, [projects, selection.projects]);
+
   /**
    * Thresholds filtered by environment selection
    * NOTE: currently no way to filter for 'None' environments
@@ -178,7 +211,7 @@ function ReleaseThresholdList({}: Props) {
                   isError={isError}
                   refetch={refetch}
                   setTempError={setTempError}
-                  allEnvironmentNames={getAllEnvironmentNames} // TODO: determine whether to move down to threshold group table
+                  allEnvironmentNames={getEnvironmentsAvailableToProject}
                 />
               ))}
             {projectsWithoutThresholds.length > 0 && (
@@ -193,7 +226,7 @@ function ReleaseThresholdList({}: Props) {
                     <NoThresholdCard
                       key={proj.id}
                       project={proj}
-                      allEnvironmentNames={getAllEnvironmentNames} // TODO: determine whether to move down to threshold group table
+                      allEnvironmentNames={getAllEnvironmentNames}
                       refetch={refetch}
                       setTempError={setTempError}
                     />


### PR DESCRIPTION
Currently we list _every_ environment if you are a superuser.

This PR modifies the filter to only present environments for the selected project, or "my projects" if selected