### PR TITLE
fix(api): Fail with 404 when deleting files for non-existing release

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -597,9 +597,14 @@ class SourceMapsEndpoint(ProjectEndpoint):
 
         if archive_name:
             with atomic_transaction(using=router.db_for_write(ReleaseFile)):
-                release = Release.objects.get(
-                    organization_id=project.organization_id, projects=project, version=archive_name
-                )
+                try:
+                    release = Release.objects.get(
+                        organization_id=project.organization_id,
+                        projects=project,
+                        version=archive_name,
+                    )
+                except Release.DoesNotExist:
+                    raise ResourceDoesNotExist(detail="The provided release does not exist")
                 if release is not None:
                     release_files = ReleaseFile.objects.filter(release_id=release.id)
                     release_files.delete()


### PR DESCRIPTION
The API currently fails with a 500 error when trying to delete sourcemaps for a release that does not exist. We should fail with 404 instead.

Fixes GH-65378
