### PR TITLE
chore(roles): remove team.orgRole from FE

### DIFF
--- a/fixtures/js-stubs/team.tsx
+++ b/fixtures/js-stubs/team.tsx
@@ -8,7 +8,6 @@ export function TeamFixture(params: Partial<DetailedTeam> = {}): DetailedTeam {
     slug: 'team-slug',
     name: 'Team Name',
     access: ['team:read'],
-    orgRole: undefined, // TODO(cathy): Rename this
     teamRole: null,
     isMember: true,
     memberCount: 0,

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -98,7 +98,6 @@ export interface Team {
   name: string;
   slug: string;
   teamRole: string | null;
-  orgRole?: string | null;
 }
 
 export interface DetailedTeam extends Team {

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -124,7 +124,7 @@ function renderDropdownOption({
 }) {
   const hasOrgAdmin = organization.access.includes('org:admin');
   const isIdpProvisioned = isAddingTeamToMember && team.flags['idp:provisioned'];
-  const isPermissionGroup = isAddingTeamToMember && !!team.orgRole && !hasOrgAdmin;
+  const isPermissionGroup = isAddingTeamToMember && !hasOrgAdmin;
   const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);
 
   return {

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -53,14 +53,14 @@ const roles = [
 describe('OrganizationMembersList', function () {
   const members = MembersFixture();
 
-  const ownerTeam = TeamFixture({slug: 'owner-team'});
+  const team = TeamFixture({slug: 'team'});
   const member = MemberFixture({
     id: '5',
     email: 'member@sentry.io',
-    teams: [ownerTeam.slug],
+    teams: [team.slug],
     teamRoles: [
       {
-        teamSlug: ownerTeam.slug,
+        teamSlug: team.slug,
         role: null,
       },
     ],
@@ -151,7 +151,7 @@ describe('OrganizationMembersList', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/teams/',
       method: 'GET',
-      body: [TeamFixture(), ownerTeam],
+      body: [TeamFixture(), team],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/invite-requests/',

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
-import startCase from 'lodash/startCase';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organizations';
@@ -184,7 +183,7 @@ class AllTeamsRow extends Component<Props, State> {
     // TODO(team-roles): team admins can also manage membership
     // org:admin is a unique scope that only org owners have
     const isOrgOwner = access.includes('org:admin');
-    const isPermissionGroup = !!team.orgRole && (!canEditTeam || !isOrgOwner);
+    const isPermissionGroup = !canEditTeam || !isOrgOwner;
     const isIdpProvisioned = team.flags['idp:provisioned'];
 
     const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);
@@ -201,8 +200,7 @@ class AllTeamsRow extends Component<Props, State> {
     // for your role + org open membership
     const canViewTeam = team.hasAccess;
 
-    const orgRoleFromTeam = team.orgRole ? `${startCase(team.orgRole)} Team` : null;
-    const isHidden = orgRoleFromTeam === null && this.getTeamRoleName() === null;
+    const teamRoleName = this.getTeamRoleName();
     const isDisabled = isIdpProvisioned || isPermissionGroup;
 
     return (
@@ -216,8 +214,7 @@ class AllTeamsRow extends Component<Props, State> {
             display
           )}
         </div>
-        <DisplayRole isHidden={isHidden}>{orgRoleFromTeam}</DisplayRole>
-        <DisplayRole isHidden={isHidden}>{this.getTeamRoleName()}</DisplayRole>
+        <DisplayRole isHidden={teamRoleName === null}>{teamRoleName}</DisplayRole>
         <div>
           {this.state.loading ? (
             <Button size="sm" disabled>

--- a/static/app/views/settings/organizationTeams/teamMembersRow.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembersRow.tsx
@@ -50,7 +50,6 @@ function TeamMembersRow({
       <div>
         <RemoveButton
           hasWriteAccess={hasWriteAccess}
-          hasOrgRoleFromTeam={!!team.orgRole}
           isOrgOwner={isOrgOwner}
           isSelf={isSelf}
           onClick={() => removeMember(member)}
@@ -62,14 +61,13 @@ function TeamMembersRow({
 }
 
 function RemoveButton(props: {
-  hasOrgRoleFromTeam: boolean;
   hasWriteAccess: boolean;
   isOrgOwner: boolean;
   isSelf: boolean;
   member: TeamMember;
   onClick: () => void;
 }) {
-  const {member, hasWriteAccess, isOrgOwner, isSelf, hasOrgRoleFromTeam, onClick} = props;
+  const {member, hasWriteAccess, isOrgOwner, isSelf, onClick} = props;
 
   const canRemoveMember = hasWriteAccess || isSelf;
   if (!canRemoveMember) {
@@ -87,31 +85,18 @@ function RemoveButton(props: {
   }
 
   const isIdpProvisioned = member.flags['idp:provisioned'];
-  const isPermissionGroup = hasOrgRoleFromTeam && !isOrgOwner;
-  const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);
-  if (isIdpProvisioned || isPermissionGroup) {
-    return (
-      <Button
-        size="xs"
-        disabled
-        icon={<IconSubtract isCircled />}
-        aria-label={t('Remove')}
-        title={buttonHelpText}
-      >
-        {t('Remove')}
-      </Button>
-    );
-  }
+  const buttonHelpText = getButtonHelpText(isIdpProvisioned, !isOrgOwner);
 
   const buttonRemoveText = isSelf ? t('Leave') : t('Remove');
   return (
     <Button
       data-test-id={`button-remove-${member.id}`}
       size="xs"
-      disabled={!canRemoveMember}
+      disabled={!canRemoveMember || isIdpProvisioned}
       icon={<IconSubtract isCircled />}
       onClick={onClick}
       aria-label={buttonRemoveText}
+      title={buttonHelpText}
     >
       {buttonRemoveText}
     </Button>


### PR DESCRIPTION
This is not being used and we are removing the org roles from teams feature, so it can be deleted.

This is the last PR to remove org roles from teams from the FE.

For https://github.com/getsentry/team-core-product-foundations/issues/51