### PR TITLE
chore(team-org-roles): remove Organization "get_teams_with_org_role"

### DIFF
--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -153,10 +153,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
                     queryset = queryset.filter(role__in=[r.id for r in roles.with_any_scope(value)])
 
                 elif key == "role":
-                    members_with_role = organization.get_members_with_org_roles(
-                        roles=value, include_null_users=True
-                    ).values_list("id", flat=True)
-                    queryset = queryset.filter(id__in=members_with_role)
+                    queryset = queryset.filter(role__in=value)
 
                 elif key == "isInvited":
                     isInvited = "true" in value

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -49,15 +49,9 @@ def has_role_in_organization(role: str, organization: Organization, user_id: int
         user_is_active=True,
         user_id=user_id,
         organization_id=organization.id,
+        role=role,
     )
-    teams_with_org_role = organization.get_teams_with_org_roles([role])
-    return bool(
-        query.filter(role=role).exists()
-        or OrganizationMemberTeam.objects.filter(
-            team__in=teams_with_org_role,
-            organizationmember_id__in=list(query.values_list("id", flat=True)),
-        ).exists()
-    )
+    return query.exists()
 
 
 class Access(abc.ABC):

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -33,10 +33,7 @@ from sentry.db.models.utils import slugify_instance
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.locks import locks
 from sentry.models.options.option import OptionMixin
-from sentry.models.organizationmember import OrganizationMember
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import OutboxCategory
-from sentry.models.team import Team
 from sentry.roles.manager import Role
 from sentry.services.hybrid_cloud.notifications import notifications_service
 from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
