### PR TITLE
ref(ui): Switch AbstractIntegrationDetailedView to abstract

### DIFF
--- a/static/app/views/settings/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -52,7 +52,7 @@ type Props = {
 } & RouteComponentProps<{integrationSlug: string}, {}> &
   DeprecatedAsyncComponent['props'];
 
-class AbstractIntegrationDetailedView<
+abstract class AbstractIntegrationDetailedView<
   P extends Props = Props,
   S extends State = State,
 > extends DeprecatedAsyncComponent<P, S> {
@@ -184,10 +184,7 @@ class AbstractIntegrationDetailedView<
   }
 
   // Returns the list of configurations for the integration
-  renderConfigurations() {
-    // Allow children to implement this
-    throw new Error('Not implemented');
-  }
+  abstract renderConfigurations(): React.ReactNode;
 
   /**
    * Actually implemented methods below


### PR DESCRIPTION
This pleases react 18. It errored lower in the file where we try to render this function that has no return type https://github.com/getsentry/sentry/blob/267e37a69b8b4b59f4f433510fc6e7850ee48f8f/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx#L416-L420

part of https://github.com/getsentry/frontend-tsc/issues/22