### PR TITLE
tests(metrics_extraction): store_on_demand_metric to exclude tags from conditions

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import hashlib
 import importlib.metadata
 import inspect
@@ -2091,7 +2089,14 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
     ) -> None:
         """Convert on-demand metric and store it"""
         relay_metric_spec = spec.to_metric_spec(self.project)
-        metric_spec_tags = relay_metric_spec["tags"] or [] if relay_metric_spec else []
+        metric_spec_tags = []
+        if relay_metric_spec:
+            tags_keys = [condition["key"] for condition in spec.tags_conditions(self.project)]
+            # Functions in _DERIVED_METRICS include their tags in their conditions
+            metric_spec_tags = [
+                tag for tag in relay_metric_spec.get("tags") if tag["key"] not in tags_keys
+            ]
+
         tags = {i["key"]: i.get("value") or i.get("field") for i in metric_spec_tags}
 
         metric_type = spec.metric_type

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1040,6 +1040,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 hour * 62 * 24,
                 spec=spec,
                 additional_tags={
+                    "measurement_rating": "matches_hash",
                     "customtag1": "foo",
                     "customtag2": "red",
                     "environment": "production",
@@ -1050,6 +1051,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 hour * 60 * 24,
                 spec=spec_two,
                 additional_tags={
+                    "measurement_rating": "matches_hash",
                     "customtag1": "bar",
                     "customtag2": "blue",
                     "environment": "production",
@@ -1116,6 +1118,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 hour * 62 * 24,
                 spec=spec,
                 additional_tags={
+                    "measurement_rating": "matches_hash",
                     "customtag1": "foo",
                     "customtag2": "red",
                     "environment": "production",
@@ -1126,6 +1129,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 hour * 60 * 24,
                 spec=spec_two,
                 additional_tags={
+                    "measurement_rating": "matches_hash",
                     "customtag1": "bar",
                     "customtag2": "blue",
                     "environment": "production",


### PR DESCRIPTION
Without this, the tag conditions of `user_misery` get included in the tags of the metric, thus, counting all metrics as frustrated.