### PR TITLE
ref(grouping): Move `get_hash_values` logic into `_save_aggregate_new`

### DIFF
--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -155,7 +155,7 @@ def _calculate_event_grouping(
         return hashes
 
 
-def _maybe_run_background_grouping(project: Project, job: Job) -> None:
+def maybe_run_background_grouping(project: Project, job: Job) -> None:
     """
     Optionally run a fraction of events with an experimental grouping config.
 
@@ -388,7 +388,7 @@ def get_hash_values(
     # Background grouping is a way for us to get performance metrics for a new
     # config without having it actually affect on how events are grouped. It runs
     # either before or after the main grouping logic, depending on the option value.
-    _maybe_run_background_grouping(project, job)
+    maybe_run_background_grouping(project, job)
 
     secondary_grouping_config, secondary_hashes = maybe_run_secondary_grouping(
         project, job, metric_tags

--- a/tests/sentry/event_manager/test_save_aggregate.py
+++ b/tests/sentry/event_manager/test_save_aggregate.py
@@ -85,7 +85,7 @@ def test_group_creation_race_new(
     group_processing_kwargs = {"level": 10, "culprit": "", "data": {}}
     save_aggregate_kwargs = {
         "event": event,
-        "job": {"event_metadata": {}, "release": "dogpark", "event": event},
+        "job": {"event_metadata": {}, "release": "dogpark", "event": event, "data": {}},
         "metric_tags": {},
     }
     if not use_save_aggregate_new:
@@ -99,8 +99,8 @@ def test_group_creation_race_new(
     def save_event():
         try:
             with patch(
-                "sentry.event_manager.get_hash_values",
-                return_value=(hashes, hashes, hashes),
+                "sentry.grouping.ingest._calculate_event_grouping",
+                return_value=hashes,
             ):
                 with patch(
                     f"sentry.event_manager.{group_kwargs_fn_name}",


### PR DESCRIPTION
Currently, during a grouping config transition, we calculate both the primary and secondary hash (in the helper `get_hash_values`) and only then look to see if either one exists. The ultimate goal of this project is to make it so the secondary hash is only calculated if needed, but that means we have to break apart the steps in `get_hash_values`.

This therefore replaces the `get_hash_values` call in `_save_aggregate_new` with the logic `get_hash_values` contains. It also makes the adjustments to tests made necessary by the fact that we can no longer just mock away all the inner workings of `get_hash_values` and instead have to ensure that its constituent pieces have the data they need to run.

Note that for this PR, the `get_hash_values` logic itself hasn't been modified at all, save to remove the parts referring to hierarchical hashes. Actual logic changes will happen in follow-up PRs.