### PR TITLE
ref(events): Pre-stuck-project-counter-fix updates to `next_short_id`

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -309,7 +309,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
     def __str__(self):
         return f"{self.name} ({self.slug})"
 
-    def next_short_id(self):
+    def next_short_id(self, delta=1):
         from sentry.models.counter import Counter
 
         with sentry_sdk.start_span(op="project.next_short_id") as span, metrics.timer(
@@ -317,7 +317,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
         ):
             span.set_data("project_id", self.id)
             span.set_data("project_slug", self.slug)
-            return Counter.increment(self)
+            return Counter.increment(self, delta)
 
     def save(self, *args, **kwargs):
         if not self.slug:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -309,7 +309,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
     def __str__(self):
         return f"{self.name} ({self.slug})"
 
-    def next_short_id(self, delta=1):
+    def next_short_id(self, delta: int = 1) -> int:
         from sentry.models.counter import Counter
 
         with sentry_sdk.start_span(op="project.next_short_id") as span, metrics.timer(

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from unittest.mock import patch
 
 from sentry.models.actor import ActorTuple, get_actor_for_user
 from sentry.models.environment import Environment, EnvironmentProject
@@ -340,6 +341,18 @@ class ProjectTest(APITestCase, TestCase):
         assert (
             url == f"http://{self.organization.slug}.testserver/issues/?project={self.project.id}"
         )
+
+    def test_get_next_short_id_simple(self):
+        with patch("sentry.models.Counter.increment", return_value=1231):
+            assert self.project.next_short_id() == 1231
+
+    def test_next_short_id_increments_by_one_if_no_delta_passed(self):
+        assert self.project.next_short_id() == 1
+        assert self.project.next_short_id() == 2
+
+    def test_get_next_short_id_increments_by_delta_value(self):
+        assert self.project.next_short_id() == 1
+        assert self.project.next_short_id(delta=2) == 3
 
 
 @region_silo_test


### PR DESCRIPTION
This contains two changes pulled out of a larger PR fixing (well, working around) the bug where projects' project counters are getting stuck, such that the project can no longer create new groups. Specifically:

- Allow `project.next_short_id` to accept a `delta` parameter to pass on to `Counter.increment`, so that we can jump by more than one if necessary. The new parameter defaults to `1` (which is what `Counter.increment` defaults to, too, and therefore what `next_short_id` has been doing all along), so no current uses of `next_short_id` should be affected.

- Pull the getting of said short id which is currently in `_create_group`  into a helper function, `_get_next_short_id`. This allows us to abstract away the timeout error handling which is currently part of `_create_group`.

Oh, and I added types to `next_short_id`, and some tests for it.