### PR TITLE
ref(notifications): Remove unused flag

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -154,7 +154,6 @@ default_manager.add("organizations:new-page-filter", OrganizationFeature, Featur
 default_manager.add("organizations:new-weekly-report", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:noisy-alert-warning", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:notification-all-recipients", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:notification-settings-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:old-user-feedback", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:on-demand-metrics-extraction-experimental", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:on-demand-metrics-extraction-widgets", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
Initially removed in https://github.com/getsentry/sentry/pull/59810/files#diff-156f5b2b4da6ecb6afd906f84b345efdc5e28efa42468674cdbd942de2db05e0 but mistakenly added back in https://github.com/getsentry/sentry/pull/60146/files, this flag is unused and not needed anymore.