### PR TITLE
perf(metrics): Faster metrics summary query using cityHash64

### DIFF
--- a/src/sentry/search/events/datasets/metrics_summaries.py
+++ b/src/sentry/search/events/datasets/metrics_summaries.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 
-from snuba_sdk import Direction, OrderBy
+from snuba_sdk import And, Condition, Direction, Function, Op, OrderBy
 
 from sentry.api.event_search import SearchFilter
 from sentry.search.events import builder, constants
@@ -23,6 +23,7 @@ class MetricsSummariesDatasetConfig(DatasetConfig):
         return {
             constants.PROJECT_ALIAS: self._project_slug_filter_converter,
             constants.PROJECT_NAME_ALIAS: self._project_slug_filter_converter,
+            "metric": self._metric_filter_converter,
         }
 
     @property
@@ -61,6 +62,23 @@ class MetricsSummariesDatasetConfig(DatasetConfig):
 
     def _project_slug_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
         return filter_aliases.project_slug_converter(self.builder, search_filter)
+
+    def _metric_filter_converter(self, search_filter: SearchFilter) -> WhereType | None:
+        column = search_filter.key.name
+        value = search_filter.value.value
+        return And(
+            [
+                Condition(self.builder.column(column), Op.EQ, value),
+                # The metrics summaries table orders by the cityHash64 of the metric name.
+                # In order to take full advantage of the order by of the table, add an
+                # additional condition on the cityHash64 of the metric name.
+                Condition(
+                    Function("cityHash64", [self.builder.column(column)]),
+                    Op.EQ,
+                    Function("cityHash64", [value]),
+                ),
+            ]
+        )
 
     def _resolve_project_slug_alias(self, alias: str) -> SelectType:
         return field_aliases.resolve_project_slug_alias(self.builder, alias)

--- a/src/sentry/sentry_metrics/querying/samples_list.py
+++ b/src/sentry/sentry_metrics/querying/samples_list.py
@@ -268,11 +268,13 @@ class CustomSamplesListExecutor(SamplesListExecutor):
     def get_span_keys(self, offset: int, limit: int) -> list[tuple[str, str, str]]:
         rounded_timestamp = f"rounded_timestamp({self.rollup})"
 
+        query = " ".join(q for q in [self.query, f"metric:{self.mri}"] if q)
+
         builder = MetricsSummariesQueryBuilder(
             Dataset.MetricsSummaries,
             self.params,
             snuba_params=self.snuba_params,
-            query=self.query,
+            query=query,
             selected_columns=[rounded_timestamp, "example()"],
             limit=limit,
             offset=offset,
@@ -280,8 +282,6 @@ class CustomSamplesListExecutor(SamplesListExecutor):
             # sample_rate=options.get("metrics.sample-list.sample-rate"),
             config=QueryBuilderConfig(functions_acl=["rounded_timestamp", "example"]),
         )
-
-        builder.add_conditions([Condition(builder.column("metric"), Op.EQ, self.mri)])
 
         query_results = builder.run_query(self.referrer.value)
         result = builder.process_results(query_results)


### PR DESCRIPTION
The metrics summaries table uses `cityHash64(metric_mri)` as one of its ORDER BY keys. A naive condition like `metric_mri = d:custom/value@none` does not take advantage of the ORDER BY and results in a full scan. Here we automatically always add a condition on the `cityHash64` for a performance boost.