### PR TITLE
fix(dynamic-sampling): Fix performance of the org recalibration cron job

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -359,7 +359,7 @@ class OrganizationDataVolume:
     # number of transactions indexed (i.e. stored)
     indexed: int | None
 
-    def is_valid_for_recalibration(self):
+    def is_valid_for_recalibration(self) -> bool:
         return self.total > 0 and self.indexed is not None and self.indexed > 0
 
 

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -22,12 +22,7 @@ from snuba_sdk import (
 
 from sentry import quotas
 from sentry.dynamic_sampling.rules.utils import OrganizationId
-from sentry.dynamic_sampling.tasks.constants import (
-    CHUNK_SIZE,
-    MAX_ORGS_PER_QUERY,
-    MAX_SECONDS,
-    RECALIBRATE_ORGS_QUERY_INTERVAL,
-)
+from sentry.dynamic_sampling.tasks.constants import CHUNK_SIZE, MAX_ORGS_PER_QUERY, MAX_SECONDS
 from sentry.dynamic_sampling.tasks.helpers.sliding_window import extrapolate_monthly_volume
 from sentry.dynamic_sampling.tasks.logging import log_extrapolated_monthly_volume, log_query_timeout
 from sentry.dynamic_sampling.tasks.task_context import DynamicSamplingLogState, TaskContext
@@ -40,6 +35,8 @@ from sentry.utils.snuba import raw_snql_query
 
 ACTIVE_ORGS_DEFAULT_TIME_INTERVAL = timedelta(hours=1)
 ACTIVE_ORGS_DEFAULT_GRANULARITY = Granularity(3600)
+
+ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL = timedelta(minutes=5)
 ACTIVE_ORGS_VOLUMES_DEFAULT_GRANULARITY = Granularity(60)
 
 
@@ -257,10 +254,10 @@ class GetActiveOrgs:
                         Condition(Column("timestamp"), Op.LT, datetime.utcnow()),
                         Condition(Column("metric_id"), Op.EQ, self.metric_id),
                     ],
-                    granularity=self.granularity,
                     orderby=[
                         OrderBy(Column("org_id"), Direction.ASC),
                     ],
+                    granularity=self.granularity,
                 )
                 .set_limit(CHUNK_SIZE + 1)
                 .set_offset(self.offset)
@@ -375,7 +372,7 @@ class GetActiveOrgsVolumes:
     def __init__(
         self,
         max_orgs: int = MAX_ORGS_PER_QUERY,
-        time_interval: timedelta = RECALIBRATE_ORGS_QUERY_INTERVAL,
+        time_interval: timedelta = ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
         granularity: Granularity = ACTIVE_ORGS_VOLUMES_DEFAULT_GRANULARITY,
         include_keep=True,
         orgs: list[int] | None = None,
@@ -448,6 +445,7 @@ class GetActiveOrgsVolumes:
                         Column("org_id"),
                     ],
                     where=where,
+                    granularity=self.granularity,
                 )
                 .set_limit(CHUNK_SIZE + 1)
                 .set_offset(self.offset)
