### PR TITLE
fix(alert): Fix cascading deletion for alert rule

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -267,6 +267,10 @@ class BaseModel(models.Model):
         self.save(force_insert=True)
         return (self.pk, ImportKind.Inserted)
 
+    @classmethod
+    def query_manager_to_use_for_deletion(cls):
+        return cls.objects
+
 
 class Model(BaseModel):
     id: models.Field[int, int] = BoundedBigAutoField(primary_key=True)

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -267,10 +267,6 @@ class BaseModel(models.Model):
         self.save(force_insert=True)
         return (self.pk, ImportKind.Inserted)
 
-    @classmethod
-    def query_manager_to_use_for_deletion(cls):
-        return cls.objects
-
 
 class Model(BaseModel):
     id: models.Field[int, int] = BoundedBigAutoField(primary_key=True)

--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -89,7 +89,7 @@ default_manager = DeletionTaskManager(default_task=ModelDeletionTask)
 def load_defaults():
     from sentry import models
     from sentry.discover.models import DiscoverSavedQuery
-    from sentry.incidents.models import AlertRule, AlertRuleTriggerAction
+    from sentry.incidents.models import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
     from sentry.models.commitfilechange import CommitFileChange
     from sentry.monitors import models as monitor_models
 
@@ -97,6 +97,8 @@ def load_defaults():
 
     default_manager.register(models.Activity, BulkModelDeletionTask)
     default_manager.register(AlertRule, defaults.AlertRuleDeletionTask)
+    default_manager.register(AlertRuleTrigger, defaults.AlertRuleTriggerDeletionTask)
+    default_manager.register(AlertRuleTriggerAction, defaults.AlertRuleTriggerActionDeletionTask)
     default_manager.register(models.ApiApplication, defaults.ApiApplicationDeletionTask)
     default_manager.register(models.ApiGrant, BulkModelDeletionTask)
     default_manager.register(models.ApiKey, BulkModelDeletionTask)
@@ -165,7 +167,6 @@ def load_defaults():
     default_manager.register(models.UserReport, BulkModelDeletionTask)
     default_manager.register(models.ArtifactBundle, ArtifactBundleDeletionTask)
     default_manager.register(models.Rule, defaults.RuleDeletionTask)
-    default_manager.register(AlertRuleTriggerAction, defaults.AlertRuleTriggerActionDeletionTask)
 
 
 load_defaults()

--- a/src/sentry/deletions/defaults/__init__.py
+++ b/src/sentry/deletions/defaults/__init__.py
@@ -1,3 +1,4 @@
+from .alert_rule_trigger import *  # noqa: F401,F403
 from .alert_rule_trigger_action import *  # noqa: F401,F403
 from .alertrule import *  # noqa: F401,F403
 from .apiapplication import *  # noqa: F401,F403

--- a/src/sentry/deletions/defaults/alert_rule_trigger.py
+++ b/src/sentry/deletions/defaults/alert_rule_trigger.py
@@ -1,0 +1,10 @@
+from ..base import ModelDeletionTask, ModelRelation
+
+
+class AlertRuleTriggerDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        from sentry.incidents.models import AlertRuleTriggerAction
+
+        return [
+            ModelRelation(AlertRuleTriggerAction, {"alert_rule_trigger_id": instance.id}),
+        ]

--- a/src/sentry/deletions/defaults/alert_rule_trigger_action.py
+++ b/src/sentry/deletions/defaults/alert_rule_trigger_action.py
@@ -2,6 +2,8 @@ from ..base import ModelDeletionTask, ModelRelation
 
 
 class AlertRuleTriggerActionDeletionTask(ModelDeletionTask):
+    manager_name = "objects_for_deletion"
+
     def get_child_relations(self, instance):
         from sentry.models.notificationmessage import NotificationMessage
 

--- a/src/sentry/deletions/defaults/alertrule.py
+++ b/src/sentry/deletions/defaults/alertrule.py
@@ -1,7 +1,14 @@
-from ..base import ModelDeletionTask
+from ..base import ModelDeletionTask, ModelRelation
 
 
 class AlertRuleDeletionTask(ModelDeletionTask):
     # The default manager for alert rules excludes snapshots
     # which we want to include when deleting an organization.
     manager_name = "objects_with_snapshots"
