### PR TITLE
ref(grouping): Remove hierarchical code from `_save_aggregate_new`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1661,10 +1661,10 @@ def _save_aggregate_new(
             span.set_tag("create_group_transaction.outcome", "no_group")
             metric_tags["create_group_transaction.outcome"] = "no_group"
 
-            all_grouphash_ids = [h.id for h in flat_grouphashes]
-
             flat_grouphashes = list(
-                GroupHash.objects.filter(id__in=all_grouphash_ids).select_for_update()
+                GroupHash.objects.filter(
+                    id__in=[h.id for h in flat_grouphashes],
+                ).select_for_update()
             )
 
             existing_grouphash, root_hierarchical_hash = find_existing_grouphash_new(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1619,13 +1619,7 @@ def _save_aggregate_new(
         GroupHash.objects.get_or_create(project=project, hash=hash)[0] for hash in hashes.hashes
     ]
 
-    # The root_hierarchical_hash is the least specific hash within the tree, so
-    # typically hierarchical_hashes[0], unless a hash `n` has been split in
-    # which case `root_hierarchical_hash = hierarchical_hashes[n + 1]`. Chosing
-    # this for select_for_update mostly provides sufficient synchronization
-    # when groups are created and also relieves contention by locking a more
-    # specific hash than `hierarchical_hashes[0]`.
-    existing_grouphash, root_hierarchical_hash = find_existing_grouphash_new(
+    existing_grouphash, _ = find_existing_grouphash_new(
         project, flat_grouphashes, hashes.hierarchical_hashes
     )
 
@@ -1667,7 +1661,7 @@ def _save_aggregate_new(
                 ).select_for_update()
             )
 
-            existing_grouphash, root_hierarchical_hash = find_existing_grouphash_new(
+            existing_grouphash, _ = find_existing_grouphash_new(
                 project, flat_grouphashes, hashes.hierarchical_hashes
             )
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1615,16 +1615,6 @@ def _save_aggregate_new(
 
     group_creation_kwargs = _get_group_creation_kwargs(job)
 
-    # Because this logic is not complex enough we want to special case the situation where we
-    # migrate from a hierarchical hash to a non hierarchical hash.  The reason being that
-    # there needs to be special logic to not create orphaned hashes in migration cases
-    # but it wants a different logic to implement splitting of hierarchical hashes.
-    migrate_off_hierarchical = bool(
-        secondary_hashes
-        and secondary_hashes.hierarchical_hashes
-        and not primary_hashes.hierarchical_hashes
-    )
-
     flat_grouphashes = [
         GroupHash.objects.get_or_create(project=project, hash=hash)[0] for hash in hashes.hashes
     ]
@@ -1751,13 +1741,7 @@ def _save_aggregate_new(
 
     is_new = False
 
-    # For the migration from hierarchical to non hierarchical we want to associate
-    # all group hashes
-    if migrate_off_hierarchical:
-        new_hashes = [h for h in flat_grouphashes if h.group_id is None]
-        if root_hierarchical_grouphash and root_hierarchical_grouphash.group_id is None:
-            new_hashes.append(root_hierarchical_grouphash)
-    elif root_hierarchical_grouphash is None:
+    if root_hierarchical_grouphash is None:
         # No hierarchical grouping was run, only consider flat hashes
         new_hashes = [h for h in flat_grouphashes if h.group_id is None]
     else:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1629,8 +1629,6 @@ def _save_aggregate_new(
         project, flat_grouphashes, hashes.hierarchical_hashes
     )
 
-    root_hierarchical_grouphash = None
-
     # In principle the group gets the same metadata as the event, so common
     # attributes can be defined in eventtypes.
     #
@@ -1674,8 +1672,6 @@ def _save_aggregate_new(
             existing_grouphash, root_hierarchical_hash = find_existing_grouphash_new(
                 project, flat_grouphashes, hashes.hierarchical_hashes
             )
-
-            root_hierarchical_grouphash = None
 
             if existing_grouphash is None:
                 group = _create_group(project, event, **group_creation_kwargs)
@@ -1741,11 +1737,7 @@ def _save_aggregate_new(
 
     is_new = False
 
-    if root_hierarchical_grouphash is None:
-        # No hierarchical grouping was run, only consider flat hashes
-        new_hashes = [h for h in flat_grouphashes if h.group_id is None]
-    else:
-        new_hashes = []
+    new_hashes = [h for h in flat_grouphashes if h.group_id is None]
 
     if new_hashes:
         # There may still be secondary hashes that we did not use to find an

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1602,7 +1602,7 @@ def _save_aggregate_new(
 ) -> GroupInfo | None:
     project = event.project
 
-    primary_hashes, secondary_hashes, hashes = get_hash_values(project, job, metric_tags)
+    _, _, hashes = get_hash_values(project, job, metric_tags)
 
     # Now that we've used the current and possibly secondary grouping config(s) to calculate the
     # hashes, we're free to perform a config update if needed. Future events will use the new

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1663,11 +1663,9 @@ def _save_aggregate_new(
 
             all_grouphash_ids = [h.id for h in flat_grouphashes]
 
-            all_grouphashes = list(
+            flat_grouphashes = list(
                 GroupHash.objects.filter(id__in=all_grouphash_ids).select_for_update()
             )
-
-            flat_grouphashes = [gh for gh in all_grouphashes if gh.hash in hashes.hashes]
 
             existing_grouphash, root_hierarchical_hash = find_existing_grouphash_new(
                 project, flat_grouphashes, hashes.hierarchical_hashes

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1615,12 +1615,12 @@ def _save_aggregate_new(
 
     group_creation_kwargs = _get_group_creation_kwargs(job)
 
-    flat_grouphashes = [
+    grouphashes = [
         GroupHash.objects.get_or_create(project=project, hash=hash)[0] for hash in hashes.hashes
     ]
 
     existing_grouphash, _ = find_existing_grouphash_new(
-        project, flat_grouphashes, hashes.hierarchical_hashes
+        project, grouphashes, hashes.hierarchical_hashes
     )
 
     # In principle the group gets the same metadata as the event, so common
@@ -1655,14 +1655,14 @@ def _save_aggregate_new(
             span.set_tag("create_group_transaction.outcome", "no_group")
             metric_tags["create_group_transaction.outcome"] = "no_group"
 
-            flat_grouphashes = list(
+            grouphashes = list(
                 GroupHash.objects.filter(
-                    id__in=[h.id for h in flat_grouphashes],
+                    id__in=[h.id for h in grouphashes],
                 ).select_for_update()
             )
 
             existing_grouphash, _ = find_existing_grouphash_new(
-                project, flat_grouphashes, hashes.hierarchical_hashes
+                project, grouphashes, hashes.hierarchical_hashes
             )
 
             if existing_grouphash is None:
@@ -1680,7 +1680,7 @@ def _save_aggregate_new(
                         },
                     )
 
-                new_hashes = list(flat_grouphashes)
+                new_hashes = list(grouphashes)
 
                 GroupHash.objects.filter(id__in=[h.id for h in new_hashes]).exclude(
                     state=GroupHash.State.LOCKED_IN_MIGRATION
@@ -1729,7 +1729,7 @@ def _save_aggregate_new(
 
     is_new = False
 
-    new_hashes = [h for h in flat_grouphashes if h.group_id is None]
+    new_hashes = [h for h in grouphashes if h.group_id is None]
 
     if new_hashes:
         # There may still be secondary hashes that we did not use to find an


### PR DESCRIPTION
Since the new group assignment logic in `event_manager` won't apply to anyone on the mobile grouping config, we have the freedom to remove the hierarchical code required by that config. This should make further refactoring easier, since it simplifies the code quite a bit.