### PR TITLE
fix(feedback): check and filter if contexts feedback message is none

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -119,6 +119,15 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
     # Right now all unreal error events without a feedback
     # actually get a sent a feedback with this message
     # signifying there is no feedback. Let's go ahead and filter these.
+
+    if (
+        event.get("contexts") is None
+        or event["contexts"].get("feedback") is None
+        or event["contexts"]["feedback"].get("message") is None
+    ):
+        metrics.incr("feedback.filtered", tags={"reason": "missing_context"}, sample_rate=1.0)
+        return True
+
     if event["contexts"]["feedback"]["message"] == UNREAL_FEEDBACK_UNATTENDED_MESSAGE:
         metrics.incr("feedback.filtered", tags={"reason": "unreal.unattended"}, sample_rate=1.0)
         return True

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -323,3 +323,101 @@ def test_create_feedback_filters_empty(default_project, mock_produce_occurrence_
     create_feedback_issue(event_2, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     assert mock_produce_occurrence_to_kafka.call_count == 0
+
+
+@django_db_all
+def test_create_feedback_filters_no_contexts_or_message(
+    default_project, mock_produce_occurrence_to_kafka
+):
+    event_no_context = {
+        "project_id": 1,
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "received": "2021-10-24T22:23:29.574000+00:00",
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+
+    event_no_message = {
+        "project_id": 1,
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "received": "2021-10-24T22:23:29.574000+00:00",
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "contexts": {
+            "feedback": {
+                "contact_email": "josh.ferge@sentry.io",
+                "name": "Josh Ferge",
+                "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+                "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            },
+        },
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+
+    event_no_feedback = {
+        "project_id": 1,
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "received": "2021-10-24T22:23:29.574000+00:00",
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "contexts": {},
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+
+    create_feedback_issue(
+        event_no_context, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+    )
+    create_feedback_issue(
+        event_no_message, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+    )
+    create_feedback_issue(
+        event_no_feedback, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+    )
+
+    assert mock_produce_occurrence_to_kafka.call_count == 0


### PR DESCRIPTION
Fixes SENTRY-2NH5

- check if a feedback is missing `contexts`, `contexts[feedback]`, or `contexts[feedback][message]`
- if so, filter it out first