### PR TITLE
feat(ddm): Implement bulk querying engine for metrics queries

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -423,7 +423,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
 
 class MetricsSamplesSerializer(serializers.Serializer):
     mri = serializers.CharField(required=True)
-    field = serializers.ListField(required=True, allow_empty=False, child=serializers.DictField())
+    field = serializers.ListField(required=True, allow_empty=False, child=serializers.CharField())
 
     def validate_mri(self, mri: str):
         if not is_mri(mri):

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -378,6 +378,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
         """
         Extracts the metrics queries plan from the request payload.
         """
+        # TODO: maybe we could use a serializer to read the body of the request.
         metrics_queries_plan = MetricsQueriesPlan()
 
         queries = request.data.get("queries") or []
@@ -406,7 +407,6 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
                 end=end,
                 interval=interval,
                 organization=organization,
-                # TODO: figure out how to make these methods work with HTTP body.
                 projects=self.get_projects(request, organization),
                 environments=self.get_environments(request, organization),
                 referrer=Referrer.API_DDM_METRICS_QUERY.value,
@@ -423,7 +423,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
 
 class MetricsSamplesSerializer(serializers.Serializer):
     mri = serializers.CharField(required=True)
-    field = serializers.ListField(required=True, allow_empty=False, child=serializers.CharField())
+    field = serializers.ListField(required=True, allow_empty=False, child=serializers.DictField())
 
     def validate_mri(self, mri: str):
         if not is_mri(mri):

--- a/src/sentry/sentry_metrics/querying/data_v2/api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/api.py
@@ -1,5 +1,6 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
+from typing import Any
 
 from snuba_sdk import MetricsQuery, MetricsScope, Rollup
 
@@ -22,7 +23,7 @@ def run_metrics_queries_plan(
     projects: Sequence[Project],
     environments: Sequence[Environment],
     referrer: str,
-):
+) -> Mapping[str, Any]:
     # For now, if the query plan is empty, we return an empty dictionary. In the future, we might want to default
     # to a better data type.
     if metrics_queries_plan.is_empty():

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -1,7 +1,8 @@
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Any
+from enum import Enum
+from typing import Any, Union, cast
 
 import sentry_sdk
 from snuba_sdk import Column, Direction, MetricsQuery, MetricsScope, Request
@@ -11,10 +12,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.querying.common import DEFAULT_QUERY_INTERVALS, SNUBA_QUERY_LIMIT
 from sentry.sentry_metrics.querying.data_v2.plan import QueryOrder
