### PR TITLE
chore(team-org-roles): remove "get_all_org_roles" from OrganizationMember

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -41,9 +41,8 @@ class EventAttachmentDetailsPermission(ProjectPermission):
             return False
 
         required_role = roles.get(required_role)
-        return any(
-            role.priority >= required_role.priority for role in om.get_all_org_roles_sorted()
-        )
+        om_role = roles.get(om.role)
+        return om_role.priority >= required_role.priority
 
 
 @region_silo_endpoint

--- a/src/sentry/api/endpoints/organization_member/__init__.py
+++ b/src/sentry/api/endpoints/organization_member/__init__.py
@@ -76,8 +76,8 @@ def can_set_team_role(request: Request, team: Team, new_role: TeamRole) -> bool:
     if not can_admin_team(access, team):
         return False
 
-    org_roles = access.get_organization_roles()
-    if any(org_role.can_manage_team_role(new_role) for org_role in org_roles):
+    org_role = access.get_organization_role()
+    if org_role.can_manage_team_role(new_role):
         return True
 
     team_role = access.get_team_role(team)

--- a/src/sentry/api/endpoints/organization_member/__init__.py
+++ b/src/sentry/api/endpoints/organization_member/__init__.py
@@ -77,7 +77,7 @@ def can_set_team_role(request: Request, team: Team, new_role: TeamRole) -> bool:
         return False
 
     org_role = access.get_organization_role()
-    if org_role.can_manage_team_role(new_role):
+    if org_role and org_role.can_manage_team_role(new_role):
         return True
 
     team_role = access.get_team_role(team)

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -412,12 +412,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                     if not request.access.has_scope("member:admin"):
                         return Response({"detail": ERR_INSUFFICIENT_SCOPE}, status=400)
                     else:
-                        can_manage = False
-                        # check org roles through teams
-                        for role in acting_member.get_all_org_roles():
-                            if roles.can_manage(role, member.role):
-                                can_manage = True
-                                break
+                        can_manage = roles.can_manage(acting_member.role, member.role)
 
                         if not can_manage:
                             return Response({"detail": ERR_INSUFFICIENT_ROLE}, status=400)

--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -88,9 +88,9 @@ def _has_elevated_scope(access: Access) -> bool:
 
 
 def _is_org_owner_or_manager(access: Access) -> bool:
-    roles = access.get_organization_roles()
+    role = access.get_organization_role()
     # only org owners and managers have org:write scope
-    return any("org:write" in role.scopes for role in roles)
+    return "org:write" in role.scopes if role else False
 
 
 @extend_schema(tags=["Teams"])

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -142,8 +142,6 @@ class Access(abc.ABC):
         return None
 
     def get_organization_roles(self) -> Iterable[OrganizationRole]:
