### PR TITLE
ref(rq): Allow methods and data in useQuery

### DIFF
--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -43,8 +43,11 @@ const PERSIST_IN_FLIGHT = true;
 type QueryKeyEndpointOptions<
   Headers = Record<string, string>,
   Query = Record<string, any>,
+  Data = Record<string, any>,
 > = {
+  data?: Data;
   headers?: Headers;
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH';
   query?: Query;
 };
 
@@ -52,7 +55,11 @@ export type ApiQueryKey =
   | readonly [url: string]
   | readonly [
       url: string,
-      options: QueryKeyEndpointOptions<Record<string, string>, Record<string, any>>,
+      options: QueryKeyEndpointOptions<
+        Record<string, string>,
+        Record<string, any>,
+        Record<string, any>
+      >,
     ];
 
 export interface UseApiQueryOptions<TApiResponse, TError = RequestError>
@@ -146,7 +153,8 @@ export function fetchDataQuery(api: Client) {
 
     return api.requestPromise(url, {
       includeAllArgs: true,
-      method: 'GET',
+      method: opts?.method ?? 'GET',
+      data: opts?.data,
       query: opts?.query,
       headers: opts?.headers,
     });

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -9,7 +9,7 @@ import type {
 } from '@tanstack/react-query';
 import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 
-import type {ApiResult, Client, ResponseMeta} from 'sentry/api';
+import type {APIRequestMethod, ApiResult, Client, ResponseMeta} from 'sentry/api';
 import type {ParsedHeader} from 'sentry/utils/parseLinkHeader';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import type RequestError from 'sentry/utils/requestError/requestError';
@@ -47,7 +47,7 @@ type QueryKeyEndpointOptions<
 > = {
   data?: Data;
   headers?: Headers;
-  method?: 'GET' | 'POST' | 'PUT' | 'PATCH';
+  method?: APIRequestMethod;
   query?: Query;
 };
 


### PR DESCRIPTION
### Summary
useApiQuery isn't solely limited to `POST`, if you aren't actually performing mutations (but need to do pre-flight validation, for example) you may want to send a data payload, which is `POST`, by convention. 
