### PR TITLE
feat(mql) Add bulk_run_query function to the metrics layer

### DIFF
--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -77,18 +77,111 @@ class ReverseMappings:
         self.reverse_mappings: dict[int, str] = dict()
 
 
+def bulk_run_query(requests: list[Request]) -> list[Mapping[str, Any]]:
+    """
+    Entrypoint for executing a list of metrics queries in Snuba.
+
+    This function is used to execute multiple metrics queries in a single request.
+    """
+    queries = []
+    for request in requests:
+        request, start, end = _setup_metrics_query(request)
+        queries.append([request, start, end])
+
+    logging_tags = {"referrer": request.tenant_ids["referrer"] or "unknown", "lang": "mql"}
+
+    for q in queries:
+        q[0], reverse_mappings, mappings = _resolve_metrics_query(q[0], logging_tags)
+        q.extend([reverse_mappings, mappings])
+
+    try:
+        snuba_results = bulk_snuba_queries(
+            [q[0] for q in queries],
+            queries[0][0].tenant_ids["referrer"],
+            use_cache=True,
+        )
+    except Exception:
+        metrics.incr(
+            "metrics_layer.query",
+            tags={**logging_tags, "status": "query_error"},
+        )
+        raise
+
+    for idx, snuba_result in enumerate(snuba_results):
+        request, start, end, reverse_mappings, mappings = queries[idx]
+        metrics_query = request.query
+
+        snuba_result = convert_snuba_result(
+            snuba_result,
+            reverse_mappings,
+            request.dataset,
+            metrics_query.scope.use_case_id,
+            metrics_query.scope.org_ids[0],
+        )
+
+        # If we normalized the start/end, return those values in the response so the caller is aware
+        results = {
+            **snuba_result,
+            "modified_start": start,
+            "modified_end": end,
+            "indexer_mappings": mappings,
+        }
+
+        snuba_results[idx] = results
+
+    metrics.incr(
+        "metrics_layer.query",
+        tags={**logging_tags, "status": "success"},
+    )
+    return snuba_results
+
+
 def run_query(request: Request) -> Mapping[str, Any]:
     """
     Entrypoint for executing a metrics query in Snuba.
-
-    First iteration:
-    The purpose of this function is to eventually replace datasource.py::get_series().
-    As a first iteration, this function will only support single timeseries metric queries.
-    This means that for now, other queries such as total, formula, or meta queries
-    will not be supported. Additionally, the first iteration will only support
-    querying raw metrics (no derived). This means that each call to this function will only
-    resolve into a single request (and single entity) to the Snuba API.
     """
+    request, start, end = _setup_metrics_query(request)
+
+    logging_tags = {"referrer": request.tenant_ids["referrer"] or "unknown", "lang": "mql"}
+    request, reverse_mappings, mappings = _resolve_metrics_query(request, logging_tags)
+    metrics_query = request.query
+
+    try:
+        snuba_result = bulk_snuba_queries(
+            [request],
+            request.tenant_ids["referrer"],
+            use_cache=True,
+        )[0]
+    except Exception:
+        metrics.incr(
+            "metrics_layer.query",
+            tags={**logging_tags, "status": "query_error"},
+        )
+        raise
+
+    snuba_result = convert_snuba_result(
+        snuba_result,
+        reverse_mappings,
+        request.dataset,
+        metrics_query.scope.use_case_id,
+        metrics_query.scope.org_ids[0],
+    )
+
+    # If we normalized the start/end, return those values in the response so the caller is aware
+    results = {
+        **snuba_result,
+        "modified_start": start,
+        "modified_end": end,
+        "indexer_mappings": mappings,
+    }
+    metrics.incr(
+        "metrics_layer.query",
+        tags={**logging_tags, "status": "success"},
+    )
+    return results
+
+
+def _setup_metrics_query(request: Request) -> tuple[Request, datetime, datetime]:
     metrics_query = request.query
     assert isinstance(metrics_query, MetricsQuery)
 
@@ -108,7 +201,7 @@ def run_query(request: Request) -> Mapping[str, Any]:
     start = metrics_query.start
     end = metrics_query.end
     if metrics_query.rollup.interval:
-        start, end, _num_intervals = to_intervals(
+        start, end, _ = to_intervals(
             metrics_query.start, metrics_query.end, metrics_query.rollup.interval
         )
         metrics_query = metrics_query.set_start(start).set_end(end)
@@ -121,7 +214,7 @@ def run_query(request: Request) -> Mapping[str, Any]:
         )
     request.query = metrics_query
 
