### PR TITLE
fix(replays): check before attempting to load in onboarding doc

### DIFF
--- a/static/app/components/replaysOnboarding/useLoadOnboardingDoc.tsx
+++ b/static/app/components/replaysOnboarding/useLoadOnboardingDoc.tsx
@@ -37,6 +37,7 @@ function useLoadOnboardingDoc({
     async function getGettingStartedDoc() {
       if (!replayPlatforms.includes(platform.id)) {
         setModule(null);
+        return;
       }
 
       const mod = await import(

--- a/static/app/components/replaysOnboarding/useLoadOnboardingDoc.tsx
+++ b/static/app/components/replaysOnboarding/useLoadOnboardingDoc.tsx
@@ -15,9 +15,13 @@ function useLoadOnboardingDoc({
   platform: PlatformIntegration;
   projectSlug: string;
 }) {
-  const [module, setModule] = useState<null | {
-    default: Docs<any>;
-  }>(null);
+  const [module, setModule] = useState<
+    | null
+    | {
+        default: Docs<any>;
+      }
+    | 'none'
+  >(null);
 
   const platformPath =
     platform?.type === 'framework'
@@ -37,7 +41,7 @@ function useLoadOnboardingDoc({
   useEffect(() => {
     async function getGettingStartedDoc() {
       if (!replayPlatforms.includes(platform.id)) {
-        setModule(null);
+        setModule('none');
         return;
       }
       try {
@@ -55,6 +59,12 @@ function useLoadOnboardingDoc({
       setModule(null);
     };
   }, [platformPath, platform.id]);
+
+  if (module === 'none') {
+    return {
+      docs: null,
+    };
+  }
 
   if (!module || projectKeysIsLoading) {
     return {

--- a/static/app/components/replaysOnboarding/useLoadOnboardingDoc.tsx
+++ b/static/app/components/replaysOnboarding/useLoadOnboardingDoc.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
 
 import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {replayPlatforms} from 'sentry/data/platformCategories';
 import type {Organization, PlatformIntegration, ProjectKey} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
@@ -34,6 +35,10 @@ function useLoadOnboardingDoc({
 
   useEffect(() => {
     async function getGettingStartedDoc() {
+      if (!replayPlatforms.includes(platform.id)) {
+        setModule(null);
+      }
+
       const mod = await import(
         /* webpackExclude: /.spec/ */
         `sentry/gettingStartedDocs/${platformPath}`
@@ -44,7 +49,7 @@ function useLoadOnboardingDoc({
     return () => {
       setModule(null);
     };
-  }, [platformPath]);
+  }, [platformPath, platform.id]);
 
   if (!module || projectKeysIsLoading) {
     return {

--- a/static/app/components/replaysOnboarding/useLoadOnboardingDoc.tsx
+++ b/static/app/components/replaysOnboarding/useLoadOnboardingDoc.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+import * as Sentry from '@sentry/react';
 
 import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {replayPlatforms} from 'sentry/data/platformCategories';
@@ -39,12 +40,15 @@ function useLoadOnboardingDoc({
         setModule(null);
         return;
       }
-
-      const mod = await import(
-        /* webpackExclude: /.spec/ */
-        `sentry/gettingStartedDocs/${platformPath}`
-      );
-      setModule(mod);
+      try {
+        const mod = await import(
+          /* webpackExclude: /.spec/ */
+          `sentry/gettingStartedDocs/${platformPath}`
+        );
+        setModule(mod);
+      } catch (err) {
+        Sentry.captureException(err);
+      }
     }
     getGettingStartedDoc();
     return () => {


### PR DESCRIPTION
the problem: the user can get to the replay onboarding sidebar from the "quick start" pendo, which we weren't checking for before. they can get to the sidebar from any platform, even those that aren't supported by replay, so we should do a check first that the platform is even supported before we attempt to load in the onboarding module. 

the solution: if the platform isn't supported, return null docs --> this will result in our classic "fiddlesticks" message.

fixes JAVASCRIPT-2QEG