### PR TITLE
ref(grouping): Pull code from `_save_aggregate_new` into helper functions

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -48,6 +48,7 @@ from sentry.exceptions import HashDiscarded
 from sentry.grouping.api import GroupingConfig, get_grouping_config_dict_for_project
 from sentry.grouping.ingest import (
     add_group_id_to_grouphashes,
+    check_for_category_mismatch,
     check_for_group_creation_load_shed,
     find_existing_grouphash,
     find_existing_grouphash_new,
@@ -1695,14 +1696,8 @@ def _save_aggregate_new(
                 return GroupInfo(group, is_new, is_regression)
 
     group = Group.objects.get(id=existing_grouphash.group_id)
-    if group.issue_category != GroupCategory.ERROR:
-        logger.info(
-            "event_manager.category_mismatch",
-            extra={
-                "issue_category": group.issue_category,
-                "event_type": "error",
-            },
-        )
+
+    if check_for_category_mismatch(group):
         return None
 
     is_new = False

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -403,3 +403,27 @@ def get_hash_values(
         job["finest_tree_label"] = all_hashes.finest_tree_label
 
     return (primary_hashes, secondary_hashes, all_hashes)
+
+
+def record_new_group_metrics(event: Event):
+    metrics.incr(
+        "group.created",
+        skip_internal=True,
+        tags={
+            "platform": event.platform or "unknown",
+            "sdk": normalized_sdk_tag_from_event(event),
+        },
+    )
+
+    # This only applies to events with stacktraces
+    frame_mix = event.get_event_metadata().get("in_app_frame_mix")
+    if frame_mix:
+        metrics.incr(
+            "grouping.in_app_frame_mix",
+            sample_rate=1.0,
+            tags={
+                "platform": event.platform or "unknown",
+                "sdk": normalized_sdk_tag_from_event(event),
+                "frame_mix": frame_mix,
+            },
+        )


### PR DESCRIPTION
As part of the on-going work cleaning up `_save_aggreagte_new`, in order to make the upcoming logic changes as easy to reason about and therefore as safe as possible, this pulls code not directly tied to the process of finding and creating grouphashes and assigning group ids to them into the following helper functions:

- `record_new_group_metrics` - There's currently a lot of logic to collect these metrics, and likely to be even more in the future.

- `_get_group_processing_kwargs` - This is the result of pulling all of the metadata-related code out of `_save_aggregate_new` and combining it with the logic in `get_group_creation_kwargs`. Before the removal of the hierarchical code this wasn't possible, as it was interleaved with the metadata logic. Now, however, the metadata-gathering code is independent of the rest and can be factored out. Also, I noticed that the `group_creation_kwargs` in `_save_aggregate` are in fact used not only when creating a group but also when updating it, hence the substitution of `processing` for `creation`.

- `check_for_group_creation_load_shed` - Quick killswitch check.

- `add_group_id_to_grouphashes` - With the hierarchical logic gone, the only difference between the new group branch and the existing group branch was that the latter filtered out any grouphashes which already had a group assigned. Though we know that in the new group branch that filter won't find anything - both grouphashes are new - it's safe to apply it in both branches.

- `check_for_category_mismatch` - Though I couldn't find any instances of it happening in our logs, apparently it's possible for an error event's hash to match a non-error-type group.