### PR TITLE
feat(integration):  Give each action a UUID

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -78,7 +78,7 @@ class DuplicateRuleEvaluator:
 
         self._keys_to_check: set[str] = self._get_keys_to_check()
 
-        self._matcher_funcs_by_key: dict[str, Callable[[], MatcherResult]] = {
+        self._matcher_funcs_by_key: dict[str, Callable[[Rule, str], MatcherResult]] = {
             self.ENVIRONMENT_KEY: self._environment_matcher,
             self.ACTIONS_KEY: self._actions_matcher,
         }
@@ -214,7 +214,7 @@ class DuplicateRuleEvaluator:
         return True
 
     @classmethod
-    def _get_clean_actions_dict(cls, actions_dict: dict[any, any]) -> dict[any, any]:
+    def _get_clean_actions_dict(cls, actions_dict: dict[Any, Any]) -> dict[Any, Any]:
         """
         Returns a dictionary where None is substituted with empty string to help compare DB values vs serialized values
         """

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1,3 +1,7 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
 from django.conf import settings
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
@@ -44,66 +48,198 @@ def pre_save_rule(instance, sender, *args, **kwargs):
     clean_rule_data(instance.data.get("actions", []))
 
 
+@dataclass
+class MatcherResult:
+    has_key: bool = False
+    key_matches: bool = False
+
+
+class DuplicateRuleEvaluator:
+    ACTIONS_KEY = "actions"
+    ENVIRONMENT_KEY = "environment"
+    SPECIAL_FIELDS = [ACTIONS_KEY, ENVIRONMENT_KEY]
+
+    EXCLUDED_FIELDS = ["name", "user_id"]
+
+    def __init__(
+        self,
+        project_id: int,
+        rule_data: dict[Any, Any] | None = None,
+        rule_id: int | None = None,
+        rule: Rule | None = None,
+    ) -> None:
+        """
+        rule.data will supersede rule_data if passed in
+        """
+        self._project_id: int = project_id
+        self._rule_data: dict[Any, Any] = rule.data if rule else rule_data
+        self._rule_id: int | None = rule_id
+        self._rule: Rule | None = rule
+
+        self._keys_to_check: set[str] = self._get_keys_to_check()
+
+        self._matcher_funcs_by_key: dict[str, Callable[[], MatcherResult]] = {
+            self.ENVIRONMENT_KEY: self._environment_matcher,
+            self.ACTIONS_KEY: self._actions_matcher,
+        }
+
+    def _get_keys_to_check(self) -> set[str]:
+        """
+        Returns a set of keys that should be checked against all existing rules.
+        Some keys are ignored as they are not part of the logic.
+        Some keys are required to check, and are added on top.
+        """
+        keys_to_check: set[str] = {
+            key for key in list(self._rule_data.keys()) if key not in self.EXCLUDED_FIELDS
+        }
+        keys_to_check.update(self.SPECIAL_FIELDS)
+
+        return keys_to_check
+
+    def _get_func_to_call(self, key_to_check: str) -> Callable:
+        return self._matcher_funcs_by_key.get(key_to_check, self._default_matcher)
+
+    def _default_matcher(self, existing_rule: Rule, key_to_check: str) -> MatcherResult:
+        """
+        Default function that checks if the key exists in both rules for comparison, and compares the values.
+        """
+        match_results = MatcherResult()
+        match_results.has_key = (
+            key_to_check in existing_rule.data and key_to_check in self._rule_data
+        )
+
+        if match_results.has_key:
+            match_results.key_matches = (
+                existing_rule.data[key_to_check] == self._rule_data[key_to_check]
+            )
+        return match_results
+
+    def _environment_matcher(self, existing_rule: Rule, key_to_check: str) -> MatcherResult:
+        """
+        Special function that checks if the environments are the same.
+        """
+        # Do the default check to see if both rules have the same environment key, and if they do, use the result.
+        if (
+            base_result := self._default_matcher(existing_rule, key_to_check)
+        ) and base_result.has_key:
+            return base_result
+
+        match_results = MatcherResult()
+        if self._rule:
+            if existing_rule.environment_id and self._rule.environment_id:
+                # If the existing rule and our rule both have environment ids, check if it's the same
+                match_results.has_key = True
+                match_results.key_matches = (
+                    existing_rule.environment_id == self._rule.environment_id
+                )
+            elif (
+                existing_rule.environment_id
+                and not self._rule.environment_id
+                or not existing_rule.environment_id
+                and self._rule.environment_id
+            ):
+                # Otherwise, if one of the rules has an environment key, but the other does not, the key was checked,
+                # but it is obviously not the same anymore
+                match_results.has_key = True
+        else:
+            if existing_rule.environment_id and self._rule_data.get(key_to_check):
+                match_results.has_key = True
+                match_results.key_matches = existing_rule.environment_id == self._rule_data.get(
+                    key_to_check
+                )
+            elif (
+                existing_rule.environment_id
+                and not self._rule_data.get(key_to_check)
+                or not existing_rule.environment_id
+                and self._rule_data.get(key_to_check)
+            ):
+                match_results.has_key = True
+
+        return match_results
+
+    def _actions_matcher(self, existing_rule: Rule, key_to_check: str) -> MatcherResult:
+        """
+        Special function that checks if the actions are the same against a rule.
+
+        TODO(Yash): Understand this logic more. Currently it respects the original logic that was implemented, and is simply
+        moved over to this method.
+        """
+        match_results = MatcherResult()
+        if key_to_check not in existing_rule.data and key_to_check not in self._rule_data:
+            return match_results
+
+        # At this point, either both have the key, or one of the rules has the key, so this has to be true
+        match_results.has_key = True
+        # Only compare if both have the key
+        if key_to_check in existing_rule.data and key_to_check in self._rule_data:
+            existing_actions = existing_rule.data[key_to_check]
+            current_actions = self._rule_data[key_to_check]
+            match_results.key_matches = self._compare_lists_of_dicts(
+                keys_to_ignore=["uuid"], list1=existing_actions, list2=current_actions
+            )
+
+        return match_results
+
+    @classmethod
+    def _compare_lists_of_dicts(
+        cls,
+        keys_to_ignore: list[str],
+        list1: list[dict[Any, Any]] | None = None,
+        list2: list[dict[Any, Any]] | None = None,
+    ) -> bool:
+        if list1 is None or list2 is None:
+            return False
+
+        if len(list1) != len(list2):
+            return False
+
+        for i, left in enumerate(list1):
+            right = list2[i]
+            clean_left = {k: v for k, v in left.items() if k not in keys_to_ignore}
+            clean_right = {k: v for k, v in right.items() if k not in keys_to_ignore}
+            if clean_left != clean_right:
+                return False
+
+        return True
+
+    def find_duplicate(self) -> Rule | None:
+        """
+        Determines whether specified rule already exists, and if it does, returns it.
+        """
+
+        existing_rules = Rule.objects.exclude(id=self._rule_id).filter(
+            project__id=self._project_id, status=ObjectStatus.ACTIVE
+        )
+        for existing_rule in existing_rules:
+            keys_checked = 0
+            keys_matched = 0
+            for key_to_check in self._keys_to_check:
+                func = self._get_func_to_call(key_to_check=key_to_check)
+                results: MatcherResult = func(
+                    existing_rule=existing_rule, key_to_check=key_to_check
+                )
+                if results.has_key:
+                    keys_checked += 1
+                    if results.key_matches:
+                        keys_matched += 1
+
+            if keys_checked == keys_matched:
+                return existing_rule
+
+        return None
+
+
 def find_duplicate_rule(project, rule_data=None, rule_id=None, rule=None):
-    if rule:
-        rule_data = rule.data
-
-    matchers = {key for key in list(rule_data.keys()) if key not in ("name", "user_id")}
-    extra_fields = ["actions", "environment"]
-    matchers.update(extra_fields)
-    existing_rules = Rule.objects.exclude(id=rule_id).filter(
-        project=project, status=ObjectStatus.ACTIVE
+    """
+    TODO(Yash): Refactor to remove this function, but for now keep it as a catch all for all existing flows.
+    """
+    evaluator = DuplicateRuleEvaluator(
+        project_id=project.id,
+        rule_data=rule_data,
+        rule_id=rule_id,
+        rule=rule,
     )
-
-    for existing_rule in existing_rules:
-        keys = 0
-        matches = 0
-        for matcher in matchers:
-            if existing_rule.data.get(matcher) and rule_data.get(matcher):
-                keys += 1
-
-                if existing_rule.data[matcher] == rule_data[matcher]:
-                    matches += 1
-
-            elif matcher in extra_fields:
-                if matcher == "environment":
-                    if rule:
-                        # we have to compare env data differently if coming from db rather than app
-                        if existing_rule.environment_id and rule.environment_id:
-                            keys += 1
-                            if existing_rule.environment_id == rule.environment_id:
-                                matches += 1
-                        elif (
-                            existing_rule.environment_id
-                            and not rule.environment_id
-                            or not existing_rule.environment_id
-                            and rule.environment_id
-                        ):
-                            keys += 1
-
-                    else:
-                        if existing_rule.environment_id and rule_data.get(matcher):
-                            keys += 1
-                            if existing_rule.environment_id == rule_data.get(matcher):
-                                matches += 1
-                        elif (
-                            existing_rule.environment_id
-                            and not rule_data.get(matcher)
-                            or not existing_rule.environment_id
-                            and rule_data.get(matcher)
-                        ):
-                            keys += 1
-                elif not existing_rule.data.get(matcher) and not rule_data.get(matcher):
-                    # neither rule has the matcher
-                    continue
-
-                else:
-                    # one rule has the matcher and the other one doesn't
-                    keys += 1
-
-        if keys == matches:
-            return existing_rule
-    return None
+    return evaluator.find_duplicate()
 
 
 class ProjectRulesPostSerializer(serializers.Serializer):

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -196,7 +196,12 @@ def _ensure_action_uuid(action: dict[Any, Any]) -> None:
     Ensure that each action is uniquely identifiable.
     The function will check that a UUID key and value exists in the action.
     If the key does not exist, or it's not a valid UUID, it will create a new one and assign it to the action.
+
+    Does not add an uuid to the action if it is empty.
     """
+    if not action:
+        return
+
     if ACTION_UUID_KEY in action:
         existing_uuid = action[ACTION_UUID_KEY]
         try:

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -1,5 +1,5 @@
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
@@ -8,7 +8,6 @@ from rest_framework import serializers
 from sentry import features
 from sentry.api.fields.actor import ActorField
 from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
-from sentry.db.models.fields import uuid
 from sentry.models.environment import Environment
 from sentry.rules import rules
 from sentry.utils import json
@@ -205,7 +204,7 @@ def _ensure_action_uuid(action: dict[Any, Any]) -> None:
     if ACTION_UUID_KEY in action:
         existing_uuid = action[ACTION_UUID_KEY]
         try:
-            uuid.UUID(existing_uuid)
+            UUID(existing_uuid)
         except (ValueError, TypeError):
             pass
         else:

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -190,7 +190,7 @@ class RuleSerializer(RuleSetSerializer):
 ACTION_UUID_KEY = "uuid"
 
 
-def _ensure_action_uuid(action: dict[Any, Any]) -> None:
+def ensure_action_uuid(action: dict[Any, Any]) -> None:
     """
     Ensure that each action is uniquely identifiable.
     The function will check that a UUID key and value exists in the action.
@@ -220,7 +220,7 @@ def validate_actions(attrs):
     # project_rule(_details) endpoints by setting it on attrs
     actions = attrs.get("actions", tuple())
     for action in actions:
-        _ensure_action_uuid(action)
+        ensure_action_uuid(action)
 
         if action.get("name"):
             del action["name"]

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3048,6 +3048,7 @@ class MonitorTestCase(APITestCase):
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "targetIdentifier": self.user.id,
                 "targetType": "Member",
+                "uuid": str(uuid4()),
             },
         ]
         rule = Creator(

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import Any
 from unittest.mock import patch
+from uuid import uuid4
 
 import responses
 from django.test import override_settings
@@ -44,7 +45,9 @@ class ProjectRuleBaseTestCase(APITestCase):
         self.first_seen_condition = [
             {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
         ]
-        self.notify_event_action = [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}]
+        self.notify_event_action = [
+            {"id": "sentry.rules.actions.notify_event.NotifyEventAction", "uuid": str(uuid4())}
+        ]
         self.notify_issue_owners_action = [
             {
                 "targetType": "IssueOwners",
@@ -52,6 +55,7 @@ class ProjectRuleBaseTestCase(APITestCase):
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "targetIdentifier": "",
                 "name": "Send a notification to IssueOwners and if none can be found then send a notification to ActiveMembers",
+                "uuid": str(uuid4()),
             }
         ]
 
@@ -167,6 +171,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             {
                 "id": "sentry.rules.actions.notify_event.NotifyEventAction",
                 "name": "Send a notification to IssueOwners and if none can be found then send a notification to ActiveMembers",
+                "uuid": str(uuid4()),
             }
         ]
 
