### PR TITLE
feat(ddm): Normalize metric values

### DIFF
--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -64,6 +64,9 @@ export const DAY = 86400000;
 export const HOUR = 3600000;
 export const MINUTE = 60000;
 export const SECOND = 1000;
+export const MILLISECOND = 1;
+export const MICROSECOND = 0.001;
+export const NANOSECOND = 0.000001;
 
 /**
  * Returns a human redable duration rounded to the largest unit.

--- a/static/app/utils/metrics/formatters.tsx
+++ b/static/app/utils/metrics/formatters.tsx
@@ -5,8 +5,11 @@ import {
   DAY,
   formatNumberWithDynamicDecimalPoints,
   HOUR,
+  MICROSECOND,
+  MILLISECOND,
   MINUTE,
   MONTH,
+  NANOSECOND,
   SECOND,
   WEEK,
 } from 'sentry/utils/formatters';
@@ -23,10 +26,6 @@ const metricTypeToReadable: Record<MetricType, string> = {
 export function getReadableMetricType(type?: string) {
   return metricTypeToReadable[type as MetricType] ?? t('unknown');
 }
-
-const MILLISECOND = 1;
-const MICROSECOND = MILLISECOND / 1000;
-const NANOSECOND = MICROSECOND / 1000;
 
 function formatDuration(seconds: number): string {
   if (!seconds) {
@@ -123,7 +122,8 @@ export const formattingSupportedMetricUnits = [
   'exabytes',
 ] as const;
 
-type FormattingSupportedMetricUnit = (typeof formattingSupportedMetricUnits)[number];
+export type FormattingSupportedMetricUnit =
+  (typeof formattingSupportedMetricUnits)[number];
 
 const METRIC_UNIT_TO_SHORT: Record<FormattingSupportedMetricUnit, string> = {
   nanosecond: 'ns',
@@ -217,6 +217,9 @@ export function formatMetricUsingUnit(value: number | null, unit: string) {
     case 'byte':
     case 'bytes':
       return formatBytesBase10(value);
+    // Only used internally to support normalized byte metrics while preserving base 2 formatting
+    case 'byte2' as FormattingSupportedMetricUnit:
+      return formatBytesBase2(value);
     case 'kibibyte':
     case 'kibibytes':
       return formatBytesBase2(value * 1024);

--- a/static/app/utils/metrics/normalizeMetricValue.spec.tsx
+++ b/static/app/utils/metrics/normalizeMetricValue.spec.tsx
@@ -1,0 +1,56 @@
+import {
+  getMetricValueNormalizer,
+  getNormalizedMetricUnit,
+} from 'sentry/utils/metrics/normalizeMetricValue';
+
+describe('getNormalizedMetricUnit', () => {
+  it('returns "millisecond" when unit is in timeConversionFactors', () => {
+    expect(getNormalizedMetricUnit('second')).toBe('millisecond');
+    expect(getNormalizedMetricUnit('hour')).toBe('millisecond');
+    expect(getNormalizedMetricUnit('hours')).toBe('millisecond');
+    expect(getNormalizedMetricUnit('minute')).toBe('millisecond');
+    expect(getNormalizedMetricUnit('nanoseconds')).toBe('millisecond');
+  });
+
+  it('returns "byte" when unit is in byte10ConversionFactors', () => {
+    expect(getNormalizedMetricUnit('kilobyte')).toBe('byte');
+    expect(getNormalizedMetricUnit('petabyte')).toBe('byte');
+    expect(getNormalizedMetricUnit('petabytes')).toBe('byte');
+  });
+
+  it('returns "byte2" when unit is in byte2ConversionFactors', () => {
+    expect(getNormalizedMetricUnit('bit')).toBe('byte2');
+    expect(getNormalizedMetricUnit('kibibyte')).toBe('byte2');
+    expect(getNormalizedMetricUnit('kibibytes')).toBe('byte2');
+  });
+
+  it('returns the unit when it is not in any of the conversion factors', () => {
+    expect(getNormalizedMetricUnit('foo')).toBe('foo');
+  });
+});
+
+describe('getMetricValueNormalizer', () => {
+  it('returns a function that normalizes the value to milliseconds when the unit is in timeConversionFactors', () => {
+    expect(getMetricValueNormalizer('second')(1)).toBe(1000);
+    expect(getMetricValueNormalizer('seconds')(2)).toBe(2000);
+
+    expect(getMetricValueNormalizer('hour')(1)).toBe(3600000);
+    expect(getMetricValueNormalizer('hours')(2)).toBe(7200000);
+  });
+
+  it('returns a function that normalizes the value to bytes when the unit is in byte10ConversionFactors', () => {
+    expect(getMetricValueNormalizer('byte')(1)).toBe(1);
+    expect(getMetricValueNormalizer('bytes')(2)).toBe(2);
+
+    expect(getMetricValueNormalizer('terabyte')(1)).toBe(1000 ** 4);
+    expect(getMetricValueNormalizer('terabytes')(2)).toBe(2 * 1000 ** 4);
+  });
+
+  it('returns a function that normalizes the value to bytes when the unit is in byte2ConversionFactors', () => {
+    expect(getMetricValueNormalizer('bit')(1)).toBe(1 / 8);
+    expect(getMetricValueNormalizer('bits')(1)).toBe(1 / 8);
+
+    expect(getMetricValueNormalizer('tebibyte')(1)).toBe(1024 ** 4);
+    expect(getMetricValueNormalizer('tebibytes')(2)).toBe(2 * 1024 ** 4);
+  });
+});

--- a/static/app/utils/metrics/normalizeMetricValue.tsx
+++ b/static/app/utils/metrics/normalizeMetricValue.tsx
@@ -1,0 +1,100 @@
+import {
+  DAY,
+  HOUR,
+  MICROSECOND,
+  MILLISECOND,
+  MINUTE,
+  NANOSECOND,
+  SECOND,
+  WEEK,
+} from 'sentry/utils/formatters';
+
+const timeConversionFactors = {
+  week: WEEK,
+  weeks: WEEK,
+  day: DAY,
+  days: DAY,
+  hour: HOUR,
+  hours: HOUR,
+  minute: MINUTE,
+  minutes: MINUTE,
+  second: SECOND,
+  seconds: SECOND,
+  millisecond: MILLISECOND,
+  milliseconds: MILLISECOND,
+  microsecond: MICROSECOND,
+  microseconds: MICROSECOND,
+  nanosecond: NANOSECOND,
+  nanoseconds: NANOSECOND,
+};
+
+const byte10ConversionFactors = {
+  byte: 1,
+  bytes: 1,
+  kilobyte: 1000,
+  kilobytes: 1000,
+  megabyte: 1000 ** 2,
+  megabytes: 1000 ** 2,
+  gigabyte: 1000 ** 3,
+  gigabytes: 1000 ** 3,
+  terabyte: 1000 ** 4,
+  terabytes: 1000 ** 4,
+  petabyte: 1000 ** 5,
+  petabytes: 1000 ** 5,
+  exabyte: 1000 ** 6,
+  exabytes: 1000 ** 6,
+};
+
+const byte2ConversionFactors = {
+  bit: 1 / 8,
+  bits: 1 / 8,
+  byte2: 1,
+  kibibyte: 1024,
+  kibibytes: 1024,
+  mebibyte: 1024 ** 2,
+  mebibytes: 1024 ** 2,
+  gibibyte: 1024 ** 3,
+  gibibytes: 1024 ** 3,
+  tebibyte: 1024 ** 4,
+  tebibytes: 1024 ** 4,
+  pebibyte: 1024 ** 5,
+  pebibytes: 1024 ** 5,
+  exbibyte: 1024 ** 6,
+  exbibytes: 1024 ** 6,
+};
+
+export function getNormalizedMetricUnit(unit: string) {
+  if (!unit) {
+    return 'none';
+  }
+
+  if (unit in timeConversionFactors) {
+    return 'millisecond';
+  }
+
+  if (unit in byte10ConversionFactors) {
+    return 'byte';
+  }
+
+  if (unit in byte2ConversionFactors) {
+    return 'byte2';
+  }
+
+  return unit;
+}
+
+export function getMetricValueNormalizer(unit: string) {
+  if (unit in timeConversionFactors) {
+    return (value: number | null) => value && value * timeConversionFactors[unit];
+  }
+
+  if (unit in byte10ConversionFactors) {
+    return (value: number | null) => value && value * byte10ConversionFactors[unit];
+  }
+
+  if (unit in byte2ConversionFactors) {
+    return (value: number | null) => value && value * byte2ConversionFactors[unit];
+  }
+
+  return (value: number | null) => value;
+}

--- a/static/app/views/ddm/chart.tsx
+++ b/static/app/views/ddm/chart.tsx
@@ -145,21 +145,14 @@ export const MetricChart = forwardRef<ReactEchartsRef, ChartProps>(
       [series, fogOfWarBuckets, displayType]
     );
 
-    const valueFormatter = useCallback(
-      (value: number) => {
-        return formatMetricsUsingUnitAndOp(value, unit, operation);
-      },
-      [unit, operation]
-    );
-
     const samples = useChartSamples({
       chartRef,
       correlations: scatter?.data,
+      unit: scatter?.unit,
       onClick: scatter?.onClick,
       highlightedSampleId: scatter?.higlightedId,
       operation,
       timeseries: series,
-      valueFormatter,
     });
 
     const chartProps = useMemo(() => {

--- a/static/app/views/ddm/useChartSamples.tsx
+++ b/static/app/views/ddm/useChartSamples.tsx
@@ -6,6 +6,8 @@ import moment from 'moment';
 
 import type {ReactEchartsRef, Series} from 'sentry/types/echarts';
 import {isCumulativeOp} from 'sentry/utils/metrics';
+import {formatMetricsUsingUnitAndOp} from 'sentry/utils/metrics/formatters';
+import {getMetricValueNormalizer} from 'sentry/utils/metrics/normalizeMetricValue';
 import type {MetricCorrelation, MetricSummary} from 'sentry/utils/metrics/types';
 import {fitToValueRect, getValueRect} from 'sentry/views/ddm/chartUtils';
 import type {Sample} from 'sentry/views/ddm/widget';
@@ -19,7 +21,7 @@ type UseChartSamplesProps = {
   onMouseOut?: (sample: Sample) => void;
   onMouseOver?: (sample: Sample) => void;
   operation?: string;
-  valueFormatter?: (value: number) => string;
+  unit?: string;
 };
 
 // TODO: remove this once we have a stabilized type for this
@@ -39,10 +41,10 @@ export function useChartSamples({
   correlations,
   onClick,
   highlightedSampleId,
+  unit = '',
   chartRef,
   operation,
   timeseries,
-  valueFormatter,
 }: UseChartSamplesProps) {
   const theme = useTheme();
 
@@ -129,11 +131,13 @@ export function useChartSamples({
       return [];
     }
 
+    const normalizeMetric = getMetricValueNormalizer(unit ?? '');
+
     return Object.values(samples).map(sample => {
       const isHighlighted = highlightedSampleId === sample.transactionId;
 
       const xValue = moment(sample.timestamp).valueOf();
-      const yValue = ((sample.min ?? 0) + (sample.max ?? 0)) / 2;
+      const yValue = normalizeMetric(((sample.min ?? 0) + (sample.max ?? 0)) / 2) ?? 0;
 
       const [xPosition, yPosition] = fitToValueRect(xValue, yValue, valueRect);
 
@@ -178,7 +182,7 @@ export function useChartSamples({
         z: 10,
       };
     });
-  }, [samples, highlightedSampleId, theme.purple400, valueRect, operation]);
+  }, [operation, unit, samples, highlightedSampleId, valueRect, theme.purple400]);
 
   const formatters = useMemo(() => {
     return {
@@ -190,15 +194,13 @@ export function useChartSamples({
         return name.substring(0, 8);
       },
       valueFormatter: (_, label?: string) => {
+        // We need to access the sample as the charts datapoints are fit to the charts viewport
         const sample = samples[label ?? ''];
         const yValue = ((sample.min ?? 0) + (sample.max ?? 0)) / 2;
-        if (!valueFormatter) {
-          return yValue.toPrecision(5);
-        }
-        return valueFormatter(yValue);
+        return formatMetricsUsingUnitAndOp(yValue, unit, operation);
       },
     };
-  }, [samples, valueFormatter]);
+  }, [operation, samples, unit]);
 
   return {
     handleClick,

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -24,6 +24,10 @@ import {
 } from 'sentry/utils/metrics';
 import {metricDisplayTypeOptions} from 'sentry/utils/metrics/constants';
 import {formatMRIField, MRIToField, parseMRI} from 'sentry/utils/metrics/mri';
+import {
+  getMetricValueNormalizer,
+  getNormalizedMetricUnit,
+} from 'sentry/utils/metrics/normalizeMetricValue';
 import type {
   FocusedMetricsSeries,
   MetricCorrelation,
@@ -400,10 +404,15 @@ export function getChartTimeseries(
     const unit = parsed?.unit ?? '';
     const field = MRIToField(query.mri, query.op ?? '');
 
+    // We normalize metric units to make related units
+    // (e.g. seconds & milliseconds) render in the correct ratio
+    const normalizedUnit = getNormalizedMetricUnit(unit);
+    const normalizeValue = getMetricValueNormalizer(unit);
+
     return group.map(entry => ({
-      unit,
+      unit: normalizedUnit,
       operation: query.op,
-      values: entry.series,
+      values: entry.series.map(normalizeValue),
       name: getMetricsSeriesName(field, entry.by, isMultiQuery),
       groupBy: entry.by,
       transaction: entry.by.transaction,

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -131,9 +131,10 @@ export const MetricWidget = memo(
       return {
         data: samplesQuery.data,
         onClick: onSampleClick,
+        unit: parseMRI(firstQuery.mri)?.unit ?? '',
         higlightedId: highlightedSampleId,
       };
-    }, [samplesQuery.data, onSampleClick, highlightedSampleId]);
+    }, [samplesQuery.data, onSampleClick, firstQuery.mri, highlightedSampleId]);
 
     const widgetTitle =
       queries.length === 1
@@ -221,6 +222,7 @@ interface MetricWidgetBodyProps {
 }
 
 export interface SamplesProps {
+  unit: string;
   data?: MetricCorrelation[];
   higlightedId?: string;
   onClick?: (sample: Sample) => void;


### PR DESCRIPTION
Normalize related metric values to the same base unit so that they are rendered in the correct relation to each other.

### Before
<img width="1146" alt="Screenshot 2024-02-15 at 14 44 21" src="https://github.com/getsentry/sentry/assets/7033940/0cfacbff-f484-415c-8097-f09c8f36d7f0">

### After

<img width="1146" alt="Screenshot 2024-02-15 at 14 43 25" src="https://github.com/getsentry/sentry/assets/7033940/6a8b6a44-6a82-4a58-88b7-5737cb66701d">

- closes https://github.com/getsentry/sentry/issues/65227