### PR TITLE
feat(organization settings): Always show audit log  tab

### DIFF
--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -58,7 +58,7 @@ const organizationNavigation: NavigationSection[] = [
       {
         path: `${pathPrefix}/audit-log/`,
         title: t('Audit Log'),
-        show: ({access}) => access!.has('org:write'),
+        show: ({access}) => access!.has('org:read'),
         description: t('View the audit log for an organization'),
         id: 'audit-log',
       },

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -58,7 +58,7 @@ const organizationNavigation: NavigationSection[] = [
       {
         path: `${pathPrefix}/audit-log/`,
         title: t('Audit Log'),
-        show: ({access}) => access!.has('org:read'),
+        show: ({access}) => access!.has('org:write'),
         description: t('View the audit log for an organization'),
         id: 'audit-log',
       },

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -58,7 +58,6 @@ const organizationNavigation: NavigationSection[] = [
       {
         path: `${pathPrefix}/audit-log/`,
         title: t('Audit Log'),
-        show: ({access}) => access!.has('org:read'),
         description: t('View the audit log for an organization'),
         id: 'audit-log',
       },

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -18,7 +18,6 @@ import {shouldUse24Hours} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
-import PermissionAlert from 'sentry/views/settings/organization/permissionAlert';
 import {
   projectDetectorSettingsId,
   retentionPrioritiesLabels,
@@ -271,59 +270,53 @@ function AuditLogList({
 
   return (
     <div>
-      {!organization.access.includes('org:write') ? (
-        <PermissionAlert />
-      ) : (
-        <div>
-          <SettingsPageHeader title={t('Audit Log')} action={action} />
-          <PanelTable
-            headers={[t('Member'), t('Action'), t('IP'), t('Time')]}
-            isEmpty={!hasEntries && entries?.length === 0}
-            emptyMessage={t('No audit entries available')}
-            isLoading={isLoading}
-          >
-            {(entries ?? []).map(entry => {
-              if (!entry) {
-                return null;
-              }
-              return (
-                <Fragment key={entry.id}>
-                  <UserInfo>
-                    <div>{getAvatarDisplay(entry.actor)}</div>
-                    <NameContainer>
-                      {addUsernameDisplay(entry.actor)}
-                      <AuditNote entry={entry} orgSlug={organization.slug} />
-                    </NameContainer>
-                  </UserInfo>
-                  <FlexCenter>
-                    <MonoDetail>{getTypeDisplay(entry.event)}</MonoDetail>
-                  </FlexCenter>
-                  <FlexCenter>
-                    {entry.ipAddress && (
-                      <IpAddressOverflow>
-                        <Tooltip
-                          title={entry.ipAddress}
-                          disabled={entry.ipAddress.length <= ipv4Length}
-                        >
-                          <MonoDetail>{entry.ipAddress}</MonoDetail>
-                        </Tooltip>
-                      </IpAddressOverflow>
-                    )}
-                  </FlexCenter>
-                  <TimestampInfo>
-                    <DateTime dateOnly date={entry.dateCreated} />
-                    <DateTime
-                      timeOnly
-                      format={is24Hours ? 'HH:mm zz' : 'LT zz'}
-                      date={entry.dateCreated}
-                    />
-                  </TimestampInfo>
-                </Fragment>
-              );
-            })}
-          </PanelTable>
-        </div>
-      )}
+      <SettingsPageHeader title={t('Audit Log')} action={action} />
+      <PanelTable
+        headers={[t('Member'), t('Action'), t('IP'), t('Time')]}
+        isEmpty={!hasEntries && entries?.length === 0}
+        emptyMessage={t('No audit entries available')}
+        isLoading={isLoading}
+      >
+        {(entries ?? []).map(entry => {
+          if (!entry) {
+            return null;
+          }
+          return (
+            <Fragment key={entry.id}>
+              <UserInfo>
+                <div>{getAvatarDisplay(entry.actor)}</div>
+                <NameContainer>
+                  {addUsernameDisplay(entry.actor)}
+                  <AuditNote entry={entry} orgSlug={organization.slug} />
+                </NameContainer>
+              </UserInfo>
+              <FlexCenter>
+                <MonoDetail>{getTypeDisplay(entry.event)}</MonoDetail>
+              </FlexCenter>
+              <FlexCenter>
+                {entry.ipAddress && (
+                  <IpAddressOverflow>
+                    <Tooltip
+                      title={entry.ipAddress}
+                      disabled={entry.ipAddress.length <= ipv4Length}
+                    >
+                      <MonoDetail>{entry.ipAddress}</MonoDetail>
+                    </Tooltip>
+                  </IpAddressOverflow>
+                )}
+              </FlexCenter>
+              <TimestampInfo>
+                <DateTime dateOnly date={entry.dateCreated} />
+                <DateTime
+                  timeOnly
+                  format={is24Hours ? 'HH:mm zz' : 'LT zz'}
+                  date={entry.dateCreated}
+                />
+              </TimestampInfo>
+            </Fragment>
+          );
+        })}
+      </PanelTable>
       {pageLinks && <Pagination pageLinks={pageLinks} onCursor={onCursor} />}
     </div>
   );

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -18,6 +18,7 @@ import {shouldUse24Hours} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+import PermissionAlert from 'sentry/views/settings/organization/permissionAlert';
 import {
   projectDetectorSettingsId,
   retentionPrioritiesLabels,
@@ -231,6 +232,7 @@ function AuditNote({
 }
 
 type Props = {
+  access: boolean;
   entries: AuditLog[] | null;
   eventType: string | undefined;
   eventTypes: string[] | null;
@@ -241,6 +243,7 @@ type Props = {
 };
 
 function AuditLogList({
+  access,
   isLoading,
   pageLinks,
   entries,
@@ -270,53 +273,59 @@ function AuditLogList({
 
   return (
     <div>
-      <SettingsPageHeader title={t('Audit Log')} action={action} />
-      <PanelTable
-        headers={[t('Member'), t('Action'), t('IP'), t('Time')]}
-        isEmpty={!hasEntries && entries?.length === 0}
-        emptyMessage={t('No audit entries available')}
-        isLoading={isLoading}
-      >
-        {(entries ?? []).map(entry => {
-          if (!entry) {
-            return null;
-          }
-          return (
-            <Fragment key={entry.id}>
-              <UserInfo>
-                <div>{getAvatarDisplay(entry.actor)}</div>
-                <NameContainer>
-                  {addUsernameDisplay(entry.actor)}
-                  <AuditNote entry={entry} orgSlug={organization.slug} />
-                </NameContainer>
-              </UserInfo>
-              <FlexCenter>
-                <MonoDetail>{getTypeDisplay(entry.event)}</MonoDetail>
-              </FlexCenter>
-              <FlexCenter>
-                {entry.ipAddress && (
-                  <IpAddressOverflow>
-                    <Tooltip
-                      title={entry.ipAddress}
-                      disabled={entry.ipAddress.length <= ipv4Length}
-                    >
-                      <MonoDetail>{entry.ipAddress}</MonoDetail>
-                    </Tooltip>
-                  </IpAddressOverflow>
-                )}
-              </FlexCenter>
-              <TimestampInfo>
-                <DateTime dateOnly date={entry.dateCreated} />
-                <DateTime
-                  timeOnly
-                  format={is24Hours ? 'HH:mm zz' : 'LT zz'}
-                  date={entry.dateCreated}
-                />
-              </TimestampInfo>
-            </Fragment>
-          );
-        })}
-      </PanelTable>
+      {!access ? (
+        <PermissionAlert />
+      ) : (
+        <div>
+          <SettingsPageHeader title={t('Audit Log')} action={action} />
+          <PanelTable
+            headers={[t('Member'), t('Action'), t('IP'), t('Time')]}
+            isEmpty={!hasEntries && entries?.length === 0}
+            emptyMessage={t('No audit entries available')}
+            isLoading={isLoading}
+          >
+            {(entries ?? []).map(entry => {
+              if (!entry) {
+                return null;
+              }
+              return (
+                <Fragment key={entry.id}>
+                  <UserInfo>
+                    <div>{getAvatarDisplay(entry.actor)}</div>
+                    <NameContainer>
+                      {addUsernameDisplay(entry.actor)}
+                      <AuditNote entry={entry} orgSlug={organization.slug} />
+                    </NameContainer>
+                  </UserInfo>
+                  <FlexCenter>
+                    <MonoDetail>{getTypeDisplay(entry.event)}</MonoDetail>
+                  </FlexCenter>
+                  <FlexCenter>
+                    {entry.ipAddress && (
+                      <IpAddressOverflow>
+                        <Tooltip
+                          title={entry.ipAddress}
+                          disabled={entry.ipAddress.length <= ipv4Length}
+                        >
+                          <MonoDetail>{entry.ipAddress}</MonoDetail>
+                        </Tooltip>
+                      </IpAddressOverflow>
+                    )}
+                  </FlexCenter>
+                  <TimestampInfo>
+                    <DateTime dateOnly date={entry.dateCreated} />
+                    <DateTime
+                      timeOnly
+                      format={is24Hours ? 'HH:mm zz' : 'LT zz'}
+                      date={entry.dateCreated}
+                    />
+                  </TimestampInfo>
+                </Fragment>
+              );
+            })}
+          </PanelTable>
+        </div>
+      )}
       {pageLinks && <Pagination pageLinks={pageLinks} onCursor={onCursor} />}
     </div>
   );

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -271,7 +271,7 @@ function AuditLogList({
 
   return (
     <div>
-      {!organization.access ? (
+      {!organization.access.includes('org:write') ? (
         <PermissionAlert />
       ) : (
         <div>

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -232,7 +232,6 @@ function AuditNote({
 }
 
 type Props = {
-  access: boolean;
   entries: AuditLog[] | null;
   eventType: string | undefined;
   eventTypes: string[] | null;
@@ -243,7 +242,6 @@ type Props = {
 };
 
 function AuditLogList({
-  access,
   isLoading,
   pageLinks,
   entries,
@@ -273,7 +271,7 @@ function AuditLogList({
 
   return (
     <div>
-      {!access ? (
+      {!organization.access ? (
         <PermissionAlert />
       ) : (
         <div>

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -9,6 +9,7 @@ import type {AuditLog} from 'sentry/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import PermissionAlert from 'sentry/views/settings/organization/permissionAlert';
 
 import AuditLogList from './auditLogList';
 
@@ -105,15 +106,19 @@ function OrganizationAuditLog({location}: Props) {
 
   return (
     <Fragment>
-      <AuditLogList
-        entries={state.entryList}
-        pageLinks={state.entryListPageLinks}
-        eventType={state.eventType}
-        eventTypes={state.eventTypes}
-        onEventSelect={handleEventSelect}
-        isLoading={state.isLoading}
-        onCursor={handleCursor}
-      />
+      {!organization.access.includes('org:write') ? (
+        <PermissionAlert />
+      ) : (
+        <AuditLogList
+          entries={state.entryList}
+          pageLinks={state.entryListPageLinks}
+          eventType={state.eventType}
+          eventTypes={state.eventTypes}
+          onEventSelect={handleEventSelect}
+          isLoading={state.isLoading}
+          onCursor={handleCursor}
+        />
+      )}
     </Fragment>
   );
 }

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -17,6 +17,7 @@ type Props = {
 };
 
 type State = {
+  access: boolean;
   entryList: AuditLog[] | null;
   entryListPageLinks: string | null;
   eventType: string | undefined;
@@ -32,6 +33,7 @@ function OrganizationAuditLog({location}: Props) {
     eventType: decodeScalar(location.query.event),
     eventTypes: [],
     isLoading: true,
+    access: true,
   });
   const organization = useOrganization();
   const api = useApi();
@@ -83,6 +85,7 @@ function OrganizationAuditLog({location}: Props) {
       setState(prevState => ({
         ...prevState,
         isLoading: false,
+        access: false,
       }));
       addErrorMessage('Unable to load audit logs.');
     }
@@ -106,6 +109,7 @@ function OrganizationAuditLog({location}: Props) {
   return (
     <Fragment>
       <AuditLogList
+        access={state.access}
         entries={state.entryList}
         pageLinks={state.entryListPageLinks}
         eventType={state.eventType}

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -17,7 +17,6 @@ type Props = {
 };
 
 type State = {
-  access: boolean;
   entryList: AuditLog[] | null;
   entryListPageLinks: string | null;
   eventType: string | undefined;
@@ -33,7 +32,6 @@ function OrganizationAuditLog({location}: Props) {
     eventType: decodeScalar(location.query.event),
     eventTypes: [],
     isLoading: true,
-    access: true,
   });
   const organization = useOrganization();
   const api = useApi();
@@ -85,7 +83,6 @@ function OrganizationAuditLog({location}: Props) {
       setState(prevState => ({
         ...prevState,
         isLoading: false,
-        access: false,
       }));
       addErrorMessage('Unable to load audit logs.');
     }
@@ -109,7 +106,6 @@ function OrganizationAuditLog({location}: Props) {
   return (
     <Fragment>
       <AuditLogList
-        access={state.access}
         entries={state.entryList}
         pageLinks={state.entryListPageLinks}
         eventType={state.eventType}


### PR DESCRIPTION
* Always shows audit log tab in organization settings
* If user doesn't have access, it will show warning

User with access:
![Screenshot 2024-02-16 at 2 46 38 PM](https://github.com/getsentry/sentry/assets/33237075/3c73b235-9350-4839-831a-42d555c327eb)

User without access:
![Screenshot 2024-02-16 at 2 46 25 PM](https://github.com/getsentry/sentry/assets/33237075/e1e268e9-a6eb-41b7-8d6b-91cbdd796dbe)

Fixes https://github.com/getsentry/team-core-product-foundations/issues/86

