### PR TITLE
fix(app-start): Add span ID to flamegraph profile link

### DIFF
--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -143,7 +143,7 @@ export function SpanSamplesTable({
             <Tooltip title={t('View Profile')}>
               <LinkButton
                 to={normalizeUrl(
-                  `/organizations/${organization.slug}/profiling/profile/${row.project}/${row.profile_id}/flamegraph/`
+                  `/organizations/${organization.slug}/profiling/profile/${row.project}/${row.profile_id}/flamegraph/?spanId=${row.span_id}`
                 )}
                 size="xs"
               >


### PR DESCRIPTION
The profile link doesn't automatically zoom into the span we clicked into, even though it's contextually there for the span drawer component