### PR TITLE
ref(slack): remove default tags

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -214,7 +214,13 @@ def get_tags(
     ):
         default_tags = set()
 
-    tags = tags | default_tags
+    use_improved_block_kit = features.has(
+        "organizations:slack-block-kit-improvements", group.project.organization
+    )
+    # improved block kit only uses alert rule tags
+    if not use_improved_block_kit:
+        tags = tags | default_tags
+
     if tags:
         event_tags = event_for_tags.tags if event_for_tags else []
         for key, value in event_tags:

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -112,9 +112,6 @@ class NoiseConfig:
 
 @dataclass(frozen=True)
 class NotificationConfig:
-    default_tags: list[str] = field(
-        default_factory=lambda: ["level", "release", "handled", "environment"]
-    )  # TODO(cathy): no tags for crons (empty list)
     text_code_formatted: bool = True  # TODO(cathy): user feedback wants it formatted as text
     context: list[str] = field(
         default_factory=lambda: ["Events", "Users Affected", "State", "First Seen"]

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -22,6 +22,7 @@ from sentry.integrations.slack.message_builder.issues import (
     get_context,
     get_option_groups,
     get_option_groups_block_kit,
+    get_tags,
     time_since,
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
@@ -1655,3 +1656,11 @@ class SlackNotificationConfigTest(TestCase, PerformanceIssueTestCase):
 
         # feedback doesn't have context
         assert get_context(self.feedback_issue) == ""
+
+    @with_feature("organizations:slack-block-kit-improvements")
+    def test_get_tags(self):
+        # don't use default tags. if we don't pass in tags to get_tags, we don't return any
+        tags = get_tags(
+            self.endpoint_regression_issue, self.endpoint_regression_issue.get_latest_event()
+        )
+        assert not tags


### PR DESCRIPTION
Removes the use of default tags. This is feature flagged under `organizations:slack-block-kit-improvements`.

Resolves https://github.com/getsentry/team-core-product-foundations/issues/84