### PR TITLE
feat(event-details): Use actionable items instead of event error

### DIFF
--- a/static/app/components/events/eventEntries.spec.tsx
+++ b/static/app/components/events/eventEntries.spec.tsx
@@ -30,6 +30,9 @@ describe('EventEntries', function () {
       url: '/organizations/org-slug/projects/',
       body: [project],
     });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/events/1/actionable-items/',
+    });
   });
 
   it('renders the replay section in the correct place', async function () {

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -5,6 +5,8 @@ import type {Location} from 'history';
 import {CommitRow} from 'sentry/components/commitRow';
 import {EventEvidence} from 'sentry/components/events/eventEvidence';
 import EventReplay from 'sentry/components/events/eventReplay';
+import {ActionableItems} from 'sentry/components/events/interfaces/crashContent/exception/actionableItems';
+import {actionableItemsEnabled} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {
@@ -25,7 +27,6 @@ import {EventDevice} from './device';
 import {EventAttachments} from './eventAttachments';
 import {EventDataSection} from './eventDataSection';
 import {EventEntry} from './eventEntry';
-import {EventErrors} from './eventErrors';
 import {EventExtraData} from './eventExtraData';
 import {EventSdk} from './eventSdk';
 import {EventTagsAndScreenshot} from './eventTagsAndScreenshot';
@@ -74,10 +75,17 @@ function EventEntries({
   }
 
   const hasContext = !objectIsEmpty(event.user ?? {}) || !objectIsEmpty(event.contexts);
+  const hasActionableItems = actionableItemsEnabled({
+    eventId: event.id,
+    organization,
+    projectSlug,
+  });
 
   return (
     <div className={className}>
-      <EventErrors event={event} project={project} isShare={isShare} />
+      {hasActionableItems && (
+        <ActionableItems event={event} project={project} isShare={isShare} />
+      )}
       {!isShare && isNotSharedOrganization(organization) && (
         <SuspectCommits
           project={project}

--- a/static/app/views/discover/eventDetails/index.spec.tsx
+++ b/static/app/views/discover/eventDetails/index.spec.tsx
@@ -105,6 +105,10 @@ describe('Discover > EventDetails', function () {
       statusCode: 404,
       body: {},
     });
+
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/events/1234/actionable-items/',
+    });
   });
 
   it('renders', async function () {

--- a/static/app/views/discover/eventDetails/index.spec.tsx
+++ b/static/app/views/discover/eventDetails/index.spec.tsx
@@ -108,6 +108,9 @@ describe('Discover > EventDetails', function () {
 
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/events/1234/actionable-items/',
+      body: {
+        errors: [],
+      },
     });
   });
 

--- a/static/app/views/performance/transactionDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionDetails/index.spec.tsx
@@ -35,6 +35,13 @@ describe('EventDetails', () => {
       statusCode: 200,
       body: [],
     });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/latest/events/1/actionable-items/`,
+      body: {
+        errors: [],
+      },
+    });
   });
 
   afterEach(() => {

--- a/static/app/views/sharedGroupDetails/index.spec.tsx
+++ b/static/app/views/sharedGroupDetails/index.spec.tsx
@@ -38,6 +38,12 @@ describe('SharedGroupDetails', function () {
         project: ProjectFixture({organization: OrganizationFixture({slug: 'test-org'})}),
       }),
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/test-org/project-slug/events/1/actionable-items/`,
+      body: {
+        errors: [],
+      },
+    });
   });
 
   afterEach(function () {


### PR DESCRIPTION
this pr adds the actionable items alert to the event details page. it has been on issue details for a while, but it was never updated on the event details page