### PR TITLE
feat(grouping): Additional message parameterizations

### DIFF
--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -15,7 +15,7 @@ from sentry.interfaces.message import Message
 from sentry.utils import metrics
 
 _parameterization_regex = re.compile(
-    # The `(?x)` tells the regex compiler to ingore comments and unescaped whitespace,
+    # The `(?x)` tells the regex compiler to ignore comments and unescaped whitespace,
     # so we can use newlines and indentation for better legibility.
     r"""(?x)
     (?P<email>
@@ -90,7 +90,7 @@ _parameterization_regex = re.compile(
         # Time
         ([0-2]\d:[0-5]\d:[0-5]\d)
         |
-        # Old Formats, TODO: possibly safe to remove?
+        # Old Date Formats, TODO: possibly safe to remove?
         (
             (\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|
             (\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|
@@ -135,10 +135,6 @@ _parameterization_regex = re.compile(
         ='([^']+)' |
         ="([^"]+)"
     ) |
-    (?P<json_str_val>
-        :\s?'([^']+)' |
-        :\s?"([^"]+)"
-    ) |
     (?P<bool>
         # The `=` here guarantees we'll only match the value half of key-value pairs,
         # rather than all instances of the words 'true' and 'false'.
@@ -146,15 +142,6 @@ _parameterization_regex = re.compile(
         =true |
         =False |
         =false
-    )
-    |
-    (?P<uniq_id>
-        \b
-        (?!\w*?[\.:\-]\w*?\b) # No colons, dots, or dashes
-        (?=\w*?[0-9]\w*?\b) # At least one digit
-        (?=\w*?[a-zA-Z]\w*?\b) # At least one letter
-        [\w_]+?
-        \b
     )
 """
 )

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -64,6 +64,31 @@ _parameterization_regex = re.compile(
         \b[0-9a-fA-F]{32}\b
     ) |
     (?P<date>
+         # RFC822, RFC1123, RFC1123Z
+        (\b(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat),\s\d{1,2}\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{2,4}\s\d{1,2}:\d{1,2}(:\d{1,2})?\s([-\+][\d]{2}[0-5][\d]|(?:UT|GMT|(?:E|C|M|P)(?:ST|DT)|[A-IK-Z]))\b)
+        |
+        # # RFC850
+        (\b(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday),\s\d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2}\s\d{2}:\d{2}:\d{2}\s(?:UT|GMT|(?:E|C|M|P)(?:ST|DT)|[A-IK-Z])\b)
+        |
+        # RFC3339, RFC3339Nano
+        (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?[Z\s]([+-]?\d{2}:\d{2})?)
+        |
+        # LongDate
+        ((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+[0-3]\d,\s+\d{4})
+        |
+        # Datetime
+        (\d{4}-[01]\d-[0-3]\d\s[0-2]\d:[0-5]\d:[0-5]\d)
+        |
+        # Kitchen
+        (\d{1,2}:\d{2}(:\d{2})?(?: [aApP][Mm])?)
+        |
+        # Date
+        (\d{4}-[01]\d-[0-3]\d)
+        |
+        # Time
+        ([0-2]\d:[0-5]\d:[0-5]\d)
+        |
+        # Old Formats, TODO: possibly safe to remove?
         (
             (\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|
             (\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -64,8 +64,7 @@ _parameterization_regex = re.compile(
         \b[0-9a-fA-F]{32}\b
     ) |
     (?P<date>
-
-        \b
+        # No word boundaries required around dates. Should there be?
         # RFC822, RFC1123, RFC1123Z
         ((?:Sun|Mon|Tue|Wed|Thu|Fri|Sat),\s\d{1,2}\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{2,4}\s\d{1,2}:\d{1,2}(:\d{1,2})?\s([-\+][\d]{2}[0-5][\d]|(?:UT|GMT|(?:E|C|M|P)(?:ST|DT)|[A-IK-Z])))
         |
@@ -113,7 +112,6 @@ _parameterization_regex = re.compile(
             ([-\+][\d]{2}[0-5][\d]|(?:UT|GMT|(?:E|C|M|P)(?:ST|DT)|[A-IK-Z]))
         ) |
         (datetime.datetime\(.*?\))
-        \b
     ) |
     (?P<duration>
         \b\d+ms\b

--- a/tests/sentry/grouping/test_normalize_message.py
+++ b/tests/sentry/grouping/test_normalize_message.py
@@ -1,121 +1,94 @@
+import pytest
+
 from sentry.grouping.strategies.message import normalize_message_for_grouping
-from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import region_silo_test
 
 
-@region_silo_test
-class NormalizeMesageTest(TestCase):
-    def test_normalize_message(
-        self,
-    ) -> None:
-        cases = [
-            ("email", """blah test@email.com had a problem""", """blah <email> had a problem"""),
-            ("url", """blah http://some.email.com had a problem""", """blah <url> had a problem"""),
-            (
-                "url - existing behavior",
-                """blah tcp://user:pass@email.com:10 had a problem""",
-                """blah tcp://user:<email>:<int> had a problem""",
-            ),
-            ("ip", """blah 0.0.0.0 had a problem""", """blah <ip> had a problem"""),
-            (
-                "UUID",
-                """blah 7c1811ed-e98f-4c9c-a9f9-58c757ff494f had a problem""",
-                """blah <uuid> had a problem""",
-            ),
-            (
-                "SHA1",
-                """blah 5fc35719b9cf96ec602dbc748ff31c587a46961d had a problem""",
-                """blah <sha1> had a problem""",
-            ),
-            (
-                "MD5",
-                """blah 0751007cd28df267e8e051b51f918c60 had a problem""",
-                """blah <md5> had a problem""",
-            ),
-            (
-                "Date",
-                """blah 2024-02-20T22:16:36 had a problem""",
-                """blah <date> had a problem""",
-            ),
-            (
-                "Date RFC822",
-                """blah Mon, 02 Jan 06 15:04 MST had a problem""",
-                """blah <date> had a problem""",
-            ),
-            (
-                "Date RFC822Z",
-                """blah Mon, 02 Jan 06 15:04 -0700 had a problem""",
-                """blah <date> had a problem""",
-            ),
-            (
-                "Date RFC850",
-                """blah Monday, 02-Jan-06 15:04:05 MST had a problem""",
-                """blah <date> had a problem""",
-            ),
-            (
-                "Date RFC1123",
-                """blah Mon, 02 Jan 2006 15:04:05 MST had a problem""",
-                """blah <date> had a problem""",
-            ),
-            (
-                "Date RFC1123Z",
-                """blah Mon, 02 Jan 2006 15:04:05 -0700 had a problem""",
-                """blah <date> had a problem""",
-            ),
-            (
-                "Date RFC3339",
-                """blah 2006-01-02T15:04:05Z07:00 had a problem""",
-                """blah <date> had a problem""",
-            ),
-            (
-                "Date RFC3339Nano",
-                """blah 2006-01-02T15:04:05.999999999Z07:00 had a problem""",
-                """blah <date> had a problem""",
-            ),
-            ("Date plain", """blah 2006-01-02 had a problem""", """blah <date> had a problem"""),
-            ("Date - long", """blah Jan 18, 2019 had a problem""", """blah <date> had a problem"""),
-            (
-                "Date - Datetime",
-                """blah 2006-01-02 15:04:05 had a problem""",
-                """blah <date> had a problem""",
-            ),
-            ("Date - Kitchen", """blah 3:04PM had a problem""", """blah <date> had a problem"""),
-            ("Date - Time", """blah 15:04:05 had a problem""", """blah <date> had a problem"""),
-            ("hex", """blah 0x9af8c3b had a problem""", """blah <hex> had a problem"""),
-            ("float", """blah 0.23 had a problem""", """blah <float> had a problem"""),
-            ("int", """blah 23 had a problem""", """blah <int> had a problem"""),
-            ("quoted str", """blah b="1" had a problem""", """blah b=<quoted_str> had a problem"""),
-            ("bool", """blah a=true had a problem""", """blah a=<bool> had a problem"""),
-            (
-                "Duration - ms",
-                """blah connection failed after 12345ms""",
-                """blah connection failed after <duration>""",
-            ),
-            (
-                "Quoted str w/ints",
-                '''SQL: RELEASE SAVEPOINT "s140177518376768_x2"''',
-                '''SQL: RELEASE SAVEPOINT "<uniq_id>"''',
-            ),
-            (
-                "Quoted str w/ints",
-                """API gateway VdLchF7iDo8sVkg= blah""",
-                """API gateway <uniq_id>= blah""",
-            ),
-            # JSON string values
-            (
-                "JSON object quoted strings",
-                """blah metadata:{'username': 'peanut', 'access_token': 'eyJh8xciOiJSUas98.dfs9d2js09d8fa09.eyJwaj2iOiI1MD'}""",
-                """blah metadata:{'username': <json_str_val>, 'access_token': <json_str_val>}""",
-            ),
-            # New cases to handle better
-            # ('''blah tcp://user:pass@email.com:10 had a problem''', '''blah <url> had a problem'''),
-            # ('''blah 0.0.0.0:10 had a problem''', '''blah <ip> had a problem'''),
-            # ('''blah Mon Jan 02, 1999 had a problem''', '''blah <date> had a problem'''),
-            # ('''2024-02-20 11:55:33.546593 had a problem''', '''blah <date> had a problem'''),
-            # JWT. TODO: Handle truncated JWTs?
-            # ("JWT", '''blah eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c''', '''blah <jwt>'''),
-            # It is possible to have fbtrace_ids without integers.
-            # ("Quoted str w/ints", '''fbtrace_id Ox_pfOzllbaBby_cYvWgYBn blah''', '''fbtrace_id <uniq_id> blah'''),
-        ]
-        for case in cases:
-            assert case[2] == normalize_message_for_grouping(case[1]), f"Case {case[0]} Failed"
+@pytest.mark.parametrize(
+    ("name", "input", "expected"),
+    [
+        ("email", """blah test@email.com had a problem""", """blah <email> had a problem"""),
+        ("url", """blah http://some.email.com had a problem""", """blah <url> had a problem"""),
+        (
+            "url - existing behavior",
+            """blah tcp://user:pass@email.com:10 had a problem""",
+            """blah tcp://user:<email>:<int> had a problem""",
+        ),
+        ("ip", """blah 0.0.0.0 had a problem""", """blah <ip> had a problem"""),
+        (
+            "UUID",
+            """blah 7c1811ed-e98f-4c9c-a9f9-58c757ff494f had a problem""",
+            """blah <uuid> had a problem""",
+        ),
+        (
+            "SHA1",
+            """blah 5fc35719b9cf96ec602dbc748ff31c587a46961d had a problem""",
+            """blah <sha1> had a problem""",
+        ),
+        (
+            "MD5",
+            """blah 0751007cd28df267e8e051b51f918c60 had a problem""",
+            """blah <md5> had a problem""",
+        ),
+        (
+            "Date",
+            """blah 2024-02-20T22:16:36 had a problem""",
+            """blah <date> had a problem""",
+        ),
+        (
+            "Date RFC822",
+            """blah Mon, 02 Jan 06 15:04 MST had a problem""",
+            """blah <date> had a problem""",
+        ),
+        (
+            "Date RFC822Z",
+            """blah Mon, 02 Jan 06 15:04 -0700 had a problem""",
+            """blah <date> had a problem""",
+        ),
+        (
+            "Date RFC850",
+            """blah Monday, 02-Jan-06 15:04:05 MST had a problem""",
+            """blah <date> had a problem""",
+        ),
+        (
+            "Date RFC1123",
+            """blah Mon, 02 Jan 2006 15:04:05 MST had a problem""",
+            """blah <date> had a problem""",
+        ),
+        (
+            "Date RFC1123Z",
+            """blah Mon, 02 Jan 2006 15:04:05 -0700 had a problem""",
+            """blah <date> had a problem""",
+        ),
+        (
+            "Date RFC3339",
+            """blah 2006-01-02T15:04:05Z07:00 had a problem""",
+            """blah <date> had a problem""",
+        ),
+        (
+            "Date RFC3339Nano",
+            """blah 2006-01-02T15:04:05.999999999Z07:00 had a problem""",
+            """blah <date> had a problem""",
+        ),
+        ("Date plain", """blah 2006-01-02 had a problem""", """blah <date> had a problem"""),
+        ("Date - long", """blah Jan 18, 2019 had a problem""", """blah <date> had a problem"""),
+        (
+            "Date - Datetime",
+            """blah 2006-01-02 15:04:05 had a problem""",
+            """blah <date> had a problem""",
+        ),
+        ("Date - Kitchen", """blah 3:04PM had a problem""", """blah <date> had a problem"""),
+        ("Date - Time", """blah 15:04:05 had a problem""", """blah <date> had a problem"""),
+        ("hex", """blah 0x9af8c3b had a problem""", """blah <hex> had a problem"""),
+        ("float", """blah 0.23 had a problem""", """blah <float> had a problem"""),
+        ("int", """blah 23 had a problem""", """blah <int> had a problem"""),
+        ("quoted str", """blah b="1" had a problem""", """blah b=<quoted_str> had a problem"""),
+        ("bool", """blah a=true had a problem""", """blah a=<bool> had a problem"""),
+        (
+            "Duration - ms",
+            """blah connection failed after 12345ms""",
+            """blah connection failed after <duration>""",
+        ),
+    ],
+)
+def test_normalize_message(name, input, expected):
+    assert expected == normalize_message_for_grouping(input), f"Case {name} Failed"

--- a/tests/sentry/grouping/test_normalize_message.py
+++ b/tests/sentry/grouping/test_normalize_message.py
@@ -1,6 +1,6 @@
+from sentry.grouping.strategies.message import normalize_message_for_grouping
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
-from src.sentry.grouping.strategies.message import normalize_message_for_grouping
 
 
 @region_silo_test

--- a/tests/sentry/grouping/test_normalize_message.py
+++ b/tests/sentry/grouping/test_normalize_message.py
@@ -1,0 +1,52 @@
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+from src.sentry.grouping.strategies.message import normalize_message_for_grouping
+
+
+@region_silo_test
+class NormalizeMesageTest(TestCase):
+    def test_normalize_message(
+        self,
+    ) -> None:
+        cases = [
+            # Email
+            ("""blah test@email.com had a problem""", """blah <email> had a problem"""),
+            # URL
+            ("""blah http://some.email.com had a problem""", """blah <url> had a problem"""),
+            # This one is existing behavior
+            (
+                """blah tcp://user:pass@email.com:10 had a problem""",
+                """blah tcp://user:<email>:<int> had a problem""",
+            ),
+            # IP
+            ("""blah 0.0.0.0 had a problem""", """blah <ip> had a problem"""),
+            # UUID
+            (
+                """blah 7c1811ed-e98f-4c9c-a9f9-58c757ff494f had a problem""",
+                """blah <uuid> had a problem""",
+            ),
+            # SHA1
+            (
+                """blah 5fc35719b9cf96ec602dbc748ff31c587a46961d had a problem""",
+                """blah <sha1> had a problem""",
+            ),
+            # MD5
+            (
+                """blah 0751007cd28df267e8e051b51f918c60 had a problem""",
+                """blah <md5> had a problem""",
+            ),
+            # Date
+            ("""blah 2022-01-15T08:30:00Z had a problem""", """blah <date> had a problem"""),
+            # Hex
+            ("""blah 0x9af8c3b had a problem""", """blah <hex> had a problem"""),
+            # Float
+            ("""blah 0.23 had a problem""", """blah <float> had a problem"""),
+            # Int
+            ("""blah 23 had a problem""", """blah <int> had a problem"""),
+            # Quoted Str
+            ("""blah b="1" had a problem""", """blah b=<quoted_str> had a problem"""),
+            # Bool
+            ("""blah a=true had a problem""", """blah a=<bool> had a problem"""),
+        ]
+        for case in cases:
+            assert case[1] == normalize_message_for_grouping(case[0])

--- a/tests/sentry/grouping/test_normalize_message.py
+++ b/tests/sentry/grouping/test_normalize_message.py
@@ -34,7 +34,7 @@ class NormalizeMesageTest(TestCase):
             ),
             (
                 "Date",
-                """blah 2022-01-15T08:30:00Z had a problem""",
+                """blah 2024-02-20T22:16:36 had a problem""",
                 """blah <date> had a problem""",
             ),
             (
@@ -86,13 +86,36 @@ class NormalizeMesageTest(TestCase):
             ("int", """blah 23 had a problem""", """blah <int> had a problem"""),
             ("quoted str", """blah b="1" had a problem""", """blah b=<quoted_str> had a problem"""),
             ("bool", """blah a=true had a problem""", """blah a=<bool> had a problem"""),
+            (
+                "Duration - ms",
+                """blah connection failed after 12345ms""",
+                """blah connection failed after <duration>""",
+            ),
+            (
+                "Quoted str w/ints",
+                '''SQL: RELEASE SAVEPOINT "s140177518376768_x2"''',
+                '''SQL: RELEASE SAVEPOINT "<uniq_id>"''',
+            ),
+            (
+                "Quoted str w/ints",
+                """API gateway VdLchF7iDo8sVkg= blah""",
+                """API gateway <uniq_id>= blah""",
+            ),
+            # JSON string values
+            (
+                "JSON object quoted strings",
+                """blah metadata:{'username': 'peanut', 'access_token': 'eyJh8xciOiJSUas98.dfs9d2js09d8fa09.eyJwaj2iOiI1MD'}""",
+                """blah metadata:{'username': <json_str_val>, 'access_token': <json_str_val>}""",
+            ),
             # New cases to handle better
             # ('''blah tcp://user:pass@email.com:10 had a problem''', '''blah <url> had a problem'''),
             # ('''blah 0.0.0.0:10 had a problem''', '''blah <ip> had a problem'''),
             # ('''blah Mon Jan 02, 1999 had a problem''', '''blah <date> had a problem'''),
             # ('''2024-02-20 11:55:33.546593 had a problem''', '''blah <date> had a problem'''),
-            # Quoted Str w/ ints
-            # ('''SQL: RELEASE SAVEPOINT "s140177518376768_x2"''', '''SQL: RELEASE SAVEPOINT "<quoted_str>"'''),
+            # JWT. TODO: Handle truncated JWTs?
+            # ("JWT", '''blah eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c''', '''blah <jwt>'''),
+            # It is possible to have fbtrace_ids without integers.
+            # ("Quoted str w/ints", '''fbtrace_id Ox_pfOzllbaBby_cYvWgYBn blah''', '''fbtrace_id <uniq_id> blah'''),
         ]
         for case in cases:
             assert case[2] == normalize_message_for_grouping(case[1]), f"Case {case[0]} Failed"

--- a/tests/sentry/grouping/test_normalize_message.py
+++ b/tests/sentry/grouping/test_normalize_message.py
@@ -9,44 +9,90 @@ class NormalizeMesageTest(TestCase):
         self,
     ) -> None:
         cases = [
-            # Email
-            ("""blah test@email.com had a problem""", """blah <email> had a problem"""),
-            # URL
-            ("""blah http://some.email.com had a problem""", """blah <url> had a problem"""),
-            # This one is existing behavior
+            ("email", """blah test@email.com had a problem""", """blah <email> had a problem"""),
+            ("url", """blah http://some.email.com had a problem""", """blah <url> had a problem"""),
             (
+                "url - existing behavior",
                 """blah tcp://user:pass@email.com:10 had a problem""",
                 """blah tcp://user:<email>:<int> had a problem""",
             ),
-            # IP
-            ("""blah 0.0.0.0 had a problem""", """blah <ip> had a problem"""),
-            # UUID
+            ("ip", """blah 0.0.0.0 had a problem""", """blah <ip> had a problem"""),
             (
+                "UUID",
                 """blah 7c1811ed-e98f-4c9c-a9f9-58c757ff494f had a problem""",
                 """blah <uuid> had a problem""",
             ),
-            # SHA1
             (
+                "SHA1",
                 """blah 5fc35719b9cf96ec602dbc748ff31c587a46961d had a problem""",
                 """blah <sha1> had a problem""",
             ),
-            # MD5
             (
+                "MD5",
                 """blah 0751007cd28df267e8e051b51f918c60 had a problem""",
                 """blah <md5> had a problem""",
             ),
-            # Date
-            ("""blah 2022-01-15T08:30:00Z had a problem""", """blah <date> had a problem"""),
-            # Hex
-            ("""blah 0x9af8c3b had a problem""", """blah <hex> had a problem"""),
-            # Float
-            ("""blah 0.23 had a problem""", """blah <float> had a problem"""),
-            # Int
-            ("""blah 23 had a problem""", """blah <int> had a problem"""),
-            # Quoted Str
-            ("""blah b="1" had a problem""", """blah b=<quoted_str> had a problem"""),
-            # Bool
-            ("""blah a=true had a problem""", """blah a=<bool> had a problem"""),
+            (
+                "Date",
+                """blah 2022-01-15T08:30:00Z had a problem""",
+                """blah <date> had a problem""",
+            ),
+            (
+                "Date RFC822",
+                """blah Mon, 02 Jan 06 15:04 MST had a problem""",
+                """blah <date> had a problem""",
+            ),
+            (
+                "Date RFC822Z",
+                """blah Mon, 02 Jan 06 15:04 -0700 had a problem""",
+                """blah <date> had a problem""",
+            ),
+            (
+                "Date RFC850",
+                """blah Monday, 02-Jan-06 15:04:05 MST had a problem""",
+                """blah <date> had a problem""",
+            ),
+            (
+                "Date RFC1123",
+                """blah Mon, 02 Jan 2006 15:04:05 MST had a problem""",
+                """blah <date> had a problem""",
+            ),
+            (
+                "Date RFC1123Z",
+                """blah Mon, 02 Jan 2006 15:04:05 -0700 had a problem""",
+                """blah <date> had a problem""",
+            ),
+            (
+                "Date RFC3339",
+                """blah 2006-01-02T15:04:05Z07:00 had a problem""",
+                """blah <date> had a problem""",
+            ),
+            (
+                "Date RFC3339Nano",
+                """blah 2006-01-02T15:04:05.999999999Z07:00 had a problem""",
+                """blah <date> had a problem""",
+            ),
+            ("Date plain", """blah 2006-01-02 had a problem""", """blah <date> had a problem"""),
+            ("Date - long", """blah Jan 18, 2019 had a problem""", """blah <date> had a problem"""),
+            (
+                "Date - Datetime",
+                """blah 2006-01-02 15:04:05 had a problem""",
+                """blah <date> had a problem""",
+            ),
+            ("Date - Kitchen", """blah 3:04PM had a problem""", """blah <date> had a problem"""),
+            ("Date - Time", """blah 15:04:05 had a problem""", """blah <date> had a problem"""),
+            ("hex", """blah 0x9af8c3b had a problem""", """blah <hex> had a problem"""),
+            ("float", """blah 0.23 had a problem""", """blah <float> had a problem"""),
+            ("int", """blah 23 had a problem""", """blah <int> had a problem"""),
+            ("quoted str", """blah b="1" had a problem""", """blah b=<quoted_str> had a problem"""),
+            ("bool", """blah a=true had a problem""", """blah a=<bool> had a problem"""),
+            # New cases to handle better
+            # ('''blah tcp://user:pass@email.com:10 had a problem''', '''blah <url> had a problem'''),
+            # ('''blah 0.0.0.0:10 had a problem''', '''blah <ip> had a problem'''),
+            # ('''blah Mon Jan 02, 1999 had a problem''', '''blah <date> had a problem'''),
+            # ('''2024-02-20 11:55:33.546593 had a problem''', '''blah <date> had a problem'''),
+            # Quoted Str w/ ints
+            # ('''SQL: RELEASE SAVEPOINT "s140177518376768_x2"''', '''SQL: RELEASE SAVEPOINT "<quoted_str>"'''),
         ]
         for case in cases:
-            assert case[1] == normalize_message_for_grouping(case[0])
+            assert case[2] == normalize_message_for_grouping(case[1]), f"Case {case[0]} Failed"


### PR DESCRIPTION
Add additional parameterization regular expressions. 

This proposes small discrete improvements to parameterization. This PR is the uncontroversial ones. Controversial ones now live in: https://github.com/getsentry/sentry/pull/65679

* Support more date formats. Notably RFC822, RFC1123, RFC1123Z, RFC850, RFC3339, RFC3339Nano, and your run of the mill “Kitchen” 3:49pm were missing

It also adds non-exhaustive tests for `test_normalize_message`