### PR TITLE
build: update redis and remove redis-py-cluster

### DIFF
--- a/fixtures/stubs-for-mypy/rediscluster/__init__.pyi
+++ b/fixtures/stubs-for-mypy/rediscluster/__init__.pyi
@@ -1,3 +1,0 @@
-from .client import RedisCluster
-
-__all__ = ('RedisCluster',)

--- a/fixtures/stubs-for-mypy/rediscluster/client.pyi
+++ b/fixtures/stubs-for-mypy/rediscluster/client.pyi
@@ -1,8 +1,0 @@
-from typing import TypeVar
-
-from redis import Redis
-
-T = TypeVar("T", str, bytes)
-
-class RedisCluster(Redis[T]):
-    ...

--- a/fixtures/stubs-for-mypy/rediscluster/exceptions.pyi
+++ b/fixtures/stubs-for-mypy/rediscluster/exceptions.pyi
@@ -1,3 +1,0 @@
-from redis.exceptions import RedisError
-
-class ClusterError(RedisError): ...

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -52,8 +52,7 @@ fido2>=0.9.2
 python3-saml>=1.15.0
 PyYAML>=6.0.1
 rb>=1.9.0
-redis-py-cluster>=2.1.0
-redis>=3.4.1
+redis>=4.1.0
 requests-oauthlib>=1.2.0
 requests>=2.25.1
 # [start] jsonschema format validators
@@ -63,7 +62,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.16.0
 sentry-kafka-schemas>=0.1.50
 sentry-ophio==0.1.5
-sentry-redis-tools>=0.1.7
+sentry-redis-tools>=0.2.0
 sentry-relay>=0.8.45
 sentry-sdk>=1.39.2
 snuba-sdk>=2.0.25

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -10,6 +10,7 @@ amqp==5.2.0
 anyio==3.7.1
 asgiref==3.7.2
 async-generator==1.10
+async-timeout==4.0.3
 attrs==23.1.0
 avalara==20.9.0
 beautifulsoup4==4.7.1
@@ -158,8 +159,7 @@ pyuwsgi==2.0.23
 pyvat==1.3.15
 pyyaml==6.0.1
 rb==1.10.0
-redis==3.4.1
-redis-py-cluster==2.1.0
+redis==4.5.4
 referencing==0.30.2
 regex==2022.9.13
 reportlab==4.0.7
@@ -179,7 +179,7 @@ sentry-forked-django-stubs==4.2.7.post3
 sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.50
 sentry-ophio==0.1.5
-sentry-redis-tools==0.1.7
+sentry-redis-tools==0.2.0
 sentry-relay==0.8.45
 sentry-sdk==1.39.2
 sentry-usage-accountant==0.0.10
@@ -211,10 +211,11 @@ types-pillow==9.5.0.4
 types-protobuf==4.23.0.1
 types-psutil==5.9.5.16
 types-psycopg2==2.9.21
+types-pyopenssl==23.2.0.2
 types-python-dateutil==2.8.19
 types-pytz==2022.1.2
 types-pyyaml==6.0.11
-types-redis==3.5.18
+types-redis==4.6.0.3
 types-requests==2.31.0.20231231
 types-setuptools==65.3.0
 types-simplejson==3.17.7.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -53,7 +53,7 @@ types-python-dateutil
 types-pytz
 types-pyyaml
 # make sure to match close-enough to redis==
-types-redis<4
+types-redis>=4.1
 types-requests>=2.31.0.20231231
 types-setuptools
 types-simplejson>=3.17.7.2

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -9,6 +9,7 @@
 amqp==5.2.0
 anyio==3.7.1
 asgiref==3.7.2
+async-timeout==4.0.3
 attrs==23.1.0
 avalara==20.9.0
 beautifulsoup4==4.7.1
@@ -105,8 +106,7 @@ pyuwsgi==2.0.23
 pyvat==1.3.15
 pyyaml==6.0.1
 rb==1.10.0
-redis==3.4.1
-redis-py-cluster==2.1.0
+redis==4.5.4
 referencing==0.30.2
 regex==2022.9.13
 reportlab==4.0.7
@@ -120,7 +120,7 @@ s3transfer==0.10.0
 sentry-arroyo==2.16.0
 sentry-kafka-schemas==0.1.50
 sentry-ophio==0.1.5
