### PR TITLE
fix(issues): Add timeline menu title, fix rerendering

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -61,9 +61,10 @@ export function TraceTimelineEvents({event, width}: TraceTimelineEventsProps) {
             column - 1,
             durationMs / totalColumns
           );
+          const hasCurrentEvent = colEvents.some(e => e.id === event.id);
           return (
             <EventColumn
-              key={column}
+              key={`${column}-${hasCurrentEvent ? 'current-event' : 'regular'}`}
               // Add 1 to the column to account for the padding
               style={{gridColumn: Math.floor(column) + 1, width: columnSize}}
             >
@@ -156,7 +157,10 @@ function NodeGroup({
         {Array.from(eventsByColumn.entries()).map(([column, groupEvents]) => {
           const isCurrentNode = groupEvents.some(e => e.id === currentEventId);
           return (
-            <EventColumn key={column} style={{gridColumn: Math.floor(column)}}>
+            <EventColumn
+              key={`${column}-currrent-event`}
+              style={{gridColumn: Math.floor(column)}}
+            >
               {isCurrentNode && (
                 <CurrentNodeContainer aria-label={t('Current Event')}>
                   <CurrentNodeRing />

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
@@ -40,6 +40,7 @@ export function TraceTimelineTooltip({event, timelineEvents}: TraceTimelineToolt
     <UnstyledUnorderedList>
       {displayYouAreHere && <YouAreHereItem>{t('You are here')}</YouAreHereItem>}
       <EventItemsWrapper>
+        <EventItemsTitle>{t('Around the same time')}</EventItemsTitle>
         {filteredTimelineEvents.slice(0, 3).map(timelineEvent => {
           const project = projects.find(p => p.slug === timelineEvent.project);
           return (
@@ -115,7 +116,15 @@ const UnstyledUnorderedList = styled('div')`
 const EventItemsWrapper = styled('div')`
   display: flex;
   flex-direction: column;
-  padding: ${space(0.5)};
+  padding: ${space(1)} ${space(0.5)} ${space(0.5)} ${space(0.5)};
+`;
+
+const EventItemsTitle = styled('div')`
+  padding-left: ${space(1)};
+  text-transform: uppercase;
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  font-weight: 600;
+  color: ${p => p.theme.subText};
 `;
 
 const YouAreHere = styled('div')`


### PR DESCRIPTION
- fixes a bug when switching between two events via the timeline, the dots weren't rerendering correctly because the keys didn't change mostly to do with the dot becoming the current event.
- adds a title to the menu

the new "around the same time" title
![Screenshot 2024-02-08 at 11 43 44 AM](https://github.com/getsentry/sentry/assets/1400464/963e9787-c79e-4733-95a1-7f327bb96f4c)
