### PR TITLE
ref(sdk): Adhere to NO_SPOTLIGHT for python

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -90,6 +90,8 @@ _env_cache: dict[str, object] = {}
 
 ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "production")
 
+NO_SPOTLIGHT = os.environ.get("NO_SPOTLIGHT", False)
+
 IS_DEV = ENVIRONMENT == "development"
 
 DEBUG = IS_DEV

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -474,7 +474,7 @@ def configure_sdk():
             ThreadingIntegration(propagate_hub=True),
             OpenAiIntegration(capture_prompts=True),
         ],
-        spotlight=settings.IS_DEV,
+        spotlight=settings.IS_DEV and not settings.NO_SPOTLIGHT,
         **sdk_options,
     )
 


### PR DESCRIPTION
We have this for webpack already, sometimes with our dev env we can have too many errors and have been hitting

```
21:15:19 [WARNING] sentry_sdk.errors: Too many errors sending to Spotlight, stop sending events there.
```

Which I'm sure will be fixed, but an env flag to temporarily turn it off like every other service should be there regardless.
