### PR TITLE
Split `proguard` from `process_event`

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event_react_native.py
+++ b/fixtures/sdk_crash_detection/crash_event_react_native.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import Mapping, MutableMapping, Sequence
 
 
@@ -164,7 +165,7 @@ def get_crash_event_with_frames(frames: Sequence[Mapping[str, str]], **kwargs) -
                 {"name": "npm:@sentry/react-native", "version": "5.15.2"},
             ],
         },
-        "timestamp": 1704969036.875,
+        "timestamp": time.time(),
         "type": "error",
         "user": {
             "email": "philipp@example.com",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1,6 +1,7 @@
 """
 These settings act as the default (base) settings for the Sentry-provided web-server
 """
+
 from __future__ import annotations
 
 import os
@@ -844,6 +845,7 @@ CELERY_QUEUES_REGION = [
     Queue("email.inbound", routing_key="email.inbound"),
     Queue("events.preprocess_event", routing_key="events.preprocess_event"),
     Queue("events.process_event", routing_key="events.process_event"),
+    Queue("events.process_event_proguard", routing_key="events.process_event_proguard"),
     Queue("events.reprocess_events", routing_key="events.reprocess_events"),
     Queue(
         "events.reprocessing.preprocess_event", routing_key="events.reprocessing.preprocess_event"
@@ -1234,6 +1236,7 @@ for queue in CELERY_QUEUES:
 PROCESSING_QUEUES = [
     "events.preprocess_event",
     "events.process_event",
+    "events.process_event_proguard",
     "events.reprocess_events",
     "events.reprocessing.preprocess_event",
     "events.reprocessing.process_event",
@@ -2877,26 +2880,32 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
     ),
     "clickhouse": lambda settings, options: (
         {
-            "image": "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:21.8.13.1.altinitystable"
-            if not ARM64
-            # altinity provides clickhouse support to other companies
-            # Official support: https://github.com/ClickHouse/ClickHouse/issues/22222
-            # This image is build with this script https://gist.github.com/filimonov/5f9732909ff66d5d0a65b8283382590d
-            else "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:21.6.1.6734-testing-arm",
+            "image": (
+                "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:21.8.13.1.altinitystable"
+                if not ARM64
+                # altinity provides clickhouse support to other companies
+                # Official support: https://github.com/ClickHouse/ClickHouse/issues/22222
+                # This image is build with this script https://gist.github.com/filimonov/5f9732909ff66d5d0a65b8283382590d
+                else "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:21.6.1.6734-testing-arm"
+            ),
             "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
             "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],
             # The arm image does not properly load the MAX_MEMORY_USAGE_RATIO
             # from the environment in loc_config.xml, thus, hard-coding it there
             "volumes": {
-                "clickhouse_dist"
-                if settings.SENTRY_DISTRIBUTED_CLICKHOUSE_TABLES
-                else "clickhouse": {"bind": "/var/lib/clickhouse"},
+                (
+                    "clickhouse_dist"
+                    if settings.SENTRY_DISTRIBUTED_CLICKHOUSE_TABLES
+                    else "clickhouse"
+                ): {"bind": "/var/lib/clickhouse"},
                 os.path.join(
                     settings.DEVSERVICES_CONFIG_DIR,
                     "clickhouse",
-                    "dist_config.xml"
-                    if settings.SENTRY_DISTRIBUTED_CLICKHOUSE_TABLES
-                    else "loc_config.xml",
+                    (
+                        "dist_config.xml"
+                        if settings.SENTRY_DISTRIBUTED_CLICKHOUSE_TABLES
+                        else "loc_config.xml"
+                    ),
                 ): {"bind": "/etc/clickhouse-server/config.d/sentry.xml"},
             },
         }
@@ -2914,22 +2923,24 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
                 "CLICKHOUSE_HOST": "{containers[clickhouse][name]}",
                 "CLICKHOUSE_PORT": "9000",
                 "CLICKHOUSE_HTTP_PORT": "8123",
-                "DEFAULT_BROKERS": ""
-                if "snuba" in settings.SENTRY_EVENTSTREAM
-                else "{containers[kafka][name]}:9093",
+                "DEFAULT_BROKERS": (
+                    ""
+                    if "snuba" in settings.SENTRY_EVENTSTREAM
+                    else "{containers[kafka][name]}:9093"
+                ),
                 "REDIS_HOST": "{containers[redis][name]}",
                 "REDIS_PORT": "6379",
                 "REDIS_DB": "1",
                 "ENABLE_SENTRY_METRICS_DEV": "1" if settings.SENTRY_USE_METRICS_DEV else "",
                 "ENABLE_PROFILES_CONSUMER": "1" if settings.SENTRY_USE_PROFILING else "",
                 "ENABLE_SPANS_CONSUMER": "1" if settings.SENTRY_USE_SPANS else "",
-                "ENABLE_ISSUE_OCCURRENCE_CONSUMER": "1"
-                if settings.SENTRY_USE_ISSUE_OCCURRENCE
-                else "",
+                "ENABLE_ISSUE_OCCURRENCE_CONSUMER": (
+                    "1" if settings.SENTRY_USE_ISSUE_OCCURRENCE else ""
+                ),
                 "ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES": "1",
-                "ENABLE_GROUP_ATTRIBUTES_CONSUMER": "1"
-                if settings.SENTRY_USE_GROUP_ATTRIBUTES
-                else "",
+                "ENABLE_GROUP_ATTRIBUTES_CONSUMER": (
+                    "1" if settings.SENTRY_USE_GROUP_ATTRIBUTES else ""
+                ),
             },
             "only_if": "snuba" in settings.SENTRY_EVENTSTREAM
             or "kafka" in settings.SENTRY_EVENTSTREAM,

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -28,7 +28,7 @@ def has_proguard_file(data):
     Checks whether an event contains a proguard file
     """
     images = get_path(data, "debug_meta", "images", filter=True)
-    return get_path(images, 0, "type") == "proguard"
+    return any(images, is_valid_proguard_image)
 
 
 def get_proguard_images(event: dict[str, Any]) -> set[str]:

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -27,8 +27,8 @@ def has_proguard_file(data):
     """
     Checks whether an event contains a proguard file
     """
-    images = get_path(data, "debug_meta", "images", filter=True)
-    return any(images, is_valid_proguard_image)
+    images = get_path(data, "debug_meta", "images", filter=True, default=())
+    return any(map(is_valid_proguard_image, images))
 
 
 def get_proguard_images(event: dict[str, Any]) -> set[str]:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -573,6 +573,14 @@ register("store.lie-about-filter-status", default=False, flags=FLAG_AUTOMATOR_MO
 # (``False``) and spawning a save_event task (``True``).
 register("store.transactions-celery", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)  # unused
 
+# The fraction of prooguard events that will be routed to the
+# separate `store.process_event_proguard` queue
+register(
+    "store.separate-proguard-queue-rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_MODIFIABLE_RATE,
+)
+
 # Symbolicator refactors
 # - Disabling minidump stackwalking in endpoints
 register(

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -1,6 +1,4 @@
 import logging
-import random
-from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from time import time
@@ -18,6 +16,7 @@ from sentry.eventstore import processing
 from sentry.eventstore.processing.base import Event
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, create_feedback_issue
 from sentry.killswitches import killswitch_matches_context
+from sentry.lang.java.utils import has_proguard_file
 from sentry.lang.native.symbolicator import SymbolicatorTaskKind
 from sentry.models.activity import Activity
 from sentry.models.options.project_option import ProjectOption
@@ -73,8 +72,14 @@ def submit_process(
     data_has_changed: bool = False,
     from_symbolicate: bool = False,
     has_attachments: bool = False,
+    is_proguard: bool = False,
 ) -> None:
-    task = process_event_from_reprocessing if from_reprocessing else process_event
+    if from_reprocessing:
+        task = process_event_from_reprocessing
+    elif is_proguard:
+        task = process_event_proguard
+    else:
+        task = process_event
     task.delay(
         cache_key=cache_key,
         start_time=start_time,
@@ -127,7 +132,7 @@ def _do_preprocess_event(
     data: Event | None,
     start_time: int | None,
     event_id: str | None,
-    process_task: Callable[[str | None, int | None, str | None, bool], None],
+    from_reprocessing: bool,
     project: Project | None,
     has_attachments: bool = False,
 ) -> None:
@@ -154,8 +159,6 @@ def _do_preprocess_event(
         project = Project.objects.get_from_cache(id=project_id)
     else:
         assert project.id == project_id, (project.id, project_id)
-
-    from_reprocessing = process_task is process_event_from_reprocessing
 
     with metrics.timer("tasks.store.preprocess_event.organization.get_from_cache"):
         project.set_cached_field_value(
@@ -200,6 +203,7 @@ def _do_preprocess_event(
             start_time=start_time,
             data_has_changed=False,
             has_attachments=has_attachments,
+            is_proguard=has_proguard_file(data),
         )
         return
 
@@ -239,7 +243,7 @@ def preprocess_event(
         data=data,
         start_time=start_time,
         event_id=event_id,
-        process_task=process_event,
+        from_reprocessing=False,
         project=project,
         has_attachments=has_attachments,
     )
@@ -265,7 +269,7 @@ def preprocess_event_from_reprocessing(
         data=data,
         start_time=start_time,
         event_id=event_id,
-        process_task=process_event_from_reprocessing,
+        from_reprocessing=True,
         project=project,
     )
 
@@ -285,6 +289,7 @@ def retry_process_event(process_task_name: str, task_kwargs: dict[str, Any], **k
     """
     tasks = {
         "process_event": process_event,
+        "process_event_proguard": process_event_proguard,
         "process_event_from_reprocessing": process_event_from_reprocessing,
     }
 
@@ -318,7 +323,7 @@ def do_process_event(
     cache_key: str,
     start_time: int | None,
     event_id: str | None,
-    process_task: Callable[[str | None, int | None, str | None, bool], None],
+    from_reprocessing: bool,
     data: Event | None = None,
     data_has_changed: bool = False,
     from_symbolicate: bool = False,
@@ -345,7 +350,7 @@ def do_process_event(
 
     def _continue_to_save_event() -> None:
         task_kind = SaveEventTaskKind(
-            from_reprocessing=process_task is process_event_from_reprocessing,
+            from_reprocessing=from_reprocessing,
             has_attachments=has_attachments,
             is_highcpu=data["platform"] in options.get("store.save-event-highcpu-platforms", []),
         )
@@ -477,7 +482,14 @@ def do_process_event(
             # If `create_failed_event` indicates that we need to retry we
             # invoke ourselves again.  This happens when the reprocessing
             # revision changed while we were processing.
-            _do_preprocess_event(cache_key, data, start_time, event_id, process_task, project)
+            _do_preprocess_event(
+                cache_key=cache_key,
+                data=data,
+                start_time=start_time,
+                event_id=event_id,
+                from_reprocessing=from_reprocessing,
+                project=project,
+            )
             return
 
         cache_key = processing.event_processing_store.store(data)
@@ -515,7 +527,42 @@ def process_event(
         cache_key=cache_key,
         start_time=start_time,
         event_id=event_id,
-        process_task=process_event,
+        from_reprocessing=False,
+        data_has_changed=data_has_changed,
+        from_symbolicate=from_symbolicate,
+        has_attachments=has_attachments,
+    )
+
+
+@instrumented_task(
+    name="sentry.tasks.store.process_event_proguard",
+    queue="events.process_event_proguard",
+    time_limit=65,
+    soft_time_limit=60,
+    silo_mode=SiloMode.REGION,
+)
+def process_event_proguard(
+    cache_key: str,
+    start_time: int | None = None,
+    event_id: str | None = None,
+    data_has_changed: bool = False,
+    from_symbolicate: bool = False,
+    has_attachments: bool = False,
+    **kwargs: Any,
+) -> None:
+    """
+    Handles event processing (for those events that need it)
+
+    :param string cache_key: the cache key for the event data
+    :param int start_time: the timestamp when the event was ingested
+    :param string event_id: the event identifier
+    :param boolean data_has_changed: set to True if the event data was changed in previous tasks
+    """
+    return do_process_event(
+        cache_key=cache_key,
+        start_time=start_time,
+        event_id=event_id,
+        from_reprocessing=False,
         data_has_changed=data_has_changed,
         from_symbolicate=from_symbolicate,
         has_attachments=has_attachments,
@@ -542,7 +589,7 @@ def process_event_from_reprocessing(
         cache_key=cache_key,
         start_time=start_time,
         event_id=event_id,
-        process_task=process_event_from_reprocessing,
+        from_reprocessing=True,
         data_has_changed=data_has_changed,
         from_symbolicate=from_symbolicate,
         has_attachments=has_attachments,


### PR DESCRIPTION
This defines a separate queue / task for `process_event_proguard`, in order to be able to individually scale this part of the processing pipeline.