### PR TITLE
fix(similarity-embedding): Handle no stacktrace

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -124,6 +124,9 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         if latest_event.data.get("exception"):
             stacktrace_string = get_stacktrace_string(latest_event.data["exception"], latest_event)
 
+        if stacktrace_string == "":
+            return Response([])  # No stacktrace or in-app frames
+
         similar_issues_params: SimilarIssuesEmbeddingsRequest = {
             "group_id": group.id,
             "project_id": group.project.id,


### PR DESCRIPTION
When an issue has no stracktrace or in-app frames, return early and do not call the seer api

Fixes [SENTRY-2KYS](https://sentry.sentry.io/issues/4961474233/)