### PR TITLE
fix(sdk): Discard generic redirects

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -221,6 +221,14 @@ def traces_sampler(sampling_context):
 
 
 def before_send_transaction(event, _):
+    # Discard generic redirects.
+    # This condition can be removed once https://github.com/getsentry/team-sdks/issues/48 is fixed.
+    if (
+        event.get("tags").get("http.status_code") == "301"
+        and event.get("transaction_info").get("source") == "url"
+    ):
+        return None
+
     # Occasionally the span limit is hit and we drop spans from transactions, this helps find transactions where this occurs.
     num_of_spans = len(event["spans"])
     event["tags"]["spans_over_limit"] = num_of_spans >= 1000

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -224,8 +224,8 @@ def before_send_transaction(event, _):
     # Discard generic redirects.
     # This condition can be removed once https://github.com/getsentry/team-sdks/issues/48 is fixed.
     if (
-        event.get("tags").get("http.status_code") == "301"
-        and event.get("transaction_info").get("source") == "url"
+        event.get("tags", {}).get("http.status_code") == "301"
+        and event.get("transaction_info", {}).get("source") == "url"
     ):
         return None
 


### PR DESCRIPTION
Discard generic redirects in `before_send_transaction` until https://github.com/getsentry/team-sdks/issues/48 is done.

ref: https://github.com/getsentry/team-ingest/issues/234