### PR TITLE
ref: Move hub clone

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
@@ -84,7 +84,8 @@ class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectEndpoint):
             description="ProjectReplayRecordingSegmentDetailsEndpoint.download_segment",
         ) as child_span:
             segment_bytes = download_segment(
-                segment, span=child_span, current_hub=sentry_sdk.Hub.current
+                segment,
+                span=child_span,
             )
             if segment_bytes is None:
                 segment_bytes = b"[]"

--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -254,11 +254,13 @@ def download_segments(segments: list[RecordingSegmentStorageMeta]) -> Iterator[b
             download_segment,
             span=span,
         )
+        current_hub = sentry_sdk.Hub.current
 
         yield b"["
         # Map all of the segments to a worker process for download.
         with ThreadPoolExecutor(max_workers=10) as exe:
-            results = exe.map(download_segment_with_fixed_args, segments)
+            with sentry_sdk.Hub(current_hub):
+                results = exe.map(download_segment_with_fixed_args, segments)
 
             for i, result in enumerate(results):
                 if result is None:


### PR DESCRIPTION
The hub clone in `download_segment` is unnecessary because the function is sometimes called from outside a Thread Pool Executor. Since cloning the hub is only necessary in the Thread Pool Executor, we move the hub clone there

Closes GH-63591