### PR TITLE
feat(trace) Adding child txn embedding when zooming in.

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
@@ -366,7 +366,8 @@ describe('TraceTree', () => {
   it('builds from spans and copies txn nodes', () => {
     // transaction                transaction
     //  - child transaction  ->    - span
-    //                             - child-transaction
+    //                             - span
+    //                               - child-transaction
     //                             - span
     const root = new TraceTreeNode(
       null,
@@ -401,7 +402,8 @@ describe('TraceTree', () => {
       {sdk: undefined}
     );
 
-    assertTransactionNode(node.children[1]);
+    assertSpanNode(node.children[1]);
+    assertTransactionNode(node.children[1].children[0]);
   });
 
   it('builds from spans and copies txn nodes to nested children', () => {
@@ -448,8 +450,9 @@ describe('TraceTree', () => {
       {sdk: undefined}
     );
 
-    assertTransactionNode(node.children[1]);
+    assertSpanNode(node.children[1]);
     assertTransactionNode(node.children[1].children[0]);
+    assertTransactionNode(node.children[1].children[0].children[0]);
   });
 
   it('injects missing spans', () => {

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -353,7 +353,7 @@ export class TraceTree {
       // of the txn as a child of the parenting span.
       if (childTxn) {
         const clonedChildTxn =
-          childTxn.deepClone() as unknown as TraceTreeNode<TraceTree.Span>;
+          childTxn.cloneDeep() as unknown as TraceTreeNode<TraceTree.Span>;
         node.spanChildren.push(clonedChildTxn);
         clonedChildTxn.parent = node;
       }
@@ -742,7 +742,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     }
   }
 
-  deepClone(): TraceTreeNode<T> {
+  cloneDeep(): TraceTreeNode<T> {
     const node = new TraceTreeNode(this.parent, this.value, this.metadata);
     node.expanded = this.expanded;
     node.zoomedIn = this.zoomedIn;
@@ -751,7 +751,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     node.metadata = this.metadata;
 
     for (const child of this.children) {
-      const childClone = child.deepClone() as TraceTreeNode<TraceTree.Span>;
+      const childClone = child.cloneDeep() as TraceTreeNode<TraceTree.Span>;
       node.children.push(childClone);
       childClone.parent = node;
     }


### PR DESCRIPTION
Instead of replacing the parent span, we add the txn as a child to it: 
<img width="770" alt="Screenshot 2024-02-22 at 10 52 20 AM" src="https://github.com/getsentry/sentry/assets/60121741/07e42e67-68e0-4423-8872-ed6ee9dac006">
