### PR TITLE
feat(sidebar): Removed superuser warning banner for demo org

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -118,10 +118,15 @@ function Sidebar() {
 
   // Avoid showing superuser UI on self-hosted instances
   const hasSuperuserSession = () => {
-    const shoulExclude = HookStore.get('component:superuser-warning-excluded')[0]?.(
+    return isActiveSuperuser() && !ConfigStore.get('isSelfHosted');
+  };
+
+  // Avoid showing superuser UI on certain organizations
+  const isExcludedOrg = () => {
+    const shouldExclude = HookStore.get('component:superuser-warning-excluded')[0]?.(
       organization
     );
-    return isActiveSuperuser() && !ConfigStore.get('isSelfHosted') && !shoulExclude;
+    return !shouldExclude;
   };
 
   useOpenOnboardingSidebar();
@@ -497,10 +502,10 @@ function Sidebar() {
   return (
     <SidebarWrapper aria-label={t('Primary Navigation')} collapsed={collapsed}>
       <SidebarSectionGroupPrimary>
-        <DropdownSidebarSection isSuperuser={hasSuperuserSession()}>
+        <DropdownSidebarSection isSuperuser={hasSuperuserSession() && isExcludedOrg()}>
           <SidebarDropdown orientation={orientation} collapsed={collapsed} />
 
-          {hasSuperuserSession() && (
+          {hasSuperuserSession() && isExcludedOrg() && (
             <Hook name="component:superuser-warning" organization={organization} />
           )}
         </DropdownSidebarSection>

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -116,8 +116,11 @@ function Sidebar() {
   const collapsed = !!preferences.collapsed;
   const horizontal = useMedia(`(max-width: ${theme.breakpoints.medium})`);
 
-  // Avoid showing superuser UI on self-hosted instances
-  const hasSuperuserSession = isActiveSuperuser() && !ConfigStore.get('isSelfHosted');
+  // Avoid showing superuser UI on self-hosted instances or demo org
+  const hasSuperuserSession =
+    isActiveSuperuser() &&
+    !ConfigStore.get('isSelfHosted') &&
+    organization?.slug !== 'demo';
 
   useOpenOnboardingSidebar();
 
@@ -495,7 +498,9 @@ function Sidebar() {
         <DropdownSidebarSection isSuperuser={hasSuperuserSession}>
           <SidebarDropdown orientation={orientation} collapsed={collapsed} />
 
-          {hasSuperuserSession && <Hook name="component:superuser-warning" />}
+          {hasSuperuserSession && (
+            <Hook name="component:superuser-warning" organization={organization} />
+          )}
         </DropdownSidebarSection>
 
         <PrimaryItems>

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -117,16 +117,13 @@ function Sidebar() {
   const horizontal = useMedia(`(max-width: ${theme.breakpoints.medium})`);
 
   // Avoid showing superuser UI on self-hosted instances
-  const hasSuperuserSession = () => {
+  const showSuperuserWarning = () => {
     return isActiveSuperuser() && !ConfigStore.get('isSelfHosted');
   };
 
   // Avoid showing superuser UI on certain organizations
   const isExcludedOrg = () => {
-    const shouldExclude = HookStore.get('component:superuser-warning-excluded')[0]?.(
-      organization
-    );
-    return !shouldExclude;
+    return HookStore.get('component:superuser-warning-excluded')[0]?.(organization);
   };
 
   useOpenOnboardingSidebar();
@@ -502,10 +499,10 @@ function Sidebar() {
   return (
     <SidebarWrapper aria-label={t('Primary Navigation')} collapsed={collapsed}>
       <SidebarSectionGroupPrimary>
-        <DropdownSidebarSection isSuperuser={hasSuperuserSession() && isExcludedOrg()}>
+        <DropdownSidebarSection isSuperuser={showSuperuserWarning() && !isExcludedOrg()}>
           <SidebarDropdown orientation={orientation} collapsed={collapsed} />
 
-          {hasSuperuserSession() && isExcludedOrg() && (
+          {showSuperuserWarning() && !isExcludedOrg() && (
             <Hook name="component:superuser-warning" organization={organization} />
           )}
         </DropdownSidebarSection>

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -116,11 +116,13 @@ function Sidebar() {
   const collapsed = !!preferences.collapsed;
   const horizontal = useMedia(`(max-width: ${theme.breakpoints.medium})`);
 
-  // Avoid showing superuser UI on self-hosted instances or demo org
-  const hasSuperuserSession =
-    isActiveSuperuser() &&
-    !ConfigStore.get('isSelfHosted') &&
-    organization?.slug !== 'demo';
+  // Avoid showing superuser UI on self-hosted instances
+  const hasSuperuserSession = () => {
+    const shoulExclude = HookStore.get('component:superuser-warning-excluded')[0]?.(
+      organization
+    );
+    return isActiveSuperuser() && !ConfigStore.get('isSelfHosted') && !shoulExclude;
+  };
 
   useOpenOnboardingSidebar();
 
@@ -495,10 +497,10 @@ function Sidebar() {
   return (
     <SidebarWrapper aria-label={t('Primary Navigation')} collapsed={collapsed}>
       <SidebarSectionGroupPrimary>
-        <DropdownSidebarSection isSuperuser={hasSuperuserSession}>
+        <DropdownSidebarSection isSuperuser={hasSuperuserSession()}>
           <SidebarDropdown orientation={orientation} collapsed={collapsed} />
 
-          {hasSuperuserSession && (
+          {hasSuperuserSession() && (
             <Hook name="component:superuser-warning" organization={organization} />
           )}
         </DropdownSidebarSection>

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -211,6 +211,7 @@ export type ComponentHooks = {
   'component:sentry-logo': () => React.ComponentType<SentryLogoProps>;
   'component:superuser-access-category': React.ComponentType<any>;
   'component:superuser-warning': React.ComponentType<any>;
+  'component:superuser-warning-excluded': SuperuserWarningExcluded;
 };
 
 /**
@@ -395,6 +396,11 @@ type FeatureDisabledHook = (opts: {
    */
   project?: Project;
 }) => React.ReactNode;
+
+/**
+ * Called to check if the superuser warning should be excluded for the given organization.
+ */
+type SuperuserWarningExcluded = (organization: Organization | null) => boolean;
 
 /**
  * Called when the app is mounted.


### PR DESCRIPTION
Removed the warning banner for superuser for the demo org

Before:
<img width="1797" alt="Screenshot 2024-02-15 at 1 38 47 PM" src="https://github.com/getsentry/sentry/assets/33237075/ca591100-2b5a-431f-a014-d71ce3cafe24">

After:
<img width="1797" alt="Screenshot 2024-02-15 at 1 31 40 PM" src="https://github.com/getsentry/sentry/assets/33237075/0791ccca-24ad-45c7-8368-5812993e5464">

Fixes https://github.com/getsentry/team-core-product-foundations/issues/73