### PR TITLE
chore(ci): Updating codecov-action to fix deprecation warning

### DIFF
--- a/.github/actions/artifacts/action.yml
+++ b/.github/actions/artifacts/action.yml
@@ -18,7 +18,7 @@ runs:
   using: 'composite'
   steps:
     - name: Upload to codecov
-      uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+      uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
       with:
         token: ${{ inputs.token }}
         flags: ${{ inputs.type }}


### PR DESCRIPTION
Bumping codecov-action version in order to move off of node16 which is now deprecated.