### PR TITLE
ref: replace trivial uses of utcnow with tz-aware now

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -569,7 +569,7 @@ class StatsMixin:
             if end_s:
                 end = to_datetime(float(end_s))
             else:
-                end = datetime.utcnow().replace(tzinfo=timezone.utc)
+                end = datetime.now(timezone.utc)
         except ValueError:
             raise ParseError(detail="until must be a numeric timestamp.")
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -333,7 +333,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return attrs
 
     def save_trusted_relays(self, incoming, changed_data, organization):
-        timestamp_now = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+        timestamp_now = datetime.now(timezone.utc).isoformat()
         option_key = "sentry:trusted-relays"
         try:
             # get what we already have

--- a/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
+++ b/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
@@ -66,7 +66,7 @@ def get_time_params(start: datetime, end: datetime) -> MappedParams:
         granularity = 600
 
     additional_time_needed = snuba_range - anomaly_detection_range
-    now = datetime.utcnow().astimezone(timezone.utc)
+    now = datetime.now(timezone.utc)
     start_limit = now - timedelta(days=90)
     end_limit = now
     start = max(start, start_limit)

--- a/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/latest_releases.py
@@ -86,7 +86,7 @@ class BoostedReleases:
         # We get release models in order to have all the information to extend the releases we get from the cache.
         models = self._get_releases_models()
 
-        current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+        current_timestamp = datetime.now(timezone.utc).timestamp()
 
         extended_boosted_releases = []
         expired_boosted_releases = []
@@ -154,7 +154,7 @@ class ProjectBoostedReleases:
         self.redis_client.hset(
             cache_key,
             self._generate_cache_key_for_boosted_release(release_id, environment),
-            datetime.utcnow().replace(tzinfo=timezone.utc).timestamp(),
+            datetime.now(timezone.utc).timestamp(),
         )
         # In order to avoid having the boosted releases hash in memory for an indefinite amount of time, we will expire
         # it after a specific timeout.
