### PR TITLE
feat(metrics-layer): Implement experimental interval normalization for cross-namespace queries

### DIFF
--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -127,7 +127,7 @@ def bulk_run_query(
         raise
 
     for idx, snuba_result in enumerate(snuba_results):
-        request, start, reverse_mappings, mappings, end, interval = queries[idx]
+        request, reverse_mappings, mappings, start, end, interval = queries[idx]
         metrics_query = request.query
 
         snuba_result = convert_snuba_result(
@@ -230,7 +230,7 @@ def _setup_metrics_query(
         # Only if the aligned interval results to be bigger, we will switch it. Note that this function
         # assumes that all supplied metrics queries have the same initial interval, otherwise this condition
         # might not apply to all.
-        if aligned_interval > interval:
+        if aligned_interval and aligned_interval > interval:
             metrics_query = metrics_query.set_rollup(
                 replace(metrics_query.rollup, interval=aligned_interval)
             )

--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -164,15 +164,20 @@ def run_query(request: Request) -> Mapping[str, Any]:
 
 
 def _calculate_aligned_interval(requests: Iterable[Request]) -> int | None:
+    # High level description of the algorithm:
     # 1. We determine all granularities for each namespaces in the query and formulas
     # 2. We compute the best granularity by getting the max and we set the interval to that
-    # sessions supports 5 min
-    # transactions 1 min
-    # custom 10 seconds
-    # We request 30s interval
-    # max is 5 min, so we can use an interval of 5 min and then align the granularities of the others,
-    # since it might be that we now set 5 min of interval, but we can satisfy that with only 1 minute granularity
-    # for transactions.
+    #
+    # For example:
+    # min sessions granularity -> 5 min
+    # min transactions granularity -> 1 min
+    # min custom granularity -> 10 seconds
+    #
+    # We now request a 30s interval
+    #
+    # Given all the granularities, the smallest interval that would match all of them is the maximum
+    # of the granularities, thus 5 minutes. We then choose an interval of 5 minutes and compute all the
+    # granularities on that (this will be done as always in its own separate step).
     computed_granularities = set()
 
     for request in requests:


### PR DESCRIPTION
This PR implements an experimental mechansm for aligning intervals across queries that belong to different namespaces. For example, if you query two metrics, one in custom and one in transactions and the namespaces have different minimum granularities, the algorithm will try to find an interval which satisfies both queries.