### PR TITLE
ref(grouping): Clean up `event_manager_grouping` tests

### DIFF
--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -39,12 +39,6 @@ class EventManagerGroupingTest(TestCase):
 
         assert event.group_id == event2.group_id
 
-        group = Group.objects.get(id=event.group_id)
-
-        assert group.times_seen == 2
-        assert group.last_seen == event2.datetime
-        assert group.message == event2.message
-
     def test_puts_events_with_different_fingerprints_in_different_groups(self):
         event = save_new_event(
             {"message": "Dogs are great!", "fingerprint": ["maisey"]}, self.project
@@ -116,6 +110,31 @@ class EventManagerGroupingTest(TestCase):
         event = save_new_event({"exception": None}, self.project)
 
         assert event.group
+
+    def test_updates_group_metadata(self):
+        event1 = save_new_event(
+            {"message": "Dogs are great!", "fingerprint": ["maisey"]}, self.project
+        )
+
+        group = Group.objects.get(id=event1.group_id)
+
+        assert group.times_seen == 1
+        assert group.last_seen == event1.datetime
+        assert group.message == event1.message
+
+        # Normally this should go into a different group, since the messages don't match, but the
+        # fingerprint takes precedence. (We need to make the messages different in order to show
+        # that the group's message gets updated.)
+        event2 = save_new_event(
+            {"message": "Adopt don't shop", "fingerprint": ["maisey"]}, self.project
+        )
+
+        assert event1.group_id == event2.group_id
+        group = Group.objects.get(id=event2.group_id)
+
+        assert group.times_seen == 2
+        assert group.last_seen == event2.datetime
+        assert group.message == event2.message
 
 
 @region_silo_test

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -17,6 +17,10 @@ from sentry.tsdb.base import TSDBModel
 pytestmark = [requires_snuba]
 
 
+LEGACY_CONFIG = "legacy:2019-03-12"
+NEWSTYLE_CONFIG = "newstyle:2023-01-11"
+
+
 def get_relevant_metrics_calls(mock_fn: MagicMock, key: str) -> list[mock._Call]:
     return [call for call in mock_fn.call_args_list if call.args[0] == key]
 
@@ -119,7 +123,7 @@ class EventManagerGroupingMetricsTest(TestCase):
     @mock.patch("sentry.event_manager.metrics.incr")
     def test_records_num_calculations(self, mock_metrics_incr: MagicMock):
         project = self.project
-        project.update_option("sentry:grouping_config", "legacy:2019-03-12")
+        project.update_option("sentry:grouping_config", LEGACY_CONFIG)
         project.update_option("sentry:secondary_grouping_config", None)
 
         save_new_event({"message": "Dogs are great!"}, self.project)
@@ -130,8 +134,8 @@ class EventManagerGroupingMetricsTest(TestCase):
         assert len(hashes_calculated_calls) == 1
         assert hashes_calculated_calls[0].kwargs["amount"] == 1
 
-        project.update_option("sentry:grouping_config", "newstyle:2023-01-11")
-        project.update_option("sentry:secondary_grouping_config", "legacy:2019-03-12")
+        project.update_option("sentry:grouping_config", NEWSTYLE_CONFIG)
+        project.update_option("sentry:secondary_grouping_config", LEGACY_CONFIG)
         project.update_option("sentry:secondary_grouping_expiry", time() + 3600)
 
         save_new_event({"message": "Dogs are great!"}, self.project)
@@ -146,8 +150,8 @@ class EventManagerGroupingMetricsTest(TestCase):
     @mock.patch("sentry.grouping.ingest._should_run_secondary_grouping", return_value=True)
     def test_records_hash_comparison(self, _, mock_metrics_incr: MagicMock):
         project = self.project
-        project.update_option("sentry:grouping_config", "newstyle:2023-01-11")
-        project.update_option("sentry:secondary_grouping_config", "legacy:2019-03-12")
+        project.update_option("sentry:grouping_config", NEWSTYLE_CONFIG)
+        project.update_option("sentry:secondary_grouping_config", LEGACY_CONFIG)
 
         cases = [
             # primary_hashes, secondary_hashes, expected_tag


### PR DESCRIPTION
This does a small amount of cleanup of the tests in `test_event_manager_grouping.py`. Specifically:

- Use constants for grouping config names.
- Split updating group metadata into a separate test.
- Simplify test showing transaction events ignore manual fingerprinting.