### PR TITLE
fix(ddm): Rework group bys validation

### DIFF
--- a/src/sentry/sentry_metrics/querying/data_v2/transformation.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation.py
@@ -115,7 +115,7 @@ class QueryTransformer:
             rows: Sequence[Mapping[str, Any]],
             group_bys: list[str],
             query_groups: OrderedDict[GroupKey, GroupValue],
-            block: Callable[[Mapping[str, Any], GroupValue], None],
+            add_to_group: Callable[[Mapping[str, Any], GroupValue], None],
         ):
             for row in rows:
                 grouped_values = []
@@ -124,7 +124,7 @@ class QueryTransformer:
                     grouped_values.append((group_by, cast(str, row.get(group_by))))
 
                 group_value = query_groups.setdefault(tuple(grouped_values), GroupValue.empty())
-                block(row, group_value)
+                add_to_group(row, group_value)
 
         for query_result in self._query_results:
             # All queries must have the same timerange, so under this assumption we take the first occurrence of each.
@@ -190,8 +190,8 @@ class QueryTransformer:
         # We build the intervals that we will return to the API user.
         intervals = _build_intervals(start, end, interval)
 
-        # We build the translated groups given the intermediate groups.
-        translated_queries_groups = []
+        # We build the transformed groups given the intermediate groups.
+        transformed_queries_groups = []
         for query_groups in queries_groups:
             translated_query_groups = []
             for group_key, group_value in query_groups.items():
@@ -209,17 +209,17 @@ class QueryTransformer:
                     }
                 )
 
-            translated_queries_groups.append(translated_query_groups)
+            transformed_queries_groups.append(translated_query_groups)
 
-        # We build the translated meta given the intermediate meta.
-        translated_queries_meta = []
+        # We build the transformed meta given the intermediate meta.
+        transformed_queries_meta = []
         for query_meta in queries_meta:
-            translated_queries_meta.append([meta.meta for meta in query_meta])
+            transformed_queries_meta.append([meta.meta for meta in query_meta])
 
         return {
             "intervals": intervals,
-            "data": translated_queries_groups,
-            "meta": translated_queries_meta,
+            "data": transformed_queries_groups,
+            "meta": transformed_queries_meta,
             "start": start,
             "end": end,
         }

--- a/src/sentry/sentry_metrics/querying/visitors.py
+++ b/src/sentry/sentry_metrics/querying/visitors.py
@@ -199,6 +199,12 @@ class ValidationV2Visitor(QueryExpressionVisitor[QueryExpression]):
         return timeseries
 
     def _validate_accumulated_group_bys(self, timeseries: Timeseries):
+        """
+        Validates that the group bys on a given `Timeseries` are equal to the ones previously encountered (if any).
+
+        To obtain the group bys of the `Timeseries` all the group bys of the upstream `Formulas` are merged and ordered
+        together with the ones of the `Timeseries`.
+        """
         group_bys = []
 
         # We first add all the group bys that we got at each stack frame.
@@ -218,6 +224,11 @@ class ValidationV2Visitor(QueryExpressionVisitor[QueryExpression]):
             )
 
     def _flatten_group_bys(self, group_bys: list[Column | AliasedExpression] | None) -> list[str]:
+        """
+        Flattens a list of group bys by converting it to a flat list of strings, representing the names of the column
+        that the query is grouping by.
+        """
+
         def _column_name(group_by: Column | AliasedExpression) -> str:
             if isinstance(group_by, Column):
                 return group_by.name
@@ -229,7 +240,6 @@ class ValidationV2Visitor(QueryExpressionVisitor[QueryExpression]):
         if group_bys is None:
             return []
 
-        # Here we are converting to sorted deduplicated list of strings.
         return list(map(_column_name, group_bys))
 
 

--- a/src/sentry/sentry_metrics/querying/visitors.py
+++ b/src/sentry/sentry_metrics/querying/visitors.py
@@ -154,19 +154,18 @@ class ValidationV2Visitor(QueryExpressionVisitor[QueryExpression]):
         self._query_namespace = None
         self._query_entity = None
         self._query_group_bys = None
+        self._query_group_bys_stack: list[list[str]] = []
 
     def _visit_formula(self, formula: Formula) -> QueryExpression:
-        visited_formula = super()._visit_formula(formula)
+        # We already add the flattened group bys in the stack, to avoid re-computation for every leaf.
+        self._query_group_bys_stack.append(self._flatten_group_bys(formula.groupby))
 
