### PR TITLE
fix(issues): reset project url param when clicking into different issue

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimelineTooltip.tsx
@@ -51,6 +51,7 @@ export function TraceTimelineTooltip({event, timelineEvents}: TraceTimelineToolt
                 pathname: `/organizations/${organization.slug}/issues/${timelineEvent['issue.id']}/events/${timelineEvent.id}/`,
                 query: {
                   ...location.query,
+                  project: undefined,
                   referrer: 'issues_trace_timeline',
                 },
               }}


### PR DESCRIPTION
Fixes https://github.com/getsentry/team-replay/issues/386

When a user is on an issue, but then clicks into a different issue (from a different project) via the trace navigator, the project param in the URL can be incorrect for the new issue (e.g., it remains the project ID of the first issue). This PR resets the project param to be undefined, which will force `?project=` in the URL to automatically reset to the correct project ID.

This was causing a bug with the replay onboarding within issue details, where the incorrect default project was selected.


Before: incorrect default project selected in onboarding tray

https://github.com/getsentry/sentry/assets/56095982/04e3aa17-a1c6-4f20-ab9a-db510c96e81f


After: correct default project selected in onboarding tray

https://github.com/getsentry/sentry/assets/56095982/6fafc51e-d6cb-4622-a32d-4a6ae96f16bc


