### PR TITLE
feat(crons-db): Stop querying `MonitorEnvironment.environment` in queries

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_checkin_index.py
@@ -66,7 +66,9 @@ class OrganizationMonitorCheckInIndexEndpoint(MonitorEndpoint):
         environments = get_environments(request, organization)
 
         if environments:
-            queryset = queryset.filter(monitor_environment__environment__in=environments)
+            queryset = queryset.filter(
+                monitor_environment__environment_id__in=[e.id for e in environments]
+            )
 
         expand: list[str] = request.GET.getlist("expand", [])
 

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -137,21 +137,23 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
         environments = None
         if "environment" in filter_params:
             environments = filter_params["environment_objects"]
+            environment_ids = [e.id for e in environments]
             # use a distinct() filter as queries spanning multiple tables can include duplicates
             if request.GET.get("includeNew"):
                 queryset = queryset.filter(
-                    Q(monitorenvironment__environment__in=environments) | Q(monitorenvironment=None)
+                    Q(monitorenvironment__environment_id__in=environment_ids)
+                    | Q(monitorenvironment=None)
                 ).distinct()
             else:
                 queryset = queryset.filter(
-                    monitorenvironment__environment__in=environments
+                    monitorenvironment__environment_id__in=environment_ids
                 ).distinct()
         else:
             environments = list(Environment.objects.filter(organization_id=organization.id))
 
         # sort monitors by top monitor environment, then by latest check-in
         monitor_environments_query = MonitorEnvironment.objects.filter(
-            monitor__id=OuterRef("id"), environment__in=environments
+            monitor__id=OuterRef("id"), environment_id__in=[e.id for e in environments]
         )
         sort_fields = []
 

--- a/src/sentry/monitors/endpoints/organization_monitor_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_stats.py
@@ -60,7 +60,9 @@ class OrganizationMonitorStatsEndpoint(MonitorEndpoint, StatsMixin):
         environments = get_environments(request, organization)
 
         if environments:
-            check_ins = check_ins.filter(monitor_environment__environment__in=environments)
+            check_ins = check_ins.filter(
+                monitor_environment__environment_id__in=[e.id for e in environments]
+            )
 
         # Use postgres' `date_bin` to bucket rounded to our rollups
         bucket = Func(

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -12,6 +12,7 @@ from django.test.utils import override_settings
 from sentry import killswitches
 from sentry.constants import ObjectStatus
 from sentry.db.models import BoundedPositiveIntegerField
+from sentry.models.environment import Environment
 from sentry.monitors.constants import TIMEOUT, PermitCheckInStatus
 from sentry.monitors.consumers.monitor_consumer import StoreMonitorCheckInStrategyFactory
 from sentry.monitors.models import (
@@ -472,10 +473,10 @@ class MonitorConsumerTest(TestCase):
         monitor = Monitor.objects.get(slug="my-monitor")
         assert monitor is not None
 
-        monitor_environment = MonitorEnvironment.objects.get(
-            monitor=monitor, environment__name="my-environment"
+        env = Environment.objects.get(
+            organization_id=monitor.organization_id, name="my-environment"
         )
-        assert monitor_environment is not None
+        assert MonitorEnvironment.objects.filter(monitor=monitor, environment_id=env.id).exists()
 
     def test_monitor_upsert_empty_timezone(self):
         self.send_checkin(


### PR DESCRIPTION
We want to move all crons related tables to a separate database. To facilitate this, we need to stop filtering to Environment using a join and instead fetch ids from Environment in a separate query.
