### PR TITLE
fix(replays): correctly use ip_address field instead of ip

### DIFF
--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -79,7 +79,7 @@ def report_rage_click_issue(project_id: int, replay_id: str, event: SentryEvent)
                 "id": replay_info["user_id"],
                 "username": replay_info["user_username"],
                 "email": replay_info["user_email"],
-                "ip": replay_info["user_ip"],
+                "ip_address": replay_info["user_ip"],
             },
         },
     )

--- a/tests/sentry/replays/unit/test_rage_click_issue.py
+++ b/tests/sentry/replays/unit/test_rage_click_issue.py
@@ -92,6 +92,6 @@ def test_report_rage_click_issue_a_tag(mock_new_issue_occurrence, default_projec
             "id": "123",
             "username": "username",
             "email": "username@example.com",
-            "ip": "127.0.0.1",
+            "ip_address": "127.0.0.1",
         },
     }


### PR DESCRIPTION
Fixes SENTRY-17QY

TODO: follow up with a test / runtime behavior that confirms validation like we do for feedbacks. for now just trying to clean up the issues feed for this.