### PR TITLE
ref(feedback/issues): refactor linked comment

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -215,15 +215,9 @@ class GitHubIssueBasic(IssueBasicMixin):
         def get_default_comment(group: Group) -> str:
             prefix = get_linked_issue_comment_prefix(group)
             url = group.get_absolute_url(params={"referrer": "github_integration"})
-            issue_id = group.qualified_short_id
+            issue_short_id = group.qualified_short_id
 
-            return (
-                "{prefix}: [{issue_id}]({url})".format(
-                    prefix=prefix,
-                    url=absolute_uri(url),
-                    issue_id=issue_id,
-                ),
-            )
+            return f"{prefix}: [{issue_short_id}]({absolute_uri(url)})"
 
         return [
             {

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -208,9 +208,22 @@ class GitHubIssueBasic(IssueBasicMixin):
 
         def get_linked_issue_comment_prefix(group: Group) -> str:
             if group.issue_category == GroupCategory.FEEDBACK:
-                return "Sentry feedback"
+                return "Sentry Feedback"
             else:
-                return "Sentry issue"
+                return "Sentry Issue"
+
+        def get_default_comment(group: Group) -> str:
+            prefix = get_linked_issue_comment_prefix(group)
+            url = group.get_absolute_url(params={"referrer": "github_integration"})
+            issue_id = group.qualified_short_id
+
+            return (
+                "{prefix}: [{issue_id}]({url})".format(
+                    prefix=prefix,
+                    url=absolute_uri(url),
+                    issue_id=issue_id,
+                ),
+            )
 
         return [
             {
@@ -235,15 +248,7 @@ class GitHubIssueBasic(IssueBasicMixin):
             {
                 "name": "comment",
                 "label": "Comment",
-                "default": (
-                    get_linked_issue_comment_prefix(group)
-                    + ": [{issue_id}]({url})".format(
-                        url=absolute_uri(
-                            group.get_absolute_url(params={"referrer": "github_integration"})
-                        ),
-                        issue_id=group.qualified_short_id,
-                    ),
-                ),
+                "default": get_default_comment(group),
                 "type": "textarea",
                 "required": False,
                 "autosize": True,

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -152,7 +152,7 @@ class GitlabIssueBasic(IssueBasicMixin):
             {
                 "name": "comment",
                 "label": "Comment",
-                "default": "Sentry issue: [{issue_id}]({url})".format(
+                "default": "Sentry Issue: [{issue_id}]({url})".format(
                     url=absolute_uri(
                         group.get_absolute_url(params={"referrer": "gitlab_integration"})
                     ),

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -143,7 +143,7 @@ class GitHubPlugin(GitHubMixin, IssuePlugin2):
             {
                 "name": "comment",
                 "label": "Comment",
-                "default": "Sentry issue: [{issue_id}]({url})".format(
+                "default": "Sentry Issue: [{issue_id}]({url})".format(
                     url=absolute_uri(group.get_absolute_url(params={"referrer": "github_plugin"})),
                     issue_id=group.qualified_short_id,
                 ),

--- a/src/sentry_plugins/phabricator/plugin.py
+++ b/src/sentry_plugins/phabricator/plugin.py
@@ -139,7 +139,7 @@ class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
             {
                 "name": "comment",
                 "label": "Comment",
-                "default": "Sentry issue: [{issue_id}]({url})".format(
+                "default": "Sentry Issue: [{issue_id}]({url})".format(
                     url=absolute_uri(
                         group.get_absolute_url(params={"referrer": "phabricator_plugin"})
                     ),

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -422,12 +422,12 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         assert issue_event.group is not None
         resp = self.install.get_link_issue_config(group=issue_event.group, **data)
         # assert comment wording for linked issue is correct
-        assert "Sentry Issue" in resp[2]["default"][0]
+        assert "Sentry Issue" in resp[2]["default"]
 
         # link a feedback issue
         resp = self.install.get_link_issue_config(group=feedback_issue, **data)
         # assert comment wording for linked feedback is correct
-        assert "Sentry Feedback" in resp[2]["default"][0]
+        assert "Sentry Feedback" in resp[2]["default"]
 
     @responses.activate
     def after_link_issue(self):

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -422,12 +422,12 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         assert issue_event.group is not None
         resp = self.install.get_link_issue_config(group=issue_event.group, **data)
         # assert comment wording for linked issue is correct
-        assert "Sentry issue" in resp[2]["default"][0]
+        assert "Sentry Issue" in resp[2]["default"][0]
 
         # link a feedback issue
         resp = self.install.get_link_issue_config(group=feedback_issue, **data)
         # assert comment wording for linked feedback is correct
-        assert "Sentry feedback" in resp[2]["default"][0]
+        assert "Sentry Feedback" in resp[2]["default"][0]
 
     @responses.activate
     def after_link_issue(self):

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -126,7 +126,7 @@ class GitlabIssuesTest(GitLabTestCase):
             {
                 "name": "comment",
                 "label": "Comment",
-                "default": "Sentry issue: [{issue_id}]({url})".format(
+                "default": "Sentry Issue: [{issue_id}]({url})".format(
                     url=absolute_uri(
                         self.group.get_absolute_url(params={"referrer": "gitlab_integration"})
                     ),


### PR DESCRIPTION
- fix a bug in which i converted the comment into a tuple, but it should be a string
- refactor the linked comment string to be more readable
- also change some instances from `Sentry issue` -> `Sentry Issue` for consistency
