### PR TITLE
fix(queries): Layout for Onboarding CTA

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -171,7 +171,9 @@ export function DatabaseLandingPage() {
             </ModuleLayout.Full>
 
             {onboardingProject && (
-              <Onboarding organization={organization} project={onboardingProject} />
+              <ModuleLayout.Full>
+                <Onboarding organization={organization} project={onboardingProject} />
+              </ModuleLayout.Full>
             )}
             {!onboardingProject && (
               <Fragment>


### PR DESCRIPTION
Wrap the onboarding CTA with `ModuleLayout.Full` so it takes the full space.

Before:
<img width="1435" alt="Screenshot 2024-02-21 at 10 52 28 AM" src="https://github.com/getsentry/sentry/assets/22846452/564ea05b-3a26-4410-a676-de8229390a11">

After:
<img width="1491" alt="Screenshot 2024-02-21 at 10 52 17 AM" src="https://github.com/getsentry/sentry/assets/22846452/a2e15d2a-011b-4a65-9488-a664a6f5bc89">
