### PR TITLE
feat(perf): Improve table error handling in HTTP and Database modules

### DIFF
--- a/static/app/views/performance/database/queriesTable.tsx
+++ b/static/app/views/performance/database/queriesTable.tsx
@@ -73,6 +73,7 @@ interface Props {
   response: {
     data: Row[];
     isLoading: boolean;
+    error?: Error | null;
     meta?: EventsMetaType;
     pageLinks?: string;
   };
@@ -99,6 +100,7 @@ export function QueriesTable({response, sort}: Props) {
     >
       <GridEditable
         isLoading={isLoading}
+        error={response.error}
         data={data}
         columnOrder={COLUMN_ORDER}
         columnSortBy={[

--- a/static/app/views/performance/http/domainsTable.tsx
+++ b/static/app/views/performance/http/domainsTable.tsx
@@ -74,6 +74,7 @@ interface Props {
   response: {
     data: Row[];
     isLoading: boolean;
+    error?: Error | null;
     meta?: EventsMetaType;
     pageLinks?: string;
   };
@@ -100,6 +101,7 @@ export function DomainsTable({response, sort}: Props) {
     >
       <GridEditable
         isLoading={isLoading}
+        error={response.error}
         data={data}
         columnOrder={COLUMN_ORDER}
         columnSortBy={[

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -62,6 +62,7 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
   const {
     data: spanTransactionMetrics = [],
     meta,
+    error,
     isLoading,
     pageLinks,
   } = useSpanTransactionMetrics(
@@ -155,6 +156,7 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
       >
         <GridEditable
           isLoading={isLoading}
+          error={error}
           data={spanTransactionsWithMetrics}
           columnOrder={getColumnOrder(span)}
           columnSortBy={[]}


### PR DESCRIPTION
Luckily, `GridEditable` already supports the `error` prop, so all I had to do was pass it down from the API response.
