### PR TITLE
feat(issue-priority): Add support for issue.priority search

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -23,7 +23,7 @@ from sentry.db.models.query import create_or_update
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.ignored import handle_archived_until_escalating, handle_ignored
 from sentry.issues.merge import handle_merge
-from sentry.issues.priority import PRIORITY_UPDATE_CHOICES, update_priority
+from sentry.issues.priority import PRIORITY_STR_TO_VALUE, update_priority
 from sentry.issues.status_change import handle_status_update
 from sentry.issues.update_inbox import update_inbox
 from sentry.models.activity import Activity, ActivityIntegration
@@ -784,7 +784,7 @@ def handle_priority(priority: str, group_list: Sequence[Group], actor: User) -> 
     for group in group_list:
         update_priority(
             group=group,
-            priority=PRIORITY_UPDATE_CHOICES[priority] if priority else None,
+            priority=PRIORITY_STR_TO_VALUE[priority] if priority else None,
             actor=actor,
         )
         group.update(priority_locked_at=django_timezone.now())

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -23,7 +23,7 @@ from sentry.db.models.query import create_or_update
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.ignored import handle_archived_until_escalating, handle_ignored
 from sentry.issues.merge import handle_merge
-from sentry.issues.priority import PRIORITY_STR_TO_VALUE, update_priority
+from sentry.issues.priority import update_priority
 from sentry.issues.status_change import handle_status_update
 from sentry.issues.update_inbox import update_inbox
 from sentry.models.activity import Activity, ActivityIntegration
@@ -54,7 +54,7 @@ from sentry.signals import issue_resolved
 from sentry.tasks.auto_ongoing_issues import TRANSITION_AFTER_DAYS
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.types.activity import ActivityType
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
+from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus, PriorityLevel
 from sentry.utils import metrics
 
 from . import ACTIVITIES_COUNT, BULK_MUTATION_LIMIT, SearchFunction, delete_group_list
@@ -784,7 +784,7 @@ def handle_priority(priority: str, group_list: Sequence[Group], actor: User) -> 
     for group in group_list:
         update_priority(
             group=group,
-            priority=PRIORITY_STR_TO_VALUE[priority] if priority else None,
+            priority=PriorityLevel.from_str(priority) if priority else None,
             actor=actor,
         )
         group.update(priority_locked_at=django_timezone.now())

--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -4,12 +4,11 @@ from typing import Any
 from rest_framework import serializers
 
 from sentry.api.fields import ActorField
-from sentry.issues.priority import PRIORITY_STR_TO_VALUE
 from sentry.models.actor import Actor
 from sentry.models.group import STATUS_UPDATE_CHOICES
 from sentry.models.team import Team
 from sentry.models.user import User
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES
+from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, PriorityLevel
 
 from . import InboxDetailsValidator, StatusDetailsValidator
 
@@ -40,7 +39,12 @@ class GroupValidator(serializers.Serializer):
     ignoreUserWindow = serializers.IntegerField(max_value=7 * 24 * 60)
     assignedTo = ActorField()
     priority = serializers.ChoiceField(
-        choices=list(zip(PRIORITY_STR_TO_VALUE.keys(), PRIORITY_STR_TO_VALUE.keys()))
+        choices=list(
+            zip(
+                [p.to_str() for p in PriorityLevel],
+                [p.to_str() for p in PriorityLevel],
+            )
+        )
     )
 
     # TODO(dcramer): remove in 9.0

--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -4,7 +4,7 @@ from typing import Any
 from rest_framework import serializers
 
 from sentry.api.fields import ActorField
-from sentry.issues.priority import PRIORITY_UPDATE_CHOICES
+from sentry.issues.priority import PRIORITY_STR_TO_VALUE
 from sentry.models.actor import Actor
 from sentry.models.group import STATUS_UPDATE_CHOICES
 from sentry.models.team import Team
