### PR TITLE
ref(slack): replace rich text formatted block with quote block in markdown

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -41,19 +41,13 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         }
 
     @staticmethod
-    def get_rich_text_preformatted_block(text: str) -> SlackBlock:
+    def get_markdown_quote_block(text: str) -> SlackBlock:
         if len(text) > MAX_BLOCK_TEXT_LENGTH:
             text = text[: MAX_BLOCK_TEXT_LENGTH - 3] + "..."
-        return {
-            "type": "rich_text",
-            "elements": [
-                {
-                    "type": "rich_text_preformatted",
-                    "elements": [{"type": "text", "text": text}],
-                    "border": 0,
-                }
-            ],
-        }
+
+        markdown_text = "```" + text + "```"
+
+        return {"type": "section", "text": {"type": "mrkdwn", "text": markdown_text}}
 
     @staticmethod
     def get_tags_block(tags) -> SlackBlock:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -675,7 +675,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             text = text.lstrip(" ")
             # XXX(CEO): sometimes text is " " and slack will error if we pass an empty string (now "")
             if text:
-                blocks.append(self.get_rich_text_preformatted_block(text))
+                blocks.append(self.get_markdown_quote_block(text))
 
         # build up actions text
         if self.actions and self.identity and not action_text:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2855,8 +2855,8 @@ class SlackActivityNotificationTest(ActivityTestCase):
             issue_link += issue_link_extra_params
         assert blocks[1]["text"]["text"] == f":chart_with_upwards_trend: <{issue_link}|*N+1 Query*>"
         assert (
-            blocks[2]["elements"][0]["elements"][0]["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+            blocks[2]["text"]["text"]
+            == "```db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21```"
         )
         assert (
             blocks[3]["text"]["text"]
@@ -2901,8 +2901,8 @@ class SlackActivityNotificationTest(ActivityTestCase):
             == f":exclamation: <{issue_link}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>"
         )
         assert (
-            blocks[2]["elements"][0]["elements"][0]["text"]
-            == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
+            blocks[2]["text"]["text"]
+            == "```" + TEST_ISSUE_OCCURRENCE.evidence_display[0].value + "```"
         )
         assert (
             blocks[5]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -965,7 +965,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert "N+1 Query" in blocks["blocks"][0]["text"]["text"]
         assert (
             "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-            in blocks["blocks"]["text"]["text"]
+            in blocks["blocks"][1]["text"]["text"]
         )
         assert blocks["text"] == f"[{self.project.slug}] N+1 Query"
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -973,7 +973,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
     def test_block_kit_truncates_long_query(self):
         text = "a" * 5000
         block = BlockSlackMessageBuilder().get_markdown_quote_block(text)
-        assert block["text"]["text"] == "a" * 253 + "..."
+        assert "a" * 253 + "..." in block["text"]["text"]
 
     def test_build_performance_issue_color_no_event_passed(self):
         """This test doesn't pass an event to the SlackIssuesMessageBuilder to mimic what

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -98,16 +98,8 @@ def build_test_message_blocks(
     if text:
         new_text = text.lstrip(" ")
         if new_text:
-            text_section = {
-                "type": "rich_text",
-                "elements": [
-                    {
-                        "type": "rich_text_preformatted",
-                        "elements": [{"type": "text", "text": new_text}],
-                        "border": 0,
-                    }
-                ],
-            }
+            markdown_text = "```" + new_text + "```"
+            text_section = {"type": "section", "text": {"type": "mrkdwn", "text": markdown_text}}
             blocks.append(text_section)
 
     tags_text = ""
@@ -905,10 +897,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             if section["type"] == "text":
                 assert occurrence.issue_title in section["text"]["text"]
 
-        assert (
-            occurrence.evidence_display[0].value
-            in blocks["blocks"][1]["elements"][0]["elements"][0]["text"]
-        )
+        assert occurrence.evidence_display[0].value in blocks["blocks"][1]["text"]["text"]
         assert blocks["text"] == f"[{self.project.slug}] {occurrence.issue_title}"
 
     @with_feature("organizations:slack-block-kit")
@@ -976,15 +965,15 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert "N+1 Query" in blocks["blocks"][0]["text"]["text"]
         assert (
             "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-            in blocks["blocks"][1]["elements"][0]["elements"][0]["text"]
+            in blocks["blocks"]["text"]["text"]
         )
         assert blocks["text"] == f"[{self.project.slug}] N+1 Query"
 
     @with_feature("organizations:slack-block-kit")
     def test_block_kit_truncates_long_query(self):
         text = "a" * 5000
-        block = BlockSlackMessageBuilder().get_rich_text_preformatted_block(text)
-        assert block["elements"][0]["elements"][0]["text"] == "a" * 253 + "..."
+        block = BlockSlackMessageBuilder().get_markdown_quote_block(text)
+        assert block["text"]["text"] == "a" * 253 + "..."
 
     def test_build_performance_issue_color_no_event_passed(self):
         """This test doesn't pass an event to the SlackIssuesMessageBuilder to mimic what
@@ -1014,10 +1003,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
         ret = SlackIssuesMessageBuilder(group, None).build()
         assert isinstance(ret, dict)
-        assert (
-            "&lt;https://example.com/|*Click Here*&gt;"
-            in ret["blocks"][1]["elements"][0]["elements"][0]["text"]
-        )
+        assert "&lt;https://example.com/|*Click Here*&gt;" in ret["blocks"][1]["text"]["text"]
 
 
 @region_silo_test

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -279,7 +279,7 @@ class UnfurlTest(TestCase):
         unfurls = link_handlers[LinkType.ISSUES].fn(self.request, self.integration, links)
         assert (
             "&amp;lt;https://example.com/|*Click Here*&amp;gt;"
-            in unfurls[links[0].url]["blocks"][1]["elements"][0]["elements"][0]["text"]
+            in unfurls[links[0].url]["blocks"][1]["text"]["text"]
         )
 
     def test_unfurl_metric_alert(self):

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -307,10 +307,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert self.group.get_status() == GroupStatus.IGNORED
             assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
             expect_status = f"*Issue archived by <@{self.external_id}>*"
-            assert (
-                resp.data["blocks"][1]["elements"][0]["elements"][0]["text"]
-                == self.notification_text
-            )
+            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
             assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -336,10 +333,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
 
             expect_status = f"*Issue archived by <@{self.external_id}>*"
-            assert (
-                resp.data["blocks"][1]["elements"][0]["elements"][0]["text"]
-                == self.notification_text
-            )
+            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
             assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -354,9 +348,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -374,9 +366,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -393,9 +383,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -415,9 +403,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -432,9 +418,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -450,9 +434,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     def test_archive_issue_with_additional_user_auth(self):
@@ -485,10 +467,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert resp.status_code == 200, resp.content
             assert self.group.get_status() == GroupStatus.IGNORED
             assert self.group.substatus == GroupSubStatus.FOREVER
-            assert (
-                resp.data["blocks"][1]["elements"][0]["elements"][0]["text"]
-                == self.notification_text
-            )
+            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
             assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -512,9 +491,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -538,9 +515,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     def test_unarchive_issue_block_kit(self):
@@ -562,9 +537,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert self.group.substatus == GroupSubStatus.NEW  # the issue is less than 7 days old
 
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     def test_unarchive_issue_block_kit_through_unfurl(self):
@@ -587,9 +560,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert self.group.substatus == GroupSubStatus.NEW  # the issue is less than 7 days old
 
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     def test_assign_issue(self):
@@ -645,10 +616,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
                 "integration": ActivityIntegration.SLACK.value,
             }
             expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-            assert (
-                resp.data["blocks"][1]["elements"][0]["elements"][0]["text"]
-                == self.notification_text
-            )
+            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
             assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     def test_assign_issue_block_kit(self):
@@ -660,18 +628,14 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         resp = self.assign_issue_block_kit(original_message, user2)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
         # Assign to team
         resp = self.assign_issue_block_kit(original_message, self.team)
         assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
         # Assert group assignment activity recorded
@@ -699,18 +663,14 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         resp = self.assign_issue_block_kit(original_message, user2, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
         # Assign to team
         resp = self.assign_issue_block_kit(original_message, self.team, payload_data)
         assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
         # Assert group assignment activity recorded
@@ -814,10 +774,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             resp = self.post_webhook(action_data=[status_action])
             assert resp.status_code == 200, resp.content
             assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
-            assert (
-                resp.data["blocks"][1]["elements"][0]["elements"][0]["text"]
-                == self.notification_text
-            )
+            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
             assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     def test_assign_issue_user_has_identity_block_kit(self):
@@ -835,9 +792,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = (
             f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
         )
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     def test_assign_issue_user_has_identity_block_kit_through_unfurl(self):
@@ -857,9 +812,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = (
             f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
         )
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     def test_assign_user_with_multiple_identities(self):
@@ -897,10 +850,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             resp = self.post_webhook(action_data=[status_action])
             assert resp.status_code == 200, resp.content
             assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
-            assert (
-                resp.data["blocks"][1]["elements"][0]["elements"][0]["text"]
-                == self.notification_text
-            )
+            assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
             assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     def test_assign_user_with_multiple_identities_block_kit(self):
@@ -924,9 +874,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
             assignee=self.external_id
         )
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     def test_assign_user_with_multiple_identities_block_kit_through_unfurl(self):
@@ -951,9 +899,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
             assignee=self.external_id
         )
