### PR TITLE
fix(similarity-embedding): Rename extra message in log

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -136,9 +136,11 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         if request.GET.get("threshold"):
             similar_issues_params.update({"threshold": float(request.GET["threshold"])})
 
-        logger.info("Similar issues embeddings parameters", extra=similar_issues_params)
-
         results = get_similar_issues_embeddings(similar_issues_params)
+
+        extra: dict[str, Any] = dict(similar_issues_params.copy())
+        extra["group_message"] = extra.pop("message")
+        logger.info("Similar issues embeddings parameters", extra=extra)
 
         analytics.record(
             "group_similar_issues_embeddings.count",

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -269,6 +269,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
             headers={"Content-Type": "application/json;charset=utf-8"},
         )
 
+        expected_seer_request_params["group_message"] = expected_seer_request_params.pop("message")
         mock_logger.info.assert_called_with(
             "Similar issues embeddings parameters", extra=expected_seer_request_params
         )


### PR DESCRIPTION
Rename extra message to group_message
Log extras cannot include message

Fixes [SENTRY-2MMY](https://sentry.sentry.io/issues/4976576152/)