### PR TITLE
ref: re-enable requiring tz-aware datetimes warning in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ filterwarnings = [
   "ignore:Type google\\._upb.*",
 
   # The following warning filters are for pytest only.
-  # This is so we don't have to wrap most datetime objects in testing code
-  # with django.utils.timezone.
-  "ignore:DateTimeField.*naive datetime:RuntimeWarning",
   "ignore:.*sentry.digests.backends.dummy.DummyBackend.*:sentry.utils.warnings.UnsupportedBackend",
 
   # pytest has not yet implemented the replacement for this yet


### PR DESCRIPTION
<!-- Describe your PR here. -->