### PR TITLE
fix(integration): Have factory method match code change

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1067,7 +1067,6 @@ class Factories:
         internal_integration: SentryApp | None = None,
         install: SentryAppInstallation | None = None,
         request=None,
-        org: Organization | None = None,
     ) -> ApiToken:
         if internal_integration and install:
             raise ValueError("Only one of internal_integration or install arg can be provided")

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -82,6 +82,7 @@ from sentry.models.integrations.integration_feature import (
 )
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.integrations.sentry_app_installation_for_provider import (
     SentryAppInstallationForProvider,
@@ -1050,7 +1051,7 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)
-    def create_internal_integration(**kwargs):
+    def create_internal_integration(**kwargs) -> SentryApp:
         args = Factories._sentry_app_kwargs(**kwargs)
         args["verify_install"] = False
         user = args.pop("user", None)
@@ -1061,19 +1062,26 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)
-    def create_internal_integration_token(user, install=None, request=None, org=None, scopes=None):
-        if scopes is None:
-            scopes = []
+    def create_internal_integration_token(
+        user,
+        internal_integration: SentryApp | None = None,
+        install: SentryAppInstallation | None = None,
+        request=None,
+        org: Organization | None = None,
+    ) -> ApiToken:
+        if internal_integration and install:
+            raise ValueError("Only one of internal_integration or install arg can be provided")
+        if internal_integration is None and install is None:
+            raise ValueError("Must pass in either internal_integration or install arg")
+
         if install is None:
-            assert org
-            sentry_app = Factories.create_internal_integration(
-                "integration token",
-            )
-            install = Factories.create_sentry_app_installation(
-                organization=org,
-                slug=sentry_app.slug,
-                user=user,
-            )
+            # Fetch install from provided or created internal integration
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                install = SentryAppInstallation.objects.get(
+                    sentry_app=internal_integration.id,
+                    organization_id=internal_integration.owner_id,
+                )
+
         return SentryAppInstallationTokenCreator(sentry_app_installation=install).run(
             user=user, request=request
         )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1054,7 +1054,9 @@ class Factories:
         args = Factories._sentry_app_kwargs(**kwargs)
         args["verify_install"] = False
         user = args.pop("user", None)
-        app = SentryAppCreator(is_internal=True, **args).run(user=user, request=None)
+        app = SentryAppCreator(is_internal=True, **args).run(
+            user=user, request=None, skip_default_auth_token=True
+        )
         return app
 
     @staticmethod
@@ -1064,13 +1066,13 @@ class Factories:
             scopes = []
         if install is None:
             assert org
