### PR TITLE
ref(issues): Mark team endpoints private

### DIFF
--- a/src/sentry/api/endpoints/team_all_unresolved_issues.py
+++ b/src/sentry/api/endpoints/team_all_unresolved_issues.py
@@ -118,7 +118,7 @@ def calculate_unresolved_counts(team, project_list, start, end, environment_id):
 class TeamAllUnresolvedIssuesEndpoint(TeamEndpoint, EnvironmentMixin):
     owner = ApiOwner.ISSUES
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, team: Team) -> Response:

--- a/src/sentry/api/endpoints/team_groups_old.py
+++ b/src/sentry/api/endpoints/team_groups_old.py
@@ -17,7 +17,7 @@ from sentry.models.group import Group, GroupStatus
 class TeamGroupsOldEndpoint(TeamEndpoint, EnvironmentMixin):
     owner = ApiOwner.ISSUES
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, team) -> Response:

--- a/src/sentry/api/endpoints/team_issue_breakdown.py
+++ b/src/sentry/api/endpoints/team_issue_breakdown.py
@@ -30,7 +30,7 @@ from sentry.models.team import Team
 class TeamIssueBreakdownEndpoint(TeamEndpoint, EnvironmentMixin):
     owner = ApiOwner.ISSUES
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, team: Team) -> Response:

--- a/src/sentry/api/endpoints/team_time_to_resolution.py
+++ b/src/sentry/api/endpoints/team_time_to_resolution.py
@@ -20,7 +20,7 @@ from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 class TeamTimeToResolutionEndpoint(TeamEndpoint, EnvironmentMixin):
     owner = ApiOwner.ISSUES
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, team) -> Response:

--- a/src/sentry/api/endpoints/team_unresolved_issue_age.py
+++ b/src/sentry/api/endpoints/team_unresolved_issue_age.py
@@ -31,7 +31,7 @@ OLDEST_LABEL = "> 1 year"
 class TeamUnresolvedIssueAgeEndpoint(TeamEndpoint, EnvironmentMixin):
     owner = ApiOwner.ISSUES
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, team: Team) -> Response:


### PR DESCRIPTION
These are only used on a single table within the stats page and will potentially be changed in the not too distant future, also confirmed all have extremely low usage.