### PR TITLE
chore(apis): Make more processing endpoints private

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -39,7 +39,7 @@ MAX_RELEASEFILES_QUERY = 10
 class ProjectArtifactLookupEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_PROCESSING
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -509,8 +509,8 @@ class DifAssembleEndpoint(ProjectEndpoint):
 class SourceMapsEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_PROCESSING
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
+++ b/src/sentry/api/endpoints/organization_artifactbundle_assemble.py
@@ -25,7 +25,7 @@ from sentry.utils import json
 class OrganizationArtifactBundleAssembleEndpoint(OrganizationReleasesBaseEndpoint):
     owner = ApiOwner.OWNERS_PROCESSING
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
     def post(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/project_artifact_bundle_file_details.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_file_details.py
@@ -50,7 +50,7 @@ class ProjectArtifactBundleFileDetailsEndpoint(
 ):
     owner = ApiOwner.OWNERS_PROCESSING
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/api/endpoints/project_artifact_bundle_files.py
+++ b/src/sentry/api/endpoints/project_artifact_bundle_files.py
@@ -55,7 +55,7 @@ class ArtifactBundleSource:
 class ProjectArtifactBundleFilesEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_PROCESSING
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
     rate_limits = RateLimitConfig(


### PR DESCRIPTION
These endpoints were transferred to the Processing team in https://github.com/getsentry/sentry/pull/64997. None of them are meant to be user-facing, so we make them all private.