@@ -40,7 +40,7 @@ class GroupValidator(serializers.Serializer):
     ignoreUserWindow = serializers.IntegerField(max_value=7 * 24 * 60)
     assignedTo = ActorField()
     priority = serializers.ChoiceField(
-        choices=list(zip(PRIORITY_UPDATE_CHOICES.keys(), PRIORITY_UPDATE_CHOICES.keys()))
+        choices=list(zip(PRIORITY_STR_TO_VALUE.keys(), PRIORITY_STR_TO_VALUE.keys()))
     )
 
     # TODO(dcramer): remove in 9.0

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -20,6 +20,7 @@ from sentry.issues.grouptype import (
     get_group_type_by_slug,
     get_group_types_by_category,
 )
+from sentry.issues.priority import PRIORITY_STR_TO_VALUE
 from sentry.models.environment import Environment
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
 from sentry.models.organization import Organization
@@ -38,7 +39,7 @@ from sentry.search.utils import (
     parse_user_value,
 )
 from sentry.services.hybrid_cloud.user import RpcUser
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus, PriorityLevel
+from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
 
 is_filter_translation = {
     "assigned": ("unassigned", False),
@@ -201,7 +202,7 @@ def convert_priority_value(
     """Convert a value like 'high' or 'medium' to the Priority value for issue lookup"""
     results: list[int] = []
     for priority in value:
-        priority_value = getattr(PriorityLevel, priority.upper(), None)
+        priority_value = PRIORITY_STR_TO_VALUE.get(priority)
         if not priority_value:
             raise InvalidSearchQuery(f"Invalid priority value of '{priority}'")
         results.append(priority_value.value)

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -38,7 +38,7 @@ from sentry.search.utils import (
     parse_user_value,
 )
 from sentry.services.hybrid_cloud.user import RpcUser
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
+from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus, PriorityLevel
 
 is_filter_translation = {
     "assigned": ("unassigned", False),
@@ -192,6 +192,22 @@ def convert_category_value(
     return results
 
 
+def convert_priority_value(
+    value: Iterable[str],
+    projects: Sequence[Project],
+    user: User,
+    environments: Sequence[Environment] | None,
+) -> list[int]:
+    """Convert a value like 'high' or 'medium' to the Priority value for issue lookup"""
+    results: list[int] = []
+    for priority in value:
+        priority_value = getattr(PriorityLevel, priority.upper(), None)
+        if not priority_value:
+            raise InvalidSearchQuery(f"Invalid priority value of '{priority}'")
+        results.append(priority_value.value)
+    return results
+
+
 def convert_type_value(
     value: Iterable[str],
     projects: Sequence[Project],
@@ -234,6 +250,7 @@ value_converters: Mapping[str, ValueConverter] = {
     "status": convert_status_value,
     "regressed_in_release": convert_first_release_value,
     "issue.category": convert_category_value,
+    "issue.priority": convert_priority_value,
     "issue.type": convert_type_value,
     "device.class": convert_device_class_value,
     "substatus": convert_substatus_value,

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -20,7 +20,6 @@ from sentry.issues.grouptype import (
     get_group_type_by_slug,
     get_group_types_by_category,
 )
-from sentry.issues.priority import PRIORITY_STR_TO_VALUE
 from sentry.models.environment import Environment
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
 from sentry.models.organization import Organization
@@ -39,7 +38,7 @@ from sentry.search.utils import (
     parse_user_value,
 )
 from sentry.services.hybrid_cloud.user import RpcUser
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
+from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus, PriorityLevel
 
 is_filter_translation = {
     "assigned": ("unassigned", False),
@@ -202,7 +201,7 @@ def convert_priority_value(
     """Convert a value like 'high' or 'medium' to the Priority value for issue lookup"""
     results: list[int] = []
     for priority in value:
-        priority_value = PRIORITY_STR_TO_VALUE.get(priority)
+        priority_value = PriorityLevel.from_str(priority)
         if not priority_value:
             raise InvalidSearchQuery(f"Invalid priority value of '{priority}'")
         results.append(priority_value.value)

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -21,7 +21,7 @@ from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import LOG_LEVELS
 from sentry.issues.grouptype import GroupCategory
-from sentry.issues.priority import PRIORITY_LEVEL_TO_STR
+from sentry.issues.priority import PRIORITY_VALUE_TO_STR
 from sentry.models.apitoken import is_api_token_auth
 from sentry.models.commit import Commit
 from sentry.models.environment import Environment
@@ -352,7 +352,7 @@ class GroupSerializerBase(Serializer, ABC):
         }
 
         if features.has("projects:issue-priority", obj.project, actor=None):
-            priority_label = PRIORITY_LEVEL_TO_STR[obj.priority] if obj.priority else None
+            priority_label = PRIORITY_VALUE_TO_STR[obj.priority] if obj.priority else None
             group_dict["priority"] = priority_label
             group_dict["priorityLockedAt"] = obj.priority_locked_at
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -21,7 +21,6 @@ from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import LOG_LEVELS
 from sentry.issues.grouptype import GroupCategory
-from sentry.issues.priority import PRIORITY_VALUE_TO_STR
 from sentry.models.apitoken import is_api_token_auth
 from sentry.models.commit import Commit
 from sentry.models.environment import Environment
@@ -54,7 +53,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tagstore.types import GroupTagValue
 from sentry.tsdb.snuba import SnubaTSDB
-from sentry.types.group import SUBSTATUS_TO_STR
+from sentry.types.group import SUBSTATUS_TO_STR, PriorityLevel
 from sentry.utils.cache import cache
 from sentry.utils.json import JSONData
 from sentry.utils.safe import safe_execute
@@ -352,7 +351,7 @@ class GroupSerializerBase(Serializer, ABC):
         }
 
         if features.has("projects:issue-priority", obj.project, actor=None):
-            priority_label = PRIORITY_VALUE_TO_STR[obj.priority] if obj.priority else None
+            priority_label = PriorityLevel(obj.priority).to_str() if obj.priority else None
             group_dict["priority"] = priority_label
             group_dict["priorityLockedAt"] = obj.priority_locked_at
 
@@ -519,9 +518,9 @@ class GroupSerializerBase(Serializer, ABC):
                 start=start,
                 orderby="group_id",
                 referrer="group.unhandled-flag",
-                tenant_ids={"organization_id": item_list[0].project.organization_id}
-                if item_list
-                else None,
+                tenant_ids=(
+                    {"organization_id": item_list[0].project.organization_id} if item_list else None
+                ),
             )
             for x in rv["data"]:
                 unhandled[x["group_id"]] = x["unhandled"]
@@ -1049,9 +1048,9 @@ class GroupSerializerSnuba(GroupSerializerBase):
             filter_keys=filters,
             aggregations=aggregations,
             referrer="serializers.GroupSerializerSnuba._execute_error_seen_stats_query",
-            tenant_ids={"organization_id": item_list[0].project.organization_id}
-            if item_list
-            else None,
+            tenant_ids=(
+                {"organization_id": item_list[0].project.organization_id} if item_list else None
+            ),
         )
 
     @staticmethod
@@ -1082,9 +1081,9 @@ class GroupSerializerSnuba(GroupSerializerBase):
             filter_keys=filters,
             aggregations=aggregations,
             referrer="serializers.GroupSerializerSnuba._execute_perf_seen_stats_query",
-            tenant_ids={"organization_id": item_list[0].project.organization_id}
-            if item_list
-            else None,
+            tenant_ids=(
+                {"organization_id": item_list[0].project.organization_id} if item_list else None
+            ),
         )
 
     @staticmethod
@@ -1111,9 +1110,9 @@ class GroupSerializerSnuba(GroupSerializerBase):
             filter_keys=filters,
             aggregations=aggregations,
             referrer="serializers.GroupSerializerSnuba._execute_generic_seen_stats_query",
-            tenant_ids={"organization_id": item_list[0].project.organization_id}
-            if item_list
-            else None,
+            tenant_ids=(
+                {"organization_id": item_list[0].project.organization_id} if item_list else None
+            ),
         )
 
     @staticmethod

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -896,6 +896,7 @@ SKIP_SNUBA_FIELDS = frozenset(
         "first_release",
         "first_seen",
         "issue.category",
+        "issue.priority",
         "issue.type",
     )
 )

--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -16,13 +16,13 @@ if TYPE_CHECKING:
     from sentry.models.group import Group
 
 
-PRIORITY_LEVEL_TO_STR: dict[int, str] = {
+PRIORITY_VALUE_TO_STR: dict[int, str] = {
     PriorityLevel.LOW: "low",
     PriorityLevel.MEDIUM: "medium",
     PriorityLevel.HIGH: "high",
 }
 
-PRIORITY_UPDATE_CHOICES: dict[str, int] = {
+PRIORITY_STR_TO_VALUE: dict[str, int] = {
     "low": PriorityLevel.LOW,
     "medium": PriorityLevel.MEDIUM,
     "high": PriorityLevel.HIGH,
@@ -58,7 +58,7 @@ def update_priority(
         type=ActivityType.SET_PRIORITY,
         user=actor,
         data={
-            "priority": PRIORITY_LEVEL_TO_STR[priority],
+            "priority": PRIORITY_VALUE_TO_STR[priority],
             "reason": reason,
         },
     )

--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -16,19 +16,6 @@ if TYPE_CHECKING:
     from sentry.models.group import Group
 
 
-PRIORITY_VALUE_TO_STR: dict[int, str] = {
-    PriorityLevel.LOW: "low",
-    PriorityLevel.MEDIUM: "medium",
-    PriorityLevel.HIGH: "high",
-}
-
-PRIORITY_STR_TO_VALUE: dict[str, int] = {
-    "low": PriorityLevel.LOW,
-    "medium": PriorityLevel.MEDIUM,
-    "high": PriorityLevel.HIGH,
-}
-
-
 class PriorityChangeReason(Enum):
     ESCALATING = "escalating"
     ONGOING = "ongoing"
@@ -58,7 +45,7 @@ def update_priority(
         type=ActivityType.SET_PRIORITY,
         user=actor,
         data={
-            "priority": PRIORITY_VALUE_TO_STR[priority],
+            "priority": priority.to_str(),
             "reason": reason,
         },
     )

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 class ActivityManager(BaseManager["Activity"]):
     def get_activities_for_group(self, group: Group, num: int) -> Sequence[Activity]:
-        from sentry.issues.priority import PRIORITY_LEVEL_TO_STR
+        from sentry.issues.priority import PRIORITY_VALUE_TO_STR
 
         activities = []
         activity_qs = self.filter(group=group).order_by("-datetime")
@@ -46,7 +46,7 @@ class ActivityManager(BaseManager["Activity"]):
             # Check if 'initial_priority' is available and the feature flag is on
             initial_priority_key = event_metadata.get("initial_priority")
             initial_priority = (
-                PRIORITY_LEVEL_TO_STR[initial_priority_key] if initial_priority_key else None
+                PRIORITY_VALUE_TO_STR[initial_priority_key] if initial_priority_key else None
             )
 
         prev_sig = None

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -24,6 +24,7 @@ from sentry.db.models import (
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.tasks import activity
 from sentry.types.activity import CHOICES, ActivityType
+from sentry.types.group import PriorityLevel
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
@@ -40,10 +41,11 @@ class ActivityManager(BaseManager["Activity"]):
         if not features.has("projects:issue-priority", group.project):
             activity_qs = activity_qs.exclude(type=ActivityType.SET_PRIORITY.value)
         else:
-            event_metadata = group.get_event_metadata()
             # Check if 'initial_priority' is available and the feature flag is on
-            initial_priority_key = event_metadata.get("initial_priority")
-            initial_priority = initial_priority_key.to_str() if initial_priority_key else None
+            initial_priority_key = group.get_event_metadata().get("initial_priority")
+            initial_priority = (
+                PriorityLevel(initial_priority_key).to_str() if initial_priority_key else None
+            )
 
         prev_sig = None
         sig = None

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -42,9 +42,9 @@ class ActivityManager(BaseManager["Activity"]):
             activity_qs = activity_qs.exclude(type=ActivityType.SET_PRIORITY.value)
         else:
             # Check if 'initial_priority' is available and the feature flag is on
-            initial_priority_key = group.get_event_metadata().get("initial_priority")
+            initial_priority_value = group.get_event_metadata().get("initial_priority")
             initial_priority = (
-                PriorityLevel(initial_priority_key).to_str() if initial_priority_key else None
+                PriorityLevel(initial_priority_value).to_str() if initial_priority_value else None
             )
 
         prev_sig = None

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -33,8 +33,6 @@ if TYPE_CHECKING:
 
 class ActivityManager(BaseManager["Activity"]):
     def get_activities_for_group(self, group: Group, num: int) -> Sequence[Activity]:
-        from sentry.issues.priority import PRIORITY_VALUE_TO_STR
-
         activities = []
         activity_qs = self.filter(group=group).order_by("-datetime")
         initial_priority = None
@@ -45,9 +43,7 @@ class ActivityManager(BaseManager["Activity"]):
             event_metadata = group.get_event_metadata()
             # Check if 'initial_priority' is available and the feature flag is on
             initial_priority_key = event_metadata.get("initial_priority")
-            initial_priority = (
-                PRIORITY_VALUE_TO_STR[initial_priority_key] if initial_priority_key else None
-            )
+            initial_priority = initial_priority_key.to_str() if initial_priority_key else None
 
         prev_sig = None
         sig = None

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -39,8 +39,8 @@ from sentry.db.models import (
 from sentry.eventstore.models import GroupEvent
 from sentry.issues.grouptype import ErrorGroupType, GroupCategory, get_group_type_by_type_id
 from sentry.issues.priority import (
-    PRIORITY_LEVEL_TO_STR,
     PRIORITY_TO_GROUP_HISTORY_STATUS,
+    PRIORITY_VALUE_TO_STR,
     PriorityChangeReason,
     get_priority_for_ongoing_group,
 )
@@ -480,7 +480,7 @@ class GroupManager(BaseManager["Group"]):
                     group=group,
                     type=ActivityType.SET_PRIORITY,
                     data={
-                        "priority": PRIORITY_LEVEL_TO_STR[new_priority],
+                        "priority": PRIORITY_VALUE_TO_STR[new_priority],
                         "reason": PriorityChangeReason.ONGOING,
                     },
                 )

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -40,7 +40,6 @@ from sentry.eventstore.models import GroupEvent
 from sentry.issues.grouptype import ErrorGroupType, GroupCategory, get_group_type_by_type_id
 from sentry.issues.priority import (
     PRIORITY_TO_GROUP_HISTORY_STATUS,
-    PRIORITY_VALUE_TO_STR,
     PriorityChangeReason,
     get_priority_for_ongoing_group,
 )
@@ -480,7 +479,7 @@ class GroupManager(BaseManager["Group"]):
                     group=group,
                     type=ActivityType.SET_PRIORITY,
                     data={
-                        "priority": PRIORITY_VALUE_TO_STR[new_priority],
+                        "priority": new_priority.to_str(),
                         "reason": PriorityChangeReason.ONGOING,
                     },
                 )

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -701,6 +701,7 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             ),
             "issue.category": QCallbackCondition(lambda categories: Q(type__in=categories)),
             "issue.type": QCallbackCondition(lambda types: Q(type__in=types)),
+            "issue.priority": QCallbackCondition(lambda priorities: Q(priority__in=priorities)),
         }
 
         message_filter = next((sf for sf in search_filters or () if "message" == sf.key.name), None)

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -72,3 +72,16 @@ class PriorityLevel(IntEnum):
     LOW = 25
     MEDIUM = 50
     HIGH = 75
+
+    def to_str(self) -> str:
+        """
+        Return the string representation of the priority level.
+        """
+        return self.name.lower()
+
+    @classmethod
+    def from_str(self, name: str) -> "PriorityLevel":
+        """
+        Return the priority level from a string representation.
+        """
+        return self[name.upper()]

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -23,12 +23,11 @@ from sentry.api.issue_search import (
 )
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
-from sentry.issues.priority import PRIORITY_VALUE_TO_STR
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
 from sentry.search.utils import get_teams_for_users
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
-from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
+from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus, PriorityLevel
 
 
 class ParseSearchQueryTest(unittest.TestCase):
@@ -316,14 +315,16 @@ class ConvertSubStatusValueTest(TestCase):
 
 class ConvertPriorityValueTest(TestCase):
     def test_valid(self):
-        for priority, priority_str in PRIORITY_VALUE_TO_STR.items():
-            filters = [SearchFilter(SearchKey("issue.priority"), "=", SearchValue([priority_str]))]
+        for priority in PriorityLevel:
+            filters = [
+                SearchFilter(SearchKey("issue.priority"), "=", SearchValue([priority.to_str()]))
+            ]
             result = convert_query_values(filters, [self.project], self.user, None)
             assert result[0].value.raw_value == [priority]
 
     def test_invalid(self):
         filters = [SearchFilter(SearchKey("issue.priority"), "=", SearchValue("wrong"))]
-        with pytest.raises(InvalidSearchQuery, match="Invalid priority value of 'wrong'"):
+        with pytest.raises(KeyError):
             convert_query_values(filters, [self.project], self.user, None)
 
 

--- a/tests/sentry/issues/test_priority.py
+++ b/tests/sentry/issues/test_priority.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock, patch
 
 from sentry.issues.priority import (
     PRIORITY_TO_GROUP_HISTORY_STATUS,
-    PRIORITY_VALUE_TO_STR,
     PriorityChangeReason,
     auto_update_priority,
 )
@@ -21,7 +20,7 @@ class TestUpdatesPriority(TestCase):
     def assert_activity_grouphistory_set(self, group, priority, reason) -> None:
         activity = Activity.objects.get(group=group, type=ActivityType.SET_PRIORITY.value)
         assert activity.data == {
-            "priority": PRIORITY_VALUE_TO_STR[priority],
+            "priority": priority.to_str(),
             "reason": reason.value,
         }
 

--- a/tests/sentry/issues/test_priority.py
+++ b/tests/sentry/issues/test_priority.py
@@ -1,8 +1,8 @@
 from unittest.mock import MagicMock, patch
 
 from sentry.issues.priority import (
-    PRIORITY_LEVEL_TO_STR,
     PRIORITY_TO_GROUP_HISTORY_STATUS,
+    PRIORITY_VALUE_TO_STR,
     PriorityChangeReason,
     auto_update_priority,
 )
@@ -21,7 +21,7 @@ class TestUpdatesPriority(TestCase):
     def assert_activity_grouphistory_set(self, group, priority, reason) -> None:
         activity = Activity.objects.get(group=group, type=ActivityType.SET_PRIORITY.value)
         assert activity.data == {
-            "priority": PRIORITY_LEVEL_TO_STR[priority],
+            "priority": PRIORITY_VALUE_TO_STR[priority],
             "reason": reason.value,
         }
 

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -1,7 +1,6 @@
 import logging
 
 from sentry.event_manager import EventManager
-from sentry.issues.priority import PRIORITY_VALUE_TO_STR
 from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
@@ -43,7 +42,7 @@ class ActivityTest(TestCase):
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.LOW]},
+                data={"priority": PriorityLevel.LOW.to_str()},
                 send_notification=False,
             ),
         ]
