### PR TITLE
fix(issues): Adjust timeline dots, menu header

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineEvents.tsx
@@ -169,7 +169,7 @@ function NodeGroup({
               )}
               {!isCurrentNode &&
                 groupEvents
-                  .slice(0, 4)
+                  .slice(0, 5)
                   .map(groupEvent =>
                     'event.type' in groupEvent ? (
                       <IconNode key={groupEvent.id} />
@@ -226,12 +226,12 @@ const IconNode = styled('div')`
   box-shadow: ${p => p.theme.dropShadowLight};
   user-select: none;
   background-color: ${p => color(p.theme.red200).alpha(0.3).string()};
-  border: 1px solid ${p => p.theme.red300};
   margin-left: -8px;
 `;
 
 const PerformanceIconNode = styled(IconNode)`
   background-color: unset;
+  border: 1px solid ${p => p.theme.red300};
 `;
 
 const CurrentNodeContainer = styled('div')`

--- a/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
@@ -40,7 +40,9 @@ export function TraceTimelineTooltip({event, timelineEvents}: TraceTimelineToolt
     <UnstyledUnorderedList>
       {displayYouAreHere && <YouAreHereItem>{t('You are here')}</YouAreHereItem>}
       <EventItemsWrapper>
-        <EventItemsTitle>{t('Around the same time')}</EventItemsTitle>
+        {(filteredTimelineEvents.length > 1 || displayYouAreHere) && (
+          <EventItemsTitle>{t('Around the same time')}</EventItemsTitle>
+        )}
         {filteredTimelineEvents.slice(0, 3).map(timelineEvent => {
           const project = projects.find(p => p.slug === timelineEvent.project);
           return (


### PR DESCRIPTION
- Hides the "Around the same time" if there is only one event or a "you are here" item
- Moves the border to only the performance issues

![image](https://github.com/getsentry/sentry/assets/1400464/d6f18cf2-a640-452b-b590-d0c24b7e0a81)
