### PR TITLE
fix(first-release): Revise logic for firstRelease with no environments

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -158,9 +158,9 @@ def first_release_all_environments_filter(
         # If no specific environments are supplied, we look at the
         # first_release of any environment that the group has been
         # seen in.
-        id__in=GroupEnvironment.objects.filter(
-            first_release_id__in=list(releases.values()),
-        ).values_list("group_id")
+        id__in=Group.objects.filter(
+            first_release__id__in=list(releases.values()),
+        ).values_list("id")
     )
 
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -154,14 +154,10 @@ def first_release_all_environments_filter(
             # We only need to find the first non-existent release here
             break
 
-    return Q(
         # If no specific environments are supplied, we look at the
         # first_release of any environment that the group has been
         # seen in.
-        id__in=Group.objects.filter(
-            first_release__id__in=list(releases.values()),
-        ).values_list("id")
-    )
+    return Q(first_release_id__in=list(releases.values()))
 
 
 def inbox_filter(inbox: bool, projects: Sequence[Project]) -> Q:

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2359,43 +2359,43 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         # query by release release_1
 
-        results = self.make_query(search_filter_query="first_release:%s" % "release_1")
+        results = self.make_query(search_filter_query="first_release:release_1")
         assert set(results) == {group_a, group_b}
 
         results = self.make_query(
             environments=[staging_env, prod_env],
-            search_filter_query="first_release:%s" % "release_1",
+            search_filter_query="first_release:release_1",
         )
         assert set(results) == {group_a}
 
         results = self.make_query(
-            environments=[staging_env], search_filter_query="first_release:%s" % "release_1"
+            environments=[staging_env], search_filter_query="first_release:release_1"
         )
         assert set(results) == {group_a}
 
         results = self.make_query(
-            environments=[prod_env], search_filter_query="first_release:%s" % "release_1"
+            environments=[prod_env], search_filter_query="first_release:release_1"
         )
         assert set(results) == set()
 
         # query by release release_2
 
-        results = self.make_query(search_filter_query="first_release:%s" % "release_2")
+        results = self.make_query(search_filter_query="first_release:release_2")
         assert set(results) == {group_c}
 
         results = self.make_query(
             environments=[staging_env, prod_env],
-            search_filter_query="first_release:%s" % "release_2",
+            search_filter_query="first_release:release_2",
         )
         assert set(results) == {group_a}
 
         results = self.make_query(
-            environments=[staging_env], search_filter_query="first_release:%s" % "release_2"
+            environments=[staging_env], search_filter_query="first_release:release_2"
         )
         assert set(results) == set()
 
         results = self.make_query(
-            environments=[prod_env], search_filter_query="first_release:%s" % "release_2"
+            environments=[prod_env], search_filter_query="first_release:release_2"
         )
         assert set(results) == {group_a}
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2000,7 +2000,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
 
         self.run_test_query(f"first_release:[{release_1.version}, {release_2.version}]", [])
 
-        # Create a new event so that we get a group in this release
+        # Create a new event so that we get a group in release 1
         group = self.store_event(
             data={
                 "fingerprint": ["put-me-in-group9001"],
@@ -2020,7 +2020,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             [self.group1, self.group2],
         )
 
-        # Create a new event so that we get a group in this release
+        # Create a new event so that we get a group in release 2
         group_2 = self.store_event(
             data={
                 "fingerprint": ["put-me-in-group9002"],
@@ -2037,6 +2037,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         self.run_test_query(
             f"first_release:[{release_1.version}, {release_2.version}]",
             [group, group_2],
+            [self.group1, self.group2],
         )
 
     def test_first_release_environments(self):
@@ -2079,6 +2080,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             group_id=self.group1.id, environment_id=self.environments["production"].id
         )
         group_1_env.update(first_release=release)
+        self.group1.first_release = release
+        self.group1.save()
 
         self.run_test_query(
             f"first_release:[{release.version}, fake2]",
@@ -2091,6 +2094,9 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             group_id=self.group2.id, environment_id=self.environments["staging"].id
         )
         group_2_env.update(first_release=release)
+        self.group2.first_release = release
+        self.group2.save()
+
         self.run_test_query(
             f"first_release:[{release.version}, fake2]",
             [self.group1, self.group2],
@@ -2287,7 +2293,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         #         env=[production]: nothing
         #
         #     first_release: 2
-        #         env=[]: A, C
+        #         env=[]: C
         #         env=[production, staging]: A
         #         env=[staging]: nothing
         #         env=[production]: A
@@ -2375,7 +2381,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         # query by release release_2
 
         results = self.make_query(search_filter_query="first_release:%s" % "release_2")
-        assert set(results) == {group_a, group_c}
+        assert set(results) == {group_c}
 
         results = self.make_query(
             environments=[staging_env, prod_env],


### PR DESCRIPTION
Fix a bug in how we query groups releases when no environment is provided