### PR TITLE
fix(metrics_extraction): `epm` and `eps` to use standard metrics when not applicable

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -689,6 +689,9 @@ def _get_args_support(fields: Sequence[str], used_in_function: str | None = None
         # apdex can have two variations, either apdex() or apdex(value).
         return SupportedBy(on_demand_metrics=True, standard_metrics=False)
 
+    if used_in_function in ["epm", "eps"]:
+        return SupportedBy.both()
+
     arg = fields[0]
     return _get_field_support(arg)
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1063,12 +1063,10 @@ def user_misery_tag_spec(project: Project, arguments: Sequence[str] | None) -> l
 
 
 # This is used to map a metric to a function which generates a specification
-_DERIVED_METRICS: dict[MetricOperationType, TagsSpecsGenerator | None] = {
+_DERIVED_METRICS: dict[MetricOperationType, TagsSpecsGenerator] = {
     "on_demand_failure_count": failure_tag_spec,
     "on_demand_failure_rate": failure_tag_spec,
     "on_demand_apdex": apdex_tag_spec,
-    "on_demand_epm": None,
-    "on_demand_eps": None,
     "on_demand_count_web_vitals": count_web_vitals_spec,
     "on_demand_user_misery": user_misery_tag_spec,
 }

--- a/tests/sentry/snuba/metrics/test_extraction.py
+++ b/tests/sentry/snuba/metrics/test_extraction.py
@@ -38,6 +38,13 @@ def test_equality_of_specs(default_project) -> None:
         ("count_unique(geo.city)", "release:a", False),
         # transaction.duration not supported by standard metrics
         ("count()", "transaction.duration:>1", True),
+        ("epm()", "transaction.duration:>1", True),
+        ("eps()", "transaction.duration:>1", True),
+        ("epm()", "", False),  # supported by standard metrics
+        ("eps()", "", False),  # supported by standard metrics
+        # the endpoints introduce the field based on the interval
+        ("epm(900)", "", False),  # supported by standard metrics
+        ("eps(900)", "", False),  # supported by standard metrics
         ("failure_count()", "transaction.duration:>1", True),  # supported by on demand
         ("failure_rate()", "transaction.duration:>1", True),  # supported by on demand
         ("apdex(10)", "", True),  # every apdex query is on-demand
@@ -141,24 +148,18 @@ class TestCreatesOndemandMetricSpec:
         "aggregate, query",
         [
             ("count()", "release:a"),  # supported by standard metrics
-            (
-                "count_unique(user)",
-                "transaction.duration:>0",
-            ),  # count_unique not supported by on demand
+            # count_unique not supported by on demand
+            ("count_unique(user)", "transaction.duration:>0"),
             ("last_seen()", "transaction.duration:>0"),  # last_seen not supported by on demand
             ("any(user)", "transaction.duration:>0"),  # any not supported by on demand
             ("p95(transaction.duration)", ""),  # p95 without query is supported by standard metrics
             # we do not support custom percentiles that can not be mapped to one of standard percentiles
             ("percentile(transaction.duration, 0.123)", "transaction.duration>0"),
-            (
-                "count()",
-                "p75(transaction.duration):>0",
-            ),  # p75 without query is supported by standard metrics
+            # p75 without query is supported by standard metrics
+            ("count()", "p75(transaction.duration):>0"),
             ("message", "transaction.duration:>0"),  # message not supported by on demand
-            (
-                "equation| count() / count()",
-                "transaction.duration:>0",
-            ),  # equation not supported by on demand
+            # equation not supported by on demand
+            ("equation| count() / count()", "transaction.duration:>0"),
             ("p75(measurements.lcp)", "!event.type:transaction"),  # supported by standard metrics
             # supported by standard metrics
             ("p95(measurements.lcp)", ""),

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1428,7 +1428,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             "fields": {"time": "date", "epm_900": "rate"},
             "units": {"time": None, "epm_900": None},
             "isMetricsData": True,
-            "isMetricsExtractedData": True,
+            "isMetricsExtractedData": False,
             "tips": {},
             "datasetReason": "unchanged",
             "dataset": "metricsEnhanced",

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1410,6 +1410,30 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             dataset="metricsEnhanced",
         )
 
+    def test_on_demand_epm_no_query(self):
+        params = {
+            "dataset": "metricsEnhanced",
+            "environment": "production",
+            "onDemandType": "dynamic_query",
+            "project": self.project.id,
+            "query": "",
+            "statsPeriod": "1h",
+            "useOnDemandMetrics": "true",
+            "yAxis": ["epm()"],
+        }
+        response = self.do_request(params)
+
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "fields": {"time": "date", "epm_900": "rate"},
+            "units": {"time": None, "epm_900": None},
+            "isMetricsData": True,
+            "isMetricsExtractedData": True,
+            "tips": {},
+            "datasetReason": "unchanged",
+            "dataset": "metricsEnhanced",
+        }
+
     def test_group_by_transaction(self):
         field = "count()"
         groupbys = ["transaction"]


### PR DESCRIPTION
The task would call `should_use_on_demand` with `epm()` while the endpoint would call with `epm(900)`. In either case, we should be using standard metrics since the query is empty.