### PR TITLE
chore(team-org-roles): remove feature-flagged ability to set team org role

### DIFF
--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -95,12 +95,8 @@ class TeamEditAuditLogEvent(AuditLogEvent):
         super().__init__(event_id=21, name="TEAM_EDIT", api_name="team.edit")
 
     def render(self, audit_log_entry: AuditLogEntry):
-        old_org_role = audit_log_entry.data.get("old_org_role")
-        new_org_role = audit_log_entry.data.get("org_role")
         slug = audit_log_entry.data["slug"]
 
-        if old_org_role != new_org_role:
-            return f"edited team {slug}'s org role to {new_org_role}"
         return f"edited team {slug}"
 
 

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -1,16 +1,13 @@
 from sentry import audit_log
-from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.deletedteam import DeletedTeam
 from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.models.team import Team, TeamStatus
 from sentry.services.hybrid_cloud.log.service import log_rpc_service
-from sentry.silo import SiloMode
 from sentry.slug.errors import DEFAULT_SLUG_ERROR_MESSAGE
-from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
 class TeamDetailsTestBase(APITestCase):
@@ -187,163 +184,6 @@ class TeamUpdateTest(TeamDetailsTestBase):
         team = Team.objects.get(id=team.id)
         assert team.name == "foo"
         assert team.slug == "bar"
-
-    @with_feature("organizations:org-roles-for-teams")
-    def test_put_team_org_role__success(self):
-        team = self.team
-        user = self.create_user("foo@example.com")
-
-        self.create_member(user=user, organization=self.organization, role="owner")
-        self.login_as(user)
-
-        with outbox_runner():
-            self.get_success_response(team.organization.slug, team.slug, orgRole="owner")
-
-        team = Team.objects.get(id=team.id)
-        assert team.org_role == "owner"
-
-        data = {
-            "id": team.id,
-            "slug": team.slug,
-            "name": team.name,
-            "status": team.status,
-            "org_role": "owner",
-            "old_org_role": None,
-        }
-        assert_org_audit_log_exists(
-            organization=self.organization,
-            event=audit_log.get_event_id("TEAM_EDIT"),
-            data=data,
-        )
-
-        test_team_edit = audit_log.get(21)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            entry = AuditLogEntry.objects.get(event=21)
-        assert test_team_edit.render(entry) == f"edited team {team.slug}'s org role to owner"
-
-    def test_put_team_org_role__missing_flag(self):
-        # the put goes through but doesn't update the org role field
-        team = self.team
-        user = self.create_user("foo@example.com")
-
-        self.create_member(user=user, organization=self.organization, role="owner")
-        self.login_as(user)
-
-        with outbox_runner():
-            self.get_success_response(team.organization.slug, team.slug, orgRole="owner")
-
-        team = Team.objects.get(id=team.id)
-        assert not team.org_role
-        test_team_edit = audit_log.get(21)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            entry = AuditLogEntry.objects.get(event=21)
-        assert test_team_edit.render(entry) == f"edited team {team.slug}"
-
-    @with_feature("organizations:org-roles-for-teams")
-    def test_put_team_org_role__success_with_org_role_from_team(self):
-        team = self.team
-        user = self.create_user("foo@example.com")
-        member_team = self.create_team(org_role="owner")
-
-        self.create_member(
-            user=user, organization=self.organization, role="member", teams=[member_team]
-        )
-        self.login_as(user)
-
-        self.get_success_response(team.organization.slug, team.slug, orgRole="owner")
-
-        team = Team.objects.get(id=team.id)
-        assert team.org_role == "owner"
-
-    @with_feature("organizations:org-roles-for-teams")
-    def test_put_team_org_role__member(self):
-        team = self.team
-        user = self.create_user("foo@example.com")
-
-        self.create_member(user=user, organization=self.organization, role="member")
-        self.login_as(user)
-
-        response = self.get_error_response(
-            team.organization.slug, team.slug, orgRole="owner", status_code=403
-        )
-        assert response.data["detail"] == "You do not have permission to perform this action."
-
-        team = Team.objects.get(id=team.id)
-        assert not team.org_role
-
-    @with_feature("organizations:org-roles-for-teams")
-    def test_put_team_org_role__manager(self):
-        team = self.team
-        user = self.create_user("foo@example.com")
-
-        self.create_member(user=user, organization=self.organization, role="manager")
-        self.login_as(user)
-
-        response = self.get_error_response(
-            team.organization.slug, team.slug, orgRole="owner", status_code=403
-        )
-        assert response.data["detail"] == "You must have the role of owner to perform this action."
-
-        team = Team.objects.get(id=team.id)
-        assert not team.org_role
-
-    @with_feature("organizations:org-roles-for-teams")
-    def test_put_team_org_role__invalid_role(self):
-        team = self.team
-        user = self.create_user("foo@example.com")
-
-        self.create_member(user=user, organization=self.organization, role="owner")
-        self.login_as(user)
-
-        self.get_error_response(team.organization.slug, team.slug, orgRole="onwer", status_code=400)
-
-        team = Team.objects.get(id=team.id)
-        assert not team.org_role
-
-    @with_feature("organizations:org-roles-for-teams")
-    def test_put_team_org_role__idp_provisioned_team(self):
-        team = self.create_team(idp_provisioned=True)
-        user = self.create_user("foo@example.com")
-
-        self.create_member(user=user, organization=self.organization, role="owner")
-        self.login_as(user)
-
-        response = self.get_error_response(
-            team.organization.slug, team.slug, orgRole="owner", status_code=403
-        )
-
-        assert (
-            response.data["detail"]
-            == "This team is managed through your organization's identity provider."
-        )
-        team = Team.objects.get(id=team.id)
-        assert not team.org_role
-
-    @with_feature("organizations:org-roles-for-teams")
-    def test_put_team_org_role__remove_success(self):
-        team = self.create_team(org_role="owner")
-        user = self.create_user("foo@example.com")
-
-        self.create_member(user=user, organization=self.organization, role="owner")
-        self.login_as(user)
-
-        self.get_success_response(team.organization.slug, team.slug, orgRole="")
-
-        team = Team.objects.get(id=team.id)
-        assert not team.org_role
-
-    @with_feature("organizations:org-roles-for-teams")
-    def test_put_team_org_role__remove_error(self):
-        team = self.create_team(org_role="owner")
-        user = self.create_user("foo@example.com")
-
-        self.create_member(user=user, organization=self.organization, role="admin")
-        self.login_as(user)
-
-        self.get_error_response(team.organization.slug, team.slug, orgRole="", status_code=403)
-
-        team = Team.objects.get(id=team.id)
-        assert team.org_role == "owner"
 
 
 @region_silo_test


### PR DESCRIPTION
This feature flag was never enabled for anyone except my test org, and we're also removing the feature. Also 0 teams have a non-null `org_role`.

For https://github.com/getsentry/team-core-product-foundations/issues/51