### PR TITLE
feat(sdks): Update `sentry-sdk` to 1.40.3

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ sentry-kafka-schemas>=0.1.38
 sentry-ophio==0.1.5
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.45
-sentry-sdk>=1.39.2
+sentry-sdk>=1.40.3
 snuba-sdk>=2.0.25
 simplejson>=3.17.6
 sqlparse>=0.4.4

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -181,7 +181,7 @@ sentry-kafka-schemas==0.1.38
 sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.45
-sentry-sdk==1.39.2
+sentry-sdk==1.40.3
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -122,7 +122,7 @@ sentry-kafka-schemas==0.1.38
 sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.45
-sentry-sdk==1.39.2
+sentry-sdk==1.40.3
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -447,9 +447,10 @@ def configure_sdk():
 
     # turn on minimetrics
     sdk_options.setdefault("_experiments", {}).update(
-        # enable_metrics is True by default, but in 1.40.3 we turn metrics off
-        # automatically if we detect we're running on uWSGI due to
-        # https://github.com/getsentry/sentry-python/issues/2699
+        # enable_metrics is True by default since SDK version 1.40.0,
+        # but in 1.40.3 we turn metrics off automatically if we detect
+        # we're running in uWSGI due to
+        # https://github.com/getsentry/sentry-python/issues/2699.
         # force_enable_metrics overrides this behavior.
         # Once we've fixed the issue with uWSGI, we can get rid of the
         # force_enable_metrics setting here altogether.

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -447,7 +447,13 @@ def configure_sdk():
 
     # turn on minimetrics
     sdk_options.setdefault("_experiments", {}).update(
-        enable_metrics=True,
+        # enable_metrics is True by default, but in 1.40.3 we turn metrics off
+        # automatically if we detect we're running on uWSGI due to
+        # https://github.com/getsentry/sentry-python/issues/2699
+        # force_enable_metrics overrides this behavior.
+        # Once we've fixed the issue with uWSGI, we can get rid of the
+        # force_enable_metrics setting here altogether.
+        force_enable_metrics=True,
         metric_code_locations=options.get("delightful_metrics.enable_code_locations"),
         before_emit_metric=minimetrics.before_emit_metric,
         # turn summaries on, but filter them dynamically in the callback


### PR DESCRIPTION
See comment in code: in 1.40.0 we enabled metrics by default, triggering an [issue](https://github.com/getsentry/sentry-python/issues/2699) with uWSGI. In 1.40.3 we turn metrics off if we detect we're running in uWSGI, which as far as I can see is also the case for Sentry. Since we're not hitting this issue ourselves, there's an override called `force_enable_metrics` that will turn metrics on regardless which I'm adding in this PR.