-        if self.roles is not None:
-            return [organization_roles.get(r) for r in self.roles]
         return []
 
     @abc.abstractmethod

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -135,14 +135,10 @@ class Access(abc.ABC):
         """
         return scope in self.scopes
 
-    # TODO(cathy): remove this
     def get_organization_role(self) -> OrganizationRole | None:
         if self.role is not None:
             return organization_roles.get(self.role)
         return None
-
-    def get_organization_roles(self) -> Iterable[OrganizationRole]:
-        return []
 
     @abc.abstractmethod
     def has_role_in_organization(

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -99,11 +99,6 @@ class Access(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def roles(self) -> Iterable[str] | None:
-        pass
-
-    @property
-    @abc.abstractmethod
     def team_ids_with_membership(self) -> frozenset[int]:
         pass
 
@@ -236,10 +231,6 @@ class DbAccess(Access):
     @property
     def role(self) -> str | None:
         return self._member.role if self._member else None
-
-    @property
-    def roles(self) -> Iterable[str] | None:
-        return self._member.get_all_org_roles() if self._member else None
 
     @cached_property
     def _team_memberships(self) -> Mapping[Team, OrganizationMemberTeam]:
@@ -471,15 +462,6 @@ class RpcBackedAccess(Access):
         if self.rpc_user_organization_context.member is None:
             return None
         return self.rpc_user_organization_context.member.role
-
-    @property
-    def roles(self) -> Iterable[str] | None:
-        if self.rpc_user_organization_context.member is None:
-            return None
-        return access_service.get_all_org_roles(
-            member_id=self.rpc_user_organization_context.member.id,
-            organization_id=self.rpc_user_organization_context.organization.id,
-        )
 
     def has_role_in_organization(
         self, role: str, organization: Organization, user_id: int | None
@@ -840,10 +822,6 @@ class OrganizationlessAccess(Access):
     # TODO(cathy): remove this
     @property
     def role(self) -> str | None:
-        return None
-
-    @property
-    def roles(self) -> Iterable[str] | None:
         return None
 
     def has_role_in_organization(

--- a/src/sentry/integrations/slack/utils/auth.py
+++ b/src/sentry/integrations/slack/utils/auth.py
@@ -12,7 +12,7 @@ ALLOWED_ROLES = ["admin", "manager", "owner"]
 
 
 def is_valid_role(org_member: "OrganizationMember") -> bool:
-    return len(set(org_member.get_all_org_roles()) & set(ALLOWED_ROLES)) > 0
+    return len(set(org_member.role) & set(ALLOWED_ROLES)) > 0
 
 
 def _encode_data(secret: str, data: bytes, timestamp: str) -> str:

--- a/src/sentry/integrations/slack/utils/auth.py
+++ b/src/sentry/integrations/slack/utils/auth.py
@@ -12,7 +12,7 @@ ALLOWED_ROLES = ["admin", "manager", "owner"]
 
 
 def is_valid_role(org_member: "OrganizationMember") -> bool:
-    return len(set(org_member.role) & set(ALLOWED_ROLES)) > 0
+    return len({org_member.role} & set(ALLOWED_ROLES)) > 0
 
 
 def _encode_data(secret: str, data: bytes, timestamp: str) -> str:

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -566,7 +566,7 @@ class OrganizationMember(ReplicatedRegionModel):
             raise UnableToAcceptMemberInvitationException(ERR_JOIN_REQUESTS_DISABLED)
 
         # members cannot invite roles higher than their own
-        if not set(self.role) & {r.id for r in allowed_roles}:
+        if not {self.role} & {r.id for r in allowed_roles}:
             raise UnableToAcceptMemberInvitationException(
                 f"You do not have permission to approve a member invitation with the role {self.role}."
             )

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -503,9 +503,9 @@ class OrganizationMember(ReplicatedRegionModel):
             "teams_slugs": [t["slug"] for t in teams],
             "has_global_access": self.has_global_access,
             "role": self.role,
-            "invite_status": invite_status_names[self.invite_status]
-            if self.invite_status is not None
-            else None,
+            "invite_status": (
+                invite_status_names[self.invite_status] if self.invite_status is not None else None
+            ),
         }
 
     def get_teams(self):
@@ -521,12 +521,9 @@ class OrganizationMember(ReplicatedRegionModel):
 
     def get_scopes(self) -> frozenset[str]:
         # include org roles from team membership
-        all_org_roles = self.get_all_org_roles()
-        scopes = set()
+        role = organization_roles.get(self.role)
+        scopes = self.organization.get_scopes(role)
 
-        for role in all_org_roles:
-            role_obj = organization_roles.get(role)
-            scopes.update(self.organization.get_scopes(role_obj))
         return frozenset(scopes)
 
     def get_org_roles_from_teams(self) -> set[str]:
@@ -542,11 +539,6 @@ class OrganizationMember(ReplicatedRegionModel):
             self.__org_roles_from_teams = team_roles
         return self.__org_roles_from_teams
 
-    def get_all_org_roles(self) -> list[str]:
-        all_org_roles = self.get_org_roles_from_teams()
-        all_org_roles.add(self.role)
-        return list(all_org_roles)
-
     def get_org_roles_from_teams_by_source(self) -> list[tuple[str, OrganizationRole]]:
         org_roles = [
             (slug, organization_roles.get(role))
@@ -557,9 +549,6 @@ class OrganizationMember(ReplicatedRegionModel):
         ]
 
         return sorted(org_roles, key=lambda r: r[1].priority, reverse=True)
-
-    def get_all_org_roles_sorted(self) -> list[OrganizationRole]:
-        return organization_roles.get_sorted_roles(self.get_all_org_roles())
 
     def validate_invitation(self, user_to_approve, allowed_roles):
         """
