### PR TITLE
fix(hybrid-cloud): Correct proxy header for Opsgenie

### DIFF
--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -81,11 +81,11 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 
         # Get the organization integration
-        org_id_header = request.headers.get(PROXY_OI_HEADER)
-        if org_id_header is None or not org_id_header.isnumeric():
+        org_integration_id_header = request.headers.get(PROXY_OI_HEADER)
+        if org_integration_id_header is None or not org_integration_id_header.isnumeric():
             logger.info("integration_proxy.missing_org_integration", extra=self.log_extra)
             return False
-        org_integration_id = int(org_id_header)
+        org_integration_id = int(org_integration_id_header)
         self.log_extra["org_integration_id"] = org_integration_id
 
         self.org_integration = (

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -38,7 +38,6 @@ from sentry.incidents.models import (
     IncidentTrigger,
     TriggerStatus,
 )
-from sentry.integrations.opsgenie.integration import OpsgenieIntegration
 from sentry.models.actor import Actor
 from sentry.models.notificationaction import ActionService, ActionTarget
 from sentry.models.project import Project
@@ -1401,6 +1400,7 @@ def get_alert_rule_trigger_action_opsgenie_team(
     input_channel_id=None,
     integrations=None,
 ) -> tuple[str, str]:
+    from sentry.integrations.opsgenie.integration import OpsgenieIntegration
     from sentry.integrations.opsgenie.utils import get_team
 
     integration, oi = integration_service.get_organization_context(

--- a/src/sentry/integrations/opsgenie/actions/form.py
+++ b/src/sentry/integrations/opsgenie/actions/form.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from sentry.integrations.opsgenie.client import OpsgenieClient
+from sentry.integrations.opsgenie.integration import OpsgenieIntegration
 from sentry.integrations.opsgenie.utils import get_team
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import (
@@ -66,13 +66,11 @@ class OpsgenieNotifyTeamForm(forms.Form):
         if not team or not team_id:
             return INVALID_TEAM
 
-        integration_key = team["integration_key"]
-        client = OpsgenieClient(
-            integration=integration,
-            integration_key=integration_key,
-            org_integration_id=org_integration.id,
-            keyid=team_id,
+        install = cast(
+            "OpsgenieIntegration",
+            integration.get_installation(organization_id=org_integration.organization_id),
         )
+        client = install.get_keyring_client(keyid=team_id)
         # the integration should be of type "sentry"
         # there's no way to authenticate that a key is an integration key
         # without specifying the type... even though the type is arbitrary

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -116,7 +116,7 @@ class OpsgenieIntegration(IntegrationInstallation):
     def get_keyring_client(self, keyid: str) -> OpsgenieClient:
         org_integration = self.org_integration
         assert org_integration, "OrganizationIntegration is required"
-        team = get_team(keyid, org_integration)
+        team = get_team(team_id=keyid, org_integration=org_integration)
         assert team, "Cannot get client for unknown team"
 
         return OpsgenieClient(

--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -6,7 +6,6 @@ from typing import Any, cast
 from sentry.constants import ObjectStatus
 from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus
 from sentry.integrations.metric_alerts import incident_attachment_info
-from sentry.integrations.opsgenie.integration import OpsgenieIntegration
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcOrganizationIntegration
 from sentry.shared_integrations.exceptions import ApiError
@@ -63,6 +62,8 @@ def send_incident_alert_notification(
     new_status: IncidentStatus,
     notification_uuid: str | None = None,
 ) -> bool:
+    from sentry.integrations.opsgenie.integration import OpsgenieIntegration
+
     integration, org_integration = integration_service.get_organization_context(
         organization_id=incident.organization_id, integration_id=action.integration_id
     )


### PR DESCRIPTION
Resolves [SENTRY-2JDF](https://sentry.sentry.io/issues/4939521218/)

This PR resolves the above bug and also ensures opsgenie clients are always created using `get_keyring_client` to hopefully avoid it in the future.