### PR TITLE
feat(issue-priority): Remove issues from stream when reprioritizing

### DIFF
--- a/static/app/views/issueList/overview.actions.spec.tsx
+++ b/static/app/views/issueList/overview.actions.spec.tsx
@@ -8,13 +8,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {
-  render,
-  screen,
-  userEvent,
-  waitFor,
-  within,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import Indicators from 'sentry/components/indicators';
 import GroupStore from 'sentry/stores/groupStore';
@@ -173,10 +167,8 @@ describe('IssueListOverview (actions)', function () {
         })
       );
 
-      await waitFor(() => {
-        expect(screen.queryByText('Group 1')).not.toBeInTheDocument();
-        expect(screen.getByText('Group 2')).toBeInTheDocument();
-      });
+      expect(screen.queryByText('Group 1')).not.toBeInTheDocument();
+      expect(screen.getByText('Group 2')).toBeInTheDocument();
     });
 
     it('can undo resolve action', async function () {
@@ -219,10 +211,8 @@ describe('IssueListOverview (actions)', function () {
         })
       );
 
-      await waitFor(() => {
-        expect(screen.queryByText('Group 1')).not.toBeInTheDocument();
-        expect(screen.getByText('Group 2')).toBeInTheDocument();
-      });
+      expect(screen.queryByText('Group 1')).not.toBeInTheDocument();
+      expect(screen.getByText('Group 2')).toBeInTheDocument();
 
       // Should show a toast message
       expect(screen.getByText('Resolved JAVASCRIPT-1')).toBeInTheDocument();
@@ -316,10 +306,8 @@ describe('IssueListOverview (actions)', function () {
         })
       );
 
-      await waitFor(() => {
-        expect(screen.queryByText('Group 1')).not.toBeInTheDocument();
-        expect(screen.getByText('Group 2')).toBeInTheDocument();
-      });
+      expect(screen.queryByText('Group 1')).not.toBeInTheDocument();
+      expect(screen.getByText('Group 2')).toBeInTheDocument();
     });
   });
 