-    return mql_query(request, start, end)
+    return request, start, end
 
 
 def _resolve_aggregate_aliases(exp: Timeseries | Formula) -> MetricsQuery:
@@ -182,9 +275,10 @@ def _resolve_granularity(start: datetime, end: datetime, interval: int | None) -
     return min(found_granularities)
 
 
-def mql_query(request: Request, start: datetime, end: datetime) -> Mapping[str, Any]:
+def _resolve_metrics_query(
+    request: Request, logging_tags: dict[str, str]
+) -> tuple[Request, ReverseMappings, dict[str, str | int]]:
     metrics_query = request.query
-    logging_tags = {"referrer": request.tenant_ids["referrer"] or "unknown", "lang": "mql"}
 
     try:
         # There are two kinds of resolving: lookup up in the indexer, and resolving things like
@@ -208,39 +302,7 @@ def mql_query(request: Request, start: datetime, end: datetime) -> Mapping[str, 
         )
         raise
 
-    try:
-        snuba_result = bulk_snuba_queries(
-            [request],
-            request.tenant_ids["referrer"],
-            use_cache=True,
-        )[0]
-    except Exception:
-        metrics.incr(
-            "metrics_layer.query",
-            tags={**logging_tags, "status": "query_error"},
-        )
-        raise
-
-    snuba_result = convert_snuba_result(
-        snuba_result,
-        reverse_mappings,
-        request.dataset,
-        metrics_query.scope.use_case_id,
-        metrics_query.scope.org_ids[0],
-    )
-
-    # If we normalized the start/end, return those values in the response so the caller is aware
-    results = {
-        **snuba_result,
-        "modified_start": start,
-        "modified_end": end,
-        "indexer_mappings": mappings,
-    }
-    metrics.incr(
-        "metrics_layer.query",
-        tags={**logging_tags, "status": "success"},
-    )
-    return results
+    return request, reverse_mappings, mappings
 
 
 def _resolve_query_metadata(

--- a/tests/snuba/test_metrics_layer.py
+++ b/tests/snuba/test_metrics_layer.py
@@ -24,7 +24,7 @@ from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics.naming_layer import SessionMRI, TransactionMRI
 from sentry.snuba.metrics.naming_layer.public import TransactionStatusTagValue, TransactionTagsKey
-from sentry.snuba.metrics_layer.query import run_query
+from sentry.snuba.metrics_layer.query import bulk_run_query, run_query
 from sentry.testutils.cases import BaseMetricsTestCase, TestCase
 
 pytestmark = pytest.mark.sentry_metrics
@@ -123,6 +123,63 @@ class MQLTest(TestCase, BaseMetricsTestCase):
         )
         result = run_query(request)
         assert len(result["data"]) == 10
+        rows = result["data"]
+        for i in range(10):
+            assert rows[i]["aggregate_value"] == i
+            assert (
+                rows[i]["time"]
+                == (
+                    self.hour_ago.replace(second=0, microsecond=0) + timedelta(minutes=1 * i)
+                ).isoformat()
+            )
+
+    def test_basic_bulk_generic_metrics(self) -> None:
+        query = MetricsQuery(
+            query=None,
+            start=self.hour_ago,
+            end=self.now,
+            rollup=Rollup(interval=60, granularity=60),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=[self.project.id],
+                use_case_id=UseCaseID.TRANSACTIONS.value,
+            ),
+        )
+
+        query1 = query.set_query(
+            Timeseries(
+                metric=Metric(
+                    "transaction.duration",
+                    TransactionMRI.DURATION.value,
+                ),
+                aggregate="max",
+            )
+        )
+        query2 = query.set_query(
+            Timeseries(
+                metric=Metric(
+                    public_name=None,
+                    mri=TransactionMRI.USER.value,
+                ),
+                aggregate="uniq",
+            )
+        )
+        request1 = Request(
+            dataset="generic_metrics",
+            app_id="tests",
+            query=query1,
+            tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
+        )
+        request2 = Request(
+            dataset="generic_metrics",
+            app_id="tests",
+            query=query2,
+            tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
+        )
+        results = bulk_run_query([request1, request2])
+        assert len(results) == 2
+
+        result = results[0]  # Distribution
         rows = result["data"]
         for i in range(10):
             assert rows[i]["aggregate_value"] == i


### PR DESCRIPTION
This new function accepts a list of requests, and uses the threaded executor in
the underlying snuba code to run the queries in parallel and then return a list
of matching results for each request.