### PR TITLE
feat(test): Add project counter test helpers

### DIFF
--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -1,8 +1,14 @@
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
 import pytest
 
 from sentry import options
 from sentry.models.counter import Counter
+from sentry.models.group import Group
+from sentry.testutils.helpers.eventprocessing import save_new_event
 from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.pytest.mocking import capture_results
 from sentry.testutils.silo import region_silo_test
 
 
@@ -14,3 +20,35 @@ def test_increment(default_project, upsert_sample_rate):
 
     assert Counter.increment(default_project, 42) == 42
     assert Counter.increment(default_project, 1) == 43
+
+
+@contextmanager
+def patch_group_creation(monkeypatch):
+    group_creation_results: list[Group | Exception] = []
+    group_creation_spy = MagicMock(
+        side_effect=capture_results(Group.objects.create, group_creation_results)
+    )
+    monkeypatch.setattr("sentry.event_manager.Group.objects.create", group_creation_spy)
+
+    yield (group_creation_spy, group_creation_results)
+
+
+def create_existing_group(project, monkeypatch, message):
+    with patch_group_creation(monkeypatch) as patches:
+        group_creation_spy, group_creation_results = patches
+
+        event = save_new_event({"message": message}, project)
+        group = Group.objects.get(id=event.group_id)
+
+        assert (
+            group.times_seen == 1
+        ), "Error: No new group was created. This is probably because the given message matched that of an existing group."
+
+        assert group_creation_spy.call_count == 1
+        assert group_creation_results[0] == group
+
+        # This equality ensures the next new group's `short_id` won't conflict with group's `short_id`.
+        counter = Counter.objects.get(project_id=project.id)
+        assert group.short_id == counter.value
+
+        return group

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -52,3 +52,11 @@ def create_existing_group(project, monkeypatch, message):
         assert group.short_id == counter.value
 
         return group
+
+
+@django_db_all
+def test_group_creation_simple(default_project, monkeypatch):
+    group = create_existing_group(default_project, monkeypatch, "Dogs are great!")
+
+    # See `create_existing_group` for more assertions
+    assert group


### PR DESCRIPTION
This adds two test helper functions, `patch_group_creation` and `create_existing_group`, to use in project counter tests. 

The former patches `Group.objects.create` in order to both spy on it and collect its results. The latter does that patching and then saves an event with a message designed to be different from existing groups' messages, so as to guarantee we'll create a new group. In that process, `Group.objects.create` runs, allowing us to make assertions about what it does.`create_existing_group` also includes some assertions to make sure that things run according to plan. 

Finally, this PR adds a simple happy path test using the helpers.