@@ -370,17 +358,15 @@ describe('IssueListOverview (actions)', function () {
       await userEvent.hover(screen.getByRole('menuitemradio', {name: /priority/i}));
       await userEvent.click(screen.getByRole('menuitemradio', {name: /low/i}));
 
-      await waitFor(() => {
-        expect(updateIssueMock).toHaveBeenCalledWith(
-          '/organizations/org-slug/issues/',
-          expect.objectContaining({
-            query: expect.objectContaining({id: ['1']}),
-            data: {priority: PriorityLevel.LOW},
-          })
-        );
+      expect(updateIssueMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/issues/',
+        expect.objectContaining({
+          query: expect.objectContaining({id: ['1']}),
+          data: {priority: PriorityLevel.LOW},
+        })
+      );
 
-        expect(screen.queryByText('Medium priority issue')).not.toBeInTheDocument();
-      });
+      expect(screen.queryByText('Medium priority issue')).not.toBeInTheDocument();
     });
 
     it('does not remove issues after reprioritizing (when query includes all priorities)', async function () {
@@ -392,18 +378,16 @@ describe('IssueListOverview (actions)', function () {
       render(
         <IssueListOverview
           {...defaultProps}
-          {...{
-            ...RouteComponentPropsFixture({
-              location: LocationFixture({
-                query: {query: 'is:unresolved'},
-              }),
-              params: {
-                orgId: organization.slug,
-                projectId: project.slug,
-                searchId: undefined,
-              },
+          {...RouteComponentPropsFixture({
+            location: LocationFixture({
+              query: {query: 'is:unresolved'},
             }),
-          }}
+            params: {
+              orgId: organization.slug,
+              projectId: project.slug,
+              searchId: undefined,
+            },
+          })}
         />,
         {organization}
       );
@@ -420,17 +404,15 @@ describe('IssueListOverview (actions)', function () {
       await userEvent.hover(screen.getByRole('menuitemradio', {name: /priority/i}));
       await userEvent.click(screen.getByRole('menuitemradio', {name: /low/i}));
 
-      await waitFor(() => {
-        expect(updateIssueMock).toHaveBeenCalledWith(
-          '/organizations/org-slug/issues/',
-          expect.objectContaining({
-            query: expect.objectContaining({id: ['1']}),
-            data: {priority: PriorityLevel.LOW},
-          })
-        );
+      expect(updateIssueMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/issues/',
+        expect.objectContaining({
+          query: expect.objectContaining({id: ['1']}),
+          data: {priority: PriorityLevel.LOW},
+        })
+      );
 
-        expect(screen.getByText('Medium priority issue')).toBeInTheDocument();
-      });
+      expect(screen.getByText('Medium priority issue')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -37,6 +37,7 @@ import type {
   Group,
   Organization,
   PageFilters,
+  PriorityLevel,
   SavedSearch,
   TagCollection,
 } from 'sentry/types';
@@ -63,6 +64,7 @@ import withPageFilters from 'sentry/utils/withPageFilters';
 import withSavedSearches from 'sentry/utils/withSavedSearches';
 import SavedIssueSearches from 'sentry/views/issueList/savedIssueSearches';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
+import {parseIssuePrioritySearch} from 'sentry/views/issueList/utils/parseIssuePrioritySearch';
 
 import IssueListActions from './actions';
 import IssueListFilters from './filters';
@@ -1091,6 +1093,18 @@ class IssueListOverview extends Component<Props, State> {
       });
       return;
     }
+
+    if ('priority' in data && typeof data.priority === 'string') {
+      const priorityValues = parseIssuePrioritySearch(query);
+      const priority = data.priority.toLowerCase() as PriorityLevel;
+
+      this.onIssueAction({
+        itemIds,
+        actionType: 'Reprioritized',
+        shouldRemove: !priorityValues.has(priority),
+      });
+      return;
+    }
   };
 
   onIssueAction = ({
@@ -1099,7 +1113,7 @@ class IssueListOverview extends Component<Props, State> {
     shouldRemove,
     undo,
   }: {
-    actionType: 'Reviewed' | 'Resolved' | 'Ignored' | 'Archived';
+    actionType: 'Reviewed' | 'Resolved' | 'Ignored' | 'Archived' | 'Reprioritized';
     itemIds: string[];
     shouldRemove: boolean;
     undo?: () => void;

--- a/static/app/views/issueList/utils/parseIssuePrioritySearch.spec.tsx
+++ b/static/app/views/issueList/utils/parseIssuePrioritySearch.spec.tsx
@@ -1,0 +1,41 @@
+import {parseIssuePrioritySearch} from 'sentry/views/issueList/utils/parseIssuePrioritySearch';
+
+describe('parseIssuePrioritySearch', function () {
+  it('can parse array values', function () {
+    const priorityValues = parseIssuePrioritySearch(
+      'is:unresolved issue.priority:[high,medium]'
+    );
+
+    expect(priorityValues).toEqual(new Set(['high', 'medium']));
+  });
+
+  it('can parse single values', function () {
+    const priorityValues = parseIssuePrioritySearch(
+      'is:unresolved issue.priority:medium'
+    );
+
+    expect(priorityValues).toEqual(new Set(['medium']));
+  });
+
+  it('can parse negated array values', function () {
+    const priorityValues = parseIssuePrioritySearch(
+      'is:unresolved !issue.priority:[low, medium]'
+    );
+
+    expect(priorityValues).toEqual(new Set(['high']));
+  });
+
+  it('can parse negated single values', function () {
+    const priorityValues = parseIssuePrioritySearch(
+      'is:unresolved !issue.priority:medium'
+    );
+
+    expect(priorityValues).toEqual(new Set(['high', 'low']));
+  });
+
+  it('can parse query without priority', function () {
+    const priorityValues = parseIssuePrioritySearch('is:unresolved');
+
+    expect(priorityValues).toEqual(new Set(['high', 'medium', 'low']));
+  });
+});

--- a/static/app/views/issueList/utils/parseIssuePrioritySearch.tsx
+++ b/static/app/views/issueList/utils/parseIssuePrioritySearch.tsx
@@ -1,0 +1,41 @@
+import type {TokenResult} from 'sentry/components/searchSyntax/parser';
+import {parseSearch, Token} from 'sentry/components/searchSyntax/parser';
+import {PriorityLevel} from 'sentry/types';
+
+const VALID_PRIORITIES = new Set([
+  PriorityLevel.HIGH,
+  PriorityLevel.MEDIUM,
+  PriorityLevel.LOW,
+]);
+
+export function parseIssuePrioritySearch(query: string) {
+  const parsed = parseSearch(query);
+
+  const issuePriorityToken = parsed?.find(
+    token => token.type === Token.FILTER && token.key.text === 'issue.priority'
+  ) as TokenResult<Token.FILTER>;
+
+  if (!issuePriorityToken) {
+    return VALID_PRIORITIES;
+  }
+
+  const values =
+    issuePriorityToken.value.type === Token.VALUE_TEXT_LIST
+      ? issuePriorityToken.value.items.map(item => item.value?.text)
+      : [issuePriorityToken.value.text];
+
+  const validValues = values
+    .map(value => value?.toLowerCase())
+    .filter(value => VALID_PRIORITIES.has(value as PriorityLevel));
+
+  if (issuePriorityToken.negated) {
+    const priorities = new Set(VALID_PRIORITIES);
+    for (const value of validValues) {
+      priorities.delete(value as PriorityLevel);
+    }
+
+    return priorities;
+  }
+
+  return new Set(validValues);
+}

--- a/static/app/views/issueList/utils/parseIssuePrioritySearch.tsx
+++ b/static/app/views/issueList/utils/parseIssuePrioritySearch.tsx
@@ -13,7 +13,7 @@ export function parseIssuePrioritySearch(query: string) {
 
   const issuePriorityToken = parsed?.find(
     token => token.type === Token.FILTER && token.key.text === 'issue.priority'
-  ) as TokenResult<Token.FILTER>;
+  ) as TokenResult<Token.FILTER> | undefined;
 
   if (!issuePriorityToken) {
     return VALID_PRIORITIES;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/65212

When changing the priority to a value that's not shown in the current query, removes it from the view similar to how it works for making issues as resolved, archived, etc.

In order to determine whether or not the issue should be removed, parses the search using `parseIssuePrioritySearch()`. This is a little smarter than the other issue actions which just check for the query string for matches like `is:unresolved`.  