### PR TITLE
feat(crons-db): Stop joining to the environment table when serializing monitors

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import MutableMapping, Sequence
 from datetime import datetime
 from typing import Any, Literal, TypedDict
 
@@ -9,6 +10,7 @@ from sentry.models.project import Project
 from sentry.monitors.utils import fetch_associated_groups
 from sentry.monitors.validators import IntervalNames
 
+from ..models import Environment
 from .models import Monitor, MonitorCheckIn, MonitorEnvironment, MonitorStatus
 
 
@@ -24,9 +26,22 @@ class MonitorEnvironmentSerializerResponse(TypedDict):
 
 @register(MonitorEnvironment)
 class MonitorEnvironmentSerializer(Serializer):
+    def get_attrs(
+        self, item_list: Sequence[Any], user: Any, **kwargs: Any
+    ) -> MutableMapping[Any, Any]:
+        env_ids = [
+            monitor_env.environment_id for monitor_env in item_list if monitor_env.environment_id
+        ]
+        environments = {env.id: env for env in Environment.objects.filter(id__in=env_ids)}
+
+        return {
+            monitor_env: {"environment": environments[monitor_env.environment_id]}
+            for monitor_env in item_list
+        }
+
     def serialize(self, obj, attrs, user, **kwargs) -> MonitorEnvironmentSerializerResponse:
         return {
-            "name": obj.environment.name,
+            "name": attrs["environment"].name,
             "status": obj.get_status_display(),
             "isMuted": obj.is_muted,
             "dateCreated": obj.monitor.date_added,
@@ -94,26 +109,24 @@ class MonitorSerializer(Serializer):
             )
         }
 
-        serialized_monitor_environments = defaultdict(list)
         monitor_environments = (
             MonitorEnvironment.objects.filter(monitor__in=item_list)
-            .select_related("environment")
             .order_by("-last_checkin")
             .exclude(
                 status__in=[MonitorStatus.PENDING_DELETION, MonitorStatus.DELETION_IN_PROGRESS]
             )
         )
         if self.environments:
-            monitor_environments = monitor_environments.filter(environment__in=self.environments)
-
-        for monitor_environment in monitor_environments:
-            # individually serialize as related objects are prefetched
-            serialized_monitor_environments[monitor_environment.monitor_id].append(
-                serialize(
-                    monitor_environment,
-                    user,
-                )
+            monitor_environments = monitor_environments.filter(
+                environment_id__in=[env.id for env in self.environments]
             )
+
+        monitor_environments = list(monitor_environments)
+        serialized_monitor_environments = defaultdict(list)
+        for monitor_env, serialized in zip(
+            monitor_environments, serialize(monitor_environments, user)
+        ):
+            serialized_monitor_environments[monitor_env.monitor_id].append(serialized)
 
         environment_data = {
             str(item.id): serialized_monitor_environments.get(item.id, []) for item in item_list

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -54,16 +54,49 @@ class OrganizationMonitorDetailsTest(MonitorTestCase):
 
     def test_filtering_monitor_environment(self):
         monitor = self._create_monitor()
-        self._create_monitor_environment(monitor, name="production")
-        self._create_monitor_environment(monitor, name="jungle")
+        prod_env = "production"
+        prod = self._create_monitor_environment(monitor, name=prod_env)
+        jungle_env = "jungle"
+        jungle = self._create_monitor_environment(monitor, name=jungle_env)
 
         response = self.get_success_response(self.organization.slug, monitor.slug)
-        assert len(response.data["environments"]) == 2
+        result_envs = response.data["environments"]
+        result_envs.sort(key=lambda env: env["name"])
+        assert result_envs == [
+            {
+                "name": jungle_env,
+                "status": jungle.get_status_display(),
+                "isMuted": jungle.is_muted,
+                "dateCreated": jungle.monitor.date_added,
+                "lastCheckIn": jungle.last_checkin,
+                "nextCheckIn": jungle.next_checkin,
+                "nextCheckInLatest": jungle.next_checkin_latest,
+            },
+            {
+                "name": prod_env,
+                "status": prod.get_status_display(),
+                "isMuted": prod.is_muted,
+                "dateCreated": prod.monitor.date_added,
+                "lastCheckIn": prod.last_checkin,
+                "nextCheckIn": prod.next_checkin,
+                "nextCheckInLatest": prod.next_checkin_latest,
+            },
+        ]
 
         response = self.get_success_response(
             self.organization.slug, monitor.slug, environment="production"
         )
-        assert len(response.data["environments"]) == 1
+        assert response.data["environments"] == [
+            {
+                "name": prod_env,
+                "status": prod.get_status_display(),
+                "isMuted": prod.is_muted,
+                "dateCreated": prod.monitor.date_added,
+                "lastCheckIn": prod.last_checkin,
+                "nextCheckIn": prod.next_checkin,
+                "nextCheckInLatest": prod.next_checkin_latest,
+            }
+        ]
 
     def test_expand_alert_rule(self):
         monitor = self._create_monitor()


### PR DESCRIPTION
We want to move all crons related tables to a separate database. This means we need to stop joining to other non-cron tables directly. Instead, we make the query separately in code.
