### PR TITLE
ref(typing): type bases/team.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ module = [
     "sentry.api.bases.project_request_change",
     "sentry.api.bases.rule",
     "sentry.api.bases.sentryapps",
-    "sentry.api.bases.team",
     "sentry.api.endpoints.accept_organization_invite",
     "sentry.api.endpoints.artifact_lookup",
     "sentry.api.endpoints.auth_config",

--- a/src/sentry/api/bases/team.py
+++ b/src/sentry/api/bases/team.py
@@ -52,7 +52,7 @@ class TeamEndpoint(Endpoint):
 
         bind_organization_context(team.organization)
 
-        request._request.organization = team.organization
+        request._request.organization = team.organization  # type: ignore[attr-defined]
 
         kwargs["team"] = team
         return (args, kwargs)


### PR DESCRIPTION
simply ignores the access to _request.organization, as in https://github.com/getsentry/sentry/blob/84e53660673428eade8419aa19944ed3bfb4e8d7/src/sentry/api/bases/group.py#L61