### PR TITLE
fix(crons): Show all env options when editing monitor notifications

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -202,7 +202,7 @@ function MonitorForm({
     return rv;
   }
 
-  const selectedProjectId = selection.projects[0];
+  const selectedProjectId = monitor?.project.id ?? selection.projects[0];
   const selectedProject = selectedProjectId
     ? projects.find(p => p.id === selectedProjectId.toString())
     : null;


### PR DESCRIPTION
<img width="925" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/587b1b6d-7f99-431c-89ad-62604514cc96">

Show all environment options for this dropdown

Fixes: https://github.com/getsentry/sentry/issues/65442