### PR TITLE
fix(hybridcloud) Fix RPC serialization issue for broken integrations

### DIFF
--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -130,15 +130,17 @@ def send_incident_alert_notification(
         integration_id=integration_id,
         organization_id=organization_id,
     )
-    if org_integration is None:
+    if org_integration:
+        org_integration_id = org_integration.id
+    else:
+        org_integrations = None
         org_integration_id = infer_org_integration(integration_id=integration_id, ctx_logger=logger)
-        org_integrations = integration_service.get_organization_integrations(
-            org_integration_ids=[org_integration_id]
-        )
+        if org_integration_id:
+            org_integrations = integration_service.get_organization_integrations(
+                org_integration_ids=[org_integration_id]
+            )
         if org_integrations:
             org_integration = org_integrations[0]
-    else:
-        org_integration_id = org_integration.id
 
     if org_integration and action.target_identifier:
         service = get_service(org_integration, action.target_identifier)

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -130,6 +130,7 @@ def send_incident_alert_notification(
         integration_id=integration_id,
         organization_id=organization_id,
     )
+    org_integration_id: int | None = None
     if org_integration:
         org_integration_id = org_integration.id
     else:


### PR DESCRIPTION
When integrations are referenced in alerts, the alert notifier can survive the orgintegration being disconneced. We shouldn't send `None` as an id in an RPC call when that happens.

Fixes HC-1106
Fixes SENTRY-2K6J