### PR TITLE
chore(hybrid-cloud): allow fetching user_ids of members in an org from control silo

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -638,6 +638,13 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
         return list(map(serialize_member, owner_members))
 
+    def get_organization_members_summaries(
+        self, *, organization_id: int
+    ) -> list[RpcOrganizationMemberSummary]:
+        org_members = OrganizationMember.objects.filter(organization_id=organization_id)
+
+        return [summarize_member(member) for member in org_members]
+
 
 class ControlOrganizationCheckService(OrganizationCheckService):
     def check_organization_by_slug(self, *, slug: str, only_visible: bool) -> int | None:

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -391,6 +391,13 @@ class OrganizationService(RpcService):
     ) -> list[RpcOrganizationMember]:
         pass
 
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def get_organization_members_summaries(
+        self, *, organization_id: int
+    ) -> list[RpcOrganizationMemberSummary]:
+        pass
+
 
 class OrganizationCheckService(abc.ABC):
     @abstractmethod


### PR DESCRIPTION
`RpcOrganizationMemberSummary` includes the org member's `user_id`. Adding a new function to fetch member summaries for all members in an organization.

I'm building an admin dashboard that lists all Sentry employees (in the `sentry` org) and their user information, and I'll be querying the `sentry` organization for the user ids.

For https://github.com/getsentry/team-core-product-foundations/issues/62