### PR TITLE
fix(security): do not set `X-Frame-Options` header on jira glance page

### DIFF
--- a/src/sentry/middleware/security.py
+++ b/src/sentry/middleware/security.py
@@ -9,7 +9,8 @@ class SecurityHeadersMiddleware(MiddlewareMixin):
     """
 
     def process_response(self, request: Request, response: Response) -> Response:
-        response.setdefault("X-Frame-Options", "deny")
+        if not request.path.startswith("/extensions/jira/issue/"):
+            response.setdefault("X-Frame-Options", "deny")
         response.setdefault("X-Content-Type-Options", "nosniff")
         response.setdefault("X-XSS-Protection", "1; mode=block")
         return response

--- a/tests/sentry/integrations/jira/test_csp.py
+++ b/tests/sentry/integrations/jira/test_csp.py
@@ -20,6 +20,7 @@ class JiraCSPTest(APITestCase):
     def test_csp_frame_ancestors(self):
         response = self.client.get(self.path)
         assert "Content-Security-Policy-Report-Only" in response
+        assert "X-Frame-Options" not in response
 
         csp = self._split_csp_policy(response["Content-Security-Policy-Report-Only"])
         assert "base_url" in csp["frame-ancestors"]


### PR DESCRIPTION
Do not set `X-Frame-Options` header for `/extensions/jira/issue/` pages (aka Jira issue glances). Although it is superseded by `frame-ancestors` keyword of CSP, but it takes effect when CSP is in report-only mode:
* local development environment;
* in production, when CSP is switched to report-only mode for tests.