### PR TITLE
feat(tests): Allow `capture_return_values` to capture thrown errors

### DIFF
--- a/src/sentry/testutils/pytest/mocking.py
+++ b/src/sentry/testutils/pytest/mocking.py
@@ -4,13 +4,13 @@ from collections.abc import Callable
 from typing import ParamSpec, TypeVar
 
 # TODO: Once we're on python 3.12, we can get rid of these and change the first line of the
-# signature of `capture_return_values` to
-#   def capture_return_values[T, **P](
+# signature of `capture_results` to
+#   def capture_results[T, **P](
 P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def capture_return_values(
+def capture_results(
     fn: Callable[P, T],
     results: list[T] | dict[str, list[T]],
 ) -> Callable[P, T]:
@@ -26,12 +26,12 @@ def capture_return_values(
     a single function in a list:
 
         from unittest import mock
-        from wherever import capture_return_values
+        from wherever import capture_results
         from animals import a_function_that_calls_get_dog, get_dog
 
         def test_getting_dog():
             get_dog_return_values = []
-            wrapped_get_dog = capture_return_values(
+            wrapped_get_dog = capture_results(
                 get_dog, get_dog_return_values
             )
 
@@ -46,7 +46,7 @@ def capture_return_values(
     dictionary:
 
         from unittest import mock
-        from wherever import capture_return_values
+        from wherever import capture_results
         from animals import (
             a_function_that_calls_get_dog,
             a_function_that_calls_get_cat,
@@ -56,10 +56,10 @@ def capture_return_values(
 
         def test_getting_animals():
             return_values = {}
-            wrapped_get_dog = capture_return_values(
+            wrapped_get_dog = capture_results(
                 get_dog, return_values
             )
-            wrapped_get_cat = capture_return_values(
+            wrapped_get_cat = capture_results(
                 get_cat, return_values
             )
 
@@ -84,12 +84,12 @@ def capture_return_values(
     by pytest. (If it bubbles up without getting caught, you can just use `pytest.raises`.):
 
         from unittest import mock
-        from wherever import capture_return_values
+        from wherever import capture_results
         from animals import a_function_that_calls_erroring_get_dog, erroring_get_dog
 
         def test_getting_dog_with_error():
             erroring_get_dog_return_values = []
-            wrapped_erroring_get_dog = capture_return_values(
+            wrapped_erroring_get_dog = capture_results(
                 erroring_get_dog, erroring_get_dog_return_values
             )
 

--- a/src/sentry/testutils/pytest/mocking.py
+++ b/src/sentry/testutils/pytest/mocking.py
@@ -12,22 +12,24 @@ T = TypeVar("T")
 
 def capture_return_values(
     fn: Callable[P, T],
-    return_values: list[T] | dict[str, list[T]],
+    results: list[T] | dict[str, list[T]],
 ) -> Callable[P, T]:
     """
-    Create a wrapped version of the given function, which stores the return value each time that
-    function is called. This is useful when you want to spy on a given function and make assertions
-    based on what it returns.
+    Create a wrapped version of the given function, which stores the return value or the error
+    raised each time that function is called. This is useful when you want to spy on a given
+    function and make assertions based on what it returns or raises.
 
-    In a test, this can be used in concert with a patching context manager like so:
+    Note that in cases where the wrapped function raises, this doesn't prevent it from raising. It
+    just records the error before it's raised.
+
+    In a test, this can be used in concert with a patching context manager to record the results of
+    a single function in a list:
 
         from unittest import mock
         from wherever import capture_return_values
-        from animals import get_dog, get_cat
+        from animals import a_function_that_calls_get_dog, get_dog
 
-        def test_getting_animals():
-            # If you're only planning to patch one function, use a list:
-
+        def test_getting_dog():
             get_dog_return_values = []
             wrapped_get_dog = capture_return_values(
                 get_dog, get_dog_return_values
@@ -40,9 +42,19 @@ def capture_return_values(
                 assert get_dog_spy.call_count == 1
                 assert get_dog_return_values[0] == "maisey"
 
-            # Alternatively, if you're planning to patch more than one function,
-            # you can pass a dictionary:
+    Alternatively, if you're planning to patch more than one function, you can pass a
+    dictionary:
 
+        from unittest import mock
+        from wherever import capture_return_values
+        from animals import (
+            a_function_that_calls_get_dog,
+            a_function_that_calls_get_cat,
+            get_dog,
+            get_cat
+        )
+
+        def test_getting_animals():
             return_values = {}
             wrapped_get_dog = capture_return_values(
                 get_dog, return_values
@@ -66,16 +78,47 @@ def capture_return_values(
                 a_function_that_calls_get_cat()
                 assert get_cat_spy.call_count == 1
                 assert return_values["get_cat"][0] == "piper"
+
+    Finally, if you want to record the error which was raised by a function, you can do that, too.
+    This is most useful when you want to test an error which gets caught before it can be recorded
+    by pytest. (If it bubbles up without getting caught, you can just use `pytest.raises`.):
+
+        from unittest import mock
+        from wherever import capture_return_values
+        from animals import a_function_that_calls_erroring_get_dog, erroring_get_dog
+
+        def test_getting_dog_with_error():
+            erroring_get_dog_return_values = []
+            wrapped_erroring_get_dog = capture_return_values(
+                erroring_get_dog, erroring_get_dog_return_values
+            )
+
+            with mock.patch(
+                "animals.erroring_get_dog", wraps=wrapped_erroring_get_dog
+            ) as erroring_get_dog_spy:
+                a_function_that_calls_erroring_get_dog()
+
+                assert erroring_get_dog_spy.call_count == 1
+
+                # Need to use `repr` since even identical errors don't count as equal
+                result = erroring_get_dog_return_values[0]
+                assert repr(result)== "TypeError('Expected dog, but got cat instead.')"
     """
 
+    def record_result(result):
+        if isinstance(results, list):
+            results.append(result)
+        elif isinstance(results, dict):
+            results.setdefault(fn.__name__, []).append(result)
+
     def wrapped_fn(*args: P.args, **kwargs: P.kwargs) -> T:
-        returned_value = fn(*args, **kwargs)
+        try:
+            returned_value = fn(*args, **kwargs)
+        except Exception as e:
+            record_result(e)
+            raise
 
-        if isinstance(return_values, list):
-            return_values.append(returned_value)
-        elif isinstance(return_values, dict):
-            return_values.setdefault(fn.__name__, []).append(returned_value)
-
+        record_result(returned_value)
         return returned_value
 
     return wrapped_fn

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -20,7 +20,7 @@ from sentry.models.project import Project
 from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.helpers.features import Feature
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.testutils.pytest.mocking import capture_return_values
+from sentry.testutils.pytest.mocking import capture_results
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
@@ -32,14 +32,12 @@ NEWSTYLE_CONFIG = "newstyle:2023-01-11"
 
 @contextmanager
 def patch_grouping_helpers(return_values: dict[str, Any]):
-    wrapped_find_existing_grouphash = capture_return_values(find_existing_grouphash, return_values)
-    wrapped_find_existing_grouphash_new = capture_return_values(
+    wrapped_find_existing_grouphash = capture_results(find_existing_grouphash, return_values)
+    wrapped_find_existing_grouphash_new = capture_results(
         find_existing_grouphash_new, return_values
     )
-    wrapped_calculate_primary_hash = capture_return_values(_calculate_primary_hash, return_values)
-    wrapped_calculate_secondary_hash = capture_return_values(
-        _calculate_secondary_hash, return_values
-    )
+    wrapped_calculate_primary_hash = capture_results(_calculate_primary_hash, return_values)
+    wrapped_calculate_secondary_hash = capture_results(_calculate_secondary_hash, return_values)
 
     with (
         mock.patch(

--- a/tests/sentry/testutils/pytest/mocking/animals/__init__.py
+++ b/tests/sentry/testutils/pytest/mocking/animals/__init__.py
@@ -6,9 +6,22 @@ def get_cat():
     return "piper"
 
 
+def erroring_get_dog():
+    raise TypeError("Expected dog, but got cat instead.")
+
+
 def a_function_that_calls_get_dog():
     return f"{get_dog()} is a good dog!"
 
 
 def a_function_that_calls_get_cat():
     return f"{get_cat()} is a good cat, because she thinks she's a dog!"
+
+
+def a_function_that_calls_erroring_get_dog():
+    try:
+        erroring_get_dog()
+    except TypeError:
+        return "Well, we tried."
+
+    return "We shouldn't ever get here"

--- a/tests/sentry/testutils/pytest/mocking/test_mocking.py
+++ b/tests/sentry/testutils/pytest/mocking/test_mocking.py
@@ -1,7 +1,7 @@
 from typing import Any
 from unittest import TestCase, mock
 
-from sentry.testutils.pytest.mocking import capture_return_values
+from sentry.testutils.pytest.mocking import capture_results
 from tests.sentry.testutils.pytest.mocking.animals import (
     a_function_that_calls_erroring_get_dog,
     a_function_that_calls_get_cat,
@@ -16,7 +16,7 @@ class CaptureReturnValuesTest(TestCase):
     def test_return_values_as_list(self):
         get_dog_return_values: list[Any] = []
 
-        wrapped_get_dog = capture_return_values(get_dog, get_dog_return_values)
+        wrapped_get_dog = capture_results(get_dog, get_dog_return_values)
 
         with mock.patch(
             "tests.sentry.testutils.pytest.mocking.animals.get_dog",
@@ -29,8 +29,8 @@ class CaptureReturnValuesTest(TestCase):
     def test_return_values_as_dict(self):
         return_values: dict[str, list[Any]] = {}
 
-        wrapped_get_dog = capture_return_values(get_dog, return_values)
-        wrapped_get_cat = capture_return_values(get_cat, return_values)
+        wrapped_get_dog = capture_results(get_dog, return_values)
+        wrapped_get_cat = capture_results(get_cat, return_values)
 
         with (
             mock.patch(
@@ -53,7 +53,7 @@ class CaptureReturnValuesTest(TestCase):
     def test_records_thrown_exception(self):
         erroring_get_dog_results: list[Any] = []
 
-        wrapped_erroring_get_dog = capture_return_values(erroring_get_dog, erroring_get_dog_results)
+        wrapped_erroring_get_dog = capture_results(erroring_get_dog, erroring_get_dog_results)
 
         with mock.patch(
             "tests.sentry.testutils.pytest.mocking.animals.erroring_get_dog",


### PR DESCRIPTION
This modifies our test helper, `capture_return_values`, so that it can also capture results when the function it's wrapping throws an error. This is helpful when spying on a function whose thrown errors are caught, and therefore unable to be examined and asserted about using `pytest.raises`.

Since recording results now happens twice, it's been pulled out into its own helper, `record_result`. Also, since the function now captures more than just return values, this also renames it to `capture_results`. 