### PR TITLE
feat(app-start): Remove loading style on widgets

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
@@ -1,7 +1,6 @@
 import {BarChart} from 'sentry/components/charts/barChart';
 import ErrorPanel from 'sentry/components/charts/errorPanel';
 import TransitionChart from 'sentry/components/charts/transitionChart';
-import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Series} from 'sentry/types/echarts';
@@ -41,10 +40,6 @@ function DeviceClassBreakdownBarChart({
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
 
-  if (isReleasesLoading || isLoading) {
-    return <LoadingContainer isLoading />;
-  }
-
   return (
     <MiniChartPanel
       title={title}
@@ -59,8 +54,8 @@ function DeviceClassBreakdownBarChart({
       }
     >
       <TransitionChart
-        loading={Boolean(isLoading)}
-        reloading={Boolean(isLoading)}
+        loading={isLoading || isReleasesLoading}
+        reloading={isLoading || isReleasesLoading}
         height={`${CHART_HEIGHT}px`}
       >
         <LoadingScreen loading={Boolean(isLoading)} />

--- a/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
@@ -1,5 +1,4 @@
 import {getInterval} from 'sentry/components/charts/utils';
-import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import {t} from 'sentry/locale';
 import type {MultiSeriesEventsStats} from 'sentry/types';
 import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
@@ -89,10 +88,6 @@ function StartDurationWidget({additionalFilters, chartHeight, type}: Props) {
     referrer: 'api.starfish.mobile-startup-series',
     initialData: {},
   });
-
-  if (isSeriesLoading) {
-    return <LoadingContainer isLoading />;
-  }
 
   // The expected response is a multi series response, but if there is no data
   // then we get an object representing a single series with all empty values


### PR DESCRIPTION
The data manipulation of the responses accounts for empty data and the charts have loading states baked in which behave better when using CSS grid here