### PR TITLE
ref(ddm): single query component

### DIFF
--- a/static/app/views/ddm/queries.tsx
+++ b/static/app/views/ddm/queries.tsx
@@ -39,53 +39,87 @@ export function Queries() {
     <Wrapper showQuerySymbols={showQuerySymbols}>
       {widgets.map((widget, index) => (
         <Row key={index} onFocusCapture={() => setSelectedWidgetIndex(index)}>
-          {showQuerySymbols && (
-            <StyledQuerySymbol
-              index={index}
-              isSelected={index === selectedWidgetIndex}
-              onClick={() => setSelectedWidgetIndex(index)}
-              role="button"
-              aria-label={t('Select query')}
-            />
-          )}
-          <QueryBuilder
+          <Query
+            widget={widget}
             onChange={data => handleChange(index, data)}
-            metricsQuery={{
-              mri: widget.mri,
-              op: widget.op,
-              groupBy: widget.groupBy,
-              query: widget.query,
-            }}
-            displayType={widget.displayType}
-            isEdit
             projects={selection.projects}
+            symbol={
+              showQuerySymbols && (
+                <StyledQuerySymbol
+                  index={index}
+                  isSelected={index === selectedWidgetIndex}
+                  onClick={() => setSelectedWidgetIndex(index)}
+                  role="button"
+                  aria-label={t('Select query')}
+                />
+              )
+            }
+            contextMenu={
+              <Feature
+                hookName="feature-disabled:dashboards-edit"
+                features="organizations:dashboards-edit"
+              >
+                {({hasFeature}) => (
+                  <MetricQueryContextMenu
+                    displayType={widget.displayType}
+                    widgetIndex={index}
+                    hasDashboardFeature={hasFeature}
+                    metricsQuery={{
+                      mri: widget.mri,
+                      query: widget.query,
+                      op: widget.op,
+                      groupBy: widget.groupBy,
+                      projects: selection.projects,
+                      datetime: selection.datetime,
+                      environments: selection.environments,
+                    }}
+                  />
+                )}
+              </Feature>
+            }
           />
-          <Feature
-            hookName="feature-disabled:dashboards-edit"
-            features="organizations:dashboards-edit"
-          >
-            {({hasFeature}) => (
-              <MetricQueryContextMenu
-                displayType={widget.displayType}
-                widgetIndex={index}
-                hasDashboardFeature={hasFeature}
-                metricsQuery={{
-                  mri: widget.mri,
-                  query: widget.query,
-                  op: widget.op,
-                  groupBy: widget.groupBy,
-                  projects: selection.projects,
-                  datetime: selection.datetime,
-                  environments: selection.environments,
-                }}
-              />
-            )}
-          </Feature>
         </Row>
       ))}
     </Wrapper>
   );
 }
