### PR TITLE
fix(issues): make user object allow additional properties

### DIFF
--- a/src/sentry/issues/event.schema.json
+++ b/src/sentry/issues/event.schema.json
@@ -3033,7 +3033,7 @@
               "type": ["string", "null"]
             }
           },
-          "additionalProperties": false
+          "additionalProperties": true
         }
       ]
     }

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -76,6 +76,7 @@ def test_fix_for_issue_platform():
             "id": 880461,
             "isStaff": False,
             "name": "Josh Ferge",
+            "sentry_user": "test@test.com",
         },
         "contexts": {
             "feedback": {


### PR DESCRIPTION
A new field, `sentry_user` was added to relay yesterday. We need to allow additional properties in our user validation schema in order to allow events with this through. Test below fails on master and is fixed here.

https://github.com/getsentry/relay/pull/3122

