### PR TITLE
fix(metrics-extraction): Don't highlight query with error conditions

### DIFF
--- a/static/app/utils/onDemandMetrics/constants.tsx
+++ b/static/app/utils/onDemandMetrics/constants.tsx
@@ -34,3 +34,5 @@ export const ON_DEMAND_METRICS_UNSUPPORTED_TAGS = new Set([
   ...Object.values(StackTags),
   ...Object.values(ErrorTags),
 ]) as Set<FieldKey>;
+
+export const ERROR_ONLY_TAGS = new Set(Object.values(ErrorTags));

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -17,6 +17,7 @@ import type {Organization, PageFilters} from 'sentry/types';
 import {
   createOnDemandFilterWarning,
   isOnDemandQueryString,
+  shouldDisplayOnDemandWidgetWarning,
 } from 'sentry/utils/onDemandMetrics';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
@@ -26,15 +27,13 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import ReleasesSelectControl from 'sentry/views/dashboards/releasesSelectControl';
-import type {
-  DashboardFilters,
-  ValidateWidgetResponse,
-  WidgetQuery,
-} from 'sentry/views/dashboards/types';
 import {
   DashboardFilterKeys,
+  type DashboardFilters,
   OnDemandExtractionState,
-  WidgetType,
+  type ValidateWidgetResponse,
+  type WidgetQuery,
+  type WidgetType,
 } from 'sentry/views/dashboards/types';
 
 import {BuildStep, SubHeading} from '../buildStep';
@@ -122,8 +121,6 @@ export function FilterResultsStep({
       }
     )
   );
-  const shouldDisplayOnDemandWarning =
-    hasOnDemandMetricWidgetFeature(organization) && widgetType === WidgetType.DISCOVER;
 
   return (
     <BuildStep
@@ -171,7 +168,9 @@ export function FilterResultsStep({
               <SearchConditionsWrapper>
                 <datasetConfig.SearchBar
                   getFilterWarning={
-                    shouldDisplayOnDemandWarning ? getOnDemandFilterWarning : undefined
+                    shouldDisplayOnDemandWidgetWarning(query, widgetType, organization)
+                      ? getOnDemandFilterWarning
+                      : undefined
                   }
                   organization={organization}
                   pageFilters={selection}
@@ -179,7 +178,7 @@ export function FilterResultsStep({
                   onSearch={handleSearch(queryIndex)}
                   widgetQuery={query}
                 />
-                {shouldDisplayOnDemandWarning && (
+                {shouldDisplayOnDemandWidgetWarning(query, widgetType, organization) && (
                   <WidgetOnDemandQueryWarning
                     query={query}
                     validatedWidgetResponse={validatedWidgetResponse}


### PR DESCRIPTION
### Summary
On-demand doesn't apply when any part of the conditions contain an error, or they have explicitly set event.type:error, which on-demand isn't applicable for. Eventually we want to explicitly let users change their dataset between transactions and errors so this is less confusing, but that's outside the scope of this PR.

**Other**:
- We can likely fold this into `isOnDemandQueryString` later but I need to confirm the scope of on-demand alerts where that is also used

#### Screenshots
| Before | After |
|--------|------|
|![Screenshot 2024-02-21 at 2 19 51 PM](https://github.com/getsentry/sentry/assets/6111995/40dda0ad-b432-4f2c-b65c-17cf535d34af) | ![Screenshot 2024-02-21 at 3 43 05 PM](https://github.com/getsentry/sentry/assets/6111995/cc73e7e4-6fe1-437f-a00f-baf1849d4a3f) |
