### PR TITLE
ref(grouping): Call `_save_aggregate_new` when feature flag enabled

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1331,8 +1331,7 @@ def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> G
         )
         and not has_mobile_config
     ):
-        # This will be updated to the new logic once it's written
-        group_info = _save_aggregate(
+        group_info = _save_aggregate_new(
             event=event,
             job=job,
             release=job["release"],


### PR DESCRIPTION
This PR is a step towards updating the logic of `_save_aggregate`. The new logic will be contained in a separate function, so as a first step, this PR creates the new function, with identical logic to `_save_aggregate`. That way, when changes are made, they'll be starting from the same baseline as they would be were `_save_aggregate` itself being modified, which should hopefully make reviewing easier. It also switches to calling this new function in the flag-on branch of `assign_event_to_group`. 

Finally, to  make sure that everything still works as expected, the `assign_event_to_group` tests have been modified to now run both branches, flag on and flag off.