### PR TITLE
feat(processing) Add a new eventprocessing store to shift between clu…

### DIFF
--- a/src/sentry/eventstore/processing/multiredis.py
+++ b/src/sentry/eventstore/processing/multiredis.py
@@ -1,0 +1,54 @@
+from datetime import timedelta
+from typing import TypeVar
+
+from rediscluster import RedisCluster
+
+from sentry.utils.codecs import JSONCodec
+from sentry.utils.kvstore.encoding import KVStorageCodecWrapper
+from sentry.utils.kvstore.redis import RedisKVStorage
+from sentry.utils.redis import redis_clusters
+
+from .base import EventProcessingStore
+
+T = TypeVar("T", str, bytes)
+
+
+class MultiRedisProcessingStore(EventProcessingStore):
+    """
+    Adapter to shift traffic from one redis cluster to another
+    """
+
+    def __init__(self, **options):
+        inner = MultiRedisKVStorage(
+            old_cluster=redis_clusters.get(options["old_cluster"]),
+            new_cluster=redis_clusters.get(options["new_cluster"]),
+        )
+        super().__init__(KVStorageCodecWrapper(inner, JSONCodec()))
+
+
+class MultiRedisKVStorage(RedisKVStorage[T]):
+    def __init__(self, old_cluster: RedisCluster, new_cluster: RedisCluster) -> None:
+        self.old_cluster = old_cluster
+        self.new_cluster = new_cluster
+
+    def get(self, key: str) -> T | None:
+        str_key = key.encode("utf8")
+        new_val = self.new_cluster.get(str_key)
+        if new_val is not None:
+            return new_val
+        return self.old_cluster.get(str_key)
+
+    def set(self, key: str, value: T, ttl: timedelta | None = None) -> None:
+        self.new_cluster.set(key.encode("utf8"), value, ex=ttl)
+
+    def delete(self, key: str) -> None:
+        str_key = key.encode("utf8")
+        self.new_cluster.delete(str_key)
+        self.old_cluster.delete(str_key)
+
+    def bootstrap(self) -> None:
+        pass  # nothing to do
+
+    def destroy(self) -> None:
+        self.old_cluster.flushdb()
+        self.new_cluster.flushdb()

--- a/src/sentry/eventstore/processing/multiredis.py
+++ b/src/sentry/eventstore/processing/multiredis.py
@@ -36,7 +36,7 @@ class MultiRedisKVStorage(RedisKVStorage[T]):
     def use_new(self, key: bytes):
         rollout = options.get("eventstore.processing.rollout")
         intkey = int(hashlib.md5(key).hexdigest(), base=16)
-        return (intkey % 10000) / 10000 <= rollout
+        return (intkey % 10000) / 10000 < rollout
 
     def get(self, key: str) -> T | None:
         bkey = key.encode("utf8")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -104,6 +104,10 @@ register(
 )
 register("redis.options", type=Dict, flags=FLAG_NOSTORE)
 
