### PR TITLE
ref(tsc): convert admin packages to FC

### DIFF
--- a/static/app/views/admin/adminPackages.tsx
+++ b/static/app/views/admin/adminPackages.tsx
@@ -1,60 +1,53 @@
 import {Fragment} from 'react';
 
 import {t} from 'sentry/locale';
-import DeprecatedAsyncView from 'sentry/views/deprecatedAsyncView';
+import {useApiQuery} from 'sentry/utils/queryClient';
 
 type Data = {
   extensions: [key: string, value: string][];
   modules: [key: string, value: string][];
 };
 
-type State = DeprecatedAsyncView['state'] & {data: Data};
+export default function AdminPackages() {
+  const {data} = useApiQuery<Data>(['/internal/packages/'], {
+    staleTime: 0,
+  });
 
-export default class AdminPackages extends DeprecatedAsyncView<{}, State> {
-  getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
-    return [['data', '/internal/packages/']];
-  }
+  return (
+    <div>
+      <h3>{t('Extensions')}</h3>
 
-  renderBody() {
-    const {data} = this.state;
-    const {extensions, modules} = data;
+      {data?.extensions && data?.extensions.length > 0 ? (
+        <dl className="vars">
+          {data?.extensions.map(([key, value]) => (
+            <Fragment key={key}>
+              <dt>{key}</dt>
+              <dd>
+                <pre className="val">{value}</pre>
+              </dd>
+            </Fragment>
+          ))}
+        </dl>
+      ) : (
+        <p>{t('No extensions registered')}</p>
+      )}
 
-    return (
-      <div>
-        <h3>{t('Extensions')}</h3>
+      <h3>{t('Modules')}</h3>
 
-        {extensions.length > 0 ? (
-          <dl className="vars">
-            {extensions.map(([key, value]) => (
-              <Fragment key={key}>
-                <dt>{key}</dt>
-                <dd>
-                  <pre className="val">{value}</pre>
-                </dd>
-              </Fragment>
-            ))}
-          </dl>
-        ) : (
-          <p>{t('No extensions registered')}</p>
-        )}
-
-        <h3>{t('Modules')}</h3>
-
-        {modules.length > 0 ? (
-          <dl className="vars">
-            {modules.map(([key, value]) => (
-              <Fragment key={key}>
-                <dt>{key}</dt>
-                <dd>
-                  <pre className="val">{value}</pre>
-                </dd>
-              </Fragment>
-            ))}
-          </dl>
-        ) : (
-          <p>{t('No modules registered')}</p>
-        )}
-      </div>
-    );
-  }
+      {data?.modules && data?.modules.length > 0 ? (
+        <dl className="vars">
+          {data?.modules.map(([key, value]) => (
+            <Fragment key={key}>
+              <dt>{key}</dt>
+              <dd>
+                <pre className="val">{value}</pre>
+              </dd>
+            </Fragment>
+          ))}
+        </dl>
+      ) : (
+        <p>{t('No modules registered')}</p>
+      )}
+    </div>
+  );
 }

--- a/static/app/views/admin/adminPackages.tsx
+++ b/static/app/views/admin/adminPackages.tsx
@@ -1,5 +1,7 @@
 import {Fragment} from 'react';
 
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
@@ -9,9 +11,17 @@ type Data = {
 };
 
 export default function AdminPackages() {
-  const {data} = useApiQuery<Data>(['/internal/packages/'], {
+  const {data, isLoading, isError} = useApiQuery<Data>(['/internal/packages/'], {
     staleTime: 0,
   });
+
+  if (isError) {
+    return <LoadingError />;
+  }
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
 
   return (
     <div>


### PR DESCRIPTION
ref https://github.com/getsentry/frontend-tsc/issues/2

converts this file into FC and use `useApiQuery` instead of `DeprecatedAsync`