### PR TITLE
chore(app-start): Expose the app_start_type tag on spans

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -130,6 +130,7 @@ SPAN_COLUMN_MAP = {
     "http.response_content_length": "sentry_tags[http.response_content_length]",
     "http.decoded_response_content_length": "sentry_tags[http.decoded_response_content_length]",
     "http.response_transfer_size": "sentry_tags[http.response_transfer_size]",
+    "app_start_type": "sentry_tags[app_start_type]",
 }
 
 SPAN_COLUMN_MAP.update(


### PR DESCRIPTION
This makes it more easily queryable in our frontend filters instead of having to
use `sentry_tags[app_start_type]`