-        assert (
-            resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     @responses.activate
@@ -1060,9 +1006,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -1077,9 +1021,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"] == expect_status
 
     @responses.activate
@@ -1095,9 +1037,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"] == expect_status
 
     @responses.activate
@@ -1216,10 +1156,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
             update_data = json.loads(responses.calls[1].request.body)
             expect_status = f"*Issue resolved by <@{self.external_id}>*"
-            assert (
-                update_data["blocks"][1]["elements"][0]["elements"][0]["text"]
-                == self.notification_text
-            )
+            assert self.notification_text in update_data["blocks"][1]["text"]["text"]
             assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -1242,9 +1179,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -1268,9 +1203,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -1292,9 +1225,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     @responses.activate
@@ -1317,9 +1248,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     def test_response_differs_on_bot_message(self):
@@ -1343,7 +1272,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert self.group.substatus == GroupSubStatus.FOREVER
             assert resp.status_code == 200, resp.content
             assert "blocks" in resp.data
-            assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] in self.group.title
+            assert resp.data["blocks"][1]["text"]["text"][3:-3] in self.group.title
 
     @responses.activate
     def test_response_differs_on_bot_message_block_kit(self):
@@ -1402,9 +1331,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert (
-            update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == self.notification_text
-        )
+        assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
     def test_permission_denied(self):


