### PR TITLE
chore(roles): remove orgRole and groupOrgRole from api responses

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -113,7 +113,6 @@ class OrganizationMemberSerializer(Serializer):
             attrs[item] = {
                 "user": user,
                 "externalUsers": external_users,
-                "groupOrgRoles": self.__sorted_org_roles_for_user(item),
                 "inviter": inviter,
                 "email": email_map.get(user_id, item.email),
             }
@@ -151,10 +150,6 @@ class OrganizationMemberSerializer(Serializer):
             "inviteStatus": obj.get_invite_status_name(),
             "inviterName": inviter_name,
         }
-
-        groupOrgRoles = attrs.get("groupOrgRoles")
-        if groupOrgRoles:
-            data["groupOrgRoles"] = groupOrgRoles
 
         if "externalUsers" in self.expand:
             data["externalUsers"] = attrs.get("externalUsers", [])

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -66,7 +66,6 @@ class _TeamRole(TypedDict):
 
 class OrganizationMemberResponseOptional(TypedDict, total=False):
     externalUsers: list[ExternalActorResponse]
-    groupOrgRoles: list[OrganizationRoleSerializerResponse]
     role: str  # Deprecated: use orgRole
     roleName: str  # Deprecated
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -88,7 +88,7 @@ def get_access_by_project(
     team_memberships = _get_team_memberships([pt.team for pt in project_teams], user)
 
     org_ids = {i.organization_id for i in projects}
-    all_org_roles = get_org_roles(org_ids, user)
+    org_roles = get_org_roles(org_ids, user)
     is_superuser = request and is_active_superuser(request) and request.user == user
     prefetch_related_objects(projects, "organization")
 
@@ -98,13 +98,13 @@ def get_access_by_project(
         parent_teams = [t.id for t in project_team_map.get(project.id, [])]
         member_teams = [m for m in team_memberships if m.team_id in parent_teams]
         is_member = any(member_teams)
-        org_roles = all_org_roles.get(project.organization_id) or []
+        org_role = org_roles.get(project.organization_id)
 
         has_access = bool(
             is_member
             or is_superuser
             or project.organization.flags.allow_joinleave
-            or any(roles.get(org_role).is_global for org_role in org_roles)
+            or roles.get(org_role).is_global
         )
 
         team_scopes = set()

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -118,13 +118,10 @@ def get_access_by_project(
                 for member in member_teams:
                     team_scopes = team_scopes.union(*[member.get_scopes(has_team_roles_cache)])
 
-                # User may have elevated team-roles from their org-role
-                top_org_role = org_roles[0] if org_roles else None
                 if is_superuser:
-                    top_org_role = organization_roles.get_top_dog().id
+                    org_role = organization_roles.get_top_dog().id
 
-                if top_org_role:
-                    minimum_team_role = roles.get_minimum_team_role(top_org_role)
+                    minimum_team_role = roles.get_minimum_team_role(org_role)
                     team_scopes = team_scopes.union(minimum_team_role.scopes)
 
         result[project] = {

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -121,8 +121,9 @@ def get_access_by_project(
                 if is_superuser:
                     org_role = organization_roles.get_top_dog().id
 
-                minimum_team_role = roles.get_minimum_team_role(org_role)
-                team_scopes = team_scopes.union(minimum_team_role.scopes)
+                if org_role:
+                    minimum_team_role = roles.get_minimum_team_role(org_role)
+                    team_scopes = team_scopes.union(minimum_team_role.scopes)
 
         result[project] = {
             "is_member": is_member,

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -104,7 +104,7 @@ def get_access_by_project(
             is_member
             or is_superuser
             or project.organization.flags.allow_joinleave
-            or roles.get(org_role).is_global
+            or (org_role and roles.get(org_role).is_global)
         )
 
         team_scopes = set()

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -121,8 +121,8 @@ def get_access_by_project(
                 if is_superuser:
                     org_role = organization_roles.get_top_dog().id
 
-                    minimum_team_role = roles.get_minimum_team_role(org_role)
-                    team_scopes = team_scopes.union(minimum_team_role.scopes)
+                minimum_team_role = roles.get_minimum_team_role(org_role)
+                team_scopes = team_scopes.union(minimum_team_role.scopes)
 
         result[project] = {
             "is_member": is_member,

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -80,7 +80,7 @@ def get_member_totals(team_list: Sequence[Team], user: User) -> Mapping[str, int
 
 def get_org_roles(
     org_ids: set[int], user: User, optimization: SingularRpcAccessOrgOptimization | None = None
-) -> Mapping[int, Sequence[str]]:
+) -> Mapping[int, str]:
     """
     Get the roles the user has in each org
     """

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -26,7 +26,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.team import Team
 from sentry.models.user import User
-from sentry.roles import organization_roles
+from sentry.roles import organization_roles, team_roles
 from sentry.scim.endpoints.constants import SCIM_SCHEMA_GROUP
 from sentry.utils.query import RangeQuerySetWrapper
 
@@ -214,10 +214,12 @@ class BaseTeamSerializer(Serializer):
                 if is_superuser:
                     org_role = organization_roles.get_top_dog().id
 
-                minimum_team_role = roles.get_minimum_team_role(org_role)
+                minimum_team_role = team_roles.get_default()
+                if org_role:
+                    minimum_team_role = roles.get_minimum_team_role(org_role)
 
-                team_role_scopes = minimum_team_role.scopes
-                team_role_id = minimum_team_role.id
+                    team_role_scopes = minimum_team_role.scopes
+                    team_role_id = minimum_team_role.id
 
             result[team] = {
                 "pending_request": team.id in access_requests,

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -207,7 +207,7 @@ class BaseTeamSerializer(Serializer):
                 is_member
                 or is_superuser
                 or organization.flags.allow_joinleave
-                or roles.get(org_role).is_global
+                or (org_role and roles.get(org_role).is_global)
             )
 
             if has_access:

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -26,7 +26,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.team import Team
 from sentry.models.user import User
-from sentry.roles import organization_roles, team_roles
+from sentry.roles import organization_roles
 from sentry.scim.endpoints.constants import SCIM_SCHEMA_GROUP
 from sentry.utils.query import RangeQuerySetWrapper
 
@@ -78,56 +78,29 @@ def get_member_totals(team_list: Sequence[Team], user: User) -> Mapping[str, int
     return {item["id"]: item["member_count"] for item in query}
 
 
-def get_member_orgs_and_roles(org_ids: set[int], user_id: int) -> Mapping[int, Sequence[str]]:
-    org_members = OrganizationMember.objects.filter(
-        user_id=user_id, organization__in=org_ids
-    ).values_list("organization_id", "id", "role")
-
-    if not len(org_members):
-        return {}
-
-    _, org_member_ids, _ = zip(*org_members)
-
-    roles_from_teams = (
-        OrganizationMemberTeam.objects.filter(organizationmember_id__in=org_member_ids)
-        .exclude(team__org_role=None)
-        .values_list("organizationmember__organization_id", "team__org_role")
-    )
-
-    orgs_and_roles = {orgs: {role} for orgs, _, role in org_members}
-
-    for org_id, org_role in roles_from_teams:
-        orgs_and_roles[org_id].add(org_role)
-
-    return {
-        org: [r.id for r in organization_roles.get_sorted_roles(org_roles)]
-        for org, org_roles in orgs_and_roles.items()
-    }
-
-
 def get_org_roles(
     org_ids: set[int], user: User, optimization: SingularRpcAccessOrgOptimization | None = None
 ) -> Mapping[int, Sequence[str]]:
     """
     Get the roles the user has in each org
-    Roles are ordered from highest to lower priority (descending priority)
     """
     if not user.is_authenticated:
         return {}
 
     if optimization:
-        if optimization.access.roles is not None:
+        if optimization.access.role is not None:
             return {
-                optimization.access.rpc_user_organization_context.organization.id: list(
-                    optimization.access.roles
-                )
+                optimization.access.api_user_organization_context.organization.id: optimization.access.role
             }
         return {}
 
     # map of org id to role
-    # can have multiple org roles through team membership
-    # return them sorted to figure out highest team role
-    return get_member_orgs_and_roles(org_ids=org_ids, user_id=user.id)
+    return {
+        om["organization_id"]: om["role"]
+        for om in OrganizationMember.objects.filter(
+            user_id=user.id, organization__in=set(org_ids)
+        ).values("role", "organization_id")
+    }
 
 
 def get_access_requests(item_list: Sequence[Team], user: User) -> AbstractSet[Team]:
@@ -144,7 +117,6 @@ class _TeamSerializerResponseOptional(TypedDict, total=False):
     externalTeams: list[ExternalActorResponse]
     organization: OrganizationSerializerResponse
     projects: list[ProjectSerializerResponse]
-    orgRole: str | None  # TODO(cathy): Change to new key
 
 
 class BaseTeamSerializerResponse(TypedDict):
@@ -228,32 +200,24 @@ class BaseTeamSerializer(Serializer):
 
         for team in item_list:
             is_member = team.id in team_memberships
-            org_roles = roles_by_org.get(team.organization_id) or []
+            org_role = roles_by_org.get(team.organization_id)
             team_role_id, team_role_scopes = team_memberships.get(team.id), set()
 
             has_access = bool(
                 is_member
                 or is_superuser
                 or organization.flags.allow_joinleave
-                or any(roles.get(org_role).is_global for org_role in org_roles)
+                or roles.get(org_role).is_global
             )
 
             if has_access:
-                effective_team_role = (
-                    team_roles.get(team_role_id) if team_role_id else team_roles.get_default()
-                )
-
-                top_org_role = org_roles[0] if org_roles else None
                 if is_superuser:
-                    top_org_role = organization_roles.get_top_dog().id
+                    org_role = organization_roles.get_top_dog().id
 
-                if top_org_role:
-                    minimum_team_role = roles.get_minimum_team_role(top_org_role)
-                    if minimum_team_role.priority > effective_team_role.priority:
-                        effective_team_role = minimum_team_role
+                minimum_team_role = roles.get_minimum_team_role(org_role)
 
-                team_role_scopes = effective_team_role.scopes
-                team_role_id = effective_team_role.id
+                team_role_scopes = minimum_team_role.scopes
+                team_role_id = minimum_team_role.id
 
             result[team] = {
                 "pending_request": team.id in access_requests,

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -211,15 +211,20 @@ class BaseTeamSerializer(Serializer):
             )
 
             if has_access:
+                effective_team_role = (
+                    team_roles.get(team_role_id) if team_role_id else team_roles.get_default()
+                )
+
                 if is_superuser:
                     org_role = organization_roles.get_top_dog().id
 
-                minimum_team_role = team_roles.get_default()
                 if org_role:
                     minimum_team_role = roles.get_minimum_team_role(org_role)
+                    if minimum_team_role.priority > effective_team_role.priority:
+                        effective_team_role = minimum_team_role
 
-                    team_role_scopes = minimum_team_role.scopes
-                    team_role_id = minimum_team_role.id
+                team_role_scopes = effective_team_role.scopes
+                team_role_id = effective_team_role.id
 
             result[team] = {
                 "pending_request": team.id in access_requests,

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -55,26 +55,6 @@ class OrganizationMemberSerializerTest(TestCase):
 
 
 @region_silo_test
-class OrganizationMemberAllRolesSerializerTest(OrganizationMemberSerializerTest):
-    def test_all_org_roles(self):
-        manager_team = self.create_team(organization=self.org, org_role="manager")
-        manager_team2 = self.create_team(organization=self.org, org_role="manager")
-        owner_team = self.create_team(organization=self.org, org_role="owner")
-        member = self.create_member(
-            organization=self.org,
-            user=self.create_user(),
-            teams=[manager_team, manager_team2, owner_team],
-        )
-        result = serialize(member, self.user_2, OrganizationMemberSerializer())
-
-        assert len(result["groupOrgRoles"]) == 3
-        assert result["groupOrgRoles"][0]["role"]["id"] == "owner"
-        assert result["groupOrgRoles"][0]["teamSlug"] == owner_team.slug
-        assert result["groupOrgRoles"][1]["role"]["id"] == "manager"
-        assert result["groupOrgRoles"][2]["role"]["id"] == "manager"
-
-
-@region_silo_test
 class OrganizationMemberWithProjectsSerializerTest(OrganizationMemberSerializerTest):
     def test_simple(self):
         projects = [self.project, self.project_2]

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -188,37 +188,6 @@ class ProjectSerializerTest(TestCase):
             assert result["hasAccess"] is True
             assert result["isMember"] is False
 
-    def test_member_on_owner_team(self):
-        organization = self.create_organization()
-        manager_team = self.create_team(organization=organization, org_role="manager")
-        owner_team = self.create_team(organization=organization, org_role="owner")
-        self.create_member(
-            user=self.user,
-            organization=self.organization,
-            role="member",
-            teams=[manager_team, owner_team],
-        )
-
-        result = serialize(self.project, self.user)
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
-
-        self.organization.flags.allow_joinleave = False
-        self.organization.save()
-        result = serialize(self.project, self.user)
-        # after changing to allow_joinleave=False
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
-
-        self.create_team_membership(user=self.user, team=self.team)
-        result = serialize(self.project, self.user)
-        # after giving them access to team
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is True
-
     @mock.patch("sentry.features.batch_has")
     def test_project_batch_has(self, mock_batch):
         mock_batch.return_value = {

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -6,7 +6,6 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamSCIMSerializer, TeamWithProjectsSerializer
 from sentry.app import env
 from sentry.models.organizationmember import InviteStatus
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -244,39 +243,6 @@ class TeamSerializerTest(TestCase):
             assert result["hasAccess"] is True
             assert result["isMember"] is False
             assert result["teamRole"] is None
-
-    def test_member_with_team_role_on_owner_team(self):
-        user = self.create_user(username="foo")
-        organization = self.create_organization()
-        manager_team = self.create_team(organization=organization, org_role="manager")
-        member = self.create_member(
-            user=user, organization=organization, role="member", teams=[manager_team]
-        )
-        team = self.create_team(organization=organization)
-        OrganizationMemberTeam(organizationmember=member, team=team, role="admin")
-
-        result = serialize(team, user)
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
-        assert result["teamRole"] is None
-
-        organization.flags.allow_joinleave = False
-        organization.save()
-        result = serialize(team, user)
-        # after changing to allow_joinleave=False
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
-        assert result["teamRole"] is None
-
-        self.create_team_membership(user=user, team=team, role="contributor")
-        result = serialize(team, user)
-        # after giving them access to team
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is True
-        assert result["teamRole"] == TEAM_ADMIN["id"]
 
 
 @region_silo_test

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -38,15 +38,6 @@ class TeamSerializerTest(TestCase):
             "memberCount": 0,
         }
 
-    def test_simple_with_group_org_role(self):
-        user = self.create_user(username="foo")
-        organization = self.create_organization()
-        team = self.create_team(organization=organization, org_role="manager")
-        self.create_member(user=user, organization=organization, role="owner")
-
-        result = serialize(team, user)
-        assert result["orgRole"] == "manager"
-
     def test_member_count(self):
         user = self.create_user(username="foo")
         other_user = self.create_user(username="bar")
@@ -253,39 +244,6 @@ class TeamSerializerTest(TestCase):
             assert result["hasAccess"] is True
             assert result["isMember"] is False
             assert result["teamRole"] is None
-
-    def test_member_on_owner_team(self):
-        user = self.create_user(username="foo")
-        organization = self.create_organization()
-        manager_team = self.create_team(organization=organization, org_role="manager")
-        owner_team = self.create_team(organization=organization, org_role="owner")
-        self.create_member(
-            user=user, organization=organization, role="member", teams=[manager_team, owner_team]
-        )
-        team = self.create_team(organization=organization)
-
-        result = serialize(team, user)
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
-        assert result["teamRole"] is None
-
-        organization.flags.allow_joinleave = False
-        organization.save()
-        result = serialize(team, user)
-        # after changing to allow_joinleave=False
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is False
-        assert result["teamRole"] is None
-
-        self.create_team_membership(user=user, team=team, role=None)
-        result = serialize(team, user)
-        # after giving them access to team
-        assert result["access"] == TEAM_ADMIN["scopes"]
-        assert result["hasAccess"] is True
-        assert result["isMember"] is True
-        assert result["teamRole"] == TEAM_ADMIN["id"]
 
     def test_member_with_team_role_on_owner_team(self):
         user = self.create_user(username="foo")


### PR DESCRIPTION
The `orgRole` on the Team model and `groupOrgRoles` for Project access are not being used on the frontend anymore, so we can remove them from the API responses.

For https://github.com/getsentry/team-core-product-foundations/issues/51