+# See eventstore.processing.multiredis
+register("eventstore.processing.rollout", type=Float, default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("eventstore.processing.readold", type=Bool, default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Processing worker caches
 register(
     "dsym.cache-path",

--- a/tests/sentry/eventstore/processing/test_multiredis.py
+++ b/tests/sentry/eventstore/processing/test_multiredis.py
@@ -1,0 +1,120 @@
+from uuid import uuid4
+
+from sentry.eventstore.processing.multiredis import MultiRedisProcessingStore
+from sentry.testutils.helpers.options import override_options
+from sentry.utils import json
+from sentry.utils.cache import cache_key_for_event
+from sentry.utils.redis import redis_clusters
+
+
+def make_event():
+    # Quacks like an event enough for eventstore
+    return {
+        "event_id": uuid4().hex,
+        "project": 123,
+    }
+
+
+def test_store_and_get():
+    adapter = MultiRedisProcessingStore(
+        **{
+            "old_cluster": "default",
+            "new_cluster": "default",
+        }
+    )
+    event = make_event()
+    key = adapter.store(event)
+    result = adapter.get(key)
+    assert result == event
+
+
+@override_options(
+    {
+        "redis.clusters": {
+            "new": {
+                "hosts": {0: {"db": 0}},
+            },
+            "old": {
+                "hosts": {0: {"db": 0}},
+            },
+        }
+    }
+)
+def test_get_from_old():
+    event = make_event()
+    adapter = MultiRedisProcessingStore(
+        **{
+            "old_cluster": "old",
+            "new_cluster": "new",
+        }
+    )
+    # Insert into the old 'cluster'
+    key = cache_key_for_event(event)
+    old_cluster = redis_clusters.get("old")
+    old_cluster.set(key, json.dumps(event))
+
+    result = adapter.get(key)
+    assert result == event
+
+
+def test_delete_by_key():
+    adapter = MultiRedisProcessingStore(
+        **{
+            "old_cluster": "default",
+            "new_cluster": "default",
+        }
+    )
+    event = make_event()
+    key = adapter.store(event)
+    assert adapter.get(key)
+    adapter.delete_by_key(key)
+    assert not adapter.get(key)
+
+
+def test_delete():
+    adapter = MultiRedisProcessingStore(
+        **{
+            "old_cluster": "default",
+            "new_cluster": "default",
+        }
+    )
+    event = make_event()
+    key = adapter.store(event)
+    assert adapter.get(key)
+    adapter.delete(event)
+    assert not adapter.get(key)
+
+
+@override_options(
+    {
+        "redis.clusters": {
+            "new": {
+                "hosts": {0: {"db": 0}},
+            },
+            "old": {
+                "hosts": {0: {"db": 0}},
+            },
+        }
+    }
+)
+def test_delete_both():
+    adapter = MultiRedisProcessingStore(
+        **{
+            "old_cluster": "default",
+            "new_cluster": "default",
+        }
+    )
+    event = make_event()
+
+    # Insert into the old 'cluster'
+    key = cache_key_for_event(event)
+    old_cluster = redis_clusters.get("old")
+    old_cluster.set(key, json.dumps(event))
+
+    # Write to and read from the new cluster
+    key = adapter.store(event)
+    assert adapter.get(key)
+
+    # delete from both, as reads cascade between new and old
+    adapter.delete(event)
+    assert not adapter.get(key)

--- a/tests/sentry/eventstore/processing/test_multiredis.py
+++ b/tests/sentry/eventstore/processing/test_multiredis.py
@@ -1,10 +1,20 @@
 from uuid import uuid4
 
 from sentry.eventstore.processing.multiredis import MultiRedisProcessingStore
+from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.redis import redis_clusters
+
+cluster_config = {
+    "new": {
+        "hosts": {0: {"db": 1}},
+    },
+    "old": {
+        "hosts": {0: {"db": 0}},
+    },
+}
 
 
 def make_event():
@@ -15,109 +25,160 @@ def make_event():
     }
 
 
-def test_store_and_get():
-    adapter = MultiRedisProcessingStore(
-        **{
-            "old_cluster": "default",
-            "new_cluster": "default",
-        }
-    )
-    event = make_event()
-    key = adapter.store(event)
-    result = adapter.get(key)
-    assert result == event
+class MultiRedisTest(TestCase):
+    @override_options({"redis.clusters": cluster_config, "eventstore.processing.rollout": 1.0})
+    def test_store_and_get_with_new(self):
+        adapter = MultiRedisProcessingStore(
+            **{
+                "old_cluster": "old",
+                "new_cluster": "new",
+            }
+        )
+        event = make_event()
+        key = adapter.store(event)
+        result = adapter.get(key)
+        assert result == event
 
+    @override_options({"redis.clusters": cluster_config, "eventstore.processing.rollout": 0.0})
+    def test_store_and_get_with_old(self):
+        adapter = MultiRedisProcessingStore(
+            **{
+                "old_cluster": "old",
+                "new_cluster": "new",
+            }
+        )
+        event = make_event()
+        key = adapter.store(event)
+        result = adapter.get(key)
+        assert result == event
 
-@override_options(
-    {
-        "redis.clusters": {
-            "new": {
-                "hosts": {0: {"db": 0}},
-            },
-            "old": {
-                "hosts": {0: {"db": 1}},
-            },
-        }
-    }
-)
-def test_get_from_old():
-    event = make_event()
-    adapter = MultiRedisProcessingStore(
-        **{
-            "old_cluster": "old",
-            "new_cluster": "new",
-        }
-    )
-    # Insert into the old 'cluster'
-    key = cache_key_for_event(event)
-    old_cluster = redis_clusters.get("old")
-    old_cluster.set(key, json.dumps(event))
+    @override_options({"redis.clusters": cluster_config})
+    def test_write_old_read_new(self):
+        adapter = MultiRedisProcessingStore(
+            **{
+                "old_cluster": "old",
+                "new_cluster": "new",
+            }
+        )
+        # write to the old cluster
+        with override_options({"eventstore.processing.rollout": 0.0}):
+            event = make_event()
+            key = adapter.store(event)
 
-    new_cluster = redis_clusters.get("new")
-    assert not new_cluster.get(key)
+        # Shift entirely to new cluster, we should still be able to read old data
+        with override_options({"eventstore.processing.rollout": 1.0}):
+            result = adapter.get(key)
+        assert result == event
 
-    result = adapter.get(key)
-    assert result == event
+    @override_options({"redis.clusters": cluster_config})
+    def test_store_new_read_old(self):
+        adapter = MultiRedisProcessingStore(
+            **{
+                "old_cluster": "old",
+                "new_cluster": "new",
+            }
+        )
+        # write to the new cluster
+        with override_options({"eventstore.processing.rollout": 1.0}):
+            event = make_event()
+            key = adapter.store(event)
+            assert adapter.get(key) == event
 
+        # Shift writes to old, can still read old
+        with override_options({"eventstore.processing.rollout": 0.0}):
+            assert adapter.get(key) == event
 
-def test_delete_by_key():
-    adapter = MultiRedisProcessingStore(
-        **{
-            "old_cluster": "default",
-            "new_cluster": "default",
-        }
-    )
-    event = make_event()
-    key = adapter.store(event)
-    assert adapter.get(key)
-    adapter.delete_by_key(key)
-    assert not adapter.get(key)
+    @override_options({"redis.clusters": cluster_config})
+    def test_store_new_no_old_read(self):
+        adapter = MultiRedisProcessingStore(
+            **{
+                "old_cluster": "old",
+                "new_cluster": "new",
+            }
+        )
+        # write to the old cluster
+        with override_options({"eventstore.processing.rollout": 0.0}):
+            event = make_event()
+            key = adapter.store(event)
 
+        # Shift traffic to new, can still read from old
+        with override_options({"eventstore.processing.rollout": 1.0}):
+            assert adapter.get(key) == event
 
-def test_delete():
-    adapter = MultiRedisProcessingStore(
-        **{
-            "old_cluster": "default",
-            "new_cluster": "default",
-        }
-    )
-    event = make_event()
-    key = adapter.store(event)
-    assert adapter.get(key)
-    adapter.delete(event)
-    assert not adapter.get(key)
+        # Disable old reads
+        with override_options(
+            {"eventstore.processing.rollout": 1.0, "eventstore.processing.readold": False}
+        ):
+            assert adapter.get(key) is None
 
+    @override_options({"redis.clusters": cluster_config})
+    def test_old_read_disabled(self):
+        event = make_event()
+        adapter = MultiRedisProcessingStore(
+            **{
+                "old_cluster": "old",
+                "new_cluster": "new",
+            }
+        )
+        # Insert into the old 'cluster'
+        key = cache_key_for_event(event)
+        old_cluster = redis_clusters.get("old")
+        old_cluster.set(key, '{"key":"should not be read"}')
 
-@override_options(
-    {
-        "redis.clusters": {
-            "new": {
-                "hosts": {0: {"db": 0}},
-            },
-            "old": {
-                "hosts": {0: {"db": 1}},
-            },
-        }
-    }
-)
-def test_delete_both():
-    adapter = MultiRedisProcessingStore(
-        **{
-            "old_cluster": "default",
-            "new_cluster": "default",
-        }
-    )
-    event = make_event()
+        with override_options(
+            {"eventstore.processing.rollout": 1.0, "eventstore.processing.readold": False}
+        ):
+            key = adapter.store(event)
+            assert adapter.get(key) == event
 
-    # Insert into the old 'cluster'
-    key = cache_key_for_event(event)
-    old_cluster = redis_clusters.get("old")
-    old_cluster.set(key, json.dumps(event))
+        with override_options({"eventstore.processing.rollout": 0.0}):
+            assert adapter.get(key) == {"key": "should not be read"}
 
-    # Write to and read from the new cluster
-    key = adapter.store(event)
-    assert adapter.get(key)
+    @override_options({"redis.clusters": cluster_config, "eventstore.processing.rollout": 1.0})
+    def test_delete_by_key(self):
+        adapter = MultiRedisProcessingStore(
+            **{
+                "old_cluster": "old",
+                "new_cluster": "new",
+            }
+        )
+        event = make_event()
+        key = adapter.store(event)
+        assert adapter.get(key)
+        adapter.delete_by_key(key)
+        assert not adapter.get(key)
 
-    # delete from both, as reads cascade between new and old
-    adapter.delete(event)
-    assert not adapter.get(key)
+    @override_options({"redis.clusters": cluster_config, "eventstore.processing.rollout": 1.0})
+    def test_delete(self):
+        adapter = MultiRedisProcessingStore(
+            **{
+                "old_cluster": "old",
+                "new_cluster": "new",
+            }
+        )
+        event = make_event()
+        key = adapter.store(event)
+        assert adapter.get(key)
+        adapter.delete(event)
+        assert not adapter.get(key)
+
+    @override_options({"redis.clusters": cluster_config})
+    def test_delete_both(self):
+        adapter = MultiRedisProcessingStore(
+            **{
+                "old_cluster": "old",
+                "new_cluster": "new",
+            }
+        )
+        event = make_event()
+        # Insert into the old 'cluster'
+        key = cache_key_for_event(event)
+        old_cluster = redis_clusters.get("old")
+        old_cluster.set(key, json.dumps(event))
+        # Write to and read from the new cluster
+        key = adapter.store(event)
+        assert adapter.get(key)
+
+        # delete from both, as reads cascade between new and old
+        adapter.delete(event)
+        assert not adapter.get(key)

--- a/tests/sentry/eventstore/processing/test_multiredis.py
+++ b/tests/sentry/eventstore/processing/test_multiredis.py
@@ -53,6 +53,9 @@ def test_get_from_old():
     old_cluster = redis_clusters.get("old")
     old_cluster.set(key, json.dumps(event))
 
+    new_cluster = redis_clusters.get("new")
+    assert not new_cluster.get(key)
+
     result = adapter.get(key)
     assert result == event
 

--- a/tests/sentry/eventstore/processing/test_multiredis.py
+++ b/tests/sentry/eventstore/processing/test_multiredis.py
@@ -35,7 +35,7 @@ def test_store_and_get():
                 "hosts": {0: {"db": 0}},
             },
             "old": {
-                "hosts": {0: {"db": 0}},
+                "hosts": {0: {"db": 1}},
             },
         }
     }
@@ -92,7 +92,7 @@ def test_delete():
                 "hosts": {0: {"db": 0}},
             },
             "old": {
-                "hosts": {0: {"db": 0}},
+                "hosts": {0: {"db": 1}},
             },
         }
     }


### PR DESCRIPTION
…sters

Add an adapter that lets us join two redis clusters to eventprocessing store. This will help us retrofit rc-processing

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
