### PR TITLE
feat(replays): add feature flag for combined envelope items in relay

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1832,6 +1832,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:session-replay-a11y-tab": False,
     # Enable the accessibility issues endpoint
     "organizations:session-replay-accessibility-issues": False,
+    # Enable combined envelope Kafka items in Relay
+    "organizations:session-replay-combined-envelope-items": False,
     # Enable core Session Replay SDK for recording onError events on sentry.io
     "organizations:session-replay-count-query-optimize": False,
     # Enable canvas recording

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -242,6 +242,7 @@ default_manager.add("organizations:sentry-functions", OrganizationFeature, Featu
 default_manager.add("organizations:sentry-pride-logo-footer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-a11y-tab", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-accessibility-issues", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:session-replay-combined-envelope-items", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:session-replay-count-query-optimize", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-enable-canvas-replayer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-enable-canvas", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -52,6 +52,7 @@ EXPOSABLE_FEATURES = [
     "organizations:transaction-name-normalize",
     "organizations:profiling",
     "organizations:session-replay",
+    "organizations:session-replay-combined-envelope-items",
     "organizations:user-feedback-ingest",
     "organizations:session-replay-recording-scrubbing",
     "organizations:device-class-synthesis",


### PR DESCRIPTION
Adds a feature flag for combining envelope items in relay -- will be used in https://github.com/getsentry/relay/pull/3035. getsentry handler PR will be linked below.