### PR TITLE
fix(issue-priority): Only evaluate high priority event condition for new or escalating issues

### DIFF
--- a/src/sentry/rules/conditions/high_priority_issue.py
+++ b/src/sentry/rules/conditions/high_priority_issue.py
@@ -33,12 +33,17 @@ class HighPriorityIssueCondition(EventCondition):
         if not has_high_priority_issue_alerts(self.project):
             return False
 
+        is_escalating = state.has_reappeared or state.has_escalated
         if features.has("projects:issue-priority", self.project):
+            if not event.group:
+                return False
+
+            if not state.is_new and not is_escalating:
+                return False
+
             return event.group.priority == PriorityLevel.HIGH
 
         is_new_high_severity = self.is_new_high_severity(state, event.group)
-        is_escalating = state.has_reappeared or state.has_escalated
-
         return is_new_high_severity or is_escalating
 
     def get_activity(

--- a/tests/sentry/rules/conditions/test_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_high_priority_issue.py
@@ -37,19 +37,23 @@ class HighPriorityIssueConditionTest(RuleTestCase):
         rule = self.get_rule()
         event = self.get_event()
 
-        # This will always pass
+        # This will never pass for non-new or non-escalating issuesalways pass
         event.group.update(priority=PriorityLevel.HIGH)
-        self.assertPasses(rule, event, is_new=False, has_reappeared=False, has_escalated=False)
-        self.assertPasses(rule, event, is_new=True, has_reappeared=False, has_escalated=True)
-        self.assertPasses(rule, event, is_new=False, has_reappeared=False, has_escalated=False)
-        self.assertPasses(rule, event, is_new=True, has_reappeared=True, has_escalated=False)
+        self.assertPasses(rule, event, is_new=True, has_reappeared=False, has_escalated=False)
+        self.assertPasses(rule, event, is_new=False, has_reappeared=True, has_escalated=False)
+        self.assertPasses(rule, event, is_new=False, has_reappeared=True, has_escalated=False)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=False, has_escalated=False)
 
         # This will never pass
         event.group.update(priority=PriorityLevel.LOW)
         self.assertDoesNotPass(rule, event, is_new=True, has_reappeared=False, has_escalated=False)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=True, has_escalated=False)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=True, has_escalated=False)
         self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=False, has_escalated=False)
 
         # This will never pass
         event.group.update(priority=PriorityLevel.MEDIUM)
-        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=False, has_escalated=True)
         self.assertDoesNotPass(rule, event, is_new=True, has_reappeared=False, has_escalated=False)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=True, has_escalated=False)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=True, has_escalated=False)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=False, has_escalated=False)


### PR DESCRIPTION
This fixes a bug in the priority alert logic using the new Group.priority value. We should only alert on high priority issue for issues that escalate or are new. 