### PR TITLE
ref: replace deprecated utcfromtimestamp

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -238,7 +238,7 @@ class EventSerializer(Serializer):
             # Sentry at one point attempted to record invalid types here.
             # Remove after June 2 2016
             try:
-                received = datetime.utcfromtimestamp(received).replace(tzinfo=timezone.utc)
+                received = datetime.fromtimestamp(received, timezone.utc)
             except TypeError:
                 received = None
 

--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -162,7 +162,7 @@ class Staff(ElevatedMode):
             current_datetime = django_timezone.now()
 
         try:
-            data["idl"] = datetime.utcfromtimestamp(float(data["idl"])).replace(tzinfo=timezone.utc)
+            data["idl"] = datetime.fromtimestamp(float(data["idl"]), timezone.utc)
         except (TypeError, ValueError):
             logger.warning(
                 "staff.invalid-idle-expiration",
@@ -179,7 +179,7 @@ class Staff(ElevatedMode):
             return
 
         try:
-            data["exp"] = datetime.utcfromtimestamp(float(data["exp"])).replace(tzinfo=timezone.utc)
+            data["exp"] = datetime.fromtimestamp(float(data["exp"]), timezone.utc)
         except (TypeError, ValueError):
             logger.warning(
                 "staff.invalid-expiration",

--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -20,7 +20,7 @@ from sentry.backup.findings import ComparatorFinding, ComparatorFindingKind, Ins
 from sentry.backup.helpers import Side
 from sentry.utils.json import JSONData
 
-UNIX_EPOCH = unix_zero_date = datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc).isoformat()
+UNIX_EPOCH = unix_zero_date = datetime.fromtimestamp(0, timezone.utc).isoformat()
 
 
 class ScrubbedData:

--- a/src/sentry/debug_files/artifact_bundle_indexing.py
+++ b/src/sentry/debug_files/artifact_bundle_indexing.py
@@ -80,13 +80,13 @@ class FlatFileMeta:
 
     @staticmethod
     def build_none():
-        return FlatFileMeta(id=-1, date=datetime.utcfromtimestamp(0))
+        return FlatFileMeta(id=-1, date=datetime.fromtimestamp(0))
 
     def to_string(self) -> str:
         return f"bundle_index/{self.id}/{int(self.date.timestamp() * 1000)}"
 
     def is_none(self):
-        return self.id == -1 and self.date == datetime.utcfromtimestamp(0)
+        return self.id == -1 and self.date == datetime.fromtimestamp(0)
 
 
 class FlatFileIdentifier(NamedTuple):

--- a/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/boost_latest_releases_bias.py
@@ -51,10 +51,10 @@ class BoostLatestReleasesBias(Bias):
                     },
                     "id": RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE] + idx,
                     "timeRange": {
-                        "start": datetime.utcfromtimestamp(boosted_release.timestamp).strftime(
+                        "start": datetime.fromtimestamp(boosted_release.timestamp).strftime(
                             self.datetime_format
                         ),
-                        "end": datetime.utcfromtimestamp(
+                        "end": datetime.fromtimestamp(
                             boosted_release.timestamp + boosted_release.platform.time_to_adoption
                         ).strftime(self.datetime_format),
                     },

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -426,7 +426,7 @@ class SnubaEventStorage(EventStorage):
         prev_filter = deepcopy(filter)
         prev_filter.conditions = prev_filter.conditions or []
         prev_filter.conditions.extend(get_before_event_condition(event))
-        prev_filter.start = datetime.utcfromtimestamp(0)
+        prev_filter.start = datetime.fromtimestamp(0)
         # the previous event can have the same timestamp, add 1 second
         # to the end condition since it uses a less than condition
         prev_filter.end = event.datetime + timedelta(seconds=1)

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -51,7 +51,7 @@ class GithubRateLimitInfo:
         self.used = info["used"]
 
     def next_window(self) -> str:
-        return datetime.utcfromtimestamp(self.reset).strftime("%H:%M:%S")
+        return datetime.fromtimestamp(self.reset).strftime("%H:%M:%S")
 
     def __repr__(self) -> str:
         return f"GithubRateLimitInfo(limit={self.limit},rem={self.remaining},reset={self.reset})"

--- a/src/sentry/integrations/gitlab/utils.py
+++ b/src/sentry/integrations/gitlab/utils.py
@@ -14,7 +14,7 @@ class GitLabRateLimitInfo:
         self.used = info["used"]
 
     def next_window(self) -> str:
-        return datetime.utcfromtimestamp(self.reset).strftime("%H:%M:%S")
+        return datetime.fromtimestamp(self.reset).strftime("%H:%M:%S")
 
     def __repr__(self) -> str:
         return f"GitLabRateLimitInfo(limit={self.limit},rem={self.remaining},reset={self.reset}),used={self.used})"

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -493,7 +493,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         def iso_format_snuba_datetime(date: str) -> str:
             return datetime.strptime(date, "%Y-%m-%dT%H:%M:%S+00:00").isoformat()[:19] + "Z"
 
-        formatted_unix_start_time = datetime.utcfromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        formatted_unix_start_time = datetime.fromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%S+00:00")
 
         def clean_date_string(d: str | None) -> str | None:
             # This check is added because if there are no sessions found, then the

--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -145,7 +145,7 @@ def track_initial_segment_event(
         key_id=key_id,
         outcome=Outcome.ACCEPTED,
         reason=None,
-        timestamp=datetime.utcfromtimestamp(received).replace(tzinfo=timezone.utc),
+        timestamp=datetime.fromtimestamp(received, timezone.utc),
         event_id=replay_id,
         category=DataCategory.REPLAY,
         quantity=1,

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -204,7 +204,7 @@ DATE_FORMAT = "%Y-%m-%d"
 
 
 def parse_unix_timestamp(value: str) -> datetime:
-    return datetime.utcfromtimestamp(float(value)).replace(tzinfo=timezone.utc)
+    return datetime.fromtimestamp(float(value), timezone.utc)
 
 
 def parse_iso_timestamp(value: str) -> datetime:

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -716,7 +716,7 @@ def _get_release_sessions_time_bounds(project_id, release, org_id, environments=
         referrer="sessions.release-sessions-time-bounds",
     )["data"]
 
-    formatted_unix_start_time = datetime.utcfromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    formatted_unix_start_time = datetime.fromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%S+00:00")
 
     if rows:
         rv = rows[0]

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -737,7 +737,7 @@ def massage_sessions_result_summary(
 
 
 def isoformat_z(date):
-    return datetime.utcfromtimestamp(int(to_timestamp(date))).isoformat() + "Z"
+    return datetime.fromtimestamp(int(to_timestamp(date))).isoformat() + "Z"
 
 
 def get_timestamps(query):
@@ -749,7 +749,7 @@ def get_timestamps(query):
     start = int(to_timestamp(query.start))
     end = int(to_timestamp(query.end))
 
-    return [datetime.utcfromtimestamp(ts).isoformat() + "Z" for ts in range(start, end, rollup)]
+    return [datetime.fromtimestamp(ts).isoformat() + "Z" for ts in range(start, end, rollup)]
 
 
 def _split_rows_groupby(rows, groupby):

--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -566,9 +566,7 @@ class RegressionDetector(ABC):
             regression_groups = []
 
             for version, prev_date_regressed, regression in regression_chunk:
-                date_regressed = datetime.utcfromtimestamp(regression["breakpoint"]).replace(
-                    tzinfo=timezone.utc
-                )
+                date_regressed = datetime.fromtimestamp(regression["breakpoint"], timezone.utc)
 
                 # enforce a buffer window after the date regressed after which the issue
                 # cannot be changed to regressed again to avoid the issue state changing frequently

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -72,7 +72,7 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
     project.update_option("sentry:_last_auto_resolve", int(time()))
 
     if cutoff:
-        cutoff = datetime.utcfromtimestamp(cutoff).replace(tzinfo=timezone.utc)
+        cutoff = datetime.fromtimestamp(cutoff, timezone.utc)
     else:
         cutoff = django_timezone.now() - timedelta(hours=int(age))
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -706,7 +706,7 @@ def create_failed_event(
     raw_event = RawEvent.objects.create(
         project_id=project_id,
         event_id=event_id,
-        datetime=datetime.utcfromtimestamp(data["timestamp"]).replace(tzinfo=timezone.utc),
+        datetime=datetime.fromtimestamp(data["timestamp"], timezone.utc),
         data=data,
     )
 

--- a/src/sentry/testutils/pytest/selenium.py
+++ b/src/sentry/testutils/pytest/selenium.py
@@ -533,7 +533,7 @@ def format_log(log):
     timestamp_format = "%Y-%m-%d %H:%M:%S.%f"
     entries = [
         "{0} {1[level]} - {1[message]}".format(
-            datetime.utcfromtimestamp(entry["timestamp"] / 1000.0).strftime(timestamp_format), entry
+            datetime.fromtimestamp(entry["timestamp"] / 1000.0).strftime(timestamp_format), entry
         ).rstrip()
         for entry in log
     ]

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -94,7 +94,7 @@ def parse_timestamp(value: Any) -> datetime | None:
     if isinstance(value, datetime):
         return value
     elif isinstance(value, (int, float)):
-        return datetime.utcfromtimestamp(value).replace(tzinfo=timezone.utc)
+        return datetime.fromtimestamp(value, timezone.utc)
     value = (value or "").rstrip("Z").encode("ascii", "replace").split(b".", 1)
     if not value:
         return None

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -16,7 +16,7 @@ from sentry.utils.canonical import CanonicalKeyDict
 from sentry.utils.dates import to_timestamp
 
 logger = logging.getLogger(__name__)
-epoch = datetime.utcfromtimestamp(0)
+epoch = datetime.fromtimestamp(0)
 
 
 def random_normal(mu, sigma, minimum, maximum=None):

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -43,12 +43,12 @@ def parametrize_backend(cls):
 
 def format_timestamp(dt):
     if not isinstance(dt, datetime):
-        dt = datetime.utcfromtimestamp(dt)
+        dt = datetime.fromtimestamp(dt)
     return dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
 
 
 def make_24h_stats(ts, adjust_start=False):
-    ret_val = _make_stats(datetime.utcfromtimestamp(ts).replace(tzinfo=timezone.utc), 3600, 24)
+    ret_val = _make_stats(datetime.fromtimestamp(ts, timezone.utc), 3600, 24)
 
     if adjust_start:
         # HACK this adds another interval at the beginning in accordance with the new way of calculating intervals
@@ -447,14 +447,14 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         )
 
         expected_formatted_lower_bound = (
-            datetime.utcfromtimestamp(self.session_started - 3600 * 2)
+            datetime.fromtimestamp(self.session_started - 3600 * 2)
             .replace(minute=0)
             .isoformat()[:19]
             + "Z"
         )
 
         expected_formatted_upper_bound = (
-            datetime.utcfromtimestamp(self.session_started).replace(minute=0).isoformat()[:19] + "Z"
+            datetime.fromtimestamp(self.session_started).replace(minute=0).isoformat()[:19] + "Z"
         )
 
         # Test for self.session_release


### PR DESCRIPTION
warning in python 3.12, fatal in python 3.14

<!-- Describe your PR here. -->