### PR TITLE
fix(copy): Change subtitle on widget charts

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -654,7 +654,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
       {...props}
       location={location}
       Subtitle={() => (
-        <Subtitle>{props.subTitle ?? t('Suggested transactions')}</Subtitle>
+        <Subtitle>{props.subTitle ?? t('Found in the following transactions')}</Subtitle>
       )}
       HeaderActions={provided => getContainerActions(provided)}
       InteractiveTitle={


### PR DESCRIPTION
### Summary
This changes the subtitle on widget charts to be a bit more descriptive
