### PR TITLE
fix(issues): add regression test for linked comment to assert string

### DIFF
--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -429,6 +429,10 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         # assert comment wording for linked feedback is correct
         assert "Sentry Feedback" in resp[2]["default"]
 
+        # ensure linked comment is a string
+        assert isinstance(resp[1]["default"], str)
+        assert isinstance(resp[0]["default"], str)
+
     @responses.activate
     def after_link_issue(self):
         responses.add(


### PR DESCRIPTION
Adds an assertion to an existing test to ensure that the default linked comment is a string.

Prevents issues similar to these: https://sentry.sentry.io/issues/?project=-1&query=Error+Communicating+with+GitHub&referrer=issue-list&statsPeriod=7d

These issues were occurring because there was a bug introduced in a previous PR which converted the default comment to a tuple, leading to an API error.
