### PR TITLE
perf: use optional chaining more

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,8 @@
         "useIsNan": "error"
       },
       "complexity": {
-        "useFlatMap": "error"
+        "useFlatMap": "error",
+        "useOptionalChain": "error"
       },
       "nursery": {
         "noDuplicateJsonKeys": "error",

--- a/build-utils/sentry-instrumentation.ts
+++ b/build-utils/sentry-instrumentation.ts
@@ -1,10 +1,9 @@
 /* eslint-env node */
+import type Sentry from '@sentry/node';
+import type {Transaction} from '@sentry/types';
 import crypto from 'node:crypto';
 import https from 'node:https';
 import os from 'node:os';
-
-import type Sentry from '@sentry/node';
-import type {Transaction} from '@sentry/types';
 import type webpack from 'webpack';
 
 const {
@@ -72,7 +71,7 @@ class SentryInstrumentation {
     sentry.setTag('arch', os.arch());
     sentry.setTag(
       'cpu',
-      cpus && cpus.length ? `${cpus[0].model} (cores: ${cpus.length})}` : 'N/A'
+      cpus?.length ? `${cpus[0].model} (cores: ${cpus.length})}` : 'N/A'
     );
 
     this.Sentry = sentry;

--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -38,7 +38,7 @@ export function assignToUser(params: AssignToUserParams) {
   const id = uniqueId();
 
   GroupStore.onAssignTo(id, params.id, {
-    email: (params.member && params.member.email) || '',
+    email: params.member?.email ?? '',
   });
 
   const request = api.requestPromise(endpoint, {

--- a/static/app/actionCreators/plugins.tsx
+++ b/static/app/actionCreators/plugins.tsx
@@ -50,7 +50,7 @@ function doUpdate({orgId, projectId, pluginId, update, ...params}: DoUpdateParam
     })
     .catch(resp => {
       const err =
-        resp && resp.responseJSON && typeof resp.responseJSON.detail === 'string'
+        typeof resp?.responseJSON?.detail === 'string'
           ? new Error(resp.responseJSON.detail)
           : new Error('Unable to update plugin');
       PluginsStore.onUpdateError(pluginId, err);

--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -63,7 +63,7 @@ function Access({
   project = project ?? undefined;
 
   const hasAccess = hasEveryAccess(access, {organization, team, project});
-  const hasSuperuser = !!(user && user.isSuperuser);
+  const hasSuperuser = Boolean(user?.isSuperuser);
 
   const renderProps: ChildRenderProps = {
     hasAccess,

--- a/static/app/components/acl/feature.tsx
+++ b/static/app/components/acl/feature.tsx
@@ -116,8 +116,8 @@ class Feature extends Component<Props> {
 
     return {
       configFeatures: config.features ? Array.from(config.features) : [],
-      organization: (organization && organization.features) || [],
-      project: (project && project.features) || [],
+      organization: organization?.features ?? [],
+      project: project?.features ?? [],
     };
   }
 

--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -154,8 +154,7 @@ function NoteInput({
     (errorJSON &&
       (typeof errorJSON.detail === 'string'
         ? errorJSON.detail
-        : (errorJSON.detail && errorJSON.detail.message) ||
-          t('Unable to post comment'))) ||
+        : errorJSON.detail?.message || t('Unable to post comment'))) ||
     null;
 
   return (

--- a/static/app/components/avatar/organizationAvatar.tsx
+++ b/static/app/components/avatar/organizationAvatar.tsx
@@ -10,14 +10,14 @@ function OrganizationAvatar({organization, ...props}: Props) {
   if (!organization) {
     return null;
   }
-  const slug = (organization && organization.slug) || '';
+  const slug = organization?.slug || '';
   const title = explodeSlug(slug);
 
   return (
     <BaseAvatar
       {...props}
-      type={(organization.avatar && organization.avatar.avatarType) || 'letter_avatar'}
-      uploadUrl={organization.avatar && organization.avatar.avatarUrl}
+      type={organization.avatar?.avatarType || 'letter_avatar'}
+      uploadUrl={organization.avatar?.avatarUrl}
       letterId={slug}
       tooltip={slug}
       title={title}

--- a/static/app/components/avatar/teamAvatar.tsx
+++ b/static/app/components/avatar/teamAvatar.tsx
@@ -11,14 +11,14 @@ function TeamAvatar({team, tooltip: tooltipProp, ...props}: TeamAvatarProps) {
     return null;
   }
 
-  const slug = (team && team.slug) || '';
+  const slug = team?.slug || '';
   const title = explodeSlug(slug);
   const tooltip = tooltipProp ?? `#${title}`;
 
   return (
     <BaseAvatar
       {...props}
-      type={(team.avatar && team.avatar.avatarType) || 'letter_avatar'}
+      type={team.avatar?.avatarType || 'letter_avatar'}
       letterId={slug}
       tooltip={tooltip}
       title={title}

--- a/static/app/components/avatar/userAvatar.tsx
+++ b/static/app/components/avatar/userAvatar.tsx
@@ -22,7 +22,7 @@ function getType(user: AvatarUser | Actor, gravatar: boolean | undefined) {
   if (user.avatar) {
     return user.avatar.avatarType;
   }
-  if (user.options && user.options.avatarType) {
+  if (user.options?.avatarType) {
     return user.options.avatarType;
   }
 

--- a/static/app/components/avatarUploader.tsx
+++ b/static/app/components/avatarUploader.tsx
@@ -362,7 +362,7 @@ class AvatarUploader extends Component<Props, State> {
 
   uploadClick = (ev: React.MouseEvent<HTMLAnchorElement>) => {
     ev.preventDefault();
-    this.file.current && this.file.current.click();
+    this.file.current?.click();
   };
 
   renderImageCrop() {

--- a/static/app/components/charts/barChartZoom.tsx
+++ b/static/app/components/charts/barChartZoom.tsx
@@ -87,7 +87,7 @@ class BarChartZoom extends Component<Props> {
     }
 
     // This attempts to activate the area zoom toolbox feature
-    const zoom = chart._componentsViews?.find(c => c._features && c._features.dataZoom);
+    const zoom = chart._componentsViews?.find(c => c._features?.dataZoom);
     if (zoom && !zoom._features.dataZoom._isZoomActive) {
       // Calling dispatchAction will re-trigger handleChartFinished
       chart.dispatchAction({

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -245,7 +245,7 @@ class ChartZoom extends Component<Props> {
     }
 
     // This attempts to activate the area zoom toolbox feature
-    const zoom = chart._componentsViews?.find(c => c._features && c._features.dataZoom);
+    const zoom = chart._componentsViews?.find(c => c._features?.dataZoom);
     if (zoom && !zoom._features.dataZoom._isZoomActive) {
       // Calling dispatchAction will re-trigger handleChartFinished
       chart.dispatchAction({

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -226,7 +226,7 @@ class Chart extends Component<ChartProps, State> {
     }
 
     // Temporary fix to improve performance on pages with a high number of releases.
-    const releases = releaseSeries && releaseSeries[0];
+    const releases = releaseSeries?.[0];
     const hideReleasesByDefault =
       Array.isArray(releaseSeries) &&
       (releases as any)?.markLine?.data &&
@@ -267,7 +267,7 @@ class Chart extends Component<ChartProps, State> {
           ...theme.charts.getColorPalette(timeseriesData.length - 2 - (hasOther ? 1 : 0)),
         ]
       : undefined;
-    if (chartColors && chartColors.length && hasOther) {
+    if (chartColors?.length && hasOther) {
       chartColors.push(theme.chartOther);
     }
     const chartOptions = {

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -332,7 +332,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
         api.clear();
         timeseriesData = await doEventsRequest(api, props);
       } catch (resp) {
-        if (resp && resp.responseJSON && resp.responseJSON.detail) {
+        if (resp?.responseJSON?.detail) {
           errorMessage = resp.responseJSON.detail;
         } else {
           errorMessage = t('Error loading chart data');

--- a/static/app/components/charts/onDemandMetricRequest.tsx
+++ b/static/app/components/charts/onDemandMetricRequest.tsx
@@ -48,11 +48,7 @@ export class OnDemandMetricRequest extends EventsRequest {
 
         timeseriesData = await this.fetchExtrapolatedData();
       } catch (resp) {
-        if (resp && resp.responseJSON && resp.responseJSON.detail) {
-          errorMessage = resp.responseJSON.detail;
-        } else {
-          errorMessage = t('Error loading chart data');
-        }
+        errorMessage = resp?.responseJSON?.detail ?? t('Error loading chart data');
         if (!hideError) {
           addErrorMessage(errorMessage);
         }

--- a/static/app/components/charts/pieChart.tsx
+++ b/static/app/components/charts/pieChart.tsx
@@ -101,8 +101,7 @@ class PieChart extends Component<Props> {
       <BaseChart
         ref={this.chart}
         colors={
-          firstSeries &&
-          firstSeries.data && [...theme.charts.getColorPalette(firstSeries.data.length)]
+          firstSeries?.data && [...theme.charts.getColorPalette(firstSeries.data.length)]
         }
         // when legend highlights it does NOT pass dataIndex :(
         onHighlight={({name}) => {

--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -120,7 +120,7 @@ function CommitRow({
         </Meta>
       </CommitMessage>
 
-      {commit.pullRequest && commit.pullRequest.externalUrl && (
+      {commit.pullRequest?.externalUrl && (
         <Button
           external
           href={commit.pullRequest.externalUrl}

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -180,7 +180,7 @@ class ContextPickerModal extends Component<Props> {
     if (el !== null) {
       const input = el.querySelector('input');
 
-      input && input.focus();
+      input?.focus();
     }
   };
 

--- a/static/app/components/deprecatedAsyncComponent.tsx
+++ b/static/app/components/deprecatedAsyncComponent.tsx
@@ -272,8 +272,8 @@ class DeprecatedAsyncComponent<
       options = options || {};
       // If you're using nested async components/views make sure to pass the
       // props through so that the child component has access to props.location
-      const locationQuery = (this.props.location && this.props.location.query) || {};
-      let query = (params && params.query) || {};
+      const locationQuery = this.props.location?.query || {};
+      let query = params?.query || {};
       // If paginate option then pass entire `query` object to API call
       // It should only be expecting `query.cursor` for pagination
       if ((options.paginate || locationQuery.cursor) && !options.disableEntireQuery) {
@@ -290,7 +290,7 @@ class DeprecatedAsyncComponent<
         error: error => {
           // Allow endpoints to fail
           // allowError can have side effects to handle the error
-          if (options.allowError && options.allowError(error)) {
+          if (options.allowError?.(error)) {
             error = null;
           }
           this.handleError(error, [stateKey, endpoint, params, options]);
@@ -341,7 +341,7 @@ class DeprecatedAsyncComponent<
 
   handleError(error, args) {
     const [stateKey] = args;
-    if (error && error.responseText) {
+    if (error?.responseText) {
       Sentry.addBreadcrumb({
         message: error.responseText,
         category: 'xhr',
@@ -381,8 +381,8 @@ class DeprecatedAsyncComponent<
 
   renderSearchInput({stateKey, url, ...props}: RenderSearchInputArgs) {
     const [firstEndpoint] = this.getEndpoints() || [null];
-    const stateKeyOrDefault = stateKey || (firstEndpoint && firstEndpoint[0]);
-    const urlOrDefault = url || (firstEndpoint && firstEndpoint[1]);
+    const stateKeyOrDefault = stateKey || firstEndpoint?.[0];
+    const urlOrDefault = url || firstEndpoint?.[1];
     return (
       <AsyncComponentSearchInput
         url={urlOrDefault}

--- a/static/app/components/deprecatedDropdownMenu.tsx
+++ b/static/app/components/deprecatedDropdownMenu.tsx
@@ -182,7 +182,7 @@ class DropdownMenu extends Component<Props, State> {
     }
 
     // Button that controls visibility of dropdown menu
-    if (this.dropdownActor && this.dropdownActor.contains(e.target)) {
+    if (this.dropdownActor?.contains(e.target)) {
       return;
     }
 

--- a/static/app/components/deprecatedforms/form.tsx
+++ b/static/app/components/deprecatedforms/form.tsx
@@ -93,7 +93,7 @@ class Form<
       errors: {},
       initialData: {...this.state.data, ...(data || {})},
     });
-    this.props.onSubmitSuccess && this.props.onSubmitSuccess(data);
+    this.props.onSubmitSuccess?.(data);
   };
 
   onSubmitError = error => {
@@ -108,7 +108,7 @@ class Form<
       });
     }
 
-    this.props.onSubmitError && this.props.onSubmitError(error);
+    this.props.onSubmitError?.(error);
   };
 
   onFieldChange = (name: string, value: string | number) => {
@@ -128,7 +128,7 @@ class Form<
       ? Object.keys(data).length && !isEqual(data, initialData)
       : true;
     const isError = this.state.state === FormState.ERROR;
-    const nonFieldErrors = this.state.errors && this.state.errors.non_field_errors;
+    const nonFieldErrors = this.state.errors?.non_field_errors;
 
     return (
       <FormContext.Provider value={this.getContext()}>

--- a/static/app/components/deprecatedforms/formField.tsx
+++ b/static/app/components/deprecatedforms/formField.tsx
@@ -73,24 +73,24 @@ export default class FormField<
   static contextType = FormContext;
 
   getValue(props: Props, context: FormContextData) {
-    const form = (context || this.context || {}).form;
+    const form = (context || this.context)?.form;
     props = props || this.props;
     if (defined(props.value)) {
       return props.value;
     }
-    if (form && form.data.hasOwnProperty(props.name)) {
+    if (form?.data.hasOwnProperty(props.name)) {
       return defined(form.data[props.name]) ? form.data[props.name] : '';
     }
     return defined(props.defaultValue) ? props.defaultValue : '';
   }
 
   getError(props: Props, context: FormContextData) {
-    const form = (context || this.context || {}).form;
+    const form = (context || this.context)?.form;
     props = props || this.props;
     if (defined(props.error)) {
       return props.error;
     }
-    return (form && form.errors[props.name]) || null;
+    return form?.errors[props.name] || null;
   }
 
   getId() {
@@ -107,7 +107,7 @@ export default class FormField<
   };
 
   setValue = (value: Value) => {
-    const form = (this.context || {}).form;
+    const form = this.context?.form;
     this.setState(
       {
         value,

--- a/static/app/components/deprecatedforms/genericField.tsx
+++ b/static/app/components/deprecatedforms/genericField.tsx
@@ -74,7 +74,7 @@ function GenericField({
     placeholder: config.placeholder,
     required,
     name: config.name,
-    error: (formErrors || {})[config.name],
+    error: formErrors?.[config.name],
     defaultValue: config.default,
     disabled: config.readonly,
     key: config.name,

--- a/static/app/components/deprecatedforms/selectAsyncField.tsx
+++ b/static/app/components/deprecatedforms/selectAsyncField.tsx
@@ -9,9 +9,9 @@ class SelectAsyncField extends SelectField {
 
   onResults = data => {
     const {name} = this.props;
-    const results = data && data[name];
+    const results = data?.[name];
 
-    return (results && results.map(({id, text}) => ({value: id, label: text}))) || [];
+    return results?.map(({id, text}) => ({value: id, label: text})) || [];
   };
 
   onQuery = query =>

--- a/static/app/components/deprecatedforms/selectField.tsx
+++ b/static/app/components/deprecatedforms/selectField.tsx
@@ -45,7 +45,7 @@ export default class SelectField extends FormField<Props> {
 
   // Overriding this so that we can support `multi` fields through property
   getValue(props, context) {
-    const form = (context || this.context || {}).form;
+    const form = (context || this.context)?.form;
     props = props || this.props;
 
     // Don't use `isMultiple` here because we're taking props from args as well
@@ -54,7 +54,7 @@ export default class SelectField extends FormField<Props> {
     if (defined(props.value)) {
       return props.value;
     }
-    if (form && form.data.hasOwnProperty(props.name)) {
+    if (form?.data.hasOwnProperty(props.name)) {
       return defined(form.data[props.name]) ? form.data[props.name] : defaultValue;
     }
     return defined(props.defaultValue) ? props.defaultValue : defaultValue;

--- a/static/app/components/discover/quickContextCommitRow.tsx
+++ b/static/app/components/discover/quickContextCommitRow.tsx
@@ -15,7 +15,7 @@ import {space} from 'sentry/styles/space';
 function QuickContextCommitRow({commit}: CommitRowProps) {
   const user = ConfigStore.get('user');
   const isUser = user?.id === commit.author?.id;
-  const hasPullRequestURL = commit.pullRequest && commit.pullRequest.externalUrl;
+  const hasPullRequestURL = commit.pullRequest?.externalUrl;
   const commitMessage = formatCommitMessage(commit.message);
 
   return (

--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -156,8 +156,7 @@ function TableRender({
   const query = decodeScalar(location.query.query, '');
   const display = decodeScalar(location.query.display, DisplayModes.DURATION);
   const performanceAtScaleContext = useContext(PerformanceAtScaleContext);
-  const hasResults =
-    tableData && tableData.data && tableData.meta && tableData.data.length > 0;
+  const hasResults = tableData?.meta && tableData.data?.length > 0;
 
   useEffect(() => {
     if (!performanceAtScaleContext) {

--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -129,7 +129,7 @@ class TransactionsTable extends PureComponent<Props> {
     } = this.props;
     const fields = eventView.getFields();
 
-    if (titles && titles.length) {
+    if (titles?.length) {
       // Slice to match length of given titles
       columnOrder = columnOrder.slice(0, titles.length);
     }
@@ -221,8 +221,7 @@ class TransactionsTable extends PureComponent<Props> {
   render() {
     const {isLoading, tableData} = this.props;
 
-    const hasResults =
-      tableData && tableData.data && tableData.meta && tableData.data.length > 0;
+    const hasResults = tableData?.meta && tableData.data?.length > 0;
 
     // Custom set the height so we don't have layout shift when results are loaded.
     const loader = <LoadingIndicator style={{margin: '70px auto'}} />;

--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -167,8 +167,7 @@ function EventDisplay({
     }
   }, [eventIds, selectedEventId]);
 
-  const eventIdIndex =
-    eventIds && eventIds.findIndex(eventId => eventId === selectedEventId);
+  const eventIdIndex = eventIds?.findIndex(eventId => eventId === selectedEventId);
   const hasNext =
     defined(eventIdIndex) && defined(eventIds) && eventIdIndex + 1 < eventIds.length;
   const hasPrev = defined(eventIdIndex) && eventIdIndex - 1 >= 0;

--- a/static/app/components/events/interfaces/crashContent/exception/banners/stacktraceBanners.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/banners/stacktraceBanners.tsx
@@ -63,8 +63,7 @@ export function StacktraceBanners({stacktrace, event}: StacktraceBannersProps) {
   const {projects} = useProjects();
   const expectedDefaultFrame: Frame | undefined = (stacktrace.frames ?? [])
     .filter(
-      frame =>
-        frame && frame.inApp && hasFileExtension(frame.absPath || frame.filename || '')
+      frame => frame?.inApp && hasFileExtension(frame.absPath || frame.filename || '')
     )
     .at(-1);
   const project = useMemo(

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -75,7 +75,7 @@ function Content({
     return (
       includeSystemFrames ||
       frame.inApp ||
-      (nextFrame && nextFrame.inApp) ||
+      nextFrame?.inApp ||
       // the last non-app frame
       (!frame.inApp && !nextFrame)
     );

--- a/static/app/components/events/interfaces/crashContent/stackTrace/hierarchicalGroupingContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/hierarchicalGroupingContent.tsx
@@ -174,7 +174,7 @@ export function HierarchicalGroupingContent({
         const isVisible =
           includeSystemFrames ||
           frame.inApp ||
-          (nextFrame && nextFrame.inApp) ||
+          nextFrame?.inApp ||
           // the last non-app frame
           (!frame.inApp && !nextFrame) ||
           isUsedForGrouping;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -63,7 +63,7 @@ export function NativeContent({
     return (
       includeSystemFrames ||
       frame.inApp ||
-      (nextFrame && nextFrame.inApp) ||
+      nextFrame?.inApp ||
       // the last non-app frame
       (!frame.inApp && !nextFrame) ||
       isFrameUsedForGrouping(frame)

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -142,7 +142,7 @@ export class DeprecatedLine extends Component<Props, State> {
   };
 
   toggleContext = evt => {
-    evt && evt.preventDefault();
+    evt?.preventDefault();
 
     this.setState({
       isExpanded: !this.state.isExpanded,
@@ -236,7 +236,7 @@ export class DeprecatedLine extends Component<Props, State> {
 
   leadsToApp() {
     const {data, nextFrame} = this.props;
-    return !data.inApp && ((nextFrame && nextFrame.inApp) || !nextFrame);
+    return !data.inApp && (nextFrame?.inApp || !nextFrame);
   }
 
   isFoundByStackScanning() {

--- a/static/app/components/events/interfaces/frame/line/index.tsx
+++ b/static/app/components/events/interfaces/frame/line/index.tsx
@@ -71,7 +71,7 @@ function Line({
   // Prioritize the frame platform but fall back to the platform
   // of the stack trace / exception
   const platform = getPlatform(frame.platform, props.platform ?? 'other') as PlatformKey;
-  const leadsToApp = !frame.inApp && ((nextFrame && nextFrame.inApp) || !nextFrame);
+  const leadsToApp = !frame.inApp && (nextFrame?.inApp || !nextFrame);
 
   const expandable =
     !leadsToApp || includeSystemFrames

--- a/static/app/components/events/interfaces/frame/packageStatus.tsx
+++ b/static/app/components/events/interfaces/frame/packageStatus.tsx
@@ -31,7 +31,7 @@ function PackageStatus({status, tooltip}: Props) {
   return (
     <StyledTooltip
       title={tooltip}
-      disabled={!(tooltip && tooltip.length)}
+      disabled={!tooltip?.length}
       containerDisplayMode="inline-flex"
     >
       <PackageStatusIcon>{icon}</PackageStatusIcon>

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -124,7 +124,7 @@ function NativeFrame({
     frame.symbolicatorStatus !== SymbolicatorStatus.UNKNOWN_IMAGE &&
     !isHoverPreviewed;
 
-  const leadsToApp = !frame.inApp && ((nextFrame && nextFrame.inApp) || !nextFrame);
+  const leadsToApp = !frame.inApp && (nextFrame?.inApp || !nextFrame);
   const expandable =
     !leadsToApp || includeSystemFrames
       ? isExpandable({

--- a/static/app/components/events/interfaces/performance/durationChart.tsx
+++ b/static/app/components/events/interfaces/performance/durationChart.tsx
@@ -163,11 +163,7 @@ function Content({affectedEvents, allEvents, errored, loading}: ContentProps) {
         valueFormatter: (value, seriesName) => {
           return tooltipFormatter(
             value,
-            aggregateOutputType(
-              affectedEvents && affectedEvents.length
-                ? affectedEvents[0].seriesName
-                : seriesName
-            )
+            aggregateOutputType(affectedEvents.at(0)?.seriesName ?? seriesName)
           );
         },
       }}

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -44,7 +44,7 @@ export function getSpanInfoFromTransactionEvent(
     ? [...spanEntry.data]
     : [];
 
-  if (event?.contexts?.trace && event?.contexts?.trace?.span_id) {
+  if (event?.contexts?.trace?.span_id) {
     // TODO: Fix this conditional and check if span_id is ever actually undefined.
     spans.push(event.contexts.trace as TraceContextSpanProxy);
   }

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanBar.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanBar.tsx
@@ -504,7 +504,7 @@ export class NewTraceDetailsSpanBar extends Component<
             if (groupType === GroupType.SIBLINGS && 'op' in span) {
               toggleSiblingSpanGroup?.(span, groupOccurrence ?? 0);
             } else {
-              toggleSpanGroup && toggleSpanGroup();
+              toggleSpanGroup?.();
             }
           }}
         >

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -598,7 +598,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
             if (groupType === GroupType.SIBLINGS && 'op' in span) {
               toggleSiblingSpanGroup?.(span, groupOccurrence ?? 0);
             } else {
-              toggleSpanGroup && toggleSpanGroup();
+              toggleSpanGroup?.();
             }
           }}
         >

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -506,17 +506,17 @@ export function parseTrace(
   const spans: Array<RawSpanType | AggregateSpanType> = spanEntry?.data ?? [];
 
   const traceContext = getTraceContext(event);
-  const traceID = (traceContext && traceContext.trace_id) || '';
-  const rootSpanID = (traceContext && traceContext.span_id) || '';
-  const rootSpanOpName = (traceContext && traceContext.op) || 'transaction';
-  const description = traceContext && traceContext.description;
-  const parentSpanID = traceContext && traceContext.parent_span_id;
-  const rootSpanStatus = traceContext && traceContext.status;
-  const hash = traceContext && traceContext.hash;
-  const exclusiveTime = traceContext && traceContext.exclusive_time;
-  const count = traceContext && traceContext.count;
-  const frequency = traceContext && traceContext.frequency;
-  const total = traceContext && traceContext.total;
+  const traceID = traceContext?.trace_id || '';
+  const rootSpanID = traceContext?.span_id || '';
+  const rootSpanOpName = traceContext?.op || 'transaction';
+  const description = traceContext?.description;
+  const parentSpanID = traceContext?.parent_span_id;
+  const rootSpanStatus = traceContext?.status;
+  const hash = traceContext?.hash;
+  const exclusiveTime = traceContext?.exclusive_time;
+  const count = traceContext?.count;
+  const frequency = traceContext?.frequency;
+  const total = traceContext?.total;
 
   if (!spanEntry || spans.length <= 0) {
     return {

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -248,7 +248,7 @@ export function Threads({
                 </Wrapper>
               )}
             </EventDataSection>
-            {activeThread && activeThread.state && (
+            {activeThread?.state && (
               <EventDataSection type={EntryType.THREAD_STATE} title={t('Thread State')}>
                 <ThreadStateWrapper>
                   {getThreadStateIcon(threadStateDisplay)}

--- a/static/app/components/events/meta/metaProxy.tsx
+++ b/static/app/components/events/meta/metaProxy.tsx
@@ -32,7 +32,7 @@ export class MetaProxy {
     // trap calls to `getMeta` to return meta object
     if (prop === GET_META) {
       return key => {
-        if (this.local && this.local[key] && this.local[key]['']) {
+        if (this.local?.[key]?.['']) {
           // TODO: Error checks
           const meta = this.local[key][''];
 
@@ -60,7 +60,7 @@ export class MetaProxy {
 
     // Make sure we apply proxy to all children (objects and arrays)
     // Do we need to check for annotated inside of objects?
-    return new Proxy(value, new MetaProxy(this.local && this.local[prop]));
+    return new Proxy(value, new MetaProxy(this.local?.[prop]));
   }
 }
 

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -110,7 +110,7 @@ export default class AbstractExternalIssueForm<
   ): {[key: string]: FieldValue | null} => {
     const {integrationDetails: integrationDetailsFromState} = this.state;
     const integrationDetails = integrationDetailsParam || integrationDetailsFromState;
-    const config = (integrationDetails || {})[this.getConfigName()];
+    const config = integrationDetails?.[this.getConfigName()];
     return Object.fromEntries(
       (config || [])
         .filter((field: IssueConfigField) => field.updatesForm)
@@ -321,7 +321,7 @@ export default class AbstractExternalIssueForm<
   loadAsyncThenFetchAllFields = (): IssueConfigField[] => {
     const {fetchedFieldOptionsCache, integrationDetails} = this.state;
 
-    const configsFromAPI = (integrationDetails || {})[this.getConfigName()];
+    const configsFromAPI = integrationDetails?.[this.getConfigName()];
     return (configsFromAPI || []).map(field => {
       const fieldCopy = {...field};
       // Overwrite choices from cache.

--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -605,7 +605,7 @@ class FormModel {
         // API can return a JSON object with either:
         // 1) map of {[fieldName] => Array<ErrorMessages>}
         // 2) {'non_field_errors' => Array<ErrorMessages>}
-        if (resp && resp.responseJSON) {
+        if (resp?.responseJSON) {
           // non-field errors can be camelcase or snake case
           const nonFieldErrors =
             resp.responseJSON.non_field_errors || resp.responseJSON.nonFieldErrors;
@@ -634,7 +634,7 @@ class FormModel {
         }
 
         // eslint-disable-next-line no-console
-        console.error('Error saving form field', resp && resp.responseJSON);
+        console.error('Error saving form field', resp?.responseJSON);
       });
 
     return request;

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -379,12 +379,11 @@ class GridEditable<
 
     return (
       <GridRow key={row} data-test-id="grid-body-row">
-        {prependColumns &&
-          prependColumns.map((item, i) => (
-            <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`}>
-              {item}
-            </GridBodyCell>
-          ))}
+        {prependColumns?.map((item, i) => (
+          <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`}>
+            {item}
+          </GridBodyCell>
+        ))}
         {columnOrder.map((col, i) => (
           <GridBodyCell data-test-id="grid-body-cell" key={`${col.key}${i}`}>
             {grid.renderBodyCell

--- a/static/app/components/hookOrDefault.tsx
+++ b/static/app/components/hookOrDefault.tsx
@@ -84,7 +84,7 @@ function HookOrDefault<H extends HookName>({
       };
     }, []);
 
-    const hookExists = hooks && hooks.length;
+    const hookExists = hooks?.length;
     const componentFromHook = hooks[0]?.();
     // Defining the props here is unnecessary and slow for typescript
     const HookComponent: React.ComponentType<any> =

--- a/static/app/components/idBadge/userBadge.tsx
+++ b/static/app/components/idBadge/userBadge.tsx
@@ -39,7 +39,7 @@ function UserBadge({
       <StyledAvatar user={user} size={avatarSize} />
       <StyledNameAndEmail>
         <StyledName hideEmail={!!hideEmail}>{title}</StyledName>
-        {!hideEmail && <StyledEmail>{displayEmail || (user && user.email)}</StyledEmail>}
+        {!hideEmail && <StyledEmail>{displayEmail || user?.email}</StyledEmail>}
       </StyledNameAndEmail>
     </StyledUserBadge>
   );

--- a/static/app/components/modals/inviteMembersModal/renderEmailValue.tsx
+++ b/static/app/components/modals/inviteMembersModal/renderEmailValue.tsx
@@ -14,7 +14,7 @@ function renderEmailValue<Option extends OptionTypeBase>(
   valueProps: MultiValueProps<Option>
 ) {
   const {children, ...props} = valueProps;
-  const error = status && status.error;
+  const error = status?.error;
 
   const emailLabel =
     status === undefined ? (

--- a/static/app/components/modals/recoveryOptionsModal.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.tsx
@@ -43,7 +43,7 @@ class RecoveryOptionsModal extends DeprecatedAsyncComponent<Props, State> {
       },
       {}
     );
-    const recoveryEnrolled = recovery && recovery.isEnrolled;
+    const recoveryEnrolled = recovery?.isEnrolled;
     const displaySmsPrompt =
       sms && !sms.isEnrolled && !skipSms && !sms.disallowNewEnrollment;
 

--- a/static/app/components/onboardingWizard/useOnboardingDocs.tsx
+++ b/static/app/components/onboardingWizard/useOnboardingDocs.tsx
@@ -116,20 +116,17 @@ function useOnboardingDocs({docKeys, isPlatformSupported, project}: Options) {
     };
   }
 
-  const isLoading =
-    docKeys &&
-    docKeys.some(key => {
-      if (key in loadingDocsRef.current) {
-        return !!loadingDocsRef.current[key];
-      }
-      return true;
-    });
+  const isLoading = docKeys?.some(key => {
+    if (key in loadingDocsRef.current) {
+      return !!loadingDocsRef.current[key];
+    }
+    return true;
+  });
 
   return {
     docKeys,
     isLoading,
-    hasOnboardingContents:
-      docKeys && docKeys.every(key => typeof docContents[key] === 'string'),
+    hasOnboardingContents: docKeys?.every(key => typeof docContents[key] === 'string'),
     docContents,
   };
 }

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
@@ -167,7 +167,7 @@ function yieldingRafFrameSearch(
   const lowercaseQuery = query.toLowerCase();
   const [_, lookup, flags] = isRegExpSearch ? regexp : ['', '', ''];
 
-  const forcedGlobalFlags = flags && flags.includes('g') ? flags : (flags || '') + 'g';
+  const forcedGlobalFlags = flags?.includes('g') ? flags : (flags || '') + 'g';
 
   const searchFramesFunction = isRegExpSearch ? searchFrameRegExp : searchFrameFzf;
   const searchSpansFunction = isRegExpSearch ? searchSpanRegExp : searchSpanFzf;

--- a/static/app/components/profiling/functionsMiniGrid.tsx
+++ b/static/app/components/profiling/functionsMiniGrid.tsx
@@ -54,45 +54,44 @@ export function FunctionsMiniGrid(props: FunctionsMiniGridProps) {
       </FunctionsMiniGridHeader>
       <FunctionsMiniGridHeader align="right">{t('Count')}</FunctionsMiniGridHeader>
 
-      {functions &&
-        functions.map((f, idx) => {
-          if (!defined(f)) {
-            return null;
-          }
+      {functions?.map((f, idx) => {
+        if (!defined(f)) {
+          return null;
+        }
 
-          let rendered = <Fragment>{f.function}</Fragment>;
+        let rendered = <Fragment>{f.function}</Fragment>;
 
-          const examples = f['examples()'];
-          if (defined(examples?.[0])) {
-            const exampleProfileId = examples![0].replaceAll('-', '');
-            rendered = (
-              <Link
-                to={linkToFlamechartRoute(
-                  exampleProfileId,
-                  f.function as string,
-                  f.package as string
-                )}
-                onClick={onLinkClick}
-              >
-                {f.function}
-              </Link>
-            );
-          }
-
-          return (
-            <Fragment key={idx}>
-              <FunctionsMiniGridCell title={f.function as string}>
-                <FunctionNameTextTruncate>{rendered}</FunctionNameTextTruncate>
-              </FunctionsMiniGridCell>
-              <FunctionsMiniGridCell align="right">
-                <PerformanceDuration nanoseconds={f['sum()'] as number} abbreviation />
-              </FunctionsMiniGridCell>
-              <FunctionsMiniGridCell align="right">
-                <NumberContainer>{f['count()']}</NumberContainer>
-              </FunctionsMiniGridCell>
-            </Fragment>
+        const examples = f['examples()'];
+        if (defined(examples?.[0])) {
+          const exampleProfileId = examples![0].replaceAll('-', '');
+          rendered = (
+            <Link
+              to={linkToFlamechartRoute(
+                exampleProfileId,
+                f.function as string,
+                f.package as string
+              )}
+              onClick={onLinkClick}
+            >
+              {f.function}
+            </Link>
           );
-        })}
+        }
+
+        return (
+          <Fragment key={idx}>
+            <FunctionsMiniGridCell title={f.function as string}>
+              <FunctionNameTextTruncate>{rendered}</FunctionNameTextTruncate>
+            </FunctionsMiniGridCell>
+            <FunctionsMiniGridCell align="right">
+              <PerformanceDuration nanoseconds={f['sum()'] as number} abbreviation />
+            </FunctionsMiniGridCell>
+            <FunctionsMiniGridCell align="right">
+              <NumberContainer>{f['count()']}</NumberContainer>
+            </FunctionsMiniGridCell>
+          </Fragment>
+        );
+      })}
     </FunctionsMiniGridContainer>
   );
 }

--- a/static/app/components/progressRing.tsx
+++ b/static/app/components/progressRing.tsx
@@ -58,7 +58,7 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   color: ${p => p.theme.chartLabel};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   transition: color 100ms;
-  ${p => p.textCss && p.textCss(p)}
+  ${p => p.textCss?.(p)}
 `;
 
 const AnimatedText = motion(Text);

--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -99,9 +99,7 @@ export default function QuickTrace({
     return noTrace;
   }
 
-  const traceLength =
-    (quickTrace.trace && quickTrace.trace.length) ||
-    (quickTrace.orphanErrors && quickTrace.orphanErrors.length);
+  const traceLength = quickTrace.trace?.length || quickTrace.orphanErrors?.length;
   const {root, ancestors, parent, children, descendants, current} = parsedQuickTrace;
 
   const nodes: React.ReactNode[] = [];

--- a/static/app/components/resultGrid.tsx
+++ b/static/app/components/resultGrid.tsx
@@ -223,7 +223,7 @@ class ResultGrid extends Component<Props, State> {
   }
 
   get query() {
-    return ((this.props.location ?? {}).query ?? {}) as {[k: string]: string};
+    return (this.props.location?.query ?? {}) as {[k: string]: string};
   }
 
   remountComponent() {

--- a/static/app/components/search/searchResult.tsx
+++ b/static/app/components/search/searchResult.tsx
@@ -50,9 +50,8 @@ function SearchResult({item, matches, highlighted}: Props) {
     let {title, description} = item;
 
     if (matches) {
-      const matchedTitle = matches && matches.find(({key}) => key === 'title');
-      const matchedDescription =
-        matches && matches.find(({key}) => key === 'description');
+      const matchedTitle = matches?.find(({key}) => key === 'title');
+      const matchedDescription = matches?.find(({key}) => key === 'description');
 
       title = matchedTitle
         ? highlightFuseMatches(matchedTitle, HighlightedMarker)

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -160,23 +160,21 @@ async function createIntegrationResults(
 ): Promise<ResultItem[]> {
   const {providers} = (await integrationsPromise) || {};
   return (
-    (providers &&
-      providers.map(provider => ({
-        title: provider.name,
-        description: (
-          <span
-            dangerouslySetInnerHTML={{
-              __html: markedSingleLine(provider.metadata.description),
-            }}
-          />
-        ),
-        model: provider,
-        sourceType: 'integration',
-        resultType: 'integration',
-        to: `/settings/${orgId}/integrations/${provider.slug}/`,
-        configUrl: `/api/0/organizations/${orgId}/integrations/?provider_key=${provider.slug}&includeConfig=0`,
-      }))) ||
-    []
+    providers?.map(provider => ({
+      title: provider.name,
+      description: (
+        <span
+          dangerouslySetInnerHTML={{
+            __html: markedSingleLine(provider.metadata.description),
+          }}
+        />
+      ),
+      model: provider,
+      sourceType: 'integration',
+      resultType: 'integration',
+      to: `/settings/${orgId}/integrations/${provider.slug}/`,
+      configUrl: `/api/0/organizations/${orgId}/integrations/?provider_key=${provider.slug}&includeConfig=0`,
+    })) || []
   );
 }
 
@@ -230,13 +228,11 @@ async function createShortIdLookupResult(
     return null;
   }
 
-  const issue = shortIdLookup && shortIdLookup.group;
+  const issue = shortIdLookup?.group;
   return {
     item: {
-      title: `${
-        (issue && issue.metadata && issue.metadata.type) || shortIdLookup.shortId
-      }`,
-      description: `${(issue && issue.metadata && issue.metadata.value) || t('Issue')}`,
+      title: `${issue?.metadata?.type || shortIdLookup.shortId}`,
+      description: `${issue?.metadata?.value || t('Issue')}`,
       model: shortIdLookup.group,
       sourceType: 'issue',
       resultType: 'issue',
@@ -255,11 +251,11 @@ async function createEventIdLookupResult(
     return null;
   }
 
-  const event = eventIdLookup && eventIdLookup.event;
+  const event = eventIdLookup?.event;
   return {
     item: {
-      title: `${(event && event.metadata && event.metadata.type) || t('Event')}`,
-      description: `${event && event.metadata && event.metadata.value}`,
+      title: `${event?.metadata?.type || t('Event')}`,
+      description: `${event?.metadata?.value}`,
       sourceType: 'event',
       resultType: 'event',
       to: `/${eventIdLookup.organizationSlug}/${eventIdLookup.projectSlug}/issues/${eventIdLookup.groupId}/events/${eventIdLookup.eventId}/`,

--- a/static/app/components/selectMembers/index.tsx
+++ b/static/app/components/selectMembers/index.tsx
@@ -12,7 +12,7 @@ import type {Member, Organization, Project, User} from 'sentry/types';
 import withApi from 'sentry/utils/withApi';
 
 const getSearchKeyForUser = (user: User) =>
-  `${user.email && user.email.toLowerCase()} ${user.name && user.name.toLowerCase()}`;
+  `${user.email?.toLowerCase()} ${user.name?.toLowerCase()}`;
 
 type MentionableUser = {
   actor: {

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1387,7 +1387,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
   fetchReleases = async (releaseVersion: string): Promise<any[]> => {
     const {api, location, organization} = this.props;
 
-    const project = location && location.query ? location.query.projectId : undefined;
+    const project = location?.query ? location.query.projectId : undefined;
 
     const url = `/organizations/${organization.slug}/releases/`;
     const fetchQuery: {[key: string]: string | number} = {
@@ -1442,9 +1442,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     // with actual tag value results
     const filteredSearchGroups = !preparedQuery
       ? this.state.searchGroups
-      : this.state.searchGroups.filter(
-          item => item.value && item.value.includes(preparedQuery)
-        );
+      : this.state.searchGroups.filter(item => item.value?.includes(preparedQuery));
 
     this.setState({
       searchTerm: query,
@@ -1478,7 +1476,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
       };
     }
 
-    if (excludedTags && excludedTags.includes(tagName)) {
+    if (excludedTags?.includes(tagName)) {
       return null;
     }
 

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -93,34 +93,33 @@ function SearchDropdown({
               <Fragment key={item.title}>
                 {item.type === 'header' && <HeaderItem group={item} />}
                 <Wrapper>
-                  {item.children &&
-                    item.children.map(child => (
-                      <DropdownItem
-                        key={getDropdownItemKey(child)}
-                        item={{
-                          ...child,
-                          ...mergeItemsWith?.[child.title!],
-                        }}
-                        searchSubstring={searchSubstring}
-                        onClick={onClick}
-                        onIconClick={onIconClick}
-                        additionalSearchConfig={{
-                          supportedTags,
-                          disallowWildcard,
-                          disallowedLogicalOperators,
-                          disallowFreeText,
-                          invalidMessages,
-                          booleanKeys,
-                          dateKeys,
-                          durationKeys,
-                          numericKeys,
-                          percentageKeys,
-                          sizeKeys,
-                          textOperatorKeys,
-                        }}
-                        customInvalidTagMessage={customInvalidTagMessage}
-                      />
-                    ))}
+                  {item.children?.map(child => (
+                    <DropdownItem
+                      key={getDropdownItemKey(child)}
+                      item={{
+                        ...child,
+                        ...mergeItemsWith?.[child.title!],
+                      }}
+                      searchSubstring={searchSubstring}
+                      onClick={onClick}
+                      onIconClick={onIconClick}
+                      additionalSearchConfig={{
+                        supportedTags,
+                        disallowWildcard,
+                        disallowedLogicalOperators,
+                        disallowFreeText,
+                        invalidMessages,
+                        booleanKeys,
+                        dateKeys,
+                        durationKeys,
+                        numericKeys,
+                        percentageKeys,
+                        sizeKeys,
+                        textOperatorKeys,
+                      }}
+                      customInvalidTagMessage={customInvalidTagMessage}
+                    />
+                  ))}
                 </Wrapper>
                 {isEmpty && <Info>{t('No items found')}</Info>}
               </Fragment>

--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -234,7 +234,7 @@ class U2fInterface extends Component<Props, State> {
   bindChallengeElement: React.RefCallback<HTMLInputElement> = ref => {
     this.setState({
       challengeElement: ref,
-      formElement: ref && ref.form,
+      formElement: ref?.form ?? null,
     });
 
     if (ref) {

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -151,7 +151,7 @@ export const fields: Record<string, Field> = {
     disabled: ({organization, name}) => !organization[name],
     disabledReason: ORG_DISABLED_REASON,
     // `props` are the props given to FormField
-    setValue: (val, props) => props.organization && props.organization[props.name] && val,
+    setValue: (val, props) => props.organization?.[props.name] && val,
     label: t('Enable JavaScript source fetching'),
     help: t('Allow Sentry to scrape missing JavaScript source context when possible'),
   },

--- a/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
+++ b/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
@@ -84,8 +84,7 @@ const formGroups: JsonFormObject[] = [
         help: t('Enable server-side data scrubbing'),
         'aria-label': t('Enable server-side data scrubbing'),
         // `props` are the props given to FormField
-        setValue: (val, props) =>
-          (props.organization && props.organization[props.name]) || val,
+        setValue: (val, props) => props.organization?.[props.name] || val,
         confirm: {
           false: t('Are you sure you want to disable server-side data scrubbing?'),
         },
@@ -103,8 +102,7 @@ const formGroups: JsonFormObject[] = [
           'Enable to apply default scrubbers to prevent things like passwords and credit cards from being stored'
         ),
         // `props` are the props given to FormField
-        setValue: (val, props) =>
-          (props.organization && props.organization[props.name]) || val,
+        setValue: (val, props) => props.organization?.[props.name] || val,
         confirm: {
           false: t('Are you sure you want to disable using default scrubbers?'),
         },
@@ -115,8 +113,7 @@ const formGroups: JsonFormObject[] = [
         disabled: hasOrgOverride,
         disabledReason: ORG_DISABLED_REASON,
         // `props` are the props given to FormField
-        setValue: (val, props) =>
-          (props.organization && props.organization[props.name]) || val,
+        setValue: (val, props) => props.organization?.[props.name] || val,
         label: t('Prevent Storing of IP Addresses'),
         help: t('Preventing IP addresses from being stored for new events'),
         'aria-label': t(

--- a/static/app/plugins/components/issueActions.tsx
+++ b/static/app/plugins/components/issueActions.tsx
@@ -316,7 +316,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
     });
 
     GroupStore.onUpdateSuccess('', [this.getGroup().id], {stale: true} as StaleGroup);
-    this.props.onSuccess && this.props.onSuccess(data);
+    this.props.onSuccess?.(data);
   }
 
   createIssue() {

--- a/static/app/plugins/components/settings.tsx
+++ b/static/app/plugins/components/settings.tsx
@@ -115,7 +115,7 @@ class PluginSettings<
       }),
       error: this.onSaveError.bind(this, error => {
         this.setState({
-          errors: (error.responseJSON || {}).errors || {},
+          errors: error.responseJSON?.errors || {},
         });
       }),
       complete: this.onSaveComplete,

--- a/static/app/plugins/jira/components/settings.tsx
+++ b/static/app/plugins/jira/components/settings.tsx
@@ -34,7 +34,7 @@ class Settings extends DefaultSettings<Props, State> {
   }
 
   isConfigured() {
-    return !!(this.state.formData && this.state.formData.default_project);
+    return !!this.state.formData?.default_project;
   }
 
   isLastPage = () => {
@@ -58,7 +58,7 @@ class Settings extends DefaultSettings<Props, State> {
             formData,
             initialData,
             // start off in edit mode if there isn't a project set
-            editing: !(formData && formData.default_project),
+            editing: !formData?.default_project,
             // call this here to prevent FormState.READY from being
             // set before fieldList is
           },
@@ -117,7 +117,7 @@ class Settings extends DefaultSettings<Props, State> {
       }),
       error: this.onSaveError.bind(this, error => {
         this.setState({
-          errors: (error.responseJSON || {}).errors || {},
+          errors: error.responseJSON?.errors || {},
         });
       }),
       complete: this.onSaveComplete,

--- a/static/app/plugins/pluginComponentBase.tsx
+++ b/static/app/plugins/pluginComponentBase.tsx
@@ -105,7 +105,7 @@ class PluginComponentBase<
       },
       () => {
         addLoadingMessage(t('Saving changes\u2026'));
-        callback && callback();
+        callback?.();
       }
     );
   }
@@ -116,7 +116,7 @@ class PluginComponentBase<
       {
         state: FormState.READY,
       },
-      () => callback && callback()
+      () => callback?.()
     );
 
     window.clearTimeout(this.successMessageTimeout);
@@ -131,7 +131,7 @@ class PluginComponentBase<
       {
         state: FormState.ERROR,
       },
-      () => callback && callback()
+      () => callback?.()
     );
 
     window.clearTimeout(this.errorMessageTimeout);
@@ -143,7 +143,7 @@ class PluginComponentBase<
   onSaveComplete(callback, ...args) {
     clearIndicators();
     callback = callbackWithArgs(this, callback, ...args);
-    callback && callback();
+    callback?.();
   }
 
   renderField(props: Omit<GenericFieldProps, 'formState'>): React.ReactNode {

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -410,7 +410,7 @@ const storeConfig: GroupStoreDefinition = {
     this.items = this.items.filter(
       item =>
         !mergedIdSet.has(item.id) ||
-        (response && response.merge && item.id === response.merge.parent)
+        (response?.merge && item.id === response.merge.parent)
     );
 
     if (ids.length > 0) {

--- a/static/app/utils/dates.tsx
+++ b/static/app/utils/dates.tsx
@@ -218,10 +218,10 @@ export function statsPeriodToDays(
   start?: DateString,
   end?: DateString
 ) {
-  if (statsPeriod && statsPeriod.endsWith('d')) {
+  if (statsPeriod?.endsWith('d')) {
     return parseInt(statsPeriod.slice(0, -1), 10);
   }
-  if (statsPeriod && statsPeriod.endsWith('h')) {
+  if (statsPeriod?.endsWith('h')) {
     return parseInt(statsPeriod.slice(0, -1), 10) / 24;
   }
   if (start && end) {

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -446,8 +446,7 @@ class EventView {
 
   static getFields(saved: NewQuery | SavedQuery) {
     return saved.fields.map((field, i) => {
-      const width =
-        saved.widths && saved.widths[i] ? Number(saved.widths[i]) : COL_WIDTH_UNDEFINED;
+      const width = saved.widths?.[i] ? Number(saved.widths[i]) : COL_WIDTH_UNDEFINED;
 
       return {field, width};
     });
@@ -722,7 +721,7 @@ class EventView {
     };
 
     for (const field of EXTERNAL_QUERY_STRING_KEYS) {
-      if (this[field] && this[field].length) {
+      if (this[field]?.length) {
         output[field] = this[field];
       }
     }
@@ -1134,7 +1133,7 @@ class EventView {
   }
 
   normalizeDateSelection(location: Location) {
-    const query = (location && location.query) || {};
+    const query = location?.query || {};
 
     // pick only the query strings that we care about
     const picked = pickRelevantLocationQueryStrings(location);
@@ -1230,7 +1229,7 @@ class EventView {
   getResultsViewShortUrlTarget(slug: string): {pathname: string; query: Query} {
     const output = {id: this.id};
     for (const field of [...Object.values(URL_PARAM), 'cursor']) {
-      if (this[field] && this[field].length) {
+      if (this[field]?.length) {
         output[field] = this[field];
       }
     }
@@ -1260,7 +1259,7 @@ class EventView {
     };
 
     for (const field of EXTERNAL_QUERY_STRING_KEYS) {
-      if (this[field] && this[field].length) {
+      if (this[field]?.length) {
         output[field] = this[field];
       }
     }

--- a/static/app/utils/metrics/dashboardImport.tsx
+++ b/static/app/utils/metrics/dashboardImport.tsx
@@ -277,7 +277,7 @@ export class WidgetParser {
     const metricNameMatch = str.match(/:(\S*){/);
     let metric = metricNameMatch ? metricNameMatch[1] : undefined;
 
-    if (metric && metric.includes('.')) {
+    if (metric?.includes('.')) {
       const lastIndex = metric.lastIndexOf('.');
       const metricName = metric.slice(0, lastIndex);
       const operationSuffix = metric.slice(lastIndex + 1);

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -366,7 +366,7 @@ export function stringifyMetricWidget(metricWidget: MetricsQuerySubject): string
     result += `{${query.trim()}}`;
   }
 
-  if (groupBy && groupBy.length) {
+  if (groupBy?.length) {
     result += ` by ${groupBy.join(', ')}`;
   }
 

--- a/static/app/utils/parseApiError.tsx
+++ b/static/app/utils/parseApiError.tsx
@@ -1,14 +1,14 @@
 import type {ResponseMeta} from 'sentry/api';
 
 export default function parseApiError(resp: ResponseMeta): string {
-  const {detail} = (resp && resp.responseJSON) || ({} as object);
+  const {detail} = resp?.responseJSON || ({} as object);
 
   // return immediately if string
   if (typeof detail === 'string') {
     return detail;
   }
 
-  if (detail && detail.message) {
+  if (detail?.message) {
     return detail.message;
   }
 

--- a/static/app/utils/performance/anomalies/anomaliesQuery.tsx
+++ b/static/app/utils/performance/anomalies/anomaliesQuery.tsx
@@ -85,7 +85,7 @@ function AnomaliesSeriesQuery(props: Props) {
     >
       {({tableData, ...rest}) => {
         return props.children({
-          data: tableData && tableData.y ? transformPayload(tableData) : null,
+          data: tableData?.y ? transformPayload(tableData) : null,
           ...rest,
         });
       }}

--- a/static/app/utils/performance/contexts/onDemandControl.tsx
+++ b/static/app/utils/performance/contexts/onDemandControl.tsx
@@ -125,7 +125,7 @@ export const shouldUseOnDemandMetrics = (
     return false;
   }
 
-  if (onDemandControlContext && onDemandControlContext.isControlEnabled) {
+  if (onDemandControlContext?.isControlEnabled) {
     return onDemandControlContext.forceOnDemand;
   }
 

--- a/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -158,11 +158,7 @@ export default function QuickTraceQuery({children, event, ...props}: QueryProps)
               // if we reach this point but there were some traces in the full results,
               // that means there were other transactions in the trace, but the current
               // event could not be found
-              type:
-                traceFullResults.traces?.transactions &&
-                traceFullResults.traces?.transactions.length
-                  ? 'missing'
-                  : 'empty',
+              type: traceFullResults.traces?.transactions?.length ? 'missing' : 'empty',
               currentEvent: null,
             });
           }}

--- a/static/app/utils/performance/quickTrace/utils.tsx
+++ b/static/app/utils/performance/quickTrace/utils.tsx
@@ -33,9 +33,7 @@ export function isCurrentEvent(
   if (isTransaction(currentEvent)) {
     return event.event_id === currentEvent.id;
   }
-  return (
-    event.errors !== undefined && event.errors.some(e => e.event_id === currentEvent.id)
-  );
+  return event.errors?.some(e => e.event_id === currentEvent.id) ?? false;
 }
 
 type PathNode = {

--- a/static/app/utils/profiling/hooks/useContextMenu.tsx
+++ b/static/app/utils/profiling/hooks/useContextMenu.tsx
@@ -123,7 +123,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
       if (
         !itemProps.menuRef ||
         itemProps.menuRef.contains(event.target as Node) ||
-        (subMenuRef.current && subMenuRef.current?.contains(event.target as Node))
+        subMenuRef.current?.contains(event.target as Node)
       ) {
         return;
       }

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -406,7 +406,7 @@ class BaseProjects extends Component<Props, State> {
       // while we load actual project data
       projects: this.state.initiallyLoaded
         ? [...this.state.fetchedProjects, ...this.state.projectsFromStore]
-        : (slugs && slugs.map(slug => ({slug}))) || [],
+        : slugs?.map(slug => ({slug})) || [],
 
       // This is set when we fail to find some slugs from both store and API
       isIncomplete: this.state.isIncomplete,
@@ -472,7 +472,7 @@ async function fetchProjects(
     collapse: ['latestDeploys'],
   };
 
-  if (slugs && slugs.length) {
+  if (slugs?.length) {
     query.query = slugs.map(slug => `slug:${slug}`).join(' ');
   }
 

--- a/static/app/utils/releases/releasesProvider.spec.tsx
+++ b/static/app/utils/releases/releasesProvider.spec.tsx
@@ -11,8 +11,9 @@ function TestComponent({other}: {other: string}) {
   return (
     <div>
       <span>{other}</span>
-      {releases &&
-        releases.map(release => <em key={release.version}>{release.version}</em>)}
+      {releases?.map(release => (
+        <em key={release.version}>{release.version}</em>
+      ))}
       {`loading: ${loading}`}
     </div>
   );

--- a/static/app/utils/useApiRequests.tsx
+++ b/static/app/utils/useApiRequests.tsx
@@ -201,7 +201,7 @@ function useApiRequests<T extends Record<string, any>>({
     (error: RequestError, args: EndpointDefinition<T>) => {
       const [stateKey] = args;
 
-      if (error && error.responseText) {
+      if (error?.responseText) {
         Sentry.addBreadcrumb({
           message: error.responseText,
           category: 'xhr',
@@ -264,8 +264,8 @@ function useApiRequests<T extends Record<string, any>>({
           options = options ?? {};
           // If you're using nested async components/views make sure to pass the
           // props through so that the child component has access to props.location
-          const locationQuery = (location && location.query) || {};
-          let query = (parameters && parameters.query) || {};
+          const locationQuery = location?.query || {};
+          let query = parameters?.query || {};
           // If paginate option then pass entire `query` object to API call
           // It should only be expecting `query.cursor` for pagination
           if ((options.paginate || locationQuery.cursor) && !options.disableEntireQuery) {
@@ -438,7 +438,7 @@ function useMeasureApiRequests() {
       error: false,
     };
 
-    if (routes && routes.length) {
+    if (routes?.length) {
       metric.mark({name: `async-component-${getRouteStringFromRoutes(routes)}`});
     }
   }, [routes]);

--- a/static/app/utils/useMedia.tsx
+++ b/static/app/utils/useMedia.tsx
@@ -4,9 +4,7 @@ import {useEffect, useState} from 'react';
  * Hook that updates when a media query result changes
  */
 export default function useMedia(query: string) {
-  const [state, setState] = useState(
-    () => window.matchMedia && window.matchMedia(query)?.matches
-  );
+  const [state, setState] = useState(() => window.matchMedia?.(query)?.matches);
 
   useEffect(() => {
     let mounted = true;

--- a/static/app/utils/useTeamsById.tsx
+++ b/static/app/utils/useTeamsById.tsx
@@ -33,7 +33,7 @@ type TeamQuery = [field: string, ids: string[]];
 function buildTeamsQueryKey(orgSlug: string, teamQuery: TeamQuery | null): ApiQueryKey {
   const query: {query?: string} = {};
 
-  if (teamQuery && teamQuery[1].length) {
+  if (teamQuery?.[1].length) {
     query.query = `${teamQuery[0]}:${teamQuery[1].join(',')}`;
   }
 

--- a/static/app/utils/withLatestContext.tsx
+++ b/static/app/utils/withLatestContext.tsx
@@ -58,7 +58,7 @@ function withLatestContext<P extends InjectedLatestContextProps>(
       // of orgs but not full org details
       const latestOrganization =
         organization ||
-        (organizations && organizations.length
+        (organizations?.length
           ? organizations.find(
               ({slug}) => slug === ConfigStore.get('lastOrganization')
             ) || organizations[0]

--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -68,7 +68,7 @@ class AcceptProjectTransfer extends DeprecatedAsyncView<Props, State> {
       },
       error: error => {
         const errorMsg =
-          error && error.responseJSON && typeof error.responseJSON.detail === 'string'
+          error?.responseJSON && typeof error.responseJSON.detail === 'string'
             ? error.responseJSON.detail
             : '';
 
@@ -83,7 +83,7 @@ class AcceptProjectTransfer extends DeprecatedAsyncView<Props, State> {
     let disableLog = false;
     // Check if there is an error message with `transferDetails` endpoint
     // If so, show as toast and ignore, otherwise log to sentry
-    if (error && error.responseJSON && typeof error.responseJSON.detail === 'string') {
+    if (error?.responseJSON && typeof error.responseJSON.detail === 'string') {
       addErrorMessage(error.responseJSON.detail);
       disableLog = true;
     }

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -775,7 +775,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     const {rule} = this.state;
     const owner = rule?.owner;
     // ownership follows the format team:<id>, just grab the id
-    return owner && owner.split(':')[1];
+    return owner?.split(':')[1];
   };
 
   handleOwnerChange = ({value}: {value: string}) => {

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -337,7 +337,7 @@ function RuleNode({
       }
       return (
         <Separator key={key}>
-          {node.formFields && node.formFields.hasOwnProperty(key)
+          {node.formFields?.hasOwnProperty(key)
             ? getField(key, node.formFields[key])
             : part}
         </Separator>

--- a/static/app/views/alerts/rules/metric/ruleNameOwnerForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleNameOwnerForm.tsx
@@ -39,7 +39,7 @@ export default function RuleNameOwnerForm({disabled, project}: Props) {
     >
       {({model}) => {
         const owner = model.getValue('owner');
-        const ownerId = owner && owner.split(':')[1];
+        const ownerId = owner?.split(':')[1];
         return (
           <TeamSelector
             value={ownerId}

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -55,9 +55,7 @@ const getCleanAction = (actionConfig, dateCreated?: string): Action => {
     unsavedDateCreated: dateCreated ?? new Date().toISOString(),
     type: actionConfig.type,
     targetType:
-      actionConfig &&
-      actionConfig.allowedTargetTypes &&
-      actionConfig.allowedTargetTypes.length > 0
+      actionConfig?.allowedTargetTypes && actionConfig.allowedTargetTypes.length > 0
         ? actionConfig.allowedTargetTypes[0]
         : null,
     targetIdentifier: actionConfig.sentryAppId || '',

--- a/static/app/views/alerts/rules/metric/triggers/form.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/form.tsx
@@ -92,7 +92,7 @@ class TriggerFormItem extends PureComponent<Props> {
         label={triggerLabel}
         help={fieldHelp}
         required={isCritical}
-        error={error && error.alertThreshold}
+        error={error?.alertThreshold}
       >
         <ThresholdControl
           disabled={disabled}
@@ -219,7 +219,7 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
               api={api}
               config={config}
               disabled={disabled}
-              error={errors && errors.get(index)}
+              error={errors?.get(index)}
               trigger={trigger}
               thresholdPeriod={thresholdPeriod}
               thresholdType={thresholdType}
@@ -260,7 +260,7 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
           api={api}
           config={config}
           disabled={disabled}
-          error={errors && errors.get(2)}
+          error={errors?.get(2)}
           trigger={resolveTrigger}
           // Flip rule thresholdType to opposite
           thresholdPeriod={thresholdPeriod}

--- a/static/app/views/alerts/utils/getIncidentDiscoverUrl.tsx
+++ b/static/app/views/alerts/utils/getIncidentDiscoverUrl.tsx
@@ -33,7 +33,7 @@ export function getIncidentDiscoverUrl(opts: {
 
   const discoverQuery: NewQuery = {
     id: undefined,
-    name: (incident && incident.title) || '',
+    name: incident?.title || '',
     orderby: `-${getAggregateAlias(incident.alertRule.aggregate)}`,
     yAxis: incident.alertRule.aggregate ? [incident.alertRule.aggregate] : undefined,
     query: incident?.discoverQuery ?? '',

--- a/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
+++ b/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
@@ -71,7 +71,7 @@ export function getMetricRuleDiscoverQuery({
 
   const eventQuery: NewQuery = {
     id: undefined,
-    name: (rule && rule.name) || 'Transactions',
+    name: rule?.name || 'Transactions',
     fields,
     orderby: `-${aggregateAlias}`,
     query: query ?? rule.query ?? '',

--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -60,7 +60,7 @@ function DashboardCard({
               <DateStatus />
             )}
           </DateSelected>
-          {renderContextMenu && renderContextMenu()}
+          {renderContextMenu?.()}
         </CardFooter>
       </StyledDashboardCard>
     </Link>

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -487,8 +487,8 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
           }
 
           const otherRegex = new RegExp(`(?:.* : ${OTHER}$)|^${OTHER}$`);
-          const shouldColorOther = timeseriesResults?.some(
-            ({seriesName}) => seriesName && seriesName.match(otherRegex)
+          const shouldColorOther = timeseriesResults?.some(({seriesName}) =>
+            seriesName?.match(otherRegex)
           );
           const colors = timeseriesResults
             ? theme.charts.getColorPalette(

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -100,7 +100,7 @@ class DiscoverLanding extends DeprecatedAsyncComponent<Props, State> {
 
           // if a search is performed on the list of queries, we filter
           // on the pre-built queries
-          if (eventView.name && eventView.name.toLowerCase().includes(needleSearch)) {
+          if (eventView.name?.toLowerCase().includes(needleSearch)) {
             return sum + 1;
           }
 

--- a/static/app/views/discover/miniGraph.tsx
+++ b/static/app/views/discover/miniGraph.tsx
@@ -202,7 +202,7 @@ class MiniGraph extends Component<Props> {
           const chartColors = allSeries.length
             ? [...theme.charts.getColorPalette(allSeries.length - 2 - (hasOther ? 1 : 0))]
             : undefined;
-          if (chartColors && chartColors.length && hasOther) {
+          if (chartColors?.length && hasOther) {
             chartColors.push(theme.chartOther);
           }
           const chartOptions = {

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -83,7 +83,7 @@ describe('Discover > QueryList', function () {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper && wrapper.unmount();
+    wrapper?.unmount();
     wrapper = null;
   });
 

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -307,11 +307,7 @@ class QueryList extends Component<Props> {
               eventView={eventView}
               organization={organization}
               referrer={referrer}
-              yAxis={
-                savedQuery.yAxis && savedQuery.yAxis.length
-                  ? savedQuery.yAxis
-                  : ['count()']
-              }
+              yAxis={savedQuery.yAxis?.length ? savedQuery.yAxis : ['count()']}
             />
           )}
           renderContextMenu={() => (

--- a/static/app/views/discover/querycard.tsx
+++ b/static/app/views/discover/querycard.tsx
@@ -66,7 +66,7 @@ class QueryCard extends PureComponent<Props> {
                 </DateStatus>
               ) : null}
             </DateSelected>
-            {renderContextMenu && renderContextMenu()}
+            {renderContextMenu?.()}
           </QueryCardFooter>
         </StyledQueryCard>
       </Link>

--- a/static/app/views/discover/savedQuery/utils.tsx
+++ b/static/app/views/discover/savedQuery/utils.tsx
@@ -51,8 +51,7 @@ export function handleCreateQuery(
         organization,
         ...extractAnalyticsQueryFields(payload),
         error:
-          (err && err.message) ||
-          `Could not save a ${isNewQuery ? 'new' : 'existing'} query`,
+          err?.message || `Could not save a ${isNewQuery ? 'new' : 'existing'} query`,
       });
     });
 
@@ -100,7 +99,7 @@ export function handleUpdateQuery(
       trackAnalytics('discover_v2.update_query_failed', {
         organization,
         ...extractAnalyticsQueryFields(payload),
-        error: (err && err.message) || 'Failed to update a query',
+        error: err?.message || 'Failed to update a query',
       });
     });
 
@@ -139,7 +138,7 @@ export function handleUpdateQueryName(
       trackAnalytics('discover_v2.update_query_failed', {
         organization,
         ...extractAnalyticsQueryFields(payload),
-        error: (err && err.message) || 'Failed to update a query name',
+        error: err?.message || 'Failed to update a query name',
       });
     });
 
@@ -171,7 +170,7 @@ export function handleDeleteQuery(
       trackAnalytics('discover_v2.delete_query_failed', {
         organization,
         ...extractAnalyticsQueryFields(eventView.toNewQuery()),
-        error: (err && err.message) || 'Failed to delete query',
+        error: err?.message || 'Failed to delete query',
       });
     });
 

--- a/static/app/views/discover/table/index.tsx
+++ b/static/app/views/discover/table/index.tsx
@@ -136,7 +136,7 @@ class Table extends PureComponent<TableProps, TableState> {
           name: 'app.api.discover-query',
           start: `discover-events-start-${apiPayload.query}`,
           data: {
-            status: resp && resp.status,
+            status: resp?.status,
           },
         });
         if (this.state.tableFetchID !== tableFetchID) {

--- a/static/app/views/discover/table/quickContext/issueContext.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.tsx
@@ -154,8 +154,7 @@ function IssueContext(props: BaseContextProps) {
     );
 
   const renderSuspectCommits = () =>
-    event &&
-    event.eventID &&
+    event?.eventID &&
     issue && (
       <SuspectCommitsContainer data-test-id="quick-context-suspect-commits-container">
         <SuspectCommits

--- a/static/app/views/discover/table/quickContext/releaseContext.tsx
+++ b/static/app/views/discover/table/quickContext/releaseContext.tsx
@@ -113,8 +113,7 @@ function ReleaseContext(props: BaseContextProps) {
   };
 
   const renderLastCommit = () =>
-    data &&
-    data.lastCommit && (
+    data?.lastCommit && (
       <ReleaseContextContainer data-test-id="quick-context-release-last-commit-container">
         <ContextHeader>
           <ContextTitle>{t('Last Commit')}</ContextTitle>

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -183,7 +183,7 @@ function TableView(props: TableViewProps) {
     if (!hasIdField) {
       let value = dataRow.id;
 
-      if (tableData && tableData.meta) {
+      if (tableData?.meta) {
         const fieldRenderer = getFieldRenderer('id', tableData.meta);
         value = fieldRenderer(dataRow, {organization, location});
       }

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -103,7 +103,7 @@ export function decodeColumnOrder(fields: Readonly<Field[]>): TableColumn<string
         column.type = outputType;
       }
       const aggregate = AGGREGATIONS[col.function[0]];
-      column.isSortable = aggregate && aggregate.isSortable;
+      column.isSortable = aggregate?.isSortable;
     } else if (col.kind === 'field') {
       if (getFieldDefinition(col.field) !== null) {
         column.type = getFieldDefinition(col.field)?.valueType as ColumnValueType;

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -182,7 +182,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
   // used with Github to redirect to the the integration detail
   onInstallWithInstallationId = (data: Integration) => {
     const {organization} = this.state;
-    const orgId = organization && organization.slug;
+    const orgId = organization?.slug;
     const normalizedUrl = normalizeUrl(
       `/settings/${orgId}/integrations/${data.provider.key}/${data.id}/`
     );

--- a/static/app/views/issueDetails/activitySection.tsx
+++ b/static/app/views/issueDetails/activitySection.tsx
@@ -28,7 +28,7 @@ function ActivitySection(props: Props) {
   const [inputId, setInputId] = useState(uniqueId());
 
   const me = ConfigStore.get('user');
-  const projectSlugs = group && group.project ? [group.project.slug] : [];
+  const projectSlugs = group?.project ? [group.project.slug] : [];
   const noteProps = {
     minHeight: 140,
     group,

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -898,7 +898,7 @@ function GroupDetails(props: GroupDetailsProps) {
           forceProject={group?.project}
           shouldForceProject
         >
-          {config && config.showFeedbackWidget && <FloatingFeedbackWidget />}
+          {config?.showFeedbackWidget && <FloatingFeedbackWidget />}
           <GroupDetailsPageContent
             {...props}
             {...{

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -83,7 +83,7 @@ const SUBSCRIPTION_REASONS = {
  * @returns Reason for subscription
  */
 export function getSubscriptionReason(group: Group) {
-  if (group.subscriptionDetails && group.subscriptionDetails.disabled) {
+  if (group.subscriptionDetails?.disabled) {
     return t('You have disabled workflow notifications for this project.');
   }
 

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -285,7 +285,7 @@ function useSelectedGroupsState() {
   const selected = SelectedGroupStore.getSelectedIds();
   const projects = [...selected]
     .map(id => GroupStore.get(id))
-    .filter((group): group is Group => !!(group && group.project))
+    .filter((group): group is Group => !!group?.project)
     .map(group => group.project.slug);
 
   const uniqProjects = uniq(projects);

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -673,7 +673,7 @@ class IssueListOverview extends Component<Props, State> {
         // If this is a direct hit, we redirect to the intended result directly.
         if (resp.getResponseHeader('X-Sentry-Direct-Hit') === '1') {
           let redirect: string;
-          if (data[0] && data[0].matchingEventId) {
+          if (data[0]?.matchingEventId) {
             const {id, matchingEventId} = data[0];
             redirect = `/organizations/${organization.slug}/issues/${id}/events/${matchingEventId}/`;
           } else {
@@ -969,7 +969,7 @@ class IssueListOverview extends Component<Props, State> {
     const {organization} = this.props;
     let path: string;
 
-    if (savedSearch && savedSearch.id) {
+    if (savedSearch?.id) {
       path = `/organizations/${organization.slug}/issues/searches/${savedSearch.id}/`;
 
       // Remove the query as saved searches bring their own query string.

--- a/static/app/views/organizationActivity/activityFeedItem.tsx
+++ b/static/app/views/organizationActivity/activityFeedItem.tsx
@@ -290,7 +290,7 @@ class ActivityItem extends Component<Props, State> {
           });
         }
         assignee = MemberListStore.getById(data.assignee);
-        if (assignee && assignee.email) {
+        if (assignee?.email) {
           return tct('[author] assigned [issue] to [assignee]', {
             author,
             assignee: <span title={assignee.email}>{assignee.name}</span>,

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreRing.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreRing.tsx
@@ -44,7 +44,7 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   color: ${p => p.theme.chartLabel};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   transition: color 300ms;
-  ${p => p.textCss && p.textCss(p)}
+  ${p => p.textCss?.(p)}
 `;
 
 function PerformanceScoreRing({

--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -200,7 +200,7 @@ function Chart({
       valueFormatter: (value, seriesName) => {
         return tooltipFormatter(
           value,
-          aggregateOutputType(data && data.length ? data[0].seriesName : seriesName)
+          aggregateOutputType(data?.length ? data[0].seriesName : seriesName)
         );
       },
       nameFormatter(value: string) {

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -110,7 +110,7 @@ export function DataDisplay<T extends WidgetDataConstraint>(
     !missingDataKeys && Object.values(props.widgetData).every(d => !d || d.hasData);
   const isLoading = Object.values(props.widgetData).some(d => !d || d.isLoading);
   const isErrored =
-    !missingDataKeys && Object.values(props.widgetData).some(d => d && d.isErrored);
+    !missingDataKeys && Object.values(props.widgetData).some(d => d?.isErrored);
 
   return (
     <Container data-test-id="performance-widget-container">

--- a/static/app/views/performance/landing/widgets/transforms/transformTrendsDiscover.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformTrendsDiscover.tsx
@@ -5,9 +5,7 @@ import {QUERY_LIMIT_PARAM} from '../utils';
 
 export function transformTrendsDiscover(_: any, props: TrendDiscoveryChildrenProps) {
   const {trendsData} = props;
-  const events = trendsData
-    ? normalizeTrends((trendsData && trendsData.events && trendsData.events.data) || [])
-    : [];
+  const events = trendsData ? normalizeTrends(trendsData?.events?.data || []) : [];
   return {
     ...props,
     data: trendsData,
@@ -17,7 +15,7 @@ export function transformTrendsDiscover(_: any, props: TrendDiscoveryChildrenPro
     isErrored: !!props.error,
     errored: props.error,
     statsData: trendsData ? trendsData.stats : {},
-    transactionsList: events && events.slice ? events.slice(0, QUERY_LIMIT_PARAM) : [],
+    transactionsList: events?.slice ? events.slice(0, QUERY_LIMIT_PARAM) : [],
     events,
   };
 }

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -84,7 +84,7 @@ function NewTraceDetailsContent(props: Props) {
     () => getTraceInfo(props.traces ?? [], props.orphanErrors),
     [props.traces, props.orphanErrors]
   );
-  const root = props.traces && props.traces[0];
+  const root = props.traces?.[0];
   const {data: rootEvent, isLoading: isRootEventLoading} = useApiQuery<EventTransaction>(
     [
       `/organizations/${props.organization.slug}/events/${root?.project_slug}:${root?.event_id}/`,

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -449,7 +449,7 @@ export class TagExplorer extends Component<Props> {
               </GuideAnchor>
               <GridEditable
                 isLoading={isLoading}
-                data={tableData && tableData.data ? tableData.data : []}
+                data={tableData?.data ? tableData.data : []}
                 columnOrder={columns}
                 columnSortBy={columnSortBy}
                 grid={{

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -187,9 +187,7 @@ function TrendChart({
           withBreakpoint
         >
           {({isLoading, trendsData}) => {
-            const events = normalizeTrends(
-              (trendsData && trendsData.events && trendsData.events.data) || []
-            );
+            const events = normalizeTrends(trendsData?.events?.data || []);
 
             // keep trend change type as regression until the backend can support passing the type
             const selectedTransaction = getSelectedTransaction(
@@ -220,7 +218,7 @@ function TrendChart({
             );
 
             const metricsTimeFrame =
-              transactionEvent && transactionEvent.start && transactionEvent.end
+              transactionEvent?.start && transactionEvent.end
                 ? {start: transactionEvent.start * 1000, end: transactionEvent.end * 1000}
                 : undefined;
 

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -307,7 +307,7 @@ export class TagValueTable extends Component<Props, State> {
         >
           <GridEditable
             isLoading={isLoading}
-            data={tableData && tableData.data ? tableData.data : []}
+            data={tableData?.data ? tableData.data : []}
             columnOrder={newColumns}
             columnSortBy={[]}
             grid={{

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -123,15 +123,10 @@ function TagsHeatMap(
 
   const xValues = new Set();
 
-  const histogramData =
-    tableData &&
-    tableData.histogram &&
-    tableData.histogram.data &&
-    tableData.histogram.data.length
-      ? tableData.histogram.data
-      : undefined;
-  const tagData =
-    tableData && tableData.tags && tableData.tags.data ? tableData.tags.data : undefined;
+  const histogramData = tableData?.histogram?.data?.length
+    ? tableData.histogram.data
+    : undefined;
+  const tagData = tableData?.tags?.data ? tableData.tags.data : undefined;
 
   const rowKey = histogramData && findRowKey(histogramData[0]);
 

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -255,9 +255,7 @@ function ChangedTransactions(props: Props) {
           projects,
           trendView.project
         );
-        const events = normalizeTrends(
-          (trendsData && trendsData.events && trendsData.events.data) || []
-        );
+        const events = normalizeTrends(trendsData?.events?.data || []);
         const selectedTransaction = getSelectedTransaction(
           location,
           trendChangeType,
@@ -265,7 +263,7 @@ function ChangedTransactions(props: Props) {
         );
 
         const statsData = trendsData?.stats || {};
-        const transactionsList = events && events.slice ? events.slice(0, 5) : [];
+        const transactionsList = events?.slice ? events.slice(0, 5) : [];
 
         const currentTrendFunction =
           isLoading && previousTrendFunction

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -391,7 +391,7 @@ export function getProjectID(
 export function transformTransaction(
   transaction: NormalizedTrendsTransaction
 ): NormalizedTrendsTransaction {
-  if (transaction && transaction.breakpoint) {
+  if (transaction?.breakpoint) {
     return {
       ...transaction,
       breakpoint: transaction.breakpoint * 1000,

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -161,7 +161,7 @@ class ProjectContext extends Component<Props, State> {
     const {organization, projectSlug, skipReload} = this.props;
     // we fetch core access/information from the global organization data
     const activeProject = this.identifyProject();
-    const hasAccess = activeProject && activeProject.hasAccess;
+    const hasAccess = activeProject?.hasAccess;
 
     this.setState((state: State) => ({
       // if `skipReload` is true, then don't change loading state

--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -1,6 +1,7 @@
 import type {Theme} from '@emotion/react';
 import type {Location} from 'history';
 import pick from 'lodash/pick';
+import type {Moment} from 'moment';
 import moment from 'moment';
 
 import MarkLine from 'sentry/components/charts/components/markLine';
@@ -248,8 +249,10 @@ export function generateReleaseMarkLines(
     return markLines;
   }
 
-  const releaseAdopted = adoptionStages?.adopted && moment(adoptionStages.adopted);
-  if (releaseAdopted && releaseAdopted.isBetween(start, end)) {
+  const releaseAdopted: Moment | undefined = adoptionStages?.adopted
+    ? moment(adoptionStages.adopted)
+    : undefined;
+  if (releaseAdopted?.isBetween(start, end)) {
     markLines.push(
       generateReleaseMarkLine(
         releaseMarkLinesLabels.adopted,
@@ -260,8 +263,10 @@ export function generateReleaseMarkLines(
     );
   }
 
-  const releaseReplaced = adoptionStages?.unadopted && moment(adoptionStages.unadopted);
-  if (releaseReplaced && releaseReplaced.isBetween(start, end)) {
+  const releaseReplaced: Moment | undefined = adoptionStages?.unadopted
+    ? moment(adoptionStages.unadopted)
+    : undefined;
+  if (releaseReplaced?.isBetween(start, end)) {
     markLines.push(
       generateReleaseMarkLine(
         releaseMarkLinesLabels.unadopted,

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -31,7 +31,14 @@ import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {space} from 'sentry/styles/space';
-import type {Organization, PageFilters, Project, Release, Tag} from 'sentry/types';
+import type {
+  AvatarProject,
+  Organization,
+  PageFilters,
+  Project,
+  Release,
+  Tag,
+} from 'sentry/types';
 import {ReleaseStatus} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
@@ -412,7 +419,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
         ? t('time range')
         : getRelativeSummary(statsPeriod || DEFAULT_STATS_PERIOD).toLowerCase();
 
-    if (searchQuery && searchQuery.length) {
+    if (searchQuery?.length) {
       return (
         <Panel>
           <EmptyMessage icon={<IconSearch size="xl" />} size="large">{`${t(
@@ -501,9 +508,10 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
     return (
       <Projects orgId={organization.slug} slugs={[selectedProject.slug]}>
         {({projects, initiallyLoaded, fetchError}) => {
-          const project = projects && projects.length === 1 && projects[0];
+          const project: AvatarProject | undefined =
+            projects?.length === 1 ? projects.at(0) : undefined;
           const projectCanHaveReleases =
-            project && project.platform && releaseHealth.includes(project.platform);
+            project?.platform && releaseHealth.includes(project.platform);
 
           if (!initiallyLoaded || fetchError || !projectCanHaveReleases) {
             return null;

--- a/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 function ReleaseCardCommits({release, withHeading = true}: Props) {
   const commitCount = release.commitCount || 0;
-  const authorCount = (release.authors && release.authors.length) || 0;
+  const authorCount = release.authors?.length || 0;
   if (commitCount === 0) {
     return null;
   }

--- a/static/app/views/releases/thresholdsList/thresholdGroupRows.tsx
+++ b/static/app/views/releases/thresholdsList/thresholdGroupRows.tsx
@@ -447,7 +447,7 @@ export function ThresholdGroupRows({
                     icon={<IconAdd color="activeText" isCircled />}
                     onClick={() =>
                       initializeNewThreshold(
-                        initialThreshold && initialThreshold.environment
+                        initialThreshold?.environment
                           ? initialThreshold.environment.name
                           : undefined,
                         initialThreshold ? initialThreshold.window_in_seconds : 0

--- a/static/app/views/releases/thresholdsList/thresholdGroupTable.tsx
+++ b/static/app/views/releases/thresholdsList/thresholdGroupTable.tsx
@@ -50,20 +50,19 @@ export default function ThresholdGroupTable({
         emptyMessage={t('No thresholds found.')}
         headers={[t('Environment'), t('Window'), t('Condition'), t(' ')]}
       >
-        {sortedThreshold &&
-          sortedThreshold.map((threshold, idx) => {
-            return (
-              <ThresholdGroupRows
-                key={threshold.id}
-                project={project}
-                allEnvironmentNames={allEnvironmentNames}
-                threshold={threshold}
-                refetch={refetch}
-                setTempError={setTempError}
-                isLastRow={idx === sortedThreshold.length - 1}
-              />
-            );
-          })}
+        {sortedThreshold?.map((threshold, idx) => {
+          return (
+            <ThresholdGroupRows
+              key={threshold.id}
+              project={project}
+              allEnvironmentNames={allEnvironmentNames}
+              threshold={threshold}
+              refetch={refetch}
+              setTempError={setTempError}
+              isLastRow={idx === sortedThreshold.length - 1}
+            />
+          );
+        })}
       </StyledPanelTable>
     </div>
   );

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -75,7 +75,7 @@ export function UploadBackup({onComplete}: StepProps) {
   };
 
   const onFileUploadLinkClick = () => {
-    inputFileRef.current && inputFileRef.current.click();
+    inputFileRef.current?.click();
   };
 
   const handleStartRelocation = async () => {

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -51,8 +51,7 @@ export default function BreadcrumbRow({
     [onDimensionChange, index]
   );
   const handleObjectInspectorExpanded = useCallback(
-    (path, expandedState, e) =>
-      onInspectorExpanded && onInspectorExpanded(index, path, expandedState, e),
+    (path, expandedState, e) => onInspectorExpanded?.(index, path, expandedState, e),
     [index, onInspectorExpanded]
   );
 

--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -39,8 +39,7 @@ function UnmemoizedConsoleLogRow({
   style,
 }: Props) {
   const handleDimensionChange = useCallback(
-    (path, expandedState, e) =>
-      onDimensionChange && onDimensionChange(index, path, expandedState, e),
+    (path, expandedState, e) => onDimensionChange?.(index, path, expandedState, e),
     [onDimensionChange, index]
   );
 

--- a/static/app/views/routeError.tsx
+++ b/static/app/views/routeError.tsx
@@ -100,7 +100,7 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
       </p>
       <p>{t("If you're daring, you may want to try the following:")}</p>
       <List symbol="bullet">
-        {window && window.adblockSuspected && (
+        {window?.adblockSuspected && (
           <ListItem>
             {t(
               "We detected something AdBlock-like. Try disabling it, as it's known to cause issues."

--- a/static/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/static/app/views/settings/components/settingsNavigationGroup.tsx
@@ -28,7 +28,7 @@ function SettingsNavigationGroup(props: NavigationGroupProps) {
       if (recordAnalytics && to !== window.location.pathname && organization) {
         trackAnalytics('sidebar.item_clicked', {
           organization,
-          project_id: project && project.id,
+          project_id: project?.id,
           sidebar_item_id: id,
           dest: path,
         });

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -47,7 +47,7 @@ function OrganizationApiKeysList({
   onAddApiKey,
   onRemove,
 }: Props) {
-  const hasKeys = keys && keys.length;
+  const hasKeys = Boolean(keys?.length);
 
   const action = (
     <Button
@@ -92,37 +92,36 @@ function OrganizationApiKeysList({
         emptyMessage={t('No API keys for this organization')}
         headers={[t('Name'), t('Key'), t('Actions')]}
       >
-        {keys &&
-          keys.map(({id, key, label}) => {
-            const apiDetailsUrl = recreateRoute(`${id}/`, {
-              params: {...params, orgId: organization.slug},
-              routes,
-            });
+        {keys?.map(({id, key, label}) => {
+          const apiDetailsUrl = recreateRoute(`${id}/`, {
+            params: {...params, orgId: organization.slug},
+            routes,
+          });
 
-            return (
-              <Fragment key={key}>
-                <Cell>
-                  <Link to={apiDetailsUrl}>{label}</Link>
-                </Cell>
+          return (
+            <Fragment key={key}>
+              <Cell>
+                <Link to={apiDetailsUrl}>{label}</Link>
+              </Cell>
 
-                <TextCopyInput size="sm" monospace>
-                  {key}
-                </TextCopyInput>
+              <TextCopyInput size="sm" monospace>
+                {key}
+              </TextCopyInput>
 
-                <Cell>
-                  <LinkWithConfirmation
-                    aria-label={t('Remove API Key')}
-                    className="btn btn-default btn-sm"
-                    onConfirm={() => onRemove(id)}
-                    message={t('Are you sure you want to remove this API key?')}
-                    title={t('Remove API Key?')}
-                  >
-                    <IconDelete size="xs" css={{position: 'relative', top: '2px'}} />
-                  </LinkWithConfirmation>
-                </Cell>
-              </Fragment>
-            );
-          })}
+              <Cell>
+                <LinkWithConfirmation
+                  aria-label={t('Remove API Key')}
+                  className="btn btn-default btn-sm"
+                  onConfirm={() => onRemove(id)}
+                  message={t('Are you sure you want to remove this API key?')}
+                  title={t('Remove API Key?')}
+                >
+                  <IconDelete size="xs" css={{position: 'relative', top: '2px'}} />
+                </LinkWithConfirmation>
+              </Cell>
+            </Fragment>
+          );
+        })}
       </PanelTable>
     </div>
   );

--- a/static/app/views/settings/organizationAuth/index.tsx
+++ b/static/app/views/settings/organizationAuth/index.tsx
@@ -78,7 +78,7 @@ class OrganizationAuth extends DeprecatedAsyncView<Props, State> {
       data: {provider, init: true},
       success: data => {
         // Redirect to auth provider URL
-        if (data && data.auth_url) {
+        if (data?.auth_url) {
           window.location.href = data.auth_url;
         }
       },

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -241,7 +241,7 @@ class SentryApplicationDetails extends DeprecatedAsyncView<Props, State> {
 
   get showAuthInfo() {
     const {app} = this.state;
-    return !(app && app.clientSecret && app.clientSecret[0] === '*');
+    return !(app?.clientSecret && app.clientSecret[0] === '*');
   }
 
   onAddToken = async (evt: React.MouseEvent): Promise<void> => {

--- a/static/app/views/settings/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.tsx
@@ -94,7 +94,7 @@ export default class AddIntegration extends Component<Props> {
     const opts = `scrollbars=yes,width=${width},height=${height},top=${top},left=${left}`;
 
     this.dialog = window.open(installUrl, name, opts);
-    this.dialog && this.dialog.focus();
+    this.dialog?.focus();
   };
 
   didReceiveMessage = (message: MessageEvent) => {

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -39,7 +39,7 @@ export default class InstalledIntegration extends Component<Props> {
   };
 
   getRemovalBodyAndText(aspects: Integration['provider']['aspects']) {
-    if (aspects && aspects.removal_dialog) {
+    if (aspects?.removal_dialog) {
       return {
         body: aspects.removal_dialog.body,
         actionText: aspects.removal_dialog.actionText,

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
@@ -111,7 +111,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
     // For alert-rule-actions, the forms are entirely custom, extra fields are
     // passed in on submission, not as part of the form. See handleAlertRuleSubmit().
     if (element === 'alert-rule-action') {
-      const defaultResetValues = (this.props.resetValues || {}).settings || [];
+      const defaultResetValues = this.props.resetValues?.settings || [];
       const initialData = defaultResetValues.reduce((acc, curr) => {
         acc[curr.name] = curr.value;
         return acc;
@@ -150,7 +150,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
   };
 
   getDefaultOptions = (field: FieldFromSchema) => {
-    const savedOption = ((this.props.resetValues || {}).settings || []).find(
+    const savedOption = (this.props.resetValues?.settings || []).find(
       value => value.name === field.name
     );
     const currentOptions = (field.choices || []).map(([value, label]) => ({
@@ -181,9 +181,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
       defaultValue = getFieldDefault(field);
     }
 
-    const reset = ((resetValues || {}).settings || []).find(
-      value => value.name === field.name
-    );
+    const reset = resetValues?.settings?.find(value => value.name === field.name);
 
     if (reset) {
       defaultValue = reset.value;

--- a/static/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/static/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -23,7 +23,7 @@ const getBooleanValue = (list: string[]) => {
     return 'all';
   }
 
-  return list && list.map(v => v.toLowerCase()).includes('true') ? 'true' : 'false';
+  return list?.map(v => v.toLowerCase()).includes('true') ? 'true' : 'false';
 };
 
 const booleanOptions = [

--- a/static/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/static/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -35,7 +35,7 @@ function InviteRequestRow({
   allRoles,
 }: Props) {
   const role = allRoles.find(r => r.id === inviteRequest.role);
-  const roleDisallowed = !(role && role.allowed);
+  const roleDisallowed = !role?.allowed;
   const {access} = organization;
   const canApprove = access.includes('member:admin');
 

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -120,8 +120,7 @@ class OrganizationMemberDetail extends DeprecatedAsyncView<Props, State> {
       });
       addSuccessMessage(t('Saved'));
     } catch (resp) {
-      const errorMessage =
-        (resp && resp.responseJSON && resp.responseJSON.detail) || t('Could not save...');
+      const errorMessage = resp?.responseJSON?.detail || t('Could not save...');
       this.setState({busy: false});
       addErrorMessage(errorMessage);
     }

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -116,7 +116,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
       canRemoveMembers && !isCurrentUser && !isIdpProvisioned && !isPartnershipUser;
     // member has a `user` property if they are registered with sentry
     // i.e. has accepted an invite to join org
-    const has2fa = user && user.has2fa;
+    const has2fa = user?.has2fa;
     const detailsUrl = `/settings/${organization.slug}/members/${id}/`;
     const isInviteSuccessful = status === 'success';
     const isInviting = status === 'loading';

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -147,8 +147,7 @@ class TeamMembers extends DeprecatedAsyncView<Props, State> {
         },
         error: resp => {
           const errorMessage =
-            (resp && resp.responseJSON && resp.responseJSON.detail) ||
-            t('Unable to add team member.');
+            resp?.responseJSON?.detail || t('Unable to add team member.');
           addErrorMessage(errorMessage);
         },
       }

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -15,7 +15,7 @@ export default function getConfiguration({
   organization,
   debugFilesNeedsReview,
 }: ConfigParams): NavigationSection[] {
-  const plugins = ((project && project.plugins) || []).filter(plugin => plugin.enabled);
+  const plugins = (project?.plugins || []).filter(plugin => plugin.enabled);
   return [
     {
       name: t('Project'),

--- a/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -142,8 +142,7 @@ function KeyRateLimitsForm({data, disabled, organization, params}: Props) {
                 validate={({form}) => {
                   // TODO(TS): is validate actually doing anything because it's an unexpected prop
                   const isValid =
-                    form &&
-                    form.rateLimit &&
+                    form?.rateLimit &&
                     typeof form.rateLimit.count !== 'undefined' &&
                     typeof form.rateLimit.window !== 'undefined';
 

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -131,7 +131,7 @@ class AddCodeOwnerModal extends DeprecatedAsyncComponent<Props, State> {
   };
 
   handleAddedFile(data: CodeOwner) {
-    this.props.onSave && this.props.onSave(data);
+    this.props.onSave?.(data);
     this.props.closeModal();
   }
 

--- a/static/app/views/settings/project/projectOwnership/modal.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.tsx
@@ -48,7 +48,7 @@ function getFrameSuggestions(eventData?: Event) {
   }
 
   // Only display in-app frames
-  frames = frames.filter(frame => frame && frame.inApp).reverse();
+  frames = frames.filter(frame => frame?.inApp).reverse();
 
   return uniq(frames.map(frame => frame.filename || frame.absPath || ''));
 }

--- a/static/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -89,7 +89,7 @@ class OwnerInput extends Component<Props, State> {
             hasChanges: false,
             text,
           },
-          () => onSave && onSave(text)
+          () => onSave?.(text)
         );
         trackIntegrationAnalytics('project_ownership.saved', {
           page,

--- a/static/app/views/settings/project/projectOwnership/selectOwners.tsx
+++ b/static/app/views/settings/project/projectOwnership/selectOwners.tsx
@@ -40,7 +40,7 @@ function ValueComponent({data, removeProps}: MultiValueProps<Owner>) {
 }
 
 const getSearchKeyForUser = (user: User) =>
-  `${user.email && user.email.toLowerCase()} ${user.name && user.name.toLowerCase()}`;
+  `${user.email?.toLowerCase()} ${user.name?.toLowerCase()}`;
 
 type Props = {
   api: Client;

--- a/static/app/views/settings/projectMetrics/access.tsx
+++ b/static/app/views/settings/projectMetrics/access.tsx
@@ -1,8 +1,7 @@
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import type {Project, Scope, Team} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
-
-import {hasEveryAccess} from '../../../components/acl/access';
 
 type Props = {
   /**
@@ -35,7 +34,7 @@ export function useAccess({access = [], team, project}: Props) {
   project = project ?? undefined;
 
   const hasAccess = hasEveryAccess(access, {organization, team, project});
-  const hasSuperuser = !!(user && user.isSuperuser);
+  const hasSuperuser = Boolean(user?.isSuperuser);
 
   return {
     hasAccess,

--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -65,7 +65,7 @@ class ProjectPluginDetails extends DeprecatedAsyncView<Props, State> {
 
   getTitle() {
     const {plugin} = this.state;
-    if (plugin && plugin.name) {
+    if (plugin?.name) {
       return plugin.name;
     }
     return 'Sentry';
@@ -145,12 +145,11 @@ class ProjectPluginDetails extends DeprecatedAsyncView<Props, State> {
     const {pluginDetails} = this.state;
     const {plugins} = this.props;
 
-    const plugin =
-      plugins &&
-      plugins.plugins &&
-      plugins.plugins.find(({slug}) => slug === this.props.params.pluginId);
+    const plugin = plugins?.plugins?.find(
+      ({slug}) => slug === this.props.params.pluginId
+    );
 
-    return plugin ? plugin.enabled : pluginDetails && pluginDetails.enabled;
+    return plugin ? plugin.enabled : pluginDetails?.enabled;
   }
 
   renderActions() {

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -326,7 +326,7 @@ function Chart({
         return tooltipFormatter(
           value,
           aggregateOutputFormat ??
-            aggregateOutputType(data && data.length ? data[0].seriesName : seriesName)
+            aggregateOutputType(data?.length ? data[0].seriesName : seriesName)
         );
       },
       nameFormatter(value: string) {

--- a/static/app/views/starfish/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/starfish/components/stackTraceMiniFrame.tsx
@@ -120,7 +120,7 @@ function SourceCodeIntegrationLink({
     projectSlug: project.slug,
   });
 
-  if (match && match.config && match.sourceUrl && frame.lineNo && !isLoading) {
+  if (match?.config && match.sourceUrl && frame.lineNo && !isLoading) {
     return (
       <DeemphasizedExternalLink
         href={getIntegrationSourceUrl(

--- a/static/app/views/starfish/queries/useProjectSpanMetricsCounts.tsx
+++ b/static/app/views/starfish/queries/useProjectSpanMetricsCounts.tsx
@@ -19,7 +19,7 @@ export const useProjectSpanMetricCounts = ({
     name: 'Has Any Span Metrics',
     query,
     fields: ['project.id', 'count()'],
-    projects: projectId && projectId.map(id => parseInt(id, 10)),
+    projects: projectId?.map(id => parseInt(id, 10)),
     dataset: DiscoverDatasets.SPANS_METRICS,
     version: 2,
   });

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -36,10 +36,7 @@ export function useReleases(searchTerm?: string) {
     {staleTime: Infinity, enabled: isReady}
   );
 
-  const chunks =
-    releaseResults.data && releaseResults.data.length
-      ? chunk(releaseResults.data, 10)
-      : [];
+  const chunks = releaseResults.data?.length ? chunk(releaseResults.data, 10) : [];
 
   const releaseMetrics = useQueries({
     queries: chunks.map(releases => {
@@ -91,7 +88,7 @@ export function useReleases(searchTerm?: string) {
     version: string;
     count?: number;
   }[] =
-    releaseResults.data && releaseResults.data.length && metricsFetched
+    releaseResults.data?.length && metricsFetched
       ? releaseResults.data.flatMap(release => {
           const releaseVersion = release.version;
           const dateCreated = release.dateCreated;

--- a/static/app/views/starfish/views/webServiceView/spanGroupBar.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBar.tsx
@@ -67,62 +67,54 @@ export function SpanGroupBar(props: SpanGroupBarProps) {
     <FlexibleRowPanel>
       <Title>{t('Time Spent Breakdown')}</Title>
       <SegmentContainer>
-        {segments &&
-          segments.map((value, index) => {
-            const percent = getPercent(value, total);
-            const spanModule = value['span.module'];
-            const to =
-              spanModule === 'db'
-                ? `/${routingContext.baseURL}/performance/database/`
-                : '';
-            function handleModulePin() {
-              if (spanModule === pinnedModule) {
-                setPinnedModule(null);
-                onHover(null);
-              } else {
-                setPinnedModule(spanModule);
-                onHover(spanModule);
-              }
+        {segments?.map((value, index) => {
+          const percent = getPercent(value, total);
+          const spanModule = value['span.module'];
+          const to =
+            spanModule === 'db' ? `/${routingContext.baseURL}/performance/database/` : '';
+          function handleModulePin() {
+            if (spanModule === pinnedModule) {
+              setPinnedModule(null);
+              onHover(null);
+            } else {
+              setPinnedModule(spanModule);
+              onHover(spanModule);
             }
-            const tooltipHttp = (
-              <div
+          }
+          const tooltipHttp = (
+            <div
+              onMouseOver={() => pinnedModule === null && debouncedHover(spanModule)}
+              onMouseLeave={() => pinnedModule === null && debouncedHover(null)}
+              onClick={handleModulePin}
+            >
+              <div>
+                {tct('Time spent on [spanModule] across all endpoints', {spanModule})}
+              </div>
+              <IconPin isSolid={spanModule === pinnedModule} /> {percent}%
+            </div>
+          );
+          return (
+            <StyledTooltip key={index} title={tooltipHttp} percent={percent} isHoverable>
+              <Segment
+                to={to}
+                hasLink={to !== ''}
+                color={theme.barBreakdownColors[index]}
                 onMouseOver={() => pinnedModule === null && debouncedHover(spanModule)}
                 onMouseLeave={() => pinnedModule === null && debouncedHover(null)}
-                onClick={handleModulePin}
               >
-                <div>
-                  {tct('Time spent on [spanModule] across all endpoints', {spanModule})}
-                </div>
-                <IconPin isSolid={spanModule === pinnedModule} /> {percent}%
-              </div>
-            );
-            return (
-              <StyledTooltip
-                key={index}
-                title={tooltipHttp}
-                percent={percent}
-                isHoverable
-              >
-                <Segment
-                  to={to}
-                  hasLink={to !== ''}
-                  color={theme.barBreakdownColors[index]}
-                  onMouseOver={() => pinnedModule === null && debouncedHover(spanModule)}
-                  onMouseLeave={() => pinnedModule === null && debouncedHover(null)}
-                >
-                  <SegmentText fontColor={theme.barBreakdownFontColors[index]}>
-                    {spanModule === pinnedModule && (
-                      <StyledIconPin
-                        isSolid
-                        iconColor={theme.barBreakdownFontColors[index]}
-                      />
-                    )}
-                    {spanModule} {percent}%
-                  </SegmentText>
-                </Segment>
-              </StyledTooltip>
-            );
-          })}
+                <SegmentText fontColor={theme.barBreakdownFontColors[index]}>
+                  {spanModule === pinnedModule && (
+                    <StyledIconPin
+                      isSolid
+                      iconColor={theme.barBreakdownFontColors[index]}
+                    />
+                  )}
+                  {spanModule} {percent}%
+                </SegmentText>
+              </Segment>
+            </StyledTooltip>
+          );
+        })}
       </SegmentContainer>
     </FlexibleRowPanel>
   );

--- a/static/app/views/userFeedback/userFeedbackEmpty.tsx
+++ b/static/app/views/userFeedback/userFeedbackEmpty.tsx
@@ -22,10 +22,9 @@ export function UserFeedbackEmpty({projectIds}: Props) {
   const loadingProjects = !initiallyLoaded;
   const organization = useOrganization();
 
-  const selectedProjects =
-    projectIds && projectIds.length
-      ? projects.filter(({id}) => projectIds.includes(id))
-      : projects;
+  const selectedProjects = projectIds?.length
+    ? projects.filter(({id}) => projectIds.includes(id))
+    : projects;
 
   const hasAnyFeedback = selectedProjects.some(({hasUserReports}) => hasUserReports);
 


### PR DESCRIPTION
This change is supported and persisted using **[Biome's useOptionalChain rule](https://biomejs.dev/linter/rules/use-optional-chain/)**

All browsers that we ship to supports `optional chaining`. This will eventually get transpiled to the previous change, unless we move away from Babel and use ES6+ on our webpack config but for development, it makes it a lot easier to review and understand the code.

- You can look into caniuse.com to see the supported browsers for optional chaining: https://caniuse.com/?search=optional%20chaining
- Relevant [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
