### PR TITLE
ref(feedback): add analytics for mark as spam buttons

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -14,6 +14,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types';
 import {GroupStatus} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -72,6 +73,13 @@ export default function FeedbackActions({
             addLoadingMessage(t('Updating feedback...'));
             const newStatus = isSpam ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
             resolve(newStatus, mutationOptions);
+            if (!isSpam) {
+              // not currently spam, clicking the button will turn it into spam
+              trackAnalytics('feedback.mark-spam-clicked', {
+                organization,
+                type: 'details',
+              });
+            }
           }}
         >
           {isSpam ? t('Move to Inbox') : t('Mark as Spam')}

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -9,7 +9,8 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import type useListItemCheckboxState from 'sentry/components/feedback/list/useListItemCheckboxState';
 import useMutateFeedback from 'sentry/components/feedback/useMutateFeedback';
 import {t, tct} from 'sentry/locale';
-import type {GroupStatus} from 'sentry/types';
+import {GroupStatus} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const statusToButtonLabel: Record<string, string> = {
@@ -42,6 +43,13 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
       openConfirmModal({
         bypass: Array.isArray(selectedIds) && selectedIds.length === 1,
         onConfirm: () => {
+          if (newMailbox === GroupStatus.IGNORED) {
+            // target action is marking as spam aka ignored
+            trackAnalytics('feedback.mark-spam-clicked', {
+              organization,
+              type: 'bulk',
+            });
+          }
           addLoadingMessage(t('Updating feedbacks...'));
           resolve(newMailbox, {
             onError: () => {
@@ -62,7 +70,7 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
         withoutBold: true,
       });
     },
-    [deselectAll, resolve, selectedIds]
+    [deselectAll, resolve, selectedIds, organization]
   );
 
   const onMarkAsRead = useCallback(

--- a/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
@@ -4,6 +4,7 @@ export type FeedbackEventParameters = {
   };
   'feedback.index-setup-viewed': {};
   'feedback.list-item-selected': {};
+  'feedback.mark-spam-clicked': {type: 'bulk' | 'details'};
   'feedback.whats-new-banner-dismissed': {};
   'feedback.whats-new-banner-viewed': {};
 };
@@ -17,4 +18,5 @@ export const feedbackEventMap: Record<FeedbackEventKey, string | null> = {
     'Clicked Integration Issue Button in Feedback Details',
   'feedback.whats-new-banner-dismissed': 'Dismissed Feedback Whatss New Banner',
   'feedback.whats-new-banner-viewed': 'Viewed Feedback Whats New Banner',
+  'feedback.mark-spam-clicked': 'Marked Feedback as Spam',
 };


### PR DESCRIPTION
track when users click the manual "mark as spam" buttons (both details and bulk)