### PR TITLE
fix(scopes): Correctly fetch member scopes

### DIFF
--- a/src/sentry/api/endpoints/organization_member/__init__.py
+++ b/src/sentry/api/endpoints/organization_member/__init__.py
@@ -102,7 +102,6 @@ def get_allowed_org_roles(
     request: Request,
     organization: Organization,
     member: OrganizationMember | None = None,
-    log_scopes: bool = False,
 ) -> Collection[Role]:
     """
     Get the set of org-level roles that the request is allowed to manage.
@@ -115,12 +114,6 @@ def get_allowed_org_roles(
     if is_active_superuser(request):
         return roles.get_all()
     if not request.access.has_scope("member:admin"):
-        ids = {}
-        if member:
-            ids["member_id"] = member.id
-        if hasattr(request, "user") and hasattr(request.user, "id"):
-            ids["user_id"] = request.user.id
-        logger.info("request.missing_scope", extra=ids)
         return ()
 
     if member is None:
@@ -133,7 +126,7 @@ def get_allowed_org_roles(
             # token whose proxy user does not have an OrganizationMember object.
             return ()
 
-    return member.get_allowed_org_roles_to_invite(log_scopes=log_scopes)
+    return member.get_allowed_org_roles_to_invite()
 
 
 from .details import OrganizationMemberDetailsEndpoint

--- a/src/sentry/api/endpoints/organization_member/details.py
+++ b/src/sentry/api/endpoints/organization_member/details.py
@@ -152,7 +152,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
 
         Will return a pending invite as long as it's already approved.
         """
-        allowed_roles = get_allowed_org_roles(request, organization, member, log_scopes=True)
+        allowed_roles = get_allowed_org_roles(request, organization, member)
         return Response(
             serialize(
                 member,

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -26,7 +26,7 @@ from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 class MockOrganizationRoles:
     TEST_ORG_ROLES = [
         {"id": "alice", "name": "Alice", "scopes": ["project:read", "project:write"]},
-        {"id": "bob", "name": "Bob", "scopes": ["project:read", "alerts:write"]},
+        {"id": "bob", "name": "Bob", "scopes": ["project:read"]},
         {"id": "carol", "name": "Carol", "scopes": ["project:write"]},
     ]
 

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -26,7 +26,7 @@ from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 class MockOrganizationRoles:
     TEST_ORG_ROLES = [
         {"id": "alice", "name": "Alice", "scopes": ["project:read", "project:write"]},
-        {"id": "bob", "name": "Bob", "scopes": ["project:read"]},
+        {"id": "bob", "name": "Bob", "scopes": ["project:read", "alerts:write"]},
         {"id": "carol", "name": "Carol", "scopes": ["project:write"]},
     ]
 
@@ -516,6 +516,32 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
             assert carol.get_allowed_org_roles_to_invite() == [
                 roles.get("carol"),
             ]
+
+    def test_get_allowed_org_roles_to_invite_subset_member_logic(self):
+        """
+        There are two org options which mutate org member scopes:
+            1. sentry:events_member_admin - if True, members have events:admin
+            2. sentry:alerts_member_write - if True, members have alerts:write
+        These settings are both True by default, although in the SENTRY_ROLES
+        config, we default to giving member alerts:write but not events:admin.
+        """
+        org_member = self.create_member(
+            user=self.create_user(), organization=self.organization, role="member"
+        )
+
+        assert "event:admin" in org_member.get_scopes()
+        assert "alerts:write" in org_member.get_scopes()
+
+        assert org_member.get_allowed_org_roles_to_invite() == [
+            roles.get("member"),
+        ]
+
+        self.organization.update_option("sentry:events_member_admin", False)
+        self.organization.update_option("sentry:events_member_admin", False)
+
+        assert org_member.get_allowed_org_roles_to_invite() == [
+            roles.get("member"),
+        ]
 
     def test_org_roles_by_source(self):
         manager_team = self.create_team(organization=self.organization, org_role="manager")


### PR DESCRIPTION
### Summary
Originally in `get_allowed_org_roles_to_invite`, we switched from checking role priority to directly checking scopes (using subset logic) in https://github.com/getsentry/sentry/pull/56648.

This doesn't account for the 2 org options that give/restrict members from having `alerts:write` and `events:admin`. The former is the main problem, as this is given by default in `SENTRY_ROLES` to org members.
https://github.com/getsentry/sentry/blob/2b68c6d51f4787d467628049617b45f62f607856/src/sentry/conf/server.py#L2500-L2516

If the org option was turned off for `alerts:write`, we would fail the subset check and return an empty array, causing the `OrganizationMemberDetailsEndpoint` GET to pass this empty array into the `OrganizationMemberWithRolesSerializer`.
https://github.com/getsentry/sentry/blob/781531e2732356a10bd5a22062bf3507041b7422/src/sentry/api/endpoints/organization_member/details.py#L156-L162

We only return the serialized user with authenticators attached if the passed roles array was not empty, so passing the empty array returns a response without authenticators causing the FE to have the button be unclickable.
https://github.com/getsentry/sentry/blob/eb55184602940adb1fc09a9c0e33515cac92c7d8/src/sentry/api/serializers/models/organization_member/expand/roles.py#L69-L70

---
I also removes debugging logs I added in https://github.com/getsentry/sentry/pull/65579

Fixes https://github.com/getsentry/sentry/issues/65155