### PR TITLE
feat(app-start): Add count_total_starts for more accurate counts

### DIFF
--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -575,6 +575,11 @@ class MetricsDatasetConfig(DatasetConfig):
                     default_result_type="integer",
                 ),
                 fields.MetricsFunction(
+                    "count_total_starts",
+                    snql_distribution=self._resolve_count_total_starts_function,
+                    default_result_type="integer",
+                ),
+                fields.MetricsFunction(
                     "count_web_vitals",
                     required_args=[
                         fields.MetricArg(
@@ -1288,6 +1293,38 @@ class MetricsDatasetConfig(DatasetConfig):
             [
                 Column("value"),
                 Function("equals", [Column("metric_id"), metric_id]),
+            ],
+            alias,
+        )
+
+    def _resolve_count_total_starts_function(
+        self,
+        args: Mapping[str, str | Column | SelectType | int | float],
+        alias: str,
+    ) -> SelectType:
+        return Function(
+            "countIf",
+            [
+                Column("value"),
+                Function(
+                    "or",
+                    [
+                        Function(
+                            "equals",
+                            [
+                                Column("metric_id"),
+                                self.resolve_metric("measurements.app_start_cold"),
+                            ],
+                        ),
+                        Function(
+                            "equals",
+                            [
+                                Column("metric_id"),
+                                self.resolve_metric("measurements.app_start_warm"),
+                            ],
+                        ),
+                    ],
+                ),
             ],
             alias,
         )

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3061,6 +3061,46 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
 
         assert meta["isMetricsData"]
 
+    def test_count_starts_returns_all_counts_when_no_arg_is_passed(self):
+        self.store_transaction_metric(
+            200,
+            metric="measurements.app_start_warm",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            100,
+            metric="measurements.app_start_warm",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            10,
+            metric="measurements.app_start_cold",
+            tags={"transaction": "foo_transaction"},
+            timestamp=self.min_ago,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "count_total_starts()",
+                ],
+                "query": "event.type:transaction",
+                "dataset": "metrics",
+                "per_page": 50,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        data = response.data["data"]
+        meta = response.data["meta"]
+
+        assert data[0]["count_total_starts()"] == 3
+
+        assert meta["isMetricsData"]
+
     def test_timestamp_groupby(self):
         self.store_transaction_metric(
             0.03,
@@ -3284,6 +3324,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     @pytest.mark.xfail(reason="Not implemented")
     def test_count_starts(self):
         super().test_count_starts()
+
+    @pytest.mark.xfail(reason="Not implemented")
+    def test_count_starts_returns_all_counts_when_no_arg_is_passed(self):
+        super().test_count_starts_returns_all_counts_when_no_arg_is_passed()
 
     @pytest.mark.xfail(reason="Not implemented")
     def test_timestamp_groupby(self):


### PR DESCRIPTION
Adds a count_total_starts function to replace the count column on the app start overview page.

The current table shows the number of events due to how the `HAVING` clause gets applied which is inaccurate. This function will let me get a more accurate number and have a better filter in the frontend.