### PR TITLE
feat(sdk-crash): Add sdk_event metric

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -55,14 +55,33 @@ class SDKCrashDetection:
         :param configs: The list of configs, one for each SDK.
         """
 
+        context = get_path(event.data, "contexts", "sdk_crash_detection")
+        if context is not None:
+            return None
+
+        sdk_name = get_path(event.data, "sdk", "name")
+        sdk_version = get_path(event.data, "sdk", "version")
+
+        if not sdk_name or not sdk_version:
+            return None
+
+        metric_tags = {"sdk_name": sdk_name, "sdk_version": sdk_version}
+        sdk_detectors = list(map(lambda config: SDKCrashDetector(config=config), configs))
+
+        num_supported_detectors = sum(
+            1 for detector in sdk_detectors if detector.is_sdk_supported(sdk_name, sdk_version)
+        )
+        if num_supported_detectors > 0:
+            metrics.incr("post_process.sdk_crash_monitoring.sdk_event", tags=metric_tags)
+
         is_error = event.group and event.group.issue_category == GroupCategory.ERROR
         if not is_error:
             return None
 
-        sdk_detectors = list(map(lambda config: SDKCrashDetector(config=config), configs))
-
         sdk_crash_detectors = [
-            detector for detector in sdk_detectors if detector.should_detect_sdk_crash(event.data)
+            detector
+            for detector in sdk_detectors
+            if detector.should_detect_sdk_crash(sdk_name, sdk_version, event.data)
         ]
 
         if not sdk_crash_detectors:
@@ -82,18 +101,10 @@ class SDKCrashDetection:
         ):
             return None
 
-        context = get_path(event.data, "contexts", "sdk_crash_detection")
-        if context is not None:
-            return None
-
         frames = get_path(event.data, "exception", "values", -1, "stacktrace", "frames")
         if not frames:
             return None
 
-        # If sdk name or version are None, detector.should_detect_sdk_crash returns False above, and we don't reach this point.
-        sdk_name = get_path(event.data, "sdk", "name")
-        sdk_version = get_path(event.data, "sdk", "version")
-        metric_tags = {"sdk_name": sdk_name, "sdk_version": sdk_version}
         metrics.incr("post_process.sdk_crash_monitoring.detecting_sdk_crash", tags=metric_tags)
 
         if sdk_crash_detector.is_sdk_crash(frames):

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
@@ -23,13 +23,12 @@ class SDKCrashDetector:
     def replace_sdk_frame_path(self, path: str) -> str:
         return self.config.sdk_frame_config.path_replacer.replace_path(path)
 
-    def should_detect_sdk_crash(self, event_data: NodeData) -> bool:
-        sdk_name = get_path(event_data, "sdk", "name")
-        if sdk_name is None or sdk_name not in self.config.sdk_names:
-            return False
-
-        sdk_version = get_path(event_data, "sdk", "version")
-        if not sdk_version:
+    def is_sdk_supported(
+        self,
+        sdk_name: str,
+        sdk_version: str,
+    ) -> bool:
+        if sdk_name not in self.config.sdk_names:
             return False
 
         try:
@@ -39,6 +38,14 @@ class SDKCrashDetector:
             if actual_sdk_version < minimum_sdk_version:
                 return False
         except InvalidVersion:
+            return False
+
+        return True
+
+    def should_detect_sdk_crash(
+        self, sdk_name: str, sdk_version: str, event_data: NodeData
+    ) -> bool:
+        if not self.is_sdk_supported(sdk_name, sdk_version):
             return False
 
         is_unhandled = (


### PR DESCRIPTION
Add metric sdk_event, which gets incremented for every type of event (error, transaction, profile, cron, replay) for every supported SDK so we can calculate an event-to-crash rate ratio with metrics.
