### PR TITLE
ref(typing): AuthenticatedRequest for logged-in endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ module = [
     "sentry.api.endpoints.group_external_issues",
     "sentry.api.endpoints.group_integration_details",
     "sentry.api.endpoints.group_integrations",
-    "sentry.api.endpoints.group_notes",
     "sentry.api.endpoints.index",
     "sentry.api.endpoints.integrations.install_request",
     "sentry.api.endpoints.integrations.sentry_apps.details",

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -29,6 +29,7 @@ from sentry.api.exceptions import StaffRequired, SuperuserRequired
 from sentry.apidocs.hooks import HTTP_METHOD_NAME
 from sentry.auth import access
 from sentry.models.environment import Environment
+from sentry.models.user import User
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
 from sentry.silo import SiloLimit, SiloMode
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -688,3 +689,7 @@ Apply to endpoints that are available in all silo modes.
 
 This should be rarely used, but is relevant for resources like ROBOTS.txt.
 """
+
+
+class AuthenticatedRequest(Request):
+    user: User

--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -59,7 +59,6 @@ class GroupEndpoint(Endpoint):
             bind_organization_context(organization)
 
             request._request.organization = organization  # type: ignore[attr-defined]
-
         else:
             organization = None
 

--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -59,6 +59,7 @@ class GroupEndpoint(Endpoint):
             bind_organization_context(organization)
 
             request._request.organization = organization  # type: ignore[attr-defined]
+
         else:
             organization = None
 

--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -2,11 +2,10 @@ from datetime import timedelta
 
 from django.utils import timezone
 from rest_framework import status
-from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import region_silo_endpoint
+from sentry.api.base import AuthenticatedRequest, region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
@@ -25,7 +24,7 @@ class GroupNotesEndpoint(GroupEndpoint):
         "POST": ApiPublishStatus.UNKNOWN,
     }
 
-    def get(self, request: Request, group) -> Response:
+    def get(self, request: AuthenticatedRequest, group) -> Response:
         notes = Activity.objects.filter(group=group, type=ActivityType.NOTE.value)
 
         return self.paginate(
@@ -36,7 +35,7 @@ class GroupNotesEndpoint(GroupEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
 
-    def post(self, request: Request, group) -> Response:
+    def post(self, request: AuthenticatedRequest, group) -> Response:
         serializer = NoteSerializer(
             data=request.data,
             context={


### PR DESCRIPTION
as described [here](https://github.com/typeddjango/django-stubs?tab=readme-ov-file#how-can-i-create-a-httprequest-thats-guaranteed-to-have-an-authenticated-user)

We can use some kind of `AuthenticatedRequest` for the type of request when we know user is logged in. I'm not sure if there's a better way, but wanted to get this PR up to test. fixes the `group_notes` endpoint as an example here, as a function it calls expects only `User`, but the default request.user is `User | AnonymousUser`.