### PR TITLE
feat(crons-db): Add caching when we fetch environment

### DIFF
--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -1,4 +1,5 @@
 import re
+from typing import ClassVar, Self
 from urllib.parse import unquote
 
 from django.db import IntegrityError, models, router, transaction
@@ -7,6 +8,7 @@ from django.utils import timezone
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import ENVIRONMENT_NAME_MAX_LENGTH, ENVIRONMENT_NAME_PATTERN
 from sentry.db.models import (
+    BaseManager,
     BoundedBigIntegerField,
     FlexibleForeignKey,
     Model,
@@ -42,6 +44,8 @@ class Environment(Model):
     projects = models.ManyToManyField("sentry.Project", through=EnvironmentProject)
     name = models.CharField(max_length=64)
     date_added = models.DateTimeField(default=timezone.now)
+
+    objects: ClassVar[BaseManager[Self]] = BaseManager(cache_fields=["pk"])
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -624,7 +624,7 @@ class MonitorEnvironment(Model):
     __repr__ = sane_repr("monitor_id", "environment_id")
 
     def get_environment(self) -> Environment:
-        return Environment.objects.get(id=self.environment_id)
+        return Environment.objects.get_from_cache(id=self.environment_id)
 
     def get_audit_log_data(self):
         return {


### PR DESCRIPTION
Missed this in https://github.com/getsentry/sentry/pull/65305. We want to cache envs if possible.

