### PR TITLE
feat(app-start): Replace top screens charts with overall stats

### DIFF
--- a/static/app/views/starfish/views/appStartup/screensTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screensTable.tsx
@@ -16,7 +16,6 @@ import {fieldAlignment} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator';
 import {COLD_START_COLOR, WARM_START_COLOR} from 'sentry/views/starfish/colours';
 import {
   PRIMARY_RELEASE_ALIAS,
@@ -24,7 +23,6 @@ import {
 } from 'sentry/views/starfish/components/releaseSelector';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import Breakdown from 'sentry/views/starfish/views/appStartup/breakdown';
-import {TOP_SCREENS} from 'sentry/views/starfish/views/screens';
 
 type Props = {
   data: TableData | undefined;
@@ -69,14 +67,11 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
       return row[column.key];
     }
 
-    const index = data.data.indexOf(row);
-
     const field = String(column.key);
 
     if (field === 'transaction') {
       return (
         <Fragment>
-          <TopResultsIndicator count={TOP_SCREENS} index={index} />
           <Link
             to={normalizeUrl(
               `/organizations/${


### PR DESCRIPTION
There was feedback that the charts that show the top screen durations wasn't effective at presenting information that wasn't already displayed in the table. We've decided to replace them with charts to represent the overall start times for the app

Before:
<img width="1475" alt="Screenshot 2024-02-15 at 9 13 42 AM" src="https://github.com/getsentry/sentry/assets/22846452/e346e95d-aa39-4915-86a3-fd07821c7578">

After:
<img width="1470" alt="Screenshot 2024-02-15 at 9 13 34 AM" src="https://github.com/getsentry/sentry/assets/22846452/efcb3c67-db78-404c-9457-530cb849536e">
