### PR TITLE
ref(grouping): Pull logic from `get_hash_values` into helper functions

### DIFF
--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -401,8 +401,7 @@ def get_hash_values(
     )
 
     all_hashes = CalculatedHashes(
-        hashes=list(primary_hashes.hashes)
-        + list(secondary_hashes and secondary_hashes.hashes or []),
+        hashes=extract_hashes(primary_hashes) + extract_hashes(secondary_hashes),
         hierarchical_hashes=(
             list(primary_hashes.hierarchical_hashes)
             + list(secondary_hashes and secondary_hashes.hierarchical_hashes or [])
@@ -517,3 +516,7 @@ def check_for_category_mismatch(group: Group) -> bool:
         return True
 
     return False
+
+
+def extract_hashes(calculated_hashes: CalculatedHashes | None) -> list[str]:
+    return [] if not calculated_hashes else list(calculated_hashes.hashes)


### PR DESCRIPTION
As prep for moving the logic from `get_hash_values` into `_save_aggregate_new`, this pulls much of the logic from `get_hash_values` into helper functions., in order to break it up into it's high-level tasks - getting both primary and secondary hashes and recording metrics. 

Since we already had `_maybe_run_background_grouping`, which calls `_maybe_run_background_grouping`, I structured the first two helpers, `run_primary_grouping` and `maybe_run_secondary_grouping` the same way. But this moved the logic getting the primary and secondary configs away from the spot they were needed in the metrics, which is why`run_primary_grouping` and `maybe_run_secondary_grouping` return their respective configs in addition to the hashes they calculate. Finally, `extract_hashes` seems a little like overkill, I realize, but it will come in handy later.