### PR TITLE
feat(metrics_extraction): Support functions in tables

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -406,16 +406,12 @@ def convert_widget_query_to_metric(
     """
     metrics_specs: list[HashedMetricSpec] = []
 
-    if not widget_query.aggregates:
-        aggregates, groupbys = _separate_aggregates_and_groupbys_from_columns(widget_query.columns)
-    else:
-        aggregates = widget_query.aggregates or []
-        groupbys = widget_query.columns
+    aggregates = widget_query.aggregates or []
+    groupbys = widget_query.columns or []
 
-    for aggregate in aggregates:
-        metrics_specs += _generate_metric_specs(
-            aggregate, widget_query, project, prefilling, groupbys
-        )
+    # Tables do not have aggregates, however, we create metrics from its columns
+    if not widget_query.aggregates:
+        aggregates, groupbys = _separate_aggregates_and_groupbys_from_columns(groupbys)
 
     for aggregate in aggregates:
         metrics_specs += _generate_metric_specs(
@@ -465,8 +461,10 @@ def _generate_metric_specs(
 
 
 def _separate_aggregates_and_groupbys_from_columns(
-    columns: str | None,
+    columns: list[str],
 ) -> tuple[list[str], list[str]]:
+    """Separate aggregates and groupbys from columns.
+    This is because columns can use functions and non-functions (e.g. transaction) fields."""
     aggregates = []
     groupbys = []
 

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -183,12 +183,12 @@ def schedule_on_demand_check() -> None:
     time_limit=120,
     expires=180,
 )
-def process_widget_specs(widget_query_ids: list[int], *args, **kwargs) -> None:
+def process_widget_specs(widget_query_ids: list[int], *args, **kwargs) -> list[HashedMetricSpec]:
     """
     Child task spawned from :func:`schedule_on_demand_check`.
     """
     if not options.get("on_demand_metrics.check_widgets.enable"):
-        return
+        return []
 
     widget_query_count = 0
     widget_query_high_cardinality_count = 0
@@ -243,12 +243,13 @@ def process_widget_specs(widget_query_ids: list[int], *args, **kwargs) -> None:
         amount=widget_query_count,
         sample_rate=1.0,
     )
+    return widget_specs
 
 
 def _get_widget_on_demand_specs(
     widget_query: DashboardWidgetQuery,
     organization: Organization,
-) -> Sequence[HashedMetricSpec]:
+) -> list[HashedMetricSpec]:
     """
     Saves on-demand state for a widget query.
     """

--- a/tests/sentry/tasks/test_on_demand_metrics.py
+++ b/tests/sentry/tasks/test_on_demand_metrics.py
@@ -580,9 +580,12 @@ def test_query_cardinality_called_with_projects(
 
 
 @django_db_all
-def test_support_columns_in_tables(project: Project) -> None:
+def test_support_columns_from_tables(project: Project) -> None:
+    """Test the task creates enabled on-demand widgets"""
     # The tag requires on-demand metrics extraction
     query = "app_recommended_owner:#onboarding-experience"
+    # We include a non-function and a function in the list of columns
+    # The non-functions are used as group bys
     columns = ["apdex(300)", "transaction"]
 
     widget_query, _, _ = create_widget([], query, project, columns=columns)
@@ -605,5 +608,5 @@ def test_support_columns_in_tables(project: Project) -> None:
             widget_model,
             has_features=True,
             expected_state=OnDemandExtractionState.ENABLED_ENROLLED,
-            expected_hashes={1: ["031ceadc"], 2: ["1705bb61"]},
+            expected_hashes={1: ["c050ea81"], 2: ["8cea6fe0"]},
         )


### PR DESCRIPTION
This change allows tables with functions that require on-demand metrics to generate the specs for it.