### PR TITLE
build: update eslint config and clean-up rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,24 +31,6 @@ module.exports = {
       {additionalHooks: ADDITIONAL_HOOKS_TO_CHECK_DEPS_FOR},
     ],
     ...(!isRelaxed && !isCi ? strictRulesNotCi : {}),
-
-    // TODO(@anonrig): Remove these rules from eslint-sentry-config.
-    'import/no-nodejs-modules': 'off',
-    semi: 'off',
-    'use-isnan': 'off',
-    curly: 'off',
-    eqeqeq: 'off',
-    'no-extra-semi': 'off',
-    'no-eq-null': 'off',
-    'comma-dangle': 'off',
-    'react/jsx-no-target-blank': 'off',
-    'react/jsx-no-duplicate-props': 'off',
-    'react-hooks/rules-of-hooks': 'off',
-    'no-duplicate-case': 'off',
-    'no-dupe-keys': 'off',
-    'no-redeclare': 'off',
-    'no-debugger': 'off',
-    'no-unreachable': 'off',
   },
   // JSON file formatting is handled by Biome. ESLint should not be linting
   // and formatting these files.
@@ -57,25 +39,6 @@ module.exports = {
     {
       files: ['tests/js/**/*.{ts,js}'],
       extends: ['plugin:testing-library/react', 'sentry-app/strict'],
-      rules: {
-        // TODO(@anonrig): Remove these rules from eslint-sentry-config.
-        'import/no-nodejs-modules': 'off',
-        semi: 'off',
-        'use-isnan': 'off',
-        curly: 'off',
-        eqeqeq: 'off',
-        'no-extra-semi': 'off',
-        'no-eq-null': 'off',
-        'comma-dangle': 'off',
-        'react/jsx-no-target-blank': 'off',
-        'react/jsx-no-duplicate-props': 'off',
-        'react-hooks/rules-of-hooks': 'off',
-        'no-duplicate-case': 'off',
-        'no-dupe-keys': 'off',
-        'no-redeclare': 'off',
-        'no-debugger': 'off',
-        'no-unreachable': 'off',
-      },
     },
     {
       files: ['*.ts', '*.tsx'],

--- a/biome.json
+++ b/biome.json
@@ -39,6 +39,10 @@
         "noDuplicateCase": "error",
         "noRedeclare": "error",
         "useIsArray": "error"
+      },
+      "style": {
+        "noVar": "error",
+        "useConst": "error"
       }
     }
   },
