### PR TITLE
fix(metrics): Add entity keys for spans

### DIFF
--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -188,6 +188,11 @@ USE_CASE_ID_TO_ENTITY_KEYS = {
         EntityKey.MetricsSets,
         EntityKey.MetricsDistributions,
     },
+    UseCaseID.SPANS: {
+        EntityKey.GenericMetricsCounters,
+        EntityKey.GenericMetricsSets,
+        EntityKey.GenericMetricsDistributions,
+    },
     UseCaseID.TRANSACTIONS: {
         EntityKey.GenericMetricsCounters,
         EntityKey.GenericMetricsSets,


### PR DESCRIPTION
We need to specify the entity keys for spans to correctly find all span metrics.