### PR TITLE
fix(ingest): Add workaround for stuck project counters

### DIFF
--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pytest
+from django.db import IntegrityError
 
 from sentry import options
 from sentry.models.counter import Counter
@@ -60,3 +61,90 @@ def test_group_creation_simple(default_project, monkeypatch):
 
     # See `create_existing_group` for more assertions
     assert group
+
+
+@django_db_all
+@pytest.mark.parametrize(
+    "discrepancy",
+    [1, 2, 3],
+    ids=[" discrepancy = 1 ", " discrepancy = 2 ", " discrepancy = 3 "],
+)
+def test_group_creation_with_stuck_project_counter(default_project, monkeypatch, discrepancy):
+    project = default_project
+
+    # Create enough groups that a discripancy larger than 1 will still land us on an existing group
+    messages = [
+        "Maisey is a silly dog",
+        "Charlie is a goofy dog",
+        "Bodhi is an adventurous dog",
+        "Cory is a loyal dog",
+    ]
+    existing_groups = [create_existing_group(project, monkeypatch, message) for message in messages]
+
+    with patch_group_creation(monkeypatch) as patches:
+        group_creation_spy, group_creation_results = patches
+
+        # Set the counter value such that it will try to create the next group with the same `short_id` as the
+        # existing group
+        counter = Counter.objects.get(project_id=project.id)
+        counter.value = counter.value - discrepancy
+        counter.save()
+
+        # Change the message so the event will create a new group... or at least try to
+        new_message = "Dogs are great!"
+        assert new_message not in messages
+        potentially_stuck_event = save_new_event({"message": new_message}, project)
+
+        # Because of the incorrect counter value, we had to try twice to create the group.
+        assert group_creation_spy.call_count == 2
+
+        first_attempt_result, second_attempt_result = group_creation_results
+
+        # The counter was indeed stuck...
+        assert isinstance(first_attempt_result, IntegrityError)
+        raised_error_message = first_attempt_result.args[0]
+        possible_error_messages = [
+            f"Key (project_id, short_id)=({project.id}, {existing_group.short_id}) already exists."
+            for existing_group in existing_groups
+        ]
+        assert any(
+            [
+                possible_message in raised_error_message
+                for possible_message in possible_error_messages
+            ]
+        )
+
+        # ... but we did manage to create a new group after fixing it
+        assert isinstance(second_attempt_result, Group)
+        new_group = second_attempt_result
+        assert potentially_stuck_event.group_id == new_group.id
+        assert new_group.id not in [group.id for group in existing_groups]
+
+        # And voila, now the counter's fixed and ready for the next new group
+        counter = Counter.objects.get(project_id=project.id)
+        assert counter.value == new_group.short_id
+
+        # These will be helpful for the next set of assertions
+        messages.append(new_message)
+        existing_groups.append(new_group)
+
+    # Just to prove that it now works, here we go (new spies just for convenience)
+    with patch_group_creation(monkeypatch) as patches:
+        group_creation_spy, group_creation_results = patches
+
+        new_new_message = "Dogs are still great!"
+        assert new_new_message not in messages
+        hopefully_normal_event = save_new_event({"message": new_new_message}, project)
+
+        # We didn't have to go through the stuck-counter-fixing process
+        assert group_creation_spy.call_count == 1
+
+        # We successfully created a new group
+        assert isinstance(group_creation_results[0], Group)
+        new_new_group = group_creation_results[0]
+        assert hopefully_normal_event.group_id == new_new_group.id
+        assert new_new_group.id not in [group.id for group in existing_groups]
+
+        # And as before, the counter has been adjusted to be ready for the next new group
+        counter = Counter.objects.get(project_id=project.id)
+        assert counter.value == new_new_group.short_id


### PR DESCRIPTION
Sometimes, a project's project counter (which is used to provide `short_id` values when groups are created) gets out of whack with respect to the project's existing groups' `short_id`s. When that happens, we try to use the `short_id` value provided by the project counter but we run into an error, because that `short_id` is already taken for that project. As a result, the group isn't created, and in fact from that point on _no_ new groups can be created in that project, because they all fail with the same error.

Though we have yet to track down how this happens, we would still like to make sure that stuck projects get unstuck, in a more efficient and reliable way than the manual migration-based fixes we've been doing. This PR does that, by recognizing when a project is stuck, fixing its project counter value, and then trying again to create the failed group. This way, even if a project does get stuck, the very next time we try to create a new group in that project it'll get fixed, which should make this bug invisible to users.

Though we won't still see the errors we've been seeing, it's still interesting to see how often this happens, so this PR includes a log and a metric allowing us to do that. It also includes a parametrized integration test, to make sure we can fix counters which are off by 1 (as has been the case in every stuck project we've seen) but also counters which are off by larger amounts (just in case).