### PR TITLE
ref(dynamic-sampling): Do not run cron jobs if dynamic sampling is not enabled

### DIFF
--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -57,14 +57,6 @@ def is_sliding_window_org_enabled(organization: Organization) -> bool:
     ) and not features.has("organizations:ds-sliding-window", organization, actor=None)
 
 
-def has_dynamic_sampling(organization: Organization | None) -> bool:
-    # If an organization can't be fetched, we will assume it has no dynamic sampling.
-    if organization is None:
-        return False
-
-    return features.has("organizations:dynamic-sampling", organization, actor=None)
-
-
 def get_guarded_blended_sample_rate(organization: Organization, project: Project) -> float:
     sample_rate = quotas.backend.get_blended_sample_rate(organization_id=organization.id)
 

--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -57,6 +57,10 @@ def is_sliding_window_org_enabled(organization: Organization) -> bool:
     ) and not features.has("organizations:ds-sliding-window", organization, actor=None)
 
 
+def has_dynamic_sampling(organization: Organization) -> bool:
+    return features.has("organizations:dynamic-sampling", organization, actor=None)
+
+
 def get_guarded_blended_sample_rate(organization: Organization, project: Project) -> float:
     sample_rate = quotas.backend.get_blended_sample_rate(organization_id=organization.id)
 

--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -57,7 +57,11 @@ def is_sliding_window_org_enabled(organization: Organization) -> bool:
     ) and not features.has("organizations:ds-sliding-window", organization, actor=None)
 
 
-def has_dynamic_sampling(organization: Organization) -> bool:
+def has_dynamic_sampling(organization: Organization | None) -> bool:
+    # If an organization can't be fetched, we will assume it has no dynamic sampling.
+    if organization is None:
+        return False
+
     return features.has("organizations:dynamic-sampling", organization, actor=None)
 
 

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -24,7 +24,7 @@ from sentry.dynamic_sampling.models.base import ModelType
 from sentry.dynamic_sampling.models.common import RebalancedItem, guarded_run
 from sentry.dynamic_sampling.models.factory import model_factory
 from sentry.dynamic_sampling.models.projects_rebalancing import ProjectsRebalancingInput
