### PR TITLE
fix(replays): fix rage click option in project serializer

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -207,8 +207,7 @@ def format_options(attrs: dict[str, Any]) -> dict[str, Any]:
             options.get(f"sentry:{FilterTypes.ERROR_MESSAGES}", [])
         ),
         "feedback:branding": options.get("feedback:branding", "1") == "1",
-        "sentry:replay_rage_click_issues": options.get("sentry:replay_rage_click_issues", "1")
-        == "1",
+        "sentry:replay_rage_click_issues": options.get("sentry:replay_rage_click_issues"),
         "quotas:spike-protection-disabled": options.get("quotas:spike-protection-disabled"),
     }
 


### PR DESCRIPTION
- [x] Don't set a default value in the .get here, as we already set a default here which should be obeyed: https://github.com/getsentry/sentry/blob/e3629860197903f263c6bcdf6fac37c7d7a0a302/src/sentry/projectoptions/defaults.py#L135
- [x] don't compare it to "1", as the value is a boolean in the database / default.

Observed an issue where if you set it to false, then back to true, it would appear in the UI as if it were still false. 

sidenote: we desperately need to refactor these project options, it is quite footgun-prone now.