### PR TITLE
fix(metrics_extraction): user_misery data for on-demand metrics differs

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -344,15 +344,17 @@ def timeseries_query(
         for snql_query, result in zip(query_list, query_results):
             results.append(
                 {
-                    "data": zerofill(
-                        result["data"],
-                        snql_query.params.start,
-                        snql_query.params.end,
-                        rollup,
-                        "time",
-                    )
-                    if zerofill_results
-                    else result["data"],
+                    "data": (
+                        zerofill(
+                            result["data"],
+                            snql_query.params.start,
+                            snql_query.params.end,
+                            rollup,
+                            "time",
+                        )
+                        if zerofill_results
+                        else result["data"]
+                    ),
                     "meta": result["meta"],
                 }
             )
@@ -509,9 +511,11 @@ def top_events_timeseries(
     ):
         return SnubaTSResult(
             {
-                "data": zerofill([], params["start"], params["end"], rollup, "time")
-                if zerofill_results
-                else [],
+                "data": (
+                    zerofill([], params["start"], params["end"], rollup, "time")
+                    if zerofill_results
+                    else []
+                ),
             },
             params["start"],
             params["end"],
@@ -553,9 +557,11 @@ def top_events_timeseries(
         for key, item in results.items():
             results[key] = SnubaTSResult(
                 {
-                    "data": zerofill(item["data"], params["start"], params["end"], rollup, "time")
-                    if zerofill_results
-                    else item["data"],
+                    "data": (
+                        zerofill(item["data"], params["start"], params["end"], rollup, "time")
+                        if zerofill_results
+                        else item["data"]
+                    ),
                     "order": item["order"],
                 },
                 params["start"],

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2016,6 +2016,8 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         self._index_metric_strings()
 
     def do_request(self, data: dict[str, Any]) -> Response:
+        """Set up self.features and self.url in the inheriting classes."""
+        self.login_as(user=self.user)
         with self.feature(self.features):
             return self.client.get(self.url, data=data, format="json")
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -40,6 +40,7 @@ from django.utils.functional import cached_property
 from requests.utils import CaseInsensitiveDict, get_encoding_from_headers
 from rest_framework import status
 from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.test import APITestCase as BaseAPITestCase
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 from snuba_sdk import Granularity, Limit, Offset
@@ -119,7 +120,7 @@ from sentry.sentry_metrics.use_case_id_registry import METRIC_PATH_MAPPING, UseC
 from sentry.silo import SiloMode, SingleProcessSiloModeState
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics.datasource import get_series
-from sentry.snuba.metrics.extraction import OnDemandMetricSpec
+from sentry.snuba.metrics.extraction import MetricSpecType, OnDemandMetricSpec
 from sentry.snuba.metrics.naming_layer.public import TransactionMetricKey
 from sentry.tagstore.snuba.backend import SnubaTagStorage
 from sentry.testutils.factories import get_fixture_path
@@ -2014,6 +2015,55 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         super().setUp()
         self._index_metric_strings()
 
+    def do_request(self, data: Any, url: str = None, features: dict[str, bool] = None) -> Response:
+        if features is None:
+            features = {"organizations:discover-basic": True}
+        features.update(self.features)
+        with self.feature(features):
+            return self.client.get(self.url if url is None else url, data=data, format="json")
+
+    def _on_demand_query_check(
+        self,
+        params: dict[str, Any],
+        groupbys: list[str] | None = None,
+        expected_on_demand_query: bool | None = True,
+        expected_dataset: str | None = "metricsEnhanced",
+    ) -> Response:
+        """Do a request to the events endpoint with metrics enhanced and on-demand enabled."""
+        if params.get("field"):
+            for field in params.get("field"):
+                spec = OnDemandMetricSpec(
+                    field=field,
+                    query=params["query"],
+                    environment=params.get("environment"),
+                    groupbys=groupbys,
+                    spec_type=MetricSpecType.DYNAMIC_QUERY,
+                )
+        elif params.get("yAxis"):
+            spec = OnDemandMetricSpec(
+                field=params["yAxis"],
+                query=params["query"],
+                environment=params.get("environment"),
+                groupbys=groupbys,
+                spec_type=MetricSpecType.DYNAMIC_QUERY,
+            )
+        else:
+            raise ValueError("Either field or yAxis must be present in the params")
+        # Expected parameters for this helper function
+        params["dataset"] = "metricsEnhanced"
+        params["useOnDemandMetrics"] = "true"
+        params["onDemandType"] = "dynamic_query"
+
+        self.store_on_demand_metric(1, spec=spec)
+        response = self.do_request(params)
+
+        assert response.status_code == 200, response.content
+        meta = response.data["meta"]
+        assert meta.get("isMetricsExtractedData", False) is expected_on_demand_query
+        assert meta["dataset"] == expected_dataset
+
+        return response
+
     def _index_metric_strings(self):
         strings = [
             "transaction",
@@ -2089,6 +2139,10 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         if additional_tags:
             # Additional tags might be needed to override field values from the spec.
             tags.update(additional_tags)
+
+        # This helps creating an environment when a spec expects it
+        if spec.environment:
+            self.create_environment(name=spec.environment)
 
         self.store_transaction_metric(
             value,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2140,10 +2140,6 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
             # Additional tags might be needed to override field values from the spec.
             tags.update(additional_tags)
 
-        # This helps creating an environment when a spec expects it
-        if spec.environment:
-            self.create_environment(name=spec.environment)
-
         self.store_transaction_metric(
             value,
             metric=self.ON_DEMAND_KEY_MAP[metric_type],

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2013,11 +2013,11 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
 
     def setUp(self):
         super().setUp()
+        self.login_as(user=self.user)
         self._index_metric_strings()
 
     def do_request(self, data: dict[str, Any]) -> Response:
         """Set up self.features and self.url in the inheriting classes."""
-        self.login_as(user=self.user)
         with self.feature(self.features):
             return self.client.get(self.url, data=data, format="json")
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2015,12 +2015,9 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         super().setUp()
         self._index_metric_strings()
 
-    def do_request(self, data: Any, url: str = None, features: dict[str, bool] = None) -> Response:
-        if features is None:
-            features = {"organizations:discover-basic": True}
-        features.update(self.features)
-        with self.feature(features):
-            return self.client.get(self.url if url is None else url, data=data, format="json")
+    def do_request(self, data: dict[str, Any]) -> Response:
+        with self.feature(self.features):
+            return self.client.get(self.url, data=data, format="json")
 
     def _on_demand_query_check(
         self,

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3134,6 +3134,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 
     def setUp(self) -> None:
         super().setUp()
+        self.url = reverse(self.viewname, kwargs={"organization_slug": self.organization.slug})
         self.features = {"organizations:on-demand-metrics-extraction-widgets": True}
 
     def _on_demand_query_check(

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3198,6 +3198,28 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
             },
         }
 
+    def test_on_demand_big_number_user_misery(self):
+        resp = self._on_demand_query_check(
+            {
+                "field": ["user_misery(300)"],
+                "project": self.project.id,
+                "query": "",
+                "environment": "prod",
+            },
+        )
+        assert resp.data == {
+            "data": [{"user_misery(300)": 0.05}],
+            "meta": {
+                "fields": {"user_misery(300)": "number"},
+                "units": {"user_misery(300)": None},
+                "isMetricsData": True,
+                "isMetricsExtractedData": True,
+                "tips": {},
+                "datasetReason": "unchanged",
+                "dataset": "metricsEnhanced",
+            },
+        }
+
 
 @region_silo_test
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3134,15 +3134,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 
     def setUp(self) -> None:
         super().setUp()
-
-    def do_request(self, query: Any) -> Any:
-        self.login_as(user=self.user)
-        url = reverse(
-            self.viewname,
-            kwargs={"organization_slug": self.organization.slug},
-        )
-        with self.feature({"organizations:on-demand-metrics-extraction-widgets": True}):
-            return self.client.get(url, query, format="json")
+        self.features = {"organizations:on-demand-metrics-extraction-widgets": True}
 
     def _on_demand_query_check(
         self,

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -43,13 +43,6 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
 
         self.additional_params = dict()
 
-    def do_request(self, data, url=None, features=None):
-        if features is None:
-            features = {"organizations:discover-basic": True}
-        features.update(self.features)
-        with self.feature(features):
-            return self.client.get(self.url if url is None else url, data=data, format="json")
-
     # These throughput tests should roughly match the ones in OrganizationEventsStatsEndpointTest
     def test_throughput_epm_hour_rollup(self):
         # Each of these denotes how many events to create in each hour
@@ -977,13 +970,6 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             kwargs={"organization_slug": self.project.organization.slug},
         )
         self.features = {"organizations:on-demand-metrics-extraction-widgets": True}
-
-    def do_request(self, data, url=None, features=None):
-        if features is None:
-            features = {"organizations:discover-basic": True}
-        features.update(self.features)
-        with self.feature(features):
-            return self.client.get(self.url if url is None else url, data=data, format="json")
 
     def test_top_events_wrong_on_demand_type(self):
         query = "transaction.duration:>=100"

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1459,11 +1459,11 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             [{"count": 10.0}],
         ]
 
-    def test_on_demand_table_user_misery(self):
+    def test_on_demand_chart_user_misery(self):
         resp = self._on_demand_query_check(
             {
                 "dataset": "metricsEnhanced",
-                "environment": "prod",
+                "environment": "production",
                 "interval": "30m",
                 "onDemandType": "dynamic_query",
                 "orderby": "",
@@ -1473,15 +1473,16 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 "referrer": "api.dashboards.widget.line-chart",
                 "statsPeriod": "7d",
                 "useOnDemandMetrics": "true",
-                "yAxis": "user_misery(300)",
+                # Not supported by MEP when it's custom
+                "yAxis": "user_misery(3000)",
             },
         )
         for datum in resp.data["data"]:
             # XXX: Find a way to have some user misery data
             assert datum[1] == [{"count": 0}]
         assert resp.data["meta"] == {
-            "fields": {"time": "date", "user_misery_300": "number"},
-            "units": {"time": None, "user_misery_300": None},
+            "fields": {"time": "date", "user_misery_3000": "number"},
+            "units": {"time": None, "user_misery_3000": None},
             "isMetricsData": True,
             "isMetricsExtractedData": True,
             "tips": {},

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1473,13 +1473,13 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             self.store_on_demand_metric(
                 (hour + 1) * 5,
                 spec=spec,
-                additional_tags={"satisfaction": "frustrated"},
+                additional_tags={"satisfaction": "frustrated", "environment": environment},
                 timestamp=self.day_ago + timedelta(hours=hour),
             )
             self.store_on_demand_metric(
                 (hour + 1) * 5,
                 spec=spec,
-                additional_tags={"satisfaction": "tolerable"},
+                additional_tags={"environment": environment},
                 timestamp=self.day_ago + timedelta(hours=hour),
             )
         resp = self.do_request(
@@ -1494,9 +1494,12 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 "referrer": "api.dashboards.widget.line-chart",
             }
         )
-        for datum in resp.data["data"]:
-            # XXX: Find a way to have some user misery data
-            assert datum[1] == [{"count": 0}]
+        num_items = len(resp.data["data"])
+        for index, value in enumerate(resp.data["data"]):
+            if index == num_items - 1:
+                assert value[1] == [{"count": 0.06586638830897704}]
+            else:
+                assert value[1] == [{"count": 0}]
 
         assert resp.data["meta"] == {
             "fields": {"time": "date", "user_misery_3000": "number"},

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1458,3 +1458,33 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             [{"count": 5.0}],
             [{"count": 10.0}],
         ]
+
+    def test_on_demand_table_user_misery(self):
+        resp = self._on_demand_query_check(
+            {
+                "dataset": "metricsEnhanced",
+                "environment": "prod",
+                "interval": "30m",
+                "onDemandType": "dynamic_query",
+                "orderby": "",
+                "partial": 1,
+                "project": self.project.id,
+                "query": "",
+                "referrer": "api.dashboards.widget.line-chart",
+                "statsPeriod": "7d",
+                "useOnDemandMetrics": "true",
+                "yAxis": "user_misery(300)",
+            },
+        )
+        for datum in resp.data["data"]:
+            # XXX: Find a way to have some user misery data
+            assert datum[1] == [{"count": 0}]
+        assert resp.data["meta"] == {
+            "fields": {"time": "date", "user_misery_300": "number"},
+            "units": {"time": None, "user_misery_300": None},
+            "isMetricsData": True,
+            "isMetricsExtractedData": True,
+            "tips": {},
+            "datasetReason": "unchanged",
+            "dataset": "metricsEnhanced",
+        }

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import timedelta
 from typing import Any
 from unittest import mock
@@ -759,7 +757,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         assert data["order"] == 0
 
     def test_user_misery_chart(self):
-        # 3000 is not a default threshold, thus, TBD
+        # 3000 is not a default threshold, thus, we can't use MEP to fetch it
         field = "user_misery(3000)"
         query = ""
         environment = "production"
@@ -802,8 +800,8 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         assert resp.data["meta"] == {
             "fields": {"time": "date", "user_misery_3000": "number"},
             "units": {"time": None, "user_misery_3000": None},
-            "isMetricsData": True,
-            "isMetricsExtractedData": True,
+            "isMetricsData": False,
+            "isMetricsExtractedData": False,
             "tips": {},
             "datasetReason": "unchanged",
             "dataset": "metricsEnhanced",

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -969,7 +969,10 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             "sentry-api-0-organization-events-stats",
             kwargs={"organization_slug": self.project.organization.slug},
         )
-        self.features = {"organizations:on-demand-metrics-extraction-widgets": True}
+        self.features = {
+            "organizations:on-demand-metrics-extraction-widgets": True,
+            "organizations:on-demand-metrics-extraction": True,
+        }
 
     def test_top_events_wrong_on_demand_type(self):
         query = "transaction.duration:>=100"
@@ -1378,7 +1381,6 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
     def _test_is_metrics_extracted_data(
         self, params: dict[str, Any], expected_on_demand_query: bool, dataset: str
     ) -> None:
-        features = {"organizations:on-demand-metrics-extraction": True}
         spec = OnDemandMetricSpec(
             field="count()",
             query="transaction.duration:>1s",
@@ -1386,7 +1388,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
         )
 
         self.store_on_demand_metric(1, spec=spec)
-        response = self.do_request(params, features=features)
+        response = self.do_request(params)
 
         assert response.status_code == 200, response.content
         meta = response.data["meta"]


### PR DESCRIPTION
If you load [this dashboard](https://sentry.sentry.io/dashboard/78807/?environment=prod&forceOnDemand=true&project=1&statsPeriod=7d) with and without extracted data you will see that the chart matches in both but it's different for the other two widgets. 
<img width="1496" alt="image" src="https://github.com/getsentry/sentry/assets/44410/4fa4914c-bfe2-40d7-bb83-f28f462c80c4">
