### PR TITLE
ref(slack): circle emojis for level indicators and category indicators

### DIFF
--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -37,6 +37,16 @@ LEVEL_TO_EMOJI = {
     "warning": ":warning:",
 }
 
+LEVEL_TO_EMOJI_V2 = {
+    "_actioned_issue": ":white_check_mark:",
+    "_incident_resolved": ":green_circle:",
+    "debug": ":bug:",
+    "error": ":red_circle:",
+    "fatal": ":red_circle:",
+    "info": ":large_blue_circle:",
+    "warning": ":large_yellow_circle:",
+}
+
 CATEGORY_TO_EMOJI = {
     GroupCategory.PERFORMANCE: ":chart_with_upwards_trend:",
     GroupCategory.FEEDBACK: ":busts_in_silhouette:",

--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -52,3 +52,9 @@ CATEGORY_TO_EMOJI = {
     GroupCategory.FEEDBACK: ":busts_in_silhouette:",
     GroupCategory.CRON: ":spiral_calendar_pad:",
 }
+
+CATEGORY_TO_EMOJI_V2 = {
+    GroupCategory.PERFORMANCE: ":large_blue_circle::chart_with_upwards_trend:",
+    GroupCategory.FEEDBACK: ":large_blue_circle::busts_in_silhouette:",
+    GroupCategory.CRON: ":large_yellow_circle::spiral_calendar_pad:",
+}

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -28,6 +28,7 @@ from sentry.integrations.message_builder import (
 from sentry.integrations.slack.message_builder import (
     CATEGORY_TO_EMOJI,
     LEVEL_TO_EMOJI,
+    LEVEL_TO_EMOJI_V2,
     SLACK_URL_FORMAT,
     SlackAttachment,
     SlackBlock,
@@ -475,9 +476,11 @@ def build_actions(
             label="Select Assignee...",
             type="select",
             selected_options=format_actor_options([assignee]) if assignee else [],
-            option_groups=get_option_groups(group)
-            if not use_block_kit
-            else get_option_groups_block_kit(group),
+            option_groups=(
+                get_option_groups(group)
+                if not use_block_kit
+                else get_option_groups_block_kit(group)
+            ),
         )
         return assign_button
 
@@ -617,8 +620,12 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             for k, v in LOG_LEVELS_MAP.items():
                 if self.group.level == v:
                     level_text = k
-
-            title_emoji = LEVEL_TO_EMOJI.get(level_text)
+            if features.has(
+                "organizations:slack-block-kit-improvements", self.group.project.organization
+            ):
+                title_emoji = LEVEL_TO_EMOJI_V2.get(level_text)
+            else:
+                title_emoji = LEVEL_TO_EMOJI.get(level_text)
         else:
             title_emoji = CATEGORY_TO_EMOJI.get(self.group.issue_category)
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -631,7 +631,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                 title_emoji = LEVEL_TO_EMOJI.get(level_text)
         else:
             if has_improvements_feature_flag:
-                title_emoji = CATEGORY_TO_EMOJI_V2.get(level_text)
+                title_emoji = CATEGORY_TO_EMOJI_V2.get(self.group.issue_category)
             else:
                 title_emoji = CATEGORY_TO_EMOJI.get(self.group.issue_category)
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -24,6 +24,7 @@ from sentry.integrations.slack.message_builder.issues import (
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.issues.grouptype import (
+    ErrorGroupType,
     FeedbackGroup,
     PerformanceNPlusOneGroupType,
     ProfileFileIOGroupType,
@@ -902,6 +903,34 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             in blocks["blocks"][1]["elements"][0]["elements"][0]["text"]
         )
         assert blocks["text"] == f"[{self.project.slug}] {occurrence.issue_title}"
+
+    @with_feature("organizations:slack-block-kit")
+    @with_feature("organizations:slack-block-kit-improvements")
+    def test_build_group_generic_issue_block_title_emojis(self):
+        """Test that a generic issue type's Slack alert contains the expected values"""
+        event = self.store_event(
+            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
+        )
+        group_event = event.for_group(event.groups[0])
+        occurrence = self.build_occurrence(level="info")
+        occurrence.save()
+        group_event.occurrence = occurrence
+
+        # uses CATEGORY_TO_EMOJI_V2
+        group_event.group.type = ProfileFileIOGroupType.type_id
+        blocks = SlackIssuesMessageBuilder(group=group_event.group, event=group_event).build()
+        assert isinstance(blocks, dict)
+        for section in blocks["blocks"]:
+            if section["type"] == "text":
+                assert ":large_blue_circle::chart_with_upwards_trend:" in section["text"]["text"]
+
+        # uses LEVEL_TO_EMOJI_V2
+        group_event.group.type = ErrorGroupType.type_id
+        blocks = SlackIssuesMessageBuilder(group=group_event.group, event=group_event).build()
+        assert isinstance(blocks, dict)
+        for section in blocks["blocks"]:
+            if section["type"] == "text":
+                assert ":red_circle:" in section["text"]["text"]
 
     def test_build_error_issue_fallback_text(self):
         event = self.store_event(data={}, project_id=self.project.id)


### PR DESCRIPTION
Replace the following emojis as level indicators / category indicators in Slack block kit messages:
- ❗️ for errors
- 💀 for fatal
- ⚠️ for warning
- ℹ️ for info
- 📈 for performance issues
- 👥 for user feedback issues
- 🗓️ for crons issues

New:
- 🔴 for errors or fatal
- 🟡 for warning
- 🔵 for info
- 🔵📈 for performance issues
- 🔵👥 for user feedback issues
- 🟡🗓️ for crons issues

These changes are feature flagged to internal only for now.

Resolves https://github.com/getsentry/team-core-product-foundations/issues/85