@@ -288,10 +293,12 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
 
     def test_pre_save(self):
         """Test that a rule with name data in the conditions and actions is saved without it"""
+        action_uuid = str(uuid4())
         actions = [
             {
                 "id": "sentry.rules.actions.notify_event.NotifyEventAction",
                 "name": "Send a notification to IssueOwners and if none can be found then send a notification to ActiveMembers",
+                "uuid": action_uuid,
             }
         ]
         response = self.get_success_response(
@@ -308,7 +315,8 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         )
         rule = Rule.objects.get(id=response.data.get("id"))
         assert rule.data["actions"][0] == {
-            "id": "sentry.rules.actions.notify_event.NotifyEventAction"
+            "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+            "uuid": action_uuid,
         }
         assert rule.data["conditions"][0] == {
             "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
@@ -401,7 +409,9 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
     @override_settings(MAX_SLOW_CONDITION_ISSUE_ALERTS=1)
     @override_settings(MAX_MORE_SLOW_CONDITION_ISSUE_ALERTS=2)
     def test_exceed_limit_slow_conditions(self):
-        actions = [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}]
+        actions = [
+            {"id": "sentry.rules.actions.notify_event.NotifyEventAction", "uuid": str(uuid4())}
+        ]
         conditions = [
             {
                 "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
@@ -437,6 +447,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
                 "fallthroughType": "ActiveMembers",
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "targetIdentifier": self.team.id,
+                "uuid": str(uuid4()),
             }
         )
         with self.feature("organizations:more-slow-alerts"):
