### PR TITLE
fix(device-class): Allow for unknown device class in spans datasets

### DIFF
--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -289,7 +289,7 @@ def semver_build_filter_converter(
 def device_class_converter(
     builder: builder.QueryBuilder,
     search_filter: SearchFilter,
-    device_class_map: Mapping[str, set[str]] | None,
+    device_class_map: Mapping[str, set[str]] | None = None,
 ) -> WhereType | None:
     if not device_class_map:
         device_class_map = DEVICE_CLASS

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -293,7 +293,7 @@ def device_class_converter(
     # Spans data stores "Unknown" for unknown device classes unlike
     # the events dataset which stores null
     device_class_map = (
-        {**DEVICE_CLASS, "Unknown": {"Unknown"}}
+        {**DEVICE_CLASS, "Unknown": {""}}
         if builder.dataset in (Dataset.SpansIndexed, Dataset.PerformanceMetrics)
         else DEVICE_CLASS
     )

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -17,7 +17,6 @@ from sentry.search.events.filter import (
 )
 from sentry.search.events.types import WhereType
 from sentry.search.utils import DEVICE_CLASS, parse_release
-from sentry.snuba.dataset import Dataset
 from sentry.utils.strings import oxfordize_list
 
 
@@ -288,15 +287,13 @@ def semver_build_filter_converter(
 
 
 def device_class_converter(
-    builder: builder.QueryBuilder, search_filter: SearchFilter
+    builder: builder.QueryBuilder,
+    search_filter: SearchFilter,
+    device_class_map: Mapping[str, set[str]] | None,
 ) -> WhereType | None:
-    # Spans data stores "Unknown" for unknown device classes unlike
-    # the events dataset which stores null
-    device_class_map = (
-        {**DEVICE_CLASS, "Unknown": {""}}
-        if builder.dataset in (Dataset.SpansIndexed, Dataset.PerformanceMetrics)
-        else DEVICE_CLASS
-    )
+    if not device_class_map:
+        device_class_map = DEVICE_CLASS
+
     value = search_filter.value.value
     if value not in device_class_map:
         raise InvalidSearchQuery(f"{value} is not a supported device.class")

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -209,9 +209,9 @@ class SpansIndexedDatasetConfig(DatasetConfig):
     def _project_slug_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
         return filter_aliases.project_slug_converter(self.builder, search_filter)
 
-    def _device_class_filter_converter(self, alias: str) -> SelectType:
+    def _device_class_filter_converter(self, search_filter: SearchFilter) -> SelectType:
         return filter_aliases.device_class_converter(
-            self.builder, alias, {**DEVICE_CLASS, "Unknown": {""}}
+            self.builder, search_filter, {**DEVICE_CLASS, "Unknown": {""}}
         )
 
     def _resolve_project_slug_alias(self, alias: str) -> SelectType:

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -21,6 +21,7 @@ from sentry.search.events.fields import (
     with_default,
 )
 from sentry.search.events.types import SelectType, WhereType
+from sentry.search.utils import DEVICE_CLASS
 
 
 class SpansIndexedDatasetConfig(DatasetConfig):
@@ -36,9 +37,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
         return {
             constants.PROJECT_ALIAS: self._project_slug_filter_converter,
             constants.PROJECT_NAME_ALIAS: self._project_slug_filter_converter,
-            constants.DEVICE_CLASS_ALIAS: lambda search_filter: filter_aliases.device_class_converter(
-                self.builder, search_filter
-            ),
+            constants.DEVICE_CLASS_ALIAS: self._device_class_filter_converter,
             constants.SPAN_IS_SEGMENT_ALIAS: filter_aliases.span_is_segment_converter,
         }
 
@@ -209,6 +208,11 @@ class SpansIndexedDatasetConfig(DatasetConfig):
 
     def _project_slug_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
         return filter_aliases.project_slug_converter(self.builder, search_filter)
+
+    def _device_class_filter_converter(self, alias: str) -> SelectType:
+        return filter_aliases.device_class_converter(
+            self.builder, alias, {**DEVICE_CLASS, "Unknown": {""}}
+        )
 
     def _resolve_project_slug_alias(self, alias: str) -> SelectType:
         return field_aliases.resolve_project_slug_alias(self.builder, alias)

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -11,6 +11,7 @@ from sentry.search.events import builder, constants, fields
 from sentry.search.events.datasets import field_aliases, filter_aliases, function_aliases
 from sentry.search.events.datasets.base import DatasetConfig
 from sentry.search.events.types import SelectType, WhereType
+from sentry.search.utils import DEVICE_CLASS
 from sentry.snuba.metrics.naming_layer.mri import SpanMRI
 from sentry.snuba.referrer import Referrer
 
@@ -28,9 +29,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
     ) -> Mapping[str, Callable[[SearchFilter], WhereType | None]]:
         return {
             constants.SPAN_DOMAIN_ALIAS: self._span_domain_filter_converter,
-            constants.DEVICE_CLASS_ALIAS: lambda search_filter: filter_aliases.device_class_converter(
-                self.builder, search_filter
-            ),
+            constants.DEVICE_CLASS_ALIAS: self._device_class_filter_converter,
         }
 
     @property
@@ -481,6 +480,11 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                 Op.NEQ if search_filter.operator in constants.EQUALITY_OPERATORS else Op.EQ,
                 0,
             )
+
+    def _device_class_filter_converter(self, alias: str) -> SelectType:
+        return filter_aliases.device_class_converter(
+            self.builder, alias, {**DEVICE_CLASS, "Unknown": {""}}
+        )
 
     def _resolve_span_module(self, alias: str) -> SelectType:
         return field_aliases.resolve_span_module(self.builder, alias)

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -481,9 +481,9 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                 0,
             )
 