@@ -135,11 +132,6 @@ class OrganizationManager(BaseManager["Organization"]):
         The default top priority role in Sentry is owner.
         """
 
-        orgs = Organization.objects.filter(
-            member_set__user_id=user_id,
-            status=OrganizationStatus.ACTIVE,
-        )
-
         # get owners from orgs
         owner_role_orgs = Organization.objects.filter(
             member_set__user_id=user_id,
@@ -147,18 +139,7 @@ class OrganizationManager(BaseManager["Organization"]):
             member_set__role=roles.get_top_dog().id,
         )
 
-        # get owner teams
-        owner_teams = Team.objects.filter(
-            organization__in=orgs, org_role=roles.get_top_dog().id
-        ).values_list("id", flat=True)
-
-        # get the orgs in which the user is a member of an owner team
-        owner_team_member_orgs = OrganizationMemberTeam.objects.filter(
-            team_id__in=owner_teams
-        ).values_list("organizationmember__organization_id", flat=True)
-
-        # use .union() (UNION) as opposed to | (OR) because it's faster
-        return self.filter(id__in=owner_team_member_orgs).union(owner_role_orgs)
+        return owner_role_orgs
 
 
 @region_silo_only_model
@@ -361,28 +342,12 @@ class Organization(
         roles: Collection[str],
         include_null_users: bool = False,
     ):
-        members_with_role_query = self.member_set.filter(role__in=roles)
+        members_with_role = self.member_set.filter(role__in=roles)
         if not include_null_users:
-            user_ids = members_with_role_query.filter(
-                user_id__isnull=False, user_is_active=True
-            ).values_list("user_id", flat=True)
-            members_with_role_query = members_with_role_query.filter(user_id__in=user_ids)
-
-        members_with_role = set(members_with_role_query.values_list("id", flat=True))
-
-        teams_with_org_role = self.get_teams_with_org_roles(roles).values_list("id", flat=True)
-
-        # may be empty
-        members_on_teams_with_role = set(
-            OrganizationMemberTeam.objects.filter(team_id__in=teams_with_org_role).values_list(
-                "organizationmember__id", flat=True
-            )
-        )
+            members_with_role = members_with_role.filter(user_id__isnull=False, user_is_active=True)
 
         # use union of sets because a subset may be empty
-        return OrganizationMember.objects.filter(
-            id__in=members_with_role.union(members_on_teams_with_role)
-        )
+        return members_with_role
 
     @property
     def option_manager(self) -> OptionManager:
@@ -454,11 +419,3 @@ class Organization(
         if not self.get_option("sentry:alerts_member_write", ALERTS_MEMBER_WRITE_DEFAULT):
             scopes.discard("alerts:write")
         return frozenset(scopes)
-
-    def get_teams_with_org_roles(self, roles: Collection[str] | None) -> QuerySet:
-        from sentry.models.team import Team
-
-        if roles is not None:
-            return Team.objects.filter(org_role__in=roles, organization=self)
-
-        return Team.objects.filter(organization=self).exclude(org_role=None)

--- a/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from abc import ABCMeta
-from collections.abc import Iterable, MutableMapping
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING
+
+from django.db.models import QuerySet
 
 from sentry import roles
 from sentry.models.organizationmember import OrganizationMember
@@ -51,15 +53,13 @@ class RoleBasedRecipientStrategy(metaclass=ABCMeta):
         # convert members to users
         return user_service.get_many(filter={"user_ids": [member.user_id for member in members]})
 
-    def determine_member_recipients(self) -> Iterable[OrganizationMember]:
+    def determine_member_recipients(self) -> QuerySet[OrganizationMember]:
         """
         Depending on the type of request this might be all organization owners,
         a specific person, or something in between.
         """
         # default strategy is OrgMembersRecipientStrategy
-        members: Iterable[
-            OrganizationMember
-        ] = OrganizationMember.objects.get_contactable_members_for_org(self.organization.id)
+        members = OrganizationMember.objects.get_contactable_members_for_org(self.organization.id)
 
         if not self.scope and not self.role:
             return members

--- a/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
@@ -72,11 +72,7 @@ class RoleBasedRecipientStrategy(metaclass=ABCMeta):
         elif self.scope:
             valid_roles = [r.id for r in roles.get_all() if r.has_scope(self.scope)]
 
-        member_ids = self.organization.get_members_with_org_roles(roles=valid_roles).values_list(
-            "id", flat=True
-        )
-        # ignore type because of optional filtering
-        members = members.filter(id__in=member_ids)  # type: ignore[attr-defined]
+        members = members.filter(role__in=valid_roles)
 
         return members
 

--- a/src/sentry/receivers/owners.py
+++ b/src/sentry/receivers/owners.py
@@ -1,10 +1,7 @@
-from django.db.models.signals import pre_delete, pre_save
+from django.db.models.signals import pre_save
 from rest_framework.serializers import ValidationError
 
-from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
-from sentry.models.team import Team
-from sentry.roles import organization_roles
 
 
 def _assert_org_has_owner_not_from_team(organization, top_role):
@@ -27,53 +24,9 @@ def prevent_demoting_last_owner(instance: OrganizationMember, **kwargs):
         raise ValidationError(detail="An organization must have at least one owner")
 
 
-def prevent_demoting_last_owner_team(instance: Team, **kwargs):
-    # if a team is being created
-    if instance.id is None:
-        return  # type: ignore[unreachable]
-
-    try:
-        team = Team.objects.get(id=instance.id)
-    except Team.DoesNotExist:
-        return
-
-    organization = Organization.objects.get_from_cache(id=team.organization_id)
-    top_role = organization_roles.get_top_dog().id
-
-    all_owner_teams = organization.get_teams_with_org_roles(roles=[top_role])
-
-    # demoting last owner team
-    if len(all_owner_teams) == 1 and team.org_role == top_role and instance.org_role != top_role:
-        _assert_org_has_owner_not_from_team(organization, top_role)
-
-
-def prevent_removing_last_owner_team(instance: Team, **kwargs):
-    organization = Organization.objects.get_from_cache(id=instance.organization_id)
-    top_role = organization_roles.get_top_dog().id
-
-    all_owner_teams = organization.get_teams_with_org_roles(roles=[top_role])
-
-    # removing last owner team
-    if len(all_owner_teams) == 1:
-        _assert_org_has_owner_not_from_team(organization, top_role)
-
-
 pre_save.connect(
     prevent_demoting_last_owner,
     sender=OrganizationMember,
     dispatch_uid="prevent_demoting_last_owner",
-    weak=False,
-)
-
-pre_save.connect(
-    prevent_demoting_last_owner_team,
-    sender=Team,
-    dispatch_uid="prevent_demoting_last_owner_team",
-    weak=False,
-)
-pre_delete.connect(
-    prevent_removing_last_owner_team,
-    sender=Team,
-    dispatch_uid="prevent_deleting_last_owner_team",
     weak=False,
 )

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -57,27 +57,22 @@ class OrganizationsListTest(OrganizationIndexTest):
 
         user2 = self.create_user(email="user2@example.com")
         org3 = self.create_organization(name="C", owner=user2)
-        org4 = self.create_organization(name="D", owner=user2)
-        org5 = self.create_organization(name="E", owner=user2)
+        self.create_organization(name="D", owner=user2)
+        org4 = self.create_organization(name="E", owner=user2)
 
         self.create_member(user=user2, organization=org2, role="owner")
         self.create_member(user=self.user, organization=org3, role="owner")
 
-        owner_team = self.create_team(organization=org4, org_role="owner")
-        # org4 has 2 owners
-        self.create_member(user=self.user, organization=org4, role="member", teams=[owner_team])
-        self.create_member(user=self.user, organization=org5, role="member")
+        self.create_member(user=self.user, organization=org4, role="member")
 
         response = self.get_success_response(qs_params={"owner": 1})
-        assert len(response.data) == 4
+        assert len(response.data) == 3
         assert response.data[0]["organization"]["id"] == str(org.id)
         assert response.data[0]["singleOwner"] is True
         assert response.data[1]["organization"]["id"] == str(org2.id)
         assert response.data[1]["singleOwner"] is False
         assert response.data[2]["organization"]["id"] == str(org3.id)
         assert response.data[2]["singleOwner"] is False
-        assert response.data[3]["organization"]["id"] == str(org4.id)
-        assert response.data[3]["singleOwner"] is False
 
     def test_status_query(self):
         org = self.create_organization(owner=self.user, status=OrganizationStatus.PENDING_DELETION)

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -262,27 +262,17 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
         assert response.data[0]["email"] == self.user.email
 
     def test_role_query(self):
-        member_team = self.create_team(organization=self.organization, org_role="member")
-        user = self.create_user("zoo@localhost", username="zoo")
-        self.create_member(
-            user=user,
-            organization=self.organization,
-            role="owner",
-            teams=[member_team],
-        )
         response = self.get_success_response(
             self.organization.slug, qs_params={"query": "role:member"}
         )
-        assert len(response.data) == 2
+        assert len(response.data) == 1
         assert response.data[0]["email"] == self.user2.email
-        assert response.data[1]["email"] == user.email
 
         response = self.get_success_response(
             self.organization.slug, qs_params={"query": "role:owner"}
         )
-        assert len(response.data) == 2
+        assert len(response.data) == 1
         assert response.data[0]["email"] == self.user.email
-        assert response.data[1]["email"] == user.email
 
     def test_is_invited_query(self):
         response = self.get_success_response(

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -43,29 +43,6 @@ class ProjectTransferTest(APITestCase):
             assert len(mail.outbox) == 1
             assert "http://testserver/accept-transfer/?" in mail.outbox[0].body
 
-    def test_transfer_project_owner_from_team(self):
-        project = self.create_project()
-        organization = project.organization
-
-        new_user = self.create_user("b@example.com")
-        org = self.create_organization(name="New Org")
-        owner_team = self.create_team(organization=org, org_role="owner")
-        self.create_member(organization=org, user=new_user, teams=[owner_team])
-
-        self.login_as(user=self.user)
-
-        url = reverse(
-            "sentry-api-0-project-transfer",
-            kwargs={"organization_slug": organization.slug, "project_slug": project.slug},
-        )
-
-        with self.tasks():
-            response = self.client.post(url, {"email": new_user.email})
-
-            assert response.status_code == 204
-            assert len(mail.outbox) == 1
-            assert organization.absolute_url("/accept-transfer/?") in mail.outbox[0].body
-
     def test_transfer_project_to_invalid_user(self):
         project = self.create_project()
         # new user is not an owner of anything

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -111,12 +111,6 @@ class SlackIntegrationLinkTeamTestBase(TestCase):
         )
         self.login_as(user)
 
-    def _create_user_with_member_role_through_team(self):
-        user = self.create_user(email="foo@example.com")
-        member_team = self.create_team(org_role="member")
-        self.create_member(organization=self.organization, user=user, teams=[member_team])
-        self.login_as(user)
-
 
 @region_silo_test
 class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
@@ -192,13 +186,6 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
         self.get_error_response(
             data={"team": ["some", "garbage"]}, status_code=status.HTTP_400_BAD_REQUEST
         )
-
-    @responses.activate
-    def test_errors_when_no_teams_found(self):
-        """Test that we successfully render an error page when no teams are found."""
-        # login as a member with no applicable teams
-        self._create_user_with_member_role_through_team()
-        self.get_error_response(status_code=status.HTTP_404_NOT_FOUND)
 
     @responses.activate
     def test_link_team_multiple_organizations(self):
@@ -307,13 +294,6 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
         self._create_user_valid_through_team_admin()
 
         self.test_unlink_team()
-
-    @responses.activate
-    def test_unlink_team_with_member_role_through_team(self):
-        """Test that a team can not be unlinked from a Slack channel with a member role"""
-        self._create_user_with_member_role_through_team()
-
-        self.get_error_response(status_code=status.HTTP_404_NOT_FOUND)
 
     @responses.activate
     def test_unlink_multiple_teams(self):

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -74,13 +74,6 @@ class OrganizationTest(TestCase, HybridCloudTestMixin):
         org = self.create_organization()
         assert org.default_owner_id is None
 
-    def test_default_owner_id_only_owner_through_team(self):
-        user = self.create_user("foo@example.com")
-        org = self.create_organization()
-        owner_team = self.create_team(organization=org, org_role="owner")
-        self.create_member(organization=org, user=user, teams=[owner_team])
-        assert org.default_owner_id == user.id
-
     @mock.patch.object(
         Organization, "get_owners", side_effect=Organization.get_owners, autospec=True
     )

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -517,48 +517,6 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
                 roles.get("carol"),
             ]
 
-    def test_get_allowed_org_roles_to_invite_subset_member_logic(self):
-        """
-        There are two org options which mutate org member scopes:
-            1. sentry:events_member_admin - if True, members have events:admin
-            2. sentry:alerts_member_write - if True, members have alerts:write
-        These settings are both True by default, although in the SENTRY_ROLES
-        config, we default to giving member alerts:write but not events:admin.
-        """
-        org_member = self.create_member(
-            user=self.create_user(), organization=self.organization, role="member"
-        )
-
-        assert "event:admin" in org_member.get_scopes()
-        assert "alerts:write" in org_member.get_scopes()
-
-        assert org_member.get_allowed_org_roles_to_invite() == [
-            roles.get("member"),
-        ]
-
-        self.organization.update_option("sentry:events_member_admin", False)
-        self.organization.update_option("sentry:events_member_admin", False)
-
-        assert org_member.get_allowed_org_roles_to_invite() == [
-            roles.get("member"),
-        ]
-
-    def test_org_roles_by_source(self):
-        manager_team = self.create_team(organization=self.organization, org_role="manager")
-        owner_team = self.create_team(organization=self.organization, org_role="owner")
-        owner_team2 = self.create_team(organization=self.organization, org_role="owner")
-        member = self.create_member(
-            organization=self.organization,
-            teams=[manager_team, owner_team, owner_team2],
-            user=self.create_user(),
-            role="member",
-        )
-
-        roles = member.get_org_roles_from_teams_by_source()
-        assert roles[0][1].id == "owner"
-        assert roles[-1][0] == manager_team.slug
-        assert roles[-1][1].id == "manager"
-
     def test_cannot_demote_last_owner(self):
         org = self.create_organization()
 

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -1,6 +1,4 @@
-import pytest
 from django.test import override_settings
-from rest_framework.serializers import ValidationError
 
 from sentry.models.notificationsettingoption import NotificationSettingOption
 from sentry.models.notificationsettingprovider import NotificationSettingProvider
@@ -67,17 +65,6 @@ class TeamTest(TestCase):
         assert team.id < 1_000_000_000
         assert Team.objects.filter(id=team.id).exists()
 
-    def test_cannot_demote_last_owner_team(self):
-        org = self.create_organization()
-
-        with pytest.raises(ValidationError):
-            team = self.create_team(org, org_role="owner")
-            self.create_member(
-                organization=org, role="member", user=self.create_user(), teams=[team]
-            )
-            team.org_role = "manager"
-            team.save()
-
 
 @region_silo_test
 class TeamDeletionTest(TestCase):
@@ -115,13 +102,3 @@ class TeamDeletionTest(TestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert not NotificationSettingOption.objects.filter(**base_params).exists()
             assert not NotificationSettingProvider.objects.filter(**base_params).exists()
-
-    def test_cannot_delete_last_owner_team(self):
-        org = self.create_organization()
-
-        with pytest.raises(ValidationError):
-            team = self.create_team(org, org_role="owner")
-            self.create_member(
-                organization=org, role="member", user=self.create_user(), teams=[team]
-            )
-            team.delete()

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -84,14 +84,6 @@ class FetchCommitsTest(TestCase):
         Repository.objects.create(name="example", provider="dummy", organization_id=org.id)
         self._test_simple_action(user=self.user, org=org)
 
-    def test_simple_owner_from_team(self):
-        user = self.create_user()
-        self.login_as(user=user)
-        org = self.create_organization(name="baz")
-        owner_team = self.create_team(organization=org, org_role="owner")
-        self.create_member(organization=org, user=user, teams=[owner_team])
-        self._test_simple_action(user=user, org=org)
-
     def test_release_locked(self):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")


### PR DESCRIPTION
Part of an ongoing effort to remove the org roles for teams feature https://github.com/getsentry/team-core-product-foundations/issues/51

We can remove the `get_teams_with_org_role` function from the `Organization` model. This is being used in a variety of places to determine the members with (a) particular org role(s). We don't need this because we're only using the `role` on the `OrganizationMember` model to determine is someone has some org role.

NOTE: most of the lines changed are deleted tests

Refactor changes
- Endpoints: OrganizationMemberIndex
- access.py: `has_role_in_organization` should just check if somebody has the org role on the `OrganizationMember` model
- Models: Organization, OrganizationMember
- RoleBasedRecipientStrategy
- Demoting owner receiver now only checks for the role on the OrganizationMember model not any teams
- Tests: removed tests relating to depending on team membership to grant access