### PR TITLE
ref(typing): type auth/system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,6 @@ module = [
     "sentry.auth.providers.saml2.provider",
     "sentry.auth.providers.saml2.rippling.provider",
     "sentry.auth.providers.saml2.views",
-    "sentry.auth.system",
     "sentry.auth.view",
     "sentry.db.mixin",
     "sentry.db.models.manager.base",

--- a/src/sentry/auth/system.py
+++ b/src/sentry/auth/system.py
@@ -79,7 +79,7 @@ class SystemToken:
     @memoize
     def user(self) -> AnonymousUser:
         user = AnonymousUser()
-        user.is_active = True
+        user.is_active = True  # type: ignore[assignment]
         return user
 
     def get_allowed_origins(self) -> list[str]:


### PR DESCRIPTION
simply ignore this assignment, as for SystemToken we set active to True on the `AnonymousUser` who's type has `is_active` set to False.