-from sentry.dynamic_sampling.rules.base import is_sliding_window_org_enabled
+from sentry.dynamic_sampling.rules.base import has_dynamic_sampling, is_sliding_window_org_enabled
 from sentry.dynamic_sampling.rules.utils import (
     DecisionDropCount,
     DecisionKeepCount,
@@ -251,6 +251,10 @@ def adjust_sample_rates_of_projects(
         # In case an org is not found, it might be that it has been deleted in the time between
         # the query triggering this job and the actual execution of the job.
         organization = None
+
+    # If the org doesn't have dynamic sampling, we want to early return to avoid unnecessary work.
+    if not has_dynamic_sampling(organization):
+        return
 
     # By default, we use the blended sample rate.
     sample_rate = quotas.backend.get_blended_sample_rate(organization_id=org_id)

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -24,7 +24,7 @@ from sentry.dynamic_sampling.models.base import ModelType
 from sentry.dynamic_sampling.models.common import RebalancedItem, guarded_run
 from sentry.dynamic_sampling.models.factory import model_factory
 from sentry.dynamic_sampling.models.projects_rebalancing import ProjectsRebalancingInput
-from sentry.dynamic_sampling.rules.base import has_dynamic_sampling, is_sliding_window_org_enabled
+from sentry.dynamic_sampling.rules.base import is_sliding_window_org_enabled
 from sentry.dynamic_sampling.rules.utils import (
     DecisionDropCount,
     DecisionKeepCount,
@@ -55,6 +55,7 @@ from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
     dynamic_sampling_task_with_context,
+    has_dynamic_sampling,
 )
 from sentry.models.organization import Organization
 from sentry.models.project import Project

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -50,7 +50,7 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
     generate_boost_low_volume_projects_cache_key,
 )
 from sentry.dynamic_sampling.tasks.helpers.sliding_window import get_sliding_window_org_sample_rate
-from sentry.dynamic_sampling.tasks.logging import log_sample_rate_source
+from sentry.dynamic_sampling.tasks.logging import log_sample_rate_source, log_skipped_job
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
@@ -255,6 +255,7 @@ def adjust_sample_rates_of_projects(
 
     # If the org doesn't have dynamic sampling, we want to early return to avoid unnecessary work.
     if not has_dynamic_sampling(organization):
+        log_skipped_job(org_id, "boost_low_volume_projects")
         return
 
     # By default, we use the blended sample rate.

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -42,7 +42,7 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_transactions import 
     set_transactions_resampling_rates,
 )
 from sentry.dynamic_sampling.tasks.helpers.sliding_window import get_sliding_window_sample_rate
-from sentry.dynamic_sampling.tasks.logging import log_sample_rate_source
+from sentry.dynamic_sampling.tasks.logging import log_sample_rate_source, log_skipped_job
 from sentry.dynamic_sampling.tasks.task_context import DynamicSamplingLogState, TaskContext
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
@@ -172,6 +172,7 @@ def boost_low_volume_transactions_of_project(project_transactions: ProjectTransa
 
     # If the org doesn't have dynamic sampling, we want to early return to avoid unnecessary work.
     if not has_dynamic_sampling(organization):
+        log_skipped_job(org_id, "boost_low_volume_transactions")
         return
 
     # By default, we use the blended sample rate.

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -24,7 +24,6 @@ from sentry.dynamic_sampling.models.common import RebalancedItem, guarded_run
 from sentry.dynamic_sampling.models.factory import model_factory
 from sentry.dynamic_sampling.models.transactions_rebalancing import TransactionsRebalancingInput
 from sentry.dynamic_sampling.rules.base import (
-    has_dynamic_sampling,
     is_sliding_window_enabled,
     is_sliding_window_org_enabled,
 )
@@ -48,6 +47,7 @@ from sentry.dynamic_sampling.tasks.task_context import DynamicSamplingLogState, 
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
     dynamic_sampling_task_with_context,
+    has_dynamic_sampling,
 )
 from sentry.models.organization import Organization
 from sentry.sentry_metrics import indexer

--- a/src/sentry/dynamic_sampling/tasks/logging.py
+++ b/src/sentry/dynamic_sampling/tasks/logging.py
@@ -62,6 +62,10 @@ def log_query_timeout(query: str, offset: int, timeout_seconds: int) -> None:
     metrics.incr("dynamic_sampling.query_timeout", tags={"query": query})
 
 
+def log_skipped_job(org_id: int, job: str):
+    logger.info("dynamic_sampling.skipped_job", extra={"org_id": org_id, "job": job})
+
+
 def log_recalibrate_org_error(org_id: int, error: str) -> None:
     logger.info("dynamic_sampling.recalibrate_org_error", extra={"org_id": org_id, "error": error})
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 import sentry_sdk
 
 from sentry import quotas
-from sentry.dynamic_sampling.rules.base import has_dynamic_sampling, is_sliding_window_org_enabled
+from sentry.dynamic_sampling.rules.base import is_sliding_window_org_enabled
 from sentry.dynamic_sampling.tasks.common import GetActiveOrgsVolumes, TimedIterator
 from sentry.dynamic_sampling.tasks.constants import (
     MAX_REBALANCE_FACTOR,
@@ -23,7 +23,10 @@ from sentry.dynamic_sampling.tasks.logging import (
     log_sample_rate_source,
 )
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
-from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task_with_context
+from sentry.dynamic_sampling.tasks.utils import (
+    dynamic_sampling_task_with_context,
+    has_dynamic_sampling,
+)
 from sentry.models.organization import Organization
 from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -21,6 +21,7 @@ from sentry.dynamic_sampling.tasks.logging import (
     log_recalibrate_org_error,
     log_recalibrate_org_state,
     log_sample_rate_source,
+    log_skipped_job,
 )
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import (
@@ -90,6 +91,7 @@ def recalibrate_org(org_id: int, total: int, indexed: int) -> None:
 
     # If the org doesn't have dynamic sampling, we want to early return to avoid unnecessary work.
     if not has_dynamic_sampling(organization):
+        log_skipped_job(org_id, "recalibrate_orgs")
         return
 
     # By default, we use the blended sample rate.

--- a/src/sentry/dynamic_sampling/tasks/utils.py
+++ b/src/sentry/dynamic_sampling/tasks/utils.py
@@ -2,10 +2,20 @@ from functools import wraps
 
 import sentry_sdk
 
+from sentry import features
 from sentry.dynamic_sampling.tasks.common import TimeoutException
 from sentry.dynamic_sampling.tasks.logging import log_task_execution, log_task_timeout
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
+from sentry.models.organization import Organization
 from sentry.utils import metrics
+
+
+def has_dynamic_sampling(organization: Organization | None) -> bool:
+    # If an organization can't be fetched, we will assume it has no dynamic sampling.
+    if organization is None:
+        return False
+
+    return features.has("organizations:dynamic-sampling", organization, actor=None)
 
 
 def _compute_task_name(function_name: str) -> str:

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -32,6 +32,7 @@ from sentry.dynamic_sampling.tasks.sliding_window import sliding_window
 from sentry.dynamic_sampling.tasks.sliding_window_org import sliding_window_org
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.testutils.cases import BaseMetricsLayerTestCase, SnubaTestCase, TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import freeze_time
 
 MOCK_DATETIME = (django_timezone.now() - timedelta(days=1)).replace(
@@ -126,6 +127,26 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
     def forecasted_volume_side_effect(*args, **kwargs):
         return kwargs["volume"]
 
+    @patch("sentry.dynamic_sampling.tasks.boost_low_volume_projects.model_factory")
+    @patch("sentry.quotas.backend.get_blended_sample_rate")
+    def test_boost_low_volume_projects_with_no_dynamic_sampling(
+        self, get_blended_sample_rate, model_factory
+    ):
+        get_blended_sample_rate.return_value = 0.25
+        test_org = self.create_old_organization(name="sample-org")
+
+        self.create_project_and_add_metrics("a", 9, test_org)
+        self.create_project_and_add_metrics("b", 7, test_org)
+        self.create_project_and_add_metrics("c", 3, test_org)
+        self.create_project_and_add_metrics("d", 1, test_org)
+
+        with self.tasks():
+            sliding_window_org()
+            boost_low_volume_projects()
+
+        model_factory.assert_not_called()
+
+    @with_feature("organizations:dynamic-sampling")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_boost_low_volume_projects_simple(
         self,
@@ -161,16 +182,15 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         }
         assert generate_rules(proj_d)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
 
+    @with_feature("organizations:dynamic-sampling")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_boost_low_volume_projects_simple_with_empty_project(
         self,
         get_blended_sample_rate,
     ):
         get_blended_sample_rate.return_value = 0.25
-        # Create a org
         test_org = self.create_old_organization(name="sample-org")
 
-        # Create 4 projects
         proj_a = self.create_project_and_add_metrics("a", 9, test_org)
         proj_b = self.create_project_and_add_metrics("b", 7, test_org)
         proj_c = self.create_project_and_add_metrics("c", 3, test_org)
@@ -198,6 +218,8 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         assert generate_rules(proj_d)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
         assert generate_rules(proj_e)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
 
+    @with_feature("organizations:dynamic-sampling")
+    @with_feature("organizations:ds-sliding-window-org")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     @patch("sentry.quotas.backend.get_transaction_sampling_tier_for_volume")
     @patch("sentry.dynamic_sampling.tasks.common.extrapolate_monthly_volume")
@@ -210,19 +232,17 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         extrapolate_monthly_volume.side_effect = self.forecasted_volume_side_effect
         get_transaction_sampling_tier_for_volume.side_effect = self.sampling_tier_side_effect
         get_blended_sample_rate.return_value = 0.8
-        # Create a org
+
         test_org = self.create_old_organization(name="sample-org")
 
-        # Create 4 projects
         proj_a = self.create_project_and_add_metrics("a", 9, test_org)
         proj_b = self.create_project_and_add_metrics("b", 7, test_org)
         proj_c = self.create_project_and_add_metrics("c", 3, test_org)
         proj_d = self.create_project_and_add_metrics("d", 1, test_org)
 
-        with self.feature("organizations:ds-sliding-window-org"):
-            with self.tasks():
-                sliding_window_org()
-                boost_low_volume_projects()
+        with self.tasks():
+            sliding_window_org()
+            boost_low_volume_projects()
 
         # we expect only uniform rule
         # also we test here that `generate_rules` can handle trough redis long floats
@@ -240,6 +260,8 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         }
         assert generate_rules(proj_d)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
 
+    @with_feature("organizations:dynamic-sampling")
+    @with_feature("organizations:ds-sliding-window-org")
     @patch(
         "sentry.dynamic_sampling.tasks.boost_low_volume_projects.schedule_invalidate_project_config"
     )
@@ -256,23 +278,23 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         extrapolate_monthly_volume.side_effect = self.forecasted_volume_side_effect
         get_transaction_sampling_tier_for_volume.side_effect = self.sampling_tier_side_effect
         get_blended_sample_rate.return_value = 0.8
-        # Create a org
+
         test_org = self.create_old_organization(name="sample-org")
 
-        # Create 2 projects
         proj_a = self.create_project_and_add_metrics("a", 9, test_org)
         proj_b = self.create_project_and_add_metrics("b", 7, test_org)
 
         self.add_sample_rate_per_project(org_id=test_org.id, project_id=proj_a.id, sample_rate=0.1)
         self.add_sample_rate_per_project(org_id=test_org.id, project_id=proj_b.id, sample_rate=0.2)
 
-        with self.feature("organizations:ds-sliding-window-org"):
-            with self.tasks():
-                sliding_window_org()
-                boost_low_volume_projects()
+        with self.tasks():
+            sliding_window_org()
+            boost_low_volume_projects()
 
         assert schedule_invalidate_project_config.call_count == 2
 
+    @with_feature("organizations:dynamic-sampling")
+    @with_feature("organizations:ds-sliding-window-org")
     @patch(
         "sentry.dynamic_sampling.tasks.boost_low_volume_projects.schedule_invalidate_project_config"
     )
@@ -290,19 +312,16 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         get_transaction_sampling_tier_for_volume.side_effect = self.sampling_tier_side_effect
         get_blended_sample_rate.return_value = 1.0
 
-        # Create a org
         test_org = self.create_old_organization(name="sample-org")
 
-        # Create 2 projects
         proj_a = self.create_project_and_add_metrics("a", 9, test_org)
         proj_b = self.create_project_and_add_metrics("b", 7, test_org)
 
         self.add_sample_rate_per_project(org_id=test_org.id, project_id=proj_a.id, sample_rate=1.0)
         self.add_sample_rate_per_project(org_id=test_org.id, project_id=proj_b.id, sample_rate=1.0)
 
-        with self.feature("organizations:ds-sliding-window-org"):
-            with self.tasks():
-                boost_low_volume_projects()
+        with self.tasks():
+            boost_low_volume_projects()
 
         schedule_invalidate_project_config.assert_not_called()
 
@@ -415,6 +434,24 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
             )
         )
 
+    @patch("sentry.dynamic_sampling.tasks.boost_low_volume_transactions.model_factory")
+    @patch("sentry.quotas.backend.get_blended_sample_rate")
+    def test_boost_low_volume_transactions_with_blended_sample_rate_and_no_dynamic_sampling(
+        self, get_blended_sample_rate, model_factory
+    ):
+        """
+        Create orgs projects & transactions and then check that the rebalancing model is not called because dynamic
+        sampling is disabled
+        """
+        BLENDED_RATE = 0.25
+        get_blended_sample_rate.return_value = BLENDED_RATE
+
+        with self.tasks():
+            boost_low_volume_transactions()
+
+        model_factory.assert_not_called()
+
+    @with_feature("organizations:dynamic-sampling")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_boost_low_volume_transactions_with_blended_sample_rate(self, get_blended_sample_rate):
         """
@@ -440,6 +477,8 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
                     )  # check we have some rate calculated for each transaction
                 assert global_rate == BLENDED_RATE
 
+    @with_feature("organizations:dynamic-sampling")
+    @with_feature("organizations:ds-sliding-window")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_boost_low_volume_transactions_with_sliding_window(self, get_blended_sample_rate):
         """
@@ -455,9 +494,8 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
             else:
                 self.set_sliding_window_sample_rate_for_all(used_sample_rate)
 
-            with self.feature("organizations:ds-sliding-window"):
-                with self.tasks():
-                    boost_low_volume_transactions()
+            with self.tasks():
+                boost_low_volume_transactions()
 
             # now redis should contain rebalancing data for our projects
             for org in self.orgs_info:
@@ -472,6 +510,8 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
                         )  # check we have some rate calculated for each transaction
                     assert global_rate == used_sample_rate
 