### PR DESCRIPTION
After some debugging we found that the root cause of unfurling not working for the Slack block kit upgrades was the new rich text formatted block we added. If we replace this with Markdown it looks about the same but also can be unfurled!

Example:
This is the actual output of `test_build_group_generic_issue_block` while substituting the text in the Markdown
<img width="475" alt="Screenshot 2024-02-21 at 15 26 20" src="https://github.com/getsentry/sentry/assets/70817427/521be9f0-b999-4c74-a51d-fb770f8ffca9">

[See it in block kit](https://app.slack.com/block-kit-builder/T024ZCV9U#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22:chart_with_upwards_trend:%20%3Chttp://testserver/organizations/baz/issues/1/?referrer=slack%7C*something%20bad%20happened*%3E%22%7D,%22block_id%22:%22%7B%5C%22issue%5C%22:1%7D%22%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22%60%60%600.%20DB::Exception::Exception(std::__1::basic_string&lt;char,%20std::__1::char_traits&lt;char&gt;,%20std::__1::allocator&lt;char&gt;%20&gt;%20const&amp;,%20int,%20bool)%20@%200x8fe7c9a%20in%20/usr/bin/clickhouse%5C%5Cn1.%20DB::Exception::Exception&lt;char%20const*,%20char%20const*,%20std::_...%60%60%60%22%7D%7D,%7B%22type%22:%22context%22,%22elements%22:%5B%7B%22type%22:%22mrkdwn%22,%22text%22:%22Events:%20*1*%20%20%20State:%20*Ongoing*%20%20%20First%20Seen:%20*Just%20now*%22%7D%5D%7D,%7B%22type%22:%22actions%22,%22elements%22:%5B%7B%22type%22:%22button%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Resolve%22%7D,%22action_id%22:%22resolved%22,%22value%22:%22resolved%22%7D,%7B%22type%22:%22button%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Archive%22%7D,%22action_id%22:%22archive_dialog%22,%22value%22:%22archive_dialog%22%7D,%7B%22type%22:%22external_select%22,%22placeholder%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Select%20Assignee...%22,%22emoji%22:true%7D,%22action_id%22:%22assign%22%7D%5D%7D,%7B%22type%22:%22context%22,%22elements%22:%5B%7B%22type%22:%22mrkdwn%22,%22text%22:%22Project:%20%3Chttp://testserver/organizations/baz/issues/?project=4553535392186369%7Cbar%3E%20%20%20%20Alert:%20BAR-1%20%20%20%20Short%20ID:%20BAR-1%22%7D%5D%7D,%7B%22type%22:%22divider%22%7D%5D%7D)

Resolves https://github.com/orgs/getsentry/projects/183/
