### PR TITLE
ref(perf): Introduce `ModuleLayout` layout primitive

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -26,6 +26,7 @@ import {NoDataMessage} from 'sentry/views/performance/database/noDataMessage';
 import {isAValidSort, QueriesTable} from 'sentry/views/performance/database/queriesTable';
 import {ThroughputChart} from 'sentry/views/performance/database/throughputChart';
 import {useSelectedDurationAggregate} from 'sentry/views/performance/database/useSelectedDurationAggregate';
+import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import Onboarding from 'sentry/views/performance/onboarding';
 import {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
@@ -145,61 +146,69 @@ export function DatabaseLandingPage() {
 
       <Layout.Body>
         <Layout.Main fullWidth>
-          {!onboardingProject && !isCriticalDataLoading && (
-            <NoDataMessage
-              Wrapper={AlertBanner}
-              isDataAvailable={isAnyCriticalDataAvailable}
-            />
-          )}
+          <ModuleLayout.Layout>
+            {!onboardingProject && !isCriticalDataLoading && (
+              <NoDataMessage
+                Wrapper={AlertBanner}
+                isDataAvailable={isAnyCriticalDataAvailable}
+              />
+            )}
 
-          <FloatingFeedbackWidget />
+            <FloatingFeedbackWidget />
 
-          <PaddedContainer>
-            <PageFilterBar condensed>
-              <ProjectPageFilter />
-              <EnvironmentPageFilter />
-              <DatePageFilter />
-            </PageFilterBar>
-          </PaddedContainer>
+            <ModuleLayout.Full>
+              <PageFilterBar condensed>
+                <ProjectPageFilter />
+                <EnvironmentPageFilter />
+                <DatePageFilter />
+              </PageFilterBar>
+            </ModuleLayout.Full>
 
-          {onboardingProject && (
-            <Onboarding organization={organization} project={onboardingProject} />
-          )}
-          {!onboardingProject && (
-            <Fragment>
-              <ChartContainer>
-                <ThroughputChart
-                  series={throughputData['spm()']}
-                  isLoading={isThroughputDataLoading}
-                />
+            {onboardingProject && (
+              <Onboarding organization={organization} project={onboardingProject} />
+            )}
+            {!onboardingProject && (
+              <Fragment>
+                <ModuleLayout.Half>
+                  <ThroughputChart
+                    series={throughputData['spm()']}
+                    isLoading={isThroughputDataLoading}
+                  />
+                </ModuleLayout.Half>
 
-                <DurationChart
-                  series={durationData[`${selectedAggregate}(span.self_time)`]}
-                  isLoading={isDurationDataLoading}
-                />
-              </ChartContainer>
+                <ModuleLayout.Half>
+                  <DurationChart
+                    series={durationData[`${selectedAggregate}(span.self_time)`]}
+                    isLoading={isDurationDataLoading}
+                  />
+                </ModuleLayout.Half>
 
-              <FilterOptionsContainer>
-                <SelectorContainer>
-                  <ActionSelector moduleName={moduleName} value={spanAction ?? ''} />
-                </SelectorContainer>
+                <ModuleLayout.Full>
+                  <FilterOptionsContainer>
+                    <SelectorContainer>
+                      <ActionSelector moduleName={moduleName} value={spanAction ?? ''} />
+                    </SelectorContainer>
 
-                <SelectorContainer>
-                  <DomainSelector moduleName={moduleName} value={spanDomain ?? ''} />
-                </SelectorContainer>
-              </FilterOptionsContainer>
+                    <SelectorContainer>
+                      <DomainSelector moduleName={moduleName} value={spanDomain ?? ''} />
+                    </SelectorContainer>
+                  </FilterOptionsContainer>
+                </ModuleLayout.Full>
 
-              <SearchBarContainer>
-                <SearchBar
-                  query={spanDescription}
-                  placeholder={t('Search for more Queries')}
-                  onSearch={handleSearch}
-                />
-              </SearchBarContainer>
+                <ModuleLayout.Full>
+                  <SearchBar
+                    query={spanDescription}
+                    placeholder={t('Search for more Queries')}
+                    onSearch={handleSearch}
+                  />
+                </ModuleLayout.Full>
 
-              <QueriesTable response={queryListResponse} sort={sort} />
-            </Fragment>
-          )}
+                <ModuleLayout.Full>
+                  <QueriesTable response={queryListResponse} sort={sort} />
+                </ModuleLayout.Full>
+              </Fragment>
+            )}
+          </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>
     </React.Fragment>
@@ -211,20 +220,6 @@ const DEFAULT_SORT = {
   kind: 'desc' as const,
 };
 
-const PaddedContainer = styled('div')`
-  margin-bottom: ${space(2)};
-`;
-
-const ChartContainer = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr;
-
-  @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: 1fr 1fr;
-    gap: ${space(2)};
-  }
-`;
-
 function AlertBanner(props) {
   return <Alert {...props} type="info" showIcon />;
 }
@@ -233,7 +228,6 @@ const FilterOptionsContainer = styled('div')`
   display: flex;
   flex-wrap: wrap;
   gap: ${space(2)};
-  margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     flex-wrap: nowrap;
@@ -246,10 +240,6 @@ const SelectorContainer = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     flex-basis: auto;
   }
