### PR TITLE
fix(replays): Add coverage and update implementation to handle malformed payload submissions

### DIFF
--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -12,6 +12,7 @@ from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.types import Commit, Message, Partition
 from django.conf import settings
 from sentry_kafka_schemas import get_codec
+from sentry_kafka_schemas.codecs import ValidationError
 from sentry_kafka_schemas.schema_types.ingest_replay_recordings_v1 import ReplayRecording
 from sentry_sdk.tracing import Span
 
@@ -25,7 +26,7 @@ RECORDINGS_CODEC = get_codec("ingest-replay-recordings")
 
 @dataclasses.dataclass
 class MessageContext:
-    message: ReplayRecording
+    message: bytes
     transaction: Span
     current_hub: sentry_sdk.Hub
 
@@ -110,14 +111,18 @@ def initialize_threaded_context(message: Message[KafkaPayload]) -> MessageContex
         < getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0),
     )
     current_hub = sentry_sdk.Hub(sentry_sdk.Hub.current)
-    message_dict = RECORDINGS_CODEC.decode(message.payload.value)
-    return MessageContext(message_dict, transaction, current_hub)
+    return MessageContext(message.payload.value, transaction, current_hub)
 
 
 def process_message_threaded(message: Message[MessageContext]) -> Any:
     """Move the replay payload to permanent storage."""
     context: MessageContext = message.payload
-    message_dict = context.message
+
+    try:
+        message_dict: ReplayRecording = RECORDINGS_CODEC.decode(context.message)
+    except ValidationError:
+        # TODO: DLQ
+        return None
 
     ingest_recording(message_dict, context.transaction, context.current_hub)
 
@@ -131,5 +136,11 @@ def process_message(message: Message[KafkaPayload]) -> Any:
         < getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0),
     )
     current_hub = sentry_sdk.Hub(sentry_sdk.Hub.current)
-    message_dict = RECORDINGS_CODEC.decode(message.payload.value)
+
+    try:
+        message_dict: ReplayRecording = RECORDINGS_CODEC.decode(message.payload.value)
+    except ValidationError:
+        # TODO: DLQ
+        return None
+
     ingest_recording(message_dict, transaction, current_hub)

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -122,6 +122,7 @@ def process_message_threaded(message: Message[MessageContext]) -> Any:
         message_dict: ReplayRecording = RECORDINGS_CODEC.decode(context.message)
     except ValidationError:
         # TODO: DLQ
+        logger.exception("Could not decode recording message.")
         return None
 
     ingest_recording(message_dict, context.transaction, context.current_hub)
@@ -141,6 +142,7 @@ def process_message(message: Message[KafkaPayload]) -> Any:
         message_dict: ReplayRecording = RECORDINGS_CODEC.decode(message.payload.value)
     except ValidationError:
         # TODO: DLQ
+        logger.exception("Could not decode recording message.")
         return None
 
     ingest_recording(message_dict, transaction, current_hub)

--- a/src/sentry/replays/consumers/recording_buffered.py
+++ b/src/sentry/replays/consumers/recording_buffered.py
@@ -195,14 +195,15 @@ def process_message(buffer: RecordingBuffer, message: bytes) -> None:
             decoded_message: ReplayRecording = RECORDINGS_CODEC.decode(message)
         except ValidationError:
             # TODO: DLQ
+            logger.exception("Could not decode recording message.")
             return None
 
     try:
         headers, recording_data = process_headers(decoded_message["payload"])
     except Exception:
         # TODO: DLQ
