### PR TITLE
fix(ui): Change child types for react 18

### DIFF
--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -11,7 +11,7 @@ type ChildRenderProps = {
   hasSuperuser: boolean;
 };
 
-type ChildFunction = (props: ChildRenderProps) => JSX.Element;
+type ChildFunction = (props: ChildRenderProps) => JSX.Element | JSX.Element[] | null;
 
 interface Props {
   /**

--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -11,7 +11,7 @@ type ChildRenderProps = {
   hasSuperuser: boolean;
 };
 
-type ChildFunction = (props: ChildRenderProps) => JSX.Element;
+type ChildFunction = (props: ChildRenderProps) => React.ReactNode;
 
 type Props = {
   organization: Organization;

--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -11,7 +11,7 @@ type ChildRenderProps = {
   hasSuperuser: boolean;
 };
 
-type ChildFunction = (props: ChildRenderProps) => JSX.Element | JSX.Element[] | null;
+type ChildFunction = React.FC<ChildRenderProps>;
 
 interface Props {
   /**

--- a/static/app/components/acl/access.tsx
+++ b/static/app/components/acl/access.tsx
@@ -2,8 +2,8 @@ import {Fragment} from 'react';
 
 import type {Organization, Project, Scope, Team} from 'sentry/types';
 import {isRenderFunc} from 'sentry/utils/isRenderFunc';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
-import withOrganization from 'sentry/utils/withOrganization';
 
 // Props that function children will get.
 type ChildRenderProps = {
@@ -11,10 +11,9 @@ type ChildRenderProps = {
   hasSuperuser: boolean;
 };
 
-type ChildFunction = (props: ChildRenderProps) => React.ReactNode;
+type ChildFunction = (props: ChildRenderProps) => JSX.Element;
 
-type Props = {
-  organization: Organization;
+interface Props {
   /**
    * List of required access levels
    */
@@ -45,19 +44,13 @@ type Props = {
    * the team, they will have appropriate scopes.
    */
   team?: Team | null | undefined;
-};
+}
 
 /**
  * Component to handle access restrictions.
  */
-function Access({
-  children,
-  isSuperuser = false,
-  access = [],
-  team,
-  project,
-  organization,
-}: Props) {
+function Access({children, isSuperuser = false, access = [], team, project}: Props) {
+  const organization = useOrganization();
   const user = useUser();
   team = team ?? undefined;
   project = project ?? undefined;
@@ -96,4 +89,4 @@ export function hasEveryAccess(
   );
 }
 
-export default withOrganization(Access);
+export default Access;

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -181,7 +181,7 @@ export default class SentryAppDetailsModal extends DeprecatedAsyncComponent<
                     {t('Cancel')}
                   </Button>
 
-                  <Access access={['org:integrations']} organization={organization}>
+                  <Access access={['org:integrations']}>
                     {({hasAccess}) =>
                       hasAccess && (
                         <Button

--- a/static/app/views/starfish/index.tsx
+++ b/static/app/views/starfish/index.tsx
@@ -7,7 +7,7 @@ import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
-  children: React.ReactChildren;
+  children: React.ReactNode;
 };
 
 const queryClient = new QueryClient();


### PR DESCRIPTION
Swap some types for `React.ReactNode` which makes typescript happy with react 18

part of https://github.com/getsentry/frontend-tsc/issues/22
