### PR TITLE
ref(grouping): Do final `_save_aggregate_new` cleanup tasks

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1378,7 +1378,6 @@ def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> G
         group_info = _save_aggregate_new(
             event=event,
             job=job,
-            release=job["release"],
             metric_tags=metric_tags,
         )
     else:
@@ -1626,7 +1625,6 @@ def _save_aggregate(
 def _save_aggregate_new(
     event: Event,
     job: Job,
-    release: Release | None,
     metric_tags: MutableTags,
 ) -> GroupInfo | None:
     project = event.project
@@ -1732,7 +1730,7 @@ def _save_aggregate_new(
         group=group,
         event=event,
         incoming_group_values=group_processing_kwargs,
-        release=release,
+        release=job["release"],
     )
 
     return GroupInfo(group, is_new, is_regression)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1669,18 +1669,6 @@ def _save_aggregate_new(
             if existing_grouphash is None:
                 group = _create_group(project, event, **group_processing_kwargs)
 
-                if (
-                    features.has("projects:first-event-severity-calculation", event.project)
-                    and group.data.get("metadata", {}).get("severity") is None
-                ):
-                    logger.error(
-                        "Group created without severity score",
-                        extra={
-                            "event_id": event.data["event_id"],
-                            "group_id": group.id,
-                        },
-                    )
-
                 add_group_id_to_grouphashes(group, grouphashes)
 
                 is_new = True

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1687,22 +1687,17 @@ def _save_aggregate_new(
 
                 add_group_id_to_grouphashes(group, grouphashes)
 
-                is_new = True
-                is_regression = False
-
                 span.set_tag("create_group_transaction.outcome", "new_group")
                 metric_tags["create_group_transaction.outcome"] = "new_group"
 
                 record_new_group_metrics(event)
 
-                return GroupInfo(group, is_new, is_regression)
+                return GroupInfo(group=group, is_new=True, is_regression=False)
 
     group = Group.objects.get(id=existing_grouphash.group_id)
 
     if check_for_category_mismatch(group):
         return None
-
-    is_new = False
 
     # There may still be secondary hashes that we did not use to find an
     # existing group. A classic example is when grouping makes changes to
@@ -1737,7 +1732,7 @@ def _save_aggregate_new(
         release=job["release"],
     )
 
-    return GroupInfo(group, is_new, is_regression)
+    return GroupInfo(group=group, is_new=False, is_regression=is_regression)
 
 
 def _create_group(project: Project, event: Event, **kwargs: Any) -> Group:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1648,12 +1648,10 @@ def _save_aggregate_new(
     if existing_grouphash is None:
         check_for_group_creation_load_shed(project, event)
 
-        with sentry_sdk.start_span(
-            op="event_manager.create_group_transaction"
-        ) as span, metrics.timer(
-            "event_manager.create_group_transaction"
-        ) as metrics_timer_tags, transaction.atomic(
-            router.db_for_write(GroupHash)
+        with (
+            sentry_sdk.start_span(op="event_manager.create_group_transaction") as span,
+            metrics.timer("event_manager.create_group_transaction") as metrics_timer_tags,
+            transaction.atomic(router.db_for_write(GroupHash)),
         ):
             span.set_tag("create_group_transaction.outcome", "no_group")
             metrics_timer_tags["create_group_transaction.outcome"] = "no_group"

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1652,11 +1652,11 @@ def _save_aggregate_new(
             op="event_manager.create_group_transaction"
         ) as span, metrics.timer(
             "event_manager.create_group_transaction"
-        ) as metric_tags, transaction.atomic(
+        ) as metrics_timer_tags, transaction.atomic(
             router.db_for_write(GroupHash)
         ):
             span.set_tag("create_group_transaction.outcome", "no_group")
-            metric_tags["create_group_transaction.outcome"] = "no_group"
+            metrics_timer_tags["create_group_transaction.outcome"] = "no_group"
 
             # If we're in this branch, we checked our grouphashes and didn't find one with a group
             # attached. We thus want to create a new group, but we need to guard against another
@@ -1688,7 +1688,7 @@ def _save_aggregate_new(
                 add_group_id_to_grouphashes(group, grouphashes)
 
                 span.set_tag("create_group_transaction.outcome", "new_group")
-                metric_tags["create_group_transaction.outcome"] = "new_group"
+                metrics_timer_tags["create_group_transaction.outcome"] = "new_group"
 
                 record_new_group_metrics(event)
 


### PR DESCRIPTION
This does a last batch of cleanup in `_save_aggregate_new` before the new logic is added.

Notes:

- `release` is only used once, and can be pulled straight out of `job`, so it doesn't need to be passed separately.

- The logging about missing severity scores is leftover from the initial POC back in September, mostly just me being paranoid. We don't need it anymore.

- I nearly took the second check of the double-check lock out before I realized what it was doing there. Fortunately Markus name-dropped double-entrant locking in his [PR description](https://github.com/getsentry/sentry/pull/23577) when he put it in. Since it's not immediately obvious why it's there, I added some explanation.

- The `metrics.timer` context manager's `metric_tags` was shadowing the `metric_tags` being passed in. Fixing that will let us use the latter tags in `record_new_group_metrics` if we ever want to.