### PR TITLE
feat(metrics): Support transaction duration samples

### DIFF
--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1000,6 +1000,50 @@ class DiscoverDatasetConfig(DatasetConfig):
                     snql_aggregate=self._resolve_count_scores_function,
                     default_result_type="integer",
                 ),
+                SnQLFunction(
+                    "example",
+                    snql_aggregate=lambda args, alias: Function(
+                        "arrayElement",
+                        [
+                            Function(
+                                "groupArraySample(1, 1)",  # TODO: paginate via the seed
+                                [
+                                    Function(
+                                        "tuple",
+                                        [Column("timestamp"), Column("span_id")],
+                                    ),
+                                ],
+                            ),
+                            1,
+                        ],
+                        alias,
+                    ),
+                    private=True,
+                ),
+                SnQLFunction(
+                    "rounded_timestamp",
+                    required_args=[IntervalDefault("interval", 1, None)],
+                    snql_column=lambda args, alias: Function(
+                        "toUInt32",
+                        [
+                            Function(
+                                "multiply",
+                                [
+                                    Function(
+                                        "intDiv",
+                                        [
+                                            Function("toUInt32", [Column("timestamp")]),
+                                            args["interval"],
+                                        ],
+                                    ),
+                                    args["interval"],
+                                ],
+                            ),
+                        ],
+                        alias,
+                    ),
+                    private=True,
+                ),
             ]
         }
 

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -211,6 +211,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                         ],
                         alias,
                     ),
+                    private=True,
                 ),
                 SnQLFunction(
                     "rounded_timestamp",
@@ -234,6 +235,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                         ],
                         alias,
                     ),
+                    private=True,
                 ),
             ]
         }

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1517,6 +1517,7 @@ class BaseSpansTestCase(SnubaTestCase):
         timestamp: datetime | None = None,
         store_only_summary: bool = False,
         store_metrics_summary: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
+        group: str = "00",
     ):
         if span_id is None:
             span_id = self._random_span_id()
@@ -1532,7 +1533,11 @@ class BaseSpansTestCase(SnubaTestCase):
             "is_segment": False,
             "received": datetime.now(tz=timezone.utc).timestamp(),
             "start_timestamp_ms": int(timestamp.timestamp() * 1000),
-            "sentry_tags": {"transaction": transaction or "/hello", "op": op or "http"},
+            "sentry_tags": {
+                "transaction": transaction or "/hello",
+                "op": op or "http",
+                "group": group,
+            },
             "retention_days": 90,
         }
 

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -21,6 +21,7 @@ from sentry.testutils.cases import APITestCase, BaseSpansTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
+from sentry.utils.samples import load_data
 
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
@@ -103,44 +104,13 @@ class OrganizationMetricsPermissionTest(APITestCase):
 
 
 @region_silo_test
-class OrganizationMetricsSamplesEndpointTest(APITestCase, BaseSpansTestCase):
+class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
     view = "sentry-api-0-organization-metrics-samples"
     default_features = ["organizations:metrics-samples-list"]
 
     def setUp(self):
+        super().setUp()
         self.login_as(user=self.user)
-
-    def create_span(self, **kwargs):
-        start_ts = kwargs.get("start_ts") or before_now(minutes=10)
-        duration = kwargs.get("duration") or 1000
-        self_time = kwargs.get("self_time") or duration
-
-        sentry_tags = kwargs.get("sentry_tags") or {}
-        if "group" not in sentry_tags:
-            sentry_tags["group"] = kwargs.get("group") or uuid4().hex[:16]
-
-        return {
-            "organization_id": self.organization.id,
-            "project_id": self.project.id,
-            "event_id": kwargs.get("event_id") or uuid4().hex,
-            "trace_id": kwargs.get("trace_id") or uuid4().hex,
-            "span_id": kwargs.get("span_id") or uuid4().hex[:16],
-            "parent_span_id": kwargs.get("parent_span_id") or uuid4().hex[:16],
-            "segment_id": kwargs.get("segment_id") or uuid4().hex[:16],
-            "group_raw": kwargs.get("group_raw") or uuid4().hex[:16],
-            "profile_id": kwargs.get("profile_id") or uuid4().hex,
-            "is_segment": kwargs.get("is_segment", False),
-            # Multiply by 1000 cause it needs to be ms
-            "start_timestamp_ms": int(start_ts.timestamp() * 1000),
-            "timestamp": int(start_ts.timestamp() * 1000),
-            "received": start_ts.timestamp(),
-            "duration_ms": duration,
-            "exclusive_time_ms": self_time,
-            "retention_days": 90,
-            "tags": kwargs.get("tags") or {},
-            "sentry_tags": sentry_tags,
-            "measurements": kwargs.get("measurements") or {},
-        }
 
     def do_request(self, query, features=None, **kwargs):
         if features is None:
@@ -191,8 +161,16 @@ class OrganizationMetricsSamplesEndpointTest(APITestCase, BaseSpansTestCase):
         }
 
     def test_span_duration_samples(self):
-        spans = [self.create_span(start_ts=before_now(days=i, minutes=10)) for i in range(10)]
-        self.store_spans(spans)
+        span_ids = [uuid4().hex[:16] for _ in range(10)]
+        for i, span_id in enumerate(span_ids):
+            self.store_indexed_span(
+                self.project.id,
+                uuid4().hex,
+                uuid4().hex,
+                span_id=span_id,
+                timestamp=before_now(days=i, minutes=10),
+                group=uuid4().hex[:16],  # we need a non 0 group
+            )
 
         query = {
             "mri": "d:spans/duration@millisecond",
@@ -202,6 +180,40 @@ class OrganizationMetricsSamplesEndpointTest(APITestCase, BaseSpansTestCase):
         }
         response = self.do_request(query)
         assert response.status_code == 200, response.data
-        expected = {int(span["span_id"], 16) for span in spans}
+        expected = {int(span_id, 16) for span_id in span_ids}
+        actual = {int(row["id"], 16) for row in response.data["data"]}
+        assert actual == expected
+
+    def test_transaction_duration_samples(self):
+        span_ids = [uuid4().hex[:16] for _ in range(1)]
+        for i, span_id in enumerate(span_ids):
+            ts = before_now(days=i, minutes=10)
+
+            # first write to the transactions dataset
+            data = load_data("transaction", timestamp=ts)
+            data["contexts"]["trace"]["span_id"] = span_id
+            self.store_event(
+                data=data,
+                project_id=self.project.id,
+            )
+
+            # next write to the spans dataset
+            self.store_segment(
+                self.project.id,
+                uuid4().hex,
+                uuid4().hex,
+                span_id=span_id,
+                timestamp=ts,
+            )
+
+        query = {
+            "mri": "d:transactions/duration@millisecond",
+            "field": ["id"],
+            "project": [self.project.id],
+            "statsPeriod": "14d",
+        }
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+        expected = {int(span_id, 16) for span_id in span_ids}
         actual = {int(row["id"], 16) for row in response.data["data"]}
         assert actual == expected


### PR DESCRIPTION
This adds support for fetching samples for the transaction duration metric.

Closes #65002