### PR TITLE
feat(webvitals): Adds performance score profiles for chrome, edge, and opera inp

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -669,7 +669,7 @@ def _get_project_config(
                     },
                 },
                 {
-                    "name": "INP",
+                    "name": "Chrome INP",
                     "scoreComponents": [
                         {
                             "measurement": "inp",

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -669,7 +669,7 @@ def _get_project_config(
                     },
                 },
                 {
-                    "name": "Chrome INP",
+                    "name": "INP",
                     "scoreComponents": [
                         {
                             "measurement": "inp",
@@ -680,9 +680,19 @@ def _get_project_config(
                         },
                     ],
                     "condition": {
-                        "op": "eq",
-                        "name": "event.contexts.browser.name",
-                        "value": "Chrome",
+                        "op": "or",
+                        "inner": [
+                            {
+                                "op": "eq",
+                                "name": "event.contexts.browser.name",
+                                "value": "Chrome",
+                            },
+                            {
+                                "op": "eq",
+                                "name": "event.contexts.browser.name",
+                                "value": "Google Chrome",
+                            },
+                        ],
                     },
                 },
                 {

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -668,6 +668,57 @@ def _get_project_config(
                         "value": "Opera",
                     },
                 },
+                {
+                    "name": "Chrome INP",
+                    "scoreComponents": [
+                        {
+                            "measurement": "inp",
+                            "weight": 1.0,
+                            "p10": 200.0,
+                            "p50": 500.0,
+                            "optional": False,
+                        },
+                    ],
+                    "condition": {
+                        "op": "eq",
+                        "name": "event.contexts.browser.name",
+                        "value": "Chrome",
+                    },
+                },
+                {
+                    "name": "Edge INP",
+                    "scoreComponents": [
+                        {
+                            "measurement": "inp",
+                            "weight": 1.0,
+                            "p10": 200.0,
+                            "p50": 500.0,
+                            "optional": False,
+                        },
+                    ],
+                    "condition": {
+                        "op": "eq",
+                        "name": "event.contexts.browser.name",
+                        "value": "Edge",
+                    },
+                },
+                {
+                    "name": "Opera INP",
+                    "scoreComponents": [
+                        {
+                            "measurement": "inp",
+                            "weight": 1.0,
+                            "p10": 200.0,
+                            "p50": 500.0,
+                            "optional": False,
+                        },
+                    ],
+                    "condition": {
+                        "op": "eq",
+                        "name": "event.contexts.browser.name",
+                        "value": "Opera",
+                    },
+                },
             ]
         }
 


### PR DESCRIPTION
Adds performance score profiles for chrome, edge, and opera inp. Firefox and Safari do not support inp yet.
For "Chrome INP", we allow the browser name condition to be either "Chrome" or "Google Chrome"