### PR TITLE
chore(inbound-filters): Reorder legacy browser filters

### DIFF
--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -181,14 +181,14 @@ describe('ProjectFilters', function () {
     expect(mock.mock.calls[0][0]).toBe(getFilterEndpoint(filter));
     expect(Array.from(mock.mock.calls[0][1].data.subfilters)).toEqual([
       'safari_pre_6',
-      'opera_pre_15',
-      'opera_mini_pre_8',
+      'android_pre_4',
       'edge_pre_79',
       'ie_pre_9',
       'ie9',
       'ie10',
       'ie11',
-      'android_pre_4',
+      'opera_pre_15',
+      'opera_mini_pre_8',
     ]);
 
     await userEvent.click(screen.getByRole('button', {name: 'None'}));

--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -180,15 +180,15 @@ describe('ProjectFilters', function () {
     await userEvent.click(await screen.findByRole('button', {name: 'All'}));
     expect(mock.mock.calls[0][0]).toBe(getFilterEndpoint(filter));
     expect(Array.from(mock.mock.calls[0][1].data.subfilters)).toEqual([
+      'safari_pre_6',
+      'opera_pre_15',
+      'opera_mini_pre_8',
+      'edge_pre_79',
       'ie_pre_9',
       'ie9',
       'ie10',
       'ie11',
-      'safari_pre_6',
-      'opera_pre_15',
-      'opera_mini_pre_8',
       'android_pre_4',
-      'edge_pre_79',
     ]);
 
     await userEvent.click(screen.getByRole('button', {name: 'None'}));

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -102,28 +102,16 @@ const LEGACY_BROWSER_SUBFILTERS = {
     helpText: 'Version 66 and lower',
     legacy: false,
   },
-  opera: {
-    icon: iconOpera,
-    title: 'Opera',
-    helpText: 'Version 50 and lower',
+  android: {
+    icon: iconAndroid,
+    title: 'Android',
+    helpText: 'Version 3 and lower',
     legacy: false,
   },
-  opera_pre_15: {
-    icon: iconOpera,
-    helpText: '(Deprecated) Version 14 and lower',
-    title: 'Opera',
-    legacy: true,
-  },
-  opera_mini: {
-    icon: iconOpera,
-    title: 'Opera Mini',
-    helpText: 'Version 34 and lower',
-    legacy: false,
-  },
-  opera_mini_pre_8: {
-    icon: iconOpera,
-    helpText: '(Deprecated) Version 8 and lower',
-    title: 'Opera Mini',
+  android_pre_4: {
+    icon: iconAndroid,
+    helpText: '(Deprecated) Version 3 and lower',
+    title: 'Android',
     legacy: true,
   },
   edge: {
@@ -168,16 +156,28 @@ const LEGACY_BROWSER_SUBFILTERS = {
     title: 'Internet Explorer',
     legacy: true,
   },
-  android: {
-    icon: iconAndroid,
-    title: 'Android',
-    helpText: 'Version 3 and lower',
+  opera: {
+    icon: iconOpera,
+    title: 'Opera',
+    helpText: 'Version 50 and lower',
     legacy: false,
   },
-  android_pre_4: {
-    icon: iconAndroid,
-    helpText: '(Deprecated) Version 3 and lower',
-    title: 'Android',
+  opera_pre_15: {
+    icon: iconOpera,
+    helpText: '(Deprecated) Version 14 and lower',
+    title: 'Opera',
+    legacy: true,
+  },
+  opera_mini: {
+    icon: iconOpera,
+    title: 'Opera Mini',
+    helpText: 'Version 34 and lower',
+    legacy: false,
+  },
+  opera_mini_pre_8: {
+    icon: iconOpera,
+    helpText: '(Deprecated) Version 8 and lower',
+    title: 'Opera Mini',
     legacy: true,
   },
 };

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -78,6 +78,72 @@ const filterDescriptions = {
 };
 
 const LEGACY_BROWSER_SUBFILTERS = {
+  chrome: {
+    icon: iconChrome,
+    title: 'Chrome',
+    helpText: 'Version 62 and lower',
+    legacy: false,
+  },
+  safari: {
+    icon: iconSafari,
+    title: 'Safari',
+    helpText: 'Version 11 and lower',
+    legacy: false,
+  },
+  safari_pre_6: {
+    icon: iconSafari,
+    helpText: '(Deprecated) Version 5 and lower',
+    title: 'Safari',
+    legacy: true,
+  },
+  firefox: {
+    icon: iconFirefox,
+    title: 'Firefox',
+    helpText: 'Version 66 and lower',
+    legacy: false,
+  },
+  opera: {
+    icon: iconOpera,
+    title: 'Opera',
+    helpText: 'Version 50 and lower',
+    legacy: false,
+  },
+  opera_pre_15: {
+    icon: iconOpera,
+    helpText: '(Deprecated) Version 14 and lower',
+    title: 'Opera',
+    legacy: true,
+  },
+  opera_mini: {
+    icon: iconOpera,
+    title: 'Opera Mini',
+    helpText: 'Version 34 and lower',
+    legacy: false,
+  },
+  opera_mini_pre_8: {
+    icon: iconOpera,
+    helpText: '(Deprecated) Version 8 and lower',
+    title: 'Opera Mini',
+    legacy: true,
+  },
+  edge: {
+    icon: iconEdgeLegacy,
+    title: 'Edge',
+    helpText: 'Version 78 and lower',
+    legacy: false,
+  },
+  edge_pre_79: {
+    icon: iconEdgeLegacy,
+    helpText: '(Deprecated) Version 18 and lower',
+    title: 'Edge (Legacy)',
+    legacy: true,
+  },
+  ie: {
+    icon: iconIe,
+    title: 'Internet Explorer',
+    helpText: 'Verison 11 and lower',
+    legacy: false,
+  },
   ie_pre_9: {
     icon: iconIe,
     helpText: '(Deprecated) Version 8 and lower',
@@ -102,83 +168,17 @@ const LEGACY_BROWSER_SUBFILTERS = {
     title: 'Internet Explorer',
     legacy: true,
   },
-  safari_pre_6: {
-    icon: iconSafari,
-    helpText: '(Deprecated) Version 5 and lower',
-    title: 'Safari',
-    legacy: true,
-  },
-  opera_pre_15: {
-    icon: iconOpera,
-    helpText: '(Deprecated) Version 14 and lower',
-    title: 'Opera',
-    legacy: true,
-  },
-  opera_mini_pre_8: {
-    icon: iconOpera,
-    helpText: '(Deprecated) Version 8 and lower',
-    title: 'Opera Mini',
-    legacy: true,
-  },
-  android_pre_4: {
-    icon: iconAndroid,
-    helpText: '(Deprecated) Version 3 and lower',
-    title: 'Android',
-    legacy: true,
-  },
-  edge_pre_79: {
-    icon: iconEdgeLegacy,
-    helpText: '(Deprecated) Version 18 and lower',
-    title: 'Edge (Legacy)',
-    legacy: true,
-  },
-  ie: {
-    icon: iconIe,
-    title: 'Internet Explorer',
-    helpText: 'Verison 11 and lower',
-    legacy: false,
-  },
-  safari: {
-    icon: iconSafari,
-    title: 'Safari',
-    helpText: 'Version 11 and lower',
-    legacy: false,
-  },
-  opera: {
-    icon: iconOpera,
-    title: 'Opera',
-    helpText: 'Version 50 and lower',
-    legacy: false,
-  },
-  opera_mini: {
-    icon: iconOpera,
-    title: 'Opera Mini',
-    helpText: 'Version 34 and lower',
-    legacy: false,
-  },
   android: {
     icon: iconAndroid,
     title: 'Android',
     helpText: 'Version 3 and lower',
     legacy: false,
   },
-  edge: {
-    icon: iconEdgeLegacy,
-    title: 'Edge',
-    helpText: 'Version 78 and lower',
-    legacy: false,
-  },
-  firefox: {
-    icon: iconFirefox,
-    title: 'Firefox',
-    helpText: 'Version 66 and lower',
-    legacy: false,
-  },
-  chrome: {
-    icon: iconChrome,
-    title: 'Chrome',
-    helpText: 'Version 62 and lower',
-    legacy: false,
+  android_pre_4: {
+    icon: iconAndroid,
+    helpText: '(Deprecated) Version 3 and lower',
+    title: 'Android',
+    legacy: true,
   },
 };
 


### PR DESCRIPTION
this pr reorders the legacy browser filters. instead of having all the old ones then the new ones, now they are ordered by browser. They are mostly ordered by popularity, with Edge being moved lower to be near IE. 