### PR TITLE
fix(crons): Handle negative durations gracefully

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -269,7 +269,13 @@ def update_existing_check_in(
         return
 
     if updated_duration is None:
-        updated_duration = int((start_time - existing_check_in.date_added).total_seconds() * 1000)
+        # We use abs here because in some cases we might end up having checkins arrive
+        # slightly out of order due to race conditions in relay. In cases like this,
+        # we're happy to just assume that the duration is the absolute different between
+        # the two dates.
+        updated_duration = abs(
+            int((start_time - existing_check_in.date_added).total_seconds() * 1000)
+        )
 
     if not valid_duration(updated_duration):
         metrics.incr(
@@ -760,6 +766,7 @@ def process_checkin(item: CheckinItem):
         ) as txn:
             _process_checkin(item, txn)
     except Exception:
+        metrics.incr("")
         logger.exception("Failed to process check-in")
 
 

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -766,7 +766,6 @@ def process_checkin(item: CheckinItem):
         ) as txn:
             _process_checkin(item, txn)
     except Exception:
-        metrics.incr("")
         logger.exception("Failed to process check-in")
 
 

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -238,6 +238,16 @@ class MonitorConsumerTest(TestCase):
         checkin = MonitorCheckIn.objects.get(guid=self.guid)
         assert checkin.duration is not None
 
+    def test_check_in_update_with_reversed_dates(self):
+        monitor = self._create_monitor(slug="my-monitor")
+        now = datetime.now()
+        self.send_checkin(monitor.slug, status="in_progress", ts=now)
+        self.send_checkin(monitor.slug, guid=self.guid, ts=now - timedelta(seconds=5))
+
+        checkin = MonitorCheckIn.objects.get(guid=self.guid)
+        assert checkin.status == CheckInStatus.OK
+        assert checkin.duration == 5000
+
     def test_check_in_existing_guid(self):
         monitor = self._create_monitor(slug="my-monitor")
         other_monitor = self._create_monitor(slug="other-monitor")


### PR DESCRIPTION
When sending checkins without an explicit timestamp, we add a timestamp in relay. If we send an in progress and an ok checkin very close to each other, then it's possible that the ok checkin will arrive first, get a lower timestamp, but still arrive in Kafka in the right order. When this happens, we end up with a missed checkin, because when the ok arrives, we calculate the duration and drop the checkin due to it being negative.

We should be more permissive here. Whenever we see a negative duration, we should just assume the timestamps were somehow switched, and convert to positive.
