### PR TITLE
feat(hybridcloud) Make number of retries options based

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1584,9 +1584,15 @@ register(
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register("hybrid_cloud.outbox_rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# === Hybrid cloud subsystem options ===
+# UI rollout
 register("hybrid_cloud.multi-region-selector", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybrid_cloud.region-user-allow-list", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
+
+# Retry controls
+register("hybrid_cloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("hybrid_cloud.integrationproxy.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# == End hybrid cloud subsystem
 
 # Decides whether an incoming transaction triggers an update of the clustering rule applied to it.
 register("txnames.bump-lifetime-sample-rate", default=0.1, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -18,6 +18,7 @@ import sentry_sdk
 from django.conf import settings
 from requests.adapters import HTTPAdapter, Retry
 
+from sentry import options
 from sentry.services.hybrid_cloud import ArgumentDict, DelegatedBySiloMode, RpcModel
 from sentry.services.hybrid_cloud.rpcmetrics import RpcMetricRecord
 from sentry.services.hybrid_cloud.sig import SerializableFunctionSignature
@@ -563,7 +564,7 @@ class _RemoteSiloCall:
     def _fire_request(self, headers: MutableMapping[str, str], data: bytes) -> requests.Response:
         retry_adapter = HTTPAdapter(
             max_retries=Retry(
-                total=5,
+                total=options.get("hybrid_cloud.rpc.retries"),
                 backoff_factor=0.1,
                 status_forcelist=[503],
                 allowed_methods=["POST"],

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -15,6 +15,7 @@ from django.utils.encoding import force_str
 from requests import PreparedRequest
 from requests.adapters import Retry
 
+from sentry import options
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.http import build_session
 from sentry.integrations.client import ApiClient
@@ -153,7 +154,7 @@ class IntegrationProxyClient(ApiClient):
             return build_session(
                 is_ipaddress_permitted=is_control_silo_ip_address,
                 max_retries=Retry(
-                    total=5,
+                    total=options.get("hybrid_cloud.integrationproxy.retries"),
                     backoff_factor=0.1,
                     status_forcelist=[503],
                     allowed_methods=["PATCH", "HEAD", "PUT", "GET", "DELETE", "POST"],


### PR DESCRIPTION
This will allow us to dial up and down the number of retries without deploys. This could be useful in an future incident where retries are causing more harm than help.
