### PR TITLE
feat(metrics): Support basic spans metrics examples

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -475,8 +475,8 @@ class OrganizationMetricsSamplesEndpoint(OrganizationEventsV2EndpointBase):
             serialized["mri"],
             params,
             snuba_params,
-            serialized.get("query", ""),
             serialized["field"],
+            serialized.get("query", ""),
             rollup,
             Referrer.API_ORGANIZATION_METRICS_SAMPLES,
         )

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -199,7 +199,9 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                     snql_aggregate=lambda args, alias: Function(
                         "argMin",
                         [
-                            Function("tuple", [Column("group"), Column("span_id")]),
+                            Function(
+                                "tuple", [Column("group"), Column("timestamp"), Column("span_id")]
+                            ),
                             Function("cityHash64", [Column("span_id")]),
                         ],
                         alias,

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -102,7 +102,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                     default_result_type="duration",
                     redundant_grouping=True,
                 ),
-                SnQLFunction(
+                SnQLFunction(  # deprecated in favour of `example()`
                     "bounded_sample",
                     required_args=[
                         NumericColumn("column", spans=True),
@@ -112,7 +112,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                     snql_aggregate=self._resolve_bounded_sample,
                     default_result_type="string",
                 ),
-                SnQLFunction(
+                SnQLFunction(  # deprecated in favour of `rounded_timestamp(...)`
                     "rounded_time",
                     optional_args=[with_default(3, NumberRange("intervals", None, None))],
                     snql_column=self._resolve_rounded_time,

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -194,6 +194,40 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                     result_type_fn=self.reflective_result_type(),
                     redundant_grouping=True,
                 ),
+                SnQLFunction(
+                    "example",
+                    snql_aggregate=lambda args, alias: Function(
+                        "argMin",
+                        [
+                            Function("tuple", [Column("group"), Column("span_id")]),
+                            Function("cityHash64", [Column("span_id")]),
+                        ],
+                        alias,
+                    ),
+                ),
+                SnQLFunction(
+                    "rounded_timestamp",
+                    required_args=[IntervalDefault("interval", 1, None)],
+                    snql_column=lambda args, alias: Function(
+                        "toUInt32",
+                        [
+                            Function(
+                                "multiply",
+                                [
+                                    Function(
+                                        "intDiv",
+                                        [
+                                            Function("toUInt32", [Column("timestamp")]),
+                                            args["interval"],
+                                        ],
+                                    ),
+                                    args["interval"],
+                                ],
+                            ),
+                        ],
+                        alias,
+                    ),
+                ),
             ]
         }
 

--- a/src/sentry/sentry_metrics/querying/samples_list.py
+++ b/src/sentry/sentry_metrics/querying/samples_list.py
@@ -1,0 +1,109 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from sentry.search.events.builder import SpansIndexedQueryBuilder
+from sentry.search.events.types import SnubaParams
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.metrics.naming_layer.mri import (
+    SpanMRI,
+    TransactionMRI,
+    is_measurement,
+    is_mri,
+    parse_mri,
+)
+from sentry.snuba.referrer import Referrer
+
+
+class SamplesListExecutor(ABC):
+    def __init__(
+        self,
+        mri: str,
+        params: dict[str, Any],
+        snuba_params: SnubaParams,
+        query: str | None,
+        fields: list[str],
+        rollup: int,
+        referrer: Referrer,
+    ):
+        self.mri = mri
+        self.params = params
+        self.snuba_params = snuba_params
+        self.query = query
+        self.fields = fields
+        self.orderby = "-timestamp"
+        self.rollup = rollup
+        self.referrer = referrer
+
+    @classmethod
+    @abstractmethod
+    def supports(cls, metric_mri: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def execute(self, offset, limit):
+        raise NotImplementedError
+
+
+class TransactionsSamplesListExecutor(SamplesListExecutor):
+    @classmethod
+    def supports(cls, mri: str) -> bool:
+        return mri in {TransactionMRI.DURATION.value}
+
+
+class SpansSamplesListExecutor(SamplesListExecutor):
+    @classmethod
+    def supports(cls, mri: str) -> bool:
+        return mri in {SpanMRI.SELF_TIME.value, SpanMRI.DURATION.value}
+
+    def execute(self, offset, limit):
+        builder = self.get_query_builder(offset, limit)
+        query_results = builder.run_query(self.referrer.value)
+        return builder.process_results(query_results)
+
+    def get_mri_field(self):
+        if self.mri == SpanMRI.SELF_TIME.value:
+            return "span.self.time"
+
+        if self.mri == SpanMRI.DURATION.value:
+            return "span.duration"
+
+        raise ValueError(f"Unsupported MRI for SpansSamplesListExecutor: {self.mri}")
+
+    def get_query_builder(self, offset: int, limit: int) -> SpansIndexedQueryBuilder:
+        fields = self.fields[:]
+
+        # These are fields we always want to return no matter what was selected.
+        for field in ["id", "project", "timestamp", self.get_mri_field()]:
+            if field not in self.fields:
+                fields.append(field)
+
+        return SpansIndexedQueryBuilder(
+            Dataset.SpansIndexed,
+            self.params,
+            snuba_params=self.snuba_params,
+            query=self.query,
+            selected_columns=fields,
+            orderby=self.orderby,
+            limit=limit,
+            offset=offset,
+        )
+
+
+class MeasurementsSamplesListExecutor(SamplesListExecutor):
+    @classmethod
+    def supports(cls, mri: str) -> bool:
+        parsed_mri = parse_mri(mri)
+        return parsed_mri is not None and is_measurement(parsed_mri)
+
+
+class CustomMetricsSamplesListExecutor(SamplesListExecutor):
+    @classmethod
+    def supports(cls, mri: str) -> bool:
+        return is_mri(mri)
+
+
+def get_sample_list_executor_cls(mri) -> type[SamplesListExecutor] | None:
+    for executor_cls in [SpansSamplesListExecutor]:
+        if executor_cls.supports(mri):
+            return executor_cls
+    return None

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -166,6 +166,7 @@ class Referrer(Enum):
     API_ORGANIZATION_SPANS_HISTOGRAM_MIN_MAX = "api.organization-spans-histogram-min-max"
     API_ORGANIZATION_VITALS_PER_PROJECT = "api.organization-vitals-per-project"
     API_ORGANIZATION_VITALS = "api.organization-vitals"
+    API_ORGANIZATION_METRICS_SAMPLES = "api.organization.metrics-samples"
     API_PERFORMANCE_DURATIONPERCENTILECHART = "api.performance.durationpercentilechart"
     API_PERFORMANCE_GENERIC_WIDGET_CHART_APDEX_AREA_METRICS_ENHANCED = (
         "api.performance.generic-widget-chart.apdex-area.metrics-enhanced"


### PR DESCRIPTION
This supports the metrics `d:spans/duration@millisecond` and `d:spans/exclusive_time@millisecond` for now. It uses a basic query to list samples. This query will change in the future to be more clever around how it picks samples.

Closes #65001