### PR TITLE
fix(superuser): pass organization to hook to exclude orgs from warning

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -495,7 +495,9 @@ function Sidebar() {
         <DropdownSidebarSection isSuperuser={hasSuperuserSession}>
           <SidebarDropdown orientation={orientation} collapsed={collapsed} />
 
-          {hasSuperuserSession && <Hook name="component:superuser-warning" />}
+          {hasSuperuserSession && (
+            <Hook name="component:superuser-warning" organization={organization} />
+          )}
         </DropdownSidebarSection>
 
         <PrimaryItems>


### PR DESCRIPTION
We need to pass the organization into the hook to check the slug to be able to exclude particular orgs from the superuser warning.