### PR TITLE
fix(processing) Disable processing per project gradually.

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -816,6 +816,14 @@ register(
     "store.load-shed-process-event-projects", type=Any, default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 register(
+    "store.load-shed-process-event-projects-gradual",
+    type=Dict,
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Applies load shedding per project gradually. 1.0 means full load shedding
+# 0.0 or no config means no load shedding.
+register(
     "store.load-shed-symbolicate-event-projects",
     type=Any,
     default=[],

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -358,6 +358,8 @@ def test_time_synthetic_monitoring_event_in_save_event(mock_metrics_timing):
 @django_db_all
 def test_killswitch():
     assert not is_process_disabled(1, "asdasdasd", "null")
+    options.set("store.load-shed-process-event-projects-gradual", {1: 0.0})
+    assert not is_process_disabled(1, "asdasdasd", "null")
     options.set("store.load-shed-process-event-projects-gradual", {1: 1.0})
     assert is_process_disabled(1, "asdasdasd", "null")
     options.set("store.load-shed-process-event-projects-gradual", {})

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -4,11 +4,12 @@ from unittest import mock
 import pytest
 from django.test.utils import override_settings
 
-from sentry import quotas
+from sentry import options, quotas
 from sentry.event_manager import EventManager
 from sentry.exceptions import HashDiscarded
 from sentry.plugins.base.v2 import Plugin2
 from sentry.tasks.store import (
+    is_process_disabled,
     preprocess_event,
     process_event,
     save_event,
@@ -352,3 +353,11 @@ def test_time_synthetic_monitoring_event_in_save_event(mock_metrics_timing):
         mock.ANY,
     )
     assert to_process.kwargs == {"tags": tags, "sample_rate": 1.0}
+
+
+@django_db_all
+def test_killswitch():
+    assert not is_process_disabled(1, "asdasdasd", "null")
+    options.set("store.load-shed-process-event-projects-gradual", {1: 1.0})
+    assert is_process_disabled(1, "asdasdasd", "null")
+    options.set("store.load-shed-process-event-projects-gradual", {})


### PR DESCRIPTION
Adding an option after the `store.load-shed-process-event-projects` killswitch to enable some traffic of a project to go through process instead of fully shutting it down.