### PR TITLE
fix(ddm): Fix wrong usage of interval and default to None null series

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -371,7 +371,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
         """
         Extracts the interval of the query from the request payload.
         """
-        interval = parse_stats_period(request.data.get("interval", "1h"))
+        interval = parse_stats_period(request.GET.get("interval", "1h"))
         return int(3600 if interval is None else interval.total_seconds())
 
     def _metrics_queries_plan_from_request(self, request: Request) -> MetricsQueriesPlan:

--- a/src/sentry/sentry_metrics/querying/data_v2/transformation.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from sentry.search.utils import parse_datetime_string
 from sentry.sentry_metrics.querying.data_v2.execution import QueryResult
-from sentry.sentry_metrics.querying.data_v2.utils import get_identity, nan_to_none
+from sentry.sentry_metrics.querying.data_v2.utils import nan_to_none
 from sentry.sentry_metrics.querying.errors import MetricsQueryExecutionError
 from sentry.sentry_metrics.querying.types import GroupKey, ResultValue, Series, Totals
 
@@ -199,11 +199,7 @@ class QueryTransformer:
                     {
                         "by": {name: value for name, value in group_key},
                         "series": _generate_full_series(
-                            int(start.timestamp()),
-                            len(intervals),
-                            interval,
-                            group_value.series,
-                            get_identity(group_value.totals),
+                            int(start.timestamp()), len(intervals), interval, group_value.series
                         ),
                         "totals": nan_to_none(group_value.totals),
                     }

--- a/src/sentry/sentry_metrics/querying/data_v2/utils.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/utils.py
@@ -3,23 +3,6 @@ import math
 from sentry.sentry_metrics.querying.types import ResultValue
 
 
