### PR TITLE
ref(metrics_summaries): Reflect changes to match the new consumer

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1347,11 +1347,39 @@ class SnubaTestCase(BaseTestCase):
             == 200
         )
 
-    def store_metric_summary(self, metric_summary):
+    def store_metrics_summary(self, span):
+        common_fields = {
+            "duration_ms": span["duration_ms"],
+            "end_timestamp": (span["start_timestamp_ms"] + span["duration_ms"]) / 1000,
+            "group": span["sentry_tags"].get("group", "0"),
+            "is_segment": span["is_segment"],
+            "project_id": span["project_id"],
+            "received": span["received"],
+            "retention_days": span["retention_days"],
+            "segment_id": span.get("segment_id", "0"),
+            "span_id": span["span_id"],
+            "trace_id": span["trace_id"],
+        }
+        rows = []
+        for mri, summaries in span.get("_metrics_summary", {}).items():
+            for summary in summaries:
+                rows.append(
+                    {
+                        **common_fields,
+                        **{
+                            "count": summary.get("count", 0),
+                            "max": summary.get("max", 0.0),
+                            "mri": mri,
+                            "min": summary.get("min", 0.0),
+                            "sum": summary.get("sum", 0.0),
+                            "tags": summary.get("tags", {}),
+                        },
+                    }
+                )
         assert (
             requests.post(
                 settings.SENTRY_SNUBA + "/tests/entities/metrics_summaries/insert",
-                data=json.dumps([metric_summary]),
+                data=json.dumps(rows),
             ).status_code
             == 200
         )
@@ -1523,7 +1551,7 @@ class BaseSpansTestCase(SnubaTestCase):
             self.store_span(payload)
 
         if "_metrics_summary" in payload:
-            self.store_metric_summary(payload)
+            self.store_metrics_summary(payload)
 
 
 class BaseMetricsTestCase(SnubaTestCase):

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -333,6 +333,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             codeLocations="true",
         )
 
+    @pytest.mark.skip("transition to new metrics summaries processor in snuba")
     def test_get_metric_spans(self):
         mri = "g:custom/page_load@millisecond"
 
@@ -421,6 +422,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             {"spanDuration": 2, "spanOp": "rpc"},
         ]
 
+    @pytest.mark.skip("transition to new metrics summaries processor in snuba")
     def test_get_metric_spans_with_environment(self):
         mri = "g:custom/page_load@millisecond"
 
@@ -489,6 +491,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
         assert len(metric_spans) == 1
         assert metric_spans[0]["transactionId"] == transaction_id_2
 
+    @pytest.mark.skip("transition to new metrics summaries processor in snuba")
     def test_get_metric_spans_with_latest_release(self):
         mri = "g:custom/page_load@millisecond"
 
@@ -563,6 +566,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             status_code=404,
         )
 
+    @pytest.mark.skip("transition to new metrics summaries processor in snuba")
     def test_get_metric_spans_with_bounds(self):
         mri = "g:custom/page_load@millisecond"
 


### PR DESCRIPTION
This changes are necessary to match the new metrics summaries consumer introduced in https://github.com/getsentry/snuba/pull/5524, reading from its own topic.

At the same time, we'll disable the tests until we've merged the Snuba changes.