### PR TITLE
ref(grouping): Only calculate secondary hash when needed

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1654,12 +1654,15 @@ def _save_aggregate_new(
         group_info = handle_existing_grouphash(
             job, primary.existing_grouphash, all_grouphashes, group_processing_kwargs
         )
-    elif secondary.existing_grouphash:
-        group_info = handle_existing_grouphash(
-            job, secondary.existing_grouphash, all_grouphashes, group_processing_kwargs
-        )
     else:
-        group_info = create_group_with_grouphashes(job, all_grouphashes, group_processing_kwargs)
+        if secondary.existing_grouphash:
+            group_info = handle_existing_grouphash(
+                job, secondary.existing_grouphash, all_grouphashes, group_processing_kwargs
+            )
+        else:
+            group_info = create_group_with_grouphashes(
+                job, all_grouphashes, group_processing_kwargs
+            )
 
     # From here on out, we're just doing housekeeping
 

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -425,7 +425,7 @@ def test_existing_group_new_hash_exists(
         new_logic_enabled=new_logic_enabled,
     )
 
-    if in_transition:
+    if in_transition and not new_logic_enabled:
         assert results == {
             "primary_hash_calculated": True,
             "secondary_hash_calculated": True,
@@ -439,6 +439,9 @@ def test_existing_group_new_hash_exists(
             "primary_grouphash_exists_now": True,
             "secondary_grouphash_exists_now": True,
         }
+    # Equivalent to `elif (in_transition and new_logic_enabled) or not in_transition`. In other
+    # words, with the new logic, if the new hash exists, it doesn't matter whether we're in
+    # transition or not - no extra calculations are performed.
     else:
         assert results == {
             "primary_hash_calculated": True,


### PR DESCRIPTION
This is it, the PR we've all been waiting for. After a _great_ deal of refactoring and breaking apart the logic of how we assign events to groups, this finally makes the desired change: to stop calculating secondary hashes when we already have a matching primary hash. 

Metrics to measure the effect of this change will be added in upcoming PRs, but one sign of the success of this change is the adjustment necessary in the tests. Whereas before, being in a transition period always meant doing two calculations, now when the new logic is enabled, being in a transition is no different than not being in a transition  - at least in the case where the current hash has already been calculated. And our research has shown that this is case the vast majority of the time, so hopefully this should make a big impact when we change configs and make it much less expensive to do so.