### PR TITLE
chore(capman)L Update project_events rate limit

### DIFF
--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -23,9 +23,9 @@ class ProjectEventsEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+            RateLimitCategory.IP: RateLimit(10, 60, 1),
+            RateLimitCategory.USER: RateLimit(10, 60, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(20, 60, 2),
         }
     }
 

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -23,9 +23,9 @@ class ProjectEventsEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(10, 60, 1),
-            RateLimitCategory.USER: RateLimit(10, 60, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(20, 60, 2),
+            RateLimitCategory.IP: RateLimit(60, 60, 1),
+            RateLimitCategory.USER: RateLimit(60, 60, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(60, 60, 2),
         }
     }
 


### PR DESCRIPTION
This endpoint is spamming snuba with lots of concurrent requests, it is also not used to serve the UI, there is no reason why anyone needs to query this 5 times a second.

reduce to 10 times a minute, 1 concurrent (2 concurrent per org)