### PR TITLE
fix: update `marked` import statement

### DIFF
--- a/static/app/utils/marked.tsx
+++ b/static/app/utils/marked.tsx
@@ -1,6 +1,6 @@
 import dompurify from 'dompurify';
 import type {MarkedOptions} from 'marked'; // eslint-disable-line no-restricted-imports
-import {marked} from 'marked'; // eslint-disable-line no-restricted-imports
+import marked from 'marked'; // eslint-disable-line no-restricted-imports
 import Prism from 'prismjs';
 
 import {NODE_ENV} from 'sentry/constants';


### PR DESCRIPTION
It seems `marked` can only be imported using a `default export`