-from sentry.sentry_metrics.querying.errors import (
-    InvalidMetricsQueryError,
-    MetricsQueryExecutionError,
-)
+from sentry.sentry_metrics.querying.errors import MetricsQueryExecutionError
 from sentry.sentry_metrics.querying.types import GroupKey, GroupsCollection
 from sentry.sentry_metrics.querying.visitors import (
     QueriedMetricsVisitor,
@@ -24,7 +22,7 @@ from sentry.sentry_metrics.querying.visitors import (
 from sentry.sentry_metrics.visibility import get_metrics_blocking_state
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics import to_intervals
-from sentry.snuba.metrics_layer.query import run_query
+from sentry.snuba.metrics_layer.query import bulk_run_query
 from sentry.utils import metrics
 from sentry.utils.snuba import SnubaError
 
@@ -99,160 +97,212 @@ def _build_aligned_seq(
     return aligned_seq
 
 
-@dataclass(frozen=True)
-class ExecutableQuery:
-    with_series: bool
-    with_totals: bool
+def _push_down_group_filters(
+    metrics_query: MetricsQuery, groups_collection: GroupsCollection | None
+) -> MetricsQuery:
+    """
+    Returns a new `MetricsQuery` with a series of filters that ensure that the new query will have the same
+    groups returned. Keep in mind that there is no guarantee that all the groups will be returned, since data might
+    change in the meanwhile, so the guarantee of this method is that the returned groups will all be belonging to
+    `groups_collection`.
 
-    identifier: str
+    The need for this filter arises because when executing multiple queries, we want to have the same groups
+    returned, in order to make results consistent. Note that in case queries have different groups, some results
+    might be missing, since the reference query dictates which values are returned during the alignment process.
+    """
+    if not groups_collection:
+        return metrics_query
+
+    # We perform a transformation in the form [(key_1 = value_1 AND key_2 = value_2) OR (key_3 = value_3)].
+    groups_filters = []
+    for groups in groups_collection:
+        inner_snuba_filters = []
+        for filter_key, filter_value in groups:
+            inner_snuba_filters.append(Condition(Column(filter_key), Op.EQ, filter_value))
+
+        # In case we have more than one filter, we have to group them into an `AND`.
+        if len(inner_snuba_filters) > 1:
+            groups_filters.append(BooleanCondition(BooleanOp.AND, inner_snuba_filters))
+        else:
+            groups_filters.append(inner_snuba_filters[0])
+
+    # In case we have more than one filter, we have to group them into an `OR`.
+    if len(groups_filters) > 1:
+        groups_filters = [BooleanCondition(BooleanOp.OR, groups_filters)]
+
+    merged_query = TimeseriesConditionInjectionVisitor(groups_filters).visit(metrics_query.query)
+    return metrics_query.set_query(merged_query)
+
+
+class ScheduledQueryType(Enum):
+    SERIES = 0
+    TOTALS = 1
+
+
+@dataclass(frozen=True)
+class ScheduledQuery:
+    type: ScheduledQueryType
     metrics_query: MetricsQuery
+    next: Union["ScheduledQuery", None]
     order: QueryOrder | None
     limit: int | None
+
+    def initialize(
+        self,
+        organization: Organization,
+        projects: Sequence[Project],
+        blocked_metrics_for_projects: Mapping[str, set[int]],
+    ) -> "ScheduledQuery":
+        updated_metrics_query = self.metrics_query
+
+        # We filter out all the projects for which the queried metrics are blocked.
+        updated_metrics_query = self._filter_blocked_projects(
+            updated_metrics_query, organization, projects, blocked_metrics_for_projects
+        )
+        # We align the date range of the query, considering the supplied interval.
+        updated_metrics_query = self._align_date_range(updated_metrics_query)
+
+        if self.type == ScheduledQueryType.SERIES:
+            updated_metrics_query = self._initialize_series(updated_metrics_query)
+        elif self.type == ScheduledQueryType.TOTALS:
+            updated_metrics_query = self._initialize_totals(updated_metrics_query)
+
+        # We recursively apply the initialization transformations downstream.
+        updated_next = None
+        if self.next is not None:
+            updated_next = self.next.initialize(
+                organization, projects, blocked_metrics_for_projects
+            )
+
+        return replace(self, metrics_query=updated_metrics_query, next=updated_next)
+
+    def _initialize_series(self, metrics_query: MetricsQuery) -> MetricsQuery:
+        updated_metrics_query = metrics_query
+
+        # A series query runs always up to the maximum query limit.
+        updated_metrics_query = updated_metrics_query.set_limit(SNUBA_QUERY_LIMIT)
+
+        return updated_metrics_query
+
+    def _initialize_totals(self, metrics_query: MetricsQuery) -> MetricsQuery:
+        updated_metrics_query = metrics_query
+
+        # A totals query doesn't have an interval.
+        updated_metrics_query = updated_metrics_query.set_rollup(
+            replace(updated_metrics_query.rollup, interval=None, totals=True)
+        )
+
+        if self.order:
+            updated_metrics_query = updated_metrics_query.set_rollup(
+                replace(updated_metrics_query.rollup, orderby=self.order.to_snuba_order())
+            )
+
+        if self.limit:
+            updated_metrics_query = updated_metrics_query.set_limit(self.limit)
+        else:
+            updated_metrics_query = updated_metrics_query.set_limit(SNUBA_QUERY_LIMIT)
+
+        return updated_metrics_query
+
+    def has_next(self):
+        return self.next is not None
 
     def is_empty(self) -> bool:
         return not self.metrics_query.scope.org_ids or not self.metrics_query.scope.project_ids
 
-    def replace_date_range(self, start: datetime, end: datetime) -> "ExecutableQuery":
-        return replace(
-            self,
-            metrics_query=self.metrics_query.set_start(start).set_end(end),
-        )
-
-    def replace_limit(self, limit: int = SNUBA_QUERY_LIMIT) -> "ExecutableQuery":
-        return replace(
-            self,
-            metrics_query=self.metrics_query.set_limit(limit),
-        )
-
-    def replace_interval(self, new_interval: int) -> "ExecutableQuery":
-        return replace(
-            self,
-            metrics_query=self.metrics_query.set_rollup(
-                replace(self.metrics_query.rollup, interval=new_interval)
-            ),
-        )
-
-    def replace_order_by(self, direction: Direction) -> "ExecutableQuery":
-        return replace(
-            self,
-            metrics_query=self.metrics_query.set_rollup(
-                replace(self.metrics_query.rollup, interval=None, totals=True, orderby=direction)
-            ),
-        )
-
-    def to_totals_query(self) -> "ExecutableQuery":
-        return replace(
-            self,
-            metrics_query=self.metrics_query.set_rollup(
-                # If an order_by is used, we must run a totals query.
-                replace(self.metrics_query.rollup, interval=None, totals=True)
-            ),
-        )
-
-    def add_group_filters(
-        self,
-        groups_collection: GroupsCollection | None,
-    ) -> "ExecutableQuery":
-        """
-        Returns a new `ExecutableQuery` with a series of filters that ensure that the new query will have the same
-        groups returned. Keep in mind that there is no guarantee that all the groups will be returned, since data might
-        change in the meanwhile, so the guarantee of this method is that the returned groups will all be belonging to
-        `groups_collection`.
-
-        The need for this filter arises because when executing multiple queries, we want to have the same groups
-        returned, in order to make results consistent. Note that in case queries have different groups, some results
-        might be missing, since the reference query dictates which values are returned during the alignment process.
-        """
-        if not groups_collection:
-            return self
-
-        # We perform a transformation in the form [(key_1 = value_1 AND key_2 = value_2) OR (key_3 = value_3)].
-        groups_filters = []
-        for groups in groups_collection:
-            inner_snuba_filters = []
-            for filter_key, filter_value in groups:
-                inner_snuba_filters.append(Condition(Column(filter_key), Op.EQ, filter_value))
-
-            # In case we have more than one filter, we have to group them into an `AND`.
-            if len(inner_snuba_filters) > 1:
-                groups_filters.append(BooleanCondition(BooleanOp.AND, inner_snuba_filters))
-            else:
-                groups_filters.append(inner_snuba_filters[0])
-
-        # In case we have more than one filter, we have to group them into an `OR`.
-        if len(groups_filters) > 1:
-            groups_filters = [BooleanCondition(BooleanOp.OR, groups_filters)]
-
-        merged_query = TimeseriesConditionInjectionVisitor(groups_filters).visit(
-            self.metrics_query.query
-        )
-        return replace(
-            self,
-            metrics_query=self.metrics_query.set_query(merged_query),
-        )
-
-    def filter_blocked_projects(
-        self,
+    @classmethod
+    def _filter_blocked_projects(
+        cls,
+        metrics_query: MetricsQuery,
         organization: Organization,
-        projects: set[Project],
+        projects: Sequence[Project],
         blocked_metrics_for_projects: Mapping[str, set[int]],
-    ) -> "ExecutableQuery":
-        """
-        Returns a new `ExecutableQuery` with the projects for which all the queries are not blocked. In case no projects
-        exist, the query will be returned with empty projects, signaling the executor to not run the query.
-        """
+    ) -> MetricsQuery:
         intersected_projects: set[int] = {project.id for project in projects}
 
-        for queried_metric in QueriedMetricsVisitor().visit(self.metrics_query.query):
+        for queried_metric in QueriedMetricsVisitor().visit(metrics_query.query):
             blocked_for_projects = blocked_metrics_for_projects.get(queried_metric)
             if blocked_for_projects:
                 metrics.incr(key="ddm.metrics_api.blocked_metric_queried", amount=1)
                 intersected_projects -= blocked_for_projects
 
-        return replace(
-            self,
-            metrics_query=self.metrics_query.set_scope(
-                MetricsScope(
-                    org_ids=[organization.id],
-                    project_ids=list(intersected_projects),
-                )
-            ),
+        return metrics_query.set_scope(
+            MetricsScope(
+                org_ids=[organization.id],
+                project_ids=list(intersected_projects),
+            )
         )
+
+    @classmethod
+    def _align_date_range(cls, metrics_query: MetricsQuery) -> MetricsQuery:
+        # We use as a reference the interval supplied via the initial version of the query.
+        interval = metrics_query.rollup.interval
+        if interval:
+            modified_start, modified_end, _ = to_intervals(
+                metrics_query.start,
+                metrics_query.end,
+                interval,
+            )
+            if modified_start and modified_end:
+                return metrics_query.set_start(modified_start).set_end(modified_end)
+
+        return metrics_query
 
 
 @dataclass(frozen=True)
 class QueryResult:
-    series_executable_query: ExecutableQuery | None
-    totals_executable_query: ExecutableQuery | None
+    series_executable_query: MetricsQuery | None
+    totals_executable_query: MetricsQuery | None
     result: Mapping[str, Any]
 
     def __post_init__(self):
         assert self.series_executable_query or self.totals_executable_query
 
     @classmethod
-    def empty_from(cls, executable_query: ExecutableQuery) -> "QueryResult":
+    def empty_from(cls, metrics_query: MetricsQuery) -> "QueryResult":
         return QueryResult(
-            series_executable_query=executable_query,
-            totals_executable_query=executable_query,
+            series_executable_query=metrics_query,
+            totals_executable_query=metrics_query,
             result={
                 "series": {"data": {}, "meta": {}},
                 "totals": {"data": {}, "meta": {}},
                 # We want to honor the date ranges of the supplied query.
-                "modified_start": executable_query.metrics_query.start,
-                "modified_end": executable_query.metrics_query.end,
+                "modified_start": metrics_query.start,
+                "modified_end": metrics_query.end,
             },
         )
 
-    @property
-    def query_name(self) -> str:
-        if self.series_executable_query:
-            return self.series_executable_query.identifier
+    @classmethod
+    def from_query_type(
+        cls, query_type: ScheduledQueryType, query: MetricsQuery, query_result: Mapping[str, Any]
+    ) -> "QueryResult":
+        extended_result = {
+            "modified_start": query_result["modified_start"],
+            "modified_end": query_result["modified_end"],
+        }
 
-        if self.totals_executable_query:
-            return self.totals_executable_query.identifier
+        if query_type == ScheduledQueryType.SERIES:
+            extended_result["series"] = query_result
+            return QueryResult(
+                series_executable_query=query,
+                totals_executable_query=None,
+                result=extended_result,
+            )
+        elif query_type == ScheduledQueryType.TOTALS:
+            extended_result["totals"] = query_result
+            return QueryResult(
+                series_executable_query=None,
+                totals_executable_query=query,
+                result=extended_result,
+            )
 
-        raise InvalidMetricsQueryError(
-            "Unable to determine the query name for a result with no queries"
+        raise MetricsQueryExecutionError(f"Can't build query result from query type {query_type}")
+
+    def merge(self, other: "QueryResult") -> "QueryResult":
+        return QueryResult(
+            series_executable_query=self.series_executable_query or other.series_executable_query,
+            totals_executable_query=self.totals_executable_query or other.totals_executable_query,
+            result={**self.result, **other.result},
         )
 
     @property
@@ -270,7 +320,7 @@ class QueryResult:
                 "You have to run a timeseries query in order to use the interval"
             )
 
-        return self.series_executable_query.metrics_query.rollup.interval
+        return self.series_executable_query.rollup.interval
 
     @property
     def series(self) -> Sequence[Mapping[str, Any]]:
@@ -300,24 +350,17 @@ class QueryResult:
         #
         # Sorting of the groups is done to maintain consistency across function calls.
         if self.series_executable_query:
-            return sorted(
-                UsedGroupBysVisitor().visit(self.series_executable_query.metrics_query.query)
-            )
+            return sorted(UsedGroupBysVisitor().visit(self.series_executable_query.query))
 
         if self.totals_executable_query:
-            return sorted(
-                UsedGroupBysVisitor().visit(self.totals_executable_query.metrics_query.query)
-            )
+            return sorted(UsedGroupBysVisitor().visit(self.totals_executable_query.query))
 
         return []
 
     @property
-    def order(self) -> str | None:
-        if self.series_executable_query and self.series_executable_query.order is not None:
-            return self.series_executable_query.order.value
-
-        if self.totals_executable_query and self.totals_executable_query.order is not None:
-            return self.totals_executable_query.order.value
+    def order(self) -> Direction | None:
+        if self.totals_executable_query:
+            return self.totals_executable_query.rollup.orderby
 
         return None
 
@@ -373,6 +416,19 @@ class QueryResult:
         return self
 
 
+@dataclass(frozen=True)
+class PartialQueryResult:
+    scheduled_query: ScheduledQuery
+    executed_result: Mapping[str, Any]
+
+    def to_query_result(self) -> QueryResult:
+        return QueryResult.from_query_type(
+            query_type=self.scheduled_query.type,
+            query=self.scheduled_query.metrics_query,
+            query_result=self.executed_result,
+        )
+
+
 class QueryExecutor:
     def __init__(self, organization: Organization, projects: Sequence[Project], referrer: str):
         self._organization = organization
@@ -383,9 +439,12 @@ class QueryExecutor:
         # to avoid an infinite recursion.
         self._interval_choices = sorted(DEFAULT_QUERY_INTERVALS)
         # List of queries scheduled for execution.
-        self._scheduled_queries: list[ExecutableQuery] = []
+        self._scheduled_queries: list[ScheduledQuery] = []
         # Tracks the number of queries that have been executed (for measuring purposes).
         self._number_of_executed_queries = 0
+        # Tracks the pending query results that have been run by the executor. The list will contain both the final
+        # `QueryResult` objects and the partial `PartialQueryResult` objects that still have to be executed.
+        self._pending_query_results: list[QueryResult | PartialQueryResult] = []
 
         # We load the blocked metrics for the supplied projects.
         self._blocked_metrics_for_projects = self._load_blocked_metrics_for_projects()
@@ -419,134 +478,83 @@ class QueryExecutor:
             tenant_ids={"referrer": self._referrer, "organization_id": self._organization.id},
         )
 
-    def _execute(self, executable_query: ExecutableQuery) -> QueryResult:
-        """
-        Executes a query as series and/or totals and returns the result.
-        """
+    def _build_request_for_partial(self, partial_query_result: PartialQueryResult) -> Request:
+        if partial_query_result.scheduled_query.type != ScheduledQueryType.TOTALS:
+            raise MetricsQueryExecutionError(
+                "A partial query must have an initial query of type totals"
+            )
+
+        groups_collection = _extract_groups_from_seq(partial_query_result.executed_result["data"])
+        next_metrics_query = partial_query_result.scheduled_query.next.metrics_query
+        next_metrics_query = _push_down_group_filters(next_metrics_query, groups_collection)
+
+        return self._build_request(next_metrics_query)
+
+    def _bulk_run_query(self, requests: list[Request]) -> list[Mapping[str, Any]]:
         try:
-            # We merge the query with the blocked projects, in order to obtain a new query with only the projects that
-            # all have the queried metrics unblocked.
-            executable_query = executable_query.filter_blocked_projects(
-                organization=self._organization,
-                projects=set(self._projects),
-                blocked_metrics_for_projects=self._blocked_metrics_for_projects,
-            )
-
-            # We try to determine the interval of the query, which will be used to define clear time bounds for both
-            # queries. This is done here since the metrics layer doesn't adjust the time for totals queries.
-            interval = executable_query.metrics_query.rollup.interval
-            if interval:
-                modified_start, modified_end, _ = to_intervals(
-                    executable_query.metrics_query.start,
-                    executable_query.metrics_query.end,
-                    interval,
-                )
-                if modified_start and modified_end:
-                    executable_query = executable_query.replace_date_range(
-                        modified_start, modified_end
-                    )
-
-            # If, after merging the query with the blocked projects, the query becomes empty, we will return an empty
-            # result.
-            if executable_query.is_empty():
-                return QueryResult.empty_from(executable_query)
-
-            totals_executable_query = executable_query
-            totals_result = None
-            if executable_query.with_totals:
-                # If there is an order by, we apply it only on the totals query. We can't order a series query, for this
-                # reason we have to perform ordering here.
-                if executable_query.order:
-                    totals_executable_query = totals_executable_query.replace_order_by(
-                        executable_query.order.to_snuba_order()
-                    )
-
-                # Only in totals, if there is a limit passed by the user, we will honor that and apply it.
-                if executable_query.limit:
-                    totals_executable_query = totals_executable_query.replace_limit(
-                        executable_query.limit
-                    )
-
-                self._number_of_executed_queries += 1
-                totals_result = run_query(
-                    request=self._build_request(
-                        totals_executable_query.to_totals_query().metrics_query
-                    )
-                )
-
-            series_executable_query = executable_query
-            series_result = None
-            if executable_query.with_series:
-                # For series queries, we always want to use the default Snuba limit.
-                series_executable_query = series_executable_query.replace_limit(SNUBA_QUERY_LIMIT)
-
-                # In order to have at least the same groups, we need to pass down the groups obtained in the
-                # previous totals query to the series query.
-                if totals_result:
-                    series_executable_query = series_executable_query.add_group_filters(
-                        _extract_groups_from_seq(totals_result["data"])
-                    )
-
-                self._number_of_executed_queries += 1
-                series_result = run_query(
-                    request=self._build_request(series_executable_query.metrics_query)
-                )
-
-            result = {}
-            if series_result and totals_result:
-                result = {
-                    "series": series_result,
-                    "totals": totals_result,
-                    "modified_start": series_result["modified_start"],
-                    "modified_end": series_result["modified_end"],
-                }
-            elif series_result:
-                result = {
-                    "series": series_result,
-                    "modified_start": series_result["modified_start"],
-                    "modified_end": series_result["modified_end"],
-                }
-            elif totals_result:
-                result = {
-                    "totals": totals_result,
-                    "modified_start": totals_result["modified_start"],
-                    "modified_end": totals_result["modified_end"],
-                }
-
-            return QueryResult(
-                series_executable_query=series_executable_query,
-                totals_executable_query=totals_executable_query,
-                result=result,
-            )
+            return bulk_run_query(requests)
         except SnubaError as e:
             sentry_sdk.capture_exception(e)
             raise MetricsQueryExecutionError("An error occurred while executing the query")
 
-    def _serial_execute(self) -> Sequence[QueryResult]:
-        """
-        Executes serially all the queries that are supplied to the QueryExecutor.
-
-        The execution will try to satisfy the query by dynamically changing its interval, in the case in which the
-        Snuba limit is reached.
-        """
-        results = []
+    def _bulk_execute(self) -> Sequence[QueryResult]:
+        bulk_requests = []
         for query in self._scheduled_queries:
-            with metrics.timer(key="ddm.metrics_api.metrics_query.execution_time"):
-                query_result = self._execute(executable_query=query)
-                results.append(query_result.align_series_to_totals())
+            bulk_requests.append(self._build_request(query.metrics_query))
 
-        return results
+        query_results = self._bulk_run_query(bulk_requests)
+        for query_index, query_result in enumerate(query_results):
+            scheduled_query = self._scheduled_queries[query_index]
+            if scheduled_query.has_next():
+                self._pending_query_results.append(
+                    PartialQueryResult(
+                        scheduled_query=scheduled_query,
+                        executed_result=query_result,
+                    )
+                )
+            else:
+                self._pending_query_results.append(
+                    QueryResult.from_query_type(
+                        query_type=scheduled_query.type,
+                        query=scheduled_query.metrics_query,
+                        query_result=query_result,
+                    )
+                )
 
-    def execute(self, batch: bool = False) -> Sequence[QueryResult]:
+        bulk_requests = []
+        mappings = []
+        for query_index, pending_query_result in enumerate(self._pending_query_results):
+            if isinstance(pending_query_result, PartialQueryResult):
+                bulk_requests.append(self._build_request_for_partial(pending_query_result))
+                mappings.append(query_index)
+
+        query_results = self._bulk_run_query(bulk_requests)
+        for query_index, query_result in zip(mappings, query_results):
+            partial_query_result = self._pending_query_results[query_index]
+            next_scheduled_query = partial_query_result.scheduled_query.next
+            if next_scheduled_query is None:
+                raise MetricsQueryExecutionError(
+                    f"No next query was scheduled for query at index {query_index}"
+                )
+
+            first_query_result = partial_query_result.to_query_result()
+            second_query_result = QueryResult.from_query_type(
+                query_type=next_scheduled_query.type,
+                query=next_scheduled_query.metrics_query,
+                query_result=query_result,
+            )
+
+            self._pending_query_results[query_index] = first_query_result.merge(second_query_result)
+
+        # TODO: PROPERLY HANDLE RETURNING ONLY QUERY RESULT OBJECTS.
+        return cast(Sequence[QueryResult], self._pending_query_results)
+
+    def execute(self) -> Sequence[QueryResult]:
         """
         Executes the scheduled queries serially.
         """
-        # TODO: implement batch execution when there will be the support for it.
-        results = self._serial_execute()
-        metrics.distribution(
-            key="ddm.metrics_api.queries_executed", value=self._number_of_executed_queries
-        )
-
+        # TODO: add execution metrics.
+        results = self._bulk_execute()
         return results
 
     def schedule(
@@ -560,13 +568,20 @@ class QueryExecutor:
 
         Note that this method won't execute the query, since it's lazy in nature.
         """
-        executable_query = ExecutableQuery(
-            with_series=True,
-            with_totals=True,
-            # We identify the query with its index.
-            identifier=str(len(self._scheduled_queries)),
+        executable_query = ScheduledQuery(
+            type=ScheduledQueryType.TOTALS,
+            next=ScheduledQuery(
+                type=ScheduledQueryType.SERIES,
+                next=None,
+                metrics_query=query,
+                order=order,
+                limit=limit,
+            ),
             metrics_query=query,
             order=order,
             limit=limit,
+        )
+        executable_query = executable_query.initialize(
+            self._organization, self._projects, self._blocked_metrics_for_projects
         )
         self._scheduled_queries.append(executable_query)

--- a/src/sentry/sentry_metrics/querying/data_v2/transformation.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation.py
@@ -184,6 +184,10 @@ class QueryTransformer:
         """
         Transforms the query results into the Sentry's API format.
         """
+        # If we have not run any queries, we won't return anything back.
+        if not self._query_results:
+            return {}
+
         # We first build intermediate results that we can work efficiently with.
         queries_groups, queries_meta = self._build_intermediate_results()
 

--- a/src/sentry/sentry_metrics/querying/data_v2/transformation.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation.py
@@ -168,7 +168,11 @@ class QueryTransformer:
 
             # We add additional metadata from the query themselves to make the API more transparent.
             query_meta.append(
-                QueryMeta(group_bys=group_bys, order=query_result.order, limit=query_result.limit)
+                QueryMeta(
+                    group_bys=group_bys,
+                    order=query_result.order.value if query_result.order else None,
+                    limit=query_result.limit,
+                )
             )
 
             queries_groups.append(query_groups)

--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -83,6 +83,9 @@ def bulk_run_query(requests: list[Request]) -> list[Mapping[str, Any]]:
 
     This function is used to execute multiple metrics queries in a single request.
     """
+    if not requests:
+        return []
+
     queries = []
     for request in requests:
         request, start, end = _setup_metrics_query(request)

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -263,7 +263,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         first_meta = sorted(meta[0], key=lambda value: value.get("name", ""))
         assert first_meta[0] == {
             "group_bys": ["platform", "transaction"],
-            "limit": None,
+            "limit": 10000,
             "order": None,
         }
 
@@ -583,9 +583,9 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         meta = results["meta"]
         assert len(meta) == 2
         first_meta = sorted(meta[0], key=lambda value: value.get("name", ""))
-        assert first_meta[0] == {"group_bys": ["platform"], "limit": 2, "order": "asc"}
+        assert first_meta[0] == {"group_bys": ["platform"], "limit": 2, "order": "ASC"}
         second_meta = sorted(meta[1], key=lambda value: value.get("name", ""))
-        assert second_meta[0] == {"group_bys": ["platform"], "limit": 2, "order": "desc"}
+        assert second_meta[0] == {"group_bys": ["platform"], "limit": 2, "order": "DESC"}
 
     def test_query_with_custom_set(self):
         mri = "s:custom/User.Click.2@none"
@@ -765,9 +765,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
                 referrer="metrics.data.api",
             )
 
-    # Different namespaces
-    # Different types
-    # Different group bys (at the formula level and also at the timeseries level)
     def test_query_with_different_namespaces(self):
         query_1 = self.mql(
             "min",


### PR DESCRIPTION
This PR implements a new querying engine that supports bulk execution of queries. The goal behind this PR is to improve multi-series execution time by leveraging the `bulk_run_query` function that is able to run multiple queries concurrently.

In order to implement bulk execution, the `execution` module had to be adapted quite a bit. It introduces a new modified object called `ScheduledQuery` which represents a query that has to be scheduled by the executor. This query can have an optional `next` `ScheduledQuery`, which will signal the executor to execute it serially since there might be some dependency between them.

The new execution schedule works in the following way:
1. A series of `ScheduledQuery` objects are added to an array, which dictates the so-called `query_index` that must be kept consistent across the execution, since the values returned must be 1-to-1 with the supplied formulas (aka queries).
3. When the execution is started, the `QueryExecutor` will prepare a bulk of requests containing all the scheduled queries.
4. All of the queries will be run and depending on if they have a `next` query or not, a `PartialQueryResult` or `QueryResult` will be stored in an array of results (again indexed by query_index).
5. A second pass will make sure to execute all the `next` queries concurrently in all `PartialQueryResult` objects.
6. All of the `PartialQueryResult`(s) will now be converted to `QueryResult`(s) and returned to the caller.

_The actual engine could support an indefinite amount of `next` passes, but for our implementation, we kept it to two, since we need to run at most a `totals` followed by a `series` query (this is clearly stated in code comments and can be seen in the `schedule` method of the `QueryExecutor`)._ 

Closes: https://github.com/getsentry/sentry/issues/64862