### PR TITLE
feat(tests): Add utility function to capture return values of mocks

### DIFF
--- a/src/sentry/testutils/pytest/mocking.py
+++ b/src/sentry/testutils/pytest/mocking.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
+
+# TODO: Once we're on python 3.12, we can get rid of these and change the first line of the
+# signature of `capture_return_values` to
+#   def capture_return_values[T, **P](
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def capture_return_values(
+    fn: Callable[P, T],
+    return_values: list[T] | dict[str, list[T]],
+) -> Callable[P, T]:
+    """
+    Create a wrapped version of the given function, which stores the return value each time that
+    function is called. This is useful when you want to spy on a given function and make assertions
+    based on what it returns.
+
+    In a test, this can be used in concert with a patching context manager like so:
+
+        from unittest import mock
+        from wherever import capture_return_values
+        from animals import get_dog, get_cat
+
+        def test_getting_animals():
+            # If you're only planning to patch one function, use a list:
+
+            get_dog_return_values = []
+            wrapped_get_dog = capture_return_values(
+                get_dog, get_dog_return_values
+            )
+
+            with mock.patch(
+                "animals.get_dog", wraps=wrapped_get_dog
+            ) as get_dog_spy:
+                a_function_that_calls_get_dog()
+                assert get_dog_spy.call_count == 1
+                assert get_dog_return_values[0] == "maisey"
+
+            # Alternatively, if you're planning to patch more than one function,
+            # you can pass a dictionary:
+
+            return_values = {}
+            wrapped_get_dog = capture_return_values(
+                get_dog, return_values
+            )
+            wrapped_get_cat = capture_return_values(
+                get_cat, return_values
+            )
+
+            with(
+                mock.patch(
+                    "animals.get_dog", wraps=wrapped_get_dog
+                ) as get_dog_spy,
+                mock.patch(
+                    "animals.get_cat", wraps=wrapped_get_cat
+                ) as get_cat_spy,
+            ):
+                a_function_that_calls_get_dog()
+                assert get_dog_spy.call_count == 1
+                assert return_values["get_dog"][0] == "charlie"
+
+                a_function_that_calls_get_cat()
+                assert get_cat_spy.call_count == 1
+                assert return_values["get_cat"][0] == "piper"
+    """
+
+    def wrapped_fn(*args: P.args, **kwargs: P.kwargs) -> T:
+        returned_value = fn(*args, **kwargs)
+
+        if isinstance(return_values, list):
+            return_values.append(returned_value)
+        elif isinstance(return_values, dict):
+            return_values.setdefault(fn.__name__, []).append(returned_value)
+
+        return returned_value
+
+    return wrapped_fn

--- a/tests/sentry/testutils/pytest/mocking/animals/__init__.py
+++ b/tests/sentry/testutils/pytest/mocking/animals/__init__.py
@@ -1,0 +1,14 @@
+def get_dog():
+    return "maisey"
+
+
+def get_cat():
+    return "piper"
+
+
+def a_function_that_calls_get_dog():
+    return f"{get_dog()} is a good dog!"
+
+
+def a_function_that_calls_get_cat():
+    return f"{get_cat()} is a good cat, because she thinks she's a dog!"

--- a/tests/sentry/testutils/pytest/mocking/test_mocking.py
+++ b/tests/sentry/testutils/pytest/mocking/test_mocking.py
@@ -1,0 +1,49 @@
+from typing import Any
+from unittest import TestCase, mock
+
+from sentry.testutils.pytest.mocking import capture_return_values
+from tests.sentry.testutils.pytest.mocking.animals import (
+    a_function_that_calls_get_cat,
+    a_function_that_calls_get_dog,
+    get_cat,
+    get_dog,
+)
+
+
+class CaptureReturnValuesTest(TestCase):
+    def test_return_values_as_list(self):
+        get_dog_return_values: list[Any] = []
+
+        wrapped_get_dog = capture_return_values(get_dog, get_dog_return_values)
+
+        with mock.patch(
+            "tests.sentry.testutils.pytest.mocking.animals.get_dog",
+            wraps=wrapped_get_dog,
+        ) as get_dog_spy:
+            a_function_that_calls_get_dog()
+            assert get_dog_spy.call_count == 1
+            assert get_dog_return_values[0] == "maisey"
+
+    def test_return_values_as_dict(self):
+        return_values: dict[str, list[Any]] = {}
+
+        wrapped_get_dog = capture_return_values(get_dog, return_values)
+        wrapped_get_cat = capture_return_values(get_cat, return_values)
+
+        with (
+            mock.patch(
+                "tests.sentry.testutils.pytest.mocking.animals.get_dog",
+                wraps=wrapped_get_dog,
+            ) as get_dog_spy,
+            mock.patch(
+                "tests.sentry.testutils.pytest.mocking.animals.get_cat",
+                wraps=wrapped_get_cat,
+            ) as get_cat_spy,
+        ):
+            a_function_that_calls_get_dog()
+            assert get_dog_spy.call_count == 1
+            assert return_values["get_dog"][0] == "maisey"
+
+            a_function_that_calls_get_cat()
+            assert get_cat_spy.call_count == 1
+            assert return_values["get_cat"][0] == "piper"


### PR DESCRIPTION
When pytest mocks or spies on a function, it keeps track of the input each time the function is called. It does not, however, keep track of the output. _Why?? Because you shouldn't be testing implementation details? But then why keep track of the input?_ In order to test certain side effects, though, sometimes you need to know what your spies return. 

This PR solves that by adding a helper, `capture_return_values`, which adds the return values of all calls of the given function to a given list, so the return values can be accessed later. (It also accepts a dictionary of lists, in case you want to keep track of the return values of more than one function at a time.)