### PR TITLE
feat(ddm): Widget url param parsing

### DIFF
--- a/static/app/utils/metrics/constants.tsx
+++ b/static/app/utils/metrics/constants.tsx
@@ -32,5 +32,4 @@ export const emptyWidget: MetricWidgetQueryParams = {
   groupBy: [],
   sort: DEFAULT_SORT_STATE,
   displayType: MetricDisplayType.LINE,
-  title: undefined,
 };

--- a/static/app/utils/metrics/dashboard.tsx
+++ b/static/app/utils/metrics/dashboard.tsx
@@ -22,7 +22,7 @@ export function convertToDashboardWidget(
 ): Widget {
   // @ts-expect-error TODO: pass interval
   return {
-    title: metricsQuery.title || getDDMWidgetName(metricsQuery),
+    title: getDDMWidgetName(metricsQuery),
     displayType: toDisplayType(displayType),
     widgetType: WidgetType.METRICS,
     limit: !metricsQuery.groupBy?.length ? 1 : 10,

--- a/static/app/utils/metrics/types.tsx
+++ b/static/app/utils/metrics/types.tsx
@@ -25,7 +25,6 @@ export interface MetricWidgetQueryParams extends MetricsQuerySubject {
   focusedSeries?: FocusedMetricsSeries[];
   highlightedSample?: string | null;
   powerUserMode?: boolean;
-  showSummaryTable?: boolean;
   sort?: SortState;
 }
 
@@ -47,13 +46,9 @@ export type MetricsQuery = {
   groupBy?: string[];
   op?: string;
   query?: string;
-  title?: string;
 };
 
-export type MetricsQuerySubject = Pick<
-  MetricsQuery,
-  'mri' | 'op' | 'query' | 'groupBy' | 'title'
->;
+export type MetricsQuerySubject = Pick<MetricsQuery, 'mri' | 'op' | 'query' | 'groupBy'>;
 
 export type MetricCodeLocationFrame = {
   absPath?: string;

--- a/static/app/views/dashboards/widgetCard/metricWidgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/metricWidgetCard/index.tsx
@@ -319,7 +319,6 @@ function convertFromWidget(widget: Widget): MetricWidgetQueryParams {
     op: parsed.op,
     query: query.conditions,
     groupBy: query.columns,
-    title: widget.title,
     displayType: toMetricDisplayType(widget.displayType),
   };
 }

--- a/static/app/views/ddm/metricsExplorer.tsx
+++ b/static/app/views/ddm/metricsExplorer.tsx
@@ -14,9 +14,7 @@ export default function MetricsExplorer() {
     groupBy: [],
     displayType: MetricDisplayType.LINE,
     powerUserMode: true,
-    showSummaryTable: true,
     sort: {name: 'name', order: 'asc'},
-    title: undefined,
   });
 
   return (

--- a/static/app/views/ddm/queries.tsx
+++ b/static/app/views/ddm/queries.tsx
@@ -54,7 +54,6 @@ export function Queries() {
               mri: widget.mri,
               op: widget.op,
               groupBy: widget.groupBy,
-              title: widget.title,
               query: widget.query,
             }}
             displayType={widget.displayType}
@@ -78,7 +77,6 @@ export function Queries() {
                   projects: selection.projects,
                   datetime: selection.datetime,
                   environments: selection.environments,
-                  title: widget.title,
                 }}
               />
             )}

