### PR TITLE
fix(app-start): Pass along device class to span samples

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -31,6 +31,7 @@ import {ScreenLoadSpanSamples} from 'sentry/views/starfish/views/screens/screenL
 import AppStartWidgets from './widgets';
 
 type Query = {
+  ['device.class']: string;
   primaryRelease: string;
   project: string;
   secondaryRelease: string;
@@ -54,6 +55,7 @@ function ScreenSummary() {
     spanDescription,
     spanOp,
     spanAppStartType,
+    ['device.class']: deviceClass,
   } = location.query;
 
   const startupModule: LocationDescriptor = {
@@ -199,6 +201,9 @@ function ScreenSummary() {
                 <ScreenLoadSpanSamples
                   additionalFilters={{
                     [SpanMetricsField.APP_START_TYPE]: spanAppStartType,
+                    ...(deviceClass
+                      ? {[SpanMetricsField.DEVICE_CLASS]: deviceClass}
+                      : {}),
                   }}
                   groupId={spanGroup}
                   transactionName={transactionName}

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -31,7 +31,7 @@ import {ScreenLoadSpanSamples} from 'sentry/views/starfish/views/screens/screenL
 import AppStartWidgets from './widgets';
 
 type Query = {
-  ['device.class']: string;
+  'device.class': string;
   primaryRelease: string;
   project: string;
   secondaryRelease: string;
@@ -55,7 +55,7 @@ function ScreenSummary() {
     spanDescription,
     spanOp,
     spanAppStartType,
-    ['device.class']: deviceClass,
+    'device.class': deviceClass,
   } = location.query;
 
   const startupModule: LocationDescriptor = {


### PR DESCRIPTION
Pass along device class to the span detail drawer

This wasn't passed before so the metrics were for all device classes, which did not match the table.