### PR TITLE
fix(feedback): don't show replay cta for unsupported platforms

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackReplay.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackReplay.tsx
@@ -53,7 +53,7 @@ export default function FeedbackReplay({eventData, feedbackItem, organization}: 
     return <Placeholder />;
   }
 
-  if (!hasSentOneReplay) {
+  if (!hasSentOneReplay && platformSupported) {
     return <ReplayInlineCTAPanel />;
   }
 


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/65006

we shouldn't show this CTA for platforms we don't support:
![image](https://github.com/getsentry/sentry/assets/56095982/f0971888-942b-431d-b84b-f81affe95a8a)