@@ -552,7 +563,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             {"id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter", "value": 10}
         ]
         actions: list[dict[str, Any]] = [
-            {"id": "sentry.rules.actions.notify_event.NotifyEventAction"}
+            {"id": "sentry.rules.actions.notify_event.NotifyEventAction", "uuid": str(uuid4())}
         ]
         self.run_test(
             actions=actions,
@@ -566,7 +577,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
         ]
         actions: list[dict[str, Any]] = [
-            {"id": "sentry.rules.actions.notify_event.NotifyEventAction"}
+            {"id": "sentry.rules.actions.notify_event.NotifyEventAction", "uuid": str(uuid4())}
         ]
 
         self.run_test(
@@ -642,6 +653,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
                 "channel": "#team-team-team",
                 "channel_id": "",
                 "tags": "",
+                "uuid": str(uuid4()),
             }
         ]
         payload: dict[str, Any] = {
@@ -687,7 +699,9 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             "interval": "1h",
             "value": 50,
         }
-        actions = [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}]
+        actions = [
+            {"id": "sentry.rules.actions.notify_event.NotifyEventAction", "uuid": str(uuid4())}
+        ]
         self.run_test(
             actions=actions,
             conditions=[condition],
@@ -708,6 +722,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
                 "fallthroughType": "ActiveMembers",
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "targetIdentifier": self.team.id,
+                "uuid": str(uuid4()),
             }
         )
         self.run_test(actions=actions, conditions=[condition])
