### PR TITLE
ref(metrics-extraction): Clean up additional n+1

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -341,7 +341,7 @@ def _update_state_with_spec_limit(
             widget_queries.setdefault(spec_version.version, set())
             widget_queries[spec_version.version].add(widget_query)
 
-    for (version, widget_query_set) in widget_queries.items():
+    for version, widget_query_set in widget_queries.items():
         for widget_query in widget_query_set:
             widget_query.dashboardwidgetqueryondemand_set.filter(spec_version=version).update(
                 extraction_state=OnDemandExtractionState.DISABLED_SPEC_LIMIT
@@ -537,9 +537,11 @@ def _widget_query_stateful_extraction_enabled(widget_query: DashboardWidgetQuery
     this assumes stateful extraction can be used, and returns the enabled state."""
 
     stateful_extraction_version = OnDemandMetricSpecVersioning.get_default_spec_version().version
-    on_demand_entries = widget_query.dashboardwidgetqueryondemand_set.filter(
-        spec_version=stateful_extraction_version
-    )
+    on_demand_entries = [
+        entry
+        for entry in widget_query.dashboardwidgetqueryondemand_set.all()
+        if entry.spec_version == stateful_extraction_version
+    ]
 
     if len(on_demand_entries) != 1:
         with sentry_sdk.push_scope() as scope:

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1155,10 +1155,6 @@ class OnDemandMetricSpec:
         self._metric_type = metric_type
         self._arguments = arguments or []
 
-        sentry_sdk.start_span(
-            op="OnDemandMetricSpec.spec_type", description=self.spec_type
-        ).finish()
-
     @property
     def field_to_extract(self):
         if self.op in ("on_demand_apdex", "on_demand_count_web_vitals"):


### PR DESCRIPTION
### Summary
Found another n+1 due to filters. Also in this PR, removing spec_type since it causes a lot of noise in spans.

This should hopefully further reduce [SoftTimelineExceeded](https://sentry.sentry.io/issues/3389239864/?project=1&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=21) (indirectly) and the `sentry.on_demand_metrics.get_widget_metric_specs` metric (directly).

Related (same fix): https://github.com/getsentry/sentry/pull/64902