### PR TITLE
fix(vue): Correct typo in browserTracingIntegration call

### DIFF
--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -47,7 +47,7 @@ const getSentryInitLayout = (params: Params, siblingOption: string): string => {
     integrations: [${
       params.isPerformanceSelected
         ? `
-          Sentry.browserTracingIntergation(),`
+          Sentry.browserTracingIntegration(),`
         : ''
     }${
       params.isReplaySelected


### PR DESCRIPTION
This commit fixes a typo in the call to Sentry's browserTracingIntegration function. Previously, the call had a typo, which lead to syntax errors.

<!-- Describe your PR here. -->

There was a typo "Intergation" vs "integration" on the Vue3 snippet for "Configure Vue SDK".

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
