### PR TITLE
fix(profiling): fix measurement chart messaging

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChart.tsx
@@ -261,6 +261,25 @@ export function FlamegraphChart({
     [configSpaceCursor, chartView]
   );
 
+  let message = t('Profile has no measurements');
+  const canRenderChart = chart?.series.every(
+    s => s.points.length >= FlamegraphChartModel.MIN_RENDERABLE_POINTS
+  );
+
+  if (chart && !canRenderChart) {
+    const profileIsTooShortToDisplayMeasurements = chart.configSpace.width < 200 * 1e6;
+    const didNotCollectAnyMeasurements = chart.series.every(s => s.points.length === 0);
+
+    if (profileIsTooShortToDisplayMeasurements) {
+      message =
+        'Profile is too short to display measurements, minimum duration is at least 200ms';
+    }
+
+    if (didNotCollectAnyMeasurements) {
+      message = noMeasurementMessage || 'Profile has no measurements';
+    }
+  }
+
   return (
     <Fragment>
       <Canvas
@@ -284,17 +303,8 @@ export function FlamegraphChart({
       {/* transaction loads after profile, so we want to show loading even if it's in initial state */}
       {profiles.type === 'loading' || profiles.type === 'initial' ? (
         <CollapsibleTimelineLoadingIndicator />
-      ) : profiles.type === 'resolved' && !chart?.series.length ? (
-        <CollapsibleTimelineMessage>
-          {noMeasurementMessage || t('Profile has no measurements')}
-        </CollapsibleTimelineMessage>
-      ) : (chart?.series?.length ?? 0) > 0 &&
-        chart?.series.every(
-          s => s.points.length < FlamegraphChartModel.MIN_RENDERABLE_POINTS
-        ) ? (
-        <CollapsibleTimelineMessage>
-          {noMeasurementMessage || t('Profile has no measurements')}
-        </CollapsibleTimelineMessage>
+      ) : profiles.type === 'resolved' && !canRenderChart ? (
+        <CollapsibleTimelineMessage>{message}</CollapsibleTimelineMessage>
       ) : null}
     </Fragment>
   );

--- a/static/app/components/profiling/flamegraph/flamegraphChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChart.tsx
@@ -271,8 +271,9 @@ export function FlamegraphChart({
     const didNotCollectAnyMeasurements = chart.series.every(s => s.points.length === 0);
 
     if (profileIsTooShortToDisplayMeasurements) {
-      message =
-        t('Profile is too short to display measurements, minimum duration is at least 200ms');
+      message = t(
+        'Profile is too short to display measurements, minimum duration is at least 200ms'
+      );
     }
 
     if (didNotCollectAnyMeasurements) {

--- a/static/app/components/profiling/flamegraph/flamegraphChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChart.tsx
@@ -276,7 +276,7 @@ export function FlamegraphChart({
     }
 
     if (didNotCollectAnyMeasurements) {
-      message = noMeasurementMessage || 'Profile has no measurements';
+      message = noMeasurementMessage || t('Profile has no measurements');
     }
   }
 

--- a/static/app/components/profiling/flamegraph/flamegraphChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChart.tsx
@@ -272,7 +272,7 @@ export function FlamegraphChart({
 
     if (profileIsTooShortToDisplayMeasurements) {
       message =
-        'Profile is too short to display measurements, minimum duration is at least 200ms';
+        t('Profile is too short to display measurements, minimum duration is at least 200ms');
     }
 
     if (didNotCollectAnyMeasurements) {

--- a/static/app/utils/profiling/flamegraphChart.tsx
+++ b/static/app/utils/profiling/flamegraphChart.tsx
@@ -47,7 +47,7 @@ export class FlamegraphChart {
     y: [0, 0],
   };
 
-  static MIN_RENDERABLE_POINTS = 3;
+  static MIN_RENDERABLE_POINTS = 2;
   static Empty = new FlamegraphChart(Rect.Empty(), [], [[0, 0, 0, 0]]);
 
   constructor(


### PR DESCRIPTION
Min renderable points is actually >1 and adjust messaging so we show the upgrade message only if the profile has no measurements at all