### PR TITLE
chore(hybridcloud) Add silo_mode as a tag

### DIFF
--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -15,6 +15,7 @@ class SdkConfig(TypedDict):
 
     send_client_reports: NotRequired[bool]
     traces_sampler: NotRequired[Callable[[dict[str, Any]], float]]
+    before_send: NotRequired[Callable[[dict[str, Any], object], dict[str, Any]]]
     before_send_transaction: NotRequired[Callable[[dict[str, Any], object], dict[str, Any]]]
     profiles_sample_rate: NotRequired[float]
     profiler_mode: NotRequired[Literal["sleep", "thread", "gevent", "unknown"]]

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -238,6 +238,12 @@ def before_send_transaction(event, _):
     return event
 
 
+def before_send(event, _):
+    if event.get("tags") and settings.SILO_MODE:
+        event["tags"]["silo_mode"] = settings.SILO_MODE
+    return event
+
+
 # Patches transport functions to add metrics to improve resolution around events sent to our ingest.
 # Leaving this in to keep a permanent measurement of sdk requests vs ingest.
 def patch_transport_for_instrumentation(transport, transport_name):
@@ -263,6 +269,7 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     sdk_options["send_client_reports"] = True
     sdk_options["traces_sampler"] = traces_sampler
     sdk_options["before_send_transaction"] = before_send_transaction
+    sdk_options["before_send"] = before_send
     sdk_options["release"] = (
         f"backend@{sdk_options['release']}" if "release" in sdk_options else None
     )


### PR DESCRIPTION
Having the SDK environment reflect region/control is causing issues for alerting and monitoring. I would still like a way to query for errors/transactions coming from silo mode application instances.