### PR TITLE
perf(metrics): Sample the sample list query

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2104,3 +2104,9 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "metrics.sample-list.sample-rate",
+    type=Float,
+    default=100_000.0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
For long date ranges and lots of data, the query can easily time out. By introducing a sample rate, we can limit the amount of data ClickHouse scans to increase the performance of the query. Since we're just returning example span ids, and it's not realistic to paginate through all spans, this should have a pretty minimal impact on the overall experience of the results.