@@ -577,11 +566,9 @@ class OrganizationMember(ReplicatedRegionModel):
             raise UnableToAcceptMemberInvitationException(ERR_JOIN_REQUESTS_DISABLED)
 
         # members cannot invite roles higher than their own
-        all_org_roles = self.get_all_org_roles()
-        if not len(set(all_org_roles) & {r.id for r in allowed_roles}):
-            highest_role = organization_roles.get_sorted_roles(all_org_roles)[0].id
+        if not set(self.role) & {r.id for r in allowed_roles}:
             raise UnableToAcceptMemberInvitationException(
-                f"You do not have permission to approve a member invitation with the role {highest_role}."
+                f"You do not have permission to approve a member invitation with the role {self.role}."
             )
         return True
 
@@ -614,9 +601,11 @@ class OrganizationMember(ReplicatedRegionModel):
             organization_id=self.organization_id,
             target_object=self.id,
             data=self.get_audit_log_data(),
-            event=audit_log.get_event_id("MEMBER_INVITE")
-            if settings.SENTRY_ENABLE_INVITES
-            else audit_log.get_event_id("MEMBER_ADD"),
+            event=(
+                audit_log.get_event_id("MEMBER_INVITE")
+                if settings.SENTRY_ENABLE_INVITES
+                else audit_log.get_event_id("MEMBER_ADD")
+            ),
         )
 
     def reject_member_invitation(
@@ -655,7 +644,7 @@ class OrganizationMember(ReplicatedRegionModel):
         return [r for r in organization_roles.get_all() if r.scopes.issubset(member_scopes)]
 
     def is_only_owner(self) -> bool:
-        if organization_roles.get_top_dog().id not in self.get_all_org_roles():
+        if organization_roles.get_top_dog().id != self.role:
             return False
 
         # check if any other member has the owner role, including through a team

--- a/src/sentry/models/organizationmemberteam.py
+++ b/src/sentry/models/organizationmemberteam.py
@@ -44,9 +44,11 @@ class OrganizationMemberTeam(ReplicatedRegionModel):
 
     def outbox_for_update(self, shard_identifier: int | None = None) -> RegionOutboxBase:
         return super().outbox_for_update(
-            shard_identifier=self.organizationmember.organization_id
-            if shard_identifier is None
-            else shard_identifier
+            shard_identifier=(
+                self.organizationmember.organization_id
+                if shard_identifier is None
+                else shard_identifier
+            )
         )
 
     def handle_async_replication(self, shard_identifier: int) -> None:
@@ -84,8 +86,7 @@ class OrganizationMemberTeam(ReplicatedRegionModel):
         If the role field is null, resolve to the minimum team role given by this
         member's organization role.
         """
-        highest_org_role = self.organizationmember.get_all_org_roles_sorted()[0].id
-        minimum_role = roles.get_minimum_team_role(highest_org_role)
+        minimum_role = roles.get_minimum_team_role(self.organizationmember.role)
 
         if self.role and features.has(
             "organizations:team-roles", self.organizationmember.organization

--- a/src/sentry/receivers/owners.py
+++ b/src/sentry/receivers/owners.py
@@ -23,7 +23,7 @@ def prevent_demoting_last_owner(instance: OrganizationMember, **kwargs):
         return
 
     # member is the last owner and the update will remove the last owner
-    if member.is_only_owner():
+    if member.is_only_owner() and instance.role != "owner":
         raise ValidationError(detail="An organization must have at least one owner")
 
 

--- a/src/sentry/receivers/owners.py
+++ b/src/sentry/receivers/owners.py
@@ -2,12 +2,28 @@ from django.db.models.signals import pre_delete, pre_save
 from rest_framework.serializers import ValidationError
 
 from sentry.models.organization import Organization
+from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.roles import organization_roles
 
 
 def _assert_org_has_owner_not_from_team(organization, top_role):
     if not organization.member_set.filter(role=top_role).exists():
+        raise ValidationError(detail="An organization must have at least one owner")
+
+
+def prevent_demoting_last_owner(instance: OrganizationMember, **kwargs):
+    # if a member is being created
+    if instance.id is None:
+        return  # type: ignore[unreachable]
+
+    try:
+        member = OrganizationMember.objects.get(id=instance.id)
+    except OrganizationMember.DoesNotExist:
+        return
+
+    # member is the last owner and the update will remove the last owner
+    if member.is_only_owner():
         raise ValidationError(detail="An organization must have at least one owner")
 
 
@@ -41,6 +57,13 @@ def prevent_removing_last_owner_team(instance: Team, **kwargs):
     if len(all_owner_teams) == 1:
         _assert_org_has_owner_not_from_team(organization, top_role)
 
+
+pre_save.connect(
+    prevent_demoting_last_owner,
+    sender=OrganizationMember,
+    dispatch_uid="prevent_demoting_last_owner",
+    weak=False,
+)
 
 pre_save.connect(
     prevent_demoting_last_owner_team,

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -160,14 +160,6 @@ class EventAttachmentDetailsPermissionTest(PermissionTestCase, CreateAttachmentM
         close_streaming_response(self.assert_can_access(self.owner, self.path))
 
     @with_feature("organizations:event-attachments")
-    def test_member_on_owner_team_can_access_for_owner_role(self):
-        self.organization.update_option("sentry:attachments_role", "owner")
-        owner_team = self.create_team(organization=self.organization, org_role="owner")
-        user = self.create_user()
-        self.create_member(organization=self.organization, user=user, teams=[owner_team, self.team])
-        close_streaming_response(self.assert_can_access(user, self.path))
-
-    @with_feature("organizations:event-attachments")
     def test_random_user_cannot_access(self):
         self.organization.update_option("sentry:attachments_role", "owner")
         user = self.create_user()

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -711,23 +711,6 @@ class DeleteOrganizationMemberTest(OrganizationMemberTestBase):
 
         assert OrganizationMember.objects.filter(id=owner_om.id).exists()
 
-    def test_can_delete_owner_if_other_owners_through_teams(self):
-        # two members of an owner team
-        member = self.create_user("bar@example.com")
-        member2 = self.create_user("foo@example.com")
-        team = self.create_team(org_role="owner")
-        owner = self.create_member(
-            organization=self.organization, role="member", user=member, teams=[team]
-        )
-        self.create_member(
-            organization=self.organization, role="member", user=member2, teams=[team]
-        )
-
-        self.login_as(member)
-        self.get_success_response(self.organization.slug, owner.id)
-
-        assert not OrganizationMember.objects.filter(id=owner.id).exists()
-
     def test_can_delete_self(self):
         other_user = self.create_user("bar@example.com")
         self.create_member(organization=self.organization, role="member", user=other_user)
@@ -797,23 +780,6 @@ class DeleteOrganizationMemberTest(OrganizationMemberTestBase):
         self.get_error_response(self.organization.slug, member_om.id)
 
         assert OrganizationMember.objects.filter(id=member_om.id).exists()
-
-    def test_can_delete_with_org_role_from_team(self):
-        member = self.create_user("bar@example.com")
-        team = self.create_team(org_role="manager")
-        self.create_member(organization=self.organization, user=member, role="member", teams=[team])
-
-        member_user = self.create_user("baz@example.com")
-        member_om = self.create_member(
-            organization=self.organization, role="manager", user=member_user
-        )
-
-        self.login_as(member)
-        self.get_success_response(self.organization.slug, member_om.id)
-
-        assert not OrganizationMember.objects.filter(
-            user_id=member_user.id, organization=self.organization
-        ).exists()
 
     def test_can_delete_pending_invite(self):
         invite = self.create_member(

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -921,24 +921,3 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
             team=self.team, organizationmember=other_member
         )
         assert target_omt.role is None
-
-    @with_feature("organizations:team-roles")
-    def test_member_on_owner_team_can_promote_member(self):
-        owner_team = self.create_team(org_role="owner")
-        member = self.create_member(
-            organization=self.org,
-            user=self.create_user(),
-            role="member",
-            teams=[owner_team],
-        )
-
-        self.login_as(member)
-        resp = self.get_response(
-            self.org.slug, self.member_on_team.id, self.team.slug, teamRole="admin"
-        )
-        assert resp.status_code == 200
-
-        updated_omt = OrganizationMemberTeam.objects.get(
-            team=self.team, organizationmember=self.member_on_team
-        )
-        assert updated_omt.role == "admin"

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -333,21 +333,6 @@ class FromUserTest(AccessFactoryTestCase):
             assert not result.has_project_scope(project_other, "project:write")
             assert result.has_project_scope(project_other, "project:read")
 
-    def test_get_organization_roles_from_teams(self):
-        user = self.create_user()
-        organization = self.create_organization()
-        owner_team = self.create_team(organization=organization, org_role="owner")
-        admin_team = self.create_team(organization=organization, org_role="admin")
-        self.create_member(organization=organization, user=user, teams=[owner_team, admin_team])
-
-        request = self.make_request(user=user)
-        results = [self.from_user(user, organization), self.from_request(request, organization)]
-
-        for result in results:
-            assert "owner" in result.roles
-            assert "member" in result.roles
-            assert "admin" in result.roles
-
     def test_unlinked_sso(self):
         user = self.create_user()
         organization = self.create_organization(owner=user)

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -101,12 +101,6 @@ class SlackIntegrationLinkTeamTestBase(TestCase):
             external_id=self.channel_id,
         )
 
-    def _create_user_with_valid_role_through_team(self):
-        user = self.create_user(email="foo@example.com")
-        self.team.update(org_role="admin")
-        self.create_member(organization=self.organization, user=user, teams=[self.team])
-        self.login_as(user)
-
     def _create_user_valid_through_team_admin(self):
         user = self.create_user(email="foo@example.com")
         self.create_member(
@@ -169,13 +163,6 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
                 value="always",
             )
             assert len(team_settings) == 1
-
-    @responses.activate
-    def test_link_team_with_valid_role_through_team(self):
-        """Test that we successfully link a team to a Slack channel with a valid role through a team"""
-        self._create_user_with_valid_role_through_team()
-
-        self.test_link_team()
 
     @responses.activate
     def test_link_team_valid_through_team_admin(self):
@@ -313,13 +300,6 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             team_settings = NotificationSettingProvider.objects.filter(team_id=self.team.id)
         assert len(team_settings) == 0
-
-    @responses.activate
-    def test_unlink_team_with_valid_role_through_team(self):
-        """Test that a team can be unlinked from a Slack channel with a valid role through a team"""
-        self._create_user_with_valid_role_through_team()
-
-        self.test_unlink_team()
 
     @responses.activate
     def test_unlink_team_valid_through_team_admin(self):

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -105,23 +105,6 @@ class SlackCommandsLinkTeamTest(SlackCommandsLinkTeamTestBase):
         assert INSUFFICIENT_ROLE_MESSAGE in get_response_text(data)
 
     @responses.activate
-    def test_link_team_sufficient_role_through_team(self):
-        """
-        Test that when a user whose org role is sufficient through team membership
-        attempts to link a team, we allow it.
-        """
-        user2 = self.create_user()
-        admin_team = self.create_team(org_role="admin")
-        self.create_member(
-            teams=[admin_team], user=user2, role="member", organization=self.organization
-        )
-        self.login_as(user2)
-        link_user(user2, self.idp, slack_id=OTHER_SLACK_ID)
-
-        data = self.send_slack_message("link team", user_id=OTHER_SLACK_ID)
-        assert "Link your Sentry team to this Slack channel!" in get_response_text(data)
-
-    @responses.activate
     def test_link_team_as_team_admin(self):
         """
         Test that when a user who is a team admin attempts to link a team we allow it.

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -14,7 +14,6 @@ from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationmember import INVITE_DAYS_VALID, InviteStatus, OrganizationMember
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.silo import SiloMode, unguarded_write
 from sentry.testutils.cases import TestCase
@@ -366,25 +365,6 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
         assert "alerts:write" not in member.get_scopes()
         assert "alerts:write" in admin.get_scopes()
 
-    def test_scopes_with_team_org_role(self):
-        member = OrganizationMember.objects.create(
-            organization=self.organization,
-            role="member",
-            email="test@example.com",
-        )
-        owner = OrganizationMember.objects.create(
-            organization=self.organization,
-            role="owner",
-            email="owner@example.com",
-        )
-        owner_member_scopes = member.get_scopes() | owner.get_scopes()
-
-        team = self.create_team(organization=self.organization, org_role="owner")
-        OrganizationMemberTeam.objects.create(organizationmember=member, team=team)
-
-        member.refresh_from_db()
-        assert member.get_scopes() == owner_member_scopes
-
     def test_get_contactable_members_for_org(self):
         organization = self.create_organization()
         user1 = self.create_user()
@@ -459,24 +439,6 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
             match="You do not have permission to approve a member invitation with the role admin.",
         ):
             member.validate_invitation(user, [roles.get("member")])
