### PR TITLE
feat(hybridcloud) Add a metric for webhook saves

### DIFF
--- a/src/sentry/hybridcloud/models/webhookpayload.py
+++ b/src/sentry/hybridcloud/models/webhookpayload.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, control_silo_only_model, sane_repr
-from sentry.utils import json
+from sentry.utils import json, metrics
 
 THE_PAST = datetime.datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=datetime.UTC)
 MAX_ATTEMPTS = 10
@@ -80,6 +80,7 @@ class WebhookPayload(Model):
         request: HttpRequest,
         integration_id: int | None = None,
     ) -> Self:
+        metrics.incr("hybridcloud.deliver_webhooks.saved")
         return cls.objects.create(
             mailbox_name=f"{provider}:{identifier}",
             region_name=region,


### PR DESCRIPTION
This is useful for determining backlog growth as we can do `saved - delivered` in metrics dashboards.
