### PR TITLE
fix(mobile-starfish): Fix release selection order when >1 release

### DIFF
--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -121,12 +121,16 @@ export function useReleaseSelection(): {
   const location = useLocation();
 
   const {data: releases, isLoading} = useReleases();
-  const primaryRelease =
-    decodeScalar(location.query.primaryRelease) ?? releases?.[0]?.version ?? undefined;
 
+  // If there are more than 1 release, the first one should be the older one
+  const primaryRelease =
+    decodeScalar(location.query.primaryRelease) ??
+    (releases && releases.length > 1 ? releases?.[1]?.version : releases?.[0]?.version);
+
+  // If there are more than 1 release, the second one should be the newest one
   const secondaryRelease =
     decodeScalar(location.query.secondaryRelease) ??
-    (releases && releases.length > 1 ? releases?.[1]?.version : undefined);
+    (releases && releases.length > 1 ? releases?.[0]?.version : undefined);
 
   return {primaryRelease, secondaryRelease, isLoading};
 }


### PR DESCRIPTION
In the case where we had two releases, the primary release was set to be the newest one and the secondary release was the older one. This made the regression view wonky because we couldn't easily swap them

e.g. these bars are showing improvements when really they've regressed

<img width="1454" alt="Screenshot 2024-02-08 at 10 04 05 AM" src="https://github.com/getsentry/sentry/assets/22846452/2f5a5f4f-660a-4d3d-ba3a-a0271bc52196">
<img width="1455" alt="Screenshot 2024-02-08 at 10 04 13 AM" src="https://github.com/getsentry/sentry/assets/22846452/29fd93ae-6685-4520-8134-cf4ca22c6c70">
