### PR TITLE
test(kafka): re-initialize consumer

### DIFF
--- a/src/sentry/testutils/pytest/kafka.py
+++ b/src/sentry/testutils/pytest/kafka.py
@@ -192,8 +192,6 @@ def wait_for_ingest_consumer(session_ingest_consumer, task_runner):
     """
 
     def factory(settings, **kwargs):
-        consumer = session_ingest_consumer(settings, **kwargs)
-
         def waiter(exit_predicate, max_time=MAX_SECONDS_WAITING_FOR_EVENT):
             """
             Implements a wait loop for the ingest consumer
@@ -203,6 +201,7 @@ def wait_for_ingest_consumer(session_ingest_consumer, task_runner):
             :return: the first non None result returned by the exit predicate or None if the
                 max time has expired without the exit predicate returning a non None value
             """
+            consumer = session_ingest_consumer(settings, **kwargs)
 
             start_wait = time.time()
             with task_runner():


### PR DESCRIPTION
[SENTRY-TESTS-Q35](https://sentry.sentry.io/issues/4716417638/) surfaces the error

```
KafkaError{code=_MAX_POLL_EXCEEDED,val=-147,str="Application maximum poll interval (300000ms) exceeded by 467ms"}
```

which can be caused by [passing a consumer to a different process](https://github.com/confluentinc/confluent-kafka-python/issues/552). I'm not 100% sure that this is the problem we're facing, but:

The kafka consumer for relay integration tests gets initialized once [here](https://github.com/getsentry/sentry/blob/e55b8d5f396199c80972b69207b14ac1190cb808/src/sentry/testutils/relay.py#L189), and is then reused in every call to `self.wait_for_ingest_consumer`. With this PR, we create a new Kafka consumer. This [does not seem to slow down our tests](https://github.com/getsentry/sentry/actions/runs/7971601968/usage) but it might give better isolation.



ref: https://github.com/getsentry/team-ingest/issues/263