### PR TITLE
feat(crons-db): Use `environment_id` when creating `MonitorEnvironment` models

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -552,7 +552,9 @@ class MonitorEnvironmentManager(BaseManager["MonitorEnvironment"]):
         environment = Environment.get_or_create(project=project, name=environment_name)
 
         monitor_env, created = MonitorEnvironment.objects.get_or_create(
-            monitor=monitor, environment=environment, defaults={"status": MonitorStatus.ACTIVE}
+            monitor=monitor,
+            environment_id=environment.id,
+            defaults={"status": MonitorStatus.ACTIVE},
         )
 
         # recompute per-project monitor check-in rate limit quota

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3059,7 +3059,7 @@ class MonitorTestCase(APITestCase):
         }
 
         return MonitorEnvironment.objects.create(
-            monitor=monitor, environment=environment, **monitorenvironment_defaults
+            monitor=monitor, environment_id=environment.id, **monitorenvironment_defaults
         )
 
     def _create_issue_alert_rule(self, monitor):

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -424,7 +424,7 @@ def create_monitor(project: Project, environment: Environment) -> None:
 
     monitor_env, _ = MonitorEnvironment.objects.get_or_create(
         monitor=monitor,
-        environment=environment,
+        environment_id=environment.id,
         defaults={
             "status": MonitorStatus.DISABLED,
             "next_checkin": django_timezone.now() + timedelta(minutes=60),

--- a/tests/sentry/deletions/test_monitor.py
+++ b/tests/sentry/deletions/test_monitor.py
@@ -28,7 +28,7 @@ class DeleteMonitorTest(APITestCase, TransactionTestCase, HybridCloudTestMixin):
         )
         monitor_env = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=env,
+            environment_id=env.id,
         )
         checkin = MonitorCheckIn.objects.create(
             monitor=monitor,

--- a/tests/sentry/deletions/test_monitor_environment.py
+++ b/tests/sentry/deletions/test_monitor_environment.py
@@ -29,11 +29,11 @@ class DeleteMonitorEnvironmentTest(APITestCase, TransactionTestCase, HybridCloud
         )
         monitor_env = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=env,
+            environment_id=env.id,
         )
         monitor_env_2 = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=env_2,
+            environment_id=env_2.id,
         )
         checkin = MonitorCheckIn.objects.create(
             monitor=monitor,

--- a/tests/sentry/deletions/test_project.py
+++ b/tests/sentry/deletions/test_project.py
@@ -99,7 +99,7 @@ class DeleteProjectTest(APITestCase, TransactionTestCase, HybridCloudTestMixin):
         )
         monitor_env = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=env,
+            environment_id=env.id,
         )
         checkin = MonitorCheckIn.objects.create(
             monitor=monitor,

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_attachment.py
@@ -50,7 +50,7 @@ class MonitorIngestCheckinAttachmentEndpointTest(MonitorIngestTestCase):
         }
 
         return MonitorEnvironment.objects.create(
-            monitor=monitor, environment=environment, **monitorenvironment_defaults
+            monitor=monitor, environment_id=environment.id, **monitorenvironment_defaults
         )
 
     def test_upload(self):

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -60,7 +60,7 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
         }
 
         return MonitorEnvironment.objects.create(
-            monitor=monitor, environment=environment, **monitorenvironment_defaults
+            monitor=monitor, environment_id=environment.id, **monitorenvironment_defaults
         )
 
     def test_noop_in_progress(self):

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -46,7 +46,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=monitor.status,
         )
         checkin = MonitorCheckIn.objects.create(
@@ -107,7 +107,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=monitor.status,
         )
         checkin = MonitorCheckIn.objects.create(
@@ -171,7 +171,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=last_checkin,
             next_checkin=next_checkin,
             next_checkin_latest=next_checkin + timedelta(minutes=1),
@@ -239,7 +239,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=monitor.status,
         )
 
@@ -356,7 +356,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=monitor.status,
         )
         successful_check_in = MonitorCheckIn.objects.create(
@@ -469,7 +469,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=last_checkin,
             next_checkin=next_checkin,
             next_checkin_latest=next_checkin + timedelta(minutes=1),
@@ -577,7 +577,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=MonitorStatus.OK,
         )
         checkin = MonitorCheckIn.objects.create(
@@ -640,7 +640,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=MonitorStatus.OK,
             last_state_change=None,
         )
@@ -759,7 +759,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=MonitorStatus.OK,
             last_state_change=None,
         )
