### PR TITLE
fix(issues): Add analytics for trace timeline "3 more events"

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -107,6 +107,9 @@ export type TeamInsightsEventParameters = {
     event_id: string;
     group_id: string;
   };
+  'issue_details.issue_tab.trace_timeline_more_events_clicked': {
+    num_hidden: number;
+  };
   'issue_details.merged_tab.unmerge_clicked': {
     /**
      * comma separated list of event ids that were unmerged
@@ -189,6 +192,8 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
     'Issue Details: Screenshot modal opened',
   'issue_details.issue_tab.trace_timeline_clicked':
     'Issue Details: Trace Timeline Clicked',
+  'issue_details.issue_tab.trace_timeline_more_events_clicked':
+    'Issue Details: Trace Timeline More Events Clicked',
   'issue_details.resources_link_clicked': 'Issue Details: Resources Link Clicked',
   'issue_details.suspect_commits.commit_clicked': 'Issue Details: Suspect Commit Clicked',
   'issue_details.suspect_commits.pull_request_clicked':

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
@@ -81,7 +81,18 @@ export function TraceTimelineTooltip({event, timelineEvents}: TraceTimelineToolt
       </EventItemsWrapper>
       {filteredTimelineEvents.length > 3 && (
         <TraceItem>
-          <Link to={generateTraceTarget(event, organization)}>
+          <Link
+            to={generateTraceTarget(event, organization)}
+            onClick={() => {
+              trackAnalytics(
+                'issue_details.issue_tab.trace_timeline_more_events_clicked',
+                {
+                  organization,
+                  num_hidden: filteredTimelineEvents.length - 3,
+                }
+              );
+            }}
+          >
             {tn(
               'View %s more event',
               'View %s more events',


### PR DESCRIPTION
Adds analytics on the link in the menu that goes to the full trace. "View 4 more events"
