### PR TITLE
Revert "Revert "ref: projectconfig_cache stores binary in redis so use decode_responses=False (#64816)""

### DIFF
--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -15,10 +15,10 @@ logger = logging.getLogger(__name__)
 class RedisProjectConfigCache(ProjectConfigCache):
     def __init__(self, **options):
         cluster_key = options.get("cluster", "default")
-        self.cluster = redis.redis_clusters.get(cluster_key)
+        self.cluster = redis.redis_clusters.get(cluster_key, decode_responses=False)
 
         read_cluster_key = options.get("read_cluster", cluster_key)
-        self.cluster_read = redis.redis_clusters.get(read_cluster_key)
+        self.cluster_read = redis.redis_clusters.get(read_cluster_key, decode_responses=False)
 
         super().__init__(**options)
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -60,7 +60,9 @@ class _RBCluster:
     def supports(self, config):
         return not config.get("is_redis_cluster", False)
 
-    def factory(self, **config):
+    def factory(self, *, decode_responses: bool, **config):
+        if not decode_responses:
+            raise NotImplementedError("decode_responses=False mode is not implemented for `rb`")
         # rb expects a dict of { host, port } dicts where the key is the host
         # ID. Coerce the configuration into the correct format if necessary.
         hosts = config["hosts"]
@@ -107,7 +109,7 @@ class _RedisCluster:
         #    in non-cluster mode.
         return config.get("is_redis_cluster", False) or len(config.get("hosts")) == 1
 
-    def factory(self, **config):
+    def factory(self, *, decode_responses: bool, **config):
         # StrictRedisCluster expects a list of { host, port } dicts. Coerce the
         # configuration into the correct format if necessary.
         hosts = config.get("hosts")
@@ -133,7 +135,7 @@ class _RedisCluster:
                     #
                     # https://github.com/Grokzen/redis-py-cluster/blob/73f27edf7ceb4a408b3008ef7d82dac570ab9c6a/rediscluster/nodemanager.py#L385
                     startup_nodes=deepcopy(hosts),
-                    decode_responses=True,
+                    decode_responses=decode_responses,
                     skip_full_coverage_check=True,
                     max_connections=16,
                     max_connections_per_node=True,
@@ -142,7 +144,7 @@ class _RedisCluster:
                 )
             else:
                 host = hosts[0].copy()
-                host["decode_responses"] = True
+                host["decode_responses"] = decode_responses
                 return (
                     import_string(config["client_class"])
                     if "client_class" in config
@@ -170,17 +172,19 @@ class ClusterManager(Generic[TCluster]):
         ...
 
     def __init__(self, options_manager, cluster_type=_RBCluster):
-        self.__clusters = {}
+        self.__clusters: dict[tuple[str, bool], TCluster] = {}
         self.__options_manager = options_manager
         self.__cluster_type = cluster_type()
 
-    def get(self, key) -> TCluster:
-        cluster = self.__clusters.get(key)
+    def get(self, key: str, *, decode_responses: bool = True) -> TCluster:
+        cache_key = (key, decode_responses)
+        try:
+            return self.__clusters[cache_key]
+        except KeyError:
+            # Do not access attributes of the `cluster` object to prevent
+            # setup/init of lazy objects. The _RedisCluster type will try to
+            # connect to the cluster during initialization.
 
-        # Do not access attributes of the `cluster` object to prevent
-        # setup/init of lazy objects. The _RedisCluster type will try to
-        # connect to the cluster during initialization.
-        if cluster is None:
             # TODO: This would probably be safer with a lock, but I'm not sure
             # that it's necessary.
             configuration = self.__options_manager.get("redis.clusters").get(key)
@@ -190,9 +194,11 @@ class ClusterManager(Generic[TCluster]):
             if not self.__cluster_type.supports(configuration):
                 raise KeyError(f"Invalid cluster type, expected: {self.__cluster_type}")
 
-            cluster = self.__clusters[key] = self.__cluster_type.factory(**configuration)
-
-        return cluster
+            ret = self.__clusters[cache_key] = self.__cluster_type.factory(
+                **configuration,
+                decode_responses=decode_responses,
+            )
+            return ret
 
 
 # TODO(epurkhiser): When migration of all rb cluster to true redis clusters has


### PR DESCRIPTION
this was reverted out of caution but it did not make a difference in redis connection counts

This reverts commit ef7a9fc2696c70aef9418f98790261b10d71b85a.

<!-- Describe your PR here. -->