### PR TITLE
ref: fix tz unaware warning in apidocs test_deploys

### DIFF
--- a/tests/apidocs/endpoints/releases/test_deploys.py
+++ b/tests/apidocs/endpoints/releases/test_deploys.py
@@ -18,7 +18,7 @@ class ReleaseDeploysDocs(APIDocsTestCase):
             ).id,
             organization_id=project.organization_id,
             release=release,
-            date_finished=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            date_finished=datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1),
         )
         Deploy.objects.create(
             environment_id=Environment.objects.create(


### PR DESCRIPTION
this warning is currently disabled but causes a lot of spam in production and will eventually be an error

```
E   RuntimeWarning: DateTimeField Deploy.date_finished received a naive datetime (2024-02-21 17:34:16.042242) while time zone support is active.
```

<!-- Describe your PR here. -->