+    @with_feature("organizations:dynamic-sampling")
+    @with_feature("organizations:ds-sliding-window-org")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_boost_low_volume_transactions_with_sliding_window_org(self, get_blended_sample_rate):
         """
@@ -495,9 +535,8 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
             elif sliding_window_step == 3:
                 self.set_boost_low_volume_projects_for_all(used_sample_rate)
 
-            with self.feature("organizations:ds-sliding-window-org"):
-                with self.tasks():
-                    boost_low_volume_transactions()
+            with self.tasks():
+                boost_low_volume_transactions()
 
             # now redis should contain rebalancing data for our projects
             for org in self.orgs_info:
@@ -521,6 +560,7 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
 
                         assert global_rate == used_sample_rate
 
+    @with_feature("organizations:dynamic-sampling")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_boost_low_volume_transactions_partial(self, get_blended_sample_rate):
         """
@@ -634,6 +674,24 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
             lambda org_id: self.set_sliding_window_org_sample_rate(org_id, sample_rate)
         )
 
+    @patch("sentry.dynamic_sampling.tasks.recalibrate_orgs.compute_adjusted_factor")
+    @patch("sentry.quotas.backend.get_blended_sample_rate")
+    def test_rebalance_orgs_with_no_dynamic_sampling(
+        self, get_blended_sample_rate, computed_adjusted_factor
+    ):
+        """
+        Test that the recalibration of orgs doesn't happen if dynamic sampling is not enabled
+        """
+        get_blended_sample_rate.return_value = 0.1
+        self.set_sliding_window_org_sample_rate_for_all(0.2)
+
+        with self.tasks():
+            recalibrate_orgs()
+
+        computed_adjusted_factor.assert_not_called()
+
+    @with_feature("organizations:dynamic-sampling")
+    @with_feature("organizations:ds-sliding-window-org")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_rebalance_orgs_with_sliding_window_org(self, get_blended_sample_rate):
         """
@@ -649,9 +707,8 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
 
         redis_client = get_redis_client_for_ds()
 
-        with self.feature("organizations:ds-sliding-window-org"):
-            with self.tasks():
-                recalibrate_orgs()
+        with self.tasks():
+            recalibrate_orgs()
 
         for idx, org in enumerate(self.orgs):
             cache_key = generate_recalibrate_orgs_cache_key(org.id)
@@ -669,9 +726,8 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
 
         # now if we run it again (with the same data in the database, the algorithm
         # should double down... the previous factor didn't do anything so apply it again)
-        with self.feature("organizations:ds-sliding-window-org"):
-            with self.tasks():
-                recalibrate_orgs()
+        with self.tasks():
+            recalibrate_orgs()
 
         for idx, org in enumerate(self.orgs):
             cache_key = generate_recalibrate_orgs_cache_key(org.id)
@@ -689,6 +745,7 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
                 # half it again to 0.25
                 assert float(val) == 0.25
 
+    @with_feature("organizations:dynamic-sampling")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_rules_generation_with_recalibrate_orgs(self, get_blended_sample_rate):
         """


### PR DESCRIPTION
This PR makes an improvement to dynamic sampling in which the following cron jobs are not run if dynamic sampling is not set:
* org recalibration
* projects boosting
* transactions boosting

It's important to note that the checks are not performed at the start of the cron jobs, but rather in all the sub-tasks, after the `Organization` model is loaded, since we don't want to load the model for each organization in the main cron job (which will go out of time).

All of these jobs are wasted work if they run when dynamic sampling is not enabled. Unfortunately, though, we can't do the same optimization for the sliding window per org, since we would have to load the `Organization` model for each organization which would take more time than just computing the org sample rate.