### PR TITLE
feature(new-trace-view): Rendering missing intrumentation bar.

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -435,6 +435,7 @@ function RenderRow(props: {
             viewManager={props.viewManager}
             color={pickBarColor('missing-instrumentation')}
             node_space={props.node.space}
+            isMissingIntrumentationBar
           />
         </div>
       </div>
@@ -712,6 +713,7 @@ interface TraceBarProps {
   node_space: [number, number] | null;
   viewManager: VirtualizedViewManager;
   virtualizedIndex: number;
+  isMissingIntrumentationBar?: boolean;
 }
 
 function TraceBar(props: TraceBarProps) {
@@ -724,7 +726,9 @@ function TraceBar(props: TraceBarProps) {
       ref={r =>
         props.viewManager.registerSpanBarRef(r, props.node_space!, props.virtualizedIndex)
       }
-      className="TraceBar"
+      className={`TraceBar ${
+        props.isMissingIntrumentationBar && 'MissingInstrumentation'
+      }`}
       style={{
         position: 'absolute',
         transform: props.viewManager.computeSpanMatrixTransform(props.node_space),
@@ -834,6 +838,11 @@ const TraceStylingWrapper = styled('div')`
     width: 100%;
     background-color: black;
     transform-origin: left center;
+
+    &.MissingInstrumentation{
+      background-image: linear-gradient(153deg, #f4f2f7 25%, #dedae3 25%, #dedae3 50%, #f4f2f7 50%, #f4f2f7 75%, #dedae3 75%, #dedae3 100%);
+      background-size: 88.11px 44.89px;
+    }
   }
 
   .TraceChildrenCount {

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -250,7 +250,7 @@ function RenderRow(props: {
           <TraceBar
             virtualizedIndex={virtualizedIndex}
             viewManager={props.viewManager}
-            color={pickBarColor('autogrouping')}
+            color={props.theme.blue300}
             node_space={props.node.space}
           />
         </div>
@@ -433,9 +433,8 @@ function RenderRow(props: {
           <TraceBar
             virtualizedIndex={virtualizedIndex}
             viewManager={props.viewManager}
-            color={pickBarColor('missing-instrumentation')}
+            color={props.theme.gray200}
             node_space={props.node.space}
-            isMissingIntrumentationBar
           />
         </div>
       </div>
@@ -713,7 +712,6 @@ interface TraceBarProps {
   node_space: [number, number] | null;
   viewManager: VirtualizedViewManager;
   virtualizedIndex: number;
-  isMissingIntrumentationBar?: boolean;
 }
 
 function TraceBar(props: TraceBarProps) {
@@ -726,9 +724,7 @@ function TraceBar(props: TraceBarProps) {
       ref={r =>
         props.viewManager.registerSpanBarRef(r, props.node_space!, props.virtualizedIndex)
       }
-      className={`TraceBar ${
-        props.isMissingIntrumentationBar && 'MissingInstrumentation'
-      }`}
+      className="TraceBar"
       style={{
         position: 'absolute',
         transform: props.viewManager.computeSpanMatrixTransform(props.node_space),
@@ -838,11 +834,6 @@ const TraceStylingWrapper = styled('div')`
     width: 100%;
     background-color: black;
     transform-origin: left center;
-
-    &.MissingInstrumentation{
-      background-image: linear-gradient(153deg, #f4f2f7 25%, #dedae3 25%, #dedae3 50%, #f4f2f7 50%, #f4f2f7 75%, #dedae3 75%, #dedae3 100%);
-      background-size: 88.11px 44.89px;
-    }
   }
 
   .TraceChildrenCount {

--- a/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
@@ -49,7 +49,7 @@ function makeRawSpan(overrides: Partial<RawSpanType> = {}): RawSpanType {
     op: '',
     description: '',
     start_timestamp: 0,
-    timestamp: 1,
+    timestamp: 10,
     ...overrides,
   } as RawSpanType;
 }
@@ -205,13 +205,13 @@ describe('TraceTree', () => {
     const node = TraceTree.FromSpans(root, [
       makeRawSpan({
         start_timestamp: date,
-        timestamp: date + 100,
+        timestamp: date + 1,
         span_id: '1',
         op: 'span 1',
       }),
       makeRawSpan({
-        start_timestamp: date + 200,
-        timestamp: date + 400,
+        start_timestamp: date + 2,
+        timestamp: date + 4,
         op: 'span 2',
         span_id: '2',
       }),

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -152,7 +152,8 @@ function maybeInsertMissingInstrumentationSpan(
     return;
   }
 
-  if (node.value.start_timestamp - lastInsertedSpan.value.timestamp < 100) {
+  const gapInMs = (node.value.start_timestamp - lastInsertedSpan.value.timestamp) * 1000;
+  if (gapInMs < 100) {
     return;
   }
 
@@ -855,7 +856,11 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     const children: TraceTreeNode<TraceTree.NodeValue>[] = [];
 
     for (let i = this.children.length - 1; i >= 0; i--) {
-      if (this.children[i].expanded || isParentAutogroupedNode(this.children[i])) {
+      if (
+        this.children[i].expanded ||
+        isParentAutogroupedNode(this.children[i]) ||
+        isMissingInstrumentationNode(this.children[i])
+      ) {
         stack.push(this.children[i]);
       }
     }

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -152,8 +152,7 @@ function maybeInsertMissingInstrumentationSpan(
     return;
   }
 
-  const gapInMs = (node.value.start_timestamp - lastInsertedSpan.value.timestamp) * 1000;
-  if (gapInMs < 100) {
+  if (node.value.start_timestamp - lastInsertedSpan.value.timestamp < 0.1) {
     return;
   }
 
@@ -831,7 +830,11 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     let count = 0;
 
     for (let i = this.children.length - 1; i >= 0; i--) {
-      if (this.children[i].expanded || isParentAutogroupedNode(this.children[i])) {
+      if (
+        this.children[i].expanded ||
+        isParentAutogroupedNode(this.children[i]) ||
+        isMissingInstrumentationNode(this.children[i])
+      ) {
         stack.push(this.children[i]);
       }
     }


### PR DESCRIPTION
Couldn't fully replicate the styling for the bar as it renders in prod without the bars getting janky. The stripes I added are a bit wider:
<img width="861" alt="Screenshot 2024-02-13 at 1 43 02 PM" src="https://github.com/getsentry/sentry/assets/60121741/6067ebd6-792b-413b-b88c-9b441a1be720">
Updated color for autogrouped bars

