### PR TITLE
fix(codeowners): Fix license rule in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 
 
 ## Legal
-/LICENSE                                                 @getsentry/owners-legal
+/LICENSE.md                                              @getsentry/owners-legal
 
 ## Migrations
 /src/sentry/migrations/                                  @getsentry/owners-migrations


### PR DESCRIPTION
Our license is named LICENSE.md, not LICENSE.