### PR TITLE
feat(crons-db): Stop accessing `MonitorEnvironment.environment` directly

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -240,7 +240,7 @@ def create_legacy_event(failed_checkin: MonitorCheckIn):
             "logentry": {"message": f"Monitor failure: {monitor_env.monitor.name} ({reason})"},
             "contexts": {"monitor": context},
             "fingerprint": ["monitor", str(monitor_env.monitor.guid), reason],
-            "environment": monitor_env.environment.name,
+            "environment": monitor_env.get_environment().name,
             # TODO: Both of these values should be get transformed from context to tags
             # We should understand why that is not happening and remove these when it correctly is
             "tags": {
@@ -290,7 +290,9 @@ def create_issue_platform_occurrence(
         subtitle=occurrence_data["subtitle"],
         evidence_display=[
             IssueEvidence(name="Failure reason", value=occurrence_data["reason"], important=True),
-            IssueEvidence(name="Environment", value=monitor_env.environment.name, important=False),
+            IssueEvidence(
+                name="Environment", value=monitor_env.get_environment().name, important=False
+            ),
             IssueEvidence(
                 name="Last successful check-in",
                 value=last_successful_checkin_timestamp,
@@ -310,7 +312,7 @@ def create_issue_platform_occurrence(
 
     event_data = {
         "contexts": {"monitor": get_monitor_environment_context(monitor_env)},
-        "environment": monitor_env.environment.name,
+        "environment": monitor_env.get_environment().name,
         "event_id": occurrence.event_id,
         "fingerprint": [fingerprint]
         if fingerprint

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -623,8 +623,15 @@ class MonitorEnvironment(Model):
 
     __repr__ = sane_repr("monitor_id", "environment_id")
 
+    def get_environment(self) -> Environment:
+        return Environment.objects.get(self.environment_id)
+
     def get_audit_log_data(self):
-        return {"name": self.environment.name, "status": self.status, "monitor": self.monitor.name}
+        return {
+            "name": self.get_environment().name,
+            "status": self.status,
+            "monitor": self.monitor.name,
+        }
 
     def get_last_successful_checkin(self):
         return (
@@ -655,7 +662,7 @@ class MonitorEnvironment(Model):
             [
                 "monitor",
                 str(self.monitor.guid),
-                self.environment.name,
+                self.get_environment().name,
                 str(self.last_state_change),
             ]
         )

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -624,7 +624,7 @@ class MonitorEnvironment(Model):
     __repr__ = sane_repr("monitor_id", "environment_id")
 
     def get_environment(self) -> Environment:
-        return Environment.objects.get(self.environment_id)
+        return Environment.objects.get(id=self.environment_id)
 
     def get_audit_log_data(self):
         return {

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_details.py
@@ -112,7 +112,8 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             checkin = MonitorCheckIn.objects.get(id=checkin.id)
             assert checkin.status == CheckInStatus.OK
             assert (
-                checkin.monitor_environment.environment.name == monitor_environment.environment.name
+                checkin.monitor_environment.get_environment().name
+                == monitor_environment.get_environment().name
             )
             assert checkin.timeout_at is None
 
@@ -148,7 +149,8 @@ class UpdateMonitorIngestCheckinTest(MonitorIngestTestCase):
             checkin = MonitorCheckIn.objects.get(id=checkin.id)
             assert checkin.status == CheckInStatus.OK
             assert (
-                checkin.monitor_environment.environment.name == monitor_environment.environment.name
+                checkin.monitor_environment.get_environment().name
+                == monitor_environment.get_environment().name
             )
 
             monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_index.py
@@ -156,7 +156,9 @@ class ListMonitorCheckInsTest(MonitorTestCase):
         )
         assert len(resp.data) == 1
         assert resp.data[0]["id"] == str(checkin1.guid)
-        assert resp.data[0]["environment"] == str(checkin1.monitor_environment.environment.name)
+        assert resp.data[0]["environment"] == str(
+            checkin1.monitor_environment.get_environment().name
+        )
 
     def test_bad_monitorenvironment(self):
         self.login_as(self.user)

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_environment_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_environment_details.py
@@ -22,7 +22,7 @@ class UpdateMonitorEnvironmentTest(MonitorTestCase):
         resp = self.get_success_response(
             self.organization.slug,
             monitor.slug,
-            monitor_environment.environment.name,
+            monitor_environment.get_environment().name,
             method="PUT",
             **{"isMuted": True},
         )
@@ -38,7 +38,7 @@ class UpdateMonitorEnvironmentTest(MonitorTestCase):
         resp = self.get_success_response(
             self.organization.slug,
             monitor.slug,
-            monitor_environment.environment.name,
+            monitor_environment.get_environment().name,
             method="PUT",
             **{"isMuted": False},
         )
@@ -54,7 +54,7 @@ class UpdateMonitorEnvironmentTest(MonitorTestCase):
         resp = self.get_success_response(
             self.organization.slug,
             monitor.slug,
-            monitor_environment.environment.name,
+            monitor_environment.get_environment().name,
             method="PUT",
             **{"status": "error"},
         )
@@ -83,7 +83,7 @@ class DeleteMonitorTest(MonitorTestCase):
         self.get_success_response(
             self.organization.slug,
             monitor.slug,
-            monitor_environment.environment.name,
+            monitor_environment.get_environment().name,
             method="DELETE",
             status_code=202,
         )

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -32,7 +32,8 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
 
     def check_valid_environments_response(self, response, monitor, expected_environments):
         assert {
-            monitor_environment.environment.name for monitor_environment in expected_environments
+            monitor_environment.get_environment().name
+            for monitor_environment in expected_environments
         } == {
             monitor_environment_resp["name"]
             for monitor_environment_resp in monitor.get("environments", [])

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -66,7 +66,7 @@ class MarkFailedTestCase(TestCase):
             **{
                 "level": "error",
                 "project": self.project.id,
-                "environment": monitor_environment.environment.name,
+                "environment": monitor_environment.get_environment().name,
                 "platform": "other",
                 "contexts": {
                     "monitor": {
@@ -127,7 +127,7 @@ class MarkFailedTestCase(TestCase):
             **{
                 "level": "error",
                 "project": self.project.id,
-                "environment": monitor_environment.environment.name,
+                "environment": monitor_environment.get_environment().name,
                 "platform": "other",
                 "contexts": {
                     "monitor": {
@@ -198,7 +198,7 @@ class MarkFailedTestCase(TestCase):
             **{
                 "level": "error",
                 "project": self.project.id,
-                "environment": monitor_environment.environment.name,
+                "environment": monitor_environment.get_environment().name,
                 "platform": "other",
                 "contexts": {
                     "monitor": {
@@ -289,7 +289,7 @@ class MarkFailedTestCase(TestCase):
                     {"name": "Failure reason", "value": "error", "important": True},
                     {
                         "name": "Environment",
-                        "value": monitor_environment.environment.name,
+                        "value": monitor_environment.get_environment().name,
                         "important": False,
                     },
                     {
@@ -326,7 +326,7 @@ class MarkFailedTestCase(TestCase):
                         "span_id": None,
                     },
                 },
-                "environment": monitor_environment.environment.name,
+                "environment": monitor_environment.get_environment().name,
                 "event_id": occurrence["event_id"],
                 "fingerprint": [monitor_incidents[0].grouphash],
                 "platform": "other",
@@ -403,7 +403,7 @@ class MarkFailedTestCase(TestCase):
                     {"name": "Failure reason", "value": "duration", "important": True},
                     {
                         "name": "Environment",
-                        "value": monitor_environment.environment.name,
+                        "value": monitor_environment.get_environment().name,
                         "important": False,
                     },
                     {
@@ -436,7 +436,7 @@ class MarkFailedTestCase(TestCase):
                         "slug": str(monitor.slug),
                     }
                 },
-                "environment": monitor_environment.environment.name,
+                "environment": monitor_environment.get_environment().name,
                 "event_id": occurrence["event_id"],
                 "fingerprint": [monitor_incidents[0].grouphash],
                 "platform": "other",
@@ -513,7 +513,7 @@ class MarkFailedTestCase(TestCase):
                     {"name": "Failure reason", "value": "missed_checkin", "important": True},
                     {
                         "name": "Environment",
-                        "value": monitor_environment.environment.name,
+                        "value": monitor_environment.get_environment().name,
                         "important": False,
                     },
                     {
@@ -546,7 +546,7 @@ class MarkFailedTestCase(TestCase):
                         "slug": str(monitor.slug),
                     }
                 },
-                "environment": monitor_environment.environment.name,
+                "environment": monitor_environment.get_environment().name,
                 "event_id": occurrence["event_id"],
                 "fingerprint": [monitor_incidents[0].grouphash],
                 "platform": "other",

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -285,7 +285,7 @@ class MonitorConsumerTest(TestCase):
 
         monitor_environment = MonitorEnvironment.objects.get(id=checkin.monitor_environment.id)
         assert monitor_environment.status == MonitorStatus.OK
-        assert monitor_environment.environment.name == "jungle"
+        assert monitor_environment.get_environment().name == "jungle"
         assert monitor_environment.last_checkin == checkin.date_added
         assert monitor_environment.next_checkin == monitor.get_next_expected_checkin(
             checkin.date_added
@@ -306,7 +306,7 @@ class MonitorConsumerTest(TestCase):
         monitor_environment = MonitorEnvironment.objects.get(id=checkin.monitor_environment.id)
         assert monitor_environment.status == MonitorStatus.OK
         assert monitor_environment.monitor.name == "my-new-monitor"
-        assert monitor_environment.environment.name == "production"
+        assert monitor_environment.get_environment().name == "production"
         assert monitor_environment.last_checkin == checkin.date_added
         assert (
             monitor_environment.next_checkin
@@ -411,13 +411,13 @@ class MonitorConsumerTest(TestCase):
         self.send_checkin(monitor.slug, status="in_progress")
 
         checkin = MonitorCheckIn.objects.get(guid=self.guid)
-        assert checkin.monitor_environment.environment.name == "production"
+        assert checkin.monitor_environment.get_environment().name == "production"
 
         self.send_checkin(monitor.slug, guid=self.guid, status="ok", environment="test")
 
         checkin = MonitorCheckIn.objects.get(guid=self.guid)
         assert checkin.status == CheckInStatus.IN_PROGRESS
-        assert checkin.monitor_environment.environment.name != "test"
+        assert checkin.monitor_environment.get_environment().name != "test"
 
     def test_invalid_duration(self):
         monitor = self._create_monitor(slug="my-monitor")


### PR DESCRIPTION
We want to move all crons related tables to a separate database. To facilitate this, we need to stop accessing the `MonitorEnvironment.environment` relation, and use a helper function instead.