### PR TITLE
feat(js-loader): Pin latest selection to highest pre-v8 version

### DIFF
--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -69,9 +69,7 @@ def match_selected_version_to_browser_sdk_version(selected_version):
     versions = load_version_from_file()
     if selected_version == "latest":
         # "latest" as an option is phased out before the v8 release of the JS SDK, meaning that we pin people to the latest pre-v8-version when they have "latest" selected
-        return get_highest_browser_sdk_version(
-            [x for x in versions if Version(x) < Version("8")]
-        )
+        return get_highest_browser_sdk_version([x for x in versions if Version(x) < Version("8")])
     return get_highest_browser_sdk_version(
         # Filter for all versions that match the selected versions major
         [x for x in versions if x.startswith(selected_version[0])]

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -68,7 +68,10 @@ def load_version_from_file():
 def match_selected_version_to_browser_sdk_version(selected_version):
     versions = load_version_from_file()
     if selected_version == "latest":
-        return get_highest_browser_sdk_version(versions)
+        # "latest" as an option is phased out before the v8 release of the JS SDK, meaning that we pin people to the latest pre-v8-version when they have "latest" selected
+        return get_highest_browser_sdk_version(
+            [x for x in versions if Version(x) < Version("8")]
+        )
     return get_highest_browser_sdk_version(
         # Filter for all versions that match the selected versions major
         [x for x in versions if x.startswith(selected_version[0])]

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -166,5 +166,5 @@ register(
 # The available loader SDK versions
 register(
     key="sentry:loader_available_sdk_versions",
-    epoch_defaults={1: ["latest", "7.x", "6.x", "5.x", "4.x"], 11: ["latest", "7.x"]},
+    epoch_defaults={1: ["7.x", "6.x", "5.x", "4.x"], 11: ["7.x"]},
 )

--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -67,7 +67,7 @@ class JavaScriptSdkLoader(BaseView):
                 "hasDebug": False,
             }
 
-        is_v7_sdk = sdk_version >= Version("7.0.0")
+        is_greater_or_equal_v7_sdk = sdk_version >= Version("7.0.0")
 
         is_lazy = True
         bundle_kind_modifier = ""
@@ -80,12 +80,12 @@ class JavaScriptSdkLoader(BaseView):
         # https://docs.sentry.io/platforms/javascript/install/cdn/
 
         # We depend on fixes in the tracing bundle that are only available in v7
-        if is_v7_sdk and has_performance:
+        if is_greater_or_equal_v7_sdk and has_performance:
             bundle_kind_modifier += ".tracing"
             is_lazy = False
 
         # If the project does not have a v7 sdk set, we cannot load the replay bundle.
-        if is_v7_sdk and has_replay:
+        if is_greater_or_equal_v7_sdk and has_replay:
             bundle_kind_modifier += ".replay"
             is_lazy = False
 
@@ -94,7 +94,7 @@ class JavaScriptSdkLoader(BaseView):
         #
         # If we are loading replay, do not add the es5 modifier, as those bundles are
         # ES6 only.
-        if is_v7_sdk and not has_replay:
+        if is_greater_or_equal_v7_sdk and not has_replay:
             bundle_kind_modifier += ".es5"
 
         if has_debug:

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.conf import settings
+from packaging.version import Version
 
 from sentry.loader.browsersdkversion import (
     get_all_browser_sdk_version_versions,
@@ -8,7 +9,6 @@ from sentry.loader.browsersdkversion import (
     match_selected_version_to_browser_sdk_version,
 )
 from sentry.testutils.cases import TestCase
-from packaging.version import Version
 
 MOCK_VERSIONS = [
     "4.0.0-rc.1",
@@ -41,7 +41,9 @@ class BrowserSdkVersionTestCase(TestCase):
     def test_get_highest_selected_version(self, load_version_from_file):
         assert str(match_selected_version_to_browser_sdk_version("4.x")) == "4.6.4"
         assert str(match_selected_version_to_browser_sdk_version("5.x")) == "5.10.1"
-        assert str(match_selected_version_to_browser_sdk_version("latest")) == "5.10.1" # Should not select version 8, since v8 is the first version that doesn't support latest
+        assert (
+            str(match_selected_version_to_browser_sdk_version("latest")) == "5.10.1"
+        )  # Should not select version 8, since v8 is the first version that doesn't support latest
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=[])
     def test_get_highest_selected_version_no_version(self, load_version_from_file):

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 from django.conf import settings
-from packaging.version import Version
 
 from sentry.loader.browsersdkversion import (
     get_all_browser_sdk_version_versions,

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -8,6 +8,7 @@ from sentry.loader.browsersdkversion import (
     match_selected_version_to_browser_sdk_version,
 )
 from sentry.testutils.cases import TestCase
+from packaging.version import Version
 
 MOCK_VERSIONS = [
     "4.0.0-rc.1",
@@ -18,6 +19,8 @@ MOCK_VERSIONS = [
     "5.0.2-beta1",
     "5.1.1",
     "5.10.1",
+    "8.0.1-beta2",
+    "8.1.1",
 ]
 
 
@@ -30,7 +33,7 @@ class BrowserSdkVersionTestCase(TestCase):
         "sentry.loader.browsersdkversion.load_version_from_file", return_value=MOCK_VERSIONS
     )
     def test_get_highest_browser_sdk_version_from_versions(self, load_version_from_file):
-        assert str(get_highest_browser_sdk_version(load_version_from_file())) == "5.10.1"
+        assert str(get_highest_browser_sdk_version(load_version_from_file())) == "8.1.1"
 
     @mock.patch(
         "sentry.loader.browsersdkversion.load_version_from_file", return_value=MOCK_VERSIONS
@@ -38,7 +41,7 @@ class BrowserSdkVersionTestCase(TestCase):
     def test_get_highest_selected_version(self, load_version_from_file):
         assert str(match_selected_version_to_browser_sdk_version("4.x")) == "4.6.4"
         assert str(match_selected_version_to_browser_sdk_version("5.x")) == "5.10.1"
-        assert str(match_selected_version_to_browser_sdk_version("latest")) == "5.10.1"
+        assert str(match_selected_version_to_browser_sdk_version("latest")) == "5.10.1" # Should not select version 8, since v8 is the first version that doesn't support latest
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=[])
     def test_get_highest_selected_version_no_version(self, load_version_from_file):

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -99,9 +99,9 @@ class JavaScriptSdkLoaderTest(TestCase):
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
         assert b"/7.0.0/bundle.es5.min.js" in resp.content
 
-    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["8.3.15"])
+    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["7.3.15"])
     @mock.patch(
-        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="latest"
+        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="7.x"
     )
     def test_greater_than_v7_returns_es5(
         self, load_version_from_file, get_selected_browser_sdk_version
@@ -112,11 +112,11 @@ class JavaScriptSdkLoaderTest(TestCase):
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
-        assert b"/8.3.15/bundle.es5.min.js" in resp.content
+        assert b"/7.3.15/bundle.es5.min.js" in resp.content
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["7.37.0"])
     @mock.patch(
-        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="latest"
+        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="7.x"
     )
     def test_returns_es6_with_defaults(
         self, load_version_from_file, get_selected_browser_sdk_version
@@ -127,9 +127,49 @@ class JavaScriptSdkLoaderTest(TestCase):
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
         assert b"/7.37.0/bundle.tracing.replay.min.js" in resp.content
 
-    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["7.37.0"])
+    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["8.1.0", "7.1.0", "7.0.1", "6.1.0"])
     @mock.patch(
         "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="latest"
+    )
+    def test_returns_latest_pre_v8_version_when_latest_is_selected(
+        self, load_version_from_file, get_selected_browser_sdk_version
+    ):
+        settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
+        assert b"/7.1.0/bundle.tracing.replay.min.js" in resp.content
+
+    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["9.1.0", "8.1.0", "6.1.0", "5.0.0"])
+    @mock.patch(
+        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="latest"
+    )
+    def test_returns_latest_pre_v8_version_when_latest_is_selected_with_no_available_v7_version(
+        self, load_version_from_file, get_selected_browser_sdk_version
+    ):
+        settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
+        assert b"/6.1.0/bundle.min.js" in resp.content
+
+    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["8.1.0", "8.0.0", "8", "8.0.0-alpha.0", "7.100.0", "6.1.0", "5.0.0"])
+    @mock.patch(
+        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="latest"
+    )
+    def test_returns_latest_pre_v8_version_when_latest_is_selected_various_v8_versions_available(
+        self, load_version_from_file, get_selected_browser_sdk_version
+    ):
+        settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
+        print(resp.content)
+        assert b"/7.100.0/bundle.tracing.replay.min.js" in resp.content
+
+    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["7.37.0"])
+    @mock.patch(
+        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="7.x"
     )
     def test_bundle_kind_modifiers(self, load_version_from_file, get_selected_browser_sdk_version):
         settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -127,7 +127,10 @@ class JavaScriptSdkLoaderTest(TestCase):
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
         assert b"/7.37.0/bundle.tracing.replay.min.js" in resp.content
 
