### PR TITLE
fix(csp): explicitly disallow worker-src

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -489,6 +489,7 @@ if ENVIRONMENT == "development":
     CSP_CONNECT_SRC += [
         "ws://127.0.0.1:8000",
         "http://localhost:8969/stream",
+        "webpack-internal:",
     ]
 
 # Before enforcing Content Security Policy, we recommend creating a separate

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -463,6 +463,9 @@ CSP_FRAME_ANCESTORS = [
 CSP_OBJECT_SRC = [
     "'none'",
 ]
+CSP_WORKER_SRC = [
+    "'none'",
+]
 CSP_BASE_URI = [
     "'none'",
 ]


### PR DESCRIPTION
According to tests on local dev and self-hosted installation, we don't need `worker-src` to be set by default. From [mdn](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src):
> If this directive is absent, the user agent will first look for the [child-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src) directive, then the [script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src) directive, then finally for the [default-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src) directive, when governing worker execution.

In our case, the fallback is script-src that contains a lot of unnecessary stuff.

Also, fixing [spotlight](https://github.com/getsentry/spotlight)-caused violation on local dev.