-def get_identity(value: ResultValue) -> ResultValue:
-    """
-    Computes the identity of a value.
-
-    For nan, we want to return None instead of 0.0 but this is just a design decision that conforms
-    to the previous implementation of the layer.
-    """
-    if value is None:
-        return None
-
-    if is_nan(value):
-        return None
-
-    # We might decide in the future to have identity values specific to each aggregate.
-    return type(value)()
-
-
 def nan_to_none(value: ResultValue) -> ResultValue:
     """
     Converts a nan value to None or returns the original value.

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -106,7 +106,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             data = results["data"]
             assert len(data) == 1
             assert data[0][0]["by"] == {}
-            assert data[0][0]["series"] == [expected_identity, expected_identity, expected_identity]
+            assert data[0][0]["series"] == [None, None, None]
             assert data[0][0]["totals"] == expected_identity
 
     def test_query_with_one_aggregation(self) -> None:
@@ -126,7 +126,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [0.0, 12.0, 9.0]
+        assert data[0][0]["series"] == [None, 12.0, 9.0]
         assert data[0][0]["totals"] == 21.0
 
     def test_query_with_one_aggregation_and_environment(self) -> None:
@@ -146,7 +146,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [0.0, 6.0, 4.0]
+        assert data[0][0]["series"] == [None, 6.0, 4.0]
         assert data[0][0]["totals"] == 10.0
 
     def test_query_with_one_aggregation_and_latest_release(self) -> None:
@@ -166,7 +166,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [0.0, 6.0, 7.0]
+        assert data[0][0]["series"] == [None, 6.0, 7.0]
         assert data[0][0]["totals"] == 13.0
 
     def test_query_with_percentile(self) -> None:
@@ -186,7 +186,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [0.0, pytest.approx(5.8), 3.8]
+        assert data[0][0]["series"] == [None, pytest.approx(5.8), 3.8]
         assert data[0][0]["totals"] == 5.5
         # We want to test that the `Array(x)` is stripped away from the `type` of the aggregate.
         meta = results["meta"]
@@ -249,13 +249,13 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
         assert len(first_query) == 3
         assert first_query[0]["by"] == {"platform": "android", "transaction": "/hello"}
-        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["series"] == [None, 1.0, 2.0]
         assert first_query[0]["totals"] == 3.0
         assert first_query[1]["by"] == {"platform": "ios", "transaction": "/hello"}
-        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["series"] == [None, 6.0, 3.0]
         assert first_query[1]["totals"] == 9.0
         assert first_query[2]["by"] == {"platform": "windows", "transaction": "/world"}
-        assert first_query[2]["series"] == [0.0, 5.0, 4.0]
+        assert first_query[2]["series"] == [None, 5.0, 4.0]
         assert first_query[2]["totals"] == 9.0
         # We want to test that the `group_bys` are shown in the meta.
         meta = results["meta"]
@@ -330,10 +330,10 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
         assert len(first_query) == 2
         assert first_query[0]["by"] == {"platform": "android"}
-        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["series"] == [None, 1.0, 2.0]
         assert first_query[0]["totals"] == 3.0
         assert first_query[1]["by"] == {"platform": "ios"}
-        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["series"] == [None, 6.0, 3.0]
         assert first_query[1]["totals"] == 9.0
 
     def test_query_with_and_filter(self) -> None:
@@ -357,7 +357,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
         assert len(first_query) == 1
         assert first_query[0]["by"] == {"platform": "ios"}
-        assert first_query[0]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[0]["series"] == [None, 6.0, 3.0]
         assert first_query[0]["totals"] == 9.0
 
     def test_query_with_or_filter(self) -> None:
@@ -381,10 +381,10 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
         assert len(first_query) == 2
         assert first_query[0]["by"] == {"platform": "android"}
-        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["series"] == [None, 1.0, 2.0]
         assert first_query[0]["totals"] == 3.0
         assert first_query[1]["by"] == {"platform": "ios"}
-        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["series"] == [None, 6.0, 3.0]
         assert first_query[1]["totals"] == 9.0
 
     def test_query_one_negated_filter(self) -> None:
@@ -408,7 +408,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
         assert len(first_query) == 1
         assert first_query[0]["by"] == {"platform": "android"}
-        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["series"] == [None, 1.0, 2.0]
         assert first_query[0]["totals"] == 3.0
 
     def test_query_one_in_filter(self) -> None:
@@ -432,10 +432,10 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
         assert len(first_query) == 2
         assert first_query[0]["by"] == {"platform": "android"}
-        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["series"] == [None, 1.0, 2.0]
         assert first_query[0]["totals"] == 3.0
         assert first_query[1]["by"] == {"platform": "ios"}
-        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["series"] == [None, 6.0, 3.0]
         assert first_query[1]["totals"] == 9.0
 
     def test_query_one_not_in_filter(self) -> None:
@@ -459,7 +459,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
         assert len(first_query) == 1
         assert first_query[0]["by"] == {"platform": "windows"}
-        assert first_query[0]["series"] == [0.0, 5.0, 4.0]
+        assert first_query[0]["series"] == [None, 5.0, 4.0]
         assert first_query[0]["totals"] == 9.0
 
     def test_query_with_multiple_aggregations(self) -> None:
@@ -486,10 +486,10 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 2
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [0.0, 1.0, 2.0]
+        assert data[0][0]["series"] == [None, 1.0, 2.0]
         assert data[0][0]["totals"] == 1.0
         assert data[1][0]["by"] == {}
-        assert data[1][0]["series"] == [0.0, 6.0, 4.0]
+        assert data[1][0]["series"] == [None, 6.0, 4.0]
         assert data[1][0]["totals"] == 6.0
 
     def test_query_with_multiple_aggregations_and_single_group_by(self) -> None:
@@ -518,24 +518,24 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
         assert len(first_query) == 3
         assert first_query[0]["by"] == {"platform": "android"}
-        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["series"] == [None, 1.0, 2.0]
         assert first_query[0]["totals"] == 1.0
         assert first_query[1]["by"] == {"platform": "ios"}
-        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["series"] == [None, 6.0, 3.0]
         assert first_query[1]["totals"] == 3.0
         assert first_query[2]["by"] == {"platform": "windows"}
-        assert first_query[2]["series"] == [0.0, 5.0, 4.0]
+        assert first_query[2]["series"] == [None, 5.0, 4.0]
         assert first_query[2]["totals"] == 4.0
         second_query = sorted(data[1], key=lambda value: value["by"]["platform"])
         assert len(second_query) == 3
         assert second_query[0]["by"] == {"platform": "android"}
-        assert second_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert second_query[0]["series"] == [None, 1.0, 2.0]
         assert second_query[0]["totals"] == 2.0
         assert second_query[1]["by"] == {"platform": "ios"}
-        assert second_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert second_query[1]["series"] == [None, 6.0, 3.0]
         assert second_query[1]["totals"] == 6.0
         assert second_query[2]["by"] == {"platform": "windows"}
-        assert second_query[2]["series"] == [0.0, 5.0, 4.0]
+        assert second_query[2]["series"] == [None, 5.0, 4.0]
         assert second_query[2]["totals"] == 5.0
 
     def test_query_with_multiple_aggregations_and_single_group_by_and_order_by_with_limit(
@@ -566,18 +566,18 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
         assert len(first_query) == 2
         assert first_query[0]["by"] == {"platform": "android"}
-        assert first_query[0]["series"] == [0.0, 1.0, 2.0]
+        assert first_query[0]["series"] == [None, 1.0, 2.0]
         assert first_query[0]["totals"] == 1.0
         assert first_query[1]["by"] == {"platform": "ios"}
-        assert first_query[1]["series"] == [0.0, 6.0, 3.0]
+        assert first_query[1]["series"] == [None, 6.0, 3.0]
         assert first_query[1]["totals"] == 3.0
         second_query = sorted(data[1], key=lambda value: value["by"]["platform"])
         assert len(second_query) == 2
         assert second_query[0]["by"] == {"platform": "ios"}
-        assert second_query[0]["series"] == [0.0, 6.0, 3.0]
+        assert second_query[0]["series"] == [None, 6.0, 3.0]
         assert second_query[0]["totals"] == 6.0
         assert second_query[1]["by"] == {"platform": "windows"}
-        assert second_query[1]["series"] == [0.0, 5.0, 4.0]
+        assert second_query[1]["series"] == [None, 5.0, 4.0]
         assert second_query[1]["totals"] == 5.0
         # We want to test that the correct order and limit are in the meta.
         meta = results["meta"]
@@ -617,7 +617,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [0, 2, 0]
+        assert data[0][0]["series"] == [None, 2, None]
         assert data[0][0]["totals"] == 2
 
     def test_query_with_one_metric_blocked_for_one_project(self):
@@ -656,7 +656,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [0.0, 15.0, 0.0]
+        assert data[0][0]["series"] == [None, 15.0, None]
         assert data[0][0]["totals"] == 15.0
 
     def test_query_with_one_metric_blocked_for_all_projects(self):
@@ -740,7 +740,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert len(data) == 2
         assert len(data[0]) == 0
         assert data[1][0]["by"] == {}
-        assert data[1][0]["series"] == [0.0, 10.0, 0.0]
+        assert data[1][0]["series"] == [None, 10.0, None]
         assert data[1][0]["totals"] == 10.0
 
     def test_query_with_invalid_syntax(


### PR DESCRIPTION
This PR fixes the wrong usage of `interval` which was obtained from the `data` instead of `GET` params. In addition, it also applies the `None` conversion as default to timeseries with no values.