### PR TITLE
feat(trace-view): Narrow timerange for the get-parents query

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -513,9 +513,9 @@ def augment_transactions_with_spans(
     projects = {e["project.id"] for e in errors if e["trace.span"]}
     ts_params = find_timestamp_params(transactions)
     if ts_params["min"]:
-        params["start"] = ts_params["min"] - timedelta(hours=6)
+        params["start"] = ts_params["min"] - timedelta(hours=1)
     if ts_params["max"]:
-        params["end"] = ts_params["max"] + timedelta(hours=6)
+        params["end"] = ts_params["max"] + timedelta(hours=1)
 
     for transaction in transactions:
         transaction["occurrence_spans"] = []

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Deque, Optional, TypedDict, TypeVar, cast
 
 import sentry_sdk
@@ -352,6 +352,25 @@ class TraceEvent:
         return result
 
 
+def find_timestamp_params(transactions: Sequence[SnubaTransaction]) -> dict[str, datetime | None]:
+    min_timestamp = None
+    max_timestamp = None
+    if transactions:
+        first_timestamp = datetime.fromisoformat(transactions[0]["timestamp"])
+        min_timestamp = first_timestamp
+        max_timestamp = first_timestamp
+        for transaction in transactions[1:]:
+            timestamp = datetime.fromisoformat(transaction["timestamp"])
+            if timestamp < min_timestamp:
+                min_timestamp = timestamp
+            elif timestamp > max_timestamp:
+                max_timestamp = timestamp
+    return {
+        "min": min_timestamp,
+        "max": max_timestamp,
+    }
+
+
 def find_event(
     items: Iterable[_T | None],
     function: Callable[[_T | None], Any],
@@ -491,7 +510,12 @@ def augment_transactions_with_spans(
     issue_occurrences = []
     occurrence_spans = set()
     error_spans = {e["trace.span"] for e in errors if e["trace.span"]}
-    projects = set()
+    projects = {e["project.id"] for e in errors if e["trace.span"]}
+    ts_params = find_timestamp_params(transactions)
+    if ts_params["min"]:
+        params["start"] = ts_params["min"] - timedelta(hours=6)
+    if ts_params["max"]:
+        params["end"] = ts_params["max"] + timedelta(hours=6)
 
     for transaction in transactions:
         transaction["occurrence_spans"] = []

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest import mock
 from uuid import uuid4
 
@@ -78,7 +78,11 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase):
                 for span in data["spans"]:
                     if span:
                         span.update({"event_id": event.event_id})
-                        self.store_span(self.create_span(span))
+                        self.store_span(
+                            self.create_span(
+                                span, start_ts=datetime.fromtimestamp(span["start_timestamp"])
+                            )
+                        )
                 self.store_span(self.convert_event_data_to_span(event))
                 return event
 
@@ -100,6 +104,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase):
                 "profile_id": uuid4().hex,
                 # Multiply by 1000 cause it needs to be ms
                 "start_timestamp_ms": int(start_ts * 1000),
+                "timestamp": int(start_ts * 1000),
                 "received": start_ts,
                 "duration_ms": int(end_ts - start_ts),
             }


### PR DESCRIPTION
- Use the timestamps of the transactions to narrow the timerange of the get-parents query which should significantly speed up the query since we will only scan a fraction of the queries