### PR TITLE
chore(teams): Remove unused `Team.transfer_to` function and tests

### DIFF
--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, ClassVar, Literal, overload
 
 from django.conf import settings
-from django.db import IntegrityError, connections, models, router, transaction
+from django.db import models, router, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -26,7 +26,7 @@ from sentry.db.models.outboxes import ReplicatedRegionModel
 from sentry.db.models.utils import slugify_instance
 from sentry.locks import locks
 from sentry.models.actor import ACTOR_TYPES, Actor
-from sentry.models.outbox import OutboxCategory, outbox_context
+from sentry.models.outbox import OutboxCategory
 from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snowflake import SnowflakeIdMixin
 
@@ -237,86 +237,6 @@ class Team(ReplicatedRegionModel, SnowflakeIdMixin):
             user_id__isnull=False,
             user_is_active=True,
         ).distinct()
-
-    def transfer_to(self, organization):
-        """
-        Transfers a team and all projects under it to the given organization.
-        """
-        from sentry.models.organizationaccessrequest import OrganizationAccessRequest
-        from sentry.models.organizationmember import OrganizationMember
-        from sentry.models.organizationmemberteam import OrganizationMemberTeam
-        from sentry.models.project import Project
-        from sentry.models.projectteam import ProjectTeam
-        from sentry.models.release import ReleaseProject
-        from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
-
-        try:
-            with transaction.atomic(router.db_for_write(Team)):
-                self.update(organization=organization)
-        except IntegrityError:
-            # likely this means a team already exists, let's try to coerce to
-            # it instead of a blind transfer
-            new_team = Team.objects.get(organization=organization, slug=self.slug)
-        else:
-            new_team = self
-
-        project_ids = list(
-            Project.objects.filter(teams=self)
-            .exclude(organization=organization)
-            .values_list("id", flat=True)
-        )
-
-        # remove associations with releases from other org
-        ReleaseProject.objects.filter(project_id__in=project_ids).delete()
-        ReleaseProjectEnvironment.objects.filter(project_id__in=project_ids).delete()
-
-        Project.objects.filter(id__in=project_ids).update(organization=organization)
-
-        ProjectTeam.objects.filter(project_id__in=project_ids).update(team=new_team)
-
-        # remove any pending access requests from the old organization
-        if self != new_team:
-            OrganizationAccessRequest.objects.filter(team=self).delete()
-
-        # identify shared members and ensure they retain team access
-        # under the new organization
-        old_memberships = OrganizationMember.objects.filter(teams=self).exclude(
-            organization=organization
-        )
-        for member in old_memberships:
-            try:
-                new_member = OrganizationMember.objects.get(
-                    user_id=member.user_id, organization=organization
-                )
-            except OrganizationMember.DoesNotExist:
-                continue
-
-            try:
-                with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
-                    OrganizationMemberTeam.objects.create(
-                        team=new_team, organizationmember=new_member
-                    )
-            except IntegrityError:
-                pass
-
-        existing = OrganizationMemberTeam.objects.filter(team=self).exclude(
-            organizationmember__organization=organization
-        )
-        OrganizationMemberTeam.objects.bulk_delete(existing)
-
-        if new_team != self:
-            with outbox_context(
-                transaction.atomic(router.db_for_write(Team)), flush=False
-            ), connections[router.db_for_write(Team)].cursor() as cursor:
-                # we use a cursor here to avoid automatic cascading of relations
-                # in Django
-                cursor.execute("DELETE FROM sentry_team WHERE id = %s", [self.id])
-                self.outbox_for_update().save()
-                cursor.execute("DELETE FROM sentry_actor WHERE team_id = %s", [new_team.id])
-
-                Actor.objects.filter(id=self.actor_id).update(team_id=new_team.id)
-                new_team.actor_id = self.actor_id
-                new_team.save()
 
     def get_audit_log_data(self):
         return {

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -6,10 +6,6 @@ from sentry.models.notificationsettingoption import NotificationSettingOption
 from sentry.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.models.project import Project
-from sentry.models.projectteam import ProjectTeam
-from sentry.models.release import Release, ReleaseProject
-from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.team import Team
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs_control
@@ -81,102 +77,6 @@ class TeamTest(TestCase):
             )
             team.org_role = "manager"
             team.save()