-        # Formulas can optionally not have group bys, since only leaf `Timeseries` nodes can have them,
-        # thus we do not perform any validation in case they are not set.
-        #
-        # We might need to rework this implementation in case the group bys in the `Formula` are merged
-        # to all the ones in the leafs.
-        if formula.groupby is not None:
-            self._validate_group_bys(formula.groupby)
+        for parameter in formula.parameters:
+            self.visit(parameter)
 
-        return visited_formula
+        self._query_group_bys_stack.pop()
+
+        return formula
 
     def _visit_timeseries(self, timeseries: Timeseries) -> QueryExpression:
         if timeseries.metric.mri is None:
@@ -195,15 +194,22 @@ class ValidationV2Visitor(QueryExpressionVisitor[QueryExpression]):
                 "Querying metrics with different metrics type is not currently supported"
             )
 
-        # If group bys are `None` for a `Timeseries`, we treat them as an empty list of group bys.
-        self._validate_group_bys(timeseries.groupby or [])
+        self._validate_accumulated_group_bys(timeseries)
 
         return timeseries
 
-    def _validate_group_bys(self, group_bys: list[Column | AliasedExpression] | None):
-        # We use a deduplicated and sorted representation of the group by fields used in the query, since
-        # we need to understand whether the same groups are used even across `Column`(s) and `AliasedExpression`(s).
-        sorted_group_bys = self._sort_group_bys(group_bys)
+    def _validate_accumulated_group_bys(self, timeseries: Timeseries):
+        group_bys = []
+
+        # We first add all the group bys that we got at each stack frame.
+        for upstream_group_bys in self._query_group_bys_stack:
+            group_bys += upstream_group_bys
+
+        # We then add all the group bys of the timeseries itself.
+        group_bys += self._flatten_group_bys(timeseries.groupby)
+
+        # We deduplicate and sort all the merged group bys in order to have a consistent view of the used group bys.
+        sorted_group_bys = sorted(set(group_bys))
         if self._query_group_bys is None:
             self._query_group_bys = sorted_group_bys
         elif self._query_group_bys != sorted_group_bys:
@@ -211,9 +217,7 @@ class ValidationV2Visitor(QueryExpressionVisitor[QueryExpression]):
                 "Querying metrics with different group bys is not allowed"
             )
 
-    def _sort_group_bys(
-        self, group_bys: list[Column | AliasedExpression] | None
-    ) -> list[str] | None:
+    def _flatten_group_bys(self, group_bys: list[Column | AliasedExpression] | None) -> list[str]:
         def _column_name(group_by: Column | AliasedExpression) -> str:
             if isinstance(group_by, Column):
                 return group_by.name
@@ -223,9 +227,10 @@ class ValidationV2Visitor(QueryExpressionVisitor[QueryExpression]):
             return ""
 
         if group_bys is None:
-            return None
+            return []
 
-        return list(set(map(_column_name, group_bys)))
+        # Here we are converting to sorted deduplicated list of strings.
+        return list(map(_column_name, group_bys))
 
 
 class FiltersCompositeVisitor(QueryExpressionVisitor[QueryExpression]):

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -844,7 +844,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             MetricsQueriesPlan()
             .declare_query("query_1", query_1)
             .declare_query("query_2", query_2)
-            .apply_formula("($query_1 * $query_2 / $query_1) by (release)")
+            .apply_formula("((($query_1 * $query_2) by (release)) / $query_1) by (browser)")
         )
 
         with pytest.raises(InvalidMetricsQueryError):

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -836,3 +836,25 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
                 environments=[],
                 referrer="metrics.data.api",
             )
+
+    def test_query_with_complex_group_by(self):
+        query_1 = self.mql("min", "d:custom/page_click@none", group_by="environment")
+        query_2 = self.mql("max", "d:custom/app_load@millisecond", group_by="transaction")
+        plan = (
+            MetricsQueriesPlan()
+            .declare_query("query_1", query_1)
+            .declare_query("query_2", query_2)
+            .apply_formula("($query_1 * $query_2 / $query_1) by (release)")
+        )
+
+        with pytest.raises(InvalidMetricsQueryError):
+            run_metrics_queries_plan(
+                metrics_queries_plan=plan,
+                start=self.now() - timedelta(minutes=30),
+                end=self.now() + timedelta(hours=1, minutes=30),
+                interval=3600,
+                organization=self.project.organization,
+                projects=[self.project],
+                environments=[],
+                referrer="metrics.data.api",
+            )


### PR DESCRIPTION
This PR improves the validation logic of the group bys, which are now properly being validated by validating them only in `Timeseries` nodes and by merging them across the `Formula`(s) tree.

E.g., a formula like `(x by (1) / y by (2)) by (3) = x by (1, 3) / y by (1, 2)` and this is the validation that the new algorithm performs.

In addition, the PR contains minor nits that were proposed in the previous PR.