### PR TITLE
fix(metrics-extraction): Elide meta information in timeseries in UI

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -79,7 +79,9 @@ export function flattenMultiSeriesDataWithGrouping(
 
   groupNames.forEach(groupName => {
     // Each group contains an order key which we should ignore
-    const aggregateNames = Object.keys(omit(result[groupName], 'order'));
+    const aggregateNames = Object.keys(
+      omit(result[groupName], ['order', 'isMetricsExtractedData'])
+    );
 
     aggregateNames.forEach(aggregate => {
       const seriesName = `${groupName} : ${aggregate}`;


### PR DESCRIPTION
### Summary
There was an edgecase for topN (topEvents) timeseries where 'isMetricsExtractedData' is returned in the root of the group along with order (it really should be in meta, but that's outside the scope of this PR). This omits it so it doesn't appear in the legend

#### Screenshot
![Screenshot 2024-02-21 at 2 12 56 PM](https://github.com/getsentry/sentry/assets/6111995/7e2b9ceb-7842-4de9-81aa-a0f889f576c2)
