### PR TITLE
feat(ddm): Add support for multi-series and formulas

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -12,7 +12,7 @@ from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.querying.data import run_metrics_query
 from sentry.sentry_metrics.querying.data_v2 import run_metrics_queries_plan
-from sentry.sentry_metrics.querying.data_v2.api import FormulaOrder, MetricsQueriesPlan
+from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan, QueryOrder
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
     LatestReleaseNotFoundError,
@@ -334,13 +334,13 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
     # Number of groups returned by default for each query.
     default_limit = 20
 
-    def _validate_order(self, order: str | None) -> FormulaOrder | None:
+    def _validate_order(self, order: str | None) -> QueryOrder | None:
         if order is None:
             return None
 
-        formula_order = FormulaOrder.from_string(order)
+        formula_order = QueryOrder.from_string(order)
         if formula_order is None:
-            order_choices = [v.value for v in FormulaOrder]
+            order_choices = [v.value for v in QueryOrder]
             raise InvalidMetricsQueryError(
                 f"The provided `order` is not a valid, only {order_choices} are supported"
             )

--- a/src/sentry/sentry_metrics/querying/data_v2/api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/api.py
@@ -23,6 +23,11 @@ def run_metrics_queries_plan(
     environments: Sequence[Environment],
     referrer: str,
 ):
