### PR TITLE
ref(ddm): Remove metrics forwarding code from saas to s4s

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3927,9 +3927,6 @@ OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL: str | None = None
 SENTRY_METRICS_INTERFACE_BACKEND = "sentry.sentry_metrics.client.snuba.SnubaMetricsBackend"
 SENTRY_METRICS_INTERFACE_BACKEND_OPTIONS: dict[str, Any] = {}
 
-# Controls whether the SDK will send the metrics upstream to the S4S transport.
-SENTRY_SDK_UPSTREAM_METRICS_ENABLED = False
-
 # Backwards compatibility for URLs that don't
 # have enough context to route via organization.
 # New usage of these endpoints should use the region domains,

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -363,28 +363,7 @@ def configure_sdk():
                 # install_id = options.get('sentry:install-id')
                 # if install_id:
                 #     event.setdefault('tags', {})['install-id'] = install_id
-                s4s_args = args
-                # We want to control whether we want to send metrics at the s4s upstream.
-                if (
-                    not settings.SENTRY_SDK_UPSTREAM_METRICS_ENABLED
-                    and method_name == "capture_envelope"
-                ):
-                    args_list = list(args)
-                    envelope = args_list[0]
-                    # We filter out all the statsd envelope items, which contain custom metrics sent by the SDK.
-                    # unless we allow them via a separate sample rate.
-                    ddm_sample_rate = options.get("store.allow-s4s-ddm-sample-rate")
-                    safe_items = [
-                        x
-                        for x in envelope.items
-                        if x.data_category != "statsd" or random.random() < ddm_sample_rate
-                    ]
-                    if len(safe_items) != len(envelope.items):
-                        relay_envelope = copy.copy(envelope)
-                        relay_envelope.items = safe_items
-                        s4s_args = (relay_envelope, *args_list[1:])
-
-                getattr(sentry4sentry_transport, method_name)(*s4s_args, **kwargs)
+                getattr(sentry4sentry_transport, method_name)(*args, **kwargs)
 
             if sentry_saas_transport and options.get("store.use-relay-dsn-sample-rate") == 1:
                 # If this is an envelope ensure envelope and its items are distinct references


### PR DESCRIPTION
This PR removes the code that was guarding the `statsd` envelope items forwarding from saas to s4s.

As a follow up, we also need to remove `SENTRY_SDK_UPSTREAM_METRICS_ENABLED` in production configs.