### PR TITLE
ref: replace deprecated utcnow in project_create_sample_transaction

### DIFF
--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -36,9 +36,8 @@ def fix_event_data(data):
     random ids for traces, spans, and the event id.
     Largely based on sentry.utils.samples.load_data but more simple
     """
-    timestamp = datetime.utcnow() - timedelta(minutes=1)
+    timestamp = datetime.now(timezone.utc) - timedelta(minutes=1)
     timestamp = timestamp - timedelta(microseconds=timestamp.microsecond % 1000)
-    timestamp = timestamp.replace(tzinfo=timezone.utc)
     data["timestamp"] = to_timestamp(timestamp)
 
     start_timestamp = timestamp - timedelta(seconds=3)


### PR DESCRIPTION
warning in 3.12, removed in 3.14

<!-- Describe your PR here. -->