### PR TITLE
ref(tsc): Convert ProjectTeams to FC + useApiQuery

### DIFF
--- a/static/app/actionCreators/projects.tsx
+++ b/static/app/actionCreators/projects.tsx
@@ -14,12 +14,8 @@ import LatestContextStore from 'sentry/stores/latestContextStore';
 import ProjectsStatsStore from 'sentry/stores/projectsStatsStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {PlatformKey, Project, Team} from 'sentry/types';
-import {
-  type ApiQueryKey,
-  setApiQueryData,
-  useApiQuery,
-  useQueryClient,
-} from 'sentry/utils/queryClient';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 
 type UpdateParams = {

--- a/static/app/views/settings/project/projectTeams.spec.tsx
+++ b/static/app/views/settings/project/projectTeams.spec.tsx
@@ -89,9 +89,7 @@ describe('ProjectTeams', function () {
 
     render(<ProjectTeams organization={org} project={project} />);
 
-    await waitFor(() =>
-      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
-    );
+    expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 
     expect(mock1).not.toHaveBeenCalled();
 
@@ -143,9 +141,7 @@ describe('ProjectTeams', function () {
 
     render(<ProjectTeams organization={org} project={project} />);
 
-    await waitFor(() =>
-      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
-    );
+    expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 
     // Remove first team
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
@@ -191,9 +187,7 @@ describe('ProjectTeams', function () {
 
     render(<ProjectTeams organization={org} project={project} />);
 
-    await waitFor(() =>
-      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
-    );
+    expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 
     expect(mock1).not.toHaveBeenCalled();
 
@@ -236,9 +230,7 @@ describe('ProjectTeams', function () {
 
     render(<ProjectTeams organization={org} project={project} />);
 
-    await waitFor(() =>
-      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
-    );
+    expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 
     expect(mock).not.toHaveBeenCalled();
 
@@ -275,9 +267,7 @@ describe('ProjectTeams', function () {
 
     render(<ProjectTeams project={project} organization={org} />);
 
-    await waitFor(() =>
-      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
-    );
+    expect(await screen.findByText('Project Teams for project-slug')).toBeInTheDocument();
 
     // Add new team
     await userEvent.click(screen.getAllByRole('button', {name: 'Add Team'})[1]);

--- a/static/app/views/settings/project/projectTeams.spec.tsx
+++ b/static/app/views/settings/project/projectTeams.spec.tsx
@@ -1,4 +1,3 @@
-import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -17,7 +16,6 @@ import ProjectTeams from 'sentry/views/settings/project/projectTeams';
 describe('ProjectTeams', function () {
   let org: Organization;
   let project: Project;
-  let routerContext: Record<string, any>;
 
   const team1WithAdmin = TeamFixture({
     access: ['team:read', 'team:write', 'team:admin'],
@@ -44,7 +42,6 @@ describe('ProjectTeams', function () {
       ...initialData.project,
       access: ['project:admin', 'project:write', 'project:admin'],
     };
-    routerContext = initialData.routerContext;
 
     TeamStore.loadInitialData([team1WithAdmin, team2WithAdmin]);
 
@@ -69,17 +66,6 @@ describe('ProjectTeams', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('renders', function () {
-    render(
-      <ProjectTeams
-        {...RouteComponentPropsFixture()}
-        params={{projectId: project.slug}}
-        organization={org}
-        project={project}
-      />
-    );
-  });
-
   it('can remove a team from project', async function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/teams/`,
@@ -101,13 +87,10 @@ describe('ProjectTeams', function () {
       statusCode: 200,
     });
 
-    render(
-      <ProjectTeams
-        {...RouteComponentPropsFixture()}
-        params={{projectId: project.slug}}
-        organization={org}
-        project={project}
-      />
+    render(<ProjectTeams organization={org} project={project} />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
     );
 
     expect(mock1).not.toHaveBeenCalled();
@@ -158,13 +141,10 @@ describe('ProjectTeams', function () {
       statusCode: 200,
     });
 
-    render(
-      <ProjectTeams
-        {...RouteComponentPropsFixture()}
-        params={{projectId: project.slug}}
-        organization={org}
-        project={project}
-      />
+    render(<ProjectTeams organization={org} project={project} />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
     );
 
     // Remove first team
@@ -209,13 +189,10 @@ describe('ProjectTeams', function () {
       body: [team3NoAdmin],
     });
 
-    render(
-      <ProjectTeams
-        {...RouteComponentPropsFixture()}
-        params={{projectId: project.slug}}
-        organization={org}
-        project={project}
-      />
+    render(<ProjectTeams organization={org} project={project} />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
     );
 
     expect(mock1).not.toHaveBeenCalled();
@@ -257,13 +234,10 @@ describe('ProjectTeams', function () {
       statusCode: 200,
     });
 
-    render(
-      <ProjectTeams
-        {...RouteComponentPropsFixture()}
-        params={{projectId: project.slug}}
-        organization={org}
-        project={project}
-      />
+    render(<ProjectTeams organization={org} project={project} />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
     );
 
     expect(mock).not.toHaveBeenCalled();
@@ -296,17 +270,13 @@ describe('ProjectTeams', function () {
     const createTeam = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/teams/`,
       method: 'POST',
-      body: {slug: 'new-team'},
+      body: TeamFixture({slug: 'new-team'}),
     });
 
-    render(
-      <ProjectTeams
-        {...RouteComponentPropsFixture()}
-        params={{projectId: project.slug}}
-        project={project}
-        organization={org}
-      />,
-      {context: routerContext}
+    render(<ProjectTeams project={project} organization={org} />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Project Teams for project-slug')).toBeInTheDocument()
     );
 
     // Add new team


### PR DESCRIPTION
Ref https://github.com/getsentry/frontend-tsc/issues/2

This page is at `/settings/projects/:projectSlug/teams/`

Added fetching/updating hooks to actionCreators in hopes of making them somewhat reusable. 