### PR TITLE
fix(typing): use correct import for PriorityLevel

### DIFF
--- a/src/sentry/rules/conditions/high_priority_issue.py
+++ b/src/sentry/rules/conditions/high_priority_issue.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from sentry import features
 from sentry.event_manager import HIGH_SEVERITY_THRESHOLD
 from sentry.eventstore.models import GroupEvent
-from sentry.issues.priority import PriorityLevel
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.receivers.rules import has_high_priority_issue_alerts
@@ -12,6 +11,7 @@ from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
 from sentry.types.activity import ActivityType
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
+from sentry.types.group import PriorityLevel
 
 
 class HighPriorityIssueCondition(EventCondition):

--- a/tests/sentry/rules/conditions/test_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_high_priority_issue.py
@@ -1,9 +1,9 @@
-from sentry.issues.priority import PriorityLevel
 from sentry.rules.conditions.high_priority_issue import HighPriorityIssueCondition
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
+from sentry.types.group import PriorityLevel
 
 pytestmark = [requires_snuba]
 


### PR DESCRIPTION
It appears https://github.com/getsentry/sentry/pull/64421 wasn't correctly rebased after another change, and thus master is now failing due to a bad import. this should fix and unblock builds.