### PR TITLE
ref(replay): remove 'new' badge from selector widgets & tab

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import Accordion from 'sentry/components/accordion/accordion';
 import {LinkButton} from 'sentry/components/button';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
-import FeatureBadge from 'sentry/components/featureBadge';
 import Placeholder from 'sentry/components/placeholder';
 import {Flex} from 'sentry/components/profiling/flex';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -51,7 +50,6 @@ function DeadRageSelectorCards() {
                   isHoverable
                 />
               </TitleTooltipContainer>
-              <FeatureBadge type="new" />
             </StyledWidgetHeader>
             <Subtitle>{t('Suggested replays to watch')}</Subtitle>
           </div>
@@ -74,7 +72,6 @@ function DeadRageSelectorCards() {
                   isHoverable
                 />
               </TitleTooltipContainer>
-              <FeatureBadge type="new" />
             </StyledWidgetHeader>
             <Subtitle>{t('Suggested replays to watch')}</Subtitle>
           </div>

--- a/static/app/views/replays/tabs.tsx
+++ b/static/app/views/replays/tabs.tsx
@@ -1,6 +1,5 @@
-import {Fragment, useMemo} from 'react';
+import {useMemo} from 'react';
 
-import FeatureBadge from 'sentry/components/featureBadge';
 import {TabList, Tabs} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -25,11 +24,7 @@ export default function ReplayTabs({selected}: Props) {
       },
       {
         key: 'selectors',
-        label: (
-          <Fragment>
-            {t('Selectors')} <FeatureBadge type="new" />
-          </Fragment>
-        ),
+        label: t('Selectors'),
         pathname: normalizeUrl(`/organizations/${organization.slug}/replays/selectors/`),
         query: {...location.query, sort: '-count_dead_clicks'},
       },


### PR DESCRIPTION
not new anymore!

<img width="1131" alt="SCR-20240207-ozja" src="https://github.com/getsentry/sentry/assets/56095982/d56209b4-fe25-440e-9af0-f3b721b84246">