+
+    def get_child_relations(self, instance):
+        from sentry.incidents.models import AlertRuleTrigger
+
+        return [
+            ModelRelation(AlertRuleTrigger, {"alert_rule_id": instance.id}),
+        ]

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -45,7 +45,7 @@ from sentry.incidents.models import (
 from sentry.models.actor import Actor
 from sentry.models.notificationaction import ActionService, ActionTarget
 from sentry.models.project import Project
-from sentry.models.scheduledeletion import ScheduledDeletion
+from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.relay.config.metric_extraction import on_demand_metrics_feature_flags
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.fields import is_function, resolve_field
@@ -910,7 +910,7 @@ def delete_alert_rule(alert_rule, user=None, ip_address=None):
                 type=AlertRuleActivityType.DELETED.value,
             )
         else:
-            ScheduledDeletion.schedule(instance=alert_rule, days=0, actor=user)
+            RegionScheduledDeletion.schedule(instance=alert_rule, days=0, actor=user)
 
     if alert_rule.id:
         # Change the incident status asynchronously, which could take awhile with many incidents due to snapshot creations.
@@ -1499,7 +1499,7 @@ def delete_alert_rule_trigger_action(trigger_action):
     """
     Deletes a AlertRuleTriggerAction
     """
-    ScheduledDeletion.schedule(instance=trigger_action, days=0)
+    RegionScheduledDeletion.schedule(instance=trigger_action, days=0)
 
 
 def get_actions_for_trigger(trigger):

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -903,7 +903,6 @@ def delete_alert_rule(alert_rule, user=None, ip_address=None):
 
         incidents = Incident.objects.filter(alert_rule=alert_rule)
         if incidents.exists():
-            alert_rule.update(status=AlertRuleStatus.SNAPSHOT.value)
             AlertRuleActivity.objects.create(
                 alert_rule=alert_rule,
                 user_id=user.id if user else None,
@@ -911,6 +910,8 @@ def delete_alert_rule(alert_rule, user=None, ip_address=None):
             )
         else:
             RegionScheduledDeletion.schedule(instance=alert_rule, days=0, actor=user)
+
+        alert_rule.update(status=AlertRuleStatus.SNAPSHOT.value)
 
     if alert_rule.id:
         # Change the incident status asynchronously, which could take awhile with many incidents due to snapshot creations.

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1498,9 +1498,11 @@ def get_alert_rule_trigger_action_sentry_app(organization, sentry_app_id, instal
 
 def delete_alert_rule_trigger_action(trigger_action):
     """
-    Deletes a AlertRuleTriggerAction
+    Schedules a deletion for a AlertRuleTriggerAction, and marks it as pending deletion.
+    Marking it as pending deletion should filter out the object through the manager when querying.
     """
     RegionScheduledDeletion.schedule(instance=trigger_action, days=0)
+    trigger_action.update(status=ObjectStatus.PENDING_DELETION)
 
 
 def get_actions_for_trigger(trigger):

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -45,6 +45,7 @@ from sentry.incidents.models import (
 from sentry.models.actor import Actor
 from sentry.models.notificationaction import ActionService, ActionTarget
 from sentry.models.project import Project
+from sentry.models.scheduledeletion import ScheduledDeletion
 from sentry.relay.config.metric_extraction import on_demand_metrics_feature_flags
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.fields import is_function, resolve_field
@@ -909,7 +910,7 @@ def delete_alert_rule(alert_rule, user=None, ip_address=None):
                 type=AlertRuleActivityType.DELETED.value,
             )
         else:
-            alert_rule.delete()
+            ScheduledDeletion.schedule(instance=alert_rule, days=0, actor=user)
 
     if alert_rule.id:
         # Change the incident status asynchronously, which could take awhile with many incidents due to snapshot creations.
@@ -1498,7 +1499,7 @@ def delete_alert_rule_trigger_action(trigger_action):
     """
     Deletes a AlertRuleTriggerAction
     """
-    trigger_action.delete()
+    ScheduledDeletion.schedule(instance=trigger_action, days=0)
 
 
 def get_actions_for_trigger(trigger):

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -539,6 +539,10 @@ class AlertRule(Model):
 
         return old_pk
 
+    @classmethod
+    def query_manager_to_use_for_deletion(cls):
+        return cls.objects_with_snapshots
+
 
 class TriggerStatus(Enum):
     ACTIVE = 0
@@ -748,6 +752,7 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
     )
 
     objects: ClassVar[AlertRuleTriggerActionManager] = AlertRuleTriggerActionManager()
