### PR TITLE
Allow create_schema_from_issue_owners to accept empty values

### DIFF
--- a/src/sentry/api/endpoints/codeowners/index.py
+++ b/src/sentry/api/endpoints/codeowners/index.py
@@ -43,8 +43,8 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):
             codeowner.repository_project_path_config,
         )
         codeowner.schema = create_schema_from_issue_owners(
-            codeowner.raw,
-            project.id,
+            project_id=project.id,
+            issue_owners=codeowner.raw,
             add_owner_ids=True,
             remove_deleted_owners=True,
         )

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -93,10 +93,12 @@ class ProjectOwnershipRequestSerializer(serializers.Serializer):
             )
 
         schema = create_schema_from_issue_owners(
-            attrs["raw"], self.context["ownership"].project_id, add_owner_ids=True
+            project_id=self.context["ownership"].project_id,
+            issue_owners=attrs["raw"],
+            add_owner_ids=True,
         )
-
-        self._validate_no_codeowners(schema["rules"])
+        if schema:
+            self._validate_no_codeowners(schema["rules"])
 
         attrs["schema"] = schema
         return attrs
@@ -203,7 +205,10 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
             return
 
         ownership.schema = create_schema_from_issue_owners(
-            ownership.raw, project.id, add_owner_ids=True, remove_deleted_owners=True
+            project_id=project.id,
+            issue_owners=ownership.raw,
+            add_owner_ids=True,
+            remove_deleted_owners=True,
         )
         ownership.save()
 

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -120,7 +120,7 @@ class ProjectCodeOwners(Model):
         # Convert IssueOwner syntax into schema syntax
         try:
             schema = create_schema_from_issue_owners(
-                issue_owners=issue_owner_rules, project_id=self.project.id
+                project_id=self.project.id, issue_owners=issue_owner_rules
             )
             # Convert IssueOwner syntax into schema syntax
             if schema:

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -504,11 +504,13 @@ def add_owner_ids_to_schema(rules: list[dict[str, Any]], owners_id: dict[str, in
 
 
 def create_schema_from_issue_owners(
-    issue_owners: str,
     project_id: int,
+    issue_owners: str | None = None,
     add_owner_ids: bool = False,
     remove_deleted_owners: bool = False,
-) -> Mapping[str, Any]:
+) -> Mapping[str, Any] | None:
+    if not issue_owners:
+        return None
     try:
         rules = parse_rules(issue_owners)
     except ParseError as e:

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -244,6 +244,26 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
             "schema": None,
         }
 
+    def test_get_schema_empty_raw(self):
+        # Create ProjectOwnership...
+        self.client.put(self.path, {"raw": "*.js admin@localhost #tiger-team"})
+        # ...then remove its contents
+        self.client.put(self.path, {"raw": ""})
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        expected_data = {
+            "raw": None,
+            "fallthrough": True,
+            "autoAssignment": "Auto Assign to Issue Owner",
+            "isActive": True,
+            "codeownersAutoSync": True,
+            "schema": None,
+        }
+        for k in expected_data:
+            assert expected_data[k] == resp.data[k]
+        assert resp.data["dateCreated"] is not None
+        assert resp.data["lastUpdated"] is not None
+
     def test_get_rule_deleted_owner(self):
         self.member_user_delete = self.create_user("member_delete@localhost", is_superuser=False)
         self.create_member(


### PR DESCRIPTION
Resolves [SENTRY-2MBV](https://sentry.sentry.io/issues/4974004981/)

Allows create_schema_from_issue_owners to receive empty values. It looks like these were already being passed and the two associated models both have `null=True` set for their DB fields. Also added a test to ensure we don't fail trying to refresh empty schemas.