### PR TITLE
chore: Track TSDB backend usage

### DIFF
--- a/src/sentry/tsdb/redissnuba.py
+++ b/src/sentry/tsdb/redissnuba.py
@@ -1,6 +1,8 @@
 import inspect
 import time
 
+import sentry_sdk
+
 from sentry.tsdb.base import BaseTSDB, TSDBModel
 from sentry.tsdb.dummy import DummyTSDB
 from sentry.tsdb.redis import RedisTSDB
@@ -80,6 +82,10 @@ def make_method(key):
     def method(self, *a, **kw):
         callargs = inspect.getcallargs(getattr(BaseTSDB, key), self, *a, **kw)
         backend = selector_func(key, callargs, self.switchover_timestamp)
+
+        sentry_sdk.set_tag("tsdb.backend", backend)
+        sentry_sdk.set_tag("tsdb.method", key)
+
         return getattr(self.backends[backend], key)(*a, **kw)
 
     return method

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -107,7 +107,7 @@ class JiraInstalledTest(APITestCase):
         )
         integration = Integration.objects.get(provider="jira", external_id=self.external_id)
 
-        mock_set_tag.assert_called_with("integration_id", integration.id)
+        mock_set_tag.assert_any_call("integration_id", integration.id)
         assert integration.status == ObjectStatus.ACTIVE
 
     @patch("sentry_sdk.set_tag")
@@ -121,5 +121,5 @@ class JiraInstalledTest(APITestCase):
         )
         integration = Integration.objects.get(provider="jira", external_id=self.external_id)
 
-        mock_set_tag.assert_called_with("integration_id", integration.id)
+        mock_set_tag.assert_any_call("integration_id", integration.id)
         assert integration.status == ObjectStatus.ACTIVE

--- a/tests/sentry/integrations/jira/test_uninstalled.py
+++ b/tests/sentry/integrations/jira/test_uninstalled.py
@@ -66,7 +66,7 @@ class JiraUninstalledTest(APITestCase):
         # We have to pull this from the DB again to see the updated status
         integration = Integration.objects.get(id=integration.id)
 
-        mock_set_tag.assert_called_with("integration_id", integration.id)
+        mock_set_tag.assert_any_call("integration_id", integration.id)
         with assume_test_silo_mode(SiloMode.REGION):
             mock_bind_org_context.assert_called_with(serialize_rpc_organization(org))
         assert integration.status == ObjectStatus.DISABLED
@@ -95,7 +95,7 @@ class JiraUninstalledTest(APITestCase):
         # We have to pull this from the DB again to see the updated status
         integration = Integration.objects.get(id=integration.id)
 
-        mock_set_tag.assert_called_with("integration_id", integration.id)
+        mock_set_tag.assert_any_call("integration_id", integration.id)
         with assume_test_silo_mode(SiloMode.REGION):
             mock_bind_org_context.assert_called_with(serialize_rpc_organization(org))
         assert integration.status == ObjectStatus.DISABLED

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -174,7 +174,7 @@ class JiraIssueUpdatedWebhookTest(APITestCase):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
             self.get_success_response(**data, extra_headers=dict(HTTP_AUTHORIZATION=TOKEN))
 
-            mock_set_tag.assert_called_with("integration_id", self.integration.id)
+            mock_set_tag.assert_any_call("integration_id", self.integration.id)
             mock_bind_org_context.assert_called_with(serialize_rpc_organization(self.organization))
 
     def test_missing_changelog(self):


### PR DESCRIPTION
Collect tags to get a quick sense of which backends
we hit with tsdb.