@@ -53,7 +52,7 @@ class ActivityTest(TestCase):
         assert act_for_group[0] == activities[-1]
         assert act_for_group[1] == activities[-2]
         assert act_for_group[-1].type == ActivityType.FIRST_SEEN.value
-        assert act_for_group[-1].data["priority"] == PRIORITY_VALUE_TO_STR[PriorityLevel.HIGH]
+        assert act_for_group[-1].data["priority"] == PriorityLevel.HIGH.to_str()
 
     @with_feature("projects:issue-priority")
     def test_get_activities_for_group_no_priority_ff_on(self):
@@ -92,21 +91,21 @@ class ActivityTest(TestCase):
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.LOW]},
+                data={"priority": PriorityLevel.LOW.to_str()},
                 send_notification=False,
             ),
             Activity.objects.create_group_activity(
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.LOW]},
+                data={"priority": PriorityLevel.LOW.to_str()},
                 send_notification=False,
             ),
             Activity.objects.create_group_activity(
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.MEDIUM]},
+                data={"priority": PriorityLevel.MEDIUM.to_str()},
                 send_notification=False,
             ),
         ]
@@ -117,7 +116,7 @@ class ActivityTest(TestCase):
         assert act_for_group[0] == activities[-1]
         assert act_for_group[1] == activities[-2]
         assert act_for_group[-1].type == ActivityType.FIRST_SEEN.value
