### PR TITLE
ref(backpressure): Track reasons for unhealthy consumers and services

### DIFF
--- a/src/sentry/processing/backpressure/health.py
+++ b/src/sentry/processing/backpressure/health.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Mapping
+from typing import Any
 
 import sentry_sdk
 from django.conf import settings
@@ -85,7 +86,7 @@ def record_consumer_health(unhealthy_services: Mapping[str, UnhealthyReasons]) -
         for name, unhealthy_reasons in unhealthy_services.items():
             pipeline.set(_service_key(name), "false" if unhealthy_reasons else "true", ex=key_ttl)
 
-            extra = {}
+            extra: dict[str, Any] = {}
             if unhealthy_reasons:
                 if isinstance(unhealthy_reasons, Exception):
                     extra = {"exception": unhealthy_reasons}

--- a/src/sentry/processing/backpressure/health.py
+++ b/src/sentry/processing/backpressure/health.py
@@ -5,10 +5,13 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry import options
+from sentry.processing.backpressure.memory import ServiceMemory
 from sentry.processing.backpressure.topology import CONSUMERS
 from sentry.utils import metrics, redis
 
 logger = logging.getLogger(__name__)
+
+UnhealthyReasons = Exception | list[ServiceMemory]
 
 
 def _prefix_key(key_name: str) -> str:
@@ -75,30 +78,47 @@ def is_consumer_healthy(consumer_name: str = "default") -> bool:
         return False
 
 
-def record_consumer_health(service_health: Mapping[str, bool]) -> None:
+def record_consumer_health(unhealthy_services: Mapping[str, UnhealthyReasons]) -> None:
     with service_monitoring_cluster.pipeline() as pipeline:
         key_ttl = options.get("backpressure.status_ttl")
 
-        for name, is_healthy in service_health.items():
-            pipeline.set(_service_key(name), "true" if is_healthy else "false", ex=key_ttl)
+        for name, unhealthy_reasons in unhealthy_services.items():
+            pipeline.set(_service_key(name), "false" if unhealthy_reasons else "true", ex=key_ttl)
 
-            if not is_healthy:
+            extra = {}
+            if unhealthy_reasons:
+                if isinstance(unhealthy_reasons, Exception):
+                    extra = {"exception": unhealthy_reasons}
+                else:
+                    for memory in unhealthy_reasons:
+                        extra[memory.name] = {
+                            "used": memory.used,
+                            "available": memory.available,
+                            "percentage": memory.percentage,
+                        }
+
                 metrics.incr("backpressure.monitor.service.unhealthy", tags={"service": name})
                 with sentry_sdk.push_scope():
                     sentry_sdk.set_tag("service", name)
-                    logger.error("Service `%s` marked as unhealthy", name)
+                    logger.error("Service `%s` marked as unhealthy", name, extra=extra)
 
         for name, dependencies in CONSUMERS.items():
-            is_healthy = True
+            unhealthy_dependencies = []
             for dependency in dependencies:
-                is_healthy = is_healthy and service_health[dependency]
+                if unhealthy_services[dependency]:
+                    unhealthy_dependencies.append(dependency)
 
-            pipeline.set(_consumer_key(name), "true" if is_healthy else "false", ex=key_ttl)
+            pipeline.set(
+                _consumer_key(name), "false" if unhealthy_dependencies else "true", ex=key_ttl
+            )
 
-            if not is_healthy:
+            if unhealthy_dependencies:
                 metrics.incr("backpressure.monitor.consumer.unhealthy", tags={"consumer": name})
                 with sentry_sdk.push_scope():
                     sentry_sdk.set_tag("consumer", name)
-                    logger.error("Consumer `%s` marked as unhealthy", name)
+                    logger.error(
+                        "Consumer `%s` marked as unhealthy",
+                        extra={"unhealthy_dependencies": unhealthy_dependencies},
+                    )
 
         pipeline.execute()

--- a/src/sentry/processing/backpressure/health.py
+++ b/src/sentry/processing/backpressure/health.py
@@ -119,6 +119,7 @@ def record_consumer_health(unhealthy_services: Mapping[str, UnhealthyReasons]) -
                     sentry_sdk.set_tag("consumer", name)
                     logger.error(
                         "Consumer `%s` marked as unhealthy",
+                        name,
                         extra={"unhealthy_dependencies": unhealthy_dependencies},
                     )
 

--- a/src/sentry/processing/backpressure/monitor.py
+++ b/src/sentry/processing/backpressure/monitor.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry import options
-from sentry.processing.backpressure.health import record_consumer_health
+from sentry.processing.backpressure.health import UnhealthyReasons, record_consumer_health
 
 # from sentry import options
 from sentry.processing.backpressure.memory import (
@@ -77,19 +77,21 @@ def assert_all_services_defined(services: dict[str, Service]) -> None:
             )
 
 
-def check_service_health(services: Mapping[str, Service]) -> Mapping[str, bool]:
-    service_health = {}
+def check_service_health(services: Mapping[str, Service]) -> Mapping[str, UnhealthyReasons]:
+    unhealthy_services = {}
 
     for name, service in services.items():
         high_watermark = options.get(f"backpressure.high_watermarks.{name}")
-        is_healthy = True
+        reasons = []
 
         logger.info("Checking service `%s` (configured high watermark: %s):", name, high_watermark)
         try:
             for memory in check_service_memory(service):
