### PR TITLE
fix(grouping): Fix bug in `assign_to_event` tests

### DIFF
--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -175,10 +175,13 @@ def get_results_from_saving_event(
             gh.hash: gh.group_id for gh in GroupHash.objects.filter(project_id=project.id)
         }
 
-        hash_search_result = return_values[find_existing_grouphash_fn][0]
+        hash_search_results = return_values[find_existing_grouphash_fn]
         # The current logic wraps the search result in an extra layer which we need to unwrap
         if not new_logic_enabled:
-            hash_search_result = hash_search_result[0]
+            hash_search_results = list(map(lambda result: result[0], hash_search_results))
+        # Filter out all the Nones to see if we actually found anything
+        filtered_results = list(filter(lambda result: bool(result), hash_search_results))
+        hash_search_result = filtered_results[0] if filtered_results else None
 
         # We should never call any of these more than once, regardless of the test
         assert calculate_primary_hash_spy.call_count <= 1


### PR DESCRIPTION
This fixes a bug in the `assign_event_to_group` tests, where it assumed that it was only the first call to `find_existing_grouphash`/`find_existing_grouphash_new` which mattered in terms of determining what was found. Though that's true given the current `_save_aggregate` logic, it won't be with the new logic.

This changes it so that:
- The results from `find_existing_grouphash` are unwrapped from their tuples first, so that the unwrapping happens for all results rather than just the first one.
- Any results which don't find anything are filtered out.

We can then safely take the first result, since our logic uses the first real result it finds.