### PR TITLE
Revert "Revert "feat(crons): Allow max_workers to be configured for consumer (#64512)""

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -102,6 +102,12 @@ def ingest_monitors_options() -> list[click.Option]:
             default=10,
             help="Maximum time spent batching check-ins to batch before processing in parallel.",
         ),
+        click.Option(
+            ["--max-workers", "max_workers"],
+            type=int,
+            default=None,
+            help="The maximum number of threads to spawn in parallel mode.",
+        ),
     ]
     return options
 

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -13,7 +13,10 @@ from sentry import killswitches
 from sentry.constants import ObjectStatus
 from sentry.db.models import BoundedPositiveIntegerField
 from sentry.monitors.constants import TIMEOUT, PermitCheckInStatus
-from sentry.monitors.consumers.monitor_consumer import StoreMonitorCheckInStrategyFactory
+from sentry.monitors.consumers.monitor_consumer import (
+    StoreMonitorCheckInStrategyFactory,
+    StrategyMode,
+)
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
@@ -23,7 +26,7 @@ from sentry.monitors.models import (
     MonitorType,
     ScheduleType,
 )
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import BaseTestCase, TestCase, TransactionTestCase
 from sentry.utils import json
 from sentry.utils.locking.manager import LockManager
 from sentry.utils.outcomes import Outcome
@@ -32,7 +35,9 @@ from sentry.utils.services import build_instance_from_options
 locks = LockManager(build_instance_from_options(settings.SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS))
 
 
-class MonitorConsumerTest(TestCase):
+class MonitorConsumerTest(BaseTestCase):
+    mode: StrategyMode = "serial"
+
     def _create_monitor(self, **kwargs):
         return Monitor.objects.create(
             organization_id=self.organization.id,
@@ -80,7 +85,10 @@ class MonitorConsumerTest(TestCase):
 
         commit = mock.Mock()
         partition = Partition(Topic("test"), 0)
-        StoreMonitorCheckInStrategyFactory().create_with_partitions(commit, {partition: 0}).submit(
+        factory = StoreMonitorCheckInStrategyFactory(
+            mode=self.mode, max_workers=1
+        ).create_with_partitions(commit, {partition: 0})
+        factory.submit(
             Message(
                 BrokerValue(
                     KafkaPayload(b"fake-key", msgpack.packb(wrapper), []),
@@ -90,7 +98,39 @@ class MonitorConsumerTest(TestCase):
                 )
             )
         )
+        factory.join()
 
+
+class ParallelMonitorConsumerTest(TransactionTestCase, MonitorConsumerTest):
+    mode: StrategyMode = "parallel"
+
+    def test(self) -> None:
+        monitor = self._create_monitor(slug="my-monitor")
+
+        self.send_checkin(monitor.slug)
+
+        checkin = MonitorCheckIn.objects.get(guid=self.guid)
+        assert checkin.status == CheckInStatus.OK
+        assert checkin.monitor_config == monitor.config
+
+        monitor_environment = MonitorEnvironment.objects.get(id=checkin.monitor_environment.id)
+        assert monitor_environment.status == MonitorStatus.OK
+        assert monitor_environment.last_checkin == checkin.date_added
+        assert monitor_environment.next_checkin == monitor.get_next_expected_checkin(
+            checkin.date_added
+        )
+        assert monitor_environment.next_checkin_latest == monitor.get_next_expected_checkin_latest(
+            checkin.date_added
+        )
+
+        # Process another check-in to verify we set an expected time for the next check-in
+        self.send_checkin(monitor.slug)
+        checkin = MonitorCheckIn.objects.get(guid=self.guid)
+        assert checkin.expected_time == monitor_environment.next_checkin
+        assert checkin.trace_id.hex == self.trace_id
+
+
+class SynchronousMonitorConsumerTest(MonitorConsumerTest, TestCase):
     def send_clock_pulse(
         self,
         ts: datetime | None = None,


### PR DESCRIPTION
This reverts commit a8bbd68b4434632a4869764e1735f82cef99ab6f.

I reverted this yesterday out of an abundance of caution, but it didn't seem to be actually causing issues. This is unchanged from https://github.com/getsentry/sentry/pull/64512