-                is_healthy = is_healthy and memory.percentage < high_watermark
+                if memory.percentage >= high_watermark:
+                    reasons.append(memory)
                 logger.info(
-                    "  used: %s, available: %s, percentage: %s",
+                    "  name: %s, used: %s, available: %s, percentage: %s",
+                    memory.name,
                     memory.used,
                     memory.available,
                     memory.percentage,
@@ -98,12 +100,12 @@ def check_service_health(services: Mapping[str, Service]) -> Mapping[str, bool]:
             with sentry_sdk.push_scope() as scope:
                 scope.set_tag("service", name)
                 sentry_sdk.capture_exception(e)
-            is_healthy = False
+            reasons = e
 
-        service_health[name] = is_healthy
-        logger.info("  => healthy: %s", is_healthy)
+        unhealthy_services[name] = reasons
+        logger.info("  => healthy: %s", not reasons)
 
-    return service_health
+    return unhealthy_services
 
 
 def start_service_monitoring() -> None:
@@ -117,11 +119,11 @@ def start_service_monitoring() -> None:
 
         with sentry_sdk.start_transaction(name="backpressure.monitoring", sampled=True):
             # first, check each base service and record its health
-            service_health = check_service_health(services)
+            unhealthy_services = check_service_health(services)
 
             # then, check the derived services and record their health
             try:
-                record_consumer_health(service_health)
+                record_consumer_health(unhealthy_services)
             except Exception as e:
                 sentry_sdk.capture_exception(e)
 

--- a/tests/sentry/processing/backpressure/test_checking.py
+++ b/tests/sentry/processing/backpressure/test_checking.py
@@ -21,7 +21,15 @@ from sentry.utils import json
     }
 )
 def test_backpressure_unhealthy():
-    record_consumer_health({"celery": False})
+    record_consumer_health(
+        {
+            "celery": Exception("Couldn't check celery"),
+            "attachments-store": [],
+            "processing-store": [],
+            "processing-locks": [],
+            "post-process-locks": [],
+        }
+    )
     with raises(MessageRejected):
         process_one_message()
 
@@ -37,11 +45,11 @@ def test_backpressure_unhealthy():
 def test_backpressure_healthy(process_profile_task):
     record_consumer_health(
         {
-            "celery": True,
-            "attachments-store": True,
-            "processing-store": True,
-            "processing-locks": True,
-            "post-process-locks": True,
+            "celery": [],
+            "attachments-store": [],
+            "processing-store": [],
+            "processing-locks": [],
+            "post-process-locks": [],
         }
     )
     process_one_message()

--- a/tests/sentry/processing/backpressure/test_monitoring.py
+++ b/tests/sentry/processing/backpressure/test_monitoring.py
@@ -1,7 +1,13 @@
+from collections.abc import MutableMapping
+
 import pytest
 from django.test.utils import override_settings
 
-from sentry.processing.backpressure.health import is_consumer_healthy, record_consumer_health
+from sentry.processing.backpressure.health import (
+    UnhealthyReasons,
+    is_consumer_healthy,
+    record_consumer_health,
+)
 from sentry.processing.backpressure.monitor import (
     Redis,
     assert_all_services_defined,
@@ -60,7 +66,7 @@ def test_check_redis_health() -> None:
     }
 )
 def test_record_consumer_health() -> None:
-    unhealthy_services = {
+    unhealthy_services: MutableMapping[str, UnhealthyReasons] = {
         "celery": [],
         "attachments-store": [],
         "processing-store": [],

--- a/tests/sentry/processing/backpressure/test_monitoring.py
+++ b/tests/sentry/processing/backpressure/test_monitoring.py
@@ -40,8 +40,8 @@ def test_check_redis_health() -> None:
             "backpressure.high_watermarks.redis": 1.0,
         }
     ):
-        service_health = check_service_health(services)
-        assert service_health["redis"] is True
+        unhealthy_services = check_service_health(services)
+        assert not unhealthy_services["redis"]
 
     with override_options(
         {
@@ -49,8 +49,8 @@ def test_check_redis_health() -> None:
             "backpressure.high_watermarks.redis": 0.0,
         }
     ):
-        service_health = check_service_health(services)
-        assert service_health["redis"] is False
+        unhealthy_services = check_service_health(services)
+        assert unhealthy_services["redis"]
 
 
 @override_options(
@@ -60,27 +60,27 @@ def test_check_redis_health() -> None:
     }
 )
 def test_record_consumer_health() -> None:
-    service_health = {
-        "celery": True,
-        "attachments-store": True,
-        "processing-store": True,
-        "processing-locks": True,
-        "post-process-locks": True,
+    unhealthy_services = {
+        "celery": [],
+        "attachments-store": [],
+        "processing-store": [],
+        "processing-locks": [],
+        "post-process-locks": [],
     }
-    record_consumer_health(service_health)
+    record_consumer_health(unhealthy_services)
     assert is_consumer_healthy() is True
 
-    service_health["celery"] = False
-    record_consumer_health(service_health)
+    unhealthy_services["celery"] = Exception("Couldn't check celery")
+    record_consumer_health(unhealthy_services)
     assert is_consumer_healthy() is False
 
     with pytest.raises(KeyError):
         record_consumer_health(
             {
-                "sellerie": True,  # oops
-                "attachments-store": True,
-                "processing-store": True,
-                "processing-locks": True,
-                "post-process-locks": True,
+                "sellerie": [],  # oops
+                "attachments-store": [],
+                "processing-store": [],
+                "processing-locks": [],
+                "post-process-locks": [],
             }
         )


### PR DESCRIPTION
This refactors backpressure management so that when a service exceeds its memory threshold or there's an exception when checking, that information is attached to the Sentry error for that service. Likewise, when a consumer is unhealthy, the error contains the list of unhealthy services.

This doesn't change the logic of backpressure management in any way, only the presentation. Unless I've introduced a bug somewhere, which I would obviously never do.