@@ -591,7 +589,7 @@ def fetch_orgs_with_total_root_transactions_count(
 
 def get_organization_volume(
     org_id: int,
-    time_interval: timedelta = RECALIBRATE_ORGS_QUERY_INTERVAL,
+    time_interval: timedelta = ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
     granularity: Granularity = ACTIVE_ORGS_VOLUMES_DEFAULT_GRANULARITY,
 ) -> OrganizationDataVolume | None:
     """

--- a/src/sentry/dynamic_sampling/tasks/constants.py
+++ b/src/sentry/dynamic_sampling/tasks/constants.py
@@ -25,5 +25,3 @@ CHUNK_SIZE = 9998
 
 # Time interval of queries for boost low volume transactions.
 BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL = timedelta(hours=1)
-# Time interval of queries for recalibrate orgs.
-RECALIBRATE_ORGS_QUERY_INTERVAL = timedelta(minutes=5)

--- a/src/sentry/dynamic_sampling/tasks/logging.py
+++ b/src/sentry/dynamic_sampling/tasks/logging.py
@@ -62,10 +62,6 @@ def log_query_timeout(query: str, offset: int, timeout_seconds: int) -> None:
     metrics.incr("dynamic_sampling.query_timeout", tags={"query": query})
 
 
-def log_recalibrate_org_error(org_id: int, error: str) -> None:
-    logger.info("dynamic_sampling.recalibrate_org_error", extra={"org_id": org_id, "error": error})
-
-
 def log_recalibrate_org_state(
     org_id: int, previous_factor: float, effective_sample_rate: float, target_sample_rate: float
 ) -> None:

--- a/src/sentry/dynamic_sampling/tasks/logging.py
+++ b/src/sentry/dynamic_sampling/tasks/logging.py
@@ -62,6 +62,10 @@ def log_query_timeout(query: str, offset: int, timeout_seconds: int) -> None:
     metrics.incr("dynamic_sampling.query_timeout", tags={"query": query})
 
 
+def log_recalibrate_org_error(org_id: int, error: str) -> None:
+    logger.info("dynamic_sampling.recalibrate_org_error", extra={"org_id": org_id, "error": error})
+
+
 def log_recalibrate_org_state(
     org_id: int, previous_factor: float, effective_sample_rate: float, target_sample_rate: float
 ) -> None:

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -1,5 +1,7 @@
 from collections.abc import Sequence
 
+import sentry_sdk
+
 from sentry import quotas
 from sentry.dynamic_sampling.rules.base import is_sliding_window_org_enabled
 from sentry.dynamic_sampling.tasks.common import GetActiveOrgsVolumes, TimedIterator
@@ -108,7 +110,7 @@ def recalibrate_org(org_id: int, total: int, indexed: int) -> None:
 
     # If we didn't find any sample rate, we can't recalibrate the organization.
     if target_sample_rate is None:
-        log_recalibrate_org_error(org_id, "The target sample rate was not found")
+        sentry_sdk.capture_message("Sample rate of org not found when trying to recalibrate it")
         return
 
     # We compute the effective sample rate that we had in the last considered time window.

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -66,7 +66,7 @@ def recalibrate_orgs(context: TaskContext) -> None:
     time_limit=2 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
-def recalibrate_orgs_batch(orgs: list[tuple[int, int, int | None]]) -> None:
+def recalibrate_orgs_batch(orgs: list[tuple[int, int, int]]) -> None:
     for org_id, total, indexed in orgs:
         try:
             recalibrate_org(org_id, total, indexed)
@@ -74,13 +74,7 @@ def recalibrate_orgs_batch(orgs: list[tuple[int, int, int | None]]) -> None:
             sentry_sdk.capture_exception(e)
 
 
-def recalibrate_org(org_id: int, total: int, indexed: int | None) -> None:
-    if indexed is None:
-        RecalibrationError(
-            org_id,
-            "missing indexed data count for organization",
-        )
-
+def recalibrate_org(org_id: int, total: int, indexed: int) -> None:
     try:
         # We need the organization object for the feature flag.
         organization = Organization.objects.get_from_cache(id=org_id)

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import sentry_sdk
 
 from sentry import quotas
@@ -66,7 +68,7 @@ def recalibrate_orgs(context: TaskContext) -> None:
     time_limit=2 * 60 + 5,
     silo_mode=SiloMode.REGION,
 )
-def recalibrate_orgs_batch(orgs: list[tuple[int, int, int]]) -> None:
+def recalibrate_orgs_batch(orgs: Sequence[tuple[int, int, int]]) -> None:
     for org_id, total, indexed in orgs:
         try:
             recalibrate_org(org_id, total, indexed)


### PR DESCRIPTION
This PR tries to improve the org recalibration cron job by using sub-tasks in batch to recalibrate a group of orgs. Currently a batch comprises 100 orgs.

This PR also includes some minor improvements such as properly propagating the granularity in the `GetActiveOrgVolumes` iterator, properly naming constants, and reworking how errors are propagated.

The error policy that was applied to this PR and which is similar to the other cron jobs of dynamic sampling is that we want to log all errors that are non-critical and might help us when troubleshooting issues, whereas all errors that might indicate a system malfunction must be reported to sentry either via `capture_message` or `capture_exception`, since we want to be able to get notified and act quickly.