### PR TITLE
chore: Add logging to find fetched scopes of member

### DIFF
--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -152,7 +152,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
 
         Will return a pending invite as long as it's already approved.
         """
-        allowed_roles = get_allowed_org_roles(request, organization, member)
+        allowed_roles = get_allowed_org_roles(request, organization, member, log_scopes=True)
         return Response(
             serialize(
                 member,

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -658,7 +658,7 @@ class OrganizationMember(ReplicatedRegionModel):
         """
         member_scopes = self.get_scopes()
         if log_scopes:
-            logger.info("member.scopes", extra={"scopes": member_scopes})
+            logger.info("member.scopes", extra={"member_id": self.id, "scopes": member_scopes})
 
         return [r for r in organization_roles.get_all() if r.scopes.issubset(member_scopes)]
 


### PR DESCRIPTION
Investigating bug in https://github.com/getsentry/sentry/issues/65155

The issue happens because `self.allowed` roles is not set here causing the user serialized with authenticators to not be attached to the response.
https://github.com/getsentry/sentry/blob/eb55184602940adb1fc09a9c0e33515cac92c7d8/src/sentry/api/serializers/models/organization_member/expand/roles.py#L69-L70

We're fetching `allowed_roles` directly in the endpoint logic, which we then pass to the serializer
https://github.com/getsentry/sentry/blob/9a8c2c709420f95a626bb23b47b3c8097fa1a4c1/src/sentry/api/endpoints/organization_member/details.py#L155-L162

Somewhere in `get_allowed_org_roles`, there's a bug with scopes causing the function to return an empty list.