### PR TITLE
ref(dynamic-sampling): Improve dynamic sampling code

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -553,16 +553,21 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         context["pendingAccessRequests"] = OrganizationAccessRequest.objects.filter(
             team__organization=obj
         ).count()
-        sample_rate = quotas.get_blended_sample_rate(organization_id=obj.id)  # type:ignore
+
+        sample_rate = quotas.backend.get_blended_sample_rate(organization_id=obj.id)
         context["isDynamicallySampled"] = (
             features.has("organizations:dynamic-sampling", obj)
             and sample_rate is not None
             and sample_rate < 1.0
         )
+
         org_volume = get_organization_volume(obj.id, timedelta(hours=24))
         if org_volume is not None and org_volume.indexed is not None and org_volume.total > 0:
             context["effectiveSampleRate"] = org_volume.indexed / org_volume.total
-        desired_sample_rate: float | None = get_sliding_window_org_sample_rate(obj.id)
+
+        desired_sample_rate = get_sliding_window_org_sample_rate(
+            org_id=obj.id, default_sample_rate=sample_rate
+        )
         if desired_sample_rate is not None:
             context["desiredSampleRate"] = desired_sample_rate
 

--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -58,7 +58,7 @@ def is_sliding_window_org_enabled(organization: Organization) -> bool:
 
 
 def get_guarded_blended_sample_rate(organization: Organization, project: Project) -> float:
