### PR TITLE
fix(app-start): Use count_total_starts() to sort table

### DIFF
--- a/static/app/views/starfish/views/appStartup/index.tsx
+++ b/static/app/views/starfish/views/appStartup/index.tsx
@@ -62,6 +62,7 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
   const query = new MutableSearch([
     'event.type:transaction',
     'transaction.op:ui.load',
+    'count_total_starts():>0',
     ...(additionalFilters ?? []),
   ]);
 
@@ -70,13 +71,9 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
     query.addStringFilter(prepareQueryForLandingPage(searchQuery, false));
   }
 
-  const queryString = `${appendReleaseFilters(
-    query,
-    primaryRelease,
-    secondaryRelease
-  )} (count_starts(measurements.app_start_cold):>0 OR count_starts(measurements.app_start_warm):>0)`;
+  const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
 
-  const orderby = decodeScalar(locationQuery.sort, `-count`);
+  const orderby = decodeScalar(locationQuery.sort, `-count_total_starts`);
   const newQuery: NewQuery = {
     name: '',
     fields: [
@@ -90,7 +87,7 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
       `avg_compare(measurements.app_start_warm,release,${primaryRelease},${secondaryRelease})`,
       'count_starts(measurements.app_start_cold)',
       'count_starts(measurements.app_start_warm)',
-      'count()',
+      'count_total_starts()',
     ],
     query: queryString,
     dataset: DiscoverDatasets.METRICS,

--- a/static/app/views/starfish/views/appStartup/screensTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screensTable.tsx
@@ -61,7 +61,7 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
     [`avg_compare(measurements.app_start_warm,release,${primaryRelease},${secondaryRelease})`]:
       t('Change'),
     app_start_breakdown: t('Type Breakdown'),
-    'count()': t('Total Count'),
+    'count_total_starts()': t('Total Count'),
   };
 
   function renderBodyCell(column, row): React.ReactNode {
@@ -180,7 +180,7 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
           `avg_if(measurements.app_start_warm,release,${secondaryRelease})`,
           `avg_compare(measurements.app_start_warm,release,${primaryRelease},${secondaryRelease})`,
           `app_start_breakdown`,
-          'count()',
+          'count_total_starts()',
         ].map(columnKey => {
           return {
             key: columnKey,
@@ -190,7 +190,7 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
         })}
         columnSortBy={[
           {
-            key: 'count()',
+            key: 'count_total_starts',
             order: 'desc',
           },
         ]}


### PR DESCRIPTION
count() doesn't work here because the filter doesn't propagate so we're left with the total number of events for that screen instead of a count of cold + warm starts

Replace `count()` with `count_total_starts()` so the total count and the start breakdown column add up to the same number.