-        logger.warning(
-            "Valid headers could not be found %s", decoded_message["replay_id"], exc_info=True
+        logger.exception(
+            "Recording headers could not be extracted %s", decoded_message["replay_id"]
         )
         return None
 

--- a/src/sentry/replays/consumers/recording_buffered.py
+++ b/src/sentry/replays/consumers/recording_buffered.py
@@ -52,15 +52,11 @@ from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import BaseValue, Commit, Message, Partition
 from sentry_kafka_schemas import get_codec
+from sentry_kafka_schemas.codecs import ValidationError
 from sentry_kafka_schemas.schema_types.ingest_replay_recordings_v1 import ReplayRecording
 
 from sentry.replays.lib.storage import RecordingSegmentStorageMeta, storage
-from sentry.replays.usecases.ingest import (
-    MissingRecordingSegmentHeaders,
-    decompress,
-    process_headers,
-    track_initial_segment_event,
-)
+from sentry.replays.usecases.ingest import decompress, process_headers, track_initial_segment_event
 from sentry.replays.usecases.ingest.dom_index import (
     ReplayActionsEvent,
     emit_replay_actions,
@@ -195,12 +191,19 @@ class RecordingBuffer:
 
 def process_message(buffer: RecordingBuffer, message: bytes) -> None:
     with sentry_sdk.start_span(op="replays.consumer.recording.decode_kafka_message"):
-        decoded_message: ReplayRecording = RECORDINGS_CODEC.decode(message)
+        try:
+            decoded_message: ReplayRecording = RECORDINGS_CODEC.decode(message)
+        except ValidationError:
+            # TODO: DLQ
+            return None
 
     try:
         headers, recording_data = process_headers(decoded_message["payload"])
-    except MissingRecordingSegmentHeaders:
-        logger.warning("missing header on %s", decoded_message["replay_id"])
+    except Exception:
+        # TODO: DLQ
+        logger.warning(
+            "Valid headers could not be found %s", decoded_message["replay_id"], exc_info=True
+        )
         return None
 
     # Append an upload event to the state object for later processing.

--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -87,7 +87,7 @@ def _ingest_recording(message: RecordingIngestMessage, transaction: Span) -> Non
         headers, recording_segment = process_headers(message.payload_with_headers)
     except Exception:
         # TODO: DLQ
-        logger.warning("Valid headers could not be found %s", message.replay_id, exc_info=True)
+        logger.exception("Recording headers could not be extracted %s", message.replay_id)
         return None
 
     # Normalize ingest data into a standardized ingest format.

--- a/tests/sentry/replays/consumers/test_recording.py
+++ b/tests/sentry/replays/consumers/test_recording.py
@@ -213,6 +213,186 @@ class RecordingTestCase(TransactionTestCase):
         # No replay actions were emitted because JSON deserialization failed.
         assert not emit_replay_actions.called
 
+    @patch("sentry.models.OrganizationOnboardingTask.objects.record")
+    @patch("sentry.analytics.record")
+    @patch("sentry.replays.usecases.ingest.dom_index.emit_replay_actions")
+    def test_invalid_payload_invalid_headers(
+        self, emit_replay_actions, mock_record, mock_onboarding_task
+    ):
+        """Test missing segment_id key does not break ingestion."""
+        segment_id = 0
+
+        self.submit(
+            [
+                {
+                    "type": "replay_recording_not_chunked",
+                    "replay_id": self.replay_id,
+                    "org_id": self.organization.id,
+                    "key_id": 123,
+                    "project_id": self.project.id,
+                    "received": int(time.time()),
+                    "retention_days": 30,
+                    "payload": b'{"something":"else"}\n' + b'[{"hello":"world"}]',
+                }
+            ]
+        )
+
+        # Assert the message was totally broken and nothing happened.
+        bytes = self.get_recording_data(segment_id)
+        assert bytes is None
+        self.project.refresh_from_db()
+        assert not self.project.flags.has_replays
+        # assert not mock_onboarding_task.called
+        # assert not mock_record.called
+        assert not emit_replay_actions.called
+
+    @patch("sentry.models.OrganizationOnboardingTask.objects.record")
+    @patch("sentry.analytics.record")
+    @patch("sentry.replays.usecases.ingest.dom_index.emit_replay_actions")
+    def test_invalid_payload_invalid_unicode_codepoint(
+        self, emit_replay_actions, mock_record, mock_onboarding_task
+    ):
+        """Test invalid unicode codepoint in headers does not break ingestion."""
+        segment_id = 0
+
+        self.submit(
+            [
+                {
+                    "type": "replay_recording_not_chunked",
+                    "replay_id": self.replay_id,
+                    "org_id": self.organization.id,
+                    "key_id": 123,
+                    "project_id": self.project.id,
+                    "received": int(time.time()),
+                    "retention_days": 30,
+                    "payload": '{"segment_id":"\\ud83c"}\n'.encode("utf-16")
+                    + b'[{"hello":"world"}]',
+                }
+            ]
+        )
+
+        # Assert the message was totally broken and nothing happened.
+        bytes = self.get_recording_data(segment_id)
+        assert bytes is None
+        self.project.refresh_from_db()
+        assert not self.project.flags.has_replays
+        # assert not mock_onboarding_task.called
+        # assert not mock_record.called
+        assert not emit_replay_actions.called
+
+    @patch("sentry.models.OrganizationOnboardingTask.objects.record")
+    @patch("sentry.analytics.record")
+    @patch("sentry.replays.usecases.ingest.dom_index.emit_replay_actions")
+    def test_invalid_payload_malformed_headers(
+        self, emit_replay_actions, mock_record, mock_onboarding_task
+    ):
+        """Test malformed headers in payload attribute do not break ingestion."""
+        segment_id = 0
+
+        self.submit(
+            [
+                {
+                    "type": "replay_recording_not_chunked",
+                    "replay_id": self.replay_id,
+                    "org_id": self.organization.id,
+                    "key_id": 123,
+                    "project_id": self.project.id,
+                    "received": int(time.time()),
+                    "retention_days": 30,
+                    "payload": b"i am invalid\n" + b'[{"hello":"world"}]',
+                }
+            ]
+        )
+
+        # Assert the message was totally broken and nothing happened.
+        bytes = self.get_recording_data(segment_id)
+        assert bytes is None
+        self.project.refresh_from_db()
+        assert not self.project.flags.has_replays
+        # assert not mock_onboarding_task.called
+        # assert not mock_record.called
+        assert not emit_replay_actions.called
+
+    @patch("sentry.models.OrganizationOnboardingTask.objects.record")
+    @patch("sentry.analytics.record")
+    @patch("sentry.replays.usecases.ingest.dom_index.emit_replay_actions")
+    def test_invalid_payload_missing_headers(
+        self, emit_replay_actions, mock_record, mock_onboarding_task
+    ):
+        """Test missing headers in payload attribute does not break ingestion."""
+        segment_id = 0
+
+        self.submit(
+            [
+                {
+                    "type": "replay_recording_not_chunked",
+                    "replay_id": self.replay_id,
+                    "org_id": self.organization.id,
+                    "key_id": 123,
+                    "project_id": self.project.id,
+                    "received": int(time.time()),
+                    "retention_days": 30,
+                    "payload": b"no headers :P",
+                }
+            ]
+        )
+
+        # Assert the message was totally broken and nothing happened.
+        bytes = self.get_recording_data(segment_id)
+        assert bytes is None
+        self.project.refresh_from_db()
+        assert not self.project.flags.has_replays
+        # assert not mock_onboarding_task.called
+        # assert not mock_record.called
+        assert not emit_replay_actions.called
+
+    @patch("sentry.models.OrganizationOnboardingTask.objects.record")
+    @patch("sentry.analytics.record")
+    @patch("sentry.replays.usecases.ingest.dom_index.emit_replay_actions")
+    def test_invalid_payload_type(self, emit_replay_actions, mock_record, mock_onboarding_task):
+        """Test invalid payload types do not break ingestion."""
+        segment_id = 0
+
+        self.submit(
+            [
+                {
+                    "type": "replay_recording_not_chunked",
+                    "replay_id": self.replay_id,
+                    "org_id": self.organization.id,
+                    "key_id": 123,
+                    "project_id": self.project.id,
+                    "received": int(time.time()),
+                    "retention_days": 30,
+                    "payload": "I'm a string!",
+                }
+            ]
+        )
+
+        # Assert the message was totally broken and nothing happened.
+        bytes = self.get_recording_data(segment_id)
+        assert bytes is None
+        self.project.refresh_from_db()
+        assert not self.project.flags.has_replays
+        # assert not mock_onboarding_task.called
+        # assert not mock_record.called
+        assert not emit_replay_actions.called
+
+    @patch("sentry.models.OrganizationOnboardingTask.objects.record")
+    @patch("sentry.analytics.record")
+    @patch("sentry.replays.usecases.ingest.dom_index.emit_replay_actions")
+    def test_invalid_message(self, emit_replay_actions, mock_record, mock_onboarding_task):
+        """Test invalid messages do not break ingestion."""
+        self.submit(["i am totally wrong"])
+
+        # Assert the message was totally broken and nothing happened.
+        bytes = self.get_recording_data(0)
+        assert bytes is None
+        self.project.refresh_from_db()
+        assert not self.project.flags.has_replays
+        # assert not mock_onboarding_task.called
+        # assert not mock_record.called
+        assert not emit_replay_actions.called
+
 
 class ThreadedRecordingTestCase(RecordingTestCase):
     force_synchronous = False


### PR DESCRIPTION
This pull attempts to add coverage for every message permutation that can break ingestion.  It also updates the implementation to satisfy the coverage.