### PR TITLE
chore(issues): Update CODEOWNERS to fix invalid paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -345,7 +345,7 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/models/identity.py                                       @getsentry/enterprise
 /src/sentry/models/integrations/                                     @getsentry/product-owners-settings-integrations
 
-/src/sentry/tasks/codeowners                                         @getsentry/issues
+/src/sentry/tasks/codeowners/                                        @getsentry/issues
 /src/sentry/tasks/commits.py                                         @getsentry/issues
 /src/sentry/tasks/commit_context.py                                  @getsentry/issues
 /src/sentry/tasks/digests.py                                         @getsentry/alerts-notifications

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -171,18 +171,16 @@ yarn.lock                                                @getsentry/owners-js-de
 /tests/sentry/incidents/                                  @getsentry/issues
 /tests/acceptance/test_incidents.py                       @getsentry/issues
 
-/src/sentry/api/helpers/group_index.py                    @getsentry/issues
 /src/sentry/api/helpers/events.py                         @getsentry/issues
-/src/sentry/api/helpers/group_index/update.py             @getsentry/issues
+/src/sentry/api/helpers/group_index/                      @getsentry/issues
 
 /src/sentry/snuba/models.py                               @getsentry/issues
-/src/sentry/snuba/query_subscription_consumer.py          @getsentry/issues
+/src/sentry/snuba/query_subscriptions/                    @getsentry/issues
 /src/sentry/snuba/subscriptions.py                        @getsentry/issues
 /tests/snuba/incidents/                                   @getsentry/issues
 /tests/sentry/snuba/test_query_subscription_consumer.py   @getsentry/issues
 /tests/sentry/snuba/test_subscriptions.py                 @getsentry/issues
 /tests/sentry/snuba/test_tasks.py                         @getsentry/issues
-/tests/snuba/snuba/test_query_subscription_consumer.py    @getsentry/issues
 /src/sentry/api/issue_search.py                           @getsentry/issues
 /tests/sentry/api/test_issue_search.py                    @getsentry/issues
 
@@ -347,7 +345,7 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/models/identity.py                                       @getsentry/enterprise
 /src/sentry/models/integrations/                                     @getsentry/product-owners-settings-integrations
 
-/src/sentry/tasks/code_owners.py                                     @getsentry/issues
+/src/sentry/tasks/codeowners                                         @getsentry/issues
 /src/sentry/tasks/commits.py                                         @getsentry/issues
 /src/sentry/tasks/commit_context.py                                  @getsentry/issues
 /src/sentry/tasks/digests.py                                         @getsentry/alerts-notifications
@@ -382,8 +380,6 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/models/project.py                 @getsentry/data @getsentry/telemetry-experience
 /src/sentry/models/projectoption.py           @getsentry/data
 /src/sentry/models/release.py                 @getsentry/data
-/src/sentry/models/sentryapp.py               @getsentry/data @getsentry/issues
-/src/sentry/models/sentryappinstallation.py   @getsentry/data @getsentry/issues
 /src/sentry/models/user.py                    @getsentry/data
 ## End of Data
 
@@ -501,7 +497,6 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/grouping/                               @getsentry/issues
 /src/sentry/issues/                                 @getsentry/issues
 /src/sentry/tasks/post_process.py                   @getsentry/issues
-/src/sentry/types/issues.py                         @getsentry/issues
 /tests/sentry/event_manager/test_event_manager.py   @getsentry/issues
 /tests/sentry/grouping/                             @getsentry/issues
 /tests/sentry/issues/                               @getsentry/issues
@@ -510,11 +505,9 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /tests/snuba/search/                                @getsentry/issues
 /src/sentry/search/snuba/                           @getsentry/issues
 /static/app/views/issueList                                  @getsentry/issues
-/static/app/views/organizationGroupDetails                   @getsentry/issues
 /src/sentry/api/helpers/source_map_helper.py                  @getsentry/issues
-/src/sentry/api/endpoints/actionable_items.py                @getsentry/issues
 /src/sentry/api/helpers/actionable_items_helper.py                  @getsentry/issues
-/static/app/components/events/interfaces/crashContent/exception/actionableItems   @getsentry/issues
+/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx   @getsentry/issues
 /static/app/utils/analytics.tsx                                 @getsentry/issues
 /static/app/utils/routeAnalytics*                               @getsentry/issues
 ## End of Issues


### PR DESCRIPTION
All non-wildcard rules which list getsentry/issues as a codeowner now refer to files which actually exist.

Many of these rules are either overly specific or potentially overlap with other rules, the goal here is simply to make sure all paths are valid first.