### PR TITLE
ref(weekly reports): Fix key perf issues

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -274,7 +274,7 @@
     <td class="project-breakdown-graph-cell {% if has_replay_graph %}transactions-below{% else %}transactions{% endif %} {% if has_replay_graph and trends.total_replay_count == 0 %}some-empty-below{% endif %}">
       <h4 class="total-count-title">Total Project Transactions</h4>
       <h1 style="margin: 0;" class="total-count">{{ trends.total_transaction_count|small_count:1 }}</h1>
-      {% url 'sentry-organization-perfomance' organization.slug as performance_landing %}
+      {% url 'sentry-organization-performance' organization.slug as performance_landing %}
       {% querystring referrer="weekly_report_view_all" notification_uuid=notification_uuid as query %}
       <a href="{% org_url organization performance_landing query=query %}"
          style="font-size: 12px; margin-bottom: 16px; display: block;">View All Transactions</a>

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -10,6 +10,7 @@ from django.db.models import F
 from django.utils import timezone as django_timezone
 
 from sentry.constants import DataCategory
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.group import GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus
 from sentry.models.notificationsettingoption import NotificationSettingOption
@@ -29,7 +30,7 @@ from sentry.tasks.summaries.weekly_reports import (
     prepare_template_context,
     schedule_organizations,
 )
-from sentry.testutils.cases import OutcomesSnubaTest, SnubaTestCase
+from sentry.testutils.cases import OutcomesSnubaTest, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
@@ -43,7 +44,7 @@ DISABLED_ORGANIZATIONS_USER_OPTION_KEY = "reports:disabled-organizations"
 
 
 @region_silo_test
-class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
+class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCase):
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_integration(self):
         with unguarded_write(using=router.db_for_write(Project)):
@@ -346,7 +347,8 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
         group2.substatus = None
         group2.resolved_at = two_days_ago
         group2.save()
-
+        self.create_performance_issue(fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group1")
+        self.create_performance_issue(fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group2")
         prepare_organization_report(to_timestamp(now), ONE_DAY * 7, self.organization.id)
 
         for call_args in message_builder.call_args_list:
@@ -360,11 +362,12 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             assert context["issue_summary"] == {
                 "escalating_substatus_count": 0,
                 "new_substatus_count": 0,
-                "ongoing_substatus_count": 0,
+                "ongoing_substatus_count": 2,
                 "regression_substatus_count": 0,
-                "total_substatus_count": 0,
+                "total_substatus_count": 2,
             }
             assert len(context["key_errors"]) == 2
+            assert len(context["key_performance_issues"]) == 2
             assert context["trends"]["total_error_count"] == 2
             assert context["trends"]["total_transaction_count"] == 10
             assert "Weekly Report for" in message_params["subject"]


### PR DESCRIPTION
Fix the snuba query in `project_key_performance_issues` to query the issues platform dataset. When we migrated performance issues from the transactions dataset to the issue platform dataset, it seems we missed this query and it's not been populating weekly report emails since. There is no `group_ids` column on it since each row is only associated with one group. I also added to the test since we weren't even checking to see that this worked before.

I also noticed the "Total Project Transactions" link was broken due to a typo so I fixed that. 