### PR TITLE
feat(profiling): provide sentry options to vroom service

### DIFF
--- a/src/sentry/api/endpoints/vroom/__init__.py
+++ b/src/sentry/api/endpoints/vroom/__init__.py
@@ -1,0 +1,3 @@
+from .vroom_options import VroomOptionsEndpoint
+
+__all__ = ("VroomOptionsEndpoint",)

--- a/src/sentry/api/endpoints/vroom/options.py
+++ b/src/sentry/api/endpoints/vroom/options.py
@@ -1,0 +1,15 @@
+import sentry.options
+
+# List of options to return.
+VROOM_OPTIONS: list[str] = ["profiling.profile_metrics.unsampled_profiles.sample_rate"]
+
+
+def get_vroom_options():
+    """Return the options for Vroom."""
+
+    options = dict()
+    for option in VROOM_OPTIONS:
+        if (value := sentry.options.get(option)) is not None:
+            options[option] = value
+
+    return options

--- a/src/sentry/api/endpoints/vroom/vroom_options.py
+++ b/src/sentry/api/endpoints/vroom/vroom_options.py
@@ -1,0 +1,23 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint
+from sentry.utils import metrics
+
+from .options import get_vroom_options
+
+
+class VroomOptionsEndpoint(Endpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    authentication_classes = ()  # TODO: add a sensible authentication for service-to-service
+    permission_classes = ()
+    owner = owner = ApiOwner.PROFILING
+    enforce_rate_limit = False
+
+    @metrics.wraps("vroom_options.request")
+    def get(self, request: Request):
+        return Response(get_vroom_options(), status=200)

--- a/src/sentry/api/endpoints/vroom/vroom_options.py
+++ b/src/sentry/api/endpoints/vroom/vroom_options.py
@@ -3,12 +3,13 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.utils import metrics
 
 from .options import get_vroom_options
 
 
+@region_silo_endpoint
 class VroomOptionsEndpoint(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -616,6 +616,7 @@ from .endpoints.user_social_identity_details import UserSocialIdentityDetailsEnd
 from .endpoints.user_subscriptions import UserSubscriptionsEndpoint
 from .endpoints.userroles_details import UserRoleDetailsEndpoint
 from .endpoints.userroles_index import UserRolesEndpoint
+from .endpoints.vroom import VroomOptionsEndpoint
 
 __all__ = ("urlpatterns",)
 
@@ -2908,11 +2909,24 @@ INTERNAL_URLS = [
     ),
 ]
 
+VROOM_URLS = [
+    re_path(
+        r"^options/$",
+        VroomOptionsEndpoint.as_view(),
+        name="sentry-api-0-vroom-options",
+    ),
+]
+
 urlpatterns = [
     # Relay
     re_path(
         r"^relays/",
         include(RELAY_URLS),
+    ),
+    # Vroom
+    re_path(
+        r"^vrooms/",
+        include(VROOM_URLS),
     ),
     # Groups / Issues
     re_path(


### PR DESCRIPTION
This is meant to add an endpoint that provides a subset of interest of the `sentry_options` to the `vroom` service.