### PR TITLE
feat: colima robustness enhancements part 1

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -174,7 +174,7 @@ s3transfer==0.10.0
 selenium==4.16.0
 sentry-arroyo==2.16.0
 sentry-cli==2.16.0
-sentry-devenv==1.2.2
+sentry-devenv==1.2.3
 sentry-forked-django-stubs==4.2.7.post3
 sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.50

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
-sentry-devenv>=1.2.2
+sentry-devenv>=1.2.3
 
 covdefaults>=2.3.0
 docker>=6

--- a/scripts/start-colima.py
+++ b/scripts/start-colima.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 import os
 import platform
 import subprocess
-import sys
 from collections.abc import Sequence
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    # platform.processor() changed at some point between these:
-    # 11.2.3: arm
-    # 12.3.1: arm64
-    APPLE_ARM64 = sys.platform == "darwin" and platform.processor() in {"arm", "arm64"}
+    macos_version = platform.mac_ver()[0]
+    macos_major_version = int(macos_version.split(".")[0])
+    if macos_major_version < 14:
+        raise SystemExit(f"macos >= 14 is required to use colima, found {macos_version}")
 
     cpus = os.cpu_count()
     if cpus is None:
@@ -31,7 +30,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--memory",
         f"{memsize_bytes//(2*1024**3)}",
     ]
-    if APPLE_ARM64:
+    if platform.machine() == "arm64":
         args = [*args, "--vm-type=vz", "--vz-rosetta", "--mount-type=virtiofs"]
     HOME = os.path.expanduser("~")
     rc = subprocess.call(

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import http
 import os
-import platform
 import signal
 import subprocess
 import sys
@@ -22,24 +21,20 @@ if TYPE_CHECKING:
 # assigned as a constant so mypy's "unreachable" detection doesn't fail on linux
 # https://github.com/python/mypy/issues/12286
 DARWIN = sys.platform == "darwin"
-
-# platform.processor() changed at some point between these:
-# 11.2.3: arm
-# 12.3.1: arm64
-APPLE_ARM64 = DARWIN and platform.processor() in {"arm", "arm64"}
-
 COLIMA = os.path.expanduser("~/.local/share/sentry-devenv/bin/colima")
 USE_COLIMA = os.path.exists(COLIMA) and os.environ.get("SENTRY_USE_COLIMA") != "0"
 
 # TODO: USE_ORBSTACK
 USE_DOCKER_DESKTOP = not USE_COLIMA
 
-if USE_COLIMA:
-    RAW_SOCKET_PATH = os.path.expanduser("~/.colima/default/docker.sock")
-elif USE_DOCKER_DESKTOP:
-    RAW_SOCKET_PATH = os.path.expanduser("~/.docker/run/docker.sock")
+if DARWIN:
+    if USE_COLIMA:
+        RAW_SOCKET_PATH = os.path.expanduser("~/.colima/default/docker.sock")
+    elif USE_DOCKER_DESKTOP:
+        # /var/run/docker.sock is now gated behind a docker desktop advanced setting
+        RAW_SOCKET_PATH = os.path.expanduser("~/.docker/run/docker.sock")
+    # TODO: USE_ORBSTACK
 else:
-    # this is now gated behind a docker desktop advanced setting
     RAW_SOCKET_PATH = "/var/run/docker.sock"
 
 


### PR DESCRIPTION
this addresses some of the recent issues with colima and docker desktop

- colima requires macos 14+ now so i've blocked start-colima with that
- newer versions of docker desktop no longer listen at /var/run/docker.sock, this is now gated behind an advanced opt-in feature
- upgrades devenv to 1.2.3 so that we can install repo-local colima 0.6.8