### PR TITLE
fix(replay): Improve render of Hydration Diffs when missing next-mutation breadcrumb

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -123,7 +123,7 @@ function BreadcrumbItem({
               replay={replay}
               leftTimestamp={frame.offsetMs}
               rightTimestamp={
-                (frame.data.mutations.next.timestamp as number) -
+                (frame.data.mutations.next?.timestamp ?? 0) -
                 (replay?.getReplay().started_at.getTime() ?? 0)
               }
             />

--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -31,7 +31,8 @@ export function OpenReplayComparisonButton({
       size="xs"
       analyticsEventKey="replay.details-hydration-modal-opened"
       analyticsEventName="Replay Details Hydration Modal Opened"
-      onClick={() => {
+      onClick={event => {
+        event.stopPropagation();
         openModal(
           deps => (
             <Suspense

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -28,6 +28,11 @@ interface Props extends ModalRenderProps {
   rightTimestamp: number;
 }
 
+enum Tab {
+  VISUAL = 'visual',
+  HTML = 'html',
+}
+
 const MAX_CLAMP_TO_START = 2000;
 
 export default function ReplayComparisonModal({
@@ -40,7 +45,7 @@ export default function ReplayComparisonModal({
 }: Props) {
   const fetching = false;
 
-  const [activeTab, setActiveTab] = useState<'visual' | 'html'>('html');
+  const [activeTab, setActiveTab] = useState<Tab>(Tab.HTML);
 
   const [leftBody, setLeftBody] = useState(null);
   const [rightBody, setRightBody] = useState(null);
@@ -89,55 +94,71 @@ export default function ReplayComparisonModal({
         <Flex gap={space(1)} column>
           <TabList
             selectedKey={activeTab}
-            onSelectionChange={tab => setActiveTab(tab as 'visual' | 'html')}
+            onSelectionChange={tab => setActiveTab(tab as Tab)}
           >
-            <TabList.Item key="html">Html Diff</TabList.Item>
-            <TabList.Item key="visual">Visual Diff</TabList.Item>
+            <TabList.Item key={Tab.HTML}>{t('Html Diff')}</TabList.Item>
+            <TabList.Item key={Tab.VISUAL}>{t('Visual Diff')}</TabList.Item>
           </TabList>
+
           <Flex
             gap={space(2)}
+            column
             style={{
               // Using css to hide since the splitdiff uses the html from the iframes
               // TODO: This causes a bit of a flash when switching tabs
-              display: activeTab === 'visual' ? undefined : 'none',
+              display: activeTab === Tab.VISUAL ? undefined : 'none',
             }}
           >
-            <ReplayContextProvider
-              analyticsContext="replay_comparison_modal_left"
-              isFetching={fetching}
-              replay={replay}
-              initialTimeOffsetMs={{offsetMs: startOffset}}
-            >
-              <ComparisonSideWrapper id="leftSide">
-                <ReplaySide
-                  selector="#leftSide iframe"
-                  expectedTime={startOffset}
-                  onLoad={setLeftBody}
-                />
-              </ComparisonSideWrapper>
-            </ReplayContextProvider>
-            <ReplayContextProvider
-              analyticsContext="replay_comparison_modal_right"
-              isFetching={fetching}
-              replay={replay}
-              initialTimeOffsetMs={{offsetMs: rightTimestamp + 1}}
-            >
-              <ComparisonSideWrapper id="rightSide">
-                <ReplaySide
-                  selector="#rightSide iframe"
-                  expectedTime={rightTimestamp + 1}
-                  onLoad={setRightBody}
-                />
-              </ComparisonSideWrapper>
-            </ReplayContextProvider>
+            <DiffHeader>
+              <Flex flex="1" align="center">
+                {t('Before Hydration')}
+              </Flex>
+              <Flex flex="1" align="center">
+                {t('After Hydration')}
+              </Flex>
+            </DiffHeader>
+            <ReplayGrid>
+              <ReplayContextProvider
+                analyticsContext="replay_comparison_modal_left"
+                isFetching={fetching}
+                replay={replay}
+                initialTimeOffsetMs={{offsetMs: startOffset}}
+              >
+                <ComparisonSideWrapper id="leftSide">
+                  <ReplaySide
+                    selector="#leftSide iframe"
+                    expectedTime={startOffset}
+                    onLoad={setLeftBody}
+                  />
+                </ComparisonSideWrapper>
+              </ReplayContextProvider>
+              <ReplayContextProvider
+                analyticsContext="replay_comparison_modal_right"
+                isFetching={fetching}
+                replay={replay}
+                initialTimeOffsetMs={{offsetMs: rightTimestamp + 1}}
+              >
+                <ComparisonSideWrapper id="rightSide">
+                  {rightTimestamp > 0 ? (
+                    <ReplaySide
+                      selector="#rightSide iframe"
+                      expectedTime={rightTimestamp + 1}
+                      onLoad={setRightBody}
+                    />
+                  ) : (
+                    <div />
+                  )}
+                </ComparisonSideWrapper>
+              </ReplayContextProvider>
+            </ReplayGrid>
           </Flex>
-          {activeTab === 'html' && leftBody && rightBody ? (
+          {activeTab === Tab.HTML ? (
             <Fragment>
               <DiffHeader>
                 <Flex flex="1" align="center">
                   {t('Before Hydration')}
                   <CopyToClipboardButton
-                    text={leftBody}
+                    text={leftBody ?? ''}
                     size="xs"
                     iconSize="xs"
                     borderless
@@ -147,7 +168,7 @@ export default function ReplayComparisonModal({
                 <Flex flex="1" align="center">
                   {t('After Hydration')}
                   <CopyToClipboardButton
-                    text={rightBody}
+                    text={rightBody ?? ''}
                     size="xs"
                     iconSize="xs"
                     borderless
@@ -156,7 +177,7 @@ export default function ReplayComparisonModal({
                 </Flex>
               </DiffHeader>
               <SplitDiffScrollWrapper>
-                <SplitDiff base={leftBody} target={rightBody} type="words" />
+                <SplitDiff base={leftBody ?? ''} target={rightBody ?? ''} type="words" />
               </SplitDiffScrollWrapper>
             </Fragment>
           ) : null}
@@ -214,9 +235,18 @@ const DiffHeader = styled('div')`
   font-weight: 600;
   line-height: 1.2;
 
+  div {
+    height: 28px; /* div with and without buttons inside are the same height */
+  }
+
   div:last-child {
     padding-left: ${space(2)};
   }
+`;
+
+const ReplayGrid = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
 `;
 
 const StyledParagraph = styled('p')`

--- a/static/app/utils/replays/hydrateBreadcrumbs.tsx
+++ b/static/app/utils/replays/hydrateBreadcrumbs.tsx
@@ -19,8 +19,8 @@ function findCloseMutations(date: Date, rrwebFrames: RecordingFrame[]) {
   const framesBefore = incrementalFrames.filter(frame => frame.timestamp <= timeMS);
   const framesAfter = incrementalFrames.filter(frame => frame.timestamp > timeMS);
   return {
-    prev: framesBefore.slice(-1)[0] ?? null,
-    next: framesAfter[0] ?? null,
+    prev: framesBefore.at(-1) ?? null,
+    next: framesAfter.at(0) ?? null,
   };
 }
 


### PR DESCRIPTION
This improves the Hydration Diff modal in a few ways, especially when the 'next' mutation isn't found (or doesn't exist!)

Specifically: 
- `stopPropagation()` when the button is clicked to open the modal. Before we were opening the modal, and changing the timestamp of the replay at the same time 
- Adds the 'Before Hydration' 'After Hydration' headers to the left/right sides of the Visual Diff tab
- When the `next` migration is not found, render nothing in right side of the Visual Diff tab. Before we would render the replay at time=0, which is not correct
- Render a text diff when `next` migration is not found, where the right side text is assumed to be `''`. Before we passed in `null` and no html diff was rendered.
 
![SCR-20240212-mokv](https://github.com/getsentry/sentry/assets/187460/8073c5fe-546d-407a-918c-d17b484d8287)
![SCR-20240212-molj](https://github.com/getsentry/sentry/assets/187460/471ecca7-375c-4a96-97f6-289d75bd17dc)



Fixes #65023