### PR TITLE
fix(slack): truncate long text in rich text blocks

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -10,6 +10,8 @@ from sentry.integrations.slack.message_builder.base.base import SlackMessageBuil
 from sentry.notifications.utils.actions import MessageAction
 from sentry.utils.dates import to_timestamp
 
+MAX_BLOCK_TEXT_LENGTH = 1000
+
 
 class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     @staticmethod
@@ -40,6 +42,8 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
     @staticmethod
     def get_rich_text_preformatted_block(text: str) -> SlackBlock:
+        if len(text) > MAX_BLOCK_TEXT_LENGTH:
+            text = text[: MAX_BLOCK_TEXT_LENGTH - 3] + "..."
         return {
             "type": "rich_text",
             "elements": [


### PR DESCRIPTION
Some slack notifications are failing to send with the error `msg_blocks_too_long`. Upon investigation it looks like the culprit is super long DB queries that we're trying to fit into the rich text block, and Slack isn't automatically truncating them for us.

To fix this, I added a max length of 1000 chars for the text in the rich text block.