### PR TITLE
feat(trace): extend trace bounds when rendered measurement falls out of trace

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -248,12 +248,19 @@ export class TraceTree {
             continue;
           }
 
+          const timestamp = measurementToTimestamp(
+            value.start_timestamp,
+            value.measurements[measurement].value,
+            value.measurements[measurement].unit ?? 'milliseconds'
+          );
+
+          // If a rendered measurement extends the trace bounds, we update the trace bounds
+          if (timestamp > traceEnd) {
+            traceEnd = timestamp;
+          }
+
           tree.indicators.push({
-            start: measurementToTimestamp(
-              value.start_timestamp,
-              value.measurements[measurement].value,
-              value.measurements[measurement].unit ?? 'milliseconds'
-            ),
+            start: timestamp,
             duration: 0,
             node,
             type: measurement as Indicator['type'],


### PR DESCRIPTION
In the new trace view, extend trace so that all of the measurements can be rendered and don't fall out of view. 