-        assert act_for_group[-1].data["priority"] == PRIORITY_VALUE_TO_STR[PriorityLevel.HIGH]
+        assert act_for_group[-1].data["priority"] == PriorityLevel.HIGH.to_str()
 
     def test_get_activities_for_group_simple_priority_ff_off(self):
         manager = EventManager(make_event(level=logging.FATAL))
@@ -139,7 +138,7 @@ class ActivityTest(TestCase):
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.LOW]},
+                data={"priority": PriorityLevel.LOW.to_str()},
                 send_notification=False,
             ),
         ]

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -1,7 +1,7 @@
 import logging
 
 from sentry.event_manager import EventManager
-from sentry.issues.priority import PRIORITY_LEVEL_TO_STR
+from sentry.issues.priority import PRIORITY_VALUE_TO_STR
 from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
@@ -43,7 +43,7 @@ class ActivityTest(TestCase):
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_LEVEL_TO_STR[PriorityLevel.LOW]},
+                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.LOW]},
                 send_notification=False,
             ),
         ]
@@ -53,7 +53,7 @@ class ActivityTest(TestCase):
         assert act_for_group[0] == activities[-1]
         assert act_for_group[1] == activities[-2]
         assert act_for_group[-1].type == ActivityType.FIRST_SEEN.value
