### PR TITLE
fix(releases): Display only the selected repo's commits

### DIFF
--- a/fixtures/js-stubs/commit.ts
+++ b/fixtures/js-stubs/commit.ts
@@ -1,9 +1,9 @@
 import {CommitAuthorFixture} from 'sentry-fixture/commitAuthor';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {type Commit} from 'sentry/types';
+import type {Commit} from 'sentry/types';
 
-export function CommitFixture(params = {}): Commit {
+export function CommitFixture(params: Partial<Commit> = {}): Commit {
   return {
     dateCreated: '2018-11-30T18:46:31Z',
     message:

--- a/static/app/views/releases/detail/commitsAndFiles/commits.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/commits.tsx
@@ -59,6 +59,9 @@ function Commits({activeReleaseRepo, releaseRepos, projectSlug}: CommitsProps) {
 
   const commitsByRepository = getCommitsByRepository(commitList);
   const reposToRender = getReposToRender(Object.keys(commitsByRepository));
+  const activeRepoName: string | undefined = activeReleaseRepo
+    ? activeReleaseRepo.name
+    : reposToRender[0];
 
   return (
     <Layout.Body>
@@ -80,18 +83,16 @@ function Commits({activeReleaseRepo, releaseRepos, projectSlug}: CommitsProps) {
         {commitListError && <LoadingError onRetry={refetch} />}
         {isLoadingCommitList ? (
           <LoadingIndicator />
-        ) : commitList.length ? (
+        ) : commitList.length && activeRepoName ? (
           <Fragment>
-            {reposToRender.map(repoName => (
-              <Panel key={repoName}>
-                <PanelHeader>{repoName}</PanelHeader>
-                <PanelBody>
-                  {commitsByRepository[repoName]?.map(commit => (
-                    <CommitRow key={commit.id} commit={commit} />
-                  ))}
-                </PanelBody>
-              </Panel>
-            ))}
+            <Panel>
+              <PanelHeader>{activeRepoName}</PanelHeader>
+              <PanelBody>
+                {commitsByRepository[activeRepoName]?.map(commit => (
+                  <CommitRow key={commit.id} commit={commit} />
+                ))}
+              </PanelBody>
+            </Panel>
             <Pagination pageLinks={getResponseHeader?.('Link')} />
           </Fragment>
         ) : (


### PR DESCRIPTION
Fixes a bug where we display a repo picker dropdown, but display all the commits for every repo anyway. See example https://sentry.sentry.io/releases/frontend%407e5a76fd75b0d41f4fc9ad440ad4d58f18d9786a/commits/?project=11276
