### PR TITLE
fix(ondemand): Ensure project is passed to querybuilder

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -573,6 +573,8 @@ class BaseQueryBuilder:
         if self.end:
             conditions.append(Condition(self.column("timestamp"), Op.LT, self.end))
 
+        if len(self.params.project_ids) == 0:
+            raise InvalidSearchQuery("Querying without projects will not return any results")
         conditions.append(
             Condition(
                 self.column("project_id"),

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -373,9 +373,11 @@ def _get_widget_query_low_cardinality(
 def _query_cardinality(
     query_columns: list[str], organization: Organization
 ) -> tuple[EventsResponse, list[str]]:
+    projects = Project.objects.filter(organization=organization)
     params: dict[str, Any] = {
         "statsPeriod": "30m",
         "organization_id": organization.id,
+        "project_objects": projects,
     }
     start, end = get_date_range_from_params(params)
     params["start"] = start

--- a/tests/sentry/tasks/test_on_demand_metrics.py
+++ b/tests/sentry/tasks/test_on_demand_metrics.py
@@ -16,7 +16,11 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.user import User
 from sentry.tasks import on_demand_metrics
-from sentry.tasks.on_demand_metrics import process_widget_specs, schedule_on_demand_check
+from sentry.tasks.on_demand_metrics import (
+    _query_cardinality,
+    process_widget_specs,
+    schedule_on_demand_check,
+)
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers import Feature, override_options
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -427,3 +431,10 @@ def assert_on_demand_model(
         return
 
     assert model.spec_hashes == expected_hashes[model.spec_version]  # Still include hashes
+
+
+@django_db_all
+@mock.patch("sentry.search.events.builder.discover.raw_snql_query")
+def test_query_cardinality(mock_query, project, organization):
+    _query_cardinality(["sometag"], organization)
+    assert mock_query.called


### PR DESCRIPTION
- This raises an error if there aren't any projects passed since the query would never return anything