### PR TITLE
ref(issues): Mark OrganizationProjectsSentFirstEventEndpoint private

### DIFF
--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -12,7 +12,7 @@ from sentry.api.serializers import serialize
 class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ISSUES
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization) -> Response:


### PR DESCRIPTION
This controls features in the Sentry UI and isn't particularly useful as a public API.