### PR TITLE
feat(crons): Add exact duration as a tooltip in monitor details

### DIFF
--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -136,7 +136,11 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                   emptyCell
                 )}
                 {defined(checkIn.duration) ? (
-                  <Duration seconds={checkIn.duration / 1000} />
+                  <div>
+                    <Tooltip title={<Duration exact seconds={checkIn.duration / 1000} />}>
+                      <Duration seconds={checkIn.duration / 1000} />
+                    </Tooltip>
+                  </div>
                 ) : (
                   emptyCell
                 )}


### PR DESCRIPTION
<img width="935" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/31a7f073-866e-46d5-9af9-1d429241d197">

From https://github.com/getsentry/team-crons/issues/126