### PR TITLE
feat(orphan-errors-banner): Added banner logic for orphan errors.

### DIFF
--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -494,12 +494,7 @@ function OnlyOrphanErrorWarnings({orphanErrors}: OnlyOrphanErrorWarningsProps) {
             </Button>
           </ActionButton>
           <ActionButton>
-            <Button
-              onClick={event => {
-                event.preventDefault();
-                SidebarPanelStore.activatePanel(SidebarPanelKey.PERFORMANCE_ONBOARDING);
-              }}
-            >
+            <Button href="https://docs.sentry.io/product/performance/" external>
               {t('Learn More')}
             </Button>
           </ActionButton>

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -2,16 +2,24 @@ import {Component, createRef, Fragment} from 'react';
 import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
+import emptyStateImg from 'sentry-images/spot/performance-empty-state.svg';
+
 import {Alert} from 'sentry/components/alert';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
+import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import DiscoverButton from 'sentry/components/discoverButton';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import TimeSince from 'sentry/components/timeSince';
+import {withPerformanceOnboarding} from 'sentry/data/platformCategories';
+import {IconClose} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
+import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -22,7 +30,6 @@ import {getDuration} from 'sentry/utils/formatters';
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 import {createFuzzySearch} from 'sentry/utils/fuzzySearch';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import emptyStateImg from 'sentry-images/spot/performance-empty-state.svg';
 import type {
   TraceError,
   TraceFullDetailed,
@@ -30,6 +37,8 @@ import type {
 } from 'sentry/utils/performance/quickTrace/types';
 import {filterTrace, reduceTrace} from 'sentry/utils/performance/quickTrace/utils';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+import useProjects from 'sentry/utils/useProjects';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 import {MetaData} from 'sentry/views/performance/transactionDetails/styles';
 
@@ -38,14 +47,6 @@ import TraceNotFound from './traceNotFound';
 import TraceView from './traceView';
 import type {TraceInfo} from './types';
 import {getTraceInfo, hasTraceData, isRootTransaction} from './utils';
-import useProjects from 'sentry/utils/useProjects';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {Button} from 'sentry/components/button';
-import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
-import {SidebarPanelKey} from 'sentry/components/sidebar/types';
-import {IconClose} from 'sentry/icons';
-import useDismissAlert from 'sentry/utils/useDismissAlert';
-import {withPerformanceOnboarding} from 'sentry/data/platformCategories';
 
 type IndexedFusedTransaction = {
   event: TraceFullDetailed | TraceError;
@@ -426,8 +427,8 @@ class TraceDetailsContent extends Component<Props, State> {
 }
 
 type OnlyOrphanErrorWarningsProps = {
-  orphanErrors: TraceError[];
   organization: Organization;
+  orphanErrors: TraceError[];
 };
 function OnlyOrphanErrorWarnings({orphanErrors}: OnlyOrphanErrorWarningsProps) {
   const {projects} = useProjects();

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -314,12 +314,7 @@ class TraceDetailsContent extends Component<Props, State> {
         </Alert>
       );
     } else if (orphanErrors && orphanErrors.length > 0) {
-      warning = (
-        <OnlyOrphanErrorWarnings
-          orphanErrors={orphanErrors}
-          organization={this.props.organization}
-        />
-      );
+      warning = <OnlyOrphanErrorWarnings orphanErrors={orphanErrors} />;
     }
 
     return warning;
@@ -427,14 +422,13 @@ class TraceDetailsContent extends Component<Props, State> {
 }
 
 type OnlyOrphanErrorWarningsProps = {
-  organization: Organization;
   orphanErrors: TraceError[];
 };
 function OnlyOrphanErrorWarnings({orphanErrors}: OnlyOrphanErrorWarningsProps) {
   const {projects} = useProjects();
   const projectSlug = orphanErrors[0] ? orphanErrors[0].project_slug : '';
   const project = projects.find(p => p.slug === projectSlug);
-  const LOCAL_STORAGE_KEY = `${project?.id}:issue-details-replay-onboarding-hide`;
+  const LOCAL_STORAGE_KEY = `${project?.id}:performance-orphan-error-onboarding-banner-hide`;
   const currentPlatform = project?.platform;
   const hasPerformanceOnboarding = currentPlatform
     ? withPerformanceOnboarding.has(currentPlatform)
@@ -479,7 +473,7 @@ function OnlyOrphanErrorWarnings({orphanErrors}: OnlyOrphanErrorWarningsProps) {
         <BannerTitle>{t('Connect with Dots')}</BannerTitle>
         <BannerDescription>
           {t(
-            "Want to know why this string of errors happend? If you haven't already, update your SDK with this snippet to figure out what operations are running between your errors."
+            "Want to know why this string of errors happened? If you haven't already, update your SDK with this snippet to figure out what operations are running between your errors."
           )}
         </BannerDescription>
         <ButtonsWrapper>

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -432,7 +432,7 @@ type OnlyOrphanErrorWarningsProps = {
 };
 function OnlyOrphanErrorWarnings({orphanErrors}: OnlyOrphanErrorWarningsProps) {
   const {projects} = useProjects();
-  const projectSlug = orphanErrors[0].project_slug;
+  const projectSlug = orphanErrors[0] ? orphanErrors[0].project_slug : '';
   const project = projects.find(p => p.slug === projectSlug);
   const LOCAL_STORAGE_KEY = `${project?.id}:issue-details-replay-onboarding-hide`;
   const currentPlatform = project?.platform;


### PR DESCRIPTION
Added banner for promoting perf setup, when trace only has orphan errors:
![Screenshot 2024-02-16 at 2 15 36 PM](https://github.com/getsentry/sentry/assets/60121741/d173c775-8d08-4952-8e30-c00d49833d61)
defaults to old banner when project platform doesn't support perf onboarding sidebar