### PR TITLE
Change rage click level to "info"

### DIFF
--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -14,7 +14,6 @@ from sentry.utils import metrics
 logger = logging.getLogger()
 
 RAGE_CLICK_TITLE = "Rage Click"
-RAGE_CLICK_LEVEL = "error"
 
 
 @instrumented_task(
@@ -55,7 +54,6 @@ def report_rage_click_issue(project_id: int, replay_id: str, event: SentryEvent)
         environment=replay_info["agg_environment"],
         fingerprint=[selector],
         issue_type=ReplayRageClickType,
-        level=RAGE_CLICK_LEVEL,
         platform="javascript",
         project_id=project_id,
         subtitle=selector,
@@ -73,7 +71,6 @@ def report_rage_click_issue(project_id: int, replay_id: str, event: SentryEvent)
         ],
         extra_event_data={
             "contexts": {"replay": {"replay_id": replay_id}},
-            "level": RAGE_CLICK_LEVEL,
             "tags": {"replayId": replay_id, "url": payload["data"]["url"]},
             "user": {
                 "id": replay_info["user_id"],

--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -14,6 +14,7 @@ from sentry.utils import metrics
 logger = logging.getLogger()
 
 RAGE_CLICK_TITLE = "Rage Click"
+RAGE_CLICK_LEVEL = "info"
 
 
 @instrumented_task(
@@ -54,6 +55,7 @@ def report_rage_click_issue(project_id: int, replay_id: str, event: SentryEvent)
         environment=replay_info["agg_environment"],
         fingerprint=[selector],
         issue_type=ReplayRageClickType,
+        level=RAGE_CLICK_LEVEL,
         platform="javascript",
         project_id=project_id,
         subtitle=selector,
@@ -71,6 +73,7 @@ def report_rage_click_issue(project_id: int, replay_id: str, event: SentryEvent)
         ],
         extra_event_data={
             "contexts": {"replay": {"replay_id": replay_id}},
+            "level": RAGE_CLICK_LEVEL,
             "tags": {"replayId": replay_id, "url": payload["data"]["url"]},
             "user": {
                 "id": replay_info["user_id"],

--- a/tests/sentry/replays/unit/test_rage_click_issue.py
+++ b/tests/sentry/replays/unit/test_rage_click_issue.py
@@ -65,7 +65,6 @@ def test_report_rage_click_issue_a_tag(mock_new_issue_occurrence, default_projec
     assert issue_occurence_call["environment"] == "production"
     assert issue_occurence_call["fingerprint"] == ["div.xyz > a"]
     assert issue_occurence_call["issue_type"].type_id == 5002
-    assert issue_occurence_call["level"] == "error"
     assert issue_occurence_call["platform"] == "javascript"
     assert issue_occurence_call["project_id"] == default_project.id
     assert issue_occurence_call["subtitle"] == "div.xyz > a"
@@ -86,7 +85,6 @@ def test_report_rage_click_issue_a_tag(mock_new_issue_occurrence, default_projec
 
     assert issue_occurence_call["extra_event_data"] == {
         "contexts": {"replay": {"replay_id": "b58a67446c914f44a4e329763420047b"}},
-        "level": "error",
         "tags": {"replayId": "b58a67446c914f44a4e329763420047b", "url": "https://www.sentry.io"},
         "user": {
             "id": "123",

--- a/tests/sentry/replays/unit/test_rage_click_issue.py
+++ b/tests/sentry/replays/unit/test_rage_click_issue.py
@@ -65,6 +65,7 @@ def test_report_rage_click_issue_a_tag(mock_new_issue_occurrence, default_projec
     assert issue_occurence_call["environment"] == "production"
     assert issue_occurence_call["fingerprint"] == ["div.xyz > a"]
     assert issue_occurence_call["issue_type"].type_id == 5002
+    assert issue_occurence_call["level"] == "info"
     assert issue_occurence_call["platform"] == "javascript"
     assert issue_occurence_call["project_id"] == default_project.id
     assert issue_occurence_call["subtitle"] == "div.xyz > a"
@@ -85,6 +86,7 @@ def test_report_rage_click_issue_a_tag(mock_new_issue_occurrence, default_projec
 
     assert issue_occurence_call["extra_event_data"] == {
         "contexts": {"replay": {"replay_id": "b58a67446c914f44a4e329763420047b"}},
+        "level": "info",
         "tags": {"replayId": "b58a67446c914f44a4e329763420047b", "url": "https://www.sentry.io"},
         "user": {
             "id": "123",


### PR DESCRIPTION
Revising previous "remove rage click level" commit. Level is required arg for new_issue_occurrence, so lowered the severity to "info" (default in issue_occurrence.py)