-    def _device_class_filter_converter(self, alias: str) -> SelectType:
+    def _device_class_filter_converter(self, search_filter: SearchFilter) -> SelectType:
         return filter_aliases.device_class_converter(
-            self.builder, alias, {**DEVICE_CLASS, "Unknown": {""}}
+            self.builder, search_filter, {**DEVICE_CLASS, "Unknown": {""}}
         )
 
     def _resolve_span_module(self, alias: str) -> SelectType:

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -95,3 +95,28 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
         assert len(data) == 1
         assert data[0]["sentry_tags[transaction.method]"] == "foo"
         assert meta["dataset"] == "spansIndexed"
+
+    def test_device_class_filter_unknown(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": {"device.class": "Unknown"}}, start_ts=self.ten_mins_ago
+                ),
+            ]
+        )
+        response = self.do_request(
+            {
+                "field": ["sentry_tags[device.class]", "count()"],
+                "query": "device.class:Unknown",
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spansIndexed",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["sentry_tags[device.class]"] == "Unknown"
+        assert meta["dataset"] == "spansIndexed"

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -99,14 +99,12 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
     def test_device_class_filter_unknown(self):
         self.store_spans(
             [
-                self.create_span(
-                    {"sentry_tags": {"device.class": "Unknown"}}, start_ts=self.ten_mins_ago
-                ),
+                self.create_span({"sentry_tags": {"device.class": ""}}, start_ts=self.ten_mins_ago),
             ]
         )
         response = self.do_request(
             {
-                "field": ["sentry_tags[device.class]", "count()"],
+                "field": ["device.class", "count()"],
                 "query": "device.class:Unknown",
                 "orderby": "count()",
                 "project": self.project.id,
@@ -118,5 +116,5 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        assert data[0]["sentry_tags[device.class]"] == "Unknown"
+        assert data[0]["device.class"] == "Unknown"
         assert meta["dataset"] == "spansIndexed"

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -996,6 +996,29 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["device.class"] == level
         assert meta["fields"]["device.class"] == "string"
 
+    def test_device_class_filter_unknown(self):
+        self.store_span_metric(
+            123,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"device.class": "Unknown"},
+        )
+        response = self.do_request(
+            {
+                "field": ["device.class", "count()"],
+                "query": "device.class:Unknown",
+                "orderby": "count()",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["device.class"] == "Unknown"
+        assert meta["fields"]["device.class"] == "string"
+
 
 @region_silo_test
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1001,7 +1001,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             123,
             internal_metric=constants.SELF_TIME_LIGHT,
             timestamp=self.min_ago,
-            tags={"device.class": "Unknown"},
+            tags={"device.class": ""},
         )
         response = self.do_request(
             {


### PR DESCRIPTION
Discover stores Unknown device class as `null` but in spans data
it's encoded as `""`. This conditionally adds `"Unknown"`
to the available device class filters so passing it in doesn't
throw an error during querying.