### PR TITLE
fix(replay): Delay hydration error diff

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -206,7 +206,7 @@ function ReplaySide({expectedTime, selector, onLoad}) {
             })
           );
         }
-      }, 0);
+      }, 50);
     }
   }, [currentTime, expectedTime, selector, onLoad]);
   return <ReplayPlayer isPreview />;


### PR DESCRIPTION
Was seeing some modals open blank (on one side?) because the replay wasn't ready yet, increases the timeout to 50ms
