### PR TITLE
chore(slack): log payload for unfurl error

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -197,7 +197,9 @@ class SlackEventEndpoint(SlackDMEndpoint):
         try:
             client.post("/chat.unfurl", data=payload)
         except ApiError as e:
-            logger.exception("slack.event.unfurl-error", extra=e.__dict__)
+            logger.exception(
+                "slack.event.unfurl-error", extra={"error": str(e), "payload": payload}
+            )
 
         return True
 


### PR DESCRIPTION
`e.__dict__` isn't returning what we expected. We can just log the payload that received the unfurl error and try it locally instead.