### PR TITLE
ref(similarity-embedding): Change no similar issues message

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -155,6 +155,43 @@ describe('Issues Similar View', function () {
     await selectNthSimilarItem(0);
     expect(screen.getByText('Merge (0)')).toBeInTheDocument();
   });
+
+  it('shows empty message', async function () {
+    // Manually clear responses and add an empty response
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+    mock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/group-id/similar/?limit=50',
+      body: [],
+    });
+
+    render(
+      <GroupSimilarIssues
+        project={project}
+        params={{orgId: 'org-slug', groupId: 'group-id'}}
+        location={router.location}
+        router={router}
+        routeParams={router.params}
+        routes={router.routes}
+        route={{}}
+      />,
+      {context: routerContext}
+    );
+    renderGlobalModal();
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+
+    await waitFor(() => expect(mock).toHaveBeenCalled());
+
+    expect(
+      screen.getByText("There don't seem to be any similar issues.")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'This can occur when the issue has no stacktrace or in-app frames.'
+      )
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe('Issues Similar Embeddings View', function () {
@@ -323,5 +360,39 @@ describe('Issues Similar Embeddings View', function () {
         value: 'Yes',
       })
     );
+  });
+
+  it('shows empty message', async function () {
+    // Manually clear responses and add an empty response
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+    mock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/group-id/similar-issues-embeddings/?k=5&threshold=0.99',
+      body: [],
+    });
+
+    render(
+      <GroupSimilarIssues
+        project={project}
+        params={{orgId: 'org-slug', groupId: 'group-id'}}
+        location={router.location}
+        router={router}
+        routeParams={router.params}
+        routes={router.routes}
+        route={{}}
+      />,
+      {context: routerContext}
+    );
+    renderGlobalModal();
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+
+    await waitFor(() => expect(mock).toHaveBeenCalled());
+
+    expect(
+      screen.getByText(
+        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames."
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -188,10 +188,21 @@ function SimilarStackTrace({params, location, project}: Props) {
               onRetry={fetchData}
             />
           )}
-          {status === 'ready' && !hasSimilarItems && (
+          {status === 'ready' && !hasSimilarItems && !hasSimilarityEmbeddingsFeature && (
             <Panel>
               <EmptyStateWarning>
                 <p>{t("There don't seem to be any similar issues.")}</p>
+              </EmptyStateWarning>
+            </Panel>
+          )}
+          {status === 'ready' && !hasSimilarItems && hasSimilarityEmbeddingsFeature && (
+            <Panel>
+              <EmptyStateWarning>
+                <p>
+                  {t(
+                    "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames."
+                  )}
+                </p>
               </EmptyStateWarning>
             </Panel>
           )}


### PR DESCRIPTION
Add "This can occur when the issue has no stacktrace or in-app frames" to message for when no similar issues are found behind the similarity embeddings flag