### PR TITLE
ref: use decode_responses=False for raw=True redis cache

### DIFF
--- a/src/sentry/cache/redis.py
+++ b/src/sentry/cache/redis.py
@@ -12,9 +12,16 @@ class CommonRedisCache(BaseCache):
     key_expire = 60 * 60  # 1 hour
     max_size = 50 * 1024 * 1024  # 50MB
 
-    def __init__(self, client, **options):
-        self.client = client
-        BaseCache.__init__(self, **options)
+    def __init__(self, client, raw_client, **options):
+        self._text_client = client
+        self._bytes_client = raw_client
+        super().__init__(**options)
+
+    def _client(self, *, raw: bool):
+        if raw:
+            return self._bytes_client
+        else:
+            return self._text_client
 
     def set(self, key, value, timeout, version=None, raw=False):
         key = self.make_key(key, version=version)
@@ -22,21 +29,21 @@ class CommonRedisCache(BaseCache):
         if len(v) > self.max_size:
             raise ValueTooLarge(f"Cache key too large: {key!r} {len(v)!r}")
         if timeout:
-            self.client.setex(key, int(timeout), v)
+            self._client(raw=raw).setex(key, int(timeout), v)
         else:
-            self.client.set(key, v)
+            self._client(raw=raw).set(key, v)
 
         self._mark_transaction("set")
 
     def delete(self, key, version=None):
         key = self.make_key(key, version=version)
-        self.client.delete(key)
+        self._client(raw=False).delete(key)
 
         self._mark_transaction("delete")
 
     def get(self, key, version=None, raw=False):
         key = self.make_key(key, version=version)
-        result = self.client.get(key)
+        result = self._client(raw=raw).get(key)
         if result is not None and not raw:
             result = json.loads(result)
 
@@ -46,10 +53,11 @@ class CommonRedisCache(BaseCache):
 
 
 class RbCache(CommonRedisCache):
-    def __init__(self, **options):
+    def __init__(self, **options: object) -> None:
         cluster, options = get_cluster_from_options("SENTRY_CACHE_OPTIONS", options)
         client = cluster.get_routing_client()
-        CommonRedisCache.__init__(self, client, **options)
+        # XXX: rb does not have a "raw" client -- use the default client
+        super().__init__(client=client, raw_client=client, **options)
 
 
 # Confusing legacy name for RbCache.  We don't actually have a pure redis cache
@@ -57,6 +65,7 @@ RedisCache = RbCache
 
 
 class RedisClusterCache(CommonRedisCache):
-    def __init__(self, cluster_id, **options):
+    def __init__(self, cluster_id: str, **options: object) -> None:
         client = redis_clusters.get(cluster_id)
-        CommonRedisCache.__init__(self, client=client, **options)
+        raw_client = redis_clusters.get(cluster_id, decode_responses=False)
+        super().__init__(client=client, raw_client=raw_client, **options)

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -49,7 +49,7 @@ def mocked_attachment_cache(request, mock_client):
     else:
         assert False
 
-    assert attachment_cache.inner.client is mock_client
+    assert attachment_cache.inner._text_client is mock_client
     yield attachment_cache
 
 

--- a/tests/sentry/cache/test_redis.py
+++ b/tests/sentry/cache/test_redis.py
@@ -1,23 +1,37 @@
 import pytest
 
-from sentry.cache.redis import RedisCache, ValueTooLarge
-from sentry.testutils.cases import TestCase
+from sentry.cache.redis import RedisCache, RedisClusterCache, ValueTooLarge
+
+clients = pytest.mark.parametrize(
+    "make_client",
+    (
+        pytest.param(RedisCache, id="RedisCache"),
+        pytest.param(lambda: RedisClusterCache("default"), id="RedisClusterCache"),
+    ),
+)
 
 
-class RedisCacheTest(TestCase):
-    def setUp(self):
-        self.backend = RedisCache()
+@clients
+def test_redis_cache_integration(make_client):
+    backend = make_client()
+    backend.set("foo", {"foo": "bar"}, timeout=50)
 
-    def test_integration(self):
-        self.backend.set("foo", {"foo": "bar"}, 50)
+    result = backend.get("foo")
+    assert result == {"foo": "bar"}
 
-        result = self.backend.get("foo")
-        assert result == {"foo": "bar"}
+    backend.delete("foo")
 
-        self.backend.delete("foo")
+    result = backend.get("foo")
+    assert result is None
 
-        result = self.backend.get("foo")
-        assert result is None
+    with pytest.raises(ValueTooLarge):
+        backend.set("foo", "x" * (RedisCache.max_size + 1), 0)
 
-        with pytest.raises(ValueTooLarge):
-            self.backend.set("foo", "x" * (RedisCache.max_size + 1), 0)
+
+@clients
+def test_raw_preserves_bytes(make_client):
+    backend = make_client()
+    backend.set("k", b"\xa0\x12\xfe", timeout=50, raw=True)
+    assert backend.get("k", raw=True) == b"\xa0\x12\xfe"
+    backend.delete("k")
+    assert backend.get("k") is None

--- a/tests/sentry/utils/kvstore/test_compat.py
+++ b/tests/sentry/utils/kvstore/test_compat.py
@@ -12,7 +12,9 @@ def test_redis_cache_compat() -> None:
     version = 5
     prefix = "test"
 
-    cache_backend = CacheKVStorage(CommonRedisCache(redis, version=version, prefix=prefix))
+    cache_backend = CacheKVStorage(
+        CommonRedisCache(client=redis, raw_client=redis, version=version, prefix=prefix)
+    )
     redis_backend = KVStorageCodecWrapper(
         CacheKeyWrapper(RedisKVStorage(redis), version=version, prefix=prefix),
         JSONCodec() | BytesCodec(),


### PR DESCRIPTION
upgrading either redis or hiredis will cause this to be strict on str / bytes conversion

<!-- Describe your PR here. -->

resolves https://sentry.sentry.io/issues/4957683897