### PR TITLE
fix(metrics-extraction): Always emit on-demand for widget

### DIFF
--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -595,6 +595,13 @@ class CheckAM2Compatibility:
             # We run this query by selecting all projects, so that the widget query should never fail in case the
             # `query` contains "project:something".
             supports_metrics = cls.is_metrics_data(organization.id, all_projects, conditions)
+
+            supports_ondemand = widget_id in ondemand_widget_ids
+            if supports_ondemand:
+                # If it supports on demand it's no longer unsupported, but until all data has begun migrating
+                # we should still be showing the widgets so they can be checked.
+                ondemand_supported_widgets[dashboard_id].append((widget_id, fields, conditions))
+
             if supports_metrics is None:
                 with sentry_sdk.push_scope() as scope:
                     scope.set_tag("org_id", organization.id)
@@ -606,16 +613,9 @@ class CheckAM2Compatibility:
 
                 continue
 
-            supports_ondemand = widget_id in ondemand_widget_ids
-
-            if not supports_metrics:
-                if supports_ondemand:
-                    # If it supports on demand it's no longer unsupported, but until all data has begun migrating
-                    # we should still be showing the widgets so they can be checked.
-                    ondemand_supported_widgets[dashboard_id].append((widget_id, fields, conditions))
-                else:
-                    # We mark whether a metric is not supported.
-                    unsupported_widgets[dashboard_id].append((widget_id, fields, conditions))
+            if not supports_metrics and not supports_ondemand:
+                # We mark whether a metric is not supported.
+                unsupported_widgets[dashboard_id].append((widget_id, fields, conditions))
 
         unsupported_alerts = []
         for alert_id, aggregate, query in cls.get_all_alerts_of_organization(organization.id):


### PR DESCRIPTION
### Summary
On-demand was being conditionally emitted depending on the supports_metrics state before. The continue can be hit by the regular support_metrics flow, and there are existing on-demand rows that aren't appearing for some orgs, so this should show them if they qualify from 'get_all_widgets_of_organization'