@@ -720,6 +735,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
                 "fallthroughType": "ActiveMembers",
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "targetIdentifier": self.user.id,
+                "uuid": str(uuid4()),
             }
         )
         self.run_test(actions=actions, conditions=[condition])
@@ -812,6 +828,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
                 "settings": self.sentry_app_settings_payload,
                 "sentryAppInstallationUuid": self.sentry_app_installation.uuid,
                 "hasSchemaFormConfig": True,
+                "uuid": str(uuid4()),
             },
         ]
         payload = {

--- a/tests/sentry/api/serializers/rest_framework/test_rule.py
+++ b/tests/sentry/api/serializers/rest_framework/test_rule.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from sentry.api.serializers.rest_framework.rule import (
     ACTION_UUID_KEY,
-    _ensure_action_uuid,
+    ensure_action_uuid,
     validate_actions,
 )
 
@@ -15,7 +15,7 @@ class TestEnsureActionUuid:
             "uuid": original_bad_key,
         }
 
-        _ensure_action_uuid(action)
+        ensure_action_uuid(action)
         assert ACTION_UUID_KEY in action
         assert action[ACTION_UUID_KEY] != original_bad_key
         assert uuid.UUID(action[ACTION_UUID_KEY])
@@ -23,7 +23,7 @@ class TestEnsureActionUuid:
     def test_when_key_is_empty(self) -> None:
         action = {"uuid": ""}
 
