### PR TITLE
feat(dynamic-sampling): Return plan sample rate in the organization details

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -565,6 +565,9 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         if org_volume is not None and org_volume.indexed is not None and org_volume.total > 0:
             context["effectiveSampleRate"] = org_volume.indexed / org_volume.total
 
+        if sample_rate is not None:
+            context["planSampleRate"] = sample_rate
+
         desired_sample_rate = get_sliding_window_org_sample_rate(
             org_id=obj.id, default_sample_rate=sample_rate
         )

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -76,6 +76,7 @@ export interface Organization extends OrganizationSummary {
   desiredSampleRate?: number | null;
   effectiveSampleRate?: number | null;
   orgRole?: string;
+  planSampleRate?: number | null;
 }
 
 export interface DetailedOrganization extends Organization {

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -299,7 +299,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             ):
                 response = self.get_success_response(self.organization.slug)
                 assert not response.data["isDynamicallySampled"]
-                assert not response.data["planSampleRate"]
+                assert "planSampleRate" not in response.data
 
         with self.feature({"organizations:dynamic-sampling": False}):
             with patch(
@@ -308,7 +308,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             ):
                 response = self.get_success_response(self.organization.slug)
                 assert not response.data["isDynamicallySampled"]
-                assert not response.data["planSampleRate"]
+                assert "planSampleRate" not in response.data
 
     def test_sensitive_fields_too_long(self):
         value = 1000 * ["0123456789"] + ["1"]

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -281,6 +281,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             ):
                 response = self.get_success_response(self.organization.slug)
                 assert response.data["isDynamicallySampled"]
+                assert response.data["planSampleRate"] == 0.5
 
         with self.feature({"organizations:dynamic-sampling": True}):
             with patch(
@@ -289,6 +290,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             ):
                 response = self.get_success_response(self.organization.slug)
                 assert not response.data["isDynamicallySampled"]
+                assert response.data["planSampleRate"] == 1.0
 
         with self.feature({"organizations:dynamic-sampling": True}):
             with patch(
@@ -297,6 +299,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             ):
                 response = self.get_success_response(self.organization.slug)
                 assert not response.data["isDynamicallySampled"]
+                assert not response.data["planSampleRate"]
 
         with self.feature({"organizations:dynamic-sampling": False}):
             with patch(
@@ -305,6 +308,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             ):
                 response = self.get_success_response(self.organization.slug)
                 assert not response.data["isDynamicallySampled"]
+                assert not response.data["planSampleRate"]
 
     def test_sensitive_fields_too_long(self):
         value = 1000 * ["0123456789"] + ["1"]


### PR DESCRIPTION
This PR returns the plan sample rate in the organization details to give even more observability into what dynamic sampling is doing.

For now, we do not plan on showing the data in the UI.