### PR TITLE
ref(notifications): Rm unused flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1470,8 +1470,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:auto-enable-codecov": False,
     # Enable change alerts for an org
     "organizations:change-alerts": True,
-    # Removes extra fields from the project serializers
-    "organizations:cleanup-project-serializer": False,
     # Enables getting commit sha from git blame for codecov.
     "organizations:codecov-commit-sha-from-git-blame": False,
     # The overall flag for codecov integration, gated by plans.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -80,7 +80,6 @@ default_manager.add("organizations:anr-improvements", OrganizationFeature, Featu
 default_manager.add("organizations:api-auth-provider", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:api-keys", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:cleanup-project-serializer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:codecov-commit-sha-from-git-blame", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:crons-disable-new-projects", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:dashboard-widget-indicators", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -28,7 +28,6 @@ from sentry.models.userreport import UserReport
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.samples import load_data
 
@@ -37,7 +36,6 @@ TEAM_ADMIN = settings.SENTRY_TEAM_ROLES[1]
 
 
 @region_silo_test
-@apply_feature_flag_on_cls("organizations:cleanup-project-serializer")
 class ProjectSerializerTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -297,7 +295,6 @@ class ProjectSerializerTest(TestCase):
 
 
 @region_silo_test
-@apply_feature_flag_on_cls("organizations:cleanup-project-serializer")
 class ProjectWithTeamSerializerTest(TestCase):
     def test_simple(self):
         user = self.create_user(username="foo")
@@ -318,7 +315,6 @@ class ProjectWithTeamSerializerTest(TestCase):
 
 
 @region_silo_test
-@apply_feature_flag_on_cls("organizations:cleanup-project-serializer")
 class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
     def setUp(self):
         super().setUp()
@@ -688,7 +684,6 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
 
 
 @region_silo_test
-@apply_feature_flag_on_cls("organizations:cleanup-project-serializer")
 class ProjectWithOrganizationSerializerTest(TestCase):
     def test_simple(self):
         user = self.create_user(username="foo")
@@ -705,7 +700,6 @@ class ProjectWithOrganizationSerializerTest(TestCase):
 
 
 @region_silo_test
-@apply_feature_flag_on_cls("organizations:cleanup-project-serializer")
 class DetailedProjectSerializerTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -743,7 +737,6 @@ class DetailedProjectSerializerTest(TestCase):
 
 
 @region_silo_test
-@apply_feature_flag_on_cls("organizations:cleanup-project-serializer")
 class BulkFetchProjectLatestReleases(TestCase):
     @cached_property
     def project(self):


### PR DESCRIPTION
Remove the unused (and partially removed in https://github.com/getsentry/sentry/pull/60216) `organizations:cleanup-project-serializer` flag. (I already checked with Snigdha it's ok to remove this). 