### PR TITLE
fix(self-hosted): Prune outdated CSRF Origin settings

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -400,16 +400,27 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
     from sentry.app import env
     from sentry.runner.settings import get_sentry_conf
 
-    # Hacky workaround to dynamically set the CSRF_TRUSTED_ORIGINS for self hosted
-    if settings.SENTRY_SELF_HOSTED and not settings.CSRF_TRUSTED_ORIGINS:
-        from sentry import options
+    if settings.SENTRY_SELF_HOSTED:
+        # XXX(isabella): Following Django upgrade, the CSRF Trusted Origins must start with a
+        # scheme. Some self-hosted users have their settings set to use old origins that are no
+        # longer valid so this updates those settings.
+        if settings.CSRF_TRUSTED_ORIGINS:
+            valid_origins = []
+            for origin in settings.CSRF_TRUSTED_ORIGINS:
+                if "://" in origin:
+                    valid_origins.append(origin)
+            settings.CSRF_TRUSTED_ORIGINS = valid_origins
 
-        system_url_prefix = options.get("system.url-prefix")
-        if system_url_prefix:
-            settings.CSRF_TRUSTED_ORIGINS = [system_url_prefix]
-        else:
-            # For first time users that have not yet set system url prefix, let's default to localhost url
-            settings.CSRF_TRUSTED_ORIGINS = ["http://localhost:9000"]
+        # Hacky workaround to dynamically set the CSRF_TRUSTED_ORIGINS for self hosted
+        if not settings.CSRF_TRUSTED_ORIGINS:
+            from sentry import options
+
+            system_url_prefix = options.get("system.url-prefix")
+            if system_url_prefix:
+                settings.CSRF_TRUSTED_ORIGINS = [system_url_prefix]
+            else:
+                # For first time users that have not yet set system url prefix, let's default to localhost url
+                settings.CSRF_TRUSTED_ORIGINS = ["http://localhost:9000"]
 
     env.data["config"] = get_sentry_conf()
     env.data["start_date"] = timezone.now()


### PR DESCRIPTION
There was an issue following Django upgrade where CSRF Trusted Origins strings needed to start with a scheme, but some users had old settings with strings that did not follow this requirement, so some commands depending on the initializer like `make build-api-docs` would fail. This PR fixes this issue by getting rid of the outdated settings and replacing them with settings that fit Django's new requirements.