### PR TITLE
bug(replay): Show the correct NotFound screen after a 404 when loading a replay

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -89,6 +89,7 @@ function useReplayData({
     error: fetchReplayError,
   } = useApiQuery<{data: unknown}>([`/organizations/${orgSlug}/replays/${replayId}/`], {
     staleTime: Infinity,
+    retry: false,
   });
   const replayRecord = useMemo(
     () => (replayData?.data ? mapResponseToReplayRecord(replayData.data) : undefined),

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -95,7 +95,7 @@ function ReplayDetails({params: {replaySlug}}: Props) {
     );
   }
   if (fetchError) {
-    if (fetchError.statusText === 'Not Found') {
+    if (fetchError.status === 404) {
       return (
         <Page
           orgSlug={orgSlug}


### PR DESCRIPTION
I think this regressed with https://github.com/getsentry/sentry/pull/63455, the error type/message might've changed or become compressed. It seemed like it's still working in dev, which makes testing the change a bit harder :(

Checking the status code could be more reliable. ~~I'll open the broken replay (https://sentry.sentry.io/replays/a7fcc2b504d34db296f2c7293bd47f28/) in the preview env to check again before landing.~~ Edit: checked, it's showing Not Found in the preview env.

Fixes [JAVASCRIPT-2RKD](https://sentry.io/organizations/sentry/issues/?project=11276&query=JAVASCRIPT-2RKD)