### PR TITLE
fix(ddm): fog of war displayed in the past

### DIFF
--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -451,6 +451,7 @@ export type Series = {
   unit: string;
   groupBy?: Record<string, string>;
   hidden?: boolean;
+  paddingIndices?: Set<number>;
   release?: string;
   transaction?: string;
 };


### PR DESCRIPTION
Fix calculation of buckets that are most likely affected by ingestion delay.
It will now properly displayed for time selections that where the end time is in the future or in the past.

<img width="1107" alt="Screenshot 2024-02-16 at 10 42 13" src="https://github.com/getsentry/sentry/assets/7033940/cd363f0c-957e-4e2d-a4f3-f0e82b2d6164">