-`;
-
-const SearchBarContainer = styled('div')`
-  margin-bottom: ${space(2)};
 `;
 
 const LIMIT: number = 25;

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -1,5 +1,4 @@
 import React, {Fragment} from 'react';
-import styled from '@emotion/styled';
 import pickBy from 'lodash/pickBy';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -10,7 +9,6 @@ import {EnvironmentPageFilter} from 'sentry/components/organizations/environment
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {fromSorts} from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -21,6 +19,7 @@ import {DurationChart} from 'sentry/views/performance/database/durationChart';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 import {DomainsTable, isAValidSort} from 'sentry/views/performance/http/domainsTable';
 import {ThroughputChart} from 'sentry/views/performance/http/throughputChart';
+import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import Onboarding from 'sentry/views/performance/onboarding';
 import {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
@@ -106,34 +105,41 @@ export function HTTPLandingPage() {
         <Layout.Main fullWidth>
           <FloatingFeedbackWidget />
 
-          <PaddedContainer>
-            <PageFilterBar condensed>
-              <ProjectPageFilter />
-              <EnvironmentPageFilter />
-              <DatePageFilter />
-            </PageFilterBar>
-          </PaddedContainer>
+          <ModuleLayout.Layout>
+            <ModuleLayout.Full>
+              <PageFilterBar condensed>
+                <ProjectPageFilter />
+                <EnvironmentPageFilter />
+                <DatePageFilter />
+              </PageFilterBar>
+            </ModuleLayout.Full>
 
-          {onboardingProject && (
-            <Onboarding organization={organization} project={onboardingProject} />
-          )}
-          {!onboardingProject && (
-            <Fragment>
-              <ChartContainer>
-                <ThroughputChart
-                  series={throughputData['spm()']}
-                  isLoading={isThroughputDataLoading}
-                />
+            {onboardingProject && (
+              <Onboarding organization={organization} project={onboardingProject} />
+            )}
 
-                <DurationChart
-                  series={durationData[`avg(span.self_time)`]}
-                  isLoading={isDurationDataLoading}
-                />
-              </ChartContainer>
+            {!onboardingProject && (
+              <Fragment>
+                <ModuleLayout.Half>
+                  <ThroughputChart
+                    series={throughputData['spm()']}
+                    isLoading={isThroughputDataLoading}
+                  />
+                </ModuleLayout.Half>
 
-              <DomainsTable response={domainsListResponse} sort={sort} />
-            </Fragment>
-          )}
+                <ModuleLayout.Half>
+                  <DurationChart
+                    series={durationData[`avg(span.self_time)`]}
+                    isLoading={isDurationDataLoading}
+                  />
+                </ModuleLayout.Half>
+
+                <ModuleLayout.Full>
+                  <DomainsTable response={domainsListResponse} sort={sort} />
+                </ModuleLayout.Full>
+              </Fragment>
+            )}
+          </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>
     </React.Fragment>
@@ -144,20 +150,6 @@ const DEFAULT_SORT = {
   field: 'time_spent_percentage()' as const,
   kind: 'desc' as const,
 };
-
-const PaddedContainer = styled('div')`
-  margin-bottom: ${space(2)};
-`;
-
-const ChartContainer = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr;
-
-  @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: 1fr 1fr;
-    gap: ${space(2)};
-  }
-`;
 
 const DOMAIN_TABLE_ROW_COUNT = 10;
 

--- a/static/app/views/performance/moduleLayout.tsx
+++ b/static/app/views/performance/moduleLayout.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+export const Layout = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: ${space(2)};
+`;
+
+export const Quarter = styled('div')`
+  grid-column: span 3;
+`;
+
+export const Third = styled('div')`
+  grid-column: span 4;
+`;
+
+export const Half = styled('div')`
+  grid-column: span 12;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-column: span 6;
+  }
+`;
+
+export const ThreeQuarters = styled('div')`
+  grid-column: span 8;
+`;
+
+export const Full = styled('div')`
+  grid-column: span 12;
+`;

--- a/static/app/views/starfish/components/chartPanel.tsx
+++ b/static/app/views/starfish/components/chartPanel.tsx
@@ -13,11 +13,19 @@ type Props = {
 
 export default function ChartPanel({title, children, button, subtitle}: Props) {
   return (
-    <Panel>
+    <PanelWithNoPadding>
       <PanelBody>
         {title && (
           <Header>
-            {title && <ChartLabel>{title}</ChartLabel>}
+            {title && (
+              <ChartLabel>
+                {typeof title === 'string' ? (
+                  <TextTitleContainer>{title}</TextTitleContainer>
+                ) : (
+                  title
+                )}
+              </ChartLabel>
+            )}
             {button}
           </Header>
         )}
@@ -28,9 +36,17 @@ export default function ChartPanel({title, children, button, subtitle}: Props) {
         )}
         {children}
       </PanelBody>
-    </Panel>
+    </PanelWithNoPadding>
   );
 }
+
+const PanelWithNoPadding = styled(Panel)`
+  margin-bottom: 0;
+`;
+
+const TextTitleContainer = styled('div')`
+  padding: 1px 0;
+`;
 
 const SubtitleContainer = styled('div')`
   padding-top: ${space(0.5)};


### PR DESCRIPTION
This is the tidiest and least silly way I could think of to re-use how we lay out our current module work.

All the modules have a _lot_ in common, on their landing and details pages!

1. The space is `2` between all elements
2. The page is divided into simple areas like 2-up and 3-up widgets with borders

And yet, we're doing a lot of strange `PaddedContainer`-like elements everywhere _and_ our padding is inconsistent as a result. Here, I'm adding a real simple `ModuleLayout` which is just a `grid` layout with some helpers. It helps _my_ two modules a bunch, should also be useful for others, since it does a _little_ bit of work to make phone layouts make sense, too.

Thoughts?