@@ -100,6 +104,16 @@
         "rules": {
           "nursery": {
             "noNodejsModules": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["src/sentry/templates/sentry/error-page-embed.js"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noVar": "off"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "benchmark": "^2.1.4",
     "eslint": "8.49.0",
-    "eslint-config-sentry-app": "2.1.0",
+    "eslint-config-sentry-app": "2.3.0",
     "html-webpack-plugin": "^5.5.0",
     "jest": "29.6.2",
     "jest-canvas-mock": "^2.5.2",

--- a/src/sentry/templates/sentry/error-page-embed.js
+++ b/src/sentry/templates/sentry/error-page-embed.js
@@ -1,4 +1,4 @@
-/* eslint no-var:0,strict:0,block-scoped-var:0 */
+/* eslint strict:0,block-scoped-var:0 */
 /* global sentryEmbedCallback:false */
 (function (window, document, JSON) {
   'use strict';

--- a/static/app/utils/statics-setup.tsx
+++ b/static/app/utils/statics-setup.tsx
@@ -1,6 +1,6 @@
 /* eslint no-native-reassign:0 */
 
-// eslint-disable-next-line no-var
+// biome-ignore lint/style/noVar: Not required
 declare var __webpack_public_path__: string;
 
 /**

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -149,12 +149,12 @@ declare global {
   /**
    * Generates a promise that resolves on the next macro-task
    */
-  // eslint-disable-next-line no-var
+  // biome-ignore lint/style/noVar: Not required
   var tick: () => Promise<void>;
   /**
    * Used to mock API requests
    */
-  // eslint-disable-next-line no-var
+  // biome-ignore lint/style/noVar: Not required
   var MockApiClient: typeof Client;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6083,40 +6083,40 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-sentry-app@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-2.1.0.tgz#8cc162bcb9958a5fe13c97fff6b5157b06a3e24d"
-  integrity sha512-q8YMWXnEYujid/3/g9MqVQ/TlOr85r8b18+ow5mS0xBEl1Kjwr5/dWPlRCZN8XuRVatDqxI8JIj/Lto2JNtoig==
+eslint-config-sentry-app@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-2.3.0.tgz#b634a0ab498e4b37127eb68825673473a76b682c"
+  integrity sha512-A9rjtxM/+UnGn1UKNYbeCjf/dgdHLbZ6bcgZ1OFr8LpYI0yNnLJjbyjSTJsN8RpEIhKKYWbzsw9gvt3b5B1lHA==
   dependencies:
     "@emotion/eslint-plugin" "^11.11.0"
     "@typescript-eslint/eslint-plugin" "^6.19.0"
     "@typescript-eslint/parser" "^6.19.0"
-    eslint-config-sentry "^2.1.0"
-    eslint-config-sentry-react "^2.1.0"
+    eslint-config-sentry "^2.3.0"
+    eslint-config-sentry-react "^2.3.0"
     eslint-import-resolver-typescript "^2.7.1"
     eslint-import-resolver-webpack "^0.13.8"
     eslint-plugin-import "^2.29.1"
     eslint-plugin-jest "^27.6.3"
     eslint-plugin-no-lookahead-lookbehind-regexp "0.1.0"
     eslint-plugin-react "^7.33.2"
-    eslint-plugin-sentry "^2.1.0"
+    eslint-plugin-sentry "^2.3.0"
     eslint-plugin-simple-import-sort "^10.0.0"
 
-eslint-config-sentry-react@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-2.1.0.tgz#9471fde40bcf6f98d05625dc9b9b4f54acf9baa6"
-  integrity sha512-6YXhXA2wXiB0H90jaDA8JEq02oFJVLb9UegTrWdV/ml//ya9D5pqameK9LY5YIqf4n1osi9lWdeSQSWvhAko3w==
+eslint-config-sentry-react@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-2.3.0.tgz#cfb73157d7e9e6575d360a9122f0e2091e10de86"
+  integrity sha512-A4LCCArBMpGm7djCbw58uDTn8/FUPz882MYxAXagDpIZadIKi2CC+OTEcHul9HNApTz1JrrJ+hxcJv1dI5W6XA==
   dependencies:
-    eslint-config-sentry "^2.1.0"
+    eslint-config-sentry "^2.3.0"
     eslint-plugin-jest-dom "^5.1.0"
     eslint-plugin-react-hooks "^4.6.0"
     eslint-plugin-testing-library "^6.2.0"
     eslint-plugin-typescript-sort-keys "^3.1.0"
 
-eslint-config-sentry@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-2.1.0.tgz#70bf894554212250f1d6ec1b8366ae7f8230944a"
-  integrity sha512-gefNirUXLh8FczVJ6OYMmoKa93VTw3tb+O+ZX3GHAeJlzUwHM3GNo2XHohoGmI3VO1mnMopIGGjJp8J8TP7kxA==
+eslint-config-sentry@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-2.3.0.tgz#df8951e7b645c6a525449e2aae31d45e8eec11d7"
+  integrity sha512-H4dt4FkJ78DN/MHhxrx3o2BznncXN0/1SQpHQRtEfX2Vv9rGanvDVDH3RG/dreFAP19pqobMHXONLH4cYJAvTw==
 
 eslint-import-resolver-node@^0.3.9:
   version "0.3.9"
@@ -6235,10 +6235,10 @@ eslint-plugin-react@^7.33.2:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.8"
 
-eslint-plugin-sentry@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-2.1.0.tgz#5ce40f57e6e0c934b111a2b09a3527028d0b7ff1"
-  integrity sha512-mUrbUJzrJ714ksg15tFyZMmWWHaq50SNFkOFPRs2Ff5OCzsOPzCKNBqZgkBKTMpLYpv9OvRxaW5h/7Lh/VHVDA==
+eslint-plugin-sentry@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-2.3.0.tgz#ef04352e92bee9e53f6f73f1ecebabef7e01c89e"
+  integrity sha512-kHcP4GfcLO4SAEMLZ/LsK+7RBC5wZEZIwoExgUXsWbtOQ+VkMjuLDBrDXlLtyte0IjstIuGB4nXJ+SAL9HuHug==
   dependencies:
     requireindex "~1.2.0"
 


### PR DESCRIPTION
Cleans up the rules since it is now added to `sentry-eslint-config` and adds `noVar` and `useConst` rules to Biome.