### PR TITLE
ref(superuser): allow read-only superusers to view audit logs

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -98,6 +98,17 @@ class OrganizationAndStaffPermission(StaffPermissionMixin, OrganizationPermissio
 class OrganizationAuditPermission(OrganizationPermission):
     scope_map = {"GET": ["org:write"]}
 
+    def has_object_permission(
+        self,
+        request: Request,
+        view: object,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ) -> bool:
+        if super().has_object_permission(request, view, organization):
+            return True
+
+        return is_active_superuser(request)
+
 
 class OrganizationEventPermission(OrganizationPermission):
     scope_map = {

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -107,6 +107,8 @@ class OrganizationAuditPermission(OrganizationPermission):
         if super().has_object_permission(request, view, organization):
             return True
 
+        # the GET requires org:write, but we want both superuser read-only +
+        # write to be able to access this GET. read-only only has :read scopes
         return is_active_superuser(request)
 
 


### PR DESCRIPTION
Audit logs are helpful for debugging, and this is a GET endpoint, so we can allow read-only superusers to view them.

For https://github.com/getsentry/team-core-product-foundations/issues/56