### PR TITLE
feat(spans): Register a new experimental group type

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -398,6 +398,18 @@ class PerformanceP95EndpointRegressionGroupType(GroupType):
     notification_config = NotificationConfig(context=["Users Affected", "State", "Regressed Date"])
 
 
+# experimental
+@dataclass(frozen=True)
+class PerformanceStreamedSpansGroupTypeExperimental(GroupType):
+    type_id = 1019
+    slug = "performance_streamed_spans_exp"
+    description = "Streamed Spans (Experimental)"
+    category = GroupCategory.PERFORMANCE.value
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+    default_priority = PriorityLevel.LOW
+
+
 # 2000 was ProfileBlockingFunctionMainThreadType
 @dataclass(frozen=True)
 class ProfileFileIOGroupType(GroupType):


### PR DESCRIPTION
We are adding support for performance issues with
span streaming. To do this, we're going to hold spans
in a buffer for a few minutes as they arrive, fetch them
from the buffer and run them through the issue detectors.

Registering a new group type to route the issues created
with streamed spans so we can check correct spans/evidence/
fingerprinting as we do dev work.