### PR TITLE
feat(issue-priority): Replace Priority search with Trends in the search backend #65297

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -43,7 +43,7 @@ COMMIT_RANGE_DELIMITER = ".."
 SEMVER_FAKE_PACKAGE = "__sentry_fake__"
 
 SORT_OPTIONS = {
-    "priority": _("Priority"),
+    "trends": _("Trends"),
     "date": _("Last Seen"),
     "new": _("First Seen"),
     "freq": _("Frequency"),

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -42,7 +42,9 @@ COMMIT_RANGE_DELIMITER = ".."
 # semver constants
 SEMVER_FAKE_PACKAGE = "__sentry_fake__"
 
+# TODO(snigdha): we will need to remove priority from here once we have renamed all instances to trends
 SORT_OPTIONS = {
+    "priority": _("Priority"),
     "trends": _("Trends"),
     "date": _("Last Seen"),
     "new": _("First Seen"),

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -185,6 +185,10 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                 result = inbox_search(**query_kwargs)
             else:
                 query_kwargs["referrer"] = "search.group_index"
+                # TODO(snigdha): remove this once we've migrated saved searches to replace priority with trends
+                if query_kwargs["sort_by"] == "priority":
+                    query_kwargs["sort_by"] = "trends"
+
                 result = search.query(**query_kwargs)
             return result, query_kwargs
 

--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -39,7 +39,6 @@ def bulk_transition_group_to_ongoing(
     for group in groups_to_transistion:
         group.status = GroupStatus.UNRESOLVED
         group.substatus = GroupSubStatus.ONGOING
-        # TODO(snigdha): do we need to update the priority here?
 
     with sentry_sdk.start_span(description="bulk_remove_groups_from_inbox"):
         bulk_remove_groups_from_inbox(groups_to_transistion)

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -83,7 +83,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             activity_type = ActivityType.SET_REGRESSION
         elif new_substatus == GroupSubStatus.ONGOING:
             if group.substatus == GroupSubStatus.ESCALATING:
-                # If the group was previously escalating, we need to update the priority via AUTO_SET_ONGOING
+                # If the group was previously escalating, update the priority via AUTO_SET_ONGOING
                 activity_type = ActivityType.AUTO_SET_ONGOING
             else:
                 activity_type = ActivityType.SET_UNRESOLVED

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -17,7 +17,7 @@ from sentry.models.search_common import SearchType
 class SortOptions:
     DATE = "date"
     NEW = "new"
-    PRIORITY = "priority"
+    TRENDS = "trends"
     FREQ = "freq"
     USER = "user"
     INBOX = "inbox"
@@ -27,7 +27,7 @@ class SortOptions:
         return (
             (cls.DATE, _("Last Seen")),
             (cls.NEW, _("First Seen")),
-            (cls.PRIORITY, _("Priority")),
+            (cls.TRENDS, _("Trends")),
             (cls.FREQ, _("Events")),
             (cls.USER, _("Users")),
             (cls.INBOX, _("Date Added")),

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -17,6 +17,7 @@ from sentry.models.search_common import SearchType
 class SortOptions:
     DATE = "date"
     NEW = "new"
+    PRIORITY = "priority"
     TRENDS = "trends"
     FREQ = "freq"
     USER = "user"
@@ -27,6 +28,7 @@ class SortOptions:
         return (
             (cls.DATE, _("Last Seen")),
             (cls.NEW, _("First Seen")),
+            (cls.PRIORITY, _("Priority")),
             (cls.TRENDS, _("Trends")),
             (cls.FREQ, _("Events")),
             (cls.USER, _("Users")),

--- a/src/sentry/search/base.py
+++ b/src/sentry/search/base.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from sentry.models.environment import Environment
     from sentry.models.group import Group
     from sentry.models.project import Project
-    from sentry.search.snuba.executors import PrioritySortWeights
+    from sentry.search.snuba.executors import TrendsSortWeights
     from sentry.utils.cursors import Cursor, CursorResult
 
 
@@ -40,6 +40,6 @@ class SearchBackend(Service):
         max_hits: int | None = None,
         referrer: str | None = None,
         actor: Any | None = None,
-        aggregate_kwargs: PrioritySortWeights | None = None,
+        aggregate_kwargs: TrendsSortWeights | None = None,
     ) -> CursorResult[Group]:
         raise NotImplementedError

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -39,7 +39,7 @@ from sentry.search.snuba.executors import (
     CdcPostgresSnubaQueryExecutor,
     InvalidQueryForExecutor,
     PostgresSnubaQueryExecutor,
-    PrioritySortWeights,
+    TrendsSortWeights,
 )
 from sentry.utils import metrics
 from sentry.utils.cursors import Cursor, CursorResult
@@ -273,7 +273,7 @@ def _group_attributes_side_query(
     max_hits: int | None = None,
     referrer: str | None = None,
     actor: Any | None = None,
-    aggregate_kwargs: PrioritySortWeights | None = None,
+    aggregate_kwargs: TrendsSortWeights | None = None,
 ) -> None:
     def __run_joined_query_and_log_metric(
         events_only_search_results: CursorResult[Group],
@@ -293,7 +293,7 @@ def _group_attributes_side_query(
         max_hits: int | None = None,
         referrer: str | None = None,
         actor: Any | None = None,
-        aggregate_kwargs: PrioritySortWeights | None = None,
+        aggregate_kwargs: TrendsSortWeights | None = None,
     ):
         from sentry.utils import metrics
 
@@ -475,7 +475,7 @@ class SnubaSearchBackendBase(SearchBackend, metaclass=ABCMeta):
         max_hits: int | None = None,
         referrer: str | None = None,
         actor: Any | None = None,
-        aggregate_kwargs: PrioritySortWeights | None = None,
+        aggregate_kwargs: TrendsSortWeights | None = None,
     ) -> CursorResult[Group]:
         search_filters = search_filters if search_filters is not None else []
         # ensure projects are from same org
@@ -711,16 +711,18 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
 
             queryset_conditions.update(
                 {
-                    "message": QCallbackCondition(
-                        lambda query: Q(type=ErrorGroupType.type_id)
-                        | _issue_platform_issue_message_condition(query)
-                    )
-                    # negation should only apply on the message search icontains, we have to include
-                    # the type filter(type=GroupType.ERROR) check since we don't wanna search on the message
-                    # column when type=GroupType.ERROR - we delegate that to snuba in that case
-                    if not message_filter.is_negation
-                    else QCallbackCondition(
-                        lambda query: _issue_platform_issue_message_condition(query)
+                    "message": (
+                        QCallbackCondition(
+                            lambda query: Q(type=ErrorGroupType.type_id)
+                            | _issue_platform_issue_message_condition(query)
+                        )
+                        # negation should only apply on the message search icontains, we have to include
+                        # the type filter(type=GroupType.ERROR) check since we don't wanna search on the message
+                        # column when type=GroupType.ERROR - we delegate that to snuba in that case
+                        if not message_filter.is_negation
+                        else QCallbackCondition(
+                            lambda query: _issue_platform_issue_message_condition(query)
+                        )
                     )
                 }
             )

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -242,7 +242,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         end: datetime,
         having: Sequence[Sequence[Any]],
         aggregate_kwargs: TrendsSortWeights | None = None,
-        replace_priority_aggregation: bool | None = False,
+        replace_trends_aggregation: bool | None = False,
     ) -> list[Any]:
         extra_aggregations = self.dependency_aggregations.get(sort_field, [])
         required_aggregations = set([sort_field, "total"] + extra_aggregations)
@@ -253,8 +253,8 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         aggregations = []
         for alias in required_aggregations:
             aggregation = self.aggregation_defs[alias]
-            if replace_priority_aggregation and alias == "priority":
-                aggregation = self.aggregation_defs["priority_issue_platform"]
+            if replace_trends_aggregation and alias == "trends":
+                aggregation = self.aggregation_defs["trends_issue_platform"]
             if callable(aggregation):
                 if aggregate_kwargs:
                     aggregation = aggregation(start, end, aggregate_kwargs.get(alias, {}))
@@ -306,7 +306,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                 else:
                     conditions.append(converted_filter)
 
-        if sort_field == "priority" and group_category is not GroupCategory.ERROR.value:
+        if sort_field == "trends" and group_category is not GroupCategory.ERROR.value:
             aggregations = self._prepare_aggregations(
                 sort_field, start, end, having, aggregate_kwargs, True
             )
@@ -506,12 +506,12 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         return sort_by in self.sort_strategies.keys()
 
 
-def priority_aggregation(
+def trends_aggregation(
     start: datetime,
     end: datetime,
     aggregate_kwargs: TrendsSortWeights,
 ) -> Sequence[str]:
-    return priority_aggregation_impl(
+    return trends_aggregation_impl(
         TrendsParams(
             max_pow=16,
             min_score=0.01,
@@ -532,12 +532,12 @@ def priority_aggregation(
     )
 
 
-def priority_issue_platform_aggregation(
+def trends_issue_platform_aggregation(
     start: datetime,
     end: datetime,
     aggregate_kwargs: TrendsSortWeights,
 ) -> Sequence[str]:
-    return priority_aggregation_impl(
+    return trends_aggregation_impl(
         TrendsParams(
             max_pow=16,
             min_score=0.01,
@@ -558,7 +558,7 @@ def priority_issue_platform_aggregation(
     )
 
 
-def priority_aggregation_impl(
+def trends_aggregation_impl(
     params: TrendsParams,
     timestamp_column: str,
     use_stacktrace: bool,
@@ -691,14 +691,14 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
     ISSUE_FIELD_NAME = "group_id"
 
     logger = logging.getLogger("sentry.search.postgressnuba")
-    dependency_aggregations = {"priority": ["last_seen", "times_seen"]}
+    dependency_aggregations = {"trends": ["last_seen", "times_seen"]}
     postgres_only_fields = {*SKIP_SNUBA_FIELDS, "regressed_in_release"}
     # add specific fields here on top of skip_snuba_fields from the serializer
     sort_strategies = {
         "date": "last_seen",
         "freq": "times_seen",
         "new": "first_seen",
-        "priority": "priority",
+        "trends": "trends",
         "user": "user_count",
         # We don't need a corresponding snuba field here, since this sort only happens
         # in Postgres
@@ -709,11 +709,11 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         "times_seen": ["count()", ""],
         "first_seen": ["multiply(toUInt64(min(timestamp)), 1000)", ""],
         "last_seen": ["multiply(toUInt64(max(timestamp)), 1000)", ""],
-        "priority": priority_aggregation,
+        "trends": trends_aggregation,
         # Only makes sense with WITH TOTALS, returns 1 for an individual group.
         "total": ["uniq", ISSUE_FIELD_NAME],
         "user_count": ["uniq", "tags[sentry:user]"],
-        "priority_issue_platform": priority_issue_platform_aggregation,
+        "trends_issue_platform": trends_issue_platform_aggregation,
     }
 
     @property
@@ -1117,7 +1117,7 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "date": "last_seen",
         "freq": "times_seen",
         "new": "first_seen",
-        "priority": "priority",
+        "trends": "trends",
         "user": "user_count",
     }
 
@@ -1164,7 +1164,7 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "first_seen": first_seen_aggregation,
         "last_seen": last_seen_aggregation,
         # https://github.com/getsentry/sentry/blob/804c85100d0003cfdda91701911f21ed5f66f67c/src/sentry/event_manager.py#L241-L271
-        "priority": Function(
+        "trends": Function(
             "toUInt64",
             [
                 Function(

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -220,66 +220,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         }
 
         response = self.get_success_response(
-            sort="trends",
-            query="is:unresolved",
-            limit=25,
-            start=iso_format(before_now(days=1)),
-            end=iso_format(before_now(seconds=1)),
-            **aggregate_kwargs,
-        )
-        assert len(response.data) == 2
-        assert [item["id"] for item in response.data] == [str(group.id), str(group_2.id)]
-
-    def test_sort_by_priority(self):
-        group = self.store_event(
-            data={
-                "timestamp": iso_format(before_now(seconds=10)),
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        ).group
-        self.store_event(
-            data={
-                "timestamp": iso_format(before_now(seconds=10)),
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={
-                "timestamp": iso_format(before_now(hours=13)),
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        )
-
-        group_2 = self.store_event(
-            data={
-                "timestamp": iso_format(before_now(seconds=5)),
-                "fingerprint": ["group-2"],
-            },
-            project_id=self.project.id,
-        ).group
-        self.store_event(
-            data={
-                "timestamp": iso_format(before_now(hours=13)),
-                "fingerprint": ["group-2"],
-            },
-            project_id=self.project.id,
-        )
-        self.login_as(user=self.user)
-
-        aggregate_kwargs: dict = {
-            "log_level": "3",
-            "has_stacktrace": "5",
-            "relative_volume": "1",
-            "event_halflife_hours": "4",
-            "issue_halflife_hours": "4",
-            "v2": "true",
-            "norm": "False",
-        }
-
-        response = self.get_success_response(
             sort="priority",
             query="is:unresolved",
             limit=25,

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -160,7 +160,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         }
 
         response = self.get_success_response(
-            sort="priority",
+            sort="trends",
             query="is:unresolved",
             limit=25,
             start=iso_format(before_now(days=1)),

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -110,7 +110,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(group.id)
 
-    def test_sort_by_priority(self):
+    def test_sort_by_trends(self):
         group = self.store_event(
             data={
                 "timestamp": iso_format(before_now(seconds=10)),
@@ -161,6 +161,66 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         response = self.get_success_response(
             sort="trends",
+            query="is:unresolved",
+            limit=25,
+            start=iso_format(before_now(days=1)),
+            end=iso_format(before_now(seconds=1)),
+            **aggregate_kwargs,
+        )
+        assert len(response.data) == 2
+        assert [item["id"] for item in response.data] == [str(group.id), str(group_2.id)]
+
+    def test_sort_by_priority(self):
+        group = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=10)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=10)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(hours=13)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+
+        group_2 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=5)),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(hours=13)),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        )
+        self.login_as(user=self.user)
+
+        aggregate_kwargs: dict = {
+            "log_level": "3",
+            "has_stacktrace": "5",
+            "relative_volume": "1",
+            "event_halflife_hours": "4",
+            "issue_halflife_hours": "4",
+            "v2": "true",
+            "norm": "False",
+        }
+
+        response = self.get_success_response(
+            sort="priority",
             query="is:unresolved",
             limit=25,
             start=iso_format(before_now(days=1)),

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -220,6 +220,66 @@ class GroupListTest(APITestCase, SnubaTestCase):
         }
 
         response = self.get_success_response(
+            sort="trends",
+            query="is:unresolved",
+            limit=25,
+            start=iso_format(before_now(days=1)),
+            end=iso_format(before_now(seconds=1)),
+            **aggregate_kwargs,
+        )
+        assert len(response.data) == 2
+        assert [item["id"] for item in response.data] == [str(group.id), str(group_2.id)]
+
+    def test_sort_by_priority(self):
+        group = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=10)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=10)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(hours=13)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+
+        group_2 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=5)),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(hours=13)),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        )
+        self.login_as(user=self.user)
+
+        aggregate_kwargs: dict = {
+            "log_level": "3",
+            "has_stacktrace": "5",
+            "relative_volume": "1",
+            "event_halflife_hours": "4",
+            "issue_halflife_hours": "4",
+            "v2": "true",
+            "norm": "False",
+        }
+
+        response = self.get_success_response(
             sort="priority",
             query="is:unresolved",
             limit=25,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -34,7 +34,7 @@ from sentry.search.snuba.backend import (
     EventsDatasetSnubaSearchBackend,
     SnubaSearchBackendBase,
 )
-from sentry.search.snuba.executors import InvalidQueryForExecutor, PrioritySortWeights
+from sentry.search.snuba.executors import InvalidQueryForExecutor, TrendsSortWeights
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import SnubaTestCase, TestCase, TransactionTestCase
 from sentry.testutils.helpers import Feature, apply_feature_flag_on_cls
@@ -376,7 +376,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         assert list(results) == [self.group1, self.group2]
 
     def test_priority_sort(self):
-        weights: PrioritySortWeights = {
+        weights: TrendsSortWeights = {
             "log_level": 5,
             "has_stacktrace": 5,
             "relative_volume": 1,
@@ -2684,7 +2684,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         # datetime(2017, 9, 6, 0, 0)
         old_event.data["timestamp"] = 1504656000.0
 
-        weights: PrioritySortWeights = {
+        weights: TrendsSortWeights = {
             "log_level": 0,
             "has_stacktrace": 0,
             "relative_volume": 1,
@@ -2734,7 +2734,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         # datetime(2017, 9, 6, 0, 0)
         old_event.data["timestamp"] = 1504656000.0
 
-        weights: PrioritySortWeights = {
+        weights: TrendsSortWeights = {
             "log_level": 0,
             "has_stacktrace": 0,
             "relative_volume": 1,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3987,7 +3987,7 @@ class CdcEventsSnubaSearchTest(TestCase, SharedSnubaMixin):
             "is:unresolved",
             [self.group1, self.group2],
             None,
-            sort_by="trends",
+            sort_by="priority",
             date_from=self.base_datetime - timedelta(days=30),
         )
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3982,6 +3982,15 @@ class CdcEventsSnubaSearchTest(TestCase, SharedSnubaMixin):
             date_from=self.base_datetime - timedelta(days=30),
         )
 
+    def test_sort_priority(self):
+        self.run_test(
+            "is:unresolved",
+            [self.group1, self.group2],
+            None,
+            sort_by="trends",
+            date_from=self.base_datetime - timedelta(days=30),
+        )
+
     def test_cursor(self):
         group3 = self.store_event(
             data={

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -85,7 +85,7 @@ class SharedSnubaMixin(SnubaTestCase):
         if limit is not None:
             kwargs["limit"] = limit
         if aggregate_kwargs:
-            kwargs["aggregate_kwargs"] = {"priority": {**aggregate_kwargs}}
+            kwargs["aggregate_kwargs"] = {"trends": {**aggregate_kwargs}}
 
         return self.backend.query(
             projects,
@@ -369,13 +369,13 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         results = self.make_query(sort_by="freq")
         assert list(results) == [self.group1, self.group2]
 
-        results = self.make_query(sort_by="priority")
+        results = self.make_query(sort_by="trends")
         assert list(results) == [self.group2, self.group1]
 
         results = self.make_query(sort_by="user")
         assert list(results) == [self.group1, self.group2]
 
-    def test_priority_sort(self):
+    def test_trends_sort(self):
         weights: TrendsSortWeights = {
             "log_level": 5,
             "has_stacktrace": 5,
@@ -386,7 +386,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             "norm": False,
         }
         results = self.make_query(
-            sort_by="priority",
+            sort_by="trends",
             aggregate_kwargs=weights,
         )
         assert list(results) == [self.group2, self.group1]
@@ -416,9 +416,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         results = self.make_query(environments=[self.environments["production"]], sort_by="freq")
         assert list(results) == [self.group2, self.group1]
 
-        results = self.make_query(
-            environments=[self.environments["production"]], sort_by="priority"
-        )
+        results = self.make_query(environments=[self.environments["production"]], sort_by="trends")
         assert list(results) == [self.group2, self.group1]
 
         results = self.make_query(environments=[self.environments["production"]], sort_by="user")
@@ -624,25 +622,25 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         assert set(results) == set()
 
-    def test_search_filter_query_with_custom_priority_tag(self):
-        priority = "high"
+    def test_search_filter_query_with_custom_trends_tag(self):
+        trends = "high"
         self.store_event(
             data={
                 "fingerprint": ["put-me-in-group2"],
                 "timestamp": iso_format(self.group2.first_seen + timedelta(days=1)),
                 "stacktrace": {"frames": [{"module": "group2"}]},
                 "message": "group2",
-                "tags": {"priority": priority},
+                "tags": {"trends": trends},
             },
             project_id=self.project.id,
         )
 
-        results = self.make_query(search_filter_query="priority:%s" % priority)
+        results = self.make_query(search_filter_query="trends:%s" % trends)
 
         assert set(results) == {self.group2}
 
-    def test_search_filter_query_with_custom_priority_tag_and_priority_sort(self):
-        priority = "high"
+    def test_search_filter_query_with_custom_trends_tag_and_trends_sort(self):
+        trends = "high"
         for i in range(1, 3):
             self.store_event(
                 data={
@@ -650,7 +648,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
                     "timestamp": iso_format(self.group2.last_seen + timedelta(days=i)),
                     "stacktrace": {"frames": [{"module": "group1"}]},
                     "message": "group1",
-                    "tags": {"priority": priority},
+                    "tags": {"trends": trends},
                 },
                 project_id=self.project.id,
             )
@@ -660,11 +658,11 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
                 "timestamp": iso_format(self.group2.last_seen + timedelta(days=2)),
                 "stacktrace": {"frames": [{"module": "group2"}]},
                 "message": "group2",
-                "tags": {"priority": priority},
+                "tags": {"trends": trends},
             },
             project_id=self.project.id,
         )
-        results = self.make_query(search_filter_query="priority:%s" % priority, sort_by="priority")
+        results = self.make_query(search_filter_query="trends:%s" % trends, sort_by="trends")
         assert list(results) == [self.group2, self.group1]
 
     def test_search_tag_overlapping_with_internal_fields(self):
@@ -2254,7 +2252,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         results = self.make_query([self.project, self.project2], sort_by="freq")
         assert list(results) == [self.group1, self.group_p2, self.group2]
 
-        results = self.make_query([self.project, self.project2], sort_by="priority")
+        results = self.make_query([self.project, self.project2], sort_by="trends")
         assert list(results) == [
             self.group_p2,
             self.group2,
@@ -2647,12 +2645,12 @@ class EventsJoinedGroupAttributesSnubaSearchTest(TransactionTestCase, EventsSnub
             self.make_query(search_filter_query="issue.category:wrong")
 
 
-class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
+class EventsTrendsTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
     @property
     def backend(self):
         return EventsDatasetSnubaSearchBackend()
 
-    def test_priority_sort_old_and_new_events(self):
+    def test_trends_sort_old_and_new_events(self):
         """Test that an issue with only one old event is ranked lower than an issue with only one new event"""
         new_project = self.create_project(organization=self.project.organization)
         base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=timezone.utc)
@@ -2694,7 +2692,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
             "norm": False,
         }
         results = self.make_query(
-            sort_by="priority",
+            sort_by="trends",
             projects=[new_project],
             aggregate_kwargs=weights,
         )
@@ -2702,7 +2700,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         old_group = Group.objects.get(id=old_event.group.id)
         assert list(results) == [recent_group, old_group]
 
-    def test_priority_sort_v2(self):
+    def test_trends_sort_v2(self):
         """Test that the v2 formula works."""
         new_project = self.create_project(organization=self.project.organization)
         base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=timezone.utc)
@@ -2744,7 +2742,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
             "norm": False,
         }
         results = self.make_query(
-            sort_by="priority",
+            sort_by="trends",
             projects=[new_project],
             aggregate_kwargs=weights,
         )
@@ -2752,7 +2750,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         old_group = Group.objects.get(id=old_event.group.id)
         assert list(results) == [recent_group, old_group]
 
-    def test_priority_log_level_results(self):
+    def test_trends_log_level_results(self):
         """Test that the scoring results change when we pass in different log level weights"""
         base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=timezone.utc)
         event1 = self.store_event(
@@ -2783,7 +2781,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         group2 = Group.objects.get(id=event2.group.id)
 
         agg_kwargs = {
-            "priority": {
+            "trends": {
                 "log_level": 0,
                 "has_stacktrace": 0,
                 "relative_volume": 1,
@@ -2799,7 +2797,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
             end=None,
             project_ids=[self.project.id],
             environment_ids=[],
-            sort_field="priority",
+            sort_field="trends",
             organization=self.organization,
             group_ids=[group1.id, group2.id],
             limit=150,
@@ -2810,14 +2808,14 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         # initially group 2's score is higher since it has a more recent event
         assert group2_score_before > group1_score_before
 
-        agg_kwargs["priority"].update({"log_level": 5})
+        agg_kwargs["trends"].update({"log_level": 5})
 
         results2 = query_executor.snuba_search(
             start=None,
             end=None,
             project_ids=[self.project.id],
             environment_ids=[],
-            sort_field="priority",
+            sort_field="trends",
             organization=self.organization,
             group_ids=[group1.id, group2.id],
             limit=150,
@@ -2828,11 +2826,11 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         # ensure fatal has a higher score than error
         assert group1_score_after > group2_score_after
 
-    def test_priority_has_stacktrace_results(self):
+    def test_trends_has_stacktrace_results(self):
         """Test that the scoring results change when we pass in different has_stacktrace weights"""
         base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=timezone.utc)
         agg_kwargs = {
-            "priority": {
+            "trends": {
                 "log_level": 0,
                 "has_stacktrace": 0,
                 "relative_volume": 1,
@@ -2883,7 +2881,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
             end=None,
             project_ids=[self.project.id],
             environment_ids=[],
-            sort_field="priority",
+            sort_field="trends",
             organization=self.organization,
             group_ids=[group1.id, group2.id],
             limit=150,
@@ -2893,13 +2891,13 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         group2_score = results[1][1]
         assert group1_score == group2_score
 
-        agg_kwargs["priority"].update({"has_stacktrace": 3})
+        agg_kwargs["trends"].update({"has_stacktrace": 3})
         results = query_executor.snuba_search(
             start=None,
             end=None,
             project_ids=[self.project.id],
             environment_ids=[],
-            sort_field="priority",
+            sort_field="trends",
             organization=self.organization,
             group_ids=[group1.id, group2.id],
             limit=150,
@@ -2910,7 +2908,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         # check that a group with an event with a stacktrace has a higher weight than one without
         assert group1_score < group2_score
 
-    def test_priority_event_halflife_results(self):
+    def test_trends_event_halflife_results(self):
         """Test that the scoring results change when we pass in different event halflife weights"""
         base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=timezone.utc)
         event1 = self.store_event(
@@ -2941,7 +2939,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         group2 = Group.objects.get(id=event2.group.id)
 
         agg_kwargs = {
-            "priority": {
+            "trends": {
                 "log_level": 0,
                 "has_stacktrace": 0,
                 "relative_volume": 1,
@@ -2957,7 +2955,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
             end=None,
             project_ids=[self.project.id],
             environment_ids=[],
-            sort_field="priority",
+            sort_field="trends",
             organization=self.organization,
             group_ids=[group1.id, group2.id],
             limit=150,
@@ -2968,13 +2966,13 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         # initially group 2's score is higher since it has a more recent event
         assert group2_score_before > group1_score_before
 
-        agg_kwargs["priority"].update({"event_halflife_hours": 2})
+        agg_kwargs["trends"].update({"event_halflife_hours": 2})
         results = query_executor.snuba_search(
             start=None,
             end=None,
             project_ids=[self.project.id],
             environment_ids=[],
-            sort_field="priority",
+            sort_field="trends",
             organization=self.organization,
             group_ids=[group1.id, group2.id],
             limit=150,
@@ -2984,7 +2982,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         group2_score_after = results[1][1]
         assert group1_score_after < group2_score_after
 
-    def test_priority_mixed_group_types(self):
+    def test_trends_mixed_group_types(self):
         base_datetime = (datetime.utcnow() - timedelta(hours=1)).replace(tzinfo=timezone.utc)
 
         error_event = self.store_event(
@@ -3017,7 +3015,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         profile_group_1 = group_info.group
 
         agg_kwargs = {
-            "priority": {
+            "trends": {
                 "log_level": 0,
                 "has_stacktrace": 0,
                 "relative_volume": 1,
@@ -3039,7 +3037,7 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
                 end=None,
                 project_ids=[self.project.id],
                 environment_ids=[],
-                sort_field="priority",
+                sort_field="trends",
                 organization=self.organization,
                 group_ids=[profile_group_1.id, error_group.id],
                 limit=150,
@@ -3975,12 +3973,12 @@ class CdcEventsSnubaSearchTest(TestCase, SharedSnubaMixin):
             date_from=self.base_datetime - timedelta(days=29),
         )
 
-    def test_sort_priority(self):
+    def test_sort_trends(self):
         self.run_test(
             "is:unresolved",
             [self.group1, self.group2],
             None,
-            sort_by="priority",
+            sort_by="trends",
             date_from=self.base_datetime - timedelta(days=30),
         )
 


### PR DESCRIPTION
Reopening this, messed up git on https://github.com/getsentry/sentry/pull/65297

Part 1/3 (4?) for https://github.com/getsentry/sentry/issues/65208:

Rename the Priority sort option to Trends to avoid confusing it with the new Group.priority column and feature. This PR changes the backend option to use trends. The frontend will continue to send priority, which we convert to trends until this rename is complete.

Some tests have been duplicated to confirm we still handle priority as expected for backwards compatibility.

Up next: we will need to migration priority to trends in SavedSearch.sort.