-        _ensure_action_uuid(action)
+        ensure_action_uuid(action)
         assert ACTION_UUID_KEY in action
         assert action[ACTION_UUID_KEY] != ""
         assert uuid.UUID(action[ACTION_UUID_KEY])
@@ -31,7 +31,7 @@ class TestEnsureActionUuid:
     def test_when_key_is_none(self) -> None:
         action = {"uuid": None}
 
-        _ensure_action_uuid(action)
+        ensure_action_uuid(action)
         assert ACTION_UUID_KEY in action
         assert action[ACTION_UUID_KEY] is not None
         assert uuid.UUID(action[ACTION_UUID_KEY])
@@ -42,7 +42,7 @@ class TestEnsureActionUuid:
             "uuid": original_good_key,
         }
 
-        _ensure_action_uuid(action)
+        ensure_action_uuid(action)
         assert ACTION_UUID_KEY in action
         assert action[ACTION_UUID_KEY] == original_good_key
         assert uuid.UUID(action[ACTION_UUID_KEY])
@@ -52,7 +52,7 @@ class TestEnsureActionUuid:
             "some_other_key": "foo",
         }
 
-        _ensure_action_uuid(action)
+        ensure_action_uuid(action)
 
         assert ACTION_UUID_KEY in action
         assert action[ACTION_UUID_KEY] is not None
@@ -60,7 +60,7 @@ class TestEnsureActionUuid:
 
     def test_ignores_empty_dicts(self) -> None:
         action: dict[Any, Any] = {}
-        _ensure_action_uuid(action)
+        ensure_action_uuid(action)
         assert ACTION_UUID_KEY not in action
 
 

