### PR TITLE
ref: default selenium_driver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ markers = [
     "sentry_metrics: test requires access to sentry metrics",
     "symbolicator: test requires access to symbolicator",
 ]
-selenium_driver = "chrome"
 filterwarnings = [
     # Consider all warnings to be errors other than the ignored ones.
     "error",

--- a/src/sentry/testutils/pytest/selenium.py
+++ b/src/sentry/testutils/pytest/selenium.py
@@ -348,6 +348,7 @@ def pytest_addoption(parser):
     group._addoption(
         "--selenium-driver",
         dest="selenium_driver",
+        default="chrome",
         help="selenium driver (chrome, or firefox)",
     )
     group._addoption(


### PR DESCRIPTION
this makes pytest not/a/test produce the correct output instead of crashing:

```console
$ pytest src/sentry/utils/json.py -q

no tests ran in 0.03s
```

<!-- Describe your PR here. -->