### PR TITLE
ref(tsc): convert user feedback index to FC

### DIFF
--- a/static/app/views/userFeedback/index.spec.tsx
+++ b/static/app/views/userFeedback/index.spec.tsx
@@ -44,7 +44,7 @@ describe('UserFeedback', function () {
     ProjectsStore.reset();
   });
 
-  it('renders', function () {
+  it('renders', async function () {
     const params = {
       organization: OrganizationFixture(),
       params: {
@@ -61,7 +61,7 @@ describe('UserFeedback', function () {
 
     render(<UserFeedback {...params} />, {context: routerContext});
 
-    expect(screen.getByText('Something bad happened')).toBeInTheDocument();
+    expect(await screen.findByText('Something bad happened')).toBeInTheDocument();
   });
 
   it('renders no project message', function () {
@@ -81,7 +81,7 @@ describe('UserFeedback', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders empty state', function () {
+  it('renders empty state', async function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/user-feedback/',
       body: [],
@@ -98,10 +98,10 @@ describe('UserFeedback', function () {
     };
     render(<UserFeedback {...params} />, {context: routerContext});
 
-    expect(screen.getByTestId('user-feedback-empty')).toBeInTheDocument();
+    expect(await screen.findByTestId('user-feedback-empty')).toBeInTheDocument();
   });
 
-  it('renders empty state with project query', function () {
+  it('renders empty state with project query', async function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/user-feedback/',
       body: [],
@@ -124,7 +124,7 @@ describe('UserFeedback', function () {
     };
     render(<UserFeedback {...params} />, {context: routerContext});
 
-    expect(screen.getByTestId('user-feedback-empty')).toBeInTheDocument();
+    expect(await screen.findByTestId('user-feedback-empty')).toBeInTheDocument();
   });
 
   it('renders issue status filter', async function () {
@@ -155,7 +155,7 @@ describe('UserFeedback', function () {
     );
   });
 
-  it('renders empty state with multi project query', function () {
+  it('renders empty state with multi project query', async function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/user-feedback/',
       body: [],
@@ -178,6 +178,6 @@ describe('UserFeedback', function () {
     };
     render(<UserFeedback {...params} />, {context: routerContext});
 
-    expect(screen.getByTestId('user-feedback-empty')).toBeInTheDocument();
+    expect(await screen.findByTestId('user-feedback-empty')).toBeInTheDocument();
   });
 });

--- a/static/app/views/userFeedback/index.tsx
+++ b/static/app/views/userFeedback/index.tsx
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/button';
 import {EventUserFeedback} from 'sentry/components/events/userFeedback';
 import CompactIssue from 'sentry/components/issues/compactIssue';
 import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
@@ -22,23 +23,18 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization, UserReport} from 'sentry/types';
+import type {UserReport} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import withOrganization from 'sentry/utils/withOrganization';
 
 import {UserFeedbackEmpty} from './userFeedbackEmpty';
 import {getQuery} from './utils';
 
-interface Props extends RouteComponentProps<{}, {}> {
-  organization: Organization;
-}
+interface Props extends RouteComponentProps<{}, {}> {}
 
-function OrganizationUserFeedback({
-  organization,
-  location: {search, pathname, query},
-  router,
-}: Props) {
+function OrganizationUserFeedback({location: {search, pathname, query}, router}: Props) {
+  const organization = useOrganization();
   const {status} = getQuery(search);
 
   const unresolvedQuery = omit(query, 'status');
@@ -48,6 +44,7 @@ function OrganizationUserFeedback({
   const {
     data: reportList,
     isLoading,
+    isError,
     getResponseHeader,
   } = useApiQuery<UserReport[]>(
     [
@@ -72,6 +69,9 @@ function OrganizationUserFeedback({
   }
 
   function StreamBody() {
+    if (isError) {
+      return <LoadingError />;
+    }
     if (isLoading) {
       return (
         <Panel>
@@ -177,7 +177,7 @@ function OrganizationUserFeedback({
   );
 }
 
-export default withOrganization(withProfiler(OrganizationUserFeedback));
+export default withProfiler(OrganizationUserFeedback);
 
 const Filters = styled('div')`
   display: grid;


### PR DESCRIPTION
ref https://github.com/getsentry/frontend-tsc/issues/2

converts this file into FC and use `useApiQuery` instead of `DeprecatedAsync`