### PR TITLE
fix(integrations) Pass organization to features.has()

### DIFF
--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -252,9 +252,12 @@ class VercelWebhookEndpoint(Endpoint):
 
         configuration = integration.metadata["configurations"].pop(configuration_id)
 
-        first_org = organization_service.get_organization_by_id(
+        org_context = organization_service.get_organization_by_id(
             id=org_ids[0], include_projects=False, include_teams=False
         )
+        first_org = None
+        if org_context:
+            first_org = org_context.organization
         has_webhooks = features.has("organizations:vercel-integration-webhooks", first_org)
         # one of two cases:
         #  1.) someone is deleting from vercel's end and we still need to delete the


### PR DESCRIPTION
In #65433 I neglected to extract the organization from the RpcOrganizationContext

Fixes SENTRY-2NQR