### PR TITLE
fix(issue-priority): Allow is:unresolved to be set as the default search

### DIFF
--- a/static/app/views/issueList/issueListSetAsDefault.tsx
+++ b/static/app/views/issueList/issueListSetAsDefault.tsx
@@ -95,8 +95,8 @@ function IssueListSetAsDefault({organization, sort, query}: IssueListSetAsDefaul
   // Hide if we are already on the default search,
   // except when the user has a different search pinned.
   if (
-    isDefaultIssueStreamSearch({query, sort}) &&
-    (!pinnedSearch || isDefaultIssueStreamSearch(pinnedSearch))
+    isDefaultIssueStreamSearch({query, sort}, {organization}) &&
+    (!pinnedSearch || isDefaultIssueStreamSearch(pinnedSearch, {organization}))
   ) {
     return null;
   }

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -175,11 +175,15 @@ export enum IssueSortOptions {
 
 export const DEFAULT_ISSUE_STREAM_SORT = IssueSortOptions.DATE;
 
-export function isDefaultIssueStreamSearch({query, sort}: {query: string; sort: string}) {
-  return (
-    (query === DEFAULT_QUERY || query === NEW_DEFAULT_QUERY) &&
-    sort === DEFAULT_ISSUE_STREAM_SORT
-  );
+export function isDefaultIssueStreamSearch(
+  {query, sort}: {query: string; sort: string},
+  {organization}: {organization: Organization}
+) {
+  const defaultQuery = organization.features.includes('issue-priority-ui')
+    ? NEW_DEFAULT_QUERY
+    : DEFAULT_QUERY;
+
+  return query === defaultQuery && sort === DEFAULT_ISSUE_STREAM_SORT;
 }
 
 export function getSortLabel(key: string) {


### PR DESCRIPTION
We hide the "Set as Default" button when on the default search. This ensures that the button shows up on `is:unresolved` if the issue priority flag is enabled.