+    # For now, if the query plan is empty, we return an empty dictionary. In the future, we might want to default
+    # to a better data type.
+    if metrics_queries_plan.is_empty():
+        return {}
+
     # We build the basic query that contains the metadata which will be shared across all queries.
     base_query = MetricsQuery(
         start=start,
@@ -45,11 +50,7 @@ def run_metrics_queries_plan(
         query = base_query.set_query(query_expression).set_rollup(Rollup(interval=interval))
         executor.schedule(query=query, order=query_order, limit=query_limit)
 
-    with metrics.timer(
-        key="ddm.metrics_api.metrics_queries_plan_execution_time",
-        # TODO: add tags to describe the type of query (e.g., formula, with order by, with group by).
-        tags={},
-    ):
+    with metrics.timer(key="ddm.metrics_api.metrics_queries_plan.execution_time"):
         # Iterating over each result.
         results = executor.execute()
 

--- a/src/sentry/sentry_metrics/querying/data_v2/api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/api.py
@@ -1,50 +1,16 @@
 from collections.abc import Sequence
-from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
-from typing import Union
+
+from snuba_sdk import MetricsQuery, MetricsScope, Rollup
 
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-
-
-# TODO: lift out types in `types.py` once endpoint is finished.
-class FormulaOrder(Enum):
-    ASC = "asc"
-    DESC = "desc"
-
-    @classmethod
-    # Used `Union` because `|` conflicts with the parser.
-    def from_string(cls, value: str) -> Union["FormulaOrder", None]:
-        for v in cls:
-            if v.value == value:
-                return v
-
-        return None
-
-
-@dataclass(frozen=True)
-class FormulaDefinition:
-    mql: str
-    order: FormulaOrder | None
-    limit: int | None
-
-
-class MetricsQueriesPlan:
-    def __init__(self):
-        self._queries: dict[str, str] = {}
-        self._formulas: list[FormulaDefinition] = []
-
-    def declare_query(self, name: str, mql: str) -> "MetricsQueriesPlan":
-        self._queries[name] = mql
-        return self
-
-    def apply_formula(
-        self, mql: str, order: FormulaOrder | None = None, limit: int | None = None
-    ) -> "MetricsQueriesPlan":
-        self._formulas.append(FormulaDefinition(mql=mql, order=order, limit=limit))
-        return self
+from sentry.sentry_metrics.querying.data_v2.execution import QueryExecutor
+from sentry.sentry_metrics.querying.data_v2.parsing import QueryParser
+from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan
+from sentry.sentry_metrics.querying.data_v2.transformation import QueryTransformer
+from sentry.utils import metrics
 
 
 def run_metrics_queries_plan(
@@ -57,5 +23,36 @@ def run_metrics_queries_plan(
     environments: Sequence[Environment],
     referrer: str,
 ):
-    # TODO: implement new querying logic.
-    return None
+    # We build the basic query that contains the metadata which will be shared across all queries.
+    base_query = MetricsQuery(
+        start=start,
+        end=end,
+        scope=MetricsScope(
+            org_ids=[organization.id],
+            project_ids=[project.id for project in projects],
+        ),
+    )
+
+    # We prepare the executor, that will be responsible for scheduling the execution of multiple queries.
+    executor = QueryExecutor(organization=organization, projects=projects, referrer=referrer)
+
+    # We parse the query plan and obtain a series of queries.
+    parser = QueryParser(
+        projects=projects, environments=environments, metrics_queries_plan=metrics_queries_plan
+    )
+
+    for query_expression, query_order, query_limit in parser.generate_queries():
+        query = base_query.set_query(query_expression).set_rollup(Rollup(interval=interval))
+        executor.schedule(query=query, order=query_order, limit=query_limit)
+
+    with metrics.timer(
+        key="ddm.metrics_api.metrics_queries_plan_execution_time",
+        # TODO: add tags to describe the type of query (e.g., formula, with order by, with group by).
+        tags={},
+    ):
+        # Iterating over each result.
+        results = executor.execute()
+
+    # We transform the result into a custom format which for now it's statically defined.
+    transformer = QueryTransformer(results)
+    return transformer.transform()

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -1,8 +1,7 @@
-import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Any, Optional, cast
+from typing import Any
 
 import sentry_sdk
 from snuba_sdk import Column, Direction, MetricsQuery, MetricsScope, Request
@@ -11,12 +10,17 @@ from snuba_sdk.conditions import BooleanCondition, BooleanOp, Condition, Op
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.querying.common import DEFAULT_QUERY_INTERVALS, SNUBA_QUERY_LIMIT
+from sentry.sentry_metrics.querying.data_v2.plan import QueryOrder
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
     MetricsQueryExecutionError,
 )
 from sentry.sentry_metrics.querying.types import GroupKey, GroupsCollection
-from sentry.sentry_metrics.querying.visitors import QueriedMetricsVisitor
+from sentry.sentry_metrics.querying.visitors import (
+    QueriedMetricsVisitor,
+    TimeseriesConditionInjectionVisitor,
+    UsedGroupBysVisitor,
+)
 from sentry.sentry_metrics.visibility import get_metrics_blocking_state
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics import to_intervals
@@ -102,8 +106,7 @@ class ExecutableQuery:
 
     identifier: str
     metrics_query: MetricsQuery
-    group_bys: Sequence[str] | None
-    order_by: str | None
+    order: QueryOrder | None
     limit: int | None
 
     def is_empty(self) -> bool:
@@ -164,7 +167,7 @@ class ExecutableQuery:
             return self
 
         # We perform a transformation in the form [(key_1 = value_1 AND key_2 = value_2) OR (key_3 = value_3)].
-        snuba_filters = []
+        groups_filters = []
         for groups in groups_collection:
             inner_snuba_filters = []
             for filter_key, filter_value in groups:
@@ -172,20 +175,20 @@ class ExecutableQuery:
 
             # In case we have more than one filter, we have to group them into an `AND`.
             if len(inner_snuba_filters) > 1:
-                snuba_filters.append(BooleanCondition(BooleanOp.AND, inner_snuba_filters))
+                groups_filters.append(BooleanCondition(BooleanOp.AND, inner_snuba_filters))
             else:
-                snuba_filters.append(inner_snuba_filters[0])
+                groups_filters.append(inner_snuba_filters[0])
 
         # In case we have more than one filter, we have to group them into an `OR`.
-        if len(snuba_filters) > 1:
-            snuba_filters = [BooleanCondition(BooleanOp.OR, snuba_filters)]
+        if len(groups_filters) > 1:
+            groups_filters = [BooleanCondition(BooleanOp.OR, groups_filters)]
 
-        original_filters = self.metrics_query.query.filters or []
+        merged_query = TimeseriesConditionInjectionVisitor(groups_filters).visit(
+            self.metrics_query.query
+        )
         return replace(
             self,
-            metrics_query=self.metrics_query.set_query(
-                self.metrics_query.query.set_filters(original_filters + snuba_filters)
-            ),
+            metrics_query=self.metrics_query.set_query(merged_query),
         )
 
     def filter_blocked_projects(
@@ -291,15 +294,22 @@ class QueryResult:
         return _extract_groups_from_seq(self.totals or self.series)
 
     @property
-    def group_bys(self) -> list[str] | None:
+    def group_bys(self) -> list[str]:
         # We return the groups directly from the query and not the actual groups returned by the query. This is done so
-        # that we can correctly render groups in case they are not returned from the db.
-        return cast(
-            Optional[list[str]],
-            (
-                cast(ExecutableQuery, self.series_executable_query or self.totals_executable_query)
-            ).group_bys,
-        )
+        # that we can correctly render groups in case they are not returned from the db because of missing data.
+        #
+        # Sorting of the groups is done to maintain consistency across function calls.
+        if self.series_executable_query:
+            return sorted(
+                UsedGroupBysVisitor().visit(self.series_executable_query.metrics_query.query)
+            )
+
+        if self.totals_executable_query:
+            return sorted(
+                UsedGroupBysVisitor().visit(self.totals_executable_query.metrics_query.query)
+            )
+
+        return []
 
     @property
     def length(self) -> int:
@@ -312,39 +322,6 @@ class QueryResult:
             return len(self.totals)
 
         return 0
-
-    def align_with(self, reference_query_result: "QueryResult") -> "QueryResult":
-        """
-        Aligns the series and totals results with a reference query.
-
-        Note that the alignment performs a mutation of the current object.
-        """
-        # Alignment keys define the order in which fields are used for indexing purposes when aligning different
-        # sequences.
-        alignment_keys = reference_query_result.group_bys
-        if not alignment_keys:
-            return self
-
-        # For timeseries, we want to align based on the time also, since group bys + time are the common values
-        # across separate queries.
-        indexed_series = _build_indexed_seq(self.series, alignment_keys + ["time"])
-        indexed_totals = _build_indexed_seq(self.totals, alignment_keys)
-
-        aligned_series = _build_aligned_seq(
-            self.series, reference_query_result.series, alignment_keys + ["time"], indexed_series
-        )
-        aligned_totals = _build_aligned_seq(
-            self.totals, reference_query_result.totals, alignment_keys, indexed_totals
-        )
-
-        # We only mutate with the aligned data, only if we have data, since if it's empty it could be that we are
-        # trying to align on a query that has no data, and we want to avoid deleting the data of this query.
-        if aligned_series:
-            self.result["series"]["data"] = aligned_series
-        if aligned_totals:
-            self.result["totals"]["data"] = aligned_totals
-
-        return self
 
     def align_series_to_totals(self) -> "QueryResult":
         """
@@ -422,9 +399,7 @@ class QueryExecutor:
             tenant_ids={"referrer": self._referrer, "organization_id": self._organization.id},
         )
 
-    def _execute(
-        self, executable_query: ExecutableQuery, is_reference_query: bool = False
-    ) -> QueryResult:
+    def _execute(self, executable_query: ExecutableQuery) -> QueryResult:
         """
         Executes a query as series and/or totals and returns the result.
         """
@@ -459,23 +434,17 @@ class QueryExecutor:
             totals_executable_query = executable_query
             totals_result = None
             if executable_query.with_totals:
-                # For totals queries, if there is a limit passed by the user, we will honor that and apply it only for
-                # the reference query, since we want to load the data for all groups that are decided by the reference
-                # query.
-                if is_reference_query and executable_query.limit:
+                # If there is an order by, we apply it only on the totals query. We can't order a series query, for this
+                # reason we have to perform ordering here.
+                if executable_query.order:
+                    totals_executable_query = totals_executable_query.replace_order_by(
+                        executable_query.order.to_snuba_order()
+                    )
+
+                # Only in totals, if there is a limit passed by the user, we will honor that and apply it.
+                if executable_query.limit:
                     totals_executable_query = totals_executable_query.replace_limit(
                         executable_query.limit
-                    )
-                else:
-                    totals_executable_query = totals_executable_query.replace_limit()
-
-                if executable_query.order_by:
-                    order_by_direction = Direction.ASC
-                    if executable_query.order_by.startswith("-"):
-                        order_by_direction = Direction.DESC
-
-                    totals_executable_query = totals_executable_query.replace_order_by(
-                        order_by_direction
                     )
 
                 self._number_of_executed_queries += 1
@@ -488,13 +457,12 @@ class QueryExecutor:
             series_executable_query = executable_query
             series_result = None
             if executable_query.with_series:
-                # For series queries, we always want to use the default limit.
-                series_executable_query = series_executable_query.replace_limit()
+                # For series queries, we always want to use the default Snuba limit.
+                series_executable_query = series_executable_query.replace_limit(SNUBA_QUERY_LIMIT)
 
-                # There is a case in which we need to apply the totals groups directly on the series, which happens only
-                # when the reference queries are executed. The reason for this is that if we don't filter the values,
-                # we might hit the limit in the series query and lose data.
-                if is_reference_query and totals_result:
+                # In order to have at least the same groups, we need to pass down the groups obtained in the
+                # previous totals query to the series query.
+                if totals_result:
                     series_executable_query = series_executable_query.add_group_filters(
                         _extract_groups_from_seq(totals_result["data"])
                     )
@@ -534,52 +502,6 @@ class QueryExecutor:
             sentry_sdk.capture_exception(e)
             raise MetricsQueryExecutionError("An error occurred while executing the query")
 
-    def _derive_next_interval(self, result: QueryResult) -> int:
-        """
-        Computes the best possible interval, given a fixed set of available intervals, which can fit in the limit
-        of rows that Snuba can return.
-        """
-        # We try to estimate the number of groups.
-        groups_number = len(result.groups)
-
-        # We compute the ideal number of intervals that can fit with a given number of groups.
-        intervals_number = math.floor(SNUBA_QUERY_LIMIT / groups_number)
-
-        # We compute the optimal size of each interval in seconds.
-        optimal_interval_size = math.floor(
-            (result.modified_end - result.modified_start).total_seconds() / intervals_number
-        )
-
-        # Get the smallest interval that is larger than optimal out of a set of defined intervals in the product.
-        for index, interval in enumerate(self._interval_choices):
-            if interval >= optimal_interval_size:
-                # We have to put the choice, otherwise we end up in an infinite recursion.
-                self._interval_choices.pop(index)
-                return interval
-
-        raise MetricsQueryExecutionError(
-            "Unable to find an interval to satisfy the query because too many results "
-            "are returned"
-        )
-
-    def _find_reference_query(self) -> int:
-        """
-        Finds the reference query among the _schedule_queries.
-
-        A reference query is the first query which is run, and it's used to determine the ordering of the follow-up
-        queries.
-        """
-        if not self._scheduled_queries:
-            raise InvalidMetricsQueryError(
-                "Can't find a reference query because no queries were supplied"
-            )
-
-        for index, query in enumerate(self._scheduled_queries):
-            if query.order_by:
-                return index
-
-        return 0
-
     def _serial_execute(self) -> Sequence[QueryResult]:
         """
         Executes serially all the queries that are supplied to the QueryExecutor.
@@ -587,56 +509,18 @@ class QueryExecutor:
         The execution will try to satisfy the query by dynamically changing its interval, in the case in which the
         Snuba limit is reached.
         """
-        if not self._scheduled_queries:
-            return []
+        results = []
+        for query in self._scheduled_queries:
+            query_result = self._execute(executable_query=query)
+            results.append(query_result.align_series_to_totals())
 
-        # We execute the first reference query which will dictate the order of the follow-up queries.
-        reference_query = self._scheduled_queries.pop(self._find_reference_query())
-        reference_query_result = self._execute(
-            executable_query=reference_query, is_reference_query=True
-        )
+        return results
 
-        # Case 1: we have fewer results that the limit. In this case we are free to run the follow-up queries under the
-        # assumption that data doesn't change much between queries.
-        if reference_query_result.length < SNUBA_QUERY_LIMIT:
-            # Snuba supports order by only for totals, thus we need to align the series to the totals ordering before
-            # we can run the other queries and align them on this reference query.
-            reference_query_result.align_series_to_totals()
-
-            results = [reference_query_result]
-            reference_groups = reference_query_result.groups
-            metrics.distribution(
-                key="ddm.metrics_api.groups_cardinality", value=len(reference_groups)
-            )
-
-            for query in self._scheduled_queries:
-                query_result = self._execute(
-                    executable_query=query.add_group_filters(reference_groups),
-                    is_reference_query=False,
-                )
-
-                query_result.align_with(reference_query_result)
-                results.append(query_result)
-
-            return results
-
-        # Case 2: we have more results than the limit. In this case we want to determine a new interval that
-        # will result in less than limit data points.
-        new_interval = self._derive_next_interval(reference_query_result)
-
-        # We update the scheduled queries to use the new interval. It's important to note that we also add back the
-        # reference query, since we need to execute it again.
-        self._scheduled_queries = [
-            query.replace_interval(new_interval)
-            for query in [reference_query] + self._scheduled_queries
-        ]
-
-        return self._serial_execute()
-
-    def execute(self) -> Sequence[QueryResult]:
+    def execute(self, batch: bool = False) -> Sequence[QueryResult]:
         """
         Executes the scheduled queries serially.
         """
+        # TODO: implement batch execution when there will be the support for it.
         results = self._serial_execute()
         metrics.distribution(
             key="ddm.metrics_api.queries_executed", value=self._number_of_executed_queries
@@ -646,10 +530,8 @@ class QueryExecutor:
 
     def schedule(
         self,
-        identifier: str,
         query: MetricsQuery,
-        group_bys: Sequence[str] | None,
-        order_by: str | None,
+        order: QueryOrder | None,
         limit: int | None,
     ):
         """
@@ -660,10 +542,10 @@ class QueryExecutor:
         executable_query = ExecutableQuery(
             with_series=True,
             with_totals=True,
-            identifier=identifier,
+            # We identify the query with its index.
+            identifier=str(len(self._scheduled_queries)),
             metrics_query=query,
-            group_bys=group_bys,
-            order_by=order_by,
+            order=order,
             limit=limit,
         )
         self._scheduled_queries.append(executable_query)

--- a/src/sentry/sentry_metrics/querying/data_v2/parsing.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/parsing.py
@@ -1,16 +1,14 @@
-import re
 from collections.abc import Generator, Sequence
 
 from parsimonious.exceptions import IncompleteParseError
-from snuba_sdk import Timeseries
 from snuba_sdk.mql.mql import parse_mql
 from snuba_sdk.query_visitors import InvalidQueryError
 
 from sentry.models.environment import Environment
 from sentry.models.project import Project
+from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan, QueryOrder
 from sentry.sentry_metrics.querying.errors import InvalidMetricsQueryError
 from sentry.sentry_metrics.querying.types import QueryExpression
-from sentry.sentry_metrics.querying.utils import remove_if_match
 from sentry.sentry_metrics.querying.visitors import (
     EnvironmentsInjectionVisitor,
     FiltersCompositeVisitor,
@@ -53,74 +51,15 @@ class VisitableQueryExpression:
 
 
 class QueryParser:
-    # We avoid having the filters expression to be closed or opened.
-    FILTERS_SANITIZATION_PATTERN = re.compile(r"[{}]$")
-    # We avoid to have any way of opening and closing other expressions.
-    GROUP_BYS_SANITIZATION_PATTERN = re.compile(r"[(){}\[\]]")
-
     def __init__(
         self,
         projects: Sequence[Project],
-        fields: Sequence[str],
-        query: str | None,
-        group_bys: Sequence[str] | None,
+        environments: Sequence[Environment],
+        metrics_queries_plan: MetricsQueriesPlan,
     ):
         self._projects = projects
-        self._fields = fields
-        self._query = query
-        self._group_bys = group_bys
-
-        # We want to sanitize the input in order to avoid any injection attacks due to the string interpolation that
-        # it's performed when building the MQL query.
-        self._sanitize()
-
-    def _sanitize(self):
-        """
-        Sanitizes the query and group bys before using them to build the MQL query.
-        """
-        if self._query:
-            self._query = remove_if_match(self.FILTERS_SANITIZATION_PATTERN, self._query)
-
-        if self._group_bys:
-            self._group_bys = [
-                remove_if_match(self.GROUP_BYS_SANITIZATION_PATTERN, group_by)
-                for group_by in self._group_bys
-            ]
-
-    def _build_mql_filters(self) -> str | None:
-        """
-        Builds a set of MQL filters from a single query string.
-
-        In this case the query passed, is assumed to be already compatible with the filters grammar of MQL, thus no
-        transformation are performed.
-        """
-        if not self._query:
-            return None
-
-        return self._query
-
-    def _build_mql_group_bys(self) -> str | None:
-        """
-        Builds a set of MQL group by filters from a list of strings.
-        """
-        if not self._group_bys:
-            return None
-
-        return ",".join(self._group_bys)
-
-    def _build_mql_query(self, field: str, filters: str | None, group_bys: str | None) -> str:
-        """
-        Builds an MQL query string in the form `aggregate(metric){tag_key:tag_value} by (group_by_1, group_by_2).
-        """
-        mql = field
-
-        if filters is not None:
-            mql += f"{{{filters}}}"
-
-        if group_bys is not None:
-            mql += f" by ({group_bys})"
-
-        return mql
+        self._environments = environments
+        self._metrics_queries_plan = metrics_queries_plan
 
     def _parse_mql(self, mql: str) -> VisitableQueryExpression:
         """
@@ -144,30 +83,25 @@ class QueryParser:
         return VisitableQueryExpression(query=query)
 
     def generate_queries(
-        self, environments: Sequence[Environment]
-    ) -> Generator[tuple[str, Timeseries], None, None]:
+        self,
+    ) -> Generator[tuple[QueryExpression, QueryOrder | None, int | None], None, None]:
         """
         Generates multiple timeseries queries given a base query.
         """
-        if not self._fields:
-            raise InvalidMetricsQueryError("You must query at least one field")
-
-        # We first parse the filters and group bys, which are then going to be applied on each individual query
-        # that is executed.
-        mql_filters = self._build_mql_filters()
-        mql_group_bys = self._build_mql_group_bys()
-
-        for field in self._fields:
-            mql_query = self._build_mql_query(field, mql_filters, mql_group_bys)
-            yield (
-                field,
-                self._parse_mql(mql_query)
+        for formula_definition in self._metrics_queries_plan.get_replaced_formulas():
+            query_expression = (
+                self._parse_mql(formula_definition.mql)
+                # TODO: implement advanced validation like:
+                #  * same groups across time series and formulas
+                #  * all components of a formula have the same entity type and namespace
                 # We validate the query.
                 .add_visitor(ValidationVisitor())
                 # We inject the environment filter in each timeseries.
-                .add_visitor(EnvironmentsInjectionVisitor(environments))
+                .add_visitor(EnvironmentsInjectionVisitor(self._environments))
                 # We transform all `release:latest` filters into the actual latest releases.
                 .add_visitor(
                     FiltersCompositeVisitor(LatestReleaseTransformationVisitor(self._projects))
-                ).get(),
+                ).get()
             )
+            # TODO: check if we want to use a better data structure for returning queries.
+            yield query_expression, formula_definition.order, formula_definition.limit

--- a/src/sentry/sentry_metrics/querying/data_v2/parsing.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/parsing.py
@@ -14,7 +14,7 @@ from sentry.sentry_metrics.querying.visitors import (
     FiltersCompositeVisitor,
     LatestReleaseTransformationVisitor,
     QueryExpressionVisitor,
-    ValidationVisitor,
+    ValidationV2Visitor,
 )
 
 
@@ -91,11 +91,8 @@ class QueryParser:
         for formula_definition in self._metrics_queries_plan.get_replaced_formulas():
             query_expression = (
                 self._parse_mql(formula_definition.mql)
-                # TODO: implement advanced validation like:
-                #  * same groups across time series and formulas
-                #  * all components of a formula have the same entity type and namespace
                 # We validate the query.
-                .add_visitor(ValidationVisitor())
+                .add_visitor(ValidationV2Visitor())
                 # We inject the environment filter in each timeseries.
                 .add_visitor(EnvironmentsInjectionVisitor(self._environments))
                 # We transform all `release:latest` filters into the actual latest releases.

--- a/src/sentry/sentry_metrics/querying/data_v2/plan.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/plan.py
@@ -57,12 +57,18 @@ class MetricsQueriesPlan:
         self._formulas: list[FormulaDefinition] = []
 
     def declare_query(self, name: str, mql: str) -> "MetricsQueriesPlan":
+        """
+        Declares a query with a name and the mql definition.
+        """
         self._queries[name] = mql
         return self
 
     def apply_formula(
         self, mql: str, order: QueryOrder | None = None, limit: int | None = None
     ) -> "MetricsQueriesPlan":
+        """
+        Applies an mql formula on the queries that were previously declared.
+        """
         self._formulas.append(FormulaDefinition(mql=mql, order=order, limit=limit))
         return self
 
@@ -78,3 +84,9 @@ class MetricsQueriesPlan:
         fragile, we might want to switch to parsing the actual input and mutating the AST.
         """
         return list(map(lambda formula: formula.replace_variables(self._queries), self._formulas))
+
+    def is_empty(self) -> bool:
+        """
+        A query plan is defined to be empty is no formulas have been applied on it.
+        """
+        return not self._formulas

--- a/src/sentry/sentry_metrics/querying/data_v2/plan.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/plan.py
@@ -48,6 +48,9 @@ class FormulaDefinition:
         return replace(self, mql=replaced_mql_formula)
 
 
+# TODO: maybe we want to evaluate a form of builder pattern where we can control the
+#  chaining of methods, so that we make sure that declaration strictly happens before formula
+#  definition.
 class MetricsQueriesPlan:
     def __init__(self):
         self._queries: dict[str, str] = {}

--- a/src/sentry/sentry_metrics/querying/data_v2/plan.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/plan.py
@@ -1,0 +1,77 @@
+import re
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Union
+
+from snuba_sdk import Direction
+
+from sentry.sentry_metrics.querying.errors import InvalidMetricsQueryError
+
+# TODO: move these types in the right folder.
+
+
+class QueryOrder(Enum):
+    ASC = "asc"
+    DESC = "desc"
+
+    @classmethod
+    # Used `Union` because `|` conflicts with the parser.
+    def from_string(cls, value: str) -> Union["QueryOrder", None]:
+        for v in cls:
+            if v.value == value:
+                return v
+
+        return None
+
+    def to_snuba_order(self) -> Direction:
+        if self == QueryOrder.ASC:
+            return Direction.ASC
+        elif self == QueryOrder.DESC:
+            return Direction.DESC
+
+        raise InvalidMetricsQueryError(f"Ordering {self} does not exist is snuba")
+
+
+@dataclass(frozen=True)
+class FormulaDefinition:
+    mql: str
+    order: QueryOrder | None
+    limit: int | None
+
+    def replace_variables(self, queries: dict[str, str]) -> "FormulaDefinition":
+        replaced_mql_formula = self.mql
+        for query_name in queries.keys():
+            replaced_mql_formula = re.sub(
+                rf"\${query_name}", queries.get(query_name, ""), replaced_mql_formula
+            )
+
+        return replace(self, mql=replaced_mql_formula)
+
+
+class MetricsQueriesPlan:
+    def __init__(self):
+        self._queries: dict[str, str] = {}
+        self._formulas: list[FormulaDefinition] = []
+
+    def declare_query(self, name: str, mql: str) -> "MetricsQueriesPlan":
+        self._queries[name] = mql
+        return self
+
+    def apply_formula(
+        self, mql: str, order: QueryOrder | None = None, limit: int | None = None
+    ) -> "MetricsQueriesPlan":
+        self._formulas.append(FormulaDefinition(mql=mql, order=order, limit=limit))
+        return self
+
+    def get_replaced_formulas(self) -> list[FormulaDefinition]:
+        """
+        Returns a list of formulas with the variables replaced with the actual mql query string.
+
+        The usage of a variable in the formulas is with the `$` + the name of the query. The rationale
+        behind choosing `$` is to keep the syntax compatible with the MQL syntax, in case we were to embed
+        variables resolution in the layer itself.
+
+        This function naively uses string substitution to replace the contents. In case we see it's too
+        fragile, we might want to switch to parsing the actual input and mutating the AST.
+        """
+        return list(map(lambda formula: formula.replace_variables(self._queries), self._formulas))

--- a/src/sentry/sentry_metrics/querying/data_v2/transformation.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation.py
@@ -1,30 +1,30 @@
 from collections import OrderedDict
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
 from sentry.search.utils import parse_datetime_string
-from sentry.sentry_metrics.querying.data.execution import QueryResult
-from sentry.sentry_metrics.querying.data.utils import get_identity, nan_to_none
+from sentry.sentry_metrics.querying.data_v2.execution import QueryResult
+from sentry.sentry_metrics.querying.data_v2.utils import get_identity, nan_to_none
 from sentry.sentry_metrics.querying.errors import MetricsQueryExecutionError
-from sentry.sentry_metrics.querying.types import GroupKey, ResultValue, Series, Total
+from sentry.sentry_metrics.querying.types import GroupKey, ResultValue, Series, Totals
 
 
 @dataclass
 class GroupValue:
     series: Series
-    total: Total
+    totals: Totals
 
     @classmethod
     def empty(cls) -> "GroupValue":
-        return GroupValue(series=[], total=None)
+        return GroupValue(series=[], totals=None)
 
     def add_series_entry(self, time: str, aggregate_value: ResultValue):
         self.series.append((time, self._transform_aggregate_value(aggregate_value)))
 
-    def add_total(self, aggregate_value: ResultValue):
-        self.total = self._transform_aggregate_value(aggregate_value)
+    def add_totals(self, aggregate_value: ResultValue):
+        self.totals = self._transform_aggregate_value(aggregate_value)
 
     def _transform_aggregate_value(self, aggregate_value: ResultValue):
         # For now, we don't support the array return type, since the set of operations that the API can support
@@ -90,7 +90,7 @@ def _generate_full_series(
 
 
 class QueryTransformer:
-    def __init__(self, query_results: list[QueryResult]):
+    def __init__(self, query_results: Sequence[QueryResult]):
         self._query_results = query_results
 
         self._start: datetime | None = None
@@ -103,24 +103,26 @@ class QueryTransformer:
 
     def _build_intermediate_results(
         self,
-    ) -> tuple[OrderedDict[GroupKey, OrderedDict[str, GroupValue]], list[QueryMeta]]:
+    ) -> tuple[list[OrderedDict[GroupKey, GroupValue]], list[list[QueryMeta]]]:
         """
         Builds a tuple of intermediate groups and metadata which is used to efficiently transform the query results.
         """
-        intermediate_groups: OrderedDict[GroupKey, OrderedDict[str, GroupValue]] = OrderedDict()
-        intermediate_meta: list[QueryMeta] = []
+        queries_groups: list[OrderedDict[GroupKey, GroupValue]] = []
+        queries_meta: list[list[QueryMeta]] = []
 
-        def _add_to_intermediate_groups(values, block):
-            for value in values:
-                # We compute a list containing all the group values.
+        def _add_to_query_groups(
+            rows: Sequence[Mapping[str, Any]],
+            group_bys: list[str],
+            query_groups: OrderedDict[GroupKey, GroupValue],
+            block: Callable[[Mapping[str, Any], GroupValue], None],
+        ):
+            for row in rows:
                 grouped_values = []
-                for group_by in query_result.group_bys or ():
-                    grouped_values.append((group_by, value.get(group_by)))
+                for group_by in group_bys:
+                    grouped_values.append((group_by, row.get(group_by)))
 
-                group_metrics = intermediate_groups.setdefault(tuple(grouped_values), OrderedDict())
-                group_value = group_metrics.setdefault(query_result.query_name, GroupValue.empty())
-
-                block(value, group_value)
+                group_value = query_groups.setdefault(tuple(grouped_values), GroupValue.empty())
+                block(row, group_value)
 
         for query_result in self._query_results:
             # All queries must have the same timerange, so under this assumption we take the first occurrence of each.
@@ -131,40 +133,49 @@ class QueryTransformer:
             if self._interval is None:
                 self._interval = query_result.interval
 
+            query_groups = OrderedDict()
+
+            # We obtain the group bys of the query.
+            group_bys = query_result.group_bys
+
             # We group the totals data first, since we want the order to be set by the totals.
-            _add_to_intermediate_groups(
+            _add_to_query_groups(
                 query_result.totals,
-                lambda value, group: group.add_total(value.get("aggregate_value")),
+                group_bys,
+                query_groups,
+                lambda value, group: group.add_totals(value.get("aggregate_value")),
             )
 
             # We group the series data second, which will use the already ordered dictionary entries added by the
             # totals.
-            _add_to_intermediate_groups(
+            _add_to_query_groups(
                 query_result.series,
+                group_bys,
+                query_groups,
                 lambda value, group: group.add_series_entry(
                     value.get("time"), value.get("aggregate_value")
                 ),
             )
 
-            meta = query_result.meta
-            for meta_item in meta:
+            query_meta = []
+
+            # TODO: figure out if we need additional metadata.
+            for meta_item in query_result.meta:
                 meta_name = meta_item["name"]
                 meta_type = meta_item["type"]
+                query_meta.append(QueryMeta(name=meta_name, type=meta_type))
 
-                # The meta of each query, contains the metadata for each field in the result. In this case,
-                # we want to map the aggregate value type to the actual query name, which is used from the outside to
-                # recognize the query.
-                name = query_result.query_name if meta_name == "aggregate_value" else meta_name
-                intermediate_meta.append(QueryMeta(name=name, type=meta_type))
+            queries_groups.append(query_groups)
+            queries_meta.append(query_meta)
 
-        return intermediate_groups, intermediate_meta
+        return queries_groups, queries_meta
 
     def transform(self) -> Mapping[str, Any]:
         """
         Transforms the query results into the Sentry's API format.
         """
         # We first build intermediate results that we can work efficiently with.
-        intermediate_groups, intermediate_meta = self._build_intermediate_results()
+        queries_groups, queries_meta = self._build_intermediate_results()
 
         # We assert that all the data we require for the transformation has been found during the building of
         # intermediate results.
@@ -174,39 +185,37 @@ class QueryTransformer:
         intervals = _build_intervals(start, end, interval)
 
         # We build the translated groups given the intermediate groups.
-        translated_groups = []
-        for group_key, group_metrics in intermediate_groups.items():
-            translated_serieses: dict[str, Sequence[ResultValue]] = {}
-            translated_totals: dict[str, ResultValue] = {}
-            for metric_name, metric_values in group_metrics.items():
-                series = metric_values.series
-                total = metric_values.total
-
-                # We generate the full series by passing as default value the identity of the totals, which is the
-                # default value applied in the timeseries. This function already aligns the series by sorting it in
-                # ascending order so there is no need to have the series elements sorted beforehand.
-                translated_serieses[metric_name] = _generate_full_series(
-                    int(start.timestamp()), len(intervals), interval, series, get_identity(total)
+        translated_queries_groups = []
+        for query_groups in queries_groups:
+            translated_query_groups = []
+            for group_key, group_value in query_groups.items():
+                translated_query_groups.append(
+                    {
+                        "by": {name: value for name, value in group_key},
+                        "series": _generate_full_series(
+                            int(start.timestamp()),
+                            len(intervals),
+                            interval,
+                            group_value.series,
+                            get_identity(group_value.totals),
+                        ),
+                        "totals": nan_to_none(group_value.totals),
+                    }
                 )
-                # In case we get nan, we will cast it to None but this can be changed in case there is the need.
-                translated_totals[metric_name] = nan_to_none(total)
 
-            # The order of the keys is not deterministic in the nested dictionaries.
-            inner_group = {
-                "by": {name: value for name, value in group_key},
-                "series": translated_serieses,
-                "totals": translated_totals,
-            }
-
-            translated_groups.append(inner_group)
+            translated_queries_groups.append(translated_query_groups)
 
         # We build the translated meta given the intermediate meta.
-        translated_meta = [{"name": meta.name, "type": meta.type} for meta in intermediate_meta]
+        translated_queries_meta = []
+        for query_meta in queries_meta:
+            translated_queries_meta.append(
+                [{"name": meta.name, "type": meta.type} for meta in query_meta]
+            )
 
         return {
             "intervals": intervals,
-            "groups": translated_groups,
-            "meta": translated_meta,
+            "data": translated_queries_groups,
+            "meta": translated_queries_meta,
             "start": start,
             "end": end,
         }

--- a/src/sentry/sentry_metrics/querying/types.py
+++ b/src/sentry/sentry_metrics/querying/types.py
@@ -3,6 +3,8 @@ from typing import Optional, Union
 
 from snuba_sdk import BooleanCondition, Condition, Formula, Timeseries
 
+# Data V1 types
+
 # Type representing the aggregate value from Snuba, which can be null, int, float or list.
 ResultValue = Optional[Union[int, float, list[Optional[Union[int, float]]]]]
 # Type representing a series of values with (`time`, `value`) pairs.
@@ -16,6 +18,12 @@ GroupKey = tuple[Group, ...]
 # Type representing a sequence of groups [[(`key_1`, `value_1`), (`key_2`, `value_2`), ...], ...]
 GroupsCollection = Sequence[Sequence[Group]]
 # Type representing the possible expressions for a query.
-QueryExpression = Union[Timeseries, Formula]
+QueryExpression = Union[Timeseries, Formula, float, str]
 # Type representing the possible conditions for a query.
 QueryCondition = Union[BooleanCondition, Condition]
+
+
+# Data V2 types
+
+# Type representing a single aggregate value.
+Totals = ResultValue

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -5,6 +5,7 @@ from django.utils import timezone as django_timezone
 
 from sentry.sentry_metrics.querying.data_v2 import run_metrics_queries_plan
 from sentry.sentry_metrics.querying.data_v2.api import MetricsQueriesPlan
+from sentry.sentry_metrics.querying.errors import MetricsQueryExecutionError
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics.naming_layer import TransactionMRI
 from sentry.testutils.cases import BaseMetricsTestCase, TestCase
@@ -122,3 +123,399 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0][0]["by"] == {}
         assert data[0][0]["series"] == [0.0, 12.0, 9.0]
         assert data[0][0]["totals"] == 21.0
+
+    def test_query_with_one_aggregation_and_environment(self) -> None:
+        query_1 = self.mql("sum", TransactionMRI.DURATION.value)
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[self.prod_env],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        assert data[0][0]["by"] == {}
+        assert data[0][0]["series"] == [0.0, 6.0, 4.0]
+        assert data[0][0]["totals"] == 10.0
+
+    def test_query_with_one_aggregation_and_latest_release(self) -> None:
+        query_1 = self.mql("sum", TransactionMRI.DURATION.value, "release:latest")
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        assert data[0][0]["by"] == {}
+        assert data[0][0]["series"] == [0.0, 6.0, 7.0]
+        assert data[0][0]["totals"] == 13.0
+
+    def test_query_with_percentile(self) -> None:
+        query_1 = self.mql("p90", TransactionMRI.DURATION.value)
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        assert data[0][0]["by"] == {}
+        assert data[0][0]["series"] == [0.0, pytest.approx(5.8), 3.8]
+        assert data[0][0]["totals"] == 5.5
+
+    def test_query_with_valid_percentiles(self) -> None:
+        # We only want to check if these percentiles return results.
+        for percentile in ("p50", "p75", "p90", "p95", "p99"):
+            query_1 = self.mql(percentile, TransactionMRI.DURATION.value)
+            plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+            results = run_metrics_queries_plan(
+                metrics_queries_plan=plan,
+                start=self.now() - timedelta(minutes=30),
+                end=self.now() + timedelta(hours=1, minutes=30),
+                interval=3600,
+                organization=self.project.organization,
+                projects=[self.project],
+                environments=[],
+                referrer="metrics.data.api",
+            )
+            data = results["data"]
+            assert len(data) == 1
+
+    def test_query_with_invalid_percentiles(self) -> None:
+        # We only want to check if these percentiles result in a error.
+        for percentile in ("p30", "p45"):
+            query_1 = self.mql(percentile, TransactionMRI.DURATION.value)
+            plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+            with pytest.raises(MetricsQueryExecutionError):
+                run_metrics_queries_plan(
+                    metrics_queries_plan=plan,
+                    start=self.now() - timedelta(minutes=30),
+                    end=self.now() + timedelta(hours=1, minutes=30),
+                    interval=3600,
+                    organization=self.project.organization,
+                    projects=[self.project],
+                    environments=[],
+                    referrer="metrics.data.api",
+                )
+
+    def test_query_with_group_by(self) -> None:
+        query_1 = self.mql("sum", TransactionMRI.DURATION.value, group_by="transaction, platform")
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
+        assert len(first_query) == 3
+        assert first_query[0]["by"] == {"platform": "android", "transaction": "/hello"}
+        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["totals"] == 3.0
+        assert first_query[1]["by"] == {"platform": "ios", "transaction": "/hello"}
+        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["totals"] == 9.0
+        assert first_query[2]["by"] == {"platform": "windows", "transaction": "/world"}
+        assert first_query[2]["series"] == [0.0, 5.0, 4.0]
+        assert first_query[2]["totals"] == 9.0
+
+    def test_query_with_group_by_on_null_tag(self) -> None:
+        for value, transaction, time in (
+            (1, "/hello", self.now()),
+            (5, None, self.now() + timedelta(minutes=30)),
+        ):
+            tags = {}
+            if transaction:
+                tags["transaction"] = transaction
+
+            self.store_metric(
+                self.project.organization.id,
+                self.project.id,
+                "distribution",
+                TransactionMRI.MEASUREMENTS_FCP.value,
+                tags,
+                self.ts(time),
+                value,
+                UseCaseID.TRANSACTIONS,
+            )
+
+        query_1 = self.mql("sum", TransactionMRI.MEASUREMENTS_FCP.value, group_by="transaction")
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now(),
+            end=self.now() + timedelta(hours=1),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        first_query = sorted(data[0], key=lambda value: value["by"]["transaction"])
+        assert len(first_query) == 2
+        assert first_query[0]["by"] == {"transaction": ""}
+        assert first_query[0]["series"] == [5.0]
+        assert first_query[0]["totals"] == 5.0
+        assert first_query[1]["by"] == {"transaction": "/hello"}
+        assert first_query[1]["series"] == [1.0]
+        assert first_query[1]["totals"] == 1.0
+
+    def test_query_with_parenthesized_filter(self) -> None:
+        query_1 = self.mql("sum", TransactionMRI.DURATION.value, "(transaction:/hello)", "platform")
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
+        assert len(first_query) == 2
+        assert first_query[0]["by"] == {"platform": "android"}
+        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["totals"] == 3.0
+        assert first_query[1]["by"] == {"platform": "ios"}
+        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["totals"] == 9.0
+
+    def test_query_with_and_filter(self) -> None:
+        query_1 = self.mql(
+            "sum", TransactionMRI.DURATION.value, "platform:ios AND transaction:/hello", "platform"
+        )
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
+        assert len(first_query) == 1
+        assert first_query[0]["by"] == {"platform": "ios"}
+        assert first_query[0]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[0]["totals"] == 9.0
+
+    def test_query_with_or_filter(self) -> None:
+        query_1 = self.mql(
+            "sum", TransactionMRI.DURATION.value, "platform:ios OR platform:android", "platform"
+        )
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
+        assert len(first_query) == 2
+        assert first_query[0]["by"] == {"platform": "android"}
+        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["totals"] == 3.0
+        assert first_query[1]["by"] == {"platform": "ios"}
+        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["totals"] == 9.0
+
+    def test_query_one_negated_filter(self) -> None:
+        query_1 = self.mql(
+            "sum", TransactionMRI.DURATION.value, "!platform:ios transaction:/hello", "platform"
+        )
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
+        assert len(first_query) == 1
+        assert first_query[0]["by"] == {"platform": "android"}
+        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["totals"] == 3.0
+
+    def test_query_one_in_filter(self) -> None:
+        query_1 = self.mql(
+            "sum", TransactionMRI.DURATION.value, "platform:[android, ios]", "platform"
+        )
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
+        assert len(first_query) == 2
+        assert first_query[0]["by"] == {"platform": "android"}
+        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["totals"] == 3.0
+        assert first_query[1]["by"] == {"platform": "ios"}
+        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["totals"] == 9.0
+
+    def test_query_one_not_in_filter(self) -> None:
+        query_1 = self.mql(
+            "sum", TransactionMRI.DURATION.value, '!platform:["android", "ios"]', "platform"
+        )
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 1
+        first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
+        assert len(first_query) == 1
+        assert first_query[0]["by"] == {"platform": "windows"}
+        assert first_query[0]["series"] == [0.0, 5.0, 4.0]
+        assert first_query[0]["totals"] == 9.0
+
+    def test_query_with_multiple_aggregations(self) -> None:
+        query_1 = self.mql("min", TransactionMRI.DURATION.value)
+        query_2 = self.mql("max", TransactionMRI.DURATION.value)
+        plan = (
+            MetricsQueriesPlan()
+            .declare_query("query_1", query_1)
+            .declare_query("query_2", query_2)
+            .apply_formula("$query_1")
+            .apply_formula("$query_2")
+        )
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 2
+        assert data[0][0]["by"] == {}
+        assert data[0][0]["series"] == [0.0, 1.0, 2.0]
+        assert data[0][0]["totals"] == 1.0
+        assert data[1][0]["by"] == {}
+        assert data[1][0]["series"] == [0.0, 6.0, 4.0]
+        assert data[1][0]["totals"] == 6.0
+
+    def test_query_with_multiple_aggregations_and_single_group_by(self) -> None:
+        query_1 = self.mql("min", TransactionMRI.DURATION.value, group_by="platform")
+        query_2 = self.mql("max", TransactionMRI.DURATION.value, group_by="platform")
+        plan = (
+            MetricsQueriesPlan()
+            .declare_query("query_1", query_1)
+            .declare_query("query_2", query_2)
+            .apply_formula("$query_1")
+            .apply_formula("$query_2")
+        )
+
+        results = run_metrics_queries_plan(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 2
+        first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
+        assert len(first_query) == 3
+        assert first_query[0]["by"] == {"platform": "android"}
+        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["totals"] == 1.0
+        assert first_query[1]["by"] == {"platform": "ios"}
+        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["totals"] == 3.0
+        assert first_query[2]["by"] == {"platform": "windows"}
+        assert first_query[2]["series"] == [0.0, 5.0, 4.0]
+        assert first_query[2]["totals"] == 4.0
+        second_query = sorted(data[1], key=lambda value: value["by"]["platform"])
+        assert len(second_query) == 3
+        assert second_query[0]["by"] == {"platform": "android"}
+        assert second_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert second_query[0]["totals"] == 2.0
+        assert second_query[1]["by"] == {"platform": "ios"}
+        assert second_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert second_query[1]["totals"] == 6.0
+        assert second_query[2]["by"] == {"platform": "windows"}
+        assert second_query[2]["series"] == [0.0, 5.0, 4.0]
+        assert second_query[2]["totals"] == 5.0

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -4,8 +4,7 @@ import pytest
 from django.utils import timezone as django_timezone
 
 from sentry.sentry_metrics.querying.data_v2 import run_metrics_queries_plan
-from sentry.sentry_metrics.querying.data_v2.api import MetricsQueriesPlan
-from sentry.sentry_metrics.querying.data_v2.plan import QueryOrder
+from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan, QueryOrder
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
     MetricsQueryExecutionError,


### PR DESCRIPTION
This PR implements the new multi-series and formulas support for the `metrics/query` endpoint. The new execution engine is a simplified version of the previous implementation. Given a query plan, the engine performs the following operations:
1. Prepares a set of queries by parsing, injecting environments, latest releases and validates the expression tree.
2. Schedules for lazy execution of the queries.
3. Each query is executed with totals and series together. The totals query is executed, the series query is executed and they are aligned.
4. The aligned results are returned to the transformer responsible for changing the return format and injecting additional metadata (groups used, limit used and order direction used).

### Follow Ups
- _In a follow-up PR, I will rework the engine to allow batch execution of the query plan, but this has not been done to avoid further increasing the complexity of the PR._
- _Since this PR is huge and there are some bugs in MQL, the tests for formulas haven't been written. This is a follow-up item._

Closes https://github.com/getsentry/sentry/issues/64853