### PR TITLE
fix(ddm): Smooth area chart series transition

### DIFF
--- a/static/app/views/ddm/chart.tsx
+++ b/static/app/views/ddm/chart.tsx
@@ -121,7 +121,7 @@ export const MetricChart = forwardRef<ReactEchartsRef, ChartProps>(
             ...(displayType === MetricDisplayType.AREA
               ? addAreaChartSeriesPadding(s.data)
               : {data: s.data}),
-            connectNulls: true,
+            connectNulls: displayType !== MetricDisplayType.AREA,
           }))
           // Split series in two parts, one for the main chart and one for the fog of war
           // The order is important as the tooltip will show the first series first (for overlaps)
@@ -226,6 +226,10 @@ export const MetricChart = forwardRef<ReactEchartsRef, ChartProps>(
                 uniqueSeries.add(param.seriesName);
                 return true;
               });
+
+              if (deDupedParams.length === 0) {
+                return '';
+              }
               return getFormatter(timeseriesFormatters)(deDupedParams, asyncTicket);
             }
             return getFormatter(timeseriesFormatters)(params, asyncTicket);


### PR DESCRIPTION
Smooth / stitch transitions between stacked area chart elements by add in padding datapoints.
Filter null values from tooltip.

#### Before
<img width="1098" alt="Screenshot 2024-02-14 at 13 18 01" src="https://github.com/getsentry/sentry/assets/7033940/c4afe0d8-433d-4198-a08d-83024696d57f">

#### After
<img width="928" alt="Screenshot 2024-02-14 at 13 08 24" src="https://github.com/getsentry/sentry/assets/7033940/555b9a49-40f9-48e9-87fd-10c13188f6a4">


Disable `connectNulls` for area charts as it can mess up the rendering:

#### Before
<img width="1098" alt="Screenshot 2024-02-14 at 13 30 16" src="https://github.com/getsentry/sentry/assets/7033940/5f9bf6f5-2738-4ced-bc81-bee5e0120d9a">

#### After
<img width="1098" alt="Screenshot 2024-02-14 at 13 29 55" src="https://github.com/getsentry/sentry/assets/7033940/6c69749b-69de-4551-897c-cd2d999789e4">
