### PR TITLE
ref(grouping): Pull more `_save_aggregate_new` logic into helpers

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1646,51 +1646,7 @@ def _save_aggregate_new(
     existing_grouphash = find_existing_grouphash_new(grouphashes)
 
     if existing_grouphash is None:
-        check_for_group_creation_load_shed(project, event)
-
-        with (
-            sentry_sdk.start_span(op="event_manager.create_group_transaction") as span,
-            metrics.timer("event_manager.create_group_transaction") as metrics_timer_tags,
-            transaction.atomic(router.db_for_write(GroupHash)),
-        ):
-            span.set_tag("create_group_transaction.outcome", "no_group")
-            metrics_timer_tags["create_group_transaction.outcome"] = "no_group"
-
-            # If we're in this branch, we checked our grouphashes and didn't find one with a group
-            # attached. We thus want to create a new group, but we need to guard against another
-            # event with the same hash coming in before we're done here and also thinking it needs
-            # to create a new group. To prevent this, we're using double-checked locking
-            # (https://en.wikipedia.org/wiki/Double-checked_locking).
-
-            # First, try to lock the relevant rows in the `GroupHash` table. If another (identically
-            # hashed) event is also in the process of creating a group and has grabbed the lock
-            # before us, we'll block here until it's done. If not, we've now got the lock and other
-            # identically-hashed events will have to wait for us.
-            grouphashes = list(
-                GroupHash.objects.filter(
-                    id__in=[h.id for h in grouphashes],
-                ).select_for_update()
-            )
-
-            # Now check again to see if any of our grouphashes have a group. In the first race
-            # condition scenario above, we'll have been blocked long enough for the other event to
-            # have created the group and updated our grouphashes with a group id, which means this
-            # time, we'll find something.
-            existing_grouphash = find_existing_grouphash_new(grouphashes)
-
-            # If we still haven't found a matching grouphash, we're now safe to go ahead and create
-            # the group.
-            if existing_grouphash is None:
-                group = _create_group(project, event, **group_processing_kwargs)
-
-                add_group_id_to_grouphashes(group, grouphashes)
-
-                span.set_tag("create_group_transaction.outcome", "new_group")
-                metrics_timer_tags["create_group_transaction.outcome"] = "new_group"
-
-                record_new_group_metrics(event)
-
-                return GroupInfo(group=group, is_new=True, is_regression=False)
+        return create_group_with_grouphashes(job, grouphashes, group_processing_kwargs)
 
     return handle_existing_grouphash(job, existing_grouphash, grouphashes, group_processing_kwargs)
 
@@ -1745,6 +1701,76 @@ def handle_existing_grouphash(
     )
 
     return GroupInfo(group=group, is_new=False, is_regression=is_regression)
+
+
+def create_group_with_grouphashes(
+    job: Job, grouphashes: list[GroupHash], group_processing_kwargs: dict[str, Any]
+) -> GroupInfo | None:
+    """
+    Create a group from the data in `job` and `group_processing_kwargs` and link it to the given
+    grouphashes.
+
+    In very rare circumstances, we can end up in a race condition with another process trying to
+    create the same group. If the current process loses the race, this function will update the
+    group the other process just created, rather than creating a group itself.
+    """
+    event = job["event"]
+    project = event.project
+
+    # If the load-shed killswitch is enabled, this will raise a `HashDiscarded` error to pop us out
+    # of this function all the way back to `save_error_events`, preventing group creation
+    check_for_group_creation_load_shed(project, event)
+
+    with (
+        sentry_sdk.start_span(op="event_manager.create_group_transaction") as span,
+        metrics.timer("event_manager.create_group_transaction") as metrics_timer_tags,
+        transaction.atomic(router.db_for_write(GroupHash)),
+    ):
+        span.set_tag("create_group_transaction.outcome", "no_group")
+        metrics_timer_tags["create_group_transaction.outcome"] = "no_group"
+
+        # If we're in this branch, we checked our grouphashes and didn't find one with a group
+        # attached. We thus want to create a new group, but we need to guard against another
+        # event with the same hash coming in before we're done here and also thinking it needs
+        # to create a new group. To prevent this, we're using double-checked locking
+        # (https://en.wikipedia.org/wiki/Double-checked_locking).
+
+        # First, try to lock the relevant rows in the `GroupHash` table. If another (identically
+        # hashed) event is also in the process of creating a group and has grabbed the lock
+        # before us, we'll block here until it's done. If not, we've now got the lock and other
+        # identically-hashed events will have to wait for us.
+        grouphashes = list(
+            GroupHash.objects.filter(
+                id__in=[h.id for h in grouphashes],
+            ).select_for_update()
+        )
+
+        # Now check again to see if any of our grouphashes have a group. In the first race
+        # condition scenario above, we'll have been blocked long enough for the other event to
+        # have created the group and updated our grouphashes with a group id, which means this
+        # time, we'll find something.
+        existing_grouphash = find_existing_grouphash_new(grouphashes)
+
+        # If we still haven't found a matching grouphash, we're now safe to go ahead and create
+        # the group.
+        if existing_grouphash is None:
+            span.set_tag("create_group_transaction.outcome", "new_group")
+            metrics_timer_tags["create_group_transaction.outcome"] = "new_group"
+            record_new_group_metrics(event)
+
+            group = _create_group(project, event, **group_processing_kwargs)
+            add_group_id_to_grouphashes(group, grouphashes)
+
+            return GroupInfo(group=group, is_new=True, is_regression=False)
+
+        # On the other hand, if we did in fact end up on the losing end of a race condition, treat
+        # this the same way we would if we'd found a grouphash to begin with (and never landed in
+        # this function at all)
+        else:
+            # TODO: should we be setting tags here, too?
+            return handle_existing_grouphash(
+                job, existing_grouphash, grouphashes, group_processing_kwargs
+            )
 
 
 def _create_group(project: Project, event: Event, **kwargs: Any) -> Group:

--- a/tests/sentry/event_manager/test_save_aggregate.py
+++ b/tests/sentry/event_manager/test_save_aggregate.py
@@ -85,7 +85,7 @@ def test_group_creation_race_new(
     group_processing_kwargs = {"level": 10, "culprit": "", "data": {}}
     save_aggregate_kwargs = {
         "event": event,
-        "job": {"event_metadata": {}, "release": "dogpark"},
+        "job": {"event_metadata": {}, "release": "dogpark", "event": event},
         "metric_tags": {},
     }
     if not use_save_aggregate_new:


### PR DESCRIPTION
This continues the process of simplifying the logic in `_save_aggregate_new` by creating two new helpers:

- `handle_existing_grouphash` - When we find a match to an existing group, this handles updating the event, the group, and any new `GroupHash` records with the right data to link them all together.

- `create_group_with_grouphashes` - When we don't find an existing group, this creates one and links it to the corresponding new `GroupHash` records.

In addition to making it easier to reason about the behavior of `_save_aggregate_new`, this will also let us make the branching behavior (choosing which of the above options to call) more complex, when we switch from calculating everything and doing one search to calculating primary and secondary hashes in sequence and doing a search at each stage.