@@ -209,7 +209,7 @@ class ProjectBoostedReleases:
         """
         cache_key = self._generate_cache_key_for_boosted_releases_hash()
         boosted_releases = self.redis_client.hgetall(cache_key)
-        current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+        current_timestamp = datetime.now(timezone.utc).timestamp()
 
         LRBRelease = namedtuple("LRBRelease", ["key", "timestamp"])
         lrb_release = None

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1103,7 +1103,7 @@ def _tsdb_record_all_metrics(jobs: Sequence[Job]) -> None:
 
 @metrics.wraps("save_event.nodestore_save_many")
 def _nodestore_save_many(jobs: Sequence[Job], app_feature: str) -> None:
-    inserted_time = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+    inserted_time = datetime.now(timezone.utc).timestamp()
     for job in jobs:
         # Write the event to Nodestore
         subkeys = {}
@@ -2392,7 +2392,7 @@ def save_attachment(
     if start_time is not None:
         timestamp = to_datetime(start_time)
     else:
-        timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
+        timestamp = datetime.now(timezone.utc)
 
     try:
         attachment.data

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -382,7 +382,7 @@ def calculate_incident_time_range(incident, start=None, end=None, windowed_stats
     retention = quotas.get_event_retention(organization=incident.organization) or 90
     start = max(
         start.replace(tzinfo=timezone.utc),
-        datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention),
+        datetime.now(timezone.utc) - timedelta(days=retention),
     )
     end = max(start, end.replace(tzinfo=timezone.utc))
 

--- a/src/sentry/incidents/receivers.py
+++ b/src/sentry/incidents/receivers.py
@@ -23,4 +23,4 @@ def add_project_to_include_all_rules(instance, created, **kwargs):
 
 @receiver(pre_save, sender=IncidentTrigger)
 def pre_save_incident_trigger(instance, sender, *args, **kwargs):
-    instance.date_modified = datetime.utcnow().replace(tzinfo=timezone.utc)
+    instance.date_modified = datetime.now(timezone.utc)

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -263,7 +263,7 @@ def create_issue_platform_occurrence(
     from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 
     monitor_env = failed_checkin.monitor_environment
-    current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
+    current_timestamp = datetime.now(timezone.utc)
 
     occurrence_data = get_occurrence_data(failed_checkin)
 

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -910,7 +910,7 @@ def _track_outcome(
         key_id=None,
         outcome=outcome,
         reason=reason,
-        timestamp=datetime.utcnow().replace(tzinfo=timezone.utc),
+        timestamp=datetime.now(timezone.utc),
         event_id=event_id,
         category=DataCategory.PROFILE_INDEXED,
         quantity=1,

--- a/src/sentry/projectoptions/manager.py
+++ b/src/sentry/projectoptions/manager.py
@@ -76,7 +76,7 @@ class ProjectOptionsManager:
         ProjectOption.objects.set_value(
             project,
             "sentry:relay-rev-lastchange",
-            json.datetime_to_str(datetime.utcnow().replace(tzinfo=timezone.utc)),
+            json.datetime_to_str(datetime.now(timezone.utc)),
         )
 
     def register(self, key, default=None, epoch_defaults=None):

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -363,7 +363,7 @@ def _get_project_config(
     public_keys = get_public_key_configs(project, full_config, project_keys=project_keys)
 
     with Hub.current.start_span(op="get_public_config"):
-        now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
         cfg = {
             "disabled": False,
             "slug": project.slug,

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -18,7 +18,7 @@ def fingerprint_regression(transaction, full=False):
 
 
 def send_regression_to_platform(regression: BreakpointData):
-    current_timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
+    current_timestamp = datetime.now(timezone.utc)
 
     displayed_old_baseline = round(float(regression["aggregate_range_1"]), 2)
     displayed_new_baseline = round(float(regression["aggregate_range_2"]), 2)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2341,7 +2341,7 @@ class ReplaysSnubaTestCase(TestCase):
 # AcceptanceTestCase and TestCase are mutually exclusive base classses
 class ReplaysAcceptanceTestCase(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        self.now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        self.now = datetime.now(timezone.utc)
         super().setUp()
         self.drop_replays()
         patcher = mock.patch("django.utils.timezone.now", return_value=self.now)

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -196,7 +196,7 @@ def outside_retention_with_modified_start(
 
     # Need to support timezone-aware and naive datetimes since
     # Snuba API only deals in naive UTC
-    now = datetime.utcnow().astimezone(timezone.utc) if start.tzinfo else datetime.utcnow()
+    now = datetime.now(timezone.utc) if start.tzinfo else datetime.utcnow()
     start = max(start, now - timedelta(days=retention))
 
     return start > end, start

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -164,7 +164,7 @@ def generate_tombstones(project, user):
 
 
 def create_system_time_series():
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
 
     for _ in range(60):
         count = randint(1, 10)
@@ -219,7 +219,7 @@ def create_sample_time_series(event, release=None):
     project = group.project
     key = project.key_set.all()[0]
 
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
 
     environment = Environment.get_or_create(
         project=project, name=Environment.get_name_or_default(event.get_tag("environment"))
@@ -743,7 +743,7 @@ def create_metric_alert_rule(organization: Organization, project: Project) -> No
         organization,
         type_=IncidentType.DETECTED,
         title="My Incident",
-        date_started=datetime.utcnow().replace(tzinfo=timezone.utc),
+        date_started=datetime.now(timezone.utc),
         alert_rule=alert_rule,
         projects=[project],
     )

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -6,7 +6,7 @@ from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.silo import no_silo_test
 from sentry.utils.samples import load_data
 
-now = datetime.utcnow().replace(tzinfo=timezone.utc)
+now = datetime.now(timezone.utc)
 
 
 @no_silo_test

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -280,7 +280,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         "My Projects" in issues list.
         """
         with self.feature("organizations:global-views"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+            mock_now.return_value = datetime.now(timezone.utc)
             self.create_issues()
             self.issues_list.visit_issue_list(self.org.slug)
             self.issues_list.wait_for_issue()
@@ -313,7 +313,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         If user has a project defined in URL, if they visit an issue and then
         return back to issues list, that project id should still exist in URL
         """
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
         self.issues_list.visit_issue_list(self.org.slug, query=f"?project={self.project_2.id}")
         self.issues_list.wait_for_issue()
@@ -347,7 +347,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         When navigating back to issues stream, should keep environment and project in context.
         """
 
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
         self.issue_details.visit_issue_in_environment(self.org.slug, self.issue_2.group.id, "prod")
 
@@ -378,7 +378,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         """
 
         with self.feature("organizations:global-views"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+            mock_now.return_value = datetime.now(timezone.utc)
             self.create_issues()
             self.issue_details.visit_issue_in_environment(
                 self.org.slug, self.issue_2.group.id, "prod"

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -65,7 +65,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_results(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
         self.page.visit_issue_list(self.org.slug)
         self.page.wait_for_stream()
@@ -77,7 +77,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_resolve_issues_removal(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
         group1 = self.event_a.group
 
@@ -96,7 +96,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_resolve_issues_removal_multi_projects(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
 
         with self.feature(["organizations:global-views"]):
@@ -117,7 +117,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_archive_issues(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
 
         group1 = self.event_a.group
@@ -137,7 +137,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_archive_issues_multi_projects(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
 
         group1 = self.event_a.group
@@ -158,7 +158,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_delete_issues(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
 
         group1 = self.event_a.group
@@ -178,7 +178,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_delete_issues_multi_projects(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
 
         group1 = self.event_a.group
@@ -199,7 +199,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_merge_issues(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
 
         group1 = self.event_a.group
@@ -222,7 +222,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_inbox_results(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=timezone.utc)
+        mock_now.return_value = datetime.now(timezone.utc)
         self.create_issues()
         # Disable for_review_guide
         AssistantActivity.objects.create(

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -6,7 +6,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import no_silo_test
 
 event_time = before_now(days=3).replace(tzinfo=timezone.utc)
-current_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+current_time = datetime.now(timezone.utc)
 
 
 @no_silo_test

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -243,9 +243,9 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         data = {"trustedRelays": trusted_relays}
 
         with self.feature("organizations:relay"):
-            start_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+            start_time = datetime.now(timezone.utc)
             self.get_success_response(self.organization.slug, method="put", **data)
-            end_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+            end_time = datetime.now(timezone.utc)
             response = self.get_success_response(self.organization.slug)
 
         response_data = response.data.get("trustedRelays")
@@ -578,9 +578,9 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         data = {"trustedRelays": trusted_relays}
 
         with self.feature("organizations:relay"), outbox_runner():
-            start_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+            start_time = datetime.now(timezone.utc)
             response = self.get_success_response(self.organization.slug, **data)
-            end_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+            end_time = datetime.now(timezone.utc)
             response_data = response.data.get("trustedRelays")
 
         actual = get_trusted_relay_value(self.organization)
@@ -662,11 +662,11 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         changed_settings = {"trustedRelays": modified_trusted_relays}
 
         with self.feature("organizations:relay"), outbox_runner():
-            start_time = datetime.utcnow().replace(tzinfo=timezone.utc)
+            start_time = datetime.now(timezone.utc)
             self.get_success_response(self.organization.slug, **initial_settings)
-            after_initial = datetime.utcnow().replace(tzinfo=timezone.utc)
+            after_initial = datetime.now(timezone.utc)
             self.get_success_response(self.organization.slug, **changed_settings)
-            after_final = datetime.utcnow().replace(tzinfo=timezone.utc)
+            after_final = datetime.now(timezone.utc)
 
         actual = get_trusted_relay_value(self.organization)
         assert len(actual) == len(modified_trusted_relays)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2988,7 +2988,7 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_boost_release_with_non_observed_release(self):
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+        ts = datetime.now(timezone.utc).timestamp()
 
         project = self.create_project(platform="python")
         release_1 = Release.get_or_create(project=project, version="1.0", date_added=datetime.now())
@@ -3049,7 +3049,7 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_boost_release_boosts_only_latest_release(self):
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+        ts = datetime.now(timezone.utc).timestamp()
 
         project = self.create_project(platform="python")
         release_1 = Release.get_or_create(project=project, version="1.0", date_added=datetime.now())
@@ -3243,7 +3243,7 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_release_not_boosted_with_deleted_release_after_event_received(self):
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+        ts = datetime.now(timezone.utc).timestamp()
 
         project = self.create_project(platform="python")
         release_1 = Release.get_or_create(project=project, version="1.0", date_added=datetime.now())
@@ -3293,7 +3293,7 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_get_boosted_releases_with_old_and_new_cache_keys(self):
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+        ts = datetime.now(timezone.utc).timestamp()
 
         project = self.create_project(platform="python")
 
@@ -3363,7 +3363,7 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_expired_boosted_releases_are_removed(self):
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+        ts = datetime.now(timezone.utc).timestamp()
 
         # We want to test with multiple platforms.
         for platform in ("python", "java", None):
@@ -3445,7 +3445,7 @@ class DSLatestReleaseBoostTest(TestCase):
     @freeze_time("2022-11-03 10:00:00")
     @mock.patch("sentry.dynamic_sampling.rules.helpers.latest_releases.BOOSTED_RELEASES_LIMIT", 2)
     def test_least_recently_boosted_release_is_removed_if_limit_is_exceeded(self):
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+        ts = datetime.now(timezone.utc).timestamp()
 
         project = self.create_project(platform="python")
         release_1 = Release.get_or_create(
@@ -3515,7 +3515,7 @@ class DSLatestReleaseBoostTest(TestCase):
     @freeze_time()
     @mock.patch("sentry.dynamic_sampling.rules.helpers.latest_releases.BOOSTED_RELEASES_LIMIT", 2)
     def test_removed_boost_not_added_again_if_limit_is_exceeded(self):
-        ts = datetime.utcnow().replace(tzinfo=timezone.utc).timestamp()
+        ts = datetime.now(timezone.utc).timestamp()
 
         project = self.create_project(platform="python")
         release_1 = Release.get_or_create(project=project, version="1.0", date_added=datetime.now())

--- a/tests/sentry/incidents/test_receivers.py
+++ b/tests/sentry/incidents/test_receivers.py
@@ -51,8 +51,8 @@ class PreSaveIncidentTriggerTest(TestCase):
             status=IncidentStatus.WARNING.value,
             type=2,
             title="a custom incident title",
-            date_started=datetime.utcnow().replace(tzinfo=timezone.utc),
-            date_detected=datetime.utcnow().replace(tzinfo=timezone.utc),
+            date_started=datetime.now(timezone.utc),
+            date_detected=datetime.now(timezone.utc),
             alert_rule=alert_rule,
         )
         incident_trigger = IncidentTrigger.objects.create(

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -2871,7 +2871,7 @@ class TestUpdateAlertRuleStats(TestCase):
     def test(self):
         alert_rule = AlertRule(id=1)
         sub = QuerySubscription(project_id=2)
-        date = datetime.utcnow().replace(tzinfo=timezone.utc)
+        date = datetime.now(timezone.utc)
         update_alert_rule_stats(alert_rule, sub, date, {3: 20, 4: 3}, {3: 10, 4: 15})
         client = get_redis_client()
         results = [

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -78,7 +78,7 @@ class RedisTSDBTest(TestCase):
         assert result == "26f980fbe1e8a9d3a0123d2049f95f28"
 
     def test_simple(self):
-        now = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(hours=4)
+        now = datetime.now(timezone.utc) - timedelta(hours=4)
         dts = [now + timedelta(hours=i) for i in range(4)]
 
         def timestamp(d):
@@ -186,7 +186,7 @@ class RedisTSDBTest(TestCase):
         assert results == {1: 0, 2: 0}
 
     def test_count_distinct(self):
-        now = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(hours=4)
+        now = datetime.now(timezone.utc) - timedelta(hours=4)
         dts = [now + timedelta(hours=i) for i in range(4)]
 
         model = TSDBModel.users_affected_by_group
@@ -324,7 +324,7 @@ class RedisTSDBTest(TestCase):
         assert results == {1: 0, 2: 0}
 
     def test_frequency_tables(self):
-        now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
         model = TSDBModel.frequent_issues_by_project
 
         # None of the registered frequency tables actually support

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -28,9 +28,7 @@ from sentry.utils.snuba import (
 
 class SnubaUtilsTest(TestCase):
     def setUp(self):
-        self.now = datetime.utcnow().replace(
-            hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc
-        )
+        self.now = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
         self.proj1 = self.create_project()
         self.proj1env1 = self.create_environment(project=self.proj1, name="prod")
         self.proj1group1 = self.create_group(self.proj1)

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -61,7 +61,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         )
 
     def test_get_group_creation_attributes(self):
-        now = datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
         e1 = self.store_event(
             data={
                 "fingerprint": ["group1"],
@@ -120,7 +120,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         }
 
     def test_get_group_backfill_attributes(self):
-        now = datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
 
         assert get_group_backfill_attributes(
             get_caches(),


### PR DESCRIPTION
utcnow is a warning in 3.12 and removed in 3.14

<!-- Describe your PR here. -->