### PR TITLE
fix(ddm): Fix gauges tags not being loaded

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -639,7 +639,8 @@ def get_all_tags(
             start=start,
             end=end,
         )
-    except InvalidParams:
+    except InvalidParams as e:
+        sentry_sdk.capture_exception(e)
         return []
 
     return tags

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -390,10 +390,12 @@ def _get_metrics_filter_ids(
                     derived_metric_obj.naively_generate_singular_entity_constituents(use_case_id)
                 )
                 metric_mris_deque.extend(single_entity_constituents)
+
     if None in metric_ids or -1 in metric_ids:
         # We are looking for tags that appear in all given metrics.
         # A tag cannot appear in a metric if the metric is not even indexed.
         raise MetricDoesNotExistInIndexer()
+
     return metric_ids
 
 
@@ -627,15 +629,18 @@ def get_all_tags(
     """Get all metric tags for the given projects and metric_names."""
     assert projects
 
-    tags, _ = _fetch_tags_or_values_for_metrics(
-        projects=projects,
-        metric_names=metric_names,
-        column="tags.key",
-        referrer="snuba.metrics.meta.get_tags",
-        use_case_id=use_case_id,
-        start=start,
-        end=end,
-    )
+    try:
+        tags, _ = _fetch_tags_or_values_for_metrics(
+            projects=projects,
+            metric_names=metric_names,
+            column="tags.key",
+            referrer="snuba.metrics.meta.get_tags",
+            use_case_id=use_case_id,
+            start=start,
+            end=end,
+        )
+    except InvalidParams:
+        return []
 
     return tags
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -6,6 +6,7 @@ from collections.abc import Collection, Generator, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Literal, TypedDict, overload
 
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import EntityKey
 
 __all__ = (
@@ -181,12 +182,40 @@ GENERIC_OP_TO_SNUBA_FUNCTION = {
     },
 }
 
+USE_CASE_ID_TO_ENTITY_KEYS = {
+    UseCaseID.SESSIONS: {
+        EntityKey.MetricsCounters,
+        EntityKey.MetricsSets,
+        EntityKey.MetricsDistributions,
+    },
+    UseCaseID.TRANSACTIONS: {
+        EntityKey.GenericMetricsCounters,
+        EntityKey.GenericMetricsSets,
+        EntityKey.GenericMetricsDistributions,
+    },
+    UseCaseID.CUSTOM: {
+        EntityKey.GenericMetricsCounters,
+        EntityKey.GenericMetricsSets,
+        EntityKey.GenericMetricsDistributions,
+        EntityKey.GenericMetricsGauges,
+    },
+}
+
 # This set contains all the operations that require the "rhs" condition to be resolved
 # in a "MetricConditionField". This solution is the simplest one and doesn't require any
 # changes in the transformer, however it requires this list to be discovered and updated
 # in case new operations are added, which is not ideal but given the fact that we already
 # define operations in this file, it is not a deal-breaker.
 REQUIRES_RHS_CONDITION_RESOLUTION = {"transform_null_to_unparameterized"}
+
+
+def get_entity_keys_of_use_case_id(use_case_id: UseCaseID) -> set[EntityKey] | None:
+    """
+    Returns a set of entity keys that are available for the use_case_id.
+
+    In case the use case id doesn't have known entities, the function will return `None`.
+    """
+    return USE_CASE_ID_TO_ENTITY_KEYS.get(use_case_id)
 
 
 def get_timestamp_column_name() -> str:
@@ -233,7 +262,6 @@ GENERIC_OPERATIONS_TO_ENTITY = {
     op: entity for entity, operations in AVAILABLE_GENERIC_OPERATIONS.items() for op in operations
 }
 
-# ToDo add gauges/summaries
 METRIC_TYPE_TO_ENTITY: Mapping[MetricType, EntityKey] = {
     "counter": EntityKey.MetricsCounters,
     "set": EntityKey.MetricsSets,
@@ -241,6 +269,7 @@ METRIC_TYPE_TO_ENTITY: Mapping[MetricType, EntityKey] = {
     "generic_counter": EntityKey.GenericMetricsCounters,
     "generic_set": EntityKey.GenericMetricsSets,
     "generic_distribution": EntityKey.GenericMetricsDistributions,
+    "generic_gauge": EntityKey.GenericMetricsGauges,
 }
 
 FIELD_ALIAS_MAPPINGS = {"project": "project_id"}
@@ -259,6 +288,21 @@ FILTERABLE_TAGS = {
     "tags[geo.country_code]",
     "tags[http.status_code]",
 }
+
+
+def entity_key_to_metric_type(entity_key: EntityKey) -> MetricType | None:
+    """
+    Returns the `MetricType` corresponding to the supplied `EntityKey`.
+
+    This function traverses in reverse the `METRIC_TYPE_TO_ENTITY` to avoid duplicating it
+    with the inverted values. Access still remains O(1) given that the size of the dictionary
+    is assumed to be fixed during the lifecycle of the program.
+    """
+    for metric_type, inner_entity_key in METRIC_TYPE_TO_ENTITY.items():
+        if entity_key == inner_entity_key:
+            return metric_type
+
+    return None
 
 
 class Tag(TypedDict):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2943,9 +2943,6 @@ class MetricsAPIBaseTestCase(BaseMetricsLayerTestCase, APITestCase):
 
 
 class OrganizationMetricsIntegrationTestCase(MetricsAPIBaseTestCase):
-    def __indexer_record(self, org_id: int, value: str) -> int:
-        return indexer.record(use_case_id=UseCaseID.SESSIONS, org_id=org_id, string=value)
-
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_organization_metrics_tags.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_tags.py
@@ -257,3 +257,24 @@ class OrganizationMetricsTagsTest(OrganizationMetricsIntegrationTestCase):
                 statsPeriod=stats_period,
             )
             assert len(response.data) == expected_count
+
+    def test_metric_tags_with_gauge(self):
+        mri = "g:custom/page_load@millisecond"
+        self.store_metric(
+            self.project.organization.id,
+            self.project.id,
+            "gauge",
+            mri,
+            {"transaction": "/hello", "release": "1.0", "environment": "prod"},
+            int(self.now.timestamp()),
+            10,
+            UseCaseID.CUSTOM,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=[mri],
+            project=self.project.id,
+            useCase="custom",
+        )
+        assert len(response.data) == 3


### PR DESCRIPTION
This PR fixes gauges tags not being loaded in the `metrics/tags` endpoint. The fix also includes a minor refactor of how entity keys are computed given the `use_case_id` which was duplicated all over the code and ultimately led to this issue.