### PR TITLE
chore(slack): log entire slack unfurl error

### DIFF
--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -54,7 +54,7 @@ CATEGORY_TO_EMOJI = {
 }
 
 CATEGORY_TO_EMOJI_V2 = {
-    GroupCategory.PERFORMANCE: ":large_blue_circle::chart_with_upwards_trend:",
-    GroupCategory.FEEDBACK: ":large_blue_circle::busts_in_silhouette:",
-    GroupCategory.CRON: ":large_yellow_circle::spiral_calendar_pad:",
+    GroupCategory.PERFORMANCE: ":large_blue_circle: :chart_with_upwards_trend:",
+    GroupCategory.FEEDBACK: ":large_blue_circle: :busts_in_silhouette:",
+    GroupCategory.CRON: ":large_yellow_circle: :spiral_calendar_pad:",
 }

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -10,7 +10,7 @@ from sentry.integrations.slack.message_builder.base.base import SlackMessageBuil
 from sentry.notifications.utils.actions import MessageAction
 from sentry.utils.dates import to_timestamp
 
-MAX_BLOCK_TEXT_LENGTH = 1000
+MAX_BLOCK_TEXT_LENGTH = 256
 
 
 class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -197,7 +197,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
         try:
             client.post("/chat.unfurl", data=payload)
         except ApiError as e:
-            logger.exception("slack.event.unfurl-error", extra={"error": str(e)})
+            logger.exception("slack.event.unfurl-error", extra=e.__dict__)
 
         return True
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -983,7 +983,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
     def test_block_kit_truncates_long_query(self):
         text = "a" * 5000
         block = BlockSlackMessageBuilder().get_rich_text_preformatted_block(text)
-        assert block["elements"][0]["elements"][0]["text"] == "a" * 997 + "..."
+        assert block["elements"][0]["elements"][0]["text"] == "a" * 253 + "..."
 
     def test_build_performance_issue_color_no_event_passed(self):
         """This test doesn't pass an event to the SlackIssuesMessageBuilder to mimic what


### PR DESCRIPTION
If we log the entire error as a dict we can get some more information. Slack should send back what we sent it.

Also added small changes to resolve https://github.com/getsentry/team-core-product-foundations/issues/104