### PR TITLE
fix(ondemand): Check projects for _query_cardinality

### DIFF
--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -423,6 +423,7 @@ def _query_cardinality(
     params: dict[str, Any] = {
         "statsPeriod": period,
         "organization_id": organization.id,
+        "projects": Project.objects.filter(organization=organization),
     }
     start, end = get_date_range_from_params(params)
     params["start"] = start

--- a/tests/sentry/tasks/test_on_demand_metrics.py
+++ b/tests/sentry/tasks/test_on_demand_metrics.py
@@ -17,6 +17,7 @@ from sentry.models.project import Project
 from sentry.models.user import User
 from sentry.tasks import on_demand_metrics
 from sentry.tasks.on_demand_metrics import (
+    _query_cardinality,
     get_field_cardinality_cache_key,
     process_widget_specs,
     schedule_on_demand_check,
@@ -603,3 +604,12 @@ def assert_on_demand_model(
         return
 
     assert model.spec_hashes == expected_hashes[model.spec_version]  # Still include hashes
+
+
+@mock.patch("sentry.tasks.on_demand_metrics.QueryBuilder")
+@django_db_all
+def test_query_cardinality_called_with_projects(raw_snql_query, project, organization):
+    _query_cardinality(["sometag"], organization)
+    raw_snql_query.assert_called_once()
+    mock_call = raw_snql_query.mock_calls[0]
+    assert [proj.id for proj in mock_call.kwargs["params"]["projects"]] == [project.id]

--- a/tests/sentry/tasks/test_on_demand_metrics.py
+++ b/tests/sentry/tasks/test_on_demand_metrics.py
@@ -608,7 +608,9 @@ def assert_on_demand_model(
 
 @mock.patch("sentry.tasks.on_demand_metrics.QueryBuilder")
 @django_db_all
-def test_query_cardinality_called_with_projects(raw_snql_query, project, organization):
+def test_query_cardinality_called_with_projects(
+    raw_snql_query: Any, project: Project, organization: Organization
+) -> None:
     _query_cardinality(["sometag"], organization)
     raw_snql_query.assert_called_once()
     mock_call = raw_snql_query.mock_calls[0]


### PR DESCRIPTION
- This adds projects to the param list for _query_cardinality, without this the query is currently a no-op