### PR TITLE
ref(similarity-embedding): Update seer API parameters

### DIFF
--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -53,6 +53,7 @@ class SimilarIssuesEmbeddingsRequestNotRequired(TypedDict, total=False):
 
 class SimilarIssuesEmbeddingsRequest(SimilarIssuesEmbeddingsRequestNotRequired):
     group_id: int
+    project_id: int
     stacktrace: str
     message: str
 

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -73,7 +73,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         num_frames_per_value: int,
         starting_frame_number: int = 1,
         in_app: bool = True,
-    ) -> Sequence[dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Return an exception value dictionary, where the line number corresponds to the total frame
         number

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -27,6 +27,7 @@ class TestSimilarIssuesEmbeddingsUtils(TestCase):
 
         params: SimilarIssuesEmbeddingsRequest = {
             "group_id": 1,
+            "project_id": 1,
             "stacktrace": "string",
             "message": "message",
         }
@@ -41,6 +42,7 @@ class TestSimilarIssuesEmbeddingsUtils(TestCase):
 
         params: SimilarIssuesEmbeddingsRequest = {
             "group_id": 1,
+            "project_id": 1,
             "stacktrace": "string",
             "message": "message",
         }


### PR DESCRIPTION
**Merge after https://github.com/getsentry/timeseries-analysis-service/pull/163 and change to frame limit for the seer API are merged**

Add 50 frame limit to stacktrace string used in seer API parameters
Add project_id to seer API parameters

closes https://github.com/getsentry/sentry/issues/64900