### PR TITLE
fix(replay-clip): Add custom recording event to extend clip duration

### DIFF
--- a/static/app/utils/replays/hydrateRRWebRecordingFrames.tsx
+++ b/static/app/utils/replays/hydrateRRWebRecordingFrames.tsx
@@ -23,3 +23,14 @@ export function recordingEndFrame(replayRecord: ReplayRecord): RecordingFrame {
     },
   };
 }
+
+export function clipEndFrame(timestamp: number): RecordingFrame {
+  return {
+    type: EventType.Custom,
+    timestamp,
+    data: {
+      tag: 'replay.clip_end',
+      payload: {},
+    },
+  };
+}

--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -442,11 +442,8 @@ describe('ReplayReader', () => {
     });
 
     it('should adjust the end time and duration for the clip window', () => {
-      // Duration should be between the clip start time and the last rrweb frame
-      // within the clip window
-      expect(replay?.getDurationMs()).toEqual(
-        rrwebFrame2.timestamp - clipStartTimestamp.getTime()
-      );
+      // Duration should be between the clip start time and end time
+      expect(replay?.getDurationMs()).toEqual(10_000);
       // Start offset should be set
       expect(replay?.getStartOffsetMs()).toEqual(
         clipStartTimestamp.getTime() - replayStartedAt.getTime()
@@ -467,6 +464,11 @@ describe('ReplayReader', () => {
         expect.objectContaining({
           type: EventType.FullSnapshot,
           timestamp: rrwebFrame2.timestamp,
+        }),
+        expect.objectContaining({
+          type: EventType.Custom,
+          data: {tag: 'replay.clip_end', payload: {}},
+          timestamp: clipEndTimestamp.getTime(),
         }),
         // rrwebFrame3 should not be returned
       ]);


### PR DESCRIPTION
When there is inactivity during the error, replay clips will trim off the inactivity and the error with them. See [this event](https://sentry.sentry.io/issues/4999290709/events/b4730759044c43a1ab3a388cf0d37391/?project=11276#replay) for an example.

To rectify this, I'm doing something similar to the default behavior which is to insert a custom recording frame with the correct timestamp where we actually want the replay to end.