### PR TITLE
ref: Add option to throttle proguard processing

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import os
 import os.path
+import random
 import re
 import shutil
 import tempfile
@@ -631,6 +632,12 @@ class DIFCache:
         """Given some ids returns an id to path mapping for where the
         debug symbol files are on the FS.
         """
+
+        # If this call is for proguard purposes, we probabilistically cut this function short
+        # right here so we don't overload filestore.
+        if "mapping" in features and random.random() >= options("filestore.proguard-throttle"):
+            return {}
+
         debug_ids = [str(debug_id).lower() for debug_id in debug_ids]
         difs = ProjectDebugFile.objects.find_by_debug_ids(project, debug_ids, features)
 

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -636,7 +636,9 @@ class DIFCache:
         # If this call is for proguard purposes, we probabilistically cut this function short
         # right here so we don't overload filestore.
         if features is not None:
-            if "mapping" in features and random.random() >= options("filestore.proguard-throttle"):
+            if "mapping" in features and random.random() >= options.get(
+                "filestore.proguard-throttle"
+            ):
                 return {}
 
         debug_ids = [str(debug_id).lower() for debug_id in debug_ids]

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -635,8 +635,9 @@ class DIFCache:
 
         # If this call is for proguard purposes, we probabilistically cut this function short
         # right here so we don't overload filestore.
-        if "mapping" in features and random.random() >= options("filestore.proguard-throttle"):
-            return {}
+        if features is not None:
+            if "mapping" in features and random.random() >= options("filestore.proguard-throttle"):
+                return {}
 
         debug_ids = [str(debug_id).lower() for debug_id in debug_ids]
         difs = ProjectDebugFile.objects.find_by_debug_ids(project, debug_ids, features)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -293,6 +293,14 @@ register(
 register("filestore.control.backend", default="", flags=FLAG_NOSTORE)
 register("filestore.control.options", default={}, flags=FLAG_NOSTORE)
 
+# Throttle filestore access in proguard processing. This is in response to
+# INC-635.
+register(
+    "filestore.proguard-throttle",
+    default=1.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_MODIFIABLE_RATE,
+)
+
 # Whether to use a redis lock on fileblob uploads and deletes
 register("fileblob.upload.use_lock", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Whether to use redis to cache `FileBlob.id` lookups


### PR DESCRIPTION
This is in response to INC-635.

It introduces an option `"filestore.proguard-throttle"` that probabilistically short-circuits the function `fetch_difs` so it doesn't access filestore. We only do this short-circuit for `proguard` cases (indicated by the `mapping` feature), but that should actually be all calls to this function.

If this throttling happens, `JavaStacktraceProcessor.preprocess_step` will report a processing issue with a cause of `proguard_missing_mapping`, I hope that is acceptable.