### PR TITLE
feat(crons-db): Stop joining to the environment table when serializing checkins

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -202,9 +202,24 @@ class MonitorCheckInSerializer(Serializer):
 
     def get_attrs(self, item_list, user, **kwargs):
         # prefetch monitor environment data
-        prefetch_related_objects(item_list, "monitor_environment__environment")
+        prefetch_related_objects(item_list, "monitor_environment")
 
-        attrs = {}
+        attrs = defaultdict(dict)
+
+        monitor_envs = [
+            checkin.monitor_environment for checkin in item_list if checkin.monitor_environment_id
+        ]
+        envs = {
+            env.id: env
+            for env in Environment.objects.filter(id__in=[me.environment_id for me in monitor_envs])
+        }
+        for checkin in item_list:
+            env_name = None
+            if checkin.monitor_environment:
+                env_name = envs[checkin.monitor_environment.environment_id].name
+
+            attrs[checkin]["environment_name"] = env_name
+
         if self._expand("groups") and self.start and self.end:
             # aggregate all the trace_ids in the given set of check-ins
             trace_ids = []
@@ -219,21 +234,17 @@ class MonitorCheckInSerializer(Serializer):
                     trace_ids, self.organization_id, self.project_id, self.start, self.end
                 )
 
-            attrs = {
-                item: {
-                    "groups": trace_groups.get(item.trace_id.hex, []) if item.trace_id else [],
-                }
-                for item in item_list
-            }
+            for checkin in item_list:
+                attrs[item]["groups"] = (
+                    trace_groups.get(checkin.trace_id.hex, []) if checkin.trace_id else []
+                )
 
         return attrs
 
     def serialize(self, obj, attrs, user, **kwargs) -> MonitorCheckInSerializerResponse:
         result: MonitorCheckInSerializerResponse = {
             "id": str(obj.guid),
-            "environment": obj.monitor_environment.environment.name
-            if obj.monitor_environment
-            else None,
+            "environment": attrs["environment_name"],
             "status": obj.get_status_display(),
             "duration": obj.duration,
             "dateCreated": obj.date_added,

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -204,7 +204,7 @@ class MonitorCheckInSerializer(Serializer):
         # prefetch monitor environment data
         prefetch_related_objects(item_list, "monitor_environment")
 
-        attrs = defaultdict(dict)
+        attrs: dict[MonitorCheckIn, dict[str, Any]] = defaultdict(dict)
 
         monitor_envs = [
             checkin.monitor_environment for checkin in item_list if checkin.monitor_environment_id

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
@@ -76,16 +76,24 @@ class ListMonitorCheckInsTest(MonitorTestCase):
             status=CheckInStatus.OK,
         )
 
+        checkin3 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            project_id=self.project.id,
+            date_added=monitor.date_added,
+            status=CheckInStatus.OK,
+        )
+
         resp = self.get_success_response(
             self.organization.slug,
             monitor.slug,
             **{"statsPeriod": "1d"},
         )
-        assert len(resp.data) == 2
+        assert len(resp.data) == 3
 
         # Newest first
-        assert resp.data[0]["id"] == str(checkin2.guid)
-        assert resp.data[1]["id"] == str(checkin1.guid)
+        assert resp.data[0]["id"] == str(checkin3.guid)
+        assert resp.data[1]["id"] == str(checkin2.guid)
+        assert resp.data[2]["id"] == str(checkin1.guid)
 
     def test_statsperiod_constraints(self):
         monitor = self._create_monitor()


### PR DESCRIPTION
We want to move all crons related tables to a separate database. This means we need to stop joining to other non-cron tables directly. Instead, we make the query separately in code.

This updates the checkin serializer to remove any joins to env.