### PR TITLE
feat(stacktrace): icon mapping for ps1 psm1

### DIFF
--- a/static/app/utils/fileExtension.tsx
+++ b/static/app/utils/fileExtension.tsx
@@ -21,6 +21,8 @@ const FILE_EXTENSION_TO_PLATFORM = {
   cs: 'csharp',
   fs: 'fsharp',
   vb: 'visualbasic',
+  ps1: 'powershell',
+  psm1: 'powershell',
   kt: 'kotlin',
   dart: 'dart',
   sc: 'scala',


### PR DESCRIPTION
Example event showing C# instead of PS: https://sentry-sdks.sentry.io/issues/4979596900/events/e48b8c28092e472ca09109ae29a27d4f/

<img width="581" alt="image" src="https://github.com/getsentry/sentry/assets/1633368/244628a5-218d-4495-bb25-e54b01c0a0e6">

Depends on (Released as version: [5.10.2](https://github.com/getsentry/platformicons/commit/32b9afb7e956dcbbdedb5ae2517fa1a2d49b5aeb)):
* https://github.com/getsentry/platformicons/pull/142

Merge first:
* https://github.com/getsentry/sentry/pull/65319

