### PR TITLE
fix(app-start): Pass along start type to samples components

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -34,6 +34,7 @@ type Query = {
   primaryRelease: string;
   project: string;
   secondaryRelease: string;
+  spanAppStartType: string;
   spanDescription: string;
   spanGroup: string;
   spanOp: string;
@@ -52,6 +53,7 @@ function ScreenSummary() {
     spanGroup,
     spanDescription,
     spanOp,
+    spanAppStartType,
   } = location.query;
 
   const startupModule: LocationDescriptor = {
@@ -61,6 +63,7 @@ function ScreenSummary() {
         QueryParameterNames.SPANS_SORT,
         'transaction',
         SpanMetricsField.SPAN_OP,
+        SpanMetricsField.APP_START_TYPE,
       ]),
     },
   };
@@ -192,8 +195,11 @@ function ScreenSummary() {
               <SamplesContainer>
                 <SamplesTables transactionName={transactionName} />
               </SamplesContainer>
-              {spanGroup && spanOp && (
+              {spanGroup && spanOp && spanAppStartType && (
                 <ScreenLoadSpanSamples
+                  additionalFilters={{
+                    [SpanMetricsField.APP_START_TYPE]: spanAppStartType,
+                  }}
                   groupId={spanGroup}
                   transactionName={transactionName}
                   spanDescription={spanDescription}

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -163,6 +163,7 @@ export function SpanOperationTable({
         spanOp: row[SpanMetricsField.SPAN_OP],
         spanGroup: row[SpanMetricsField.SPAN_GROUP],
         spanDescription: row[SpanMetricsField.SPAN_DESCRIPTION],
+        spanAppStartType: row[SpanMetricsField.APP_START_TYPE],
       };
 
       return (

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
@@ -21,6 +21,7 @@ import {ScreenLoadSampleContainer} from 'sentry/views/starfish/views/screens/scr
 type Props = {
   groupId: string;
   transactionName: string;
+  additionalFilters?: Record<string, string>;
   onClose?: () => void;
   spanDescription?: string;
   spanOp?: string;
@@ -36,6 +37,7 @@ export function ScreenLoadSpanSamples({
   onClose,
   transactionRoute = '/performance/summary/',
   spanOp,
+  additionalFilters,
 }: Props) {
   const router = useRouter();
 
@@ -118,6 +120,7 @@ export function ScreenLoadSpanSamples({
               sectionTitle={t('Release 1')}
               project={project}
               spanOp={spanOp}
+              additionalFilters={additionalFilters}
             />
           </ChartsContainerItem>
           <ChartsContainerItem key="release2">
@@ -129,6 +132,7 @@ export function ScreenLoadSpanSamples({
               sectionTitle={t('Release 2')}
               project={project}
               spanOp={spanOp}
+              additionalFilters={additionalFilters}
             />
           </ChartsContainerItem>
         </ChartsContainer>

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
@@ -35,6 +35,7 @@ const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 type Props = {
   groupId: string;
   transactionName: string;
+  additionalFilters?: Record<string, string>;
   project?: Project | null;
   release?: string;
   sectionSubtitle?: string;
@@ -50,6 +51,7 @@ export function ScreenLoadSampleContainer({
   release,
   project,
   spanOp,
+  additionalFilters,
 }: Props) {
   const router = useRouter();
   const location = useLocation();
@@ -97,7 +99,7 @@ export function ScreenLoadSampleContainer({
   }
 
   const {data} = useSpanMetrics({
-    filters,
+    filters: {...filters, ...additionalFilters},
     fields: [`avg(${SPAN_SELF_TIME})`, 'count()', SPAN_OP],
     referrer: 'api.starfish.span-summary-panel-samples-table-avg',
   });
@@ -148,6 +150,12 @@ export function ScreenLoadSampleContainer({
         </Block>
       </Container>
       <DurationChart
+        query={
+          additionalFilters
+            ? Object.entries(additionalFilters).map(([key, value]) => `${key}:${value}`)
+            : undefined
+        }
+        additionalFilters={additionalFilters}
         groupId={groupId}
         transactionName={transactionName}
         transactionMethod={transactionMethod}
@@ -167,6 +175,12 @@ export function ScreenLoadSampleContainer({
         }
       />
       <SampleTable
+        query={
+          additionalFilters
+            ? Object.entries(additionalFilters).map(([key, value]) => `${key}:${value}`)
+            : undefined
+        }
+        additionalFilters={additionalFilters}
         highlightedSpanId={highlightedSpanId}
         transactionMethod={transactionMethod}
         onMouseLeaveSample={() => setHighlightedSpanId(undefined)}

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -31,6 +31,7 @@ type Props = {
   groupId: string;
   transactionName: string;
   additionalFields?: string[];
+  additionalFilters?: Record<string, string>;
   highlightedSpanId?: string;
   onClickSample?: (sample: SpanSample) => void;
   onMouseLeaveSample?: () => void;
@@ -77,6 +78,7 @@ function DurationChart({
   release,
   query,
   platform,
+  additionalFilters,
 }: Props) {
   const theme = useTheme();
   const {setPageError} = usePageAlert();
@@ -104,7 +106,7 @@ function DurationChart({
     data: spanMetricsSeriesData,
     error: spanMetricsSeriesError,
   } = useSpanMetricsSeries({
-    filters,
+    filters: {...filters, ...additionalFilters},
     yAxis: [`avg(${SPAN_SELF_TIME})`],
     referrer: 'api.starfish.sidebar-span-metrics-chart',
   });

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -28,6 +28,7 @@ type Props = {
   groupId: string;
   transactionName: string;
   additionalFields?: string[];
+  additionalFilters?: Record<string, string>;
   columnOrder?: SamplesTableColumnHeader[];
   highlightedSpanId?: string;
   onMouseLeaveSample?: () => void;
@@ -48,6 +49,7 @@ function SampleTable({
   release,
   query,
   additionalFields,
+  additionalFilters,
 }: Props) {
   const filters: SpanMetricsQueryFilters = {
     'span.group': groupId,
@@ -63,7 +65,7 @@ function SampleTable({
   }
 
   const {data, isFetching: isFetchingSpanMetrics} = useSpanMetrics({
-    filters,
+    filters: {...filters, ...additionalFilters},
     fields: [`avg(${SPAN_SELF_TIME})`, SPAN_OP],
     referrer: 'api.starfish.span-summary-panel-samples-table-avg',
   });


### PR DESCRIPTION
The start type wasn't being passed along to the event samples drawer. I added some props to let me pass along this filter.

Along the way I noticed the hooks we use for querying were using different APIs for passing along filters. Some wanted a list of `key:value` or others wanted an object with a `{key: value}` mapping.

Some components used `query` in the `key:value` format, but only applied it to some of the hooks. I've passed along both and added filters to wherever it was necessary, but this feels pretty tech-debt-y and I'd like to fix it in a future PR.