-
-
-@region_silo_test
-class TransferTest(TestCase):
-    def test_simple(self):
-        user = self.create_user()
-        org = self.create_organization(name="foo", owner=user)
-        org2 = self.create_organization(name="bar", owner=None)
-        team = self.create_team(organization=org)
-        project = self.create_project(teams=[team])
-        user2 = self.create_user("foo@example.com")
-        self.create_member(user=user2, organization=org, role="admin", teams=[team])
-        self.create_member(user=user2, organization=org2, role="member", teams=[])
-        team.transfer_to(org2)
-
-        assert team.organization == org2
-        team = Team.objects.get(id=team.id)
-        assert team.organization == org2
-
-        project = Project.objects.get(id=project.id)
-        assert project.organization == org2
-
-        # owner does not exist on new org, so should not be transferred
-        assert not OrganizationMember.objects.filter(user_id=user.id, organization=org2).exists()
-
-        # existing member should now have access
-        member = OrganizationMember.objects.get(user_id=user2.id, organization=org2)
-        assert list(member.teams.all()) == [team]
-        # role should not automatically upgrade
-        assert member.role == "member"
-
-        # old member row should still exist
-        assert OrganizationMember.objects.filter(user_id=user2.id, organization=org).exists()
-
-        # no references to old org for this team should exist
-        assert not OrganizationMemberTeam.objects.filter(
-            organizationmember__organization=org, team=team
-        ).exists()
-
-    def test_existing_team(self):
-        org = self.create_organization(name="foo")
-        org2 = self.create_organization(name="bar")
-        team = self.create_team(name="foo", organization=org)
-        team2 = self.create_team(name="foo", organization=org2)
-        project = self.create_project(teams=[team])
-        with outbox_runner():
-            team.transfer_to(org2)
-
-        project = Project.objects.get(id=project.id)
-        assert ProjectTeam.objects.filter(project=project, team=team2).exists()
-
-        assert not Team.objects.filter(id=team.id).exists()
-
-    def test_release_projects(self):
-        user = self.create_user()
-        org = self.create_organization(name="foo", owner=user)
-        org2 = self.create_organization(name="bar", owner=None)
-        team = self.create_team(organization=org)
-        project = self.create_project(teams=[team])
-
-        release = Release.objects.create(version="a" * 7, organization=org)
-
-        release.add_project(project)
-
-        assert ReleaseProject.objects.filter(release=release, project=project).exists()
-
-        team.transfer_to(org2)
-
-        assert Release.objects.filter(id=release.id).exists()
-
-        assert not ReleaseProject.objects.filter(release=release, project=project).exists()
-
-    def test_release_project_envs(self):
-        user = self.create_user()
-        org = self.create_organization(name="foo", owner=user)
-        org2 = self.create_organization(name="bar", owner=None)
-        team = self.create_team(organization=org)
-        project = self.create_project(teams=[team])
-
-        release = Release.objects.create(version="a" * 7, organization=org)
-
-        release.add_project(project)
-        env = self.create_environment(name="prod", project=project)
-        ReleaseProjectEnvironment.objects.create(release=release, project=project, environment=env)
-
-        assert ReleaseProjectEnvironment.objects.filter(
-            release=release, project=project, environment=env
-        ).exists()
-
-        team.transfer_to(org2)
-
-        assert Release.objects.filter(id=release.id).exists()
-
-        assert not ReleaseProjectEnvironment.objects.filter(
-            release=release, project=project, environment=env
-        ).exists()
 
 
 @region_silo_test


### PR DESCRIPTION
This code is unused and will not work well if it's ever called. Just killing it to simplify the codebase