### PR TITLE
ref(ui): Declare class context types

### DIFF
--- a/static/app/components/deprecatedAsyncComponent.tsx
+++ b/static/app/components/deprecatedAsyncComponent.tsx
@@ -152,6 +152,8 @@ class DeprecatedAsyncComponent<
     document.removeEventListener('visibilitychange', this.visibilityReloader);
   }
 
+  declare context: RouteComponentProps<{}, {}>;
+
   /**
    * Override this flag to have the component reload its state when the window
    * becomes visible again. This will set the loading and reloading state, but

--- a/static/app/components/deprecatedAsyncComponent.tsx
+++ b/static/app/components/deprecatedAsyncComponent.tsx
@@ -1,5 +1,5 @@
 import {Component} from 'react';
-import type {RouteComponentProps} from 'react-router';
+import type {RouteComponentProps, RouteContextInterface} from 'react-router';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 
@@ -152,7 +152,7 @@ class DeprecatedAsyncComponent<
     document.removeEventListener('visibilitychange', this.visibilityReloader);
   }
 
-  declare context: RouteComponentProps<{}, {}>;
+  declare context: {router: RouteContextInterface};
 
   /**
    * Override this flag to have the component reload its state when the window

--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -13,7 +13,14 @@ import {defined} from 'sentry/utils';
 type Snapshot = Map<string, FieldValue>;
 type SaveSnapshot = (() => number) | null;
 
-export type FieldValue = string | number | boolean | Choice | Set<string> | undefined; // is undefined valid here?
+export type FieldValue =
+  | string
+  | string[]
+  | Set<string>
+  | number
+  | boolean
+  | Choice
+  | undefined; // is undefined valid here?
 
 export type FormOptions = {
   /**

--- a/static/app/views/releases/detail/commitsAndFiles/withReleaseRepos.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/withReleaseRepos.tsx
@@ -68,6 +68,7 @@ function withReleaseRepos<P extends DependentProps>(
       }
     }
 
+    declare context: React.ContextType<typeof ReleaseContext>;
     static contextType = ReleaseContext;
 
     setActiveReleaseRepo(props: P & HoCsProps) {

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -49,6 +49,7 @@ export default class Subscriptions extends Component<Props> {
     }
   }
 
+  declare context: Required<React.ContextType<typeof FormContext>>;
   static contextType = FormContext;
 
   onChange = (resource: Resource, checked: boolean) => {


### PR DESCRIPTION
related to https://github.com/getsentry/sentry/pull/65107 declares types of context that are currently "any" and will be unknown with react 18

part of https://github.com/getsentry/frontend-tsc/issues/22