-    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["8.1.0", "7.1.0", "7.0.1", "6.1.0"])
+    @mock.patch(
+        "sentry.loader.browsersdkversion.load_version_from_file",
+        return_value=["8.1.0", "7.1.0", "7.0.1", "6.1.0"],
+    )
     @mock.patch(
         "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="latest"
     )
@@ -140,7 +143,10 @@ class JavaScriptSdkLoaderTest(TestCase):
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
         assert b"/7.1.0/bundle.tracing.replay.min.js" in resp.content
 
-    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["9.1.0", "8.1.0", "6.1.0", "5.0.0"])
+    @mock.patch(
+        "sentry.loader.browsersdkversion.load_version_from_file",
+        return_value=["9.1.0", "8.1.0", "6.1.0", "5.0.0"],
+    )
     @mock.patch(
         "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="latest"
     )
@@ -153,7 +159,10 @@ class JavaScriptSdkLoaderTest(TestCase):
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
         assert b"/6.1.0/bundle.min.js" in resp.content
 
-    @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["8.1.0", "8.0.0", "8", "8.0.0-alpha.0", "7.100.0", "6.1.0", "5.0.0"])
+    @mock.patch(
+        "sentry.loader.browsersdkversion.load_version_from_file",
+        return_value=["8.1.0", "8.0.0", "8", "8.0.0-alpha.0", "7.100.0", "6.1.0", "5.0.0"],
+    )
     @mock.patch(
         "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="latest"
     )

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -173,7 +173,6 @@ class JavaScriptSdkLoaderTest(TestCase):
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
-        print(resp.content)
         assert b"/7.100.0/bundle.tracing.replay.min.js" in resp.content
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["7.37.0"])


### PR DESCRIPTION
We want to remove the option to select "latest" in the JS loader because it makes the maintenance of the JS SDK hell in terms of backwards compatibility.

We need to migrate people off of latest:
- We map "latest" internally to the latest pre-v8 version when selected.
- We remove it from the possible selections in the project settings.