### PR TITLE
feat(node): Use CJS require in onboarding

### DIFF
--- a/static/app/gettingStartedDocs/node/serverlesscloud.tsx
+++ b/static/app/gettingStartedDocs/node/serverlesscloud.tsx
@@ -9,12 +9,12 @@ import {t, tct} from 'sentry/locale';
 type Params = DocsParams;
 
 const getSdkSetupSnippet = (params: Params) => `
-import api from "@serverless/cloud";
-import * as Sentry from "@sentry/node";
+const api = require("@serverless/cloud");
+const Sentry = require('@sentry/node');
 
-// or using CommonJS
-// const api = require("@serverless/cloud");
-// const Sentry = require('@sentry/node');
+// or using ESM
+// import api from "@serverless/cloud";
+// import * as Sentry from "@sentry/node";
 
 Sentry.init({
 dsn: "${params.dsn}",

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -98,8 +98,8 @@ export function getDefaultNodeImports({
   productSelection: ProductSelectionMap;
 }) {
   const imports: string[] = [
-    `// You can also use CommonJS \`require('@sentry/node')\` instead of \`import\``,
-    `import * as Sentry from "@sentry/node";`,
+    `// You can also use ESM \`import * as Sentry from "@sentry/node"\` instead of \`require\``,
+    `const Sentry = require("@sentry/node");`,
   ];
   if (productSelection.profiling) {
     imports.push(`import { ProfilingIntegration } from "@sentry/profiling-node";`);


### PR DESCRIPTION
Given our current troubles with ESM, let's put the CJS snippets first for Node onboarding. We can change this later once v8 comes out.

ref https://github.com/getsentry/sentry-javascript/issues/10046