### PR TITLE
ref(similarity-embedding): Move log

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -136,11 +136,11 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         if request.GET.get("threshold"):
             similar_issues_params.update({"threshold": float(request.GET["threshold"])})
 
-        results = get_similar_issues_embeddings(similar_issues_params)
-
         extra: dict[str, Any] = dict(similar_issues_params.copy())
         extra["group_message"] = extra.pop("message")
         logger.info("Similar issues embeddings parameters", extra=extra)
+
+        results = get_similar_issues_embeddings(similar_issues_params)
 
         analytics.record(
             "group_similar_issues_embeddings.count",


### PR DESCRIPTION
Move log before seer api call so it's called if seer api call fails