### PR TITLE
feat(actionable-items): Make more event errors "warnings" 

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
@@ -40,6 +40,9 @@ export const ActionableItemWarning = [
   GenericSchemaErrors.CLOCK_DRIFT,
   GenericSchemaErrors.PAST_TIMESTAMP,
   GenericSchemaErrors.VALUE_TOO_LONG,
+  GenericSchemaErrors.INVALID_DATA,
+  GenericSchemaErrors.INVALID_ATTRIBUTE,
+  GenericSchemaErrors.MISSING_ATTRIBUTE,
 ];
 
 interface BaseActionableItem {


### PR DESCRIPTION
this pr adds a few more event errors as "warnings" which will show up as a yellow alert instead of a red one. we initially set them as red alerts, but the feedback recently has said that they would be better as yellow ones. 