### PR TITLE
ref(query-builder): Unify rounded timestamp and examples functions de…

### DIFF
--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1002,45 +1002,16 @@ class DiscoverDatasetConfig(DatasetConfig):
                 ),
                 SnQLFunction(
                     "example",
-                    snql_aggregate=lambda args, alias: Function(
-                        "arrayElement",
-                        [
-                            Function(
-                                "groupArraySample(1, 1)",  # TODO: paginate via the seed
-                                [
-                                    Function(
-                                        "tuple",
-                                        [Column("timestamp"), Column("span_id")],
-                                    ),
-                                ],
-                            ),
-                            1,
-                        ],
-                        alias,
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_random_sample(
+                        ["timestamp", "span_id"], alias
                     ),
                     private=True,
                 ),
                 SnQLFunction(
                     "rounded_timestamp",
                     required_args=[IntervalDefault("interval", 1, None)],
-                    snql_column=lambda args, alias: Function(
-                        "toUInt32",
-                        [
-                            Function(
-                                "multiply",
-                                [
-                                    Function(
-                                        "intDiv",
-                                        [
-                                            Function("toUInt32", [Column("timestamp")]),
-                                            args["interval"],
-                                        ],
-                                    ),
-                                    args["interval"],
-                                ],
-                            ),
-                        ],
-                        alias,
+                    snql_column=lambda args, alias: function_aliases.resolve_rounded_timestamp(
+                        args["interval"], alias
                     ),
                     private=True,
                 ),

--- a/src/sentry/search/events/datasets/function_aliases.py
+++ b/src/sentry/search/events/datasets/function_aliases.py
@@ -323,3 +323,36 @@ def resolve_division(
         ],
         alias,
     )
+
+
+def resolve_rounded_timestamp(interval: int, alias: str, timestamp_column: str = "timestamp"):
+    return Function(
+        "toUInt32",
+        [
+            Function(
+                "multiply",
+                [
+                    Function(
+                        "intDiv",
+                        [Function("toUInt32", [Column(timestamp_column)]), interval],
+                    ),
+                    interval,
+                ],
+            ),
+        ],
+        alias,
+    )
+
+
+def resolve_random_sample(columns: list[str], alias: str, seed: int = 1):
+    return Function(
+        "arrayElement",
+        [
+            Function(
+                f"groupArraySample(1, {seed})",
+                [Function("tuple", [Column(column) for column in columns])],
+            ),
+            1,
+        ],
+        alias,
+    )

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -7,7 +7,7 @@ from snuba_sdk import Column, Direction, Function, OrderBy
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events import builder, constants
-from sentry.search.events.datasets import field_aliases, filter_aliases
+from sentry.search.events.datasets import field_aliases, filter_aliases, function_aliases
 from sentry.search.events.datasets.base import DatasetConfig
 from sentry.search.events.fields import (
     ColumnTagArg,
@@ -195,45 +195,16 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                 ),
                 SnQLFunction(
                     "example",
-                    snql_aggregate=lambda args, alias: Function(
-                        "arrayElement",
-                        [
-                            Function(
-                                "groupArraySample(1, 1)",  # TODO: paginate via the seed
-                                [
-                                    Function(
-                                        "tuple",
-                                        [Column("group"), Column("timestamp"), Column("span_id")],
-                                    ),
-                                ],
-                            ),
-                            1,
-                        ],
-                        alias,
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_random_sample(
+                        ["group", "timestamp", "span_id"], alias
                     ),
                     private=True,
                 ),
                 SnQLFunction(
                     "rounded_timestamp",
                     required_args=[IntervalDefault("interval", 1, None)],
-                    snql_column=lambda args, alias: Function(
-                        "toUInt32",
-                        [
-                            Function(
-                                "multiply",
-                                [
-                                    Function(
-                                        "intDiv",
-                                        [
-                                            Function("toUInt32", [Column("timestamp")]),
-                                            args["interval"],
-                                        ],
-                                    ),
-                                    args["interval"],
-                                ],
-                            ),
-                        ],
-                        alias,
+                    snql_column=lambda args, alias: function_aliases.resolve_rounded_timestamp(
+                        args["interval"], alias
                     ),
                     private=True,
                 ),


### PR DESCRIPTION
…finition

These functions have been defined 3 times in different datasets now. Move them to a shared utility for better reuse.