### PR TITLE
clean(metrics-extraction): Remove hashes mismatch message

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -530,12 +530,6 @@ def _can_widget_query_use_stateful_extraction(
 
     if set(spec_hashes) != set(on_demand_hashes):
         # Spec hashes should match.
-        with sentry_sdk.push_scope() as scope:
-            scope.set_extra("spec_hashes", spec_hashes)
-            scope.set_extra("on_demand_hashes", on_demand_hashes)
-            scope.set_extra("spec_entries", metrics_specs)
-            scope.set_extra("on_demand_entries", on_demand_entries)
-            sentry_sdk.capture_message(f"Hashes don't match for widget_query: {widget_query.id}")
         metrics.incr(
             "on_demand_metrics.on_demand_spec.failed_on_demand_hashes",
             amount=len(metrics_specs),


### PR DESCRIPTION
### Summary
We already have a metric for this (`failed_on_demand_hashes`), which we can alert on. Now that we're no longer developing we don't need to check. This message can perhaps be moved to the widget save in the future if we need debugging as that should also show drift in the metric hashes.
