### PR TITLE
ref(ddm): streamline metrics query type

### DIFF
--- a/static/app/components/modals/metricWidgetViewerModal.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal.tsx
@@ -246,15 +246,7 @@ function Queries({metricWidgetQueries, handleChange, addQuery, removeQuery}) {
               removeQuery={removeQuery}
               queryIndex={index}
               canRemoveQuery={metricWidgetQueries.length > 1}
-              metricsQuery={{
-                mri: query.mri,
-                query: query.query,
-                op: query.op,
-                groupBy: query.groupBy,
-                projects: selection.projects,
-                datetime: selection.datetime,
-                environments: selection.environments,
-              }}
+              metricsQuery={query}
             />
           }
         />

--- a/static/app/utils/metrics/dashboard.spec.tsx
+++ b/static/app/utils/metrics/dashboard.spec.tsx
@@ -14,16 +14,8 @@ describe('convertToDashboardWidget', () => {
       convertToDashboardWidget(
         [
           {
-            datetime: {
-              start: '2021-06-01T00:00:00',
-              end: '2021-06-02T00:00:00',
-              period: '1d',
-              utc: false,
-            },
             groupBy: ['project'],
             query: 'event.type:transaction',
-            projects: [1],
-            environments: ['prod'],
             mri: 'c:custom/login@second',
             op: 'p95',
           },
@@ -53,16 +45,8 @@ describe('convertToDashboardWidget', () => {
       convertToDashboardWidget(
         [
           {
-            datetime: {
-              start: '2021-06-01T00:00:00',
-              end: '2021-06-02T00:00:00',
-              period: '1d',
-              utc: false,
-            },
             groupBy: [],
             query: '',
-            projects: [1],
-            environments: ['prod'],
             mri: 'd:transactions/measurements.duration@second',
             op: 'p95',
           },

--- a/static/app/utils/metrics/dashboard.tsx
+++ b/static/app/utils/metrics/dashboard.tsx
@@ -85,12 +85,12 @@ export function encodeWidgetQuery(query) {
 }
 
 export function getWidgetAsQueryParams(
-  metricsQuery: MetricsQuery,
+  selection: PageFilters,
   urlWidgetQuery: string,
   displayType?: MetricDisplayType
 ) {
-  const {start, end, period} = metricsQuery.datetime;
-  const {projects} = metricsQuery;
+  const {start, end, period} = selection.datetime;
+  const {projects} = selection;
 
   return {
     source: DashboardWidgetSource.DDM,
@@ -100,7 +100,7 @@ export function getWidgetAsQueryParams(
     defaultWidgetQuery: urlWidgetQuery,
     defaultTableColumns: [],
     defaultTitle: '',
-    environment: metricsQuery.environments,
+    environment: selection.environments,
     displayType,
     project: projects,
   };

--- a/static/app/utils/metrics/dashboardImport.tsx
+++ b/static/app/utils/metrics/dashboardImport.tsx
@@ -44,10 +44,10 @@ type Formula = {
 };
 
 // result types
-type MetricWidget = Pick<MetricsQuery, 'mri' | 'op' | 'query' | 'groupBy'> & {
+interface MetricWidget extends MetricsQuery {
   displayType: MetricDisplayType;
   title: string;
-};
+}
 
 type MetricWidgetReport = {
   errors: string[];

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -36,7 +36,6 @@ import {formatMRI, formatMRIField, MRIToField, parseMRI} from 'sentry/utils/metr
 import type {
   DdmQueryParams,
   MetricsQuery,
-  MetricsQuerySubject,
   MetricWidgetQueryParams,
 } from 'sentry/utils/metrics/types';
 import {MetricDisplayType} from 'sentry/utils/metrics/types';
@@ -291,9 +290,7 @@ export function getFieldFromMetricsQuery(metricsQuery: MetricsQuery) {
   return formatMRIField(MRIToField(metricsQuery.mri, metricsQuery.op!));
 }
 
-export function getFormattedMQL(metricWidget: MetricsQuerySubject): string {
-  const {mri, op, query, groupBy} = metricWidget;
-
+export function getFormattedMQL({mri, op, query, groupBy}: MetricsQuery): string {
   if (!op) {
     return '';
   }
@@ -333,7 +330,7 @@ export function isFormattedMQL(mql: string) {
   return true;
 }
 
-export function getWidgetTitle(queries: MetricsQuerySubject[]) {
+export function getWidgetTitle(queries: MetricsQuery[]) {
   if (queries.length === 1) {
     return getFormattedMQL(queries[0]);
   }

--- a/static/app/utils/metrics/types.tsx
+++ b/static/app/utils/metrics/types.tsx
@@ -1,4 +1,4 @@
-import type {DateString, MRI, PageFilters} from 'sentry/types';
+import type {DateString, MRI} from 'sentry/types';
 
 export enum MetricDisplayType {
   LINE = 'line',
@@ -20,7 +20,14 @@ export interface FocusedMetricsSeries {
   groupBy?: Record<string, string>;
 }
 
-export interface MetricWidgetQueryParams extends MetricsQuerySubject {
+export interface MetricsQuery {
+  mri: MRI;
+  groupBy?: string[];
+  op?: string;
+  query?: string;
+}
+
+export interface MetricWidgetQueryParams extends MetricsQuery {
   displayType: MetricDisplayType;
   id: number;
   focusedSeries?: FocusedMetricsSeries[];
@@ -38,18 +45,6 @@ export interface DdmQueryParams {
   statsPeriod?: string | null;
   utc?: boolean | null;
 }
-
-export type MetricsQuery = {
-  datetime: PageFilters['datetime'];
-  environments: PageFilters['environments'];
-  mri: MRI;
-  projects: PageFilters['projects'];
-  groupBy?: string[];
-  op?: string;
-  query?: string;
-};
-
-export type MetricsQuerySubject = Pick<MetricsQuery, 'mri' | 'op' | 'query' | 'groupBy'>;
 
 export type MetricCodeLocationFrame = {
   absPath?: string;

--- a/static/app/views/ddm/contextMenu.tsx
+++ b/static/app/views/ddm/contextMenu.tsx
@@ -47,12 +47,11 @@ export function MetricQueryContextMenu({
 }: ContextMenuProps) {
   const organization = useOrganization();
   const router = useRouter();
-  const {selection} = usePageFilters();
 
   const {removeWidget, duplicateWidget, widgets} = useDDMContext();
   const createAlert = useMemo(
-    () => getCreateAlert(organization, {...metricsQuery, ...selection}),
-    [metricsQuery, organization, selection]
+    () => getCreateAlert(organization, metricsQuery),
+    [metricsQuery, organization]
   );
   const createDashboardWidget = useCreateDashboardWidget(
     organization,

--- a/static/app/views/ddm/contextMenu.tsx
+++ b/static/app/views/ddm/contextMenu.tsx
@@ -28,6 +28,7 @@ import {
 import {hasDDMFeature} from 'sentry/utils/metrics/features';
 import type {MetricDisplayType, MetricsQuery} from 'sentry/utils/metrics/types';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {useDDMContext} from 'sentry/views/ddm/context';
 import {CreateAlertModal} from 'sentry/views/ddm/createAlertModal';
@@ -46,10 +47,12 @@ export function MetricQueryContextMenu({
 }: ContextMenuProps) {
   const organization = useOrganization();
   const router = useRouter();
+  const {selection} = usePageFilters();
+
   const {removeWidget, duplicateWidget, widgets} = useDDMContext();
   const createAlert = useMemo(
-    () => getCreateAlert(organization, metricsQuery),
-    [metricsQuery, organization]
+    () => getCreateAlert(organization, {...metricsQuery, ...selection}),
+    [metricsQuery, organization, selection]
   );
   const createDashboardWidget = useCreateDashboardWidget(
     organization,
@@ -200,7 +203,7 @@ export function useCreateDashboardWidget(
   displayType?: MetricDisplayType
 ) {
   const router = useRouter();
-  const {projects, environments, datetime} = metricsQuery;
+  const {selection} = usePageFilters();
 
   return useMemo(() => {
     if (!metricsQuery.mri || !metricsQuery.op || isCustomMeasurement(metricsQuery)) {
@@ -210,7 +213,7 @@ export function useCreateDashboardWidget(
     const widgetQuery = getWidgetQuery(metricsQuery);
     const urlWidgetQuery = encodeWidgetQuery(widgetQuery);
     const widgetAsQueryParams = getWidgetAsQueryParams(
-      metricsQuery,
+      selection,
       urlWidgetQuery,
       displayType
     );
@@ -218,18 +221,14 @@ export function useCreateDashboardWidget(
     return () =>
       openAddToDashboardModal({
         organization,
-        selection: {
-          projects,
-          environments,
-          datetime,
-        },
+        selection,
         widget: convertToDashboardWidget([metricsQuery], displayType),
         router,
         widgetAsQueryParams,
         location: router.location,
         actions: ['add-and-open-dashboard', 'add-and-stay-on-current-page'],
       });
-  }, [metricsQuery, datetime, displayType, environments, organization, projects, router]);
+  }, [metricsQuery, selection, displayType, organization, router]);
 }
 
 const AddToDashboardItem = styled('div')<{disabled: boolean}>`

--- a/static/app/views/ddm/createAlertModal.tsx
+++ b/static/app/views/ddm/createAlertModal.tsx
@@ -60,8 +60,7 @@ function getInitialFormState(selection: PageFilters): FormState {
   };
 }
 
-function getAlertPeriod(selection: PageFilters) {
-  const {period, start, end} = selection.datetime;
+function getAlertPeriod({period, start, end}: PageFilters['datetime']) {
   const inHours = statsPeriodToDays(period, start, end) * 24;
 
   switch (true) {
@@ -92,9 +91,13 @@ const TIME_WINDOWS_TO_CHECK = [
   TimeWindow.ONE_DAY,
 ];
 
-export function getAlertInterval(metricsQuery, period: TimePeriod) {
+export function getAlertInterval(
+  metricsQuery: MetricsQuery,
+  datetime: PageFilters['datetime'],
+  period: TimePeriod
+) {
   const useCase = getUseCaseFromMRI(metricsQuery.mri) ?? 'custom';
-  const interval = getDDMInterval(metricsQuery.datetime, useCase);
+  const interval = getDDMInterval(datetime, useCase);
   const inMinutes = parsePeriodToHours(interval) * 60;
 
   function toInterval(timeWindow: TimeWindow) {
@@ -127,10 +130,13 @@ export function CreateAlertModal({Header, Body, Footer, metricsQuery}: Props) {
   const selectedProject = projects.find(p => p.id === formState.project);
   const isFormValid = formState.project !== null;
 
-  const alertPeriod = useMemo(() => getAlertPeriod(selection), [selection]);
+  const alertPeriod = useMemo(
+    () => getAlertPeriod(selection.datetime),
+    [selection.datetime]
+  );
   const alertInterval = useMemo(
-    () => getAlertInterval(metricsQuery, alertPeriod),
-    [metricsQuery, alertPeriod]
+    () => getAlertInterval(metricsQuery, selection.datetime, alertPeriod),
+    [metricsQuery, selection.datetime, alertPeriod]
   );
 
   const alertChartQuery = pick(metricsQuery, 'mri', 'op', 'query');

--- a/static/app/views/ddm/pageHeaderActions.tsx
+++ b/static/app/views/ddm/pageHeaderActions.tsx
@@ -21,7 +21,6 @@ import {isCustomMeasurement} from 'sentry/utils/metrics';
 import {MRIToField} from 'sentry/utils/metrics/mri';
 import {middleEllipsis} from 'sentry/utils/middleEllipsis';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {useDDMContext} from 'sentry/views/ddm/context';
 import {getCreateAlert} from 'sentry/views/ddm/contextMenu';
@@ -36,7 +35,6 @@ interface Props {
 export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Props) {
   const router = useRouter();
   const organization = useOrganization();
-  const {selection} = usePageFilters();
   const createDashboard = useCreateDashboard();
   const {
     addWidget,
@@ -120,9 +118,6 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
     () =>
       widgets.map((widget, index) => {
         const createAlert = getCreateAlert(organization, {
-          datetime: selection.datetime,
-          projects: selection.projects,
-          environments: selection.environments,
           query: widget.query,
           mri: widget.mri,
           groupBy: widget.groupBy,
@@ -155,15 +150,7 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
           },
         };
       }),
-    [
-      organization,
-      selectedWidgetIndex,
-      selection.datetime,
-      selection.environments,
-      selection.projects,
-      showQuerySymbols,
-      widgets,
-    ]
+    [organization, selectedWidgetIndex, showQuerySymbols, widgets]
   );
 
   return (

--- a/static/app/views/ddm/queries.tsx
+++ b/static/app/views/ddm/queries.tsx
@@ -71,9 +71,6 @@ export function Queries() {
                     query: widget.query,
                     op: widget.op,
                     groupBy: widget.groupBy,
-                    projects: selection.projects,
-                    datetime: selection.datetime,
-                    environments: selection.environments,
                   }}
                 />
               }

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -21,7 +21,7 @@ import {getReadableMetricType} from 'sentry/utils/metrics/formatters';
 import {formatMRI} from 'sentry/utils/metrics/mri';
 import type {
   MetricDisplayType,
-  MetricsQuerySubject,
+  MetricsQuery,
   MetricWidgetQueryParams,
 } from 'sentry/utils/metrics/types';
 import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
@@ -37,7 +37,7 @@ import {MetricSearchBar} from 'sentry/views/ddm/metricSearchBar';
 type QueryBuilderProps = {
   displayType: MetricDisplayType;
   isEdit: boolean;
-  metricsQuery: MetricsQuerySubject;
+  metricsQuery: MetricsQuery;
   onChange: (data: Partial<MetricWidgetQueryParams>) => void;
   projects: number[];
   fixedWidth?: boolean;
@@ -95,11 +95,8 @@ export const QueryBuilder = memo(function QueryBuilder({
   }, [meta, metricsQuery.mri]);
 
   const incrementQueryMetric = useIncrementQueryMetric({
+    ...metricsQuery,
     displayType,
-    op: metricsQuery.op,
-    groupBy: metricsQuery.groupBy,
-    query: metricsQuery.query,
-    mri: metricsQuery.mri,
   });
 
   const handleMRIChange = useCallback(


### PR DESCRIPTION
- removes `MetricsQuerySubject` type
- removes page filters from `MetricsQuery` so that it is now essentially a parsed MQL expression
- passes page filters selection separately from metrics query wherever possible 