-            sentry_app = Factories.create_sentry_app(
-                name="Integration Token",
-                organization=org,
-                scopes=scopes,
+            sentry_app = Factories.create_internal_integration(
+                "integration token",
             )
             install = Factories.create_sentry_app_installation(
-                organization=org, slug=sentry_app.slug, user=user
+                organization=org,
+                slug=sentry_app.slug,
+                user=user,
             )
         return SentryAppInstallationTokenCreator(sentry_app_installation=install).run(
             user=user, request=request
@@ -1098,7 +1100,11 @@ class Factories:
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
     def create_sentry_app_installation(
-        organization=None, slug=None, user=None, status=None, prevent_token_exchange=False
+        organization=None,
+        slug=None,
+        user=None,
+        status=None,
+        prevent_token_exchange=False,
     ):
         if not organization:
             organization = Factories.create_organization()

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -102,6 +102,7 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
 
     def test_remove_tokens_internal_app(self):
         internal_app = self.create_internal_integration(name="Internal App", organization=self.org)
+        self.create_internal_integration_token(user=self.user, internal_integration=internal_app)
         url = f"/settings/{self.org.slug}/developer-settings/{internal_app.slug}"
 
         self.load_page(url)

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -211,7 +211,10 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             organization=self.organization,
             scopes=("project:read", "org:read", "event:write"),
         )
-        token = internal_app.installations.first().api_token
+        token = self.create_internal_integration_token(
+            user=self.user,
+            internal_integration=internal_app,
+        )
 
         group = self.create_group(project=project)
         url = f"/api/0/issues/{group.id}/"

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -9,7 +9,6 @@ from sentry.auth.authenticators.recovery_code import RecoveryCodeInterface
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.models.authenticator import Authenticator
 from sentry.models.authprovider import AuthProvider
-from sentry.models.integrations.sentry_app_installation_token import SentryAppInstallationToken
 from sentry.models.options.user_option import UserOption
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
@@ -523,20 +522,20 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
     def test_with_internal_integration(self):
         member = self.create_user("baz@example.com")
         member_om = self.create_member(organization=self.organization, user=member, role="member")
-        self.create_internal_integration(
+        internal_integration = self.create_internal_integration(
             name="my_app",
             organization=self.organization,
             scopes=("member:admin",),
             webhook_url="http://example.com",
         )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            # there should only be one record created so just grab the first one
-            token = SentryAppInstallationToken.objects.first()
+        token = self.create_internal_integration_token(
+            user=self.user, internal_integration=internal_integration
+        )
 
         response = self.client.put(
             reverse(self.endpoint, args=[self.organization.slug, member_om.id]),
             {"role": "manager"},
-            HTTP_AUTHORIZATION=f"Bearer {token.api_token.token}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
         # The app token has no associated OrganizationMember and therefore no role.

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -691,9 +691,12 @@ class OrganizationMemberListPostTest(OrganizationMemberListTestBase, HybridCloud
         mock_send_invite_email.assert_called_with("test_referrer")
 
     @patch.object(OrganizationMember, "send_invite_email")
-    def test_integration_token_can_only_invite_member_role(self, mock_send_invite_email):
+    def test_internal_integration_token_can_only_invite_member_role(self, mock_send_invite_email):
+        internal_integration = self.create_internal_integration(
+            name="Internal App", organization=self.organization, scopes=["member:write"]
+        )
         token = self.create_internal_integration_token(
-            user=self.user, org=self.organization, scopes=["member:write"]
+            user=self.user, internal_integration=internal_integration
         )
         err_message = (
             "Integration tokens are restricted to inviting new members with the member role only."

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -398,9 +398,12 @@ class CreateWithClosedMembershipTest(CreateOrganizationMemberTeamTest):
         ).exists()
 
     def test_integration_token_needs_elevated_permissions(self):
+        internal_integration = self.create_internal_integration(
+            name="Internal App", organization=self.org, scopes=["org:read"]
+        )
         # Integration tokens with org:read should generate an access request when open membership is off
         integration_token = self.create_internal_integration_token(
-            user=self.user, org=self.org, scopes=["org:read"]
+            user=self.user, internal_integration=internal_integration
         )
 
         self.get_success_response(

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -67,6 +67,9 @@ class SentryAppsTest(APITestCase):
         self.internal_app = self.create_internal_integration(
             name="Internal", organization=self.internal_organization
         )
+        self.create_internal_integration_token(
+            user=self.user, internal_integration=self.internal_app
+        )
 
     def assert_response_has_serialized_sentry_app(
         self,

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
@@ -20,8 +20,9 @@ class SentryInternalAppTokenCreationTest(APITestCase):
         self.internal_sentry_app = self.create_internal_integration(
             name="My Internal App", organization=self.org
         )
-
-        self.api_token = ApiToken.objects.get(application=self.internal_sentry_app.application)
+        self.api_token = self.create_internal_integration_token(
+            user=self.user, internal_integration=self.internal_sentry_app
+        )
 
         self.superuser = self.create_user(is_superuser=True)
 
@@ -45,7 +46,9 @@ class SentryInternalAppTokenCreationTest(APITestCase):
 
     def test_delete_token_another_app(self):
         another_app = self.create_internal_integration(name="Another app", organization=self.org)
-        api_token = ApiToken.objects.get(application=another_app.application)
+        api_token = self.create_internal_integration_token(
+            user=self.user, internal_integration=another_app
+        )
 
         self.login_as(user=self.user)
         self.get_error_response(

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -52,8 +52,10 @@ class TestSentryAppInstallationDeletionTask(TestCase):
 
     def test_deletes_api_tokens(self):
         internal_app = self.create_internal_integration(organization=self.org)
+        api_token = self.create_internal_integration_token(
+            user=self.user, internal_integration=internal_app
+        )
         install = SentryAppInstallation.objects.get(sentry_app_id=internal_app.id)
-        api_token = install.api_token
 
         deletions.exec_sync(install)
 

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -89,6 +89,7 @@ class VercelReleasesTest(APITestCase):
             name="Vercel Internal Integration",
             organization=self.organization,
         )
+        self.create_internal_integration_token(user=self.user, internal_integration=self.sentry_app)
         self.installation_for_provider = self.create_sentry_app_installation_for_provider(
             sentry_app_id=self.sentry_app.id,
             organization_id=self.organization.id,

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -15,7 +15,6 @@ from sentry.api.base import Endpoint
 from sentry.api.endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from sentry.middleware.ratelimit import RatelimitMiddleware
 from sentry.models.apikey import ApiKey
-from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.user import User
 from sentry.ratelimits.config import RateLimitConfig, get_default_rate_limits_for_group
 from sentry.ratelimits.utils import get_rate_limit_config, get_rate_limit_key, get_rate_limit_value
@@ -67,13 +66,10 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
             webhook_url="http://example.com",
         )
 
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            install = SentryAppInstallation.objects.get(
-                sentry_app=internal_integration.id, organization_id=self.organization.id
-            )
-
         token = self.create_internal_integration_token(
-            user=self.user, install=install, org=self.organization, scopes=["project:read"]
+            user=self.user,
+            internal_integration=internal_integration,
+            scopes=["project:read"],
         )
 
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -69,7 +69,6 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         token = self.create_internal_integration_token(
             user=self.user,
             internal_integration=internal_integration,
-            scopes=["project:read"],
         )
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -237,9 +236,9 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
 
         self.populate_internal_integration_request(request)
         key_pattern = re.compile(r"^org:default:OrganizationGroupIndexEndpoint:GET:[a-zA-Z]$")
-        assert key_pattern.match(
-            get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
-        )
+        key = get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
+        assert key
+        assert key_pattern.match(key)
 
         # Test for
         request.user = AnonymousUser()

--- a/tests/sentry/models/test_apitoken.py
+++ b/tests/sentry/models/test_apitoken.py
@@ -88,9 +88,9 @@ class ApiTokenInternalIntegrationTest(TestCase):
         self.install = SentryAppInstallation.objects.get(sentry_app=self.internal_app)
 
     def test_multiple_tokens_have_correct_organization_id(self):
-        # First token is created automatically with the application
-        token_1 = self.internal_app.installations.first().api_token
-        # Second token is created manually and isn't directly linked from the SentryAppInstallation model
+        # First token is no longer created automatically with the application, so we must manually
+        # create multiple tokens that aren't directly linked from the SentryAppInstallation model.
+        token_1 = self.create_internal_integration_token(install=self.install, user=self.user)
         token_2 = self.create_internal_integration_token(install=self.install, user=self.user)
 
         assert token_1.organization_id == self.org.id

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_token_creator.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_token_creator.py
@@ -23,7 +23,7 @@ class TestCreatorInternal(TestCreatorBase):
     def setUp(self):
         super().setUp()
 
-        # will create the installation and the first token
+        # Create the internal integration (NOTE: This no longer creates an initial token as well)
         self.sentry_app = self.create_internal_integration(
             name="internal_app", organization=self.org
         )
@@ -41,12 +41,10 @@ class TestCreatorInternal(TestCreatorBase):
         # verify token was created properly
         assert api_token.expires_at is None
 
-        # check we have two tokens
         sentry_app_installation_tokens = SentryAppInstallationToken.objects.filter(
             sentry_app_installation=self.sentry_app_installation
         )
-
-        assert len(sentry_app_installation_tokens) == 2
+        assert len(sentry_app_installation_tokens) == 1
 
         assert not create_audit_entry.called
 

--- a/tests/sentry/sentry_apps/test_sentry_app_updater.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_updater.py
@@ -38,9 +38,15 @@ class TestUpdater(TestCase):
         sentry_app = self.create_internal_integration(
             scopes=("project:read",), organization=self.org
         )
+        token = self.create_internal_integration_token(
+            user=self.user, internal_integration=sentry_app
+        )
+
         updater = SentryAppUpdater(sentry_app=sentry_app)
         updater.scopes = ["project:read", "project:write"]
         updater.run(user=self.user)
+        token.refresh_from_db()
+
         assert sentry_app.get_scopes() == ["project:read", "project:write"]
         assert ApiToken.objects.get(application=sentry_app.application).get_scopes() == [
             "project:read",


### PR DESCRIPTION
Have `self.create_internal_integration` match code change in https://github.com/getsentry/sentry/pull/64814 of not creating a token by default
Changing the factory method exposes an existing bug in our rate limiter that I created a temporary fix for in https://github.com/getsentry/sentry/pull/53673

I'm making a permanent fix in another PR, but I want to break up the exposing the test failure in this PR first