### PR TITLE
ref(grouping): Clean up event manager grouping types

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -45,7 +45,12 @@ from sentry.eventstore.processing import event_processing_store
 from sentry.eventtypes import EventType
 from sentry.eventtypes.transaction import TransactionEvent
 from sentry.exceptions import HashDiscarded
-from sentry.grouping.api import GroupHashInfo, GroupingConfig, get_grouping_config_dict_for_project
+from sentry.grouping.api import (
+    NULL_GROUPHASH_INFO,
+    GroupHashInfo,
+    GroupingConfig,
+    get_grouping_config_dict_for_project,
+)
 from sentry.grouping.ingest import (
     add_group_id_to_grouphashes,
     check_for_category_mismatch,
@@ -1634,7 +1639,7 @@ def _save_aggregate_new(
     metric_tags: MutableTags,
 ) -> GroupInfo | None:
     project = event.project
-    secondary = GroupHashInfo(None, None, [], None)
+    secondary = NULL_GROUPHASH_INFO
 
     group_processing_kwargs = _get_group_processing_kwargs(job)
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -45,7 +45,7 @@ from sentry.eventstore.processing import event_processing_store
 from sentry.eventtypes import EventType
 from sentry.eventtypes.transaction import TransactionEvent
 from sentry.exceptions import HashDiscarded
-from sentry.grouping.api import GroupingConfig, get_grouping_config_dict_for_project
+from sentry.grouping.api import GroupHashInfo, GroupingConfig, get_grouping_config_dict_for_project
 from sentry.grouping.ingest import (
     add_group_id_to_grouphashes,
     check_for_category_mismatch,
@@ -144,14 +144,6 @@ class GroupInfo:
     is_regression: bool
     group_release: GroupRelease | None = None
     is_new_group_environment: bool = False
-
-
-@dataclass
-class GroupHashInfo:
-    config: GroupingConfig | None
-    hashes: CalculatedHashes | None
-    grouphashes: list[GroupHash]
-    existing_grouphash: GroupHash | None
 
 
 def pop_tag(data: dict[str, Any], key: str) -> None:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1711,9 +1711,6 @@ def create_and_seek_grouphashes(
     """
     project = job["event"].project
 
-    grouphashes = []
-    existing_grouphash = None
-
     # These will come back as Nones if the calculation decides it doesn't need to run
     grouping_config, hashes = hash_calculation_function(project, job, metric_tags)
 
@@ -1725,7 +1722,9 @@ def create_and_seek_grouphashes(
 
         existing_grouphash = find_existing_grouphash_new(grouphashes)
 
-    return GroupHashInfo(grouping_config, hashes, grouphashes, existing_grouphash)
+        return GroupHashInfo(grouping_config, hashes, grouphashes, existing_grouphash)
+    else:
+        return NULL_GROUPHASH_INFO
 
 
 def handle_existing_grouphash(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1674,14 +1674,7 @@ def _save_aggregate_new(
     maybe_run_background_grouping(project, job)
 
     record_hash_calculation_metrics(
-        # Cast in lieu of a non-null assertion operator, which Python doesn't have
-        #
-        # TODO: The typing and necessity of casting here is gross, but might be able to be improved
-        # once hierarchical grouping is gone
-        cast(GroupingConfig, primary.config),
-        cast(CalculatedHashes, primary.hashes),
-        secondary.config,
-        secondary.hashes,
+        primary.config, primary.hashes, secondary.config, secondary.hashes
     )
 
     # Now that we've used the current and possibly secondary grouping config(s) to calculate the

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1697,7 +1697,7 @@ def create_and_seek_grouphashes(
     job: Job,
     hash_calculation_function: Callable[
         [Project, Job, MutableTags],
-        tuple[GroupingConfig | None, CalculatedHashes | None],
+        tuple[GroupingConfig, CalculatedHashes],
     ],
     metric_tags: MutableTags,
 ) -> GroupHashInfo:
@@ -1717,7 +1717,7 @@ def create_and_seek_grouphashes(
     # These will come back as Nones if the calculation decides it doesn't need to run
     grouping_config, hashes = hash_calculation_function(project, job, metric_tags)
 
-    if hashes:
+    if extract_hashes(hashes):
         grouphashes = [
             GroupHash.objects.get_or_create(project=project, hash=hash)[0]
             for hash in extract_hashes(hashes)

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -68,6 +68,11 @@ class GroupHashInfo:
     existing_grouphash: GroupHash | None
 
 
+NULL_GROUPING_CONFIG: GroupingConfig = {"id": "", "enhancements": ""}
+NULL_HASHES = CalculatedHashes(hashes=[], hierarchical_hashes=[], tree_labels=[])
+NULL_GROUPHASH_INFO = GroupHashInfo(NULL_GROUPING_CONFIG, NULL_HASHES, [], None)
+
+
 class GroupingConfigNotFound(LookupError):
     pass
 

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypedDict
 
 from sentry import options
@@ -9,6 +10,7 @@ from sentry.db.models.fields.node import NodeData
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.enhancer import LATEST_VERSION, Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
+from sentry.grouping.result import CalculatedHashes
 from sentry.grouping.strategies.base import DEFAULT_GROUPING_ENHANCEMENTS_BASE, GroupingContext
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.grouping.utils import (
@@ -27,6 +29,7 @@ from sentry.grouping.variants import (
     FallbackVariant,
     SaltedComponentVariant,
 )
+from sentry.models.grouphash import GroupHash
 from sentry.utils.safe import get_path
 
 if TYPE_CHECKING:
@@ -55,6 +58,14 @@ _synthetic_exception_type_re = re.compile(
     """,
     re.X,
 )
+
+
+@dataclass
+class GroupHashInfo:
+    config: GroupingConfig
+    hashes: CalculatedHashes
+    grouphashes: list[GroupHash]
+    existing_grouphash: GroupHash | None
 
 
 class GroupingConfigNotFound(LookupError):


### PR DESCRIPTION
Currently, when we run secondary grouping, we return `None` in cases where we're not in a transition period and therefore don't calculate any hashes. This necessitates typing anything which handles both primary grouping (which never returns `None`) and secondary grouping (which might return `None`) with `| None`. That in turn means that when we know we have a value (in the case of primary hashes), we have to cast the potential `None`s back to real types. (Python doesn't have a non-null assertion operator.) TL;DR, it's all around just kind of gross.

This fixes that by changing our grouping-didn't-happen sentinel value from `None` to a new `NULL_HASHES` object, which is just an instance of `CalculatedHashes` with nothing in it. To go along with `NULL_HASHES`, `NULL_GROUPING_CONFIG` and `NULL_GROUPHASH_INFO` have also been added. Making that switch allows us to type the secondary grouping functions as always returning a value, which in turn cleans up many of the downstream types.