-
-    def test_validate_invitation_with_org_role_from_team(self):
-        team = self.create_team(org_role="admin")
-        member = self.create_member(
-            organization=self.organization,
-            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
-            email="hello@sentry.io",
-            role="member",
-            teams=[team],
-        )
-        user = self.create_user()
-        assert member.validate_invitation(user, [roles.get("admin"), roles.get("member")])
-
-        with pytest.raises(
-            UnableToAcceptMemberInvitationException,
-            match="You do not have permission to approve a member invitation with the role admin.",
-        ):
-            member.validate_invitation(user, [roles.get("manager")])
 
     def test_approve_member_invitation(self):
         member = self.create_member(

--- a/tests/sentry/models/test_organizationmemberteam.py
+++ b/tests/sentry/models/test_organizationmemberteam.py
@@ -27,13 +27,3 @@ class OrganizationMemberTest(TestCase):
         for org_role in ("admin", "manager", "owner"):
             self.member.role = org_role
             assert omt.get_team_role() == team_roles.get("admin")
-
-    @with_feature("organizations:team-roles")
-    def test_get_team_role_derives_minimum_role_from_team_membership(self):
-        manager_team = self.create_team(org_role="manager")
-        member = self.create_member(
-            organization=self.organization, user=self.create_user(), teams=[manager_team]
-        )
-        omt = OrganizationMemberTeam(organizationmember=member, team=manager_team)
-
-        assert omt.get_team_role() == team_roles.get("admin")


### PR DESCRIPTION
Part of an ongoing effort to remove the org roles for teams feature https://github.com/getsentry/team-core-product-foundations/issues/51

We can remove the `get_all_org_roles` function from `OrganizationMember`. This function is being used across many areas in the codebase but it's not returning anything other than the member's singular org role because the feature was never released. So we can simplify all the checks to only check for `member.role` because it is equivalent.

NOTE: most of the lines changed are deleted tests

Refactor changes
- Endpoints: EventAttachmentDetails, OrganizationMemberDetails, OrganizationMemberTeamDetails
- access.py: removed `roles` (plural) property, reverting back to using `role` (singular) property
- Utils: can_set_team_role, is_valid_role, prevent_demoting_last_owner receiver
- Models: OrganizationMember and OrganizationMemberTeam -- removes `get_all_org_roles` function and usage of it
- Tests: removed tests relating to creating teams with org roles and depending on team membership to grant access