### PR TITLE
fix(devenv): remove venv.sync

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -77,9 +77,6 @@ def main(context: dict[str, str]) -> int:
     print(f"ensuring venv at {venv_dir}...")
     venv.ensure(venv_dir, python_version, url, sha256)
 
-    print(f"syncing {venv_dir} with {requirements}...")
-    venv.sync(venv_dir, requirements, editable_paths, bins)
-
     if not run_procs(
         repo,
         reporoot,


### PR DESCRIPTION
let's keep using install-py-dev for now - i'm not sure why but having `lib.sync` then `make install-py-dev` would stall in ci before [this](https://github.com/getsentry/devenv/pull/88/commits/2622acc75d60a170f62278da3a1b9f9dbb471caf) commit and couldn't repro locally