@@ -843,7 +843,7 @@ class MarkFailedTestCase(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=MonitorStatus.OK,
         )
         for _ in range(0, failure_issue_threshold):

--- a/tests/sentry/monitors/logic/test_mark_ok.py
+++ b/tests/sentry/monitors/logic/test_mark_ok.py
@@ -42,7 +42,7 @@ class MarkOkTestCase(TestCase):
         # Start with monitor in an ERROR state
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=MonitorStatus.ERROR,
             last_checkin=now - timedelta(minutes=1),
             next_checkin=now,
@@ -87,7 +87,7 @@ class MarkOkTestCase(TestCase):
         # Start with monitor in an ERROR state with an active incident
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=MonitorStatus.ERROR,
             last_state_change=None,
         )

--- a/tests/sentry/monitors/test_rate_limit.py
+++ b/tests/sentry/monitors/test_rate_limit.py
@@ -40,7 +40,7 @@ class MonitorRateLimit(TestCase):
             env = self.create_environment(self.project, name=f"test-{i}")
             MonitorEnvironment.objects.create(
                 monitor=monitor,
-                environment=env,
+                environment_id=env.id,
                 status=MonitorStatus.OK,
             )
 
@@ -55,7 +55,7 @@ class MonitorRateLimit(TestCase):
         )
         MonitorEnvironment.objects.create(
             monitor=monitor2,
-            environment=self.environment,
+            environment_id=self.environment.id,
             status=MonitorStatus.OK,
         )
 

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -84,7 +84,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         # Expected check-in was a full minute ago.
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts - timedelta(minutes=2),
             next_checkin=ts - timedelta(minutes=1),
             next_checkin_latest=ts,
@@ -151,7 +151,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         # Last check-in was yesterday
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts - timedelta(days=1),
             next_checkin=ts,
             next_checkin_latest=ts + timedelta(minutes=1),
@@ -211,7 +211,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         # still have 3 minutes to check in.
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts - timedelta(minutes=12),
             next_checkin=ts - timedelta(minutes=2),
             next_checkin_latest=ts + timedelta(minutes=3),
@@ -313,7 +313,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         # minutes from now. There will be 5 minutes of overlap.
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts - timedelta(minutes=5),
             next_checkin=ts,
             next_checkin_latest=ts + timedelta(minutes=10),
@@ -389,7 +389,7 @@ class MonitorTaskCheckMissingTest(TestCase):
 
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts - timedelta(minutes=1),
             next_checkin=ts,
             next_checkin_latest=ts + timedelta(minutes=1),
@@ -470,7 +470,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         # `state` the monitor would usually end up marked as timed out
         MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             next_checkin=ts - timedelta(minutes=1),
             next_checkin_latest=ts,
             status=MonitorStatus.ACTIVE,
@@ -527,7 +527,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         # Expected checkin is this minute
         MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=last_checkin_ts,
             next_checkin=ts,
             next_checkin_latest=ts + timedelta(minutes=1),
@@ -571,7 +571,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         )
         failing_monitor_environment = MonitorEnvironment.objects.create(
             monitor=exception_monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts - timedelta(minutes=2),
             next_checkin=ts - timedelta(minutes=1),
             next_checkin_latest=ts,
@@ -591,7 +591,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         )
         successful_monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts - timedelta(minutes=2),
             next_checkin=ts - timedelta(minutes=1),
             next_checkin_latest=ts,
@@ -641,7 +641,7 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts,
             next_checkin=ts + timedelta(hours=24),
             next_checkin_latest=ts + timedelta(hours=24, minutes=1),
@@ -716,7 +716,7 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts,
             next_checkin=ts + timedelta(hours=1),
             next_checkin_latest=ts + timedelta(hours=1, minutes=1),
@@ -814,7 +814,7 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts - timedelta(hours=1),
             next_checkin=ts,
             next_checkin_latest=ts + timedelta(minutes=1),
@@ -876,7 +876,7 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             last_checkin=ts,
             next_checkin=ts + timedelta(minutes=10),
             next_checkin_latest=ts + timedelta(minutes=11),
@@ -942,7 +942,7 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         )
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
-            environment=self.environment,
+            environment_id=self.environment.id,
             # Next checkin is in the future, we just completed our last checkin
             last_checkin=ts,
             next_checkin=ts + timedelta(hours=24),


### PR DESCRIPTION
We want to move all crons related tables to a separate database. This means we need to stop referring to foreign key relations in Django and just use ids on creation.

This pr changes uses of `environment=environment` to `environment_id=environment.id` so that we're not relying on the fk.
