### PR TITLE
feat(sidebar):  Always show all tabs in the Organization Settings view (Part 2)

### DIFF
--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -30,7 +30,6 @@ const organizationNavigation: NavigationSection[] = [
       {
         path: `${pathPrefix}/members/`,
         title: t('Members'),
-        show: ({access}) => access!.has('member:read'),
         description: t('Manage user membership for an organization'),
         id: 'members',
       },
@@ -64,8 +63,7 @@ const organizationNavigation: NavigationSection[] = [
       {
         path: `${pathPrefix}/rate-limits/`,
         title: t('Rate Limits'),
-        show: ({access, features}) =>
-          features!.has('legacy-rate-limits') && access!.has('org:write'),
+        show: ({features}) => features!.has('legacy-rate-limits'),
         description: t('Configure rate limits for all projects in the organization'),
         id: 'rate-limits',
       },

--- a/static/app/views/settings/organizationRateLimits/index.tsx
+++ b/static/app/views/settings/organizationRateLimits/index.tsx
@@ -1,11 +1,20 @@
 import withOrganization from 'sentry/utils/withOrganization';
+import PermissionAlert from 'sentry/views/settings/organization/permissionAlert';
 
 import OrganizationRateLimits from './organizationRateLimits';
 
 function OrganizationRateLimitsContainer(
   props: React.ComponentProps<typeof OrganizationRateLimits>
 ) {
-  return !props.organization ? null : <OrganizationRateLimits {...props} />;
+  if (!props.organization) {
+    return null;
+  }
+
+  return props.organization.access.includes('org:write') ? (
+    <OrganizationRateLimits {...props} />
+  ) : (
+    <PermissionAlert />
+  );
 }
 
 export default withOrganization(OrganizationRateLimitsContainer);


### PR DESCRIPTION
* Removed show prop so tabs are always shown regardless of access
* Continuation of https://github.com/getsentry/getsentry/pull/13022

Rate-limit page
<img width="948" alt="image" src="https://github.com/getsentry/sentry/assets/33237075/f9650136-16c2-4b6f-b969-deddb0a7e5c0">

 