### PR TITLE
feat(opsgenie): Allow plugin migrations for Opsgenie users

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1424,7 +1424,6 @@ SENTRY_EARLY_FEATURES = {
     "organizations:grouping-title-ui": "Enable tweaks to group title in relation to hierarchical grouping.",
     "organizations:grouping-tree-ui": "Enable experimental new version of Merged Issues where sub-hashes are shown",
     "organizations:integrations-gh-invite": "Enables inviting new members based on GitHub commit activity",
-    "organizations:integrations-opsgenie-migration": "Enable one-click migration from Opsgenie plugin",
     "organizations:issue-details-tag-improvements": "Enable tag improvements in the issue details page",
     "organizations:mobile-cpu-memory-in-transactions": "Display CPU and memory metrics in transactions with profiles",
     "organizations:performance-metrics-backed-transaction-summary": "Enable metrics-backed transaction summary view",
@@ -1601,8 +1600,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:integrations-open-pr-comment-js": False,
     # Enable Opsgenie integration
     "organizations:integrations-opsgenie": True,
-    # Enable one-click migration from Opsgenie plugin
-    "organizations:integrations-opsgenie-migration": False,
     # Enable stacktrace linking
     "organizations:integrations-stacktrace-link": True,
     # Allow orgs to automatically create Tickets in Issue Alerts

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -116,7 +116,6 @@ default_manager.add("organizations:integrations-feature-flag-integration", Organ
 default_manager.add("organizations:integrations-gh-invite", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:integrations-open-pr-comment", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:integrations-open-pr-comment-js", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:integrations-opsgenie-migration", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:investigation-bias", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:invite-members", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -18,7 +18,6 @@ describe('OpsgenieMigrationButton', function () {
   });
   const integrationId = '1';
   it('Migrate Plugin button hits migration endpoint', async function () {
-    org.features.push('integrations-opsgenie-migration');
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/config/integrations/`,
       body: {

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -217,11 +217,12 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
     }
   };
 
-  const isInstalledOpsgeniePlugin = (plugin: PluginWithProjectList) => {
-    return (
-      plugin.id === 'opsgenie' &&
-      plugin.projectList.length >= 1 &&
-      plugin.projectList.find(({enabled}) => enabled === true)
+  const isOpsgeniePluginInstalled = () => {
+    return (plugins || []).some(
+      p =>
+        p.id === 'opsgenie' &&
+        p.projectList.length >= 1 &&
+        p.projectList.some(({enabled}) => enabled === true)
     );
   };
 
@@ -261,10 +262,10 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
       );
     }
 
-    const shouldMigrateJiraPlugin =
+    const canMigrateJiraPlugin =
       ['jira', 'jira_server'].includes(provider.key) &&
       (plugins || []).find(({id}) => id === 'jira');
-    if (shouldMigrateJiraPlugin) {
+    if (canMigrateJiraPlugin) {
       return (
         <Access access={['org:integrations']}>
           {({hasAccess}) => (
@@ -303,11 +304,9 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
       );
     }
 
-    const shouldMigrateOpsgeniePlugin =
-      provider.key === 'opsgenie' &&
-      organization.features.includes('integrations-opsgenie-migration') &&
-      (plugins || []).find(isInstalledOpsgeniePlugin);
-    if (shouldMigrateOpsgeniePlugin) {
+    const canMigrateOpsgeniePlugin =
+      provider.key === 'opsgenie' && isOpsgeniePluginInstalled();
+    if (canMigrateOpsgeniePlugin) {
       return (
         <Access access={['org:integrations']}>
           {({hasAccess}) => (


### PR DESCRIPTION
Enables the button in the UI to migrate Opsgenie users away from the plugin.