### PR TITLE
ref: fix incorrect assert in reprocessing2 test

### DIFF
--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -97,7 +97,7 @@ def reprocess_group(
                         start_time=start_time,
                     )
                 except CannotReprocess as e:
-                    logger.error("reprocessing2.%s", e)
+                    logger.error("reprocessing2.%s", str(e))
                 except Exception:
                     sentry_sdk.capture_exception()
                 else:

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -464,7 +464,7 @@ def test_nodestore_missing(
             GroupRedirect.objects.get(previous_group_id=old_group.id).group_id == new_event.group_id
         )
 
-    assert mock_logger.error.called_with("reprocessing2.unprocessed_event.not_found")
+    mock_logger.error.assert_called_once_with("reprocessing2.%s", "unprocessed_event.not_found")
 
 
 @django_db_all


### PR DESCRIPTION
<!-- Describe your PR here. -->

`assert <mock_object>.called_with` will always succeed, in python 3.12 it becomes an error since it is almost always a programming mistake