### PR TITLE
build: optimize extract-ios-device-names command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ sentry-package.json
 /env
 /tmp
 node_modules
-/static/app/constants/ios-device-list.tsx
 /src/sentry/apidocs/api_ownership_stats_dont_modify.json
 /src/sentry/assets.json
 /src/sentry/static/version

--- a/package.json
+++ b/package.json
@@ -247,7 +247,8 @@
     "build": "NODE_OPTIONS=--max-old-space-size=4096 yarn webpack",
     "build-js-loader": "ts-node scripts/build-js-loader.ts",
     "validate-api-examples": "cd api-docs && yarn openapi-examples-validator ../tests/apidocs/openapi-derefed.json --no-additional-properties",
-    "mkcert-localhost": "mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost 127.0.0.1 dev.getsentry.net *.dev.getsentry.net && mkcert -install"
+    "mkcert-localhost": "mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost 127.0.0.1 dev.getsentry.net *.dev.getsentry.net && mkcert -install",
+    "extract-ios-device-names": "ts-node scripts/extract-ios-device-names.ts"
   },
   "browserslist": {
     "production": [

--- a/scripts/extract-ios-device-names.ts
+++ b/scripts/extract-ios-device-names.ts
@@ -1,8 +1,7 @@
 /* eslint-env node */
-import fs from 'node:fs';
+import {existsSync, unlinkSync} from 'node:fs';
+import fs from 'node:fs/promises';
 import path from 'node:path';
-
-import prettier from 'prettier';
 
 // joining path of directory
 const tmpOutputPath = path.join(
@@ -12,29 +11,28 @@ const tmpOutputPath = path.join(
 const outputPath = path.join(__dirname, '../static/app/constants/ios-device-list.tsx');
 const directoryPath = path.join(__dirname, '../node_modules/ios-device-list/');
 
+type Generation = string;
+type Identifier = string;
+type Mapping = Record<Identifier, Generation>;
+
 async function getDefinitionFiles(): Promise<string[]> {
   const files: string[] = [];
 
-  const maybeJSONFiles = await fs.readdirSync(directoryPath);
+  const maybeJSONFiles = await fs.readdir(directoryPath);
 
   // listing all files using forEach
-  maybeJSONFiles.forEach(file => {
+  for (const file of maybeJSONFiles) {
     if (!file.endsWith('.json') || file === 'package.json') {
-      return;
+      continue;
     }
 
     files.push(path.join(path.resolve(directoryPath), file));
-  });
+  }
 
   return files;
 }
 
-type Generation = string;
-type Identifier = string;
-
-type Mapping = Record<Identifier, Generation>;
-
-function collectDefinitions(files: string[]): Mapping {
+async function collectDefinitions(files: string[]): Promise<Mapping> {
   const definitions: Mapping = {};
 
   const queue = [...files];
@@ -46,7 +44,7 @@ function collectDefinitions(files: string[]): Mapping {
       throw new Error('Empty queue');
     }
 
-    const contents = fs.readFileSync(file, 'utf-8');
+    const contents = await fs.readFile(file, 'utf8');
     const content = JSON.parse(contents);
 
     if (typeof content?.[0]?.Identifier === 'undefined') {
@@ -54,11 +52,9 @@ function collectDefinitions(files: string[]): Mapping {
     }
 
     for (let i = 0; i < content.length; i++) {
-      if (!content[i].Identifier) {
-        continue;
+      if (content[i].Identifier) {
+        definitions[content[i].Identifier] = content[i].Generation;
       }
-
-      definitions[content[i].Identifier] = content[i].Generation;
     }
   }
 
@@ -72,6 +68,8 @@ const HEADER = `
 // and discard the rest of the JSON so we do not end up bloating bundle size.
 `;
 
+// The formatting issues will be picked up by the CI and can quickly be fixed by
+// running `yarn fix` command that triggers the linter and formatter.
 const template = (contents: string) => {
   return `
       ${HEADER}
@@ -81,37 +79,30 @@ const template = (contents: string) => {
   `;
 };
 
-const formatOutput = async (unformatted: string) => {
-  const config = await prettier.resolveConfig(outputPath);
-  if (config) {
-    return prettier.format(unformatted, {...config, parser: 'typescript'});
-  }
-
-  return unformatted;
-};
-
-export async function extractIOSDeviceNames() {
+async function run() {
   const files = await getDefinitionFiles();
-  const definitions = collectDefinitions(files);
-  const formatted = await formatOutput(
-    template(JSON.stringify(definitions, undefined, 2))
-  );
+  const definitions = await collectDefinitions(files);
+  const formatted = template(JSON.stringify(definitions, undefined, 2));
 
   // All exit code has to synchronous
-  const cleanup = () => {
-    if (fs.existsSync(tmpOutputPath)) {
-      fs.unlinkSync(tmpOutputPath);
+  function cleanup() {
+    if (existsSync(tmpOutputPath)) {
+      unlinkSync(tmpOutputPath);
     }
-  };
+  }
 
-  process.on('exit', cleanup);
-  process.on('SIGINT', () => {
+  process.once('exit', cleanup);
+  process.once('SIGINT', () => {
     cleanup();
     process.exit(1);
   });
 
   // Write to tmp output path
-  fs.writeFileSync(tmpOutputPath, formatted);
+  await fs.writeFile(tmpOutputPath, formatted);
   // Rename the file (atomic)
-  fs.renameSync(tmpOutputPath, outputPath);
+  await fs.rename(tmpOutputPath, outputPath);
 }
+
+run()
+  // eslint-disable-next-line no-console
+  .catch(error => console.error(`Failed to run extract-ios-device-names`, error));

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -19,18 +19,12 @@ import FixStyleOnlyEntriesPlugin from 'webpack-remove-empty-scripts';
 
 import LastBuiltPlugin from './build-utils/last-built-plugin';
 import SentryInstrumentation from './build-utils/sentry-instrumentation';
-import {extractIOSDeviceNames} from './scripts/extract-ios-device-names';
 import babelConfig from './babel.config';
 import packageJson from './package.json';
 
 type MinimizerPluginOptions = {
   targets: lightningcss.TransformAttributeOptions['targets'];
 };
-
-// Runs as part of prebuild step to generate a list of identifier -> name mappings for  iOS
-(async () => {
-  await extractIOSDeviceNames();
-})();
 
 /**
  * Merges the devServer config into the webpack config


### PR DESCRIPTION
`extract-ios-device-names` previously had lots of sync filesystem operations that block the main thread. Now, all of the filesystem calls are async.

Upon investigation, I found out that we don't need to run this command on every build, since the output is committed into the Git. Making it optional saves 3 seconds on m2 MacBook Pro for `yarn build` command.