### PR TITLE
feat(issue-priority): Add inbox tab for new search query

### DIFF
--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -4,33 +4,31 @@ import {getTabs} from './utils';
 
 describe('getTabs', () => {
   it('should enable/disable tabs for escalating-issues', () => {
-    expect(getTabs(OrganizationFixture({})).map(tab => tab[1].name)).toEqual([
-      'Unresolved',
-      'For Review',
-      'Regressed',
-      'Escalating',
-      'Archived',
-      'Custom',
-    ]);
-
-    expect(getTabs(OrganizationFixture({})).map(tab => tab[1].name)).toEqual([
-      'Unresolved',
-      'For Review',
-      'Regressed',
-      'Escalating',
-      'Archived',
-      'Custom',
-    ]);
+    expect(
+      getTabs(OrganizationFixture({}))
+        .filter(tab => !tab[1].hidden)
+        .map(tab => tab[1].name)
+    ).toEqual(['Unresolved', 'For Review', 'Regressed', 'Escalating', 'Archived']);
   });
 
   it('should enable/disable my_teams filter in For Review tab', () => {
-    expect(getTabs(OrganizationFixture({features: []})).map(tab => tab[0])).toEqual([
+    expect(
+      getTabs(OrganizationFixture({}))
+        .filter(tab => !tab[1].hidden)
+        .map(tab => tab[0])
+    ).toEqual([
       'is:unresolved',
       'is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]',
       'is:regressed',
       'is:escalating',
       'is:archived',
-      '__custom__',
+    ]);
+  });
+
+  it('should add inbox tab for issue-priority-ui feature', () => {
+    expect(getTabs(OrganizationFixture({features: ['issue-priority-ui']}))[0]).toEqual([
+      'is:unresolved issue.priority:[high, medium]',
+      expect.objectContaining({hidden: false, name: 'Inbox'}),
     ]);
   });
 });

--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -3,32 +3,23 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {getTabs} from './utils';
 
 describe('getTabs', () => {
-  it('should enable/disable tabs for escalating-issues', () => {
-    expect(
-      getTabs(OrganizationFixture({}))
-        .filter(tab => !tab[1].hidden)
-        .map(tab => tab[1].name)
-    ).toEqual(['Unresolved', 'For Review', 'Regressed', 'Escalating', 'Archived']);
-  });
-
-  it('should enable/disable my_teams filter in For Review tab', () => {
-    expect(
-      getTabs(OrganizationFixture({}))
-        .filter(tab => !tab[1].hidden)
-        .map(tab => tab[0])
-    ).toEqual([
-      'is:unresolved',
-      'is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]',
-      'is:regressed',
-      'is:escalating',
-      'is:archived',
+  it('displays the correct list of tabs', () => {
+    expect(getTabs(OrganizationFixture({})).filter(tab => !tab[1].hidden)).toEqual([
+      ['is:unresolved', expect.objectContaining({name: 'Unresolved'})],
+      [
+        'is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]',
+        expect.objectContaining({name: 'For Review'}),
+      ],
+      ['is:regressed', expect.objectContaining({name: 'Regressed'})],
+      ['is:escalating', expect.objectContaining({name: 'Escalating'})],
+      ['is:archived', expect.objectContaining({name: 'Archived'})],
     ]);
   });
 
   it('should add inbox tab for issue-priority-ui feature', () => {
     expect(getTabs(OrganizationFixture({features: ['issue-priority-ui']}))[0]).toEqual([
       'is:unresolved issue.priority:[high, medium]',
-      expect.objectContaining({hidden: false, name: 'Inbox'}),
+      expect.objectContaining({name: 'Inbox'}),
     ]);
   });
 });

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -5,6 +5,7 @@ import type {Organization} from 'sentry/types';
 
 export enum Query {
   FOR_REVIEW = 'is:unresolved is:for_review assigned_or_suggested:[me, my_teams, none]',
+  INBOX = NEW_DEFAULT_QUERY,
   UNRESOLVED = 'is:unresolved',
   IGNORED = 'is:ignored',
   NEW = 'is:new',
@@ -46,6 +47,16 @@ type OverviewTab = {
  */
 export function getTabs(organization: Organization) {
   const tabs: Array<[string, OverviewTab]> = [
+    [
+      Query.INBOX,
+      {
+        name: t('Inbox'),
+        analyticsName: 'inbox',
+        count: true,
+        enabled: true,
+        hidden: !organization.features.includes('issue-priority-ui'),
+      },
+    ],
     [
       Query.UNRESOLVED,
       {

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -53,8 +53,7 @@ export function getTabs(organization: Organization) {
         name: t('Inbox'),
         analyticsName: 'inbox',
         count: true,
-        enabled: true,
-        hidden: !organization.features.includes('issue-priority-ui'),
+        enabled: organization.features.includes('issue-priority-ui'),
       },
     ],
     [


### PR DESCRIPTION
The default query was already modified to include the new `issue.priority`, this adds a tab for it.

![CleanShot 2024-02-21 at 16 36 06](https://github.com/getsentry/sentry/assets/10888943/c1240909-edf7-4e3e-b5f0-c3ee151ffdf2)