--- a/static/app/views/ddm/utils/parseMetricWidgetsQueryParam.spec.tsx
+++ b/static/app/views/ddm/utils/parseMetricWidgetsQueryParam.spec.tsx
@@ -1,0 +1,220 @@
+import {parseMetricWidgetsQueryParam} from 'sentry/views/ddm/utils/parseMetricWidgetsQueryParam';
+
+describe('parseMetricWidgetQueryParam', () => {
+  it('returns undefined for invalid param', () => {
+    expect(parseMetricWidgetsQueryParam(undefined)).toBe(undefined);
+    expect(parseMetricWidgetsQueryParam('')).toBe(undefined);
+    expect(parseMetricWidgetsQueryParam('{}')).toBe(undefined);
+    expect(parseMetricWidgetsQueryParam('true')).toBe(undefined);
+    expect(parseMetricWidgetsQueryParam('2')).toBe(undefined);
+    expect(parseMetricWidgetsQueryParam('"test"')).toBe(undefined);
+
+    // empty array is not valid
+    expect(parseMetricWidgetsQueryParam('[]')).toEqual(undefined);
+  });
+
+  it('returns a single widget', () => {
+    expect(
+      parseMetricWidgetsQueryParam(
+        JSON.stringify([
+          {
+            mri: 'd:transactions/duration@millisecond',
+            op: 'sum',
+            query: 'test:query',
+            groupBy: ['dist'],
+            displayType: 'line',
+            focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+            powerUserMode: true,
+            sort: {order: 'asc'},
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        mri: 'd:transactions/duration@millisecond',
+        op: 'sum',
+        query: 'test:query',
+        groupBy: ['dist'],
+        displayType: 'line',
+        focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+        powerUserMode: true,
+        sort: {name: undefined, order: 'asc'},
+      },
+    ]);
+  });
+
+  it('returns multiple widgets', () => {
+    expect(
+      parseMetricWidgetsQueryParam(
+        JSON.stringify([
+          {
+            mri: 'd:transactions/duration@millisecond',
+            op: 'sum',
+            query: 'test:query',
+            groupBy: ['dist'],
+            displayType: 'line',
+            focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+            powerUserMode: true,
+            sort: {name: 'avg', order: 'desc'},
+          },
+          {
+            mri: 'd:custom/sentry.event_manager.save@second',
+            op: 'avg',
+            query: '',
+            groupBy: ['event_type'],
+            displayType: 'line',
+            powerUserMode: false,
+            focusedSeries: [{seriesName: 'default', groupBy: {event_type: 'default'}}],
+            sort: {name: 'sum', order: 'asc'},
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        mri: 'd:transactions/duration@millisecond',
+        op: 'sum',
+        query: 'test:query',
+        groupBy: ['dist'],
+        displayType: 'line',
+        focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+        powerUserMode: true,
+        sort: {name: 'avg', order: 'desc'},
+      },
+      {
+        mri: 'd:custom/sentry.event_manager.save@second',
+        op: 'avg',
+        query: '',
+        groupBy: ['event_type'],
+        displayType: 'line',
+        powerUserMode: false,
+        focusedSeries: [{seriesName: 'default', groupBy: {event_type: 'default'}}],
+        sort: {name: 'sum', order: 'asc'},
+      },
+    ]);
+  });
+
+  it('falls back to defaults', () => {
+    // Missing values
+    expect(
+      parseMetricWidgetsQueryParam(
+        JSON.stringify([
+          {
+            mri: 'd:transactions/duration@millisecond',
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        mri: 'd:transactions/duration@millisecond',
+        op: 'avg',
+        query: '',
+        groupBy: [],
+        displayType: 'line',
+        focusedSeries: [],
+        powerUserMode: false,
+        sort: {name: undefined, order: 'asc'},
+      },
+    ]);
+
+    // Invalid values
+    expect(
+      parseMetricWidgetsQueryParam(
+        JSON.stringify([
+          {
+            mri: 'd:transactions/duration@millisecond',
+            op: 1,
+            query: 12,
+            groupBy: true,
+            displayType: 'aasfcsdf',
+            focusedSeries: {},
+            powerUserMode: 1,
+            sort: {name: 1, order: 'invalid'},
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        mri: 'd:transactions/duration@millisecond',
+        op: 'avg',
+        query: '',
+        groupBy: [],
+        displayType: 'line',
+        focusedSeries: [],
+        powerUserMode: false,
+        sort: {name: undefined, order: 'asc'},
+      },
+    ]);
+  });
+
+  it('ignores invalid widgets', () => {
+    expect(
+      parseMetricWidgetsQueryParam(
+        JSON.stringify([
+          {
+            mri: 'd:transactions/duration@millisecond',
+          },
+          {
+            // Missing MRI
+          },
+          {
+            // Mallformed MRI
+            mri: 'transactions/duration@millisecond',
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        mri: 'd:transactions/duration@millisecond',
+        op: 'avg',
+        query: '',
+        groupBy: [],
+        displayType: 'line',
+        focusedSeries: [],
+        powerUserMode: false,
+        sort: {order: 'asc'},
+      },
+    ]);
+  });
+
+  it('returns undefined if there is no valid widget', () => {
+    expect(
+      parseMetricWidgetsQueryParam(
+        JSON.stringify([
+          {
+            // Missing MRI
+          },
+        ])
+      )
+    ).toBe(undefined);
+  });
+
+  it('handles missing array in array params', () => {
+    expect(
+      parseMetricWidgetsQueryParam(
+        JSON.stringify([
+          {
+            mri: 'd:transactions/duration@millisecond',
+            op: 'sum',
+            query: 'test:query',
+            groupBy: 'dist',
+            displayType: 'line',
+            focusedSeries: {seriesName: 'default', groupBy: {dist: 'default'}},
+            powerUserMode: true,
+            sort: {order: 'asc'},
+          },
+        ])
+      )
+    ).toEqual([
+      {
+        mri: 'd:transactions/duration@millisecond',
+        op: 'sum',
+        query: 'test:query',
+        groupBy: ['dist'],
+        displayType: 'line',
+        focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+        powerUserMode: true,
+        sort: {name: undefined, order: 'asc'},
+      },
+    ]);
+  });
+});

--- a/static/app/views/ddm/utils/parseMetricWidgetsQueryParam.tsx
+++ b/static/app/views/ddm/utils/parseMetricWidgetsQueryParam.tsx
@@ -1,0 +1,148 @@
+import {getDefaultMetricDisplayType, getDefaultMetricOp} from 'sentry/utils/metrics';
+import {DEFAULT_SORT_STATE} from 'sentry/utils/metrics/constants';
+import {isMRI} from 'sentry/utils/metrics/mri';
+import {
+  type FocusedMetricsSeries,
+  MetricDisplayType,
+  type MetricWidgetQueryParams,
+  type SortState,
+} from 'sentry/utils/metrics/types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isMetricDisplayType(value: unknown): value is MetricDisplayType {
+  return Object.values(MetricDisplayType).includes(value as MetricDisplayType);
+}
+
+function getMRIParam(widget: Record<string, unknown>) {
+  return 'mri' in widget && isMRI(widget.mri) ? widget.mri : undefined;
+}
+
+function parseStringParam(
+  widget: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = widget[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function parseBooleanParam(
+  widget: Record<string, unknown>,
+  key: string
+): boolean | undefined {
+  const value = widget[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function parseArrayParam<T extends Exclude<any, undefined>>(
+  widget: object,
+  key: string,
+  entryParser: (entry: unknown) => T | undefined
+): T[] {
+  if (!(key in widget)) {
+    return [];
+  }
+
+  // allow single values instead of arrays
+  if (!Array.isArray(widget[key])) {
+    const entry = entryParser(widget[key]);
+    return entry === undefined ? [] : [entry];
+  }
+
+  return widget[key].map(entryParser).filter((entry): entry is T => entry !== undefined);
+}
+
+function parseFocusedSeries(series: any): FocusedMetricsSeries | undefined {
+  if (!isRecord(series)) {
+    return undefined;
+  }
+  const seriesName = parseStringParam(series, 'seriesName');
+  const groupBy =
+    'groupBy' in series && isRecord(series.groupBy)
+      ? (series.groupBy as Record<string, string>)
+      : undefined;
+
+  if (!seriesName) {
+    return undefined;
+  }
+
+  return {seriesName, groupBy};
+}
+
+function parseSortParam(widget: Record<string, unknown>, key: string): SortState {
+  const sort = widget[key];
+  if (!isRecord(sort)) {
+    return DEFAULT_SORT_STATE;
+  }
+
+  const name = parseStringParam(sort, 'name');
+  const order =
+    'order' in sort && (sort.order === 'desc' || sort.order === 'asc')
+      ? sort.order
+      : DEFAULT_SORT_STATE.order;
+
+  if (
+    name === 'name' ||
+    name === 'avg' ||
+    name === 'min' ||
+    name === 'max' ||
+    name === 'sum'
+  ) {
+    return {name, order};
+  }
+
+  return {name: undefined, order};
+}
+
+export function parseMetricWidgetsQueryParam(
+  queryParam?: string
+): MetricWidgetQueryParams[] | undefined {
+  let currentWidgets: unknown = undefined;
+
+  try {
+    currentWidgets = JSON.parse(queryParam || '');
+  } catch (_) {
+    return undefined;
+  }
+
+  // It has to be an array and non-empty
+  if (!Array.isArray(currentWidgets) || currentWidgets.length === 0) {
+    return undefined;
+  }
+
+  const parsedWidgets = currentWidgets
+    .map((widget: unknown): MetricWidgetQueryParams | null => {
+      if (!isRecord(widget)) {
+        return null;
+      }
+
+      const mri = getMRIParam(widget);
+      // If we cannot retrieve an MRI the resulting widget will be useless anyway
+      if (!mri) {
+        return null;
+      }
+
+      const op = parseStringParam(widget, 'op');
+      const displayType = parseStringParam(widget, 'displayType');
+
+      return {
+        mri,
+        op: parseStringParam(widget, 'op') ?? getDefaultMetricOp(mri),
+        query: parseStringParam(widget, 'query') ?? '',
+        groupBy: parseArrayParam(widget, 'groupBy', entry =>
+          typeof entry === 'string' ? entry : undefined
+        ),
+        displayType: isMetricDisplayType(displayType)
+          ? displayType
+          : getDefaultMetricDisplayType(mri, op),
+        focusedSeries: parseArrayParam(widget, 'focusedSeries', parseFocusedSeries),
+        powerUserMode: parseBooleanParam(widget, 'powerUserMode') ?? false,
+        sort: parseSortParam(widget, 'sort'),
+      };
+    })
+    .filter((widget): widget is MetricWidgetQueryParams => !!widget);
+
+  return parsedWidgets.length > 0 ? parsedWidgets : undefined;
+}

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -99,14 +99,12 @@ export const MetricWidget = memo(
         projects,
         datetime,
         environments,
-        title: widget.title,
       }),
       [
         widget.mri,
         widget.query,
         widget.op,
         widget.groupBy,
-        widget.title,
         projects,
         datetime,
         environments,
@@ -144,7 +142,7 @@ export const MetricWidget = memo(
       };
     }, [samplesQuery.data, onSampleClick, highlightedSampleId]);
 
-    const widgetTitle = metricsQuery.title ?? stringifyMetricWidget(metricsQuery);
+    const widgetTitle = stringifyMetricWidget(metricsQuery);
 
     return (
       <MetricWidgetPanel
@@ -380,17 +378,15 @@ const MetricWidgetBody = memo(
           focusArea={focusArea}
           group={chartGroup}
         />
-        {metricsQuery.showSummaryTable && (
-          <SummaryTable
-            series={chartSeries}
-            onSortChange={handleSortChange}
-            sort={sort}
-            operation={metricsQuery.op}
-            onRowClick={setSeriesVisibility}
-            onColorDotClick={toggleSeriesVisibility}
-            setHoveredSeries={setHoveredSeries}
-          />
-        )}
+        <SummaryTable
+          series={chartSeries}
+          onSortChange={handleSortChange}
+          sort={sort}
+          operation={metricsQuery.op}
+          onRowClick={setSeriesVisibility}
+          onColorDotClick={toggleSeriesVisibility}
+          setHoveredSeries={setHoveredSeries}
+        />
       </StyledMetricWidgetBody>
     );
   }


### PR DESCRIPTION
Add parsing with fallback to defaults to for the metrics page's widgets URL param.
Remove unused widget params `showSummaryTable` & `title`.