### PR TITLE
fix(integrations): allow superuser to install unpublished unowned app

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -10,6 +10,7 @@ from sentry.api.bases import SentryAppInstallationsBaseEndpoint
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.auth.superuser import superuser_has_permission
 from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH, SentryAppStatus
 from sentry.features.exceptions import FeatureNotRegistered
 from sentry.models.integrations.integration_feature import IntegrationFeature, IntegrationTypes
@@ -54,7 +55,7 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
         if app is None or (
             app.status != SentryAppStatus.PUBLISHED
             and app.owner_id != organization.id
-            and not request.user.is_superuser
+            and not superuser_has_permission(request)
         ):
             return Response(status=404)
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -52,7 +52,9 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
         # only published or owned apps are allowed to be installed
         app = SentryApp.objects.filter(slug=slug).first()
         if app is None or (
-            app.status != SentryAppStatus.PUBLISHED and app.owner_id != organization.id
+            app.status != SentryAppStatus.PUBLISHED
+            and app.owner_id != organization.id
+            and not request.user.is_superuser
         ):
             return Response(status=404)
 

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -156,6 +156,14 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
             app = self.create_sentry_app(name="Sample 2", organization=self.org, published=True)
             self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
 
+    def test_can_install_unpublished_unowned_app_as_superuser(self):
+        self.login_as(user=self.user)
+        org2 = self.create_organization()
+        app2 = self.create_sentry_app(name="Unpublished", organization=org2)
+
+        self.login_as(user=self.superuser, superuser=True)
+        self.get_success_response(self.org.slug, slug=app2.slug, status_code=200)
+
     @override_settings(SENTRY_SELF_HOSTED=False)
     @with_feature("auth:enterprise-superuser-read-write")
     def test_install_superuser_read(self):


### PR DESCRIPTION
This is required for testing 3rd party sentry apps before allowing them to be published.