### PR TITLE
chore(api): Tighten up rate limits on `ProjectEventsEndpoint`

### DIFF
--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -23,8 +23,8 @@ class ProjectEventsEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(60, 60, 2),
-            RateLimitCategory.USER: RateLimit(60, 60, 2),
+            RateLimitCategory.IP: RateLimit(60, 60, 1),
+            RateLimitCategory.USER: RateLimit(60, 60, 1),
             RateLimitCategory.ORGANIZATION: RateLimit(60, 60, 2),
         }
     }

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -23,9 +23,9 @@ class ProjectEventsEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+            RateLimitCategory.IP: RateLimit(60, 60, 2),
+            RateLimitCategory.USER: RateLimit(60, 60, 2),
+            RateLimitCategory.ORGANIZATION: RateLimit(60, 60, 2),
         }
     }
 


### PR DESCRIPTION
This endpoint isn't used in the product, and is used heavily by a small number of customers. These queries can be expensive, so we'd like to rate limit more aggressively here.

<!-- Describe your PR here. -->