### PR TITLE
feat(dashboards): ddm chart intervals

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -31,7 +31,7 @@ export type MetricsApiRequestMetric = {
   query?: string;
 };
 
-export type MetricsApiRequestQuery = MetricsApiRequestMetric & {
+export interface MetricsApiRequestQuery extends MetricsApiRequestMetric {
   interval: string;
   end?: DateString;
   environment?: string[];
@@ -41,7 +41,7 @@ export type MetricsApiRequestQuery = MetricsApiRequestMetric & {
   project?: number[];
   start?: DateString;
   statsPeriod?: string;
-};
+}
 
 export type MetricsDataIntervalLadder = 'ddm' | 'bar' | 'dashboard';
 

--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -43,9 +43,11 @@ export type MetricsApiRequestQuery = MetricsApiRequestMetric & {
   statsPeriod?: string;
 };
 
-export type MetricsApiRequestQueryOptions = Partial<MetricsApiRequestQuery> & {
-  fidelity?: 'high' | 'low';
-};
+export type MetricsDataIntervalLadder = 'ddm' | 'bar' | 'dashboard';
+
+export interface MetricsApiRequestQueryOptions extends Partial<MetricsApiRequestQuery> {
+  intervalLadder?: MetricsDataIntervalLadder;
+}
 
 export type MetricsApiResponse = {
   end: string;

--- a/static/app/utils/metrics/index.spec.tsx
+++ b/static/app/utils/metrics/index.spec.tsx
@@ -183,7 +183,7 @@ describe('getMetricsApiRequestQuery', () => {
       environments: ['production'],
       datetime: {start: '2023-01-01', end: '2023-01-02', period: null, utc: true},
     };
-    const overrides: MetricsApiRequestQueryOptions = {fidelity: 'high'};
+    const overrides: MetricsApiRequestQueryOptions = {intervalLadder: 'ddm'};
 
     const result = getMetricsApiRequestQuery(metric, filters, overrides);
 
@@ -219,7 +219,7 @@ describe('getDDMInterval', () => {
     };
     const useCase = 'custom';
 
-    const result = getDDMInterval(dateTimeObj, useCase, 'high');
+    const result = getDDMInterval(dateTimeObj, useCase);
 
     expect(result).toBe('10s');
   });

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -145,7 +145,7 @@ const intervalLadders: Record<MetricsDataIntervalLadder, GranularityLadder> = {
     [ONE_WEEK, '30m'],
     [TWENTY_FOUR_HOURS, '5m'],
     [ONE_HOUR, '1m'],
-    [0, '5m'],
+    [0, '1m'],
   ]),
   bar: new GranularityLadder([
     [SIXTY_DAYS, '1d'],

--- a/static/app/views/dashboards/datasetConfig/metrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/metrics.tsx
@@ -401,7 +401,7 @@ function getMetricRequest(
     pageFilters,
     {
       limit: limit || undefined,
-      fidelity: displayType === DisplayType.BAR ? 'low' : 'high',
+      intervalLadder: displayType === DisplayType.BAR ? 'bar' : 'dashboard',
     }
   );
 

--- a/static/app/views/dashboards/widgetCard/metricWidgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/metricWidgetCard/index.tsx
@@ -14,10 +14,7 @@ import {space} from 'sentry/styles/space';
 import type {MRI, Organization, PageFilters} from 'sentry/types';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import {stringifyMetricWidget} from 'sentry/utils/metrics';
-import {
-  MetricDisplayType,
-  type MetricWidgetQueryParams,
-} from 'sentry/utils/metrics/types';
+import type {MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
 import {useMetricsDataZoom} from 'sentry/utils/metrics/useMetricsData';
 import {WidgetCardPanel, WidgetTitleRow} from 'sentry/views/dashboards/widgetCard';
 import type {AugmentedEChartDataZoomHandler} from 'sentry/views/dashboards/widgetCard/chart';
@@ -232,7 +229,7 @@ export function MetricWidgetChartContainer({
       environments,
       datetime,
     },
-    {fidelity: displayType === MetricDisplayType.BAR ? 'low' : 'high'}
+    {intervalLadder: 'dashboard'}
   );
 
   const chartRef = useRef<ReactEchartsRef>(null);

--- a/static/app/views/dashboards/widgetCard/metricWidgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/metricWidgetCard/index.tsx
@@ -14,7 +14,10 @@ import {space} from 'sentry/styles/space';
 import type {MRI, Organization, PageFilters} from 'sentry/types';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import {stringifyMetricWidget} from 'sentry/utils/metrics';
-import type {MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
+import {
+  MetricDisplayType,
+  type MetricWidgetQueryParams,
+} from 'sentry/utils/metrics/types';
 import {useMetricsDataZoom} from 'sentry/utils/metrics/useMetricsData';
 import {WidgetCardPanel, WidgetTitleRow} from 'sentry/views/dashboards/widgetCard';
 import type {AugmentedEChartDataZoomHandler} from 'sentry/views/dashboards/widgetCard/chart';
@@ -229,7 +232,7 @@ export function MetricWidgetChartContainer({
       environments,
       datetime,
     },
-    {intervalLadder: 'dashboard'}
+    {intervalLadder: displayType === MetricDisplayType.BAR ? 'bar' : 'dashboard'}
   );
 
   const chartRef = useRef<ReactEchartsRef>(null);

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -255,7 +255,7 @@ const MetricWidgetBody = memo(
         environments,
         datetime,
       },
-      {fidelity: displayType === MetricDisplayType.BAR ? 'low' : 'high'}
+      {intervalLadder: displayType === MetricDisplayType.BAR ? 'bar' : 'ddm'}
     );
 
     const chartRef = useRef<ReactEchartsRef>(null);


### PR DESCRIPTION
- closes #61029 

Note: Consolidating chart intervals cross-dataset is not easily achievable across different datasets, this PR aims to align metric widget intervals with other dashboard widgets.

<img width="1212" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/8e7a9f71-202e-41cb-8ed4-19b2ad3170ea">
