### PR TITLE
fix(pr-comments): allow merged PR comments on PRs with open PR comments

### DIFF
--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -1147,7 +1147,9 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
 
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
-    def test_gh_comment_multiple_comments(self, get_jwt, mock_comment_workflow):
+    def test_gh_comment_multiple_comments(
+        self, get_jwt, mock_comment_workflow, mock_get_commit_context
+    ):
         self.add_responses()
 
         assert not GroupOwner.objects.filter(group=self.event.group).exists()


### PR DESCRIPTION
Fixes [SENTRY-2FDS](https://sentry.sentry.io/issues/4914740825/)

The test I wrote in this PR fails with the exact Sentry error without the new changes. We were not commenting suspect PR comments on PRs that already had open PR comments because the logic is expecting single comment (of any type) to exist or not exist for the PR. Fixed this so the logic only looks for an existing merged PR comment before deciding whether to debounce or commented on a merged PR.