### PR TITLE
feat(integration): Support deleting on relation

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -165,6 +165,7 @@ def load_defaults():
     default_manager.register(models.UserReport, BulkModelDeletionTask)
     default_manager.register(models.ArtifactBundle, ArtifactBundleDeletionTask)
     default_manager.register(models.Rule, defaults.RuleDeletionTask)
+    default_manager.register(models.NotificationMessage, defaults.NotificationMessageDeletionTask)
 
 
 load_defaults()

--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -89,7 +89,7 @@ default_manager = DeletionTaskManager(default_task=ModelDeletionTask)
 def load_defaults():
     from sentry import models
     from sentry.discover.models import DiscoverSavedQuery
-    from sentry.incidents.models import AlertRule
+    from sentry.incidents.models import AlertRule, AlertRuleTriggerAction
     from sentry.models.commitfilechange import CommitFileChange
     from sentry.monitors import models as monitor_models
 
@@ -165,7 +165,7 @@ def load_defaults():
     default_manager.register(models.UserReport, BulkModelDeletionTask)
     default_manager.register(models.ArtifactBundle, ArtifactBundleDeletionTask)
     default_manager.register(models.Rule, defaults.RuleDeletionTask)
-    default_manager.register(models.NotificationMessage, defaults.NotificationMessageDeletionTask)
+    default_manager.register(AlertRuleTriggerAction, defaults.AlertRuleTriggerActionDeletionTask)
 
 
 load_defaults()

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -6,6 +6,7 @@ from .discoversavedquery import *  # noqa: F401,F403
 from .group import *  # noqa: F401,F403
 from .monitor import *  # noqa: F401,F403
 from .monitor_environment import *  # noqa: F401,F403
+from .notificationmessage import *  # noqa: F401,F403
 from .organization import *  # noqa: F401,F403
 from .organizationintegration import *  # noqa: F401,F403
 from .platform_external_issue import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -1,3 +1,4 @@
+from .alert_rule_trigger_action import *  # noqa: F401,F403
 from .alertrule import *  # noqa: F401,F403
 from .apiapplication import *  # noqa: F401,F403
 from .commit import *  # noqa: F401,F403
@@ -6,7 +7,6 @@ from .discoversavedquery import *  # noqa: F401,F403
 from .group import *  # noqa: F401,F403
 from .monitor import *  # noqa: F401,F403
 from .monitor_environment import *  # noqa: F401,F403
-from .notificationmessage import *  # noqa: F401,F403
 from .organization import *  # noqa: F401,F403
 from .organizationintegration import *  # noqa: F401,F403
 from .platform_external_issue import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/alert_rule_trigger_action.py
+++ b/src/sentry/deletions/defaults/alert_rule_trigger_action.py
@@ -1,12 +1,12 @@
 from ..base import ModelDeletionTask, ModelRelation
 
 
-class NotificationMessageDeletionTask(ModelDeletionTask):
+class AlertRuleTriggerActionDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
-        from sentry.incidents.models import AlertRuleTriggerAction
+        from sentry.models.notificationmessage import NotificationMessage
 
         return [
-            ModelRelation(AlertRuleTriggerAction, {"notificationmessage_id": instance.id}),
+            ModelRelation(NotificationMessage, {"trigger_action": instance.id}),
         ]
 
     def mark_deletion_in_progress(self, instance_list):

--- a/src/sentry/deletions/defaults/alert_rule_trigger_action.py
+++ b/src/sentry/deletions/defaults/alert_rule_trigger_action.py
@@ -6,12 +6,5 @@ class AlertRuleTriggerActionDeletionTask(ModelDeletionTask):
         from sentry.models.notificationmessage import NotificationMessage
 
         return [
-            ModelRelation(NotificationMessage, {"trigger_action": instance.id}),
+            ModelRelation(NotificationMessage, {"trigger_action_id": instance.id}),
         ]
-
-    def mark_deletion_in_progress(self, instance_list):
-        from sentry.constants import ObjectStatus
-
-        for instance in instance_list:
-            if instance.status != ObjectStatus.PENDING_DELETION:
-                instance.update(status=ObjectStatus.PENDING_DELETION)

--- a/src/sentry/deletions/defaults/notificationmessage.py
+++ b/src/sentry/deletions/defaults/notificationmessage.py
@@ -1,0 +1,17 @@
+from ..base import ModelDeletionTask, ModelRelation
+
+
+class NotificationMessageDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        from sentry.incidents.models import AlertRuleTriggerAction
+
+        return [
+            ModelRelation(AlertRuleTriggerAction, {"notificationmessage_id": instance.id}),
+        ]
+
+    def mark_deletion_in_progress(self, instance_list):
+        from sentry.constants import ObjectStatus
+
+        for instance in instance_list:
+            if instance.status != ObjectStatus.PENDING_DELETION:
+                instance.update(status=ObjectStatus.PENDING_DELETION)

--- a/tests/sentry/deletions/test_alert_rule_trigger_action.py
+++ b/tests/sentry/deletions/test_alert_rule_trigger_action.py
@@ -1,4 +1,4 @@
-from sentry.constants import ObjectStatus
+from sentry.incidents.models import AlertRuleTriggerAction
 from sentry.models.notificationmessage import NotificationMessage
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TestCase
@@ -23,6 +23,5 @@ class DeleteAlertRuleTriggerActionTest(TestCase, HybridCloudTestMixin):
         with self.tasks():
             run_scheduled_deletions()
 
-        assert not NotificationMessage.objects.filter(
-            id=notification_message.id, status=ObjectStatus.PENDING_DELETION
-        ).exists()
+        assert not AlertRuleTriggerAction.objects.filter(id=action.id).exists()
+        assert not NotificationMessage.objects.filter(id=notification_message.id).exists()

--- a/tests/sentry/deletions/test_alert_rule_trigger_action.py
+++ b/tests/sentry/deletions/test_alert_rule_trigger_action.py
@@ -1,0 +1,28 @@
+from sentry.constants import ObjectStatus
+from sentry.models.notificationmessage import NotificationMessage
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
+from sentry.testutils.cases import TestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class DeleteAlertRuleTriggerActionTest(TestCase, HybridCloudTestMixin):
+    def test_simple(self):
+        incident = self.create_incident()
+        action = self.create_alert_rule_trigger_action()
+        notification_message = NotificationMessage(
+            message_identifier="s3iojewd90j23eqw",
+            incident=incident,
+            trigger_action=action,
+        )
+        notification_message.save()
+
+        self.ScheduledDeletion.schedule(instance=action, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not NotificationMessage.objects.filter(
+            id=notification_message.id, status=ObjectStatus.PENDING_DELETION
+        ).exists()


### PR DESCRIPTION
Following up on PR comment!

Some relations might have a lot of data associated, and using cascade delete could cause a timeout problem. To address this, Sentry has a way of handling deletions properly, so adding support for the new table here.