### PR TITLE
feat(app-start): Move start type selector to top of page

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.spec.tsx
@@ -61,7 +61,6 @@ describe('ScreenLoadEventSamples', function () {
       body: {
         meta: {
           fields: {
-            'span.description': 'string',
             profile_id: 'string',
             'transaction.id': 'string',
             'span.duration': 'duration',
@@ -71,7 +70,6 @@ describe('ScreenLoadEventSamples', function () {
         },
         data: [
           {
-            'span.description': 'Warm Start',
             profile_id: 'profile-id',
             'transaction.id': '76af98a3ac9d4448b894e44b1819970e',
             'span.duration': 131,
@@ -97,7 +95,6 @@ describe('ScreenLoadEventSamples', function () {
     // Check that headers are set properly
     expect(screen.getByRole('columnheader', {name: 'Event ID (R1)'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Profile'})).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Start Type'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Duration'})).toBeInTheDocument();
 
     expect(mockEventsRequest).toHaveBeenCalledTimes(1);
@@ -114,9 +111,6 @@ describe('ScreenLoadEventSamples', function () {
       'href',
       '/organizations/org-slug/profiling/profile/sentry-cocoa/profile-id/flamegraph/'
     );
-
-    // Start Type is the span description, "Warm Start"
-    expect(screen.getByText('Warm Start')).toBeInTheDocument();
 
     expect(screen.getByText('131.00ms')).toBeInTheDocument();
   });

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -75,19 +75,12 @@ export function EventSamples({
       release === primaryRelease ? PRIMARY_RELEASE_ALIAS : SECONDARY_RELEASE_ALIAS
     ),
     profile_id: t('Profile'),
-    'span.description': t('Start Type'),
     'span.duration': t('Duration'),
   };
 
   const newQuery: NewQuery = {
     name: '',
-    fields: [
-      'transaction.id',
-      'project.name',
-      'profile_id',
-      'span.description',
-      'span.duration',
-    ],
+    fields: ['transaction.id', 'project.name', 'profile_id', 'span.duration'],
     query: searchQuery.formatString(),
     dataset: DiscoverDatasets.SPANS_INDEXED,
     version: 2,

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -238,7 +238,7 @@ function ScreenSummary() {
 export default ScreenSummary;
 
 const ControlsContainer = styled('div')`
-  display:flex;
+  display: flex;
   gap: ${space(1.5)};
 `;
 

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -24,6 +24,7 @@ import {
 } from 'sentry/views/starfish/components/releaseSelector';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {SamplesTables} from 'sentry/views/starfish/views/appStartup/screenSummary/samples';
+import {StartTypeSelector} from 'sentry/views/starfish/views/appStartup/screenSummary/startTypeSelector';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {MetricsRibbon} from 'sentry/views/starfish/views/screens/screenLoadSpans/metricsRibbon';
 import {ScreenLoadSpanSamples} from 'sentry/views/starfish/views/screens/screenLoadSpans/samples';
@@ -98,10 +99,13 @@ function ScreenSummary() {
               <PageAlert />
               <PageFiltersContainer>
                 <Container>
-                  <PageFilterBar condensed>
-                    <DatePageFilter />
-                  </PageFilterBar>
-                  <ReleaseComparisonSelector />
+                  <AppleSauce>
+                    <PageFilterBar condensed>
+                      <DatePageFilter />
+                    </PageFilterBar>
+                    <ReleaseComparisonSelector />
+                    <StartTypeSelector />
+                  </AppleSauce>
                   <MetricsRibbon
                     dataset={DiscoverDatasets.SPANS_METRICS}
                     filters={[
@@ -233,15 +237,15 @@ function ScreenSummary() {
 
 export default ScreenSummary;
 
-const Container = styled('div')`
-  display: grid;
-  grid-template-rows: auto auto auto;
-  gap: ${space(2)};
+const AppleSauce = styled('div')`
+  display:flex;
+  gap: ${space(1.5)};
+`;
 
-  @media (min-width: ${p => p.theme.breakpoints.large}) {
-    grid-template-rows: auto;
-    grid-template-columns: auto 1fr auto;
-  }
+// TODO(nar): revisit behaviour when screen is small
+const Container = styled('div')`
+  display: flex;
+  justify-content: space-between;
 `;
 
 const SamplesContainer = styled('div')`

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -97,104 +97,104 @@ function ScreenSummary() {
           <Layout.Body>
             <Layout.Main fullWidth>
               <PageAlert />
-              <PageFiltersContainer>
-                <Container>
-                  <AppleSauce>
+              <HeaderContainer>
+                <ControlsContainer>
+                  <PageFiltersContainer>
                     <PageFilterBar condensed>
                       <DatePageFilter />
                     </PageFilterBar>
-                    <ReleaseComparisonSelector />
-                    <StartTypeSelector />
-                  </AppleSauce>
-                  <MetricsRibbon
-                    dataset={DiscoverDatasets.SPANS_METRICS}
-                    filters={[
-                      `transaction:${transactionName}`,
-                      `span.op:[app.start.cold,app.start.warm]`,
-                      '(',
-                      'span.description:"Cold Start"',
-                      'OR',
-                      'span.description:"Warm Start"',
-                      ')',
-                    ]}
-                    fields={[
-                      `avg_if(span.duration,release,${primaryRelease})`,
-                      `avg_if(span.duration,release,${secondaryRelease})`,
-                      'span.op',
-                      'count()',
-                    ]}
-                    blocks={[
-                      {
-                        type: 'duration',
-                        title: t('Cold Start (%s)', PRIMARY_RELEASE_ALIAS),
-                        dataKey: data => {
-                          const matchingRow = data?.find(
-                            row => row['span.op'] === 'app.start.cold'
-                          );
-                          return (
-                            (matchingRow?.[
-                              `avg_if(span.duration,release,${primaryRelease})`
-                            ] as number) ?? 0
-                          );
-                        },
+                  </PageFiltersContainer>
+                  <ReleaseComparisonSelector />
+                  <StartTypeSelector />
+                </ControlsContainer>
+                <MetricsRibbon
+                  dataset={DiscoverDatasets.SPANS_METRICS}
+                  filters={[
+                    `transaction:${transactionName}`,
+                    `span.op:[app.start.cold,app.start.warm]`,
+                    '(',
+                    'span.description:"Cold Start"',
+                    'OR',
+                    'span.description:"Warm Start"',
+                    ')',
+                  ]}
+                  fields={[
+                    `avg_if(span.duration,release,${primaryRelease})`,
+                    `avg_if(span.duration,release,${secondaryRelease})`,
+                    'span.op',
+                    'count()',
+                  ]}
+                  blocks={[
+                    {
+                      type: 'duration',
+                      title: t('Cold Start (%s)', PRIMARY_RELEASE_ALIAS),
+                      dataKey: data => {
+                        const matchingRow = data?.find(
+                          row => row['span.op'] === 'app.start.cold'
+                        );
+                        return (
+                          (matchingRow?.[
+                            `avg_if(span.duration,release,${primaryRelease})`
+                          ] as number) ?? 0
+                        );
                       },
-                      {
-                        type: 'duration',
-                        title: t('Cold Start (%s)', SECONDARY_RELEASE_ALIAS),
-                        dataKey: data => {
-                          const matchingRow = data?.find(
-                            row => row['span.op'] === 'app.start.cold'
-                          );
-                          return (
-                            (matchingRow?.[
-                              `avg_if(span.duration,release,${secondaryRelease})`
-                            ] as number) ?? 0
-                          );
-                        },
+                    },
+                    {
+                      type: 'duration',
+                      title: t('Cold Start (%s)', SECONDARY_RELEASE_ALIAS),
+                      dataKey: data => {
+                        const matchingRow = data?.find(
+                          row => row['span.op'] === 'app.start.cold'
+                        );
+                        return (
+                          (matchingRow?.[
+                            `avg_if(span.duration,release,${secondaryRelease})`
+                          ] as number) ?? 0
+                        );
                       },
-                      {
-                        type: 'duration',
-                        title: t('Warm Start (%s)', PRIMARY_RELEASE_ALIAS),
-                        dataKey: data => {
-                          const matchingRow = data?.find(
-                            row => row['span.op'] === 'app.start.warm'
-                          );
-                          return (
-                            (matchingRow?.[
-                              `avg_if(span.duration,release,${primaryRelease})`
-                            ] as number) ?? 0
-                          );
-                        },
+                    },
+                    {
+                      type: 'duration',
+                      title: t('Warm Start (%s)', PRIMARY_RELEASE_ALIAS),
+                      dataKey: data => {
+                        const matchingRow = data?.find(
+                          row => row['span.op'] === 'app.start.warm'
+                        );
+                        return (
+                          (matchingRow?.[
+                            `avg_if(span.duration,release,${primaryRelease})`
+                          ] as number) ?? 0
+                        );
                       },
-                      {
-                        type: 'duration',
-                        title: t('Warm Start (%s)', SECONDARY_RELEASE_ALIAS),
-                        dataKey: data => {
-                          const matchingRow = data?.find(
-                            row => row['span.op'] === 'app.start.warm'
-                          );
-                          return (
-                            (matchingRow?.[
-                              `avg_if(span.duration,release,${secondaryRelease})`
-                            ] as number) ?? 0
-                          );
-                        },
+                    },
+                    {
+                      type: 'duration',
+                      title: t('Warm Start (%s)', SECONDARY_RELEASE_ALIAS),
+                      dataKey: data => {
+                        const matchingRow = data?.find(
+                          row => row['span.op'] === 'app.start.warm'
+                        );
+                        return (
+                          (matchingRow?.[
+                            `avg_if(span.duration,release,${secondaryRelease})`
+                          ] as number) ?? 0
+                        );
                       },
-                      {
-                        type: 'count',
-                        title: t('Count'),
-                        dataKey: data => {
-                          return data?.reduce(
-                            (acc, row) => acc + (row['count()'] as number),
-                            0
-                          );
-                        },
+                    },
+                    {
+                      type: 'count',
+                      title: t('Count'),
+                      dataKey: data => {
+                        return data?.reduce(
+                          (acc, row) => acc + (row['count()'] as number),
+                          0
+                        );
                       },
-                    ]}
-                    referrer="api.starfish.mobile-startup-totals"
-                  />
-                </Container>
-              </PageFiltersContainer>
+                    },
+                  ]}
+                  referrer="api.starfish.mobile-startup-totals"
+                />
+              </HeaderContainer>
               <ErrorBoundary mini>
                 <AppStartWidgets additionalFilters={[`transaction:${transactionName}`]} />
               </ErrorBoundary>
@@ -237,14 +237,15 @@ function ScreenSummary() {
 
 export default ScreenSummary;
 
-const AppleSauce = styled('div')`
+const ControlsContainer = styled('div')`
   display:flex;
   gap: ${space(1.5)};
 `;
 
-// TODO(nar): revisit behaviour when screen is small
-const Container = styled('div')`
+const HeaderContainer = styled('div')`
   display: flex;
+  flex-wrap: wrap;
+  gap: ${space(2)};
   justify-content: space-between;
 `;
 

--- a/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
@@ -9,7 +9,6 @@ import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {EventSamples} from 'sentry/views/starfish/views/appStartup/screenSummary/eventSamples';
 import {SpanOperationTable} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOperationTable';
 import {SpanOpSelector} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOpSelector';
-import {StartTypeSelector} from 'sentry/views/starfish/views/appStartup/screenSummary/startTypeSelector';
 import {
   MobileCursors,
   MobileSortKeys,
@@ -79,7 +78,6 @@ export function SamplesTables({transactionName}) {
               secondaryRelease={secondaryRelease}
             />
           )}
-          <StartTypeSelector />
           <DeviceClassSelector size="md" clearSpansTableCursor />
         </FiltersContainer>
         <SegmentedControl onChange={value => setSampleType(value)} defaultValue={SPANS}>

--- a/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
@@ -93,7 +93,7 @@ export function SamplesTables({transactionName}) {
 const EventSplitContainer = styled('div')`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: ${space(1.5)}
+  gap: ${space(1.5)};
 `;
 
 const Controls = styled('div')`

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -41,14 +41,8 @@ import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
-const {
-  SPAN_SELF_TIME,
-  SPAN_DESCRIPTION,
-  SPAN_GROUP,
-  SPAN_OP,
-  PROJECT_ID,
-  APP_START_TYPE,
-} = SpanMetricsField;
+const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
+  SpanMetricsField;
 
 type Props = {
   primaryRelease?: string;
@@ -110,7 +104,6 @@ export function SpanOperationTable({
       `avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`,
       `avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`,
       `avg_compare(${SPAN_SELF_TIME},release,${primaryRelease},${secondaryRelease})`,
-      SpanMetricsField.APP_START_TYPE,
       `sum(${SPAN_SELF_TIME})`,
     ],
     query: queryStringPrimary,
@@ -143,7 +136,6 @@ export function SpanOperationTable({
     ),
     [`avg_compare(${SPAN_SELF_TIME},release,${primaryRelease},${secondaryRelease})`]:
       t('Change'),
-    [APP_START_TYPE]: t('Start Type'),
   };
 
   function renderBodyCell(column, row): React.ReactNode {
@@ -245,7 +237,6 @@ export function SpanOperationTable({
         isLoading={isLoading}
         data={data?.data as TableDataRow[]}
         columnOrder={[
-          APP_START_TYPE,
           String(SPAN_OP),
           String(SPAN_DESCRIPTION),
           `avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`,

--- a/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
@@ -16,6 +16,10 @@ import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {useEventsStatsQuery} from 'sentry/views/starfish/utils/useEventsStatsQuery';
+import {
+  COLD_START_TYPE,
+  type WARM_START_TYPE,
+} from 'sentry/views/starfish/views/appStartup/screenSummary/startTypeSelector';
 
 const COLD_START_CONDITIONS = ['span.op:app.start.cold', 'span.description:"Cold Start"'];
 const WARM_START_CONDITIONS = ['span.op:app.start.warm', 'span.description:"Warm Start"'];
@@ -45,7 +49,7 @@ export function transformData(data?: MultiSeriesEventsStats, primaryRelease?: st
 
 interface Props {
   chartHeight: number;
-  type: 'cold' | 'warm';
+  type: typeof COLD_START_TYPE | typeof WARM_START_TYPE;
   additionalFilters?: string[];
 }
 
@@ -58,7 +62,7 @@ function StartDurationWidget({additionalFilters, chartHeight, type}: Props) {
   } = useReleaseSelection();
 
   const query = new MutableSearch([
-    ...(type === 'cold' ? COLD_START_CONDITIONS : WARM_START_CONDITIONS),
+    ...(type === COLD_START_TYPE ? COLD_START_CONDITIONS : WARM_START_CONDITIONS),
     ...(additionalFilters ?? []),
   ]);
   const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
@@ -102,7 +106,9 @@ function StartDurationWidget({additionalFilters, chartHeight, type}: Props) {
   return (
     <MiniChartPanel
       title={
-        type === 'cold' ? t('Avg. Cold Start Duration') : t('Avg. Warm Start Duration')
+        type === COLD_START_TYPE
+          ? t('Avg. Cold Start Duration')
+          : t('Avg. Warm Start Duration')
       }
     >
       <Chart

--- a/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {browserHistory} from 'react-router';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -15,15 +16,26 @@ export function StartTypeSelector() {
 
   const value = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
 
+  useEffect(() => {
+    if (!value) {
+      browserHistory.replace({
+        ...location,
+        query: {
+          ...location.query,
+          [SpanMetricsField.APP_START_TYPE]: COLD_START_TYPE,
+        },
+      });
+    }
+  });
+
   const options = [
-    {value: '', label: t('All')},
-    {value: COLD_START_TYPE, label: t('Cold')},
-    {value: WARM_START_TYPE, label: t('Warm')},
+    {value: COLD_START_TYPE, label: t('Cold Start')},
+    {value: WARM_START_TYPE, label: t('Warm Start')},
   ];
 
   return (
     <CompactSelect
-      triggerProps={{prefix: t('Start Type')}}
+      triggerProps={{prefix: t('App Start')}}
       value={value}
       options={options ?? []}
       onChange={newValue => {

--- a/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
@@ -26,7 +26,10 @@ export function StartTypeSelector() {
         },
       });
     }
-  });
+
+    // This hook should only run once to set the default type
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const options = [
     {value: COLD_START_TYPE, label: t('Cold Start')},


### PR DESCRIPTION
Moves the Start Type selector to the top of the page. The filter has not yet been applied to the widgets at the top of the page yet, but the span operation table and the event samples tables have been updated to remove the columns that call out start type.

A follow up PR will come to modify and apply the filter to the other widgets