### PR TITLE
ref(ui): Change renderContextMenu return type

### DIFF
--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -16,7 +16,7 @@ interface Props {
   createdBy?: User;
   dateStatus?: React.ReactNode;
   onEventClick?: () => void;
-  renderContextMenu?: () => void;
+  renderContextMenu?: () => React.ReactNode;
 }
 
 function DashboardCard({


### PR DESCRIPTION
This is rendered, in react 18 it catches this type as an error

https://github.com/getsentry/sentry/blob/7994210ec5bbc22f362606a52a88987d99a3150a/static/app/views/dashboards/manage/dashboardCard.tsx#L63

part of https://github.com/getsentry/frontend-tsc/issues/22