### PR TITLE
fix(inbound-filters): Fix "All" Button for legacy browsers

### DIFF
--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -148,6 +148,7 @@ const LEGACY_BROWSER_SUBFILTERS = {
     icon: iconOpera,
     title: 'Opera',
     helpText: 'Version 50 and lower',
+    legacy: false,
   },
   opera_mini: {
     icon: iconOpera,


### PR DESCRIPTION
this pr fixes the behavior for the "All" button. Previously, Opera wouldn't be set as "on" , but now it will be. 



