### PR TITLE
feat(metrics_extraction): user_misery to fall back to Discover

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -237,7 +237,8 @@ _SEARCH_TO_DERIVED_METRIC_AGGREGATES: dict[str, MetricOperationType] = {
     "count_web_vitals": "on_demand_count_web_vitals",
     "epm": "on_demand_epm",
     "eps": "on_demand_eps",
-    "user_misery": "on_demand_user_misery",
+    # XXX: Remove support until we can fix the count_unique(users)
+    # "user_misery": "on_demand_user_misery",
 }
 
 # Mapping to infer metric type from Discover function.

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -1159,6 +1159,7 @@ def test_get_metric_extraction_config_with_count_web_vitals(
             ]
 
 
+@pytest.mark.skip(reason="Re-enable when user misery is supported again.")
 @django_db_all
 def test_get_metric_extraction_config_with_user_misery(default_project: Project) -> None:
     threshold = 100
@@ -1209,6 +1210,7 @@ def test_get_metric_extraction_config_with_user_misery(default_project: Project)
         ]
 
 
+@pytest.mark.skip(reason="Re-enable when user misery is supported again.")
 @django_db_all
 def test_get_metric_extraction_config_user_misery_with_tag_columns(
     default_project: Project,

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -2928,12 +2928,14 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             ],
         )
 
+    @pytest.mark.skip(reason="Re-enable when user misery is supported again.")
     def test_run_query_with_on_demand_user_misery(self) -> None:
         self._test_user_misery(
             [("happy user", False), ("sad user", True)],
             _user_misery_formula(1, 2),
         )
 
+    @pytest.mark.skip(reason="Re-enable when user misery is supported again.")
     def test_run_query_with_on_demand_user_misery_no_miserable_users(self) -> None:
         self._test_user_misery(
             [("happy user", False), ("ok user", False)],

--- a/tests/sentry/snuba/metrics/test_extraction.py
+++ b/tests/sentry/snuba/metrics/test_extraction.py
@@ -166,6 +166,8 @@ class TestCreatesOndemandMetricSpec:
             ("failure_count()", ""),
             ("failure_rate()", "release:bar"),
             ("failure_rate()", ""),
+            ("user_misery(300)", ""),
+            ("user_misery(300)", "transaction.duration:>0"),
         ],
     )
     def test_does_not_create_on_demand_spec(self, aggregate, query) -> None:

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3221,6 +3221,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         response = self._make_on_demand_request(params)
         self._assert_on_demand_response(response)
 
+    @pytest.mark.skip(reason="Re-enable when user misery is supported again.")
     def test_transaction_user_misery(self) -> None:
         user_misery_field = "user_misery(300)"
         apdex_field = "apdex(300)"


### PR DESCRIPTION
Unfortunately, the count unique field we have been using is `user.id` which does not match what Discover uses, thus, the data return diverges.

We need to do some work on Relay in order to have the same `user` field available to on-demand. Until then we will be dropping support for `user_misery` in on-demand.