--- a/tests/sentry/api/serializers/rest_framework/test_rule.py
+++ b/tests/sentry/api/serializers/rest_framework/test_rule.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 from sentry.api.serializers.rest_framework.rule import (
     ACTION_UUID_KEY,
@@ -47,7 +48,7 @@ class TestEnsureActionUuid:
         assert uuid.UUID(action[ACTION_UUID_KEY])
 
     def test_adds_uuid_key_when_not_found(self) -> None:
-        action = {}
+        action: dict[Any, Any] = {}
 
         _ensure_action_uuid(action)
 

--- a/tests/sentry/api/serializers/rest_framework/test_rule.py
+++ b/tests/sentry/api/serializers/rest_framework/test_rule.py
@@ -48,13 +48,20 @@ class TestEnsureActionUuid:
         assert uuid.UUID(action[ACTION_UUID_KEY])
 
     def test_adds_uuid_key_when_not_found(self) -> None:
-        action: dict[Any, Any] = {}
+        action: dict[Any, Any] = {
+            "some_other_key": "foo",
+        }
 
         _ensure_action_uuid(action)
 
         assert ACTION_UUID_KEY in action
         assert action[ACTION_UUID_KEY] is not None
         assert uuid.UUID(action[ACTION_UUID_KEY])
+
+    def test_ignores_empty_dicts(self) -> None:
+        action: dict[Any, Any] = {}
+        _ensure_action_uuid(action)
+        assert ACTION_UUID_KEY not in action
 
 
 class TestValidateActions:

--- a/tests/sentry/api/serializers/rest_framework/test_rule.py
+++ b/tests/sentry/api/serializers/rest_framework/test_rule.py
@@ -1,0 +1,82 @@
+import uuid
+
+from sentry.api.serializers.rest_framework.rule import (
+    ACTION_UUID_KEY,
+    _ensure_action_uuid,
+    validate_actions,
+)
+
+
+class TestEnsureActionUuid:
+    def test_overrides_bad_key(self) -> None:
+        original_bad_key = "BAD_KEY-12312312"
+        action = {
+            "uuid": original_bad_key,
+        }
+
+        _ensure_action_uuid(action)
+        assert ACTION_UUID_KEY in action
+        assert action[ACTION_UUID_KEY] != original_bad_key
+        assert uuid.UUID(action[ACTION_UUID_KEY])
+
+    def test_when_key_is_empty(self) -> None:
+        action = {"uuid": ""}
+
+        _ensure_action_uuid(action)
+        assert ACTION_UUID_KEY in action
+        assert action[ACTION_UUID_KEY] != ""
+        assert uuid.UUID(action[ACTION_UUID_KEY])
+
+    def test_when_key_is_none(self) -> None:
+        action = {"uuid": None}
+
+        _ensure_action_uuid(action)
+        assert ACTION_UUID_KEY in action
+        assert action[ACTION_UUID_KEY] is not None
+        assert uuid.UUID(action[ACTION_UUID_KEY])
+
+    def test_respects_good_key(self) -> None:
+        original_good_key = str(uuid.uuid4())
+        action = {
+            "uuid": original_good_key,
+        }
+
+        _ensure_action_uuid(action)
+        assert ACTION_UUID_KEY in action
+        assert action[ACTION_UUID_KEY] == original_good_key
+        assert uuid.UUID(action[ACTION_UUID_KEY])
+
+    def test_adds_uuid_key_when_not_found(self) -> None:
+        action = {}
+
+        _ensure_action_uuid(action)
+
+        assert ACTION_UUID_KEY in action
+        assert action[ACTION_UUID_KEY] is not None
+        assert uuid.UUID(action[ACTION_UUID_KEY])
+
+
+class TestValidateActions:
+    def test_updates_actions(self) -> None:
+        bad_action = {
+            "id": "whatever",
+        }
+        good_action_uuid = str(uuid.uuid4())
+        good_action = {
+            "id": "whatever",
+            "uuid": good_action_uuid,
+        }
+
+        actions = [good_action, bad_action]
+        attributes = {
+            "actions": actions,
+        }
+
+        validated_data = validate_actions(attributes)
+        validated_actions = validated_data["actions"]
+        assert len(validated_actions) == len(actions)
+
+        assert validated_actions[0][ACTION_UUID_KEY] == good_action_uuid
+
+        assert ACTION_UUID_KEY in validated_actions[1]
+        assert uuid.UUID(validated_actions[1][ACTION_UUID_KEY])

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -328,7 +328,12 @@ class UpdateMonitorTest(MonitorTestCase):
         monitor_rule = monitor.get_alert_rule()
         assert monitor_rule.id == rule.id
         assert monitor_rule.label == "Monitor Alert: new-name"
-        assert monitor_rule.data["actions"] == [
+
+        monitor_rule_actions = monitor_rule.data["actions"].copy()
+        assert len(monitor_rule_actions) == 1
+        monitor_rule_actions[0].pop("uuid")
+
+        assert monitor_rule_actions == [
             {
                 "id": "sentry.mail.actions.NotifyEmailAction",
                 "targetIdentifier": new_user.id,


### PR DESCRIPTION
Give each Rule Action a UUID so it's identifiable in future work. Currently we only store related information about what the action should do, but not how to differentiate it uniquely across the platform between one another. For example, a singular Rule could have 3 actions, each one describing that it should be a Slack notification to a different channel. To differentiate, you would have to check the channel id against each other. This is even harder when you need to compare against other rule action types (Discord, email, etc). To understand which action has what side effect, this will get us closer to that visibility.

> Why is this in the serializer?

We use the validated data to create and update actions, which are subsets of a Rule. This makes sure all locations where we need validated data are going to get a UUID. We could optionally move this to the "save" method in the Rule model, but felt like this is not the responsibility of the Rule model to ensure.

Resolves: https://github.com/getsentry/sentry/issues/64916
