### PR TITLE
feat(sdk-crashes): Add metrics

### DIFF
--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -1,6 +1,6 @@
 import abc
 from collections.abc import Sequence
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -202,3 +202,101 @@ def test_multiple_configs_first_one_picked(mock_sdk_crash_reporter, store_event)
     assert mock_sdk_crash_reporter.report.call_count == 1
     project_id = mock_sdk_crash_reporter.report.call_args.args[1]
     assert project_id == 1234
+
+
+@django_db_all
+@pytest.mark.snuba
+@patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection.sdk_crash_reporter")
+@patch("sentry.utils.metrics.incr")
+def test_should_increment_counters_for_sdk_crash(incr, sdk_crash_reporter, store_event):
+    event = store_event(data=get_crash_event())
+
+    sdk_configs = build_sdk_configs()
+    configs = [sdk_configs[0], sdk_configs[0]]
+
+    sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
+
+    incr.assert_has_calls(
+        [
+            call(
+                "post_process.sdk_crash_monitoring.detecting_sdk_crash",
+                tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+            ),
+            call(
+                "post_process.sdk_crash_monitoring.sdk_crash_detected",
+                tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+            ),
+        ],
+        any_order=True,
+    )
+
+
+@django_db_all
+@pytest.mark.snuba
+@patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection.sdk_crash_reporter")
+@patch("sentry.utils.metrics.incr")
+def test_should_only_increment_detecting_counter_for_non_crash_event(
+    incr, sdk_crash_reporter, store_event
+):
+    non_crash_event = store_event(data=get_crash_event(function="+[SentrySDK crash]"))
+
+    sdk_configs = build_sdk_configs()
+    configs = [sdk_configs[0], sdk_configs[0]]
+
+    sdk_crash_detection.detect_sdk_crash(event=non_crash_event, configs=configs)
+
+    incr.assert_called_with(
+        "post_process.sdk_crash_monitoring.detecting_sdk_crash",
+        tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+    )
+
+    # Ensure that the counter sdk_crash_detected is not incremented
+    for call_args in incr.call_args_list:
+        assert call_args[0][0] != "post_process.sdk_crash_monitoring.sdk_crash_detected"
+
+
+@django_db_all
+@pytest.mark.snuba
+@patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection.sdk_crash_reporter")
+@patch("sentry.utils.metrics.incr")
+def test_should_not_increment_counters_for_not_supported_sdk(incr, sdk_crash_reporter, store_event):
+    event_data = get_crash_event()
+    set_path(event_data, "sdk", "name", value="sentry.coco")
+    crash_event = store_event(data=event_data)
+
+    sdk_configs = build_sdk_configs()
+    configs = [sdk_configs[0], sdk_configs[0]]
+
+    sdk_crash_detection.detect_sdk_crash(event=crash_event, configs=configs)
+
+    # Ensure that no counter is incremented
+    for call_args in incr.call_args_list:
+        assert call_args[0][0] != "post_process.sdk_crash_monitoring.detecting_sdk_crash"
+        assert call_args[0][0] != "post_process.sdk_crash_monitoring.sdk_crash_detected"
+
+
+@django_db_all
+@pytest.mark.snuba
+@patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection.sdk_crash_reporter")
+@patch("sentry.utils.metrics.incr")
+def test_should_not_increment_counters_already_reported_sdk_crash(
+    incr, sdk_crash_reporter, store_event
+):
+    event_data = get_crash_event()
+    set_path(
+        event_data,
+        "contexts",
+        "sdk_crash_detection",
+        value={"original_project_id": 1234, "original_event_id": 1234},
+    )
+    crash_event = store_event(data=event_data)
+
+    sdk_configs = build_sdk_configs()
+    configs = [sdk_configs[0], sdk_configs[0]]
+
+    sdk_crash_detection.detect_sdk_crash(event=crash_event, configs=configs)
+
+    # Ensure that no counter is incremented
+    for call_args in incr.call_args_list:
+        assert call_args[0][0] != "post_process.sdk_crash_monitoring.detecting_sdk_crash"
+        assert call_args[0][0] != "post_process.sdk_crash_monitoring.sdk_crash_detected"


### PR DESCRIPTION
Add detecting_sdk_crash and sdk_crash_detected metrics to calculate crash rates per SDK and version.