### PR TITLE
fix(crons): Fix muted sort order on the monitor index

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -184,9 +184,9 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
         elif sort == "muted":
             queryset = queryset.annotate(
                 muted_ordering=Case(
-                    When(is_muted=True, then=Value(0)),
+                    When(is_muted=True, then=Value(2)),
                     When(Exists(monitor_environments_query.filter(is_muted=True)), then=Value(1)),
-                    default=2,
+                    default=0,
                 ),
             )
             sort_fields = ["muted_ordering", "name"]

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -142,7 +142,7 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
             self._create_monitor(name="A monitor"),
             self._create_monitor(name="ZA monitor"),
         ]
-        monitors.sort(key=lambda m: (not m.is_muted, m.name))
+        monitors.sort(key=lambda m: (m.is_muted, m.name))
 
         response = self.get_success_response(self.organization.slug, sort="muted")
         self.check_valid_response(response, monitors)
@@ -182,13 +182,13 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
 
         response = self.get_success_response(self.organization.slug, sort="muted")
         expected = [
-            muted_monitor_2,
-            muted_monitor_1,
-            muted_env_monitor,
-            muted_other_env_monitor,
             non_muted_monitor_2,
             non_muted_monitor_1,
             not_muted_env_monitor,
+            muted_env_monitor,
+            muted_other_env_monitor,
+            muted_monitor_2,
+            muted_monitor_1,
         ]
         self.check_valid_response(response, expected)
 
@@ -200,13 +200,13 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
             self.organization.slug, sort="muted", environment=["prod"]
         )
         expected = [
-            muted_monitor_2,
-            muted_monitor_1,
-            muted_env_monitor,
             non_muted_monitor_2,
             non_muted_monitor_1,
             muted_other_env_monitor,
             not_muted_env_monitor,
+            muted_env_monitor,
+            muted_monitor_2,
+            muted_monitor_1,
         ]
         self.check_valid_response(response, expected)
 


### PR DESCRIPTION
Fixing the sort order here, in other sorts, muted/disabled has a higher value than a valid status

<!-- Describe your PR here. -->