+
+interface Props {
+  onChange: (data: Partial<MetricWidgetQueryParams>) => void;
+  projects: number[];
+  widget: MetricWidgetQueryParams;
+  contextMenu?: React.ReactNode;
+  symbol?: React.ReactNode;
+}
+
+export function Query({widget, projects, onChange, contextMenu, symbol}: Props) {
+  return (
+    <QueryWrapper hasSymbol={!!symbol}>
+      {symbol}
+      <QueryBuilder
+        onChange={onChange}
+        metricsQuery={{
+          mri: widget.mri,
+          op: widget.op,
+          groupBy: widget.groupBy,
+          query: widget.query,
+        }}
+        displayType={widget.displayType}
+        isEdit
+        projects={projects}
+      />
+      {contextMenu}
+    </QueryWrapper>
+  );
+}
+
+const QueryWrapper = styled('div')<{hasSymbol: boolean}>`
+  display: grid;
+  gap: ${space(1)};
+  padding-bottom: ${space(1)};
+  grid-template-columns: 1fr max-content;
+  ${p => p.hasSymbol && `grid-template-columns: min-content 1fr max-content;`}
+`;
 
 const StyledQuerySymbol = styled(QuerySymbol)`
   margin-top: 10px;
@@ -94,15 +128,6 @@ const StyledQuerySymbol = styled(QuerySymbol)`
 
 const Wrapper = styled('div')<{showQuerySymbols: boolean}>`
   padding-bottom: ${space(2)};
-  display: grid;
-  grid-template-columns: 1fr max-content;
-  gap: ${space(1)};
-
-  ${p =>
-    p.showQuerySymbols &&
-    `
-    grid-template-columns: min-content 1fr max-content;
-  `}
 `;
 
 const Row = styled('div')`

--- a/static/app/views/ddm/sampleTable.tsx
+++ b/static/app/views/ddm/sampleTable.tsx
@@ -57,7 +57,7 @@ function sortAndLimitSpans(samples?: SpanSummary[], limit: number = 5) {
   ]);
 }
 
-interface SamplesTableProps extends SelectionRange {
+export interface SamplesTableProps extends SelectionRange {
   mri?: MRI;
   onRowHover?: (sampleId?: string) => void;
   query?: string;

--- a/static/app/views/ddm/widgetDetails.tsx
+++ b/static/app/views/ddm/widgetDetails.tsx
@@ -12,6 +12,7 @@ import type {MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import {CodeLocations} from 'sentry/views/ddm/codeLocations';
 import {useDDMContext} from 'sentry/views/ddm/context';
+import type {SamplesTableProps} from 'sentry/views/ddm/sampleTable';
 import {SampleTable} from 'sentry/views/ddm/sampleTable';
 import {getQueryWithFocusedSeries} from 'sentry/views/ddm/utils';
 
@@ -83,19 +84,12 @@ export function WidgetDetails() {
         <ContentWrapper>
           <TabPanels>
             <TabPanels.Item key={Tab.SAMPLES}>
-              {organization.features.includes('metrics-samples-list') ? (
-                <MetricSamplesTable
-                  mri={selectedWidget?.mri}
-                  query={queryWithFocusedSeries}
-                />
-              ) : (
-                <SampleTable
-                  mri={selectedWidget?.mri}
-                  query={queryWithFocusedSeries}
-                  {...focusArea?.selection?.range}
-                  onRowHover={handleSampleRowHover}
-                />
-              )}
+              <MetricSamplesTab
+                mri={selectedWidget?.mri}
+                query={queryWithFocusedSeries}
+                {...focusArea?.selection?.range}
+                onRowHover={handleSampleRowHover}
+              />
             </TabPanels.Item>
             <TabPanels.Item key={Tab.CODE_LOCATIONS}>
               <CodeLocations mri={selectedWidget?.mri} {...focusArea?.selection?.range} />
@@ -105,6 +99,15 @@ export function WidgetDetails() {
       </Tabs>
     </TrayWrapper>
   );
+}
+
+export function MetricSamplesTab({mri, query, onRowHover, ...range}: SamplesTableProps) {
+  const organization = useOrganization();
+
+  if (organization.features.includes('metrics-samples-list')) {
+    return <MetricSamplesTable mri={mri} query={query} />;
+  }
+  return <SampleTable mri={mri} query={query} {...range} onRowHover={onRowHover} />;
 }
 
 const TrayWrapper = styled('div')`


### PR DESCRIPTION
- Part of: #64548 

Refactors `Queries` component, extracting a single `Query` that can be reused
Exports `MetricsSamplesTab` that abstracts the feature flag check

Allows us to recreate ddm layout without ddm context dependency in the following way: 

```typescript
<Query
  widget={metricWidget}
  projects={selection.projects}
  onChange={() => {}}
/>
<MetricWidget
  widget={metricWidget}
  onChange={() => {}}
  datetime={selection.datetime}
  projects={selection.projects}
  environments={selection.environments}
/>
<MetricSamplesTab mri={metricWidget.mri} />
```