### PR TITLE
ref(grouping): Remove hierarchical code from `find_existing_grouphash_new`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1607,7 +1607,7 @@ def _save_aggregate_new(
         GroupHash.objects.get_or_create(project=project, hash=hash)[0] for hash in hashes.hashes
     ]
 
-    existing_grouphash, _ = find_existing_grouphash_new(grouphashes)
+    existing_grouphash = find_existing_grouphash_new(grouphashes)
 
     # In principle the group gets the same metadata as the event, so common
     # attributes can be defined in eventtypes.
@@ -1647,7 +1647,7 @@ def _save_aggregate_new(
                 ).select_for_update()
             )
 
-            existing_grouphash, _ = find_existing_grouphash_new(grouphashes)
+            existing_grouphash = find_existing_grouphash_new(grouphashes)
 
             if existing_grouphash is None:
                 group = _create_group(project, event, **group_creation_kwargs)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1607,9 +1607,7 @@ def _save_aggregate_new(
         GroupHash.objects.get_or_create(project=project, hash=hash)[0] for hash in hashes.hashes
     ]
 
-    existing_grouphash, _ = find_existing_grouphash_new(
-        project, grouphashes, hashes.hierarchical_hashes
-    )
+    existing_grouphash, _ = find_existing_grouphash_new(grouphashes)
 
     # In principle the group gets the same metadata as the event, so common
     # attributes can be defined in eventtypes.
@@ -1649,9 +1647,7 @@ def _save_aggregate_new(
                 ).select_for_update()
             )
 
-            existing_grouphash, _ = find_existing_grouphash_new(
-                project, grouphashes, hashes.hierarchical_hashes
-            )
+            existing_grouphash, _ = find_existing_grouphash_new(grouphashes)
 
             if existing_grouphash is None:
                 group = _create_group(project, event, **group_creation_kwargs)

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -304,14 +304,11 @@ def find_existing_grouphash(
 
 
 def find_existing_grouphash_new(
-    flat_grouphashes: Sequence[GroupHash],
+    grouphashes: Sequence[GroupHash],
 ) -> tuple[GroupHash | None, str | None]:
-    all_grouphashes = []
     root_hierarchical_hash = None
 
-    all_grouphashes.extend(flat_grouphashes)
-
-    for group_hash in all_grouphashes:
+    for group_hash in grouphashes:
         if group_hash.group_id is not None:
             return group_hash, root_hierarchical_hash
 

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -305,12 +305,12 @@ def find_existing_grouphash(
 
 def find_existing_grouphash_new(
     grouphashes: Sequence[GroupHash],
-) -> tuple[GroupHash | None, str | None]:
+) -> GroupHash | None:
     root_hierarchical_hash = None
 
     for group_hash in grouphashes:
         if group_hash.group_id is not None:
-            return group_hash, root_hierarchical_hash
+            return group_hash
 
         # When refactoring for hierarchical grouping, we noticed that a
         # tombstone may get ignored entirely if there is another hash *before*
@@ -327,7 +327,7 @@ def find_existing_grouphash_new(
                 tombstone_id=group_hash.group_tombstone_id,
             )
 
-    return None, root_hierarchical_hash
+    return None
 
 
 def get_hash_values(

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -306,8 +306,6 @@ def find_existing_grouphash(
 def find_existing_grouphash_new(
     grouphashes: Sequence[GroupHash],
 ) -> GroupHash | None:
-    root_hierarchical_hash = None
-
     for group_hash in grouphashes:
         if group_hash.group_id is not None:
             return group_hash

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -304,9 +304,7 @@ def find_existing_grouphash(
 
 
 def find_existing_grouphash_new(
-    project: Project,
     flat_grouphashes: Sequence[GroupHash],
-    hierarchical_hashes: Sequence[str] | None,
 ) -> tuple[GroupHash | None, str | None]:
     all_grouphashes = []
     root_hierarchical_hash = None

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -309,14 +309,7 @@ def find_existing_grouphash_new(
     all_grouphashes = []
     root_hierarchical_hash = None
 
-    found_split = False
-    if not found_split:
-        # In case of a split we want to avoid accidentally finding the split-up
-        # group again via flat hashes, which are very likely associated with
-        # whichever group is attached to the split hash. This distinction will
-        # become irrelevant once we start moving existing events into child
-        # groups and delete the parent group.
-        all_grouphashes.extend(flat_grouphashes)
+    all_grouphashes.extend(flat_grouphashes)
 
     for group_hash in all_grouphashes:
         if group_hash.group_id is not None:

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -310,14 +310,10 @@ def find_existing_grouphash_new(
         if group_hash.group_id is not None:
             return group_hash
 
-        # When refactoring for hierarchical grouping, we noticed that a
+        # TODO: When refactoring for hierarchical grouping, we noticed that a
         # tombstone may get ignored entirely if there is another hash *before*
         # that happens to have a group_id. This bug may not have been noticed
-        # for a long time because most events only ever have 1-2 hashes. It
-        # will definitely get more noticeable with hierarchical grouping and
-        # it's not clear what good behavior would look like. Do people want to
-        # be able to tombstone `hierarchical_hashes[4]` while still having a
-        # group attached to `hierarchical_hashes[0]`? Maybe.
+        # for a long time because most events only ever have 1-2 hashes.
         if group_hash.group_tombstone_id is not None:
             raise HashDiscarded(
                 "Matches group tombstone %s" % group_hash.group_tombstone_id,

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -171,10 +171,14 @@ def get_results_from_saving_event(
         )
 
         new_event = save_new_event(event_data, project)
-        hash_search_result = return_values[find_existing_grouphash_fn][0][0]
         post_save_grouphashes = {
             gh.hash: gh.group_id for gh in GroupHash.objects.filter(project_id=project.id)
         }
+
+        hash_search_result = return_values[find_existing_grouphash_fn][0]
+        # The current logic wraps the search result in an extra layer which we need to unwrap
+        if not new_logic_enabled:
+            hash_search_result = hash_search_result[0]
 
         # We should never call any of these more than once, regardless of the test
         assert calculate_primary_hash_spy.call_count <= 1


### PR DESCRIPTION
This PR is a follow-up to https://github.com/getsentry/sentry/pull/64858, which removed all hierarchical grouping code from `_save_aggregate_new`. This does the same for `find_existing_grouphash_new`. In both cases, we're able to do this because these functions will only be called for events not using the mobile config (and therefore not ever producing hierarchical hashes).

This is part of an effort to clean up and simplify these functions as much as possible before changing their logic, so that change can be as safe as possible.