### PR TITLE
fix(ui): Add `org:billing` to access types

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -59,6 +59,7 @@ export const ALLOWED_SCOPES = [
   'member:read',
   'member:write',
   'org:admin',
+  'org:billing',
   'org:integrations',
   'org:read',
   'org:superuser', // not an assignable API access scope


### PR DESCRIPTION
This is only used in getsentry but its just easier to declare with all the other ones. Fixes weird little types like this one https://github.com/getsentry/getsentry/blob/76383ddae68c6ca1695c3cfa7cc86a49fe19a59c/tests/js/fixtures/organizationFixture.ts#L11

and this one https://github.com/getsentry/getsentry/blob/76383ddae68c6ca1695c3cfa7cc86a49fe19a59c/static/getsentry/gsApp/types/index.tsx#L498

**motivation**
We have to redeclare organization in a bunch of places because access is missing the 'org:billing' type and its really not a secret. eg - useOrganization needs to use the correct organization type in getsentry