### PR TITLE
ref(slack): Fix empty text

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -629,7 +629,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         # build up text block
         if text:
             text = text.lstrip(" ")
-            blocks.append(self.get_rich_text_preformatted_block(text))
+            if text:
+                blocks.append(self.get_rich_text_preformatted_block(text))
 
         # build up actions text
         if self.actions and self.identity and not action_text:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -629,6 +629,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         # build up text block
         if text:
             text = text.lstrip(" ")
+            # XXX(CEO): sometimes text is " " and slack will error if we pass an empty string (now "")
             if text:
                 blocks.append(self.get_rich_text_preformatted_block(text))
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from sentry.eventstore.models import Event
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
 from sentry.incidents.models import IncidentStatus
+from sentry.integrations.message_builder import build_attachment_text, build_attachment_title
 from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.integrations.slack.message_builder.issues import (
@@ -66,7 +67,8 @@ def build_test_message_blocks(
 ) -> dict[str, Any]:
     project = group.project
 
-    title = group.title
+    title = build_attachment_title(group)
+    text = build_attachment_text(group)
     title_link = f"http://testserver/organizations/{project.organization.slug}/issues/{group.id}"
     formatted_title = title
     if event:
@@ -85,6 +87,20 @@ def build_test_message_blocks(
             "block_id": f'{{"issue":{group.id}}}',
         },
     ]
+    if text:
+        new_text = text.lstrip(" ")
+        if new_text:
+            text_section = {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_preformatted",
+                        "elements": [{"type": "text", "text": new_text}],
+                        "border": 0,
+                    }
+                ],
+            }
+            blocks.append(text_section)
 
     tags_text = ""
     if not tags:
@@ -181,9 +197,12 @@ def build_test_message_blocks(
 
     blocks.append({"type": "divider"})
 
+    popup_text = (
+        f"[{project.slug}] {title}: {text}" if text is not None else f"[{project.slug}] {title}"
+    )
     return {
         "blocks": blocks,
-        "text": f"[{project.slug}] {title}",
+        "text": popup_text,
     }
 
 
@@ -308,7 +327,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
     @with_feature("organizations:slack-block-kit")
     def test_build_group_block(self):
-
         release = self.create_release(project=self.project)
         event = self.store_event(
             data={
@@ -399,6 +417,70 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
 
         assert SlackIssuesMessageBuilder(group).build() == test_message
+
+    @with_feature("organizations:slack-block-kit")
+    def test_build_group_block_with_message(self):
+        event_data = {
+            "event_id": "a" * 32,
+            "message": "IntegrationError",
+            "fingerprint": ["group-1"],
+            "exception": {
+                "values": [
+                    {
+                        "type": "IntegrationError",
+                        "value": "Identity not found.",
+                    }
+                ]
+            },
+        }
+        event = self.store_event(
+            data=event_data,
+            project_id=self.project.id,
+        )
+        assert event.group
+        group = event.group
+        self.project.flags.has_releases = True
+        self.project.save(update_fields=["flags"])
+        base_tags = {"level": "error"}
+
+        assert SlackIssuesMessageBuilder(group).build() == build_test_message_blocks(
+            teams={self.team},
+            users={self.user},
+            group=group,
+            tags=base_tags,
+        )
+
+    @with_feature("organizations:slack-block-kit")
+    def test_build_group_block_with_empty_string_message(self):
+        event_data = {
+            "event_id": "a" * 32,
+            "message": "IntegrationError",
+            "fingerprint": ["group-1"],
+            "exception": {
+                "values": [
+                    {
+                        "type": "IntegrationError",
+                        "value": " ",
+                    }
+                ]
+            },
+        }
+        event = self.store_event(
+            data=event_data,
+            project_id=self.project.id,
+        )
+        assert event.group
+        group = event.group
+        self.project.flags.has_releases = True
+        self.project.save(update_fields=["flags"])
+        base_tags = {"level": "error"}
+
+        assert SlackIssuesMessageBuilder(group).build() == build_test_message_blocks(
+            teams={self.team},
+            users={self.user},
+            group=group,
+            tags=base_tags,
+        )
 
     @patch(
         "sentry.integrations.slack.message_builder.issues.get_option_groups",


### PR DESCRIPTION
I see a few `invalid_blocks` [errors](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D~%22sentry%22%0AjsonPayload.event%20%3D%20%22rule.fail.slack_post%22%0Ajson_payload.error%3D%22invalid_blocks%22;summaryFields=:true:32:beginning;lfeCustomFields=jsonPayload%252Ferror;cursorTimestamp=2024-02-08T18:56:57.727384762Z;duration=PT10M?project=internal-sentry&rapt=AEjHL4OrXdLbKrht86-HuSjck8ZerOjuSSiY6ZnMnpy12mCMG2egSebe97-lXg7C0LRv8OHYAcj0tn9v98A-FI11k6e8Vq0OIZNzfEn3bASivMtyEWxTnvI) for one specific project where the text seems to be `" "` so after we strip the space, there is nothing, resulting in an error from Slack. 