### PR TITLE
ref(ddm): Use series id for coloring and identification

### DIFF
--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -261,6 +261,16 @@ export function getMetricsSeriesName(
   return formattedGrouping;
 }
 
+export function getMetricsSeriesId(
+  query: MetricsQueryApiQueryParams,
+  groupBy?: Record<string, string>
+) {
+  if (Object.keys(groupBy ?? {}).length === 0) {
+    return `${query.name}-${JSON.stringify(groupBy)}`;
+  }
+  return `${query.name}-${JSON.stringify(groupBy)}`;
+}
+
 export function groupByOp(metrics: MetricMeta[]): Record<string, MetricMeta[]> {
   const uniqueOperations = [
     ...new Set(metrics.flatMap(field => field.operations).filter(isAllowedOp)),

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -266,7 +266,7 @@ export function getMetricsSeriesId(
   groupBy?: Record<string, string>
 ) {
   if (Object.keys(groupBy ?? {}).length === 0) {
-    return `${query.name}-${JSON.stringify(groupBy)}`;
+    return `${query.name}`;
   }
   return `${query.name}-${JSON.stringify(groupBy)}`;
 }

--- a/static/app/utils/metrics/types.tsx
+++ b/static/app/utils/metrics/types.tsx
@@ -16,7 +16,7 @@ export type SortState = {
 };
 
 export interface FocusedMetricsSeries {
-  seriesName: string;
+  id: string;
   groupBy?: Record<string, string>;
 }
 

--- a/static/app/views/ddm/chart.tsx
+++ b/static/app/views/ddm/chart.tsx
@@ -414,10 +414,12 @@ function createIngestionSeries(
 const EXTRAPOLATED_AREA_STRIPE_IMG =
   'image://data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAABkCAYAAAC/zKGXAAAAMUlEQVR4Ae3KoREAIAwEsMKgrMeYj8BzyIpEZyTZda16mPVJFEVRFEVRFEVRFMWO8QB4uATKpuU51gAAAABJRU5ErkJggg==';
 
+export const getIngestionSeriesId = (seriesId: string) => `${seriesId}-ingestion`;
+
 function createIngestionBarSeries(series: Series, fogBucketCnt = 0) {
   return {
     ...series,
-    id: `${series.id}-ingestion`,
+    id: getIngestionSeriesId(series.id),
     silent: true,
     data: series.data.map((data, index) => ({
       ...data,
@@ -439,7 +441,7 @@ function createIngestionBarSeries(series: Series, fogBucketCnt = 0) {
 function createIngestionLineSeries(series: Series, fogBucketCnt = 0) {
   return {
     ...series,
-    id: `${series.id}-ingestion`,
+    id: getIngestionSeriesId(series.id),
     silent: true,
     // We include the last non-fog of war bucket so that the line is connected
     data: series.data.slice(-fogBucketCnt - 1),
@@ -452,7 +454,7 @@ function createIngestionLineSeries(series: Series, fogBucketCnt = 0) {
 function createIngestionAreaSeries(series: Series, fogBucketCnt = 0) {
   return {
     ...series,
-    id: `${series.id}-ingestion`,
+    id: getIngestionSeriesId(series.id),
     silent: true,
     stack: 'fogOfWar',
     // We include the last non-fog of war bucket so that the line is connected

--- a/static/app/views/ddm/chart.tsx
+++ b/static/app/views/ddm/chart.tsx
@@ -417,6 +417,7 @@ const EXTRAPOLATED_AREA_STRIPE_IMG =
 function createIngestionBarSeries(series: Series, fogBucketCnt = 0) {
   return {
     ...series,
+    id: `${series.id}-ingestion`,
     silent: true,
     data: series.data.map((data, index) => ({
       ...data,
@@ -438,6 +439,7 @@ function createIngestionBarSeries(series: Series, fogBucketCnt = 0) {
 function createIngestionLineSeries(series: Series, fogBucketCnt = 0) {
   return {
     ...series,
+    id: `${series.id}-ingestion`,
     silent: true,
     // We include the last non-fog of war bucket so that the line is connected
     data: series.data.slice(-fogBucketCnt - 1),
@@ -450,6 +452,7 @@ function createIngestionLineSeries(series: Series, fogBucketCnt = 0) {
 function createIngestionAreaSeries(series: Series, fogBucketCnt = 0) {
   return {
     ...series,
+    id: `${series.id}-ingestion`,
     silent: true,
     stack: 'fogOfWar',
     // We include the last non-fog of war bucket so that the line is connected

--- a/static/app/views/ddm/context.tsx
+++ b/static/app/views/ddm/context.tsx
@@ -78,15 +78,13 @@ export function useDDMContext() {
   return useContext(DDMContext);
 }
 
-const DEFAULT_WIDGETS_STATE: MetricWidgetQueryParams[] = [emptyMetricsQueryWidget];
-
 export function useMetricWidgets() {
   const {widgets: urlWidgets} = useLocationQuery({fields: {widgets: decodeScalar}});
   const updateQuery = useUpdateQuery();
 
   const widgets = useStructuralSharing(
     useMemo<MetricWidgetQueryParams[]>(
-      () => parseMetricWidgetsQueryParam(urlWidgets) ?? DEFAULT_WIDGETS_STATE,
+      () => parseMetricWidgetsQueryParam(urlWidgets),
       [urlWidgets]
     )
   );

--- a/static/app/views/ddm/scratchpad.tsx
+++ b/static/app/views/ddm/scratchpad.tsx
@@ -25,20 +25,20 @@ function widgetToQuery(
 ): MetricsQueryApiQueryParams {
   return widget.type === MetricQueryType.FORMULA
     ? {
+        name: getQuerySymbol(widget.id),
         // TODO(aknaus): Properly parse formulas to format identifiers
         // This solution is limited to single character identifiers
         formula: widget.formula
           .split('')
           .map(char => (queryLookup.has(char) ? `$${char}` : char))
           .join(''),
-        name: getQuerySymbol(widget.id),
       }
     : {
+        name: getQuerySymbol(widget.id),
         mri: widget.mri,
         op: widget.op,
         groupBy: widget.groupBy,
         query: widget.query,
-        name: getQuerySymbol(widget.id),
         isQueryOnly: isQueryOnly,
       };
 }

--- a/static/app/views/ddm/summaryTable.tsx
+++ b/static/app/views/ddm/summaryTable.tsx
@@ -168,6 +168,7 @@ export const SummaryTable = memo(function SummaryTable({
         {rows.map(
           ({
             seriesName,
+            id,
             groupBy,
             color,
             hidden,
@@ -181,19 +182,19 @@ export const SummaryTable = memo(function SummaryTable({
             sum,
           }) => {
             return (
-              <Fragment key={seriesName}>
+              <Fragment key={id}>
                 <CellWrapper
                   onClick={() => {
                     if (hasMultipleSeries) {
                       onRowClick({
-                        seriesName,
+                        id,
                         groupBy,
                       });
                     }
                   }}
                   onMouseEnter={() => {
                     if (hasMultipleSeries) {
-                      setHoveredSeries?.(seriesName);
+                      setHoveredSeries?.(id);
                     }
                   }}
                 >
@@ -202,7 +203,7 @@ export const SummaryTable = memo(function SummaryTable({
                       event.stopPropagation();
                       if (hasMultipleSeries) {
                         onColorDotClick?.({
-                          seriesName,
+                          id,
                           groupBy,
                         });
                       }

--- a/static/app/views/ddm/useChartSamples.tsx
+++ b/static/app/views/ddm/useChartSamples.tsx
@@ -147,6 +147,7 @@ export function useChartSamples({
 
       return {
         seriesName: sample.transactionId,
+        id: sample.transactionId,
         // TODO: we should not use the same Series type for samples and metrics
         operation: '',
         unit: '',

--- a/static/app/views/ddm/utils/parseMetricWidgetsQueryParam.spec.tsx
+++ b/static/app/views/ddm/utils/parseMetricWidgetsQueryParam.spec.tsx
@@ -1,17 +1,19 @@
+import {emptyMetricsQueryWidget} from 'sentry/utils/metrics/constants';
 import {MetricQueryType} from 'sentry/utils/metrics/types';
 import {parseMetricWidgetsQueryParam} from 'sentry/views/ddm/utils/parseMetricWidgetsQueryParam';
 
 describe('parseMetricWidgetQueryParam', () => {
-  it('returns undefined for invalid param', () => {
-    expect(parseMetricWidgetsQueryParam(undefined)).toBe(undefined);
-    expect(parseMetricWidgetsQueryParam('')).toBe(undefined);
-    expect(parseMetricWidgetsQueryParam('{}')).toBe(undefined);
-    expect(parseMetricWidgetsQueryParam('true')).toBe(undefined);
-    expect(parseMetricWidgetsQueryParam('2')).toBe(undefined);
-    expect(parseMetricWidgetsQueryParam('"test"')).toBe(undefined);
+  it('returns single default widget for invalid param', () => {
+    const defaultState = [emptyMetricsQueryWidget];
+    expect(parseMetricWidgetsQueryParam(undefined)).toBe(defaultState);
+    expect(parseMetricWidgetsQueryParam('')).toBe(defaultState);
+    expect(parseMetricWidgetsQueryParam('{}')).toBe(defaultState);
+    expect(parseMetricWidgetsQueryParam('true')).toBe(defaultState);
+    expect(parseMetricWidgetsQueryParam('2')).toBe(defaultState);
+    expect(parseMetricWidgetsQueryParam('"test"')).toBe(defaultState);
 
     // empty array is not valid
-    expect(parseMetricWidgetsQueryParam('[]')).toEqual(undefined);
+    expect(parseMetricWidgetsQueryParam('[]')).toEqual(defaultState);
   });
 
   it('returns a single widget', () => {

--- a/static/app/views/ddm/utils/parseMetricWidgetsQueryParam.spec.tsx
+++ b/static/app/views/ddm/utils/parseMetricWidgetsQueryParam.spec.tsx
@@ -3,17 +3,17 @@ import {MetricQueryType} from 'sentry/utils/metrics/types';
 import {parseMetricWidgetsQueryParam} from 'sentry/views/ddm/utils/parseMetricWidgetsQueryParam';
 
 describe('parseMetricWidgetQueryParam', () => {
-  it('returns single default widget for invalid param', () => {
-    const defaultState = [emptyMetricsQueryWidget];
-    expect(parseMetricWidgetsQueryParam(undefined)).toBe(defaultState);
-    expect(parseMetricWidgetsQueryParam('')).toBe(defaultState);
-    expect(parseMetricWidgetsQueryParam('{}')).toBe(defaultState);
-    expect(parseMetricWidgetsQueryParam('true')).toBe(defaultState);
-    expect(parseMetricWidgetsQueryParam('2')).toBe(defaultState);
-    expect(parseMetricWidgetsQueryParam('"test"')).toBe(defaultState);
+  const defaultState = [{...emptyMetricsQueryWidget, id: 0}];
+  it('returns default widget for invalid param', () => {
+    expect(parseMetricWidgetsQueryParam(undefined)).toStrictEqual(defaultState);
+    expect(parseMetricWidgetsQueryParam('')).toStrictEqual(defaultState);
+    expect(parseMetricWidgetsQueryParam('{}')).toStrictEqual(defaultState);
+    expect(parseMetricWidgetsQueryParam('true')).toStrictEqual(defaultState);
+    expect(parseMetricWidgetsQueryParam('2')).toStrictEqual(defaultState);
+    expect(parseMetricWidgetsQueryParam('"test"')).toStrictEqual(defaultState);
 
     // empty array is not valid
-    expect(parseMetricWidgetsQueryParam('[]')).toEqual(defaultState);
+    expect(parseMetricWidgetsQueryParam('[]')).toStrictEqual(defaultState);
   });
 
   it('returns a single widget', () => {
@@ -28,13 +28,13 @@ describe('parseMetricWidgetQueryParam', () => {
             query: 'test:query',
             groupBy: ['dist'],
             displayType: 'line',
-            focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+            focusedSeries: [{id: 'default', groupBy: {dist: 'default'}}],
             powerUserMode: true,
             sort: {order: 'asc'},
           },
         ])
       )
-    ).toEqual([
+    ).toStrictEqual([
       {
         id: 0,
         type: MetricQueryType.QUERY,
@@ -43,7 +43,7 @@ describe('parseMetricWidgetQueryParam', () => {
         query: 'test:query',
         groupBy: ['dist'],
         displayType: 'line',
-        focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+        focusedSeries: [{id: 'default', groupBy: {dist: 'default'}}],
         powerUserMode: true,
         sort: {name: undefined, order: 'asc'},
       },
@@ -62,7 +62,7 @@ describe('parseMetricWidgetQueryParam', () => {
             query: 'test:query',
             groupBy: ['dist'],
             displayType: 'line',
-            focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+            focusedSeries: [{id: 'default', groupBy: {dist: 'default'}}],
             powerUserMode: true,
             sort: {name: 'avg', order: 'desc'},
           },
@@ -75,7 +75,7 @@ describe('parseMetricWidgetQueryParam', () => {
             groupBy: ['event_type'],
             displayType: 'line',
             powerUserMode: false,
-            focusedSeries: [{seriesName: 'default', groupBy: {event_type: 'default'}}],
+            focusedSeries: [{id: 'default', groupBy: {event_type: 'default'}}],
             sort: {name: 'sum', order: 'asc'},
           },
           {
@@ -88,7 +88,7 @@ describe('parseMetricWidgetQueryParam', () => {
           },
         ])
       )
-    ).toEqual([
+    ).toStrictEqual([
       {
         id: 0,
         type: MetricQueryType.QUERY,
@@ -97,7 +97,7 @@ describe('parseMetricWidgetQueryParam', () => {
         query: 'test:query',
         groupBy: ['dist'],
         displayType: 'line',
-        focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+        focusedSeries: [{id: 'default', groupBy: {dist: 'default'}}],
         powerUserMode: true,
         sort: {name: 'avg', order: 'desc'},
       },
@@ -110,7 +110,7 @@ describe('parseMetricWidgetQueryParam', () => {
         groupBy: ['event_type'],
         displayType: 'line',
         powerUserMode: false,
-        focusedSeries: [{seriesName: 'default', groupBy: {event_type: 'default'}}],
+        focusedSeries: [{id: 'default', groupBy: {event_type: 'default'}}],
         sort: {name: 'sum', order: 'asc'},
       },
       {
@@ -138,7 +138,7 @@ describe('parseMetricWidgetQueryParam', () => {
           },
         ])
       )
-    ).toEqual([
+    ).toStrictEqual([
       {
         id: 0,
         type: MetricQueryType.QUERY,
@@ -179,7 +179,7 @@ describe('parseMetricWidgetQueryParam', () => {
           },
         ])
       )
-    ).toEqual([
+    ).toStrictEqual([
       {
         id: 0,
         type: MetricQueryType.QUERY,
@@ -221,7 +221,7 @@ describe('parseMetricWidgetQueryParam', () => {
           },
         ])
       )
-    ).toEqual([
+    ).toStrictEqual([
       {
         id: 0,
         type: MetricQueryType.QUERY,
@@ -232,12 +232,12 @@ describe('parseMetricWidgetQueryParam', () => {
         displayType: 'line',
         focusedSeries: [],
         powerUserMode: false,
-        sort: {order: 'asc'},
+        sort: {name: undefined, order: 'asc'},
       },
     ]);
   });
 
-  it('returns undefined if there is no valid widget', () => {
+  it('returns default widget if there is no valid widget', () => {
     expect(
       parseMetricWidgetsQueryParam(
         JSON.stringify([
@@ -250,7 +250,7 @@ describe('parseMetricWidgetQueryParam', () => {
           },
         ])
       )
-    ).toBe(undefined);
+    ).toStrictEqual(defaultState);
   });
 
   it('handles missing array in array params', () => {
@@ -265,13 +265,13 @@ describe('parseMetricWidgetQueryParam', () => {
             query: 'test:query',
             groupBy: 'dist',
             displayType: 'line',
-            focusedSeries: {seriesName: 'default', groupBy: {dist: 'default'}},
+            focusedSeries: {id: 'default', groupBy: {dist: 'default'}},
             powerUserMode: true,
             sort: {order: 'asc'},
           },
         ])
       )
-    ).toEqual([
+    ).toStrictEqual([
       {
         id: 0,
         type: MetricQueryType.QUERY,
@@ -280,7 +280,7 @@ describe('parseMetricWidgetQueryParam', () => {
         query: 'test:query',
         groupBy: ['dist'],
         displayType: 'line',
-        focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+        focusedSeries: [{id: 'default', groupBy: {dist: 'default'}}],
         powerUserMode: true,
         sort: {name: undefined, order: 'asc'},
       },
@@ -296,7 +296,7 @@ describe('parseMetricWidgetQueryParam', () => {
       query: 'test:query',
       groupBy: ['dist'],
       displayType: 'line',
-      focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+      focusedSeries: [{id: 'default', groupBy: {dist: 'default'}}],
       powerUserMode: true,
       sort: {name: 'avg', order: 'desc'},
     });
@@ -313,7 +313,7 @@ describe('parseMetricWidgetQueryParam', () => {
           widgetWithId(3),
         ])
       )
-    ).toEqual([
+    ).toStrictEqual([
       widgetWithId(0),
       widgetWithId(1),
       widgetWithId(2),
@@ -334,13 +334,13 @@ describe('parseMetricWidgetQueryParam', () => {
             query: 'test:query',
             groupBy: ['dist'],
             displayType: 'line',
-            focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+            focusedSeries: [{id: 'default', groupBy: {dist: 'default'}}],
             powerUserMode: true,
             sort: {name: 'avg', order: 'desc'},
           },
         ])
       )
-    ).toEqual([
+    ).toStrictEqual([
       {
         id: 0,
         type: MetricQueryType.QUERY,
@@ -349,7 +349,7 @@ describe('parseMetricWidgetQueryParam', () => {
         query: 'test:query',
         groupBy: ['dist'],
         displayType: 'line',
-        focusedSeries: [{seriesName: 'default', groupBy: {dist: 'default'}}],
+        focusedSeries: [{id: 'default', groupBy: {dist: 'default'}}],
         powerUserMode: true,
         sort: {name: 'avg', order: 'desc'},
       },

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -45,7 +45,7 @@ import {
   type MetricsQueryApiRequestQuery,
   useMetricsQuery,
 } from 'sentry/utils/metrics/useMetricsQuery';
-import {MetricChart} from 'sentry/views/ddm/chart';
+import {getIngestionSeriesId, MetricChart} from 'sentry/views/ddm/chart';
 import type {FocusAreaProps} from 'sentry/views/ddm/context';
 import {QuerySymbol} from 'sentry/views/ddm/querySymbol';
 import {SummaryTable} from 'sentry/views/ddm/summaryTable';
@@ -299,7 +299,7 @@ const MetricWidgetBody = memo(
       const echartsInstance = chartRef.current.getEchartsInstance();
       echartsInstance.dispatchAction({
         type: 'highlight',
-        seriesId: seriesId,
+        seriesId: [seriesId, getIngestionSeriesId(seriesId)],
       });
     }, []);
 

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -22,6 +22,7 @@ import {
   formatMetricsFormula,
   getDefaultMetricDisplayType,
   getFormattedMQL,
+  getMetricsSeriesId,
   getMetricsSeriesName,
 } from 'sentry/utils/metrics';
 import {metricDisplayTypeOptions} from 'sentry/utils/metrics/constants';
@@ -291,14 +292,14 @@ const MetricWidgetBody = memo(
 
     const chartRef = useRef<ReactEchartsRef>(null);
 
-    const setHoveredSeries = useCallback((legend: string) => {
+    const setHoveredSeries = useCallback((seriesId: string) => {
       if (!chartRef.current) {
         return;
       }
       const echartsInstance = chartRef.current.getEchartsInstance();
       echartsInstance.dispatchAction({
         type: 'highlight',
-        seriesName: legend,
+        seriesId: seriesId,
       });
     }, []);
 
@@ -306,8 +307,7 @@ const MetricWidgetBody = memo(
       return timeseriesData
         ? getChartTimeseries(timeseriesData, queries, {
             getChartPalette,
-            focusedSeries:
-              focusedSeries && new Set(focusedSeries?.map(s => s.seriesName)),
+            focusedSeries: focusedSeries && new Set(focusedSeries?.map(s => s.id)),
           })
         : [];
     }, [timeseriesData, queries, getChartPalette, focusedSeries]);
@@ -320,18 +320,16 @@ const MetricWidgetBody = memo(
         if (!focusedSeries || focusedSeries.length === 0) {
           onChange?.({
             focusedSeries: chartSeries
-              .filter(s => s.seriesName !== series.seriesName)
+              .filter(s => s.id !== series.id)
               .map(s => ({
-                seriesName: s.seriesName,
+                id: s.id,
                 groupBy: s.groupBy,
               })),
           });
           return;
         }
 
-        const filteredSeries = focusedSeries.filter(
-          s => s.seriesName !== series.seriesName
-        );
+        const filteredSeries = focusedSeries.filter(s => s.id !== series.id);
 
         if (filteredSeries.length === focusedSeries.length) {
           // The series was not focused before so we can add it
@@ -348,10 +346,7 @@ const MetricWidgetBody = memo(
     const setSeriesVisibility = useCallback(
       (series: FocusedMetricsSeries) => {
         setHoveredSeries('');
-        if (
-          focusedSeries?.length === 1 &&
-          focusedSeries[0].seriesName === series.seriesName
-        ) {
+        if (focusedSeries?.length === 1 && focusedSeries[0].id === series.id) {
           onChange?.({
             focusedSeries: [],
           });
@@ -462,21 +457,23 @@ export function getChartTimeseries(
       operation: operation,
       values: entry.series.map(normalizeValue),
       name: getMetricsSeriesName(query, entry.by, isMultiQuery),
+      id: getMetricsSeriesId(query, entry.by),
       groupBy: entry.by,
       transaction: entry.by.transaction,
       release: entry.by.release,
     }));
   });
 
-  const chartPalette = getChartPalette(series.map(s => s.name));
+  const chartPalette = getChartPalette(series.map(s => s.id));
 
   return series.map(item => ({
+    id: item.id,
     seriesName: item.name,
     groupBy: item.groupBy,
     unit: item.unit,
     operation: item.operation,
-    color: chartPalette[item.name],
-    hidden: focusedSeries && focusedSeries.size > 0 && !focusedSeries.has(item.name),
+    color: chartPalette[item.id],
+    hidden: focusedSeries && focusedSeries.size > 0 && !focusedSeries.has(item.id),
     data: item.values.map((value, index) => ({
       name: moment(data.intervals[index]).valueOf(),
       value,
@@ -492,6 +489,7 @@ export function getChartTimeseries(
 export type Series = {
   color: string;
   data: {name: number; value: number}[];
+  id: string;
   operation: string;
   seriesName: string;
   unit: string;


### PR DESCRIPTION
Assign ids to series to uniquely identify them. Use the id for coloring and highlighting.

- closes https://github.com/getsentry/sentry/issues/65376