-sentry-redis-tools==0.1.7
+sentry-redis-tools==0.2.0
 sentry-relay==0.8.45
 sentry-sdk==1.39.2
 sentry-usage-accountant==0.0.10

--- a/src/sentry/eventstore/processing/multiredis.py
+++ b/src/sentry/eventstore/processing/multiredis.py
@@ -2,7 +2,7 @@ import hashlib
 from datetime import timedelta
 from typing import TypeVar
 
-from rediscluster import RedisCluster
+from redis.cluster import RedisCluster
 
 from sentry import options
 from sentry.utils.codecs import JSONCodec
@@ -20,10 +20,10 @@ class MultiRedisProcessingStore(EventProcessingStore):
     Adapter to shift traffic from one redis cluster to another
     """
 
-    def __init__(self, **options):
+    def __init__(self, old_cluster: str, new_cluster: str):
         inner = MultiRedisKVStorage(
-            old_cluster=redis_clusters.get(options["old_cluster"]),
-            new_cluster=redis_clusters.get(options["new_cluster"]),
+            old_cluster=redis_clusters.get(old_cluster),  # type: ignore[arg-type]
+            new_cluster=redis_clusters.get(new_cluster),  # type: ignore[arg-type]
         )
         super().__init__(KVStorageCodecWrapper(inner, JSONCodec()))
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -10,6 +10,7 @@ from typing import TypeVar, cast
 from django.conf import settings
 from django.db import router, transaction
 from django.utils import timezone
+from sentry_redis_tools.retrying_cluster import RetryingRedisCluster
 from snuba_sdk import Column, Condition, Limit, Op
 
 from sentry import features
@@ -47,7 +48,6 @@ from sentry.snuba.models import QuerySubscription
 from sentry.snuba.tasks import build_query_builder
 from sentry.utils import metrics, redis
 from sentry.utils.dates import to_datetime, to_timestamp
-from sentry.utils.redis import RetryingRedisCluster
 
 logger = logging.getLogger(__name__)
 REDIS_TTL = int(timedelta(days=7).total_seconds())

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -60,10 +60,11 @@ class RedisRuleStore:
         key = self._get_rules_key(project)
 
         with client.pipeline() as p:
-            # to be consistent with other stores, clear previous hash entries:
-            p.delete(key)
             if len(rules) > 0:
-                p.hmset(key, rules)
+                p.hset(key, mapping=rules)
+            else:
+                # to be consistent with other stores, clear previous hash entries:
+                p.delete(key)
             p.execute()
 
     def update_rule(self, project: Project, rule: str, last_used: int) -> None:

--- a/src/sentry/processing/backpressure/memory.py
+++ b/src/sentry/processing/backpressure/memory.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 
 import rb
 import requests
-from rediscluster import RedisCluster
+from redis.cluster import RedisCluster
 
 
 @dataclass

--- a/src/sentry/ratelimits/concurrent.py
+++ b/src/sentry/ratelimits/concurrent.py
@@ -8,6 +8,7 @@ from django.conf import settings
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import redis
+from sentry.utils.redis import disconnect_redis_connection_pools
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class ConcurrentRateLimiter:
     def validate(self) -> None:
         try:
             self.client.ping()
-            self.client.connection_pool.disconnect()
+            disconnect_redis_connection_pools(self.client)
         except Exception as e:
             raise InvalidConfiguration(str(e))
 

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -11,6 +11,7 @@ from sentry.exceptions import InvalidConfiguration
 from sentry.ratelimits.base import RateLimiter
 from sentry.utils import redis
 from sentry.utils.hashlib import md5_text
+from sentry.utils.redis import disconnect_redis_connection_pools
 
 if TYPE_CHECKING:
     from sentry.models.project import Project
@@ -65,7 +66,7 @@ class RedisRateLimiter(RateLimiter):
     def validate(self) -> None:
         try:
             self.client.ping()
-            self.client.connection_pool.disconnect()
+            disconnect_redis_connection_pools(self.client)
         except Exception as e:
             raise InvalidConfiguration(str(e))
 

--- a/src/sentry/ratelimits/sliding_windows.py
+++ b/src/sentry/ratelimits/sliding_windows.py
@@ -12,6 +12,7 @@ from sentry_redis_tools.sliding_windows_rate_limiter import RequestedQuota, Time
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import redis
+from sentry.utils.redis import disconnect_redis_connection_pools
 from sentry.utils.services import Service
 
 __all__ = ["Quota", "GrantedQuota", "RequestedQuota", "Timestamp"]
@@ -142,7 +143,7 @@ class RedisSlidingWindowRateLimiter(SlidingWindowRateLimiter):
     def validate(self) -> None:
         try:
             self.client.ping()
-            self.client.connection_pool.disconnect()
+            disconnect_redis_connection_pools(self.client)
         except Exception as e:
             raise InvalidConfiguration(str(e))
 

--- a/src/sentry/statistical_detectors/redis.py
+++ b/src/sentry/statistical_detectors/redis.py
@@ -55,7 +55,7 @@ class RedisDetectorStore(DetectorStore):
                 if state is None:
                     continue
                 key = self.make_key(payload)
-                pipeline.hmset(key, state)
+                pipeline.hset(key, mapping=state)
                 pipeline.expire(key, self.ttl)
 
             pipeline.execute()

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -11,7 +11,7 @@ from typing import ContextManager, TypeVar
 
 from django.utils import timezone
 from django.utils.encoding import force_bytes
-from redis.client import Script
+from redis.commands.core import Script
 
 from sentry.tsdb.base import BaseTSDB
 from sentry.utils.compat import crc32

--- a/src/sentry/utils/kvstore/redis.py
+++ b/src/sentry/utils/kvstore/redis.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TypeVar
 
-from redis import StrictRedis
-from rediscluster import RedisCluster
+from redis.client import StrictRedis
+from redis.cluster import RedisCluster
 
 from sentry.utils.kvstore.abstract import KVStorage
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -9,11 +9,11 @@ from typing import Any, Generic, TypeVar, overload
 
 import rb
 from django.utils.functional import SimpleLazyObject
-from redis.client import Script
+from redis.client import StrictRedis
+from redis.cluster import RedisCluster
+from redis.commands.core import Script
 from redis.connection import ConnectionPool
-from redis.exceptions import BusyLoadingError, ConnectionError
-from rediscluster import RedisCluster
-from rediscluster.exceptions import ClusterError
+from redis.exceptions import BusyLoadingError, ClusterError, ConnectionError
 from sentry_redis_tools.failover_redis import FailoverRedis
 
 from sentry import options
@@ -157,7 +157,7 @@ class _RedisCluster:
         return "Redis Cluster"
 
 
-TCluster = TypeVar("TCluster", rb.Cluster, RedisCluster)
+TCluster = TypeVar("TCluster", rb.Cluster, RedisCluster | StrictRedis)
 
 
 class ClusterManager(Generic[TCluster]):
@@ -167,7 +167,7 @@ class ClusterManager(Generic[TCluster]):
 
     @overload
     def __init__(
-        self: ClusterManager[RedisCluster], options_manager, cluster_type: type[Any]
+        self: ClusterManager[RedisCluster | StrictRedis], options_manager, cluster_type: type[Any]
     ) -> None:
         ...
 
@@ -205,7 +205,7 @@ class ClusterManager(Generic[TCluster]):
 # completed, remove the rb ``clusters`` module variable and rename
 # redis_clusters to clusters.
 clusters: ClusterManager[rb.Cluster] = ClusterManager(options.default_manager)
-redis_clusters: ClusterManager[RedisCluster] = ClusterManager(
+redis_clusters: ClusterManager[RedisCluster | StrictRedis] = ClusterManager(
     options.default_manager, _RedisCluster
 )
 
@@ -320,3 +320,13 @@ def load_script(path):
         return script[0](keys, args, client)
 
     return call_script
+
+
+# Since the implementation to disconnect connection pools differ between
+# RedisCluster and StrictRedis after v4, we need this function.
+def disconnect_redis_connection_pools(client: StrictRedis | RedisCluster) -> None:
+    if isinstance(client, RedisCluster):
+        client.disconnect_connection_pools()
+    else:
+        assert isinstance(client, StrictRedis)
+        client.connection_pool.disconnect()

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -62,9 +62,9 @@ class TestRedisBuffer:
     def test_process_does_bubble_up_json(self, process):
         client = self.buf.get_routing_client()
 
-        client.hmset(
+        client.hset(
             "foo",
-            {
+            mapping={
                 "e+foo": '["s","bar"]',
                 "e+datetime": '["dt","1493791566.000000"]',
                 "f": '{"pk": ["i","1"]}',
@@ -87,9 +87,9 @@ class TestRedisBuffer:
     def test_process_does_bubble_up_pickle(self, process):
         client = self.buf.get_routing_client()
 
-        client.hmset(
+        client.hset(
             "foo",
-            {
+            mapping={
                 "e+foo": "S'bar'\np1\n.",
                 "f": "(dp1\nS'pk'\np2\nI1\ns.",
                 "i+times_seen": "2",
@@ -246,9 +246,9 @@ class TestRedisBuffer:
     def test_process_uses_signal_only(self, process):
         client = self.buf.get_routing_client()
 
-        client.hmset(
+        client.hset(
             "foo",
-            {
+            mapping={
                 "f": '{"pk": ["i","1"]}',
                 "i+times_seen": "1",
                 "m": "unittest.mock.Mock",

--- a/tests/sentry/eventstore/processing/test_multiredis.py
+++ b/tests/sentry/eventstore/processing/test_multiredis.py
@@ -28,12 +28,7 @@ def make_event():
 class MultiRedisTest(TestCase):
     @override_options({"redis.clusters": cluster_config, "eventstore.processing.rollout": 1.0})
     def test_store_and_get_with_new(self):
-        adapter = MultiRedisProcessingStore(
-            **{
-                "old_cluster": "old",
-                "new_cluster": "new",
-            }
-        )
+        adapter = MultiRedisProcessingStore(old_cluster="old", new_cluster="new")
         event = make_event()
         key = adapter.store(event)
         result = adapter.get(key)
@@ -44,12 +39,7 @@ class MultiRedisTest(TestCase):
 
     @override_options({"redis.clusters": cluster_config, "eventstore.processing.rollout": 0.0})
     def test_store_and_get_with_old(self):
-        adapter = MultiRedisProcessingStore(
-            **{
-                "old_cluster": "old",
-                "new_cluster": "new",
-            }
-        )
+        adapter = MultiRedisProcessingStore(old_cluster="old", new_cluster="new")
         event = make_event()
         key = adapter.store(event)
         result = adapter.get(key)
@@ -63,12 +53,7 @@ class MultiRedisTest(TestCase):
 
     @override_options({"redis.clusters": cluster_config})
     def test_write_old_read_new(self):
-        adapter = MultiRedisProcessingStore(
-            **{
-                "old_cluster": "old",
-                "new_cluster": "new",
-            }
-        )
+        adapter = MultiRedisProcessingStore(old_cluster="old", new_cluster="new")
         # write to the old cluster
         with override_options({"eventstore.processing.rollout": 0.0}):
             event = make_event()
@@ -81,12 +66,7 @@ class MultiRedisTest(TestCase):
 
     @override_options({"redis.clusters": cluster_config})
     def test_store_new_read_old(self):
-        adapter = MultiRedisProcessingStore(
-            **{
-                "old_cluster": "old",
-                "new_cluster": "new",
-            }
-        )
+        adapter = MultiRedisProcessingStore(old_cluster="old", new_cluster="new")
         # write to the new cluster
         with override_options({"eventstore.processing.rollout": 1.0}):
             event = make_event()
@@ -105,12 +85,7 @@ class MultiRedisTest(TestCase):
 
     @override_options({"redis.clusters": cluster_config})
     def test_store_new_no_old_read(self):
-        adapter = MultiRedisProcessingStore(
-            **{
-                "old_cluster": "old",
-                "new_cluster": "new",
-            }
-        )
+        adapter = MultiRedisProcessingStore(old_cluster="old", new_cluster="new")
         # write to the old cluster
         with override_options({"eventstore.processing.rollout": 0.0}):
             event = make_event()
@@ -129,12 +104,7 @@ class MultiRedisTest(TestCase):
     @override_options({"redis.clusters": cluster_config})
     def test_old_read_disabled(self):
         event = make_event()
-        adapter = MultiRedisProcessingStore(
-            **{
-                "old_cluster": "old",
-                "new_cluster": "new",
-            }
-        )
+        adapter = MultiRedisProcessingStore(old_cluster="old", new_cluster="new")
         # Insert into the old 'cluster'
         key = cache_key_for_event(event)
         old_cluster = redis_clusters.get("old")
@@ -151,12 +121,7 @@ class MultiRedisTest(TestCase):
 
     @override_options({"redis.clusters": cluster_config, "eventstore.processing.rollout": 1.0})
     def test_delete_by_key(self):
-        adapter = MultiRedisProcessingStore(
-            **{
-                "old_cluster": "old",
-                "new_cluster": "new",
-            }
-        )
+        adapter = MultiRedisProcessingStore(old_cluster="old", new_cluster="new")
         event = make_event()
         key = adapter.store(event)
         assert adapter.get(key)
@@ -165,12 +130,7 @@ class MultiRedisTest(TestCase):
 
     @override_options({"redis.clusters": cluster_config, "eventstore.processing.rollout": 1.0})
     def test_delete(self):
-        adapter = MultiRedisProcessingStore(
-            **{
-                "old_cluster": "old",
-                "new_cluster": "new",
-            }
-        )
+        adapter = MultiRedisProcessingStore(old_cluster="old", new_cluster="new")
         event = make_event()
         key = adapter.store(event)
         assert adapter.get(key)
@@ -179,12 +139,7 @@ class MultiRedisTest(TestCase):
 
     @override_options({"redis.clusters": cluster_config})
     def test_delete_both(self):
-        adapter = MultiRedisProcessingStore(
-            **{
-                "old_cluster": "old",
-                "new_cluster": "new",
-            }
-        )
+        adapter = MultiRedisProcessingStore(old_cluster="old", new_cluster="new")
         event = make_event()
         # Insert into the old 'cluster'
         key = cache_key_for_event(event)

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -6,6 +6,7 @@ from unittest import TestCase, mock
 
 import pytest
 from django.utils.functional import SimpleLazyObject
+from redis.exceptions import RedisClusterException
 from sentry_redis_tools.failover_redis import FailoverRedis
 
 from sentry.exceptions import InvalidConfiguration
@@ -26,9 +27,9 @@ logger.setLevel(logging.ERROR)
 def _options_manager() -> dict[str, Any]:
     return {
         "redis.clusters": {
-            "foo": {"hosts": {0: {"db": 0}}},
-            "bar": {"hosts": {0: {"db": 0}, 1: {"db": 1}}},
-            "baz": {"is_redis_cluster": True, "hosts": {0: {}}},
+            "foo": {"hosts": {0: {"db": 0, "host": "127.0.0.1", "port": 6379}}},
+            "bar": {"hosts": {0: {"db": 0}, 1: {"db": 1, "host": "127.0.0.1", "port": 6379}}},
+            "baz": {"is_redis_cluster": True, "hosts": {0: {"host": "127.0.0.1", "port": 6379}}},
         }
     }
 
@@ -122,3 +123,19 @@ def test_get_cluster_from_options_both_options_invalid():
             {"hosts": {0: {"db": 0}}, "cluster": "foo", "foo": "bar"},
             cluster_manager=manager,
         )
+
+
+def test_construct_redis_cluster_with_is_redis_cluster_flag():
+    cluster = _RedisCluster()
+    lazy_object = cluster.factory(
+        decode_responses=True,
+        is_redis_cluster=True,
+        hosts=[{"host": "127.0.0.1", "port": 6379}],
+    )
+    with pytest.raises(RedisClusterException) as exception_info:
+        assert lazy_object
+    (msg,) = exception_info.value.args
+    assert (
+        msg
+        == "Redis Cluster cannot be connected. Please provide at least one reachable node: Cluster mode is not enabled on this node"
+    )

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -53,9 +53,9 @@ class ClusterManagerTestCase(TestCase):
         # object to verify it's correct.
 
         # cluster foo is fine since it's a single node, without specific client_class
-        assert isinstance(manager.get("foo")._setupfunc(), FailoverRedis)  # type: ignore[attr-defined]
-        # baz works becasue it's explicitly is_redis_cluster
-        assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value  # type: ignore[attr-defined]
+        assert isinstance(manager.get("foo")._setupfunc(), FailoverRedis)  # type: ignore[union-attr]
+        # baz works because it's explicitly is_redis_cluster
+        assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value  # type: ignore[union-attr]
 
         # bar is not a valid redis or redis cluster definition
         # becasue it is two hosts, without explicitly saying is_redis_cluster


### PR DESCRIPTION
Fixes the increasing amount of redis errors due to `redis-py-cluster`

Thanks to `@asottile-sentry` for pinpointing the issue

Fixes https://getsentry.atlassian.net/browse/INC-641