### PR TITLE
ref(weekly reports): Add spans to a couple functions

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -190,7 +190,8 @@ def prepare_organization_report(
     with sentry_sdk.start_span(op="weekly_reports.project_event_counts_for_organization"):
         project_event_counts_for_organization(ctx)
 
-    organization_project_issue_substatus_summaries(ctx)
+    with sentry_sdk.start_span(op="weekly_reports.organization_project_issue_substatus_summaries"):
+        organization_project_issue_substatus_summaries(ctx)
 
     with sentry_sdk.start_span(op="weekly_reports.project_passes"):
         # Run project passes
@@ -204,7 +205,8 @@ def prepare_organization_report(
     with sentry_sdk.start_span(op="weekly_reports.fetch_key_performance_issue_groups"):
         fetch_key_performance_issue_groups(ctx)
 
-    report_is_available = not check_if_ctx_is_empty(ctx)
+    with sentry_sdk.start_span(op="weekly_reports.check_if_ctx_is_empty"):
+        report_is_available = not check_if_ctx_is_empty(ctx)
     set_tag("report.available", report_is_available)
 
     if not report_is_available:


### PR DESCRIPTION
Add instrumentation to the 2 functions missing it in the weekly report task. This task is [very slow](https://sentry.sentry.io/performance/summary/?end=2024-02-12T09%3A59%3A47&project=1&query=&referrer=performance-transaction-summary&start=2024-02-11T21%3A02%3A11&transaction=sentry.tasks.weekly_reports.prepare_organization_report&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29) and it'd help us understand exactly what is slow better if we had everything instrumented.