+    objects_for_deletion: ClassVar[BaseManager] = BaseManager()
 
     alert_rule_trigger = FlexibleForeignKey("sentry.AlertRuleTrigger")
 
@@ -825,6 +830,10 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
     @classmethod
     def get_registered_types(cls):
         return list(cls._type_registrations.values())
+
+    @classmethod
+    def query_manager_to_use_for_deletion(cls):
+        return cls.objects_for_deletion
 
 
 class AlertRuleActivityType(Enum):

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -706,6 +706,15 @@ class AlertRuleTriggerExclusion(Model):
         unique_together = (("alert_rule_trigger", "query_subscription"),)
 
 
+class AlertRuleTriggerActionManager(BaseManager["AlertRuleTriggerAction"]):
+    """
+    A manager that excludes trigger actions that are pending to be deleted
+    """
+
+    def get_queryset(self):
+        return super().get_queryset().exclude(status=ObjectStatus.PENDING_DELETION)
+
+
 @region_silo_only_model
 class AlertRuleTriggerAction(AbstractNotificationAction):
     """

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -747,6 +747,8 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
         ["handler", "slug", "type", "supported_target_types", "integration_provider"],
     )
 
+    objects: ClassVar[AlertRuleTriggerActionManager] = AlertRuleTriggerActionManager()
+
     alert_rule_trigger = FlexibleForeignKey("sentry.AlertRuleTrigger")
 
     date_added = models.DateTimeField(default=timezone.now)

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -539,10 +539,6 @@ class AlertRule(Model):
 
         return old_pk
 
-    @classmethod
-    def query_manager_to_use_for_deletion(cls):
-        return cls.objects_with_snapshots
-
 
 class TriggerStatus(Enum):
     ACTIVE = 0
@@ -830,10 +826,6 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
     @classmethod
     def get_registered_types(cls):
         return list(cls._type_registrations.values())
-
-    @classmethod
-    def query_manager_to_use_for_deletion(cls):
-        return cls.objects_for_deletion
 
 
 class AlertRuleActivityType(Enum):

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -120,7 +120,9 @@ class BaseScheduledDeletion(Model):
         return apps.get_model(self.app_label, self.model_name)
 
     def get_instance(self):
-        return self.get_model().objects.get(pk=self.object_id)
+        model = self.get_model()
+        query_manager = model.query_manager_to_use_for_deletion()
+        return query_manager.get(pk=self.object_id)
 
     def get_actor(self) -> RpcUser | None:
         if not self.actor_id:

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -120,8 +120,10 @@ class BaseScheduledDeletion(Model):
         return apps.get_model(self.app_label, self.model_name)
 
     def get_instance(self):
+        from sentry import deletions
+
         model = self.get_model()
-        query_manager = model.query_manager_to_use_for_deletion()
+        query_manager = getattr(model, deletions.get(model=model, query=None).manager_name)
         return query_manager.get(pk=self.object_id)
 
     def get_actor(self) -> RpcUser | None:

--- a/tests/sentry/deletions/test_alert_rule.py
+++ b/tests/sentry/deletions/test_alert_rule.py
@@ -18,6 +18,6 @@ class DeleteAlertRuleTest(TestCase, HybridCloudTestMixin):
         with self.tasks():
             run_scheduled_deletions()
 
-        assert Organization.objects.filter(id=organization.id).exist()
+        assert Organization.objects.filter(id=organization.id).exists()
         assert not AlertRule.objects.filter(id=alert_rule.id).exists()
         assert not AlertRuleTrigger.objects.filter(id=alert_rule_trigger.id).exists()

--- a/tests/sentry/deletions/test_alert_rule.py
+++ b/tests/sentry/deletions/test_alert_rule.py
@@ -1,0 +1,23 @@
+from sentry.incidents.models import AlertRule, AlertRuleTrigger
+from sentry.models.organization import Organization
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
+from sentry.testutils.cases import TestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class DeleteAlertRuleTest(TestCase, HybridCloudTestMixin):
+    def test_simple(self):
+        organization = self.create_organization()
+        alert_rule = self.create_alert_rule(organization=organization)
+        alert_rule_trigger = self.create_alert_rule_trigger(alert_rule=alert_rule)
+
+        self.ScheduledDeletion.schedule(instance=alert_rule, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert Organization.objects.filter(id=organization.id).exist()
+        assert not AlertRule.objects.filter(id=alert_rule.id).exists()
+        assert not AlertRuleTrigger.objects.filter(id=alert_rule_trigger.id).exists()

--- a/tests/sentry/deletions/test_alert_rule_trigger.py
+++ b/tests/sentry/deletions/test_alert_rule_trigger.py
@@ -1,0 +1,24 @@
+from sentry.incidents.models import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
+from sentry.testutils.cases import TestCase
+from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class DeleteAlertRuleTriggerTest(TestCase, HybridCloudTestMixin):
+    def test_simple(self):
+        alert_rule = self.create_alert_rule()
+        alert_rule_trigger = self.create_alert_rule_trigger(alert_rule=alert_rule)
+        alert_rule_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=alert_rule_trigger
+        )
+
+        self.ScheduledDeletion.schedule(instance=alert_rule_trigger, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert AlertRule.objects.filter(id=alert_rule.id).exists()
+        assert not AlertRuleTrigger.objects.filter(id=alert_rule_trigger.id).exists()
+        assert not AlertRuleTriggerAction.objects.filter(id=alert_rule_trigger_action.id).exists()

--- a/tests/sentry/deletions/test_alert_rule_trigger_action.py
+++ b/tests/sentry/deletions/test_alert_rule_trigger_action.py
@@ -10,18 +10,18 @@ from sentry.testutils.silo import region_silo_test
 class DeleteAlertRuleTriggerActionTest(TestCase, HybridCloudTestMixin):
     def test_simple(self):
         incident = self.create_incident()
-        action = self.create_alert_rule_trigger_action()
+        alert_rule_trigger_action = self.create_alert_rule_trigger_action()
         notification_message = NotificationMessage(
             message_identifier="s3iojewd90j23eqw",
             incident=incident,
-            trigger_action=action,
+            trigger_action=alert_rule_trigger_action,
         )
         notification_message.save()
 
-        self.ScheduledDeletion.schedule(instance=action, days=0)
+        self.ScheduledDeletion.schedule(instance=alert_rule_trigger_action, days=0)
 
         with self.tasks():
             run_scheduled_deletions()
 
-        assert not AlertRuleTriggerAction.objects.filter(id=action.id).exists()
+        assert not AlertRuleTriggerAction.objects.filter(id=alert_rule_trigger_action.id).exists()
         assert not NotificationMessage.objects.filter(id=notification_message.id).exists()

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -30,6 +30,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo import SiloMode
+from sentry.tasks.deletion import run_scheduled_deletions
 from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )
@@ -1196,6 +1197,12 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             )
 
         assert not AlertRule.objects.filter(id=self.alert_rule.id).exists()
+        assert AlertRule.objects_with_snapshots.filter(name=self.alert_rule.name).exists()
+        assert AlertRule.objects_with_snapshots.filter(id=self.alert_rule.id).exists()
+
+        with self.tasks():
+            run_scheduled_deletions()
+
         assert not AlertRule.objects_with_snapshots.filter(name=self.alert_rule.name).exists()
         assert not AlertRule.objects_with_snapshots.filter(id=self.alert_rule.id).exists()
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -30,7 +30,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo import SiloMode
-from sentry.tasks.deletion import run_scheduled_deletions
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -6,6 +6,7 @@ from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.models import AlertRule
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo import SiloMode
+from sentry.tasks.deletion import run_scheduled_deletions
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
@@ -112,6 +113,9 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             self.get_success_response(
                 self.organization.slug, self.project.slug, self.alert_rule.id, status_code=204
             )
+
+        with self.tasks():
+            run_scheduled_deletions()
 
         assert not AlertRule.objects.filter(id=self.alert_rule.id).exists()
         assert not AlertRule.objects_with_snapshots.filter(name=self.alert_rule.id).exists()

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -6,7 +6,7 @@ from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.models import AlertRule
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo import SiloMode
-from sentry.tasks.deletion import run_scheduled_deletions
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -77,7 +77,7 @@ from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError,
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
-from sentry.tasks.deletion import run_scheduled_deletions
+from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import BaseIncidentsTest, BaseMetricsTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, region_silo_test


### PR DESCRIPTION
Continuing the deletion chain from discussion in https://github.com/getsentry/sentry/pull/65287#issuecomment-1949203972

We didn't previously have the correct deleting chain for Alert Rules setup, so adding that in this PR to close up the gap.
