### PR TITLE
feat(ddm): Switch to query endpoint (ddm part)

### DIFF
--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -20,7 +20,7 @@ import {
   parseStatsPeriod,
 } from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
-import type {MetricsApiResponse, Organization, PageFilters} from 'sentry/types';
+import type {Organization, PageFilters} from 'sentry/types';
 import type {
   MetricMeta,
   MetricsApiRequestMetric,
@@ -325,32 +325,6 @@ export function getFieldFromMetricsQuery(metricsQuery: MetricsQuery) {
   }
 
   return formatMRIField(MRIToField(metricsQuery.mri, metricsQuery.op!));
-}
-
-// TODO(ddm): remove this and all of its usages once backend sends mri fields
-export function mapToMRIFields(
-  data: MetricsApiResponse | undefined,
-  fields: string[]
-): void {
-  if (!data) {
-    return;
-  }
-
-  data.groups.forEach(group => {
-    group.series = swapObjectKeys(group.series, fields);
-    group.totals = swapObjectKeys(group.totals, fields);
-  });
-}
-
-function swapObjectKeys(obj: Record<string, unknown> | undefined, newKeys: string[]) {
-  if (!obj) {
-    return {};
-  }
-
-  return Object.keys(obj).reduce((acc, key, index) => {
-    acc[newKeys[index]] = obj[key];
-    return acc;
-  }, {});
 }
 
 export function stringifyMetricWidget(metricWidget: MetricsQuerySubject): string {

--- a/static/app/utils/metrics/useMetricsData.tsx
+++ b/static/app/utils/metrics/useMetricsData.tsx
@@ -1,12 +1,77 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 
-import type {DateString, MetricsApiResponse} from 'sentry/types';
-import {getMetricsApiRequestQuery, mapToMRIFields} from 'sentry/utils/metrics';
+import type {DateString, MetricsApiResponse, PageFilters} from 'sentry/types';
+import {getDateTimeParams, getDDMInterval} from 'sentry/utils/metrics';
+import {getUseCaseFromMRI, parseField} from 'sentry/utils/metrics/mri';
 import type {MetricsQuery} from 'sentry/utils/metrics/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import type {MetricsApiRequestQueryOptions} from '../../types/metrics';
+
+function createMqlQuery({
+  field,
+  query,
+  groupBy = [],
+}: {field: string; query: string; groupBy?: string[]}) {
+  let mql = field;
+  if (query) {
+    mql = `${mql}{${query}}`;
+  }
+  if (groupBy.length) {
+    mql = `${mql} by (${groupBy.join(',')})`;
+  }
+  return mql;
+}
+
+export function getMetricsApiRequestQuery(
+  {
+    field,
+    query,
+    groupBy,
+    orderBy,
+  }: {field: string; query: string; groupBy?: string[]; orderBy?: 'asc' | 'desc'},
+  {projects, environments, datetime}: PageFilters,
+  {intervalLadder, ...overrides}: Partial<MetricsApiRequestQueryOptions> = {}
+) {
+  const {mri: mri} = parseField(field) ?? {};
+  const useCase = getUseCaseFromMRI(mri) ?? 'custom';
+  const interval = getDDMInterval(datetime, useCase, intervalLadder);
+
+  return {
+    query: {
+      ...getDateTimeParams(datetime),
+      project: projects,
+      environment: environments,
+      interval,
+      ...overrides,
+    },
+    body: {
+      queries: [
+        {
+          name: 'query_1',
+          mql: createMqlQuery({field, query, groupBy}),
+        },
+      ],
+      formulas: [{mql: '$query_1', limit: overrides.limit, order: orderBy ?? 'desc'}],
+    },
+  };
+}
+
+interface NewMetricsApiResponse {
+  data: {
+    by: Record<string, string>;
+    series: Array<number | null>;
+    totals: Record<string, number | null>;
+  }[][];
+  end: string;
+  intervals: string[];
+  meta: [
+    {name: string; type: string},
+    {group_bys: string[]; limit: number | null; order: string | null},
+  ][];
+  start: string;
+}
 
 export function useMetricsData(
   {mri, op, datetime, projects, environments, query, groupBy}: MetricsQuery,
@@ -16,7 +81,7 @@ export function useMetricsData(
 
   const field = op ? `${op}(${mri})` : mri;
 
-  const queryToSend = getMetricsApiRequestQuery(
+  const {query: queryToSend, body} = getMetricsApiRequestQuery(
     {
       field,
       query: query ?? '',
@@ -26,8 +91,11 @@ export function useMetricsData(
     {...overrides}
   );
 
-  const metricsApiRepsonse = useApiQuery<MetricsApiResponse>(
-    [`/organizations/${organization.slug}/metrics/data/`, {query: queryToSend}],
+  const metricsApiResponse = useApiQuery<NewMetricsApiResponse>(
+    [
+      `/organizations/${organization.slug}/metrics/query/`,
+      {query: queryToSend, data: body, method: 'POST'},
+    ],
     {
       retry: 0,
       staleTime: 0,
@@ -36,9 +104,38 @@ export function useMetricsData(
       refetchInterval: false,
     }
   );
-  mapToMRIFields(metricsApiRepsonse.data, [field]);
 
-  return metricsApiRepsonse;
+  const dataInOldShape = useMemo(
+    () => mapToOldResponseShape(metricsApiResponse.data, field),
+    [field, metricsApiResponse.data]
+  );
+
+  return {
+    ...metricsApiResponse,
+    data: dataInOldShape,
+  };
+}
+
+function mapToOldResponseShape(
+  responseData: NewMetricsApiResponse | undefined,
+  field: string
+): MetricsApiResponse | undefined {
+  return (
+    responseData &&
+    ({
+      groups: responseData.data[0].map(group => ({
+        ...group,
+        series: {
+          [field]: group.series,
+        },
+      })),
+      intervals: responseData.intervals,
+      meta: [],
+      query: '',
+      start: responseData.start,
+      end: responseData.end,
+    } satisfies MetricsApiResponse)
+  );
 }
 
 // Wraps useMetricsData and provides two additional features:

--- a/static/app/views/dashboards/widgetCard/metricWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/metricWidgetQueries.tsx
@@ -8,7 +8,6 @@ import type {MetricsApiResponse, Organization, PageFilters} from 'sentry/types';
 import type {Series} from 'sentry/types/echarts';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {TOP_N} from 'sentry/utils/discover/types';
-import {mapToMRIFields} from 'sentry/utils/metrics';
 
 import {MetricsConfig} from '../datasetConfig/metrics';
 import type {DashboardFilters, Widget} from '../types';
@@ -113,11 +112,6 @@ class MetricWidgetQueries extends Component<Props, State> {
     );
   };
 
-  afterFetchData = (data: MetricsApiResponse) => {
-    const fields = this.props.widget.queries[0].aggregates;
-    mapToMRIFields(data, fields);
-  };
-
   render() {
     const {
       api,
@@ -144,8 +138,6 @@ class MetricWidgetQueries extends Component<Props, State> {
         onDataFetched={onDataFetched}
         loading={undefined}
         customDidUpdateComparator={this.customDidUpdateComparator}
-        afterFetchTableData={this.afterFetchData}
-        afterFetchSeriesData={this.afterFetchData}
       >
         {({errorMessage, ...rest}) =>
           children({

--- a/static/app/views/ddm/chart.tsx
+++ b/static/app/views/ddm/chart.tsx
@@ -99,6 +99,7 @@ export const MetricChart = forwardRef<ReactEchartsRef, ChartProps>(
               ...s,
               silent: true,
               data: s.data.slice(0, -fogOfWarBuckets),
+              connectNulls: true,
             },
             displayType === MetricDisplayType.BAR
               ? createFogOfWarBarSeries(s, fogOfWarBuckets)


### PR DESCRIPTION
Switch from `metrics/data` to `metrics/query` endpoint in DDM related code.
In this PR we simply map the new response to the old structure. There will be a follow-up that removes the mapping and properly handles the new response shape.

- relates to https://github.com/getsentry/sentry/issues/64770