-    sample_rate = quotas.get_blended_sample_rate(organization_id=organization.id)  # type:ignore
+    sample_rate = quotas.backend.get_blended_sample_rate(organization_id=organization.id)
 
     # If the sample rate is None, it means that dynamic sampling rules shouldn't be generated.
     if sample_rate is None:

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -258,7 +258,7 @@ def adjust_sample_rates_of_projects(
     # If we have the sliding window org enabled, we use that and fall back to the blended sample rate in case of issues.
     if organization is not None and is_sliding_window_org_enabled(organization):
         sample_rate = get_sliding_window_org_sample_rate(
-            org_id=org_id, default_sample_rate=sample_rate
+            org_id=org_id, default_sample_rate=sample_rate, notify_missing=True
         )
         log_sample_rate_source(
             org_id, None, "boost_low_volume_projects", "sliding_window_org", sample_rate

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -251,14 +251,18 @@ def adjust_sample_rates_of_projects(
         # the query triggering this job and the actual execution of the job.
         organization = None
 
+    # By default, we use the blended sample rate.
+    sample_rate = quotas.backend.get_blended_sample_rate(organization_id=org_id)
+
     # We get the sample rate either directly from quotas or from the new sliding window org mechanism.
     if organization is not None and is_sliding_window_org_enabled(organization):
-        sample_rate = get_sliding_window_org_sample_rate(org_id)
+        sample_rate = get_sliding_window_org_sample_rate(
+            org_id=org_id, default_sample_rate=sample_rate
+        )
         log_sample_rate_source(
             org_id, None, "boost_low_volume_projects", "sliding_window_org", sample_rate
         )
     else:
-        sample_rate = quotas.backend.get_blended_sample_rate(organization_id=org_id)
         log_sample_rate_source(
             org_id, None, "boost_low_volume_projects", "blended_sample_rate", sample_rate
         )

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 
+import sentry_sdk
 from sentry_sdk.crons.decorator import monitor
 from snuba_sdk import (
     Column,
@@ -254,7 +255,7 @@ def adjust_sample_rates_of_projects(
     # By default, we use the blended sample rate.
     sample_rate = quotas.backend.get_blended_sample_rate(organization_id=org_id)
 
-    # We get the sample rate either directly from quotas or from the new sliding window org mechanism.
+    # If we have the sliding window org enabled, we use that and fall back to the blended sample rate in case of issues.
     if organization is not None and is_sliding_window_org_enabled(organization):
         sample_rate = get_sliding_window_org_sample_rate(
             org_id=org_id, default_sample_rate=sample_rate
@@ -269,6 +270,9 @@ def adjust_sample_rates_of_projects(
 
     # If we didn't find any sample rate, it doesn't make sense to run the adjustment model.
     if sample_rate is None:
+        sentry_sdk.capture_message(
+            "Sample rate of org not found when trying to adjust the sample rates of its projects"
+        )
         return
 
     projects_with_counts = {

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -687,7 +687,7 @@ def compute_sliding_window_sample_rate(
 
     func_name = "get_transaction_sampling_tier_for_volume"
     with context.get_timer(func_name):
-        sampling_tier = quotas.get_transaction_sampling_tier_for_volume(  # type:ignore
+        sampling_tier = quotas.backend.get_transaction_sampling_tier_for_volume(
             org_id, extrapolated_volume
         )
         state = context.get_function_state(func_name)

--- a/src/sentry/dynamic_sampling/tasks/helpers/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/boost_low_volume_projects.py
@@ -33,5 +33,5 @@ def get_boost_low_volume_projects_sample_rate(
         return error_sample_rate_fallback
     # Thrown if the input is not a valid float.
     except ValueError:
-        sentry_sdk.capture_message("Invalid sliding window org value stored in cache")
+        sentry_sdk.capture_message("Invalid boosted project sample rate value stored in cache")
         return error_sample_rate_fallback

--- a/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
@@ -102,7 +102,7 @@ def generate_sliding_window_org_cache_key(org_id: int) -> str:
 
 
 def get_sliding_window_org_sample_rate(
-    org_id: int, default_sample_rate: float | None = None
+    org_id: int, default_sample_rate: float | None = None, notify_missing: bool = False
 ) -> float | None:
     redis_client = get_redis_client_for_ds()
     cache_key = generate_sliding_window_org_cache_key(org_id)
@@ -110,6 +110,9 @@ def get_sliding_window_org_sample_rate(
     try:
         return float(redis_client.get(cache_key))
     except (TypeError, ValueError):
+        if notify_missing:
+            sentry_sdk.capture_message("Missing or invalid sliding window org sample rate in cache")
+
         return default_sample_rate
 
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from snuba_sdk import Granularity
 
 from sentry import quotas
+from sentry.dynamic_sampling.rules.base import is_sliding_window_org_enabled
 from sentry.dynamic_sampling.tasks.common import (
     GetActiveOrgsVolumes,
     OrganizationDataVolume,
@@ -31,6 +32,7 @@ from sentry.dynamic_sampling.tasks.logging import (
 )
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task_with_context
+from sentry.models.organization import Organization
 from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task
 
@@ -89,8 +91,25 @@ def recalibrate_org(org_volume: OrganizationDataVolume, context: TaskContext) ->
 
         assert org_volume.indexed is not None
 
-        target_sample_rate = get_sliding_window_org_sample_rate(org_id=org_volume.org_id)
-        if target_sample_rate is not None:
+        try:
+            # We need the organization object for the feature flag.
+            organization = Organization.objects.get_from_cache(id=org_volume.org_id)
+        except Organization.DoesNotExist:
+            # In case an org is not found, it might be that it has been deleted in the time between
+            # the query triggering this job and the actual execution of the job.
+            organization = None
+
+        # By default, we use the blended sample rate.
+        target_sample_rate = quotas.backend.get_blended_sample_rate(
+            organization_id=org_volume.org_id
+        )
+
+        # If we have the sliding window org enabled, we use that and fall back to the blended sample rate in case
+        # of issues.
+        if organization is not None and is_sliding_window_org_enabled(organization):
+            target_sample_rate = get_sliding_window_org_sample_rate(
+                org_id=org_volume.org_id, default_sample_rate=target_sample_rate
+            )
             log_sample_rate_source(
                 org_volume.org_id,
                 None,
@@ -99,22 +118,19 @@ def recalibrate_org(org_volume: OrganizationDataVolume, context: TaskContext) ->
                 target_sample_rate,
             )
         else:
-            target_sample_rate = quotas.backend.get_blended_sample_rate(
-                organization_id=org_volume.org_id
+            log_sample_rate_source(
+                org_volume.org_id,
+                None,
+                "recalibrate_orgs",
+                "blended_sample_rate",
+                target_sample_rate,
             )
-            if target_sample_rate is not None:
-                log_sample_rate_source(
-                    org_volume.org_id,
-                    None,
-                    "recalibrate_orgs",
-                    "blended_sample_rate",
-                    target_sample_rate,
-                )
 
+        # If we didn't find any sample rate, we can't recalibrate the organization.
         if target_sample_rate is None:
             raise RecalibrationError(
                 org_id=org_volume.org_id,
-                message="Couldn't get target sample rate for recalibration",
+                message="Couldn't get target sample rate for org recalibration",
             )
 
         # We compute the effective sample rate that we had in the last considered time window.
@@ -132,7 +148,7 @@ def recalibrate_org(org_volume: OrganizationDataVolume, context: TaskContext) ->
         )
         if adjusted_factor is None:
             raise RecalibrationError(
-                org_id=org_volume.org_id, message="adjusted factor can't be computed"
+                org_id=org_volume.org_id, message="The adjusted factor can't be computed"
             )
 
         if adjusted_factor < MIN_REBALANCE_FACTOR or adjusted_factor > MAX_REBALANCE_FACTOR:
@@ -141,7 +157,7 @@ def recalibrate_org(org_volume: OrganizationDataVolume, context: TaskContext) ->
             delete_adjusted_factor(org_volume.org_id)
             raise RecalibrationError(
                 org_id=org_volume.org_id,
-                message=f"factor {adjusted_factor} outside of the acceptable range [{MIN_REBALANCE_FACTOR}.."
+                message=f"The adjusted factor {adjusted_factor} outside of the acceptable range [{MIN_REBALANCE_FACTOR}.."
                 f"{MAX_REBALANCE_FACTOR}]",
             )
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -108,7 +108,9 @@ def recalibrate_org(org_volume: OrganizationDataVolume, context: TaskContext) ->
         # of issues.
         if organization is not None and is_sliding_window_org_enabled(organization):
             target_sample_rate = get_sliding_window_org_sample_rate(
-                org_id=org_volume.org_id, default_sample_rate=target_sample_rate
+                org_id=org_volume.org_id,
+                default_sample_rate=target_sample_rate,
+                notify_missing=True,
             )
             log_sample_rate_source(
                 org_volume.org_id,

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -276,7 +276,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
     def test_is_dynamically_sampled(self):
         with self.feature({"organizations:dynamic-sampling": True}):
             with patch(
-                "sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate",
+                "sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate",
                 return_value=0.5,
             ):
                 response = self.get_success_response(self.organization.slug)
@@ -284,7 +284,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
 
         with self.feature({"organizations:dynamic-sampling": True}):
             with patch(
-                "sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate",
+                "sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate",
                 return_value=1.0,
             ):
                 response = self.get_success_response(self.organization.slug)
@@ -292,7 +292,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
 
         with self.feature({"organizations:dynamic-sampling": True}):
             with patch(
-                "sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate",
+                "sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate",
                 return_value=None,
             ):
                 response = self.get_success_response(self.organization.slug)
@@ -300,7 +300,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
 
         with self.feature({"organizations:dynamic-sampling": False}):
             with patch(
-                "sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate",
+                "sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate",
                 return_value=None,
             ):
                 response = self.get_success_response(self.organization.slug)

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -288,7 +288,8 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
     ):
         extrapolate_monthly_volume.side_effect = self.forecasted_volume_side_effect
         get_transaction_sampling_tier_for_volume.side_effect = self.sampling_tier_side_effect
-        get_blended_sample_rate.return_value = 0.8
+        get_blended_sample_rate.return_value = 1.0
+
         # Create a org
         test_org = self.create_old_organization(name="sample-org")
 

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -643,8 +643,7 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
         The second org is at 20%, so we are spot on
         The third is at 30%, so we should decrease the sampling
         """
-        BLENDED_RATE = 0.20
-        self.set_sliding_window_org_sample_rate_for_all(BLENDED_RATE)
+        get_blended_sample_rate.return_value = 0.2
 
         redis_client = get_redis_client_for_ds()
 
@@ -686,14 +685,12 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
                 # half it again to 0.25
                 assert float(val) == 0.25
 
-    def test_rules_generation_with_recalibrate_orgs(self):
+    @patch("sentry.quotas.backend.get_blended_sample_rate")
+    def test_rules_generation_with_recalibrate_orgs(self, get_blended_sample_rate):
         """
-        Test that we pass rebalancing values all the way to the rules
-
-        (An integration test)
+        Test that we pass rebalancing values all the way to the rules.
         """
-        BLENDED_RATE = 0.20
-        self.set_sliding_window_org_sample_rate_for_all(BLENDED_RATE)
+        get_blended_sample_rate.return_value = 0.20
 
         with self.tasks():
             recalibrate_orgs()

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -85,7 +85,7 @@ def _validate_rules(project):
 
 
 @patch("sentry.dynamic_sampling.rules.base.sentry_sdk")
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_capture_exception(get_blended_sample_rate, sentry_sdk):
     get_blended_sample_rate.return_value = None
     # since we mock get_blended_sample_rate function
@@ -100,7 +100,7 @@ def test_generate_rules_capture_exception(get_blended_sample_rate, sentry_sdk):
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_only_always_allowed_rules_if_sample_rate_is_100_and_other_rules_are_enabled(
     get_blended_sample_rate, default_old_project
 ):
@@ -130,7 +130,7 @@ def test_generate_rules_return_only_always_allowed_rules_if_sample_rate_is_100_a
 
 @django_db_all
 @patch("sentry.dynamic_sampling.rules.base.get_enabled_user_biases")
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rules_with_rate(
     get_blended_sample_rate, get_enabled_user_biases, default_old_project
 ):
@@ -152,7 +152,7 @@ def test_generate_rules_return_uniform_rules_with_rate(
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rules_and_env_rule(
     get_blended_sample_rate, default_old_project
 ):
@@ -209,7 +209,7 @@ def test_generate_rules_return_uniform_rules_and_env_rule(
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rule_with_100_rate_and_without_env_rule(
     get_blended_sample_rate, default_old_project
 ):
@@ -228,7 +228,7 @@ def test_generate_rules_return_uniform_rule_with_100_rate_and_without_env_rule(
 
 @freeze_time("2022-10-21T18:50:25Z")
 @patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 @django_db_all
 @pytest.mark.parametrize(
     ["version", "platform", "end"],
@@ -301,7 +301,7 @@ def test_generate_rules_with_different_project_platforms(
 @django_db_all
 @freeze_time("2022-10-21T18:50:25Z")
 @patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rules_and_latest_release_rule(
     get_blended_sample_rate, apply_dynamic_factor, default_project, latest_release_only
 ):
@@ -382,7 +382,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
 @django_db_all
 @freeze_time("2022-10-21T18:50:25Z")
 @patch("sentry.dynamic_sampling.rules.biases.boost_latest_releases_bias.apply_dynamic_factor")
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_does_not_return_rule_with_deleted_release(
     get_blended_sample_rate, apply_dynamic_factor, default_project, latest_release_only
 ):
@@ -436,7 +436,7 @@ def test_generate_rules_does_not_return_rule_with_deleted_release(
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rule_with_100_rate_and_without_latest_release_rule(
     get_blended_sample_rate, default_old_project, latest_release_only
 ):
@@ -456,7 +456,7 @@ def test_generate_rules_return_uniform_rule_with_100_rate_and_without_latest_rel
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rule_with_non_existent_releases(
     get_blended_sample_rate, default_old_project, latest_release_only
 ):
@@ -480,7 +480,7 @@ def test_generate_rules_return_uniform_rule_with_non_existent_releases(
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_with_zero_base_sample_rate(get_blended_sample_rate, default_old_project):
     get_blended_sample_rate.return_value = 0.0
 
@@ -497,7 +497,7 @@ def test_generate_rules_with_zero_base_sample_rate(get_blended_sample_rate, defa
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 @patch(
     "sentry.dynamic_sampling.rules.biases.boost_low_volume_transactions_bias.get_transactions_resampling_rates"
 )
@@ -570,7 +570,7 @@ def test_generate_rules_return_uniform_rules_and_low_volume_transactions_rules(
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 @patch(
     "sentry.dynamic_sampling.rules.biases.boost_low_volume_transactions_bias.get_transactions_resampling_rates"
 )
@@ -610,7 +610,7 @@ def test_low_volume_transactions_rules_not_returned_when_inactive(
 
 @django_db_all
 @freeze_time("2022-10-21T18:50:25Z")
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rules_and_recalibrate_orgs_rule(
     get_blended_sample_rate, default_project
 ):
@@ -656,7 +656,7 @@ def test_generate_rules_return_uniform_rules_and_recalibrate_orgs_rule(
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_boost_replay_id(get_blended_sample_rate, default_old_project):
     get_blended_sample_rate.return_value = 0.5
     default_old_project.update_option(
@@ -697,7 +697,7 @@ def test_generate_rules_return_boost_replay_id(get_blended_sample_rate, default_
 
 
 @django_db_all
-@patch("sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate")
+@patch("sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate")
 def test_generate_rules_return_custom_rules(get_blended_sample_rate, default_old_project):
     """
     Tests the generation of custom rules ( from CustomDynamicSamplingRule models )

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -342,7 +342,7 @@ def test_project_config_with_all_biases_enabled(
         }
     ):
         with patch(
-            "sentry.dynamic_sampling.rules.base.quotas.get_blended_sample_rate",
+            "sentry.dynamic_sampling.rules.base.quotas.backend.get_blended_sample_rate",
             return_value=0.1,
         ):
             project_cfg = get_project_config(default_project)


### PR DESCRIPTION
This PR contains driveby improvements to dynamic sampling which include:
1. Implement sample rate fetching behavior in recalibrate_orgs which is identical to the one in the boost_low_volume_projects
2. Fallback to blended sample rate in case sliding window org is not found in both orgs recalibration and project boosting
3. Add more observability in the system when the sample rate can't be fetched
4. Fix false positives in tests and improve them

_These problems were found when trying to figure out the dependencies between dynamic sampling cron jobs._
