### PR TITLE
ref(slack): customizable context using NotificationConfig

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -560,7 +560,7 @@ class FeedbackGroup(GroupType):
     category = GroupCategory.FEEDBACK.value
     creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
     default_priority = PriorityLevel.MEDIUM
-    notification_config = NotificationConfig(context=["State", "First Seen"])
+    notification_config = NotificationConfig(context=[])
 
 
 @metrics.wraps("noise_reduction.should_create_group", sample_rate=1.0)

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -118,7 +118,7 @@ class NotificationConfig:
     text_code_formatted: bool = True  # TODO(cathy): user feedback wants it formatted as text
     context: list[str] = field(
         default_factory=lambda: ["Events", "Users Affected", "State", "First Seen"]
-    )  # see SUPPORTED_CONTEXT_DATA for all possible values
+    )  # see SUPPORTED_CONTEXT_DATA for all possible values, order matters!
     actions: list[str] = field(default_factory=lambda: ["archive", "resolve", "assign"])
     extra_action: dict[str, str] = field(
         default_factory=lambda: {}
@@ -398,9 +398,7 @@ class PerformanceP95EndpointRegressionGroupType(GroupType):
     enable_escalation_detection = False
     default_priority = PriorityLevel.MEDIUM
     released = True
-    notification_config = NotificationConfig(
-        context=["Events", "Users Affected", "State", "Regressed Date"]
-    )
+    notification_config = NotificationConfig(context=["Users Affected", "State", "Regressed Date"])
 
 
 # 2000 was ProfileBlockingFunctionMainThreadType

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1652,5 +1652,5 @@ class SlackNotificationConfigTest(TestCase, PerformanceIssueTestCase):
         # crons don't have context
         assert get_context(self.cron_issue) == ""
 
-        # feedback has state and first seen
-        assert get_context(self.feedback_issue) == "State: *New*   First Seen: *Just now*"
+        # feedback doesn't have context
+        assert get_context(self.feedback_issue) == ""

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1643,6 +1643,7 @@ class SlackNotificationConfigTest(TestCase, PerformanceIssueTestCase):
             type=FeedbackGroup.type_id, substatus=GroupSubStatus.NEW
         )
 
+    @with_feature("organizations:slack-block-kit-improvements")
     def test_get_context(self):
         # endpoint regression should use Regressed Date
         context = get_context(self.endpoint_regression_issue)
@@ -1652,4 +1653,4 @@ class SlackNotificationConfigTest(TestCase, PerformanceIssueTestCase):
         assert get_context(self.cron_issue) == ""
 
         # feedback has state and first seen
-        assert get_context(self.feedback_issue) == "State: *New*   First Seen: *Just now*   "
+        assert get_context(self.feedback_issue) == "State: *New*   First Seen: *Just now*"

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import copy
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import Mock, patch
 
 from django.urls import reverse
+from django.utils import timezone
 
 from sentry.eventstore.models import Event
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
@@ -18,6 +19,7 @@ from sentry.integrations.slack.message_builder.issues import (
     SlackIssuesMessageBuilder,
     build_actions,
     format_release_tag,
+    get_context,
     get_option_groups,
     get_option_groups_block_kit,
     time_since,
@@ -26,7 +28,9 @@ from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricA
 from sentry.issues.grouptype import (
     ErrorGroupType,
     FeedbackGroup,
+    MonitorCheckInFailure,
     PerformanceNPlusOneGroupType,
+    PerformanceP95EndpointRegressionGroupType,
     ProfileFileIOGroupType,
 )
 from sentry.models.group import Group, GroupStatus
@@ -48,6 +52,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
+from sentry.types.group import GroupSubStatus
 from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -1623,3 +1628,28 @@ class ActionsTest(TestCase):
                 res[0],
                 {"label": "Select Assignee...", "name": "assign", "type": "select", "value": None},
             )
+
+
+@region_silo_test
+class SlackNotificationConfigTest(TestCase, PerformanceIssueTestCase):
+    def setUp(self):
+        self.one_hour_ago = timezone.now() - timedelta(hours=1)
+        self.endpoint_regression_issue = self.create_group(
+            type=PerformanceP95EndpointRegressionGroupType.type_id, active_at=self.one_hour_ago
+        )
+
+        self.cron_issue = self.create_group(type=MonitorCheckInFailure.type_id)
+        self.feedback_issue = self.create_group(
+            type=FeedbackGroup.type_id, substatus=GroupSubStatus.NEW
+        )
+
+    def test_get_context(self):
+        # endpoint regression should use Regressed Date
+        context = get_context(self.endpoint_regression_issue)
+        assert "Regressed Date: *1\xa0hour ago*" in context
+
+        # crons don't have context
+        assert get_context(self.cron_issue) == ""
+
+        # feedback has state and first seen
+        assert get_context(self.feedback_issue) == "State: *New*   First Seen: *Just now*   "


### PR DESCRIPTION
**NOTE: This PR only uses `NotificationConfig` to change the `context` we are including in the Slack message.**

Adds a `NotificationConfig` class to `GroupTypes` that will allow for customization of Slack messages (and eventually other notification providers).

By default, all `GroupTypes` will have [`Events`, `Users Affected`, `State`, `First Seen`] in their Slack messages.
- Crons and Replays will have no context
- Function regressions will have no context

New in this PR
- Endpoint regressions will have [`Users Affected`, `State`, `Regressed Date`]
- User feedback will have no context

Resolves https://github.com/getsentry/team-core-product-foundations/issues/80