-        assert act_for_group[-1].data["priority"] == PRIORITY_LEVEL_TO_STR[PriorityLevel.HIGH]
+        assert act_for_group[-1].data["priority"] == PRIORITY_VALUE_TO_STR[PriorityLevel.HIGH]
 
     @with_feature("projects:issue-priority")
     def test_get_activities_for_group_no_priority_ff_on(self):
@@ -92,21 +92,21 @@ class ActivityTest(TestCase):
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_LEVEL_TO_STR[PriorityLevel.LOW]},
+                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.LOW]},
                 send_notification=False,
             ),
             Activity.objects.create_group_activity(
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_LEVEL_TO_STR[PriorityLevel.LOW]},
+                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.LOW]},
                 send_notification=False,
             ),
             Activity.objects.create_group_activity(
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_LEVEL_TO_STR[PriorityLevel.MEDIUM]},
+                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.MEDIUM]},
                 send_notification=False,
             ),
         ]
@@ -117,7 +117,7 @@ class ActivityTest(TestCase):
         assert act_for_group[0] == activities[-1]
         assert act_for_group[1] == activities[-2]
         assert act_for_group[-1].type == ActivityType.FIRST_SEEN.value
-        assert act_for_group[-1].data["priority"] == PRIORITY_LEVEL_TO_STR[PriorityLevel.HIGH]
+        assert act_for_group[-1].data["priority"] == PRIORITY_VALUE_TO_STR[PriorityLevel.HIGH]
 
     def test_get_activities_for_group_simple_priority_ff_off(self):
         manager = EventManager(make_event(level=logging.FATAL))
@@ -139,7 +139,7 @@ class ActivityTest(TestCase):
                 group=group,
                 type=ActivityType.SET_PRIORITY,
                 user=user1,
-                data={"priority": PRIORITY_LEVEL_TO_STR[PriorityLevel.LOW]},
+                data={"priority": PRIORITY_VALUE_TO_STR[PriorityLevel.LOW]},
                 send_notification=False,
             ),
         ]

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -29,6 +29,7 @@ class ActivityTest(TestCase):
         user1 = self.create_user()
         group = event.group
         assert group is not None
+        group.refresh_from_db()
 
         activities = [
             Activity.objects.create_group_activity(
@@ -60,6 +61,7 @@ class ActivityTest(TestCase):
         group.data.get("metadata", {})[""] = None
         group.save()
         user1 = self.create_user()
+        group.refresh_from_db()
 
         activities = [
             Activity.objects.create_group_activity(
@@ -85,6 +87,7 @@ class ActivityTest(TestCase):
         user1 = self.create_user()
         group = event.group
         assert group is not None
+        group.refresh_from_db()
 
         activities = [
             Activity.objects.create_group_activity(
@@ -125,6 +128,7 @@ class ActivityTest(TestCase):
         user1 = self.create_user()
         group = event.group
         assert group is not None
+        group.refresh_from_db()
 
         activities = [
             Activity.objects.create_group_activity(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -40,7 +40,7 @@ from sentry.testutils.cases import SnubaTestCase, TestCase, TransactionTestCase
 from sentry.testutils.helpers import Feature, apply_feature_flag_on_cls
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.skips import xfail_if_not_postgres
-from sentry.types.group import GroupSubStatus
+from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.utils import json
 from sentry.utils.snuba import SENTRY_SNUBA_MAP, SnubaError
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -158,6 +158,7 @@ class EventsDatasetTestSetup(SharedSnubaMixin):
         self.group1.times_seen = 5
         self.group1.status = GroupStatus.UNRESOLVED
         self.group1.substatus = GroupSubStatus.ONGOING
+        self.group1.priority = PriorityLevel.HIGH
         self.group1.update(type=ErrorGroupType.type_id)
         self.group1.save()
         self.store_group(self.group1)
@@ -188,6 +189,7 @@ class EventsDatasetTestSetup(SharedSnubaMixin):
         self.group2.substatus = None
         self.group2.times_seen = 10
         self.group2.update(type=ErrorGroupType.type_id)
+        self.group2.priority = PriorityLevel.HIGH
         self.group2.save()
         self.store_group(self.group2)
 
@@ -2614,6 +2616,29 @@ class EventsJoinedGroupAttributesSnubaSearchTest(TransactionTestCase, EventsSnub
             if "snuba.search.group_attributes_joined.duration" in set(args):
                 metrics_timer_called = True
         assert metrics_timer_called
+
+    def test_issue_priority(self):
+        results = self.make_query(search_filter_query="issue.priority:high")
+        assert set(results) == {self.group1, self.group2}
+
+        event_3 = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group3"],
+                "event_id": "c" * 32,
+                "timestamp": iso_format(self.base_datetime - timedelta(days=20)),
+            },
+            project_id=self.project.id,
+        )
+        group_3 = event_3.group
+        group_3.update(priority=PriorityLevel.LOW)
+        results = self.make_query(search_filter_query="issue.priority:low")
+        assert set(results) == {group_3}
+
+        results = self.make_query(search_filter_query="issue.priority:[high, low]")
+        assert set(results) == {self.group1, self.group2, group_3}
+
+        with pytest.raises(InvalidSearchQuery):
+            self.make_query(search_filter_query="issue.category:wrong")
 
 
 class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):


### PR DESCRIPTION
Undo revert of https://github.com/getsentry/sentry/pull/65205
The previous PR had incorrectly setup tests in `test_activity.py`. Refreshing the group from the db fixed the types and raised the expected error, which is fixed in this PR. 

Adds support for searching for issue.priority with a single value or an array of values.

![image](https://github.com/getsentry/sentry/assets/16563948/1ffdfc68-d7c2-4c5a-a01a-2d376d46dc67)

Fixes https://github.com/getsentry/sentry/issues/65097