### PR TITLE
ref(grouping): Split primary from secondary grouping and add helper

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -4,7 +4,7 @@ import ipaddress
 import logging
 import re
 import uuid
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, TypedDict, cast
@@ -61,6 +61,7 @@ from sentry.grouping.ingest import (
     run_primary_grouping,
     update_grouping_config_if_needed,
 )
+from sentry.grouping.result import CalculatedHashes
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -143,6 +144,14 @@ class GroupInfo:
     is_regression: bool
     group_release: GroupRelease | None = None
     is_new_group_environment: bool = False
+
+
+@dataclass
+class GroupHashInfo:
+    config: GroupingConfig | None
+    hashes: CalculatedHashes | None
+    grouphashes: list[GroupHash]
+    existing_grouphash: GroupHash | None
 
 
 def pop_tag(data: dict[str, Any], key: str) -> None:
@@ -1636,31 +1645,18 @@ def _save_aggregate_new(
 
     group_processing_kwargs = _get_group_processing_kwargs(job)
 
-    primary_grouping_config, primary_hashes = run_primary_grouping(project, job, metric_tags)
-    primary_grouphashes = [
-        GroupHash.objects.get_or_create(project=project, hash=hash)[0]
-        for hash in extract_hashes(primary_hashes)
-    ]
-    existing_primary_grouphash = find_existing_grouphash_new(primary_grouphashes)
+    primary = create_and_seek_grouphashes(job, run_primary_grouping, metric_tags)
+    secondary = create_and_seek_grouphashes(job, maybe_run_secondary_grouping, metric_tags)
 
-    secondary_grouping_config, secondary_hashes = maybe_run_secondary_grouping(
-        project, job, metric_tags
-    )
-    secondary_grouphashes = [
-        GroupHash.objects.get_or_create(project=project, hash=hash)[0]
-        for hash in extract_hashes(secondary_hashes)
-    ]
-    existing_secondary_grouphash = find_existing_grouphash_new(secondary_grouphashes)
+    all_grouphashes = primary.grouphashes + secondary.grouphashes
 
-    all_grouphashes = primary_grouphashes + secondary_grouphashes
-
-    if existing_primary_grouphash:
+    if primary.existing_grouphash:
         group_info = handle_existing_grouphash(
-            job, existing_primary_grouphash, all_grouphashes, group_processing_kwargs
+            job, primary.existing_grouphash, all_grouphashes, group_processing_kwargs
         )
-    elif existing_secondary_grouphash:
+    elif secondary.existing_grouphash:
         group_info = handle_existing_grouphash(
-            job, existing_secondary_grouphash, all_grouphashes, group_processing_kwargs
+            job, secondary.existing_grouphash, all_grouphashes, group_processing_kwargs
         )
     else:
         group_info = create_group_with_grouphashes(job, all_grouphashes, group_processing_kwargs)
@@ -1673,7 +1669,14 @@ def _save_aggregate_new(
     maybe_run_background_grouping(project, job)
 
     record_hash_calculation_metrics(
-        primary_grouping_config, primary_hashes, secondary_grouping_config, secondary_hashes
+        # Cast in lieu of a non-null assertion operator, which Python doesn't have
+        #
+        # TODO: The typing and necessity of casting here is gross, but might be able to be improved
+        # once hierarchical grouping is gone
+        cast(GroupingConfig, primary.config),
+        cast(CalculatedHashes, primary.hashes),
+        secondary.config,
+        secondary.hashes,
     )
 
     # Now that we've used the current and possibly secondary grouping config(s) to calculate the
@@ -1683,6 +1686,41 @@ def _save_aggregate_new(
     update_grouping_config_if_needed(project)
 
     return group_info
+
+
+def create_and_seek_grouphashes(
+    job: Job,
+    hash_calculation_function: Callable[
+        [Project, Job, MutableTags],
+        tuple[GroupingConfig | None, CalculatedHashes | None],
+    ],
+    metric_tags: MutableTags,
+) -> GroupHashInfo:
+    """
+    Calculate hashes for the job's event, create corresponding `GroupHash` entries if they don't yet
+    exist, and determine if there's an existing group associated with any of the hashes.
+
+    If the callback determines that it doesn't need to run its calculations (as may be the case with
+    secondary grouping), this will return an empty list of grouphashes (so iteration won't break)
+    and Nones for everything else.
+    """
+    project = job["event"].project
+
+    grouphashes = []
+    existing_grouphash = None
+
+    # These will come back as Nones if the calculation decides it doesn't need to run
+    grouping_config, hashes = hash_calculation_function(project, job, metric_tags)
+
+    if hashes:
+        grouphashes = [
+            GroupHash.objects.get_or_create(project=project, hash=hash)[0]
+            for hash in extract_hashes(hashes)
+        ]
+
+        existing_grouphash = find_existing_grouphash_new(grouphashes)
+
+    return GroupHashInfo(grouping_config, hashes, grouphashes, existing_grouphash)
 
 
 def handle_existing_grouphash(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1641,6 +1641,7 @@ def _save_aggregate_new(
         GroupHash.objects.get_or_create(project=project, hash=hash)[0]
         for hash in extract_hashes(primary_hashes)
     ]
+    existing_primary_grouphash = find_existing_grouphash_new(primary_grouphashes)
 
     secondary_grouping_config, secondary_hashes = maybe_run_secondary_grouping(
         project, job, metric_tags
@@ -1649,14 +1650,17 @@ def _save_aggregate_new(
         GroupHash.objects.get_or_create(project=project, hash=hash)[0]
         for hash in extract_hashes(secondary_hashes)
     ]
+    existing_secondary_grouphash = find_existing_grouphash_new(secondary_grouphashes)
 
     all_grouphashes = primary_grouphashes + secondary_grouphashes
 
-    existing_grouphash = find_existing_grouphash_new(all_grouphashes)
-
-    if existing_grouphash:
+    if existing_primary_grouphash:
         group_info = handle_existing_grouphash(
-            job, existing_grouphash, all_grouphashes, group_processing_kwargs
+            job, existing_primary_grouphash, all_grouphashes, group_processing_kwargs
+        )
+    elif existing_secondary_grouphash:
+        group_info = handle_existing_grouphash(
+            job, existing_secondary_grouphash, all_grouphashes, group_processing_kwargs
         )
     else:
         group_info = create_group_with_grouphashes(job, all_grouphashes, group_processing_kwargs)


### PR DESCRIPTION
In `_save_aggregate_new`, we currently calculate primary and secondary hashes separately, but we then lump them together for the purposes of creating grouphashes and then searching for one associated with a group.

This PR breaks those latter steps apart, such that each stage is done separately for primary and secondary hashes. Then, since that creates two identical processes, it pulls that logic out into a new helper function, `create_and_seek_grouphashes`, which handles all three tasks - calculation, creation, and searching. In order to not just return an enormous tuple from that function, it also creates a dataclass to contain the values it returns.

~Note to reviewers: In order to make the process between primary and secondary hashing truly identical, I had to type `GroupHashInfo` such that all values could be null, because in the case of secondary grouping which doesn't run, they are. This then means that even in the case of primary grouping (where we know for sure we're at least going to get back a grouping config and some hash values), we have to deal with the possibility of Nones - specifically, in this case, by casting them before using them to record metrics. It's not great, but I also couldn't figure out a great way around it. Definitely open to suggestions here, but also willing the kick that particular can down the road if the typing grossness doesn't seem like a huge problem.~ UPDATE: I fixed this in https://github.com/getsentry/sentry/pull/65372, so it's still ugly here, but won't be a few PRs from now.