### PR TITLE
ref(ddm): Move ddm/meta to metrics/metadata

### DIFF
--- a/src/sentry/api/endpoints/organization_ddm.py
+++ b/src/sentry/api/endpoints/organization_ddm.py
@@ -31,7 +31,6 @@ from sentry.sentry_metrics.querying.metadata import (
 
 class MetricMetaType(Enum):
     CODE_LOCATIONS = "codeLocations"
-    # TODO: change name when we settled on the naming.
     CORRELATIONS = "metricSpans"
 
 
@@ -44,7 +43,7 @@ METRIC_META_TYPE_SERIALIZER = {
 @region_silo_endpoint
 class OrganizationDDMMetaEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -516,7 +516,7 @@ class OrganizationMetricsSamplesEndpoint(OrganizationEventsV2EndpointBase):
 @region_silo_endpoint
 class OrganizationMetricsMetadataEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -388,6 +388,7 @@ from .endpoints.organization_metrics import (
     OrganizationMetricDetailsEndpoint,
     OrganizationMetricsDataEndpoint,
     OrganizationMetricsDetailsEndpoint,
+    OrganizationMetricsMetadataEndpoint,
     OrganizationMetricsQueryEndpoint,
     OrganizationMetricsSamplesEndpoint,
     OrganizationMetricsTagDetailsEndpoint,
@@ -1963,6 +1964,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^/]+)/ddm/meta/$",
         OrganizationDDMMetaEndpoint.as_view(),
         name="sentry-api-0-organization-ddm-meta",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^/]+)/metrics/metadata/$",
+        OrganizationMetricsMetadataEndpoint.as_view(),
+        name="sentry-api-0-organization-metrics-metadata",
     ),
     re_path(
         r"^(?P<organization_slug>[^/]+)/metrics/meta/$",

--- a/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
@@ -1,0 +1,331 @@
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.sentry_metrics.querying.metadata.metrics_code_locations import (
+    get_cache_key_for_code_location,
+)
+from sentry.sentry_metrics.querying.utils import get_redis_client_for_metrics_meta
+from sentry.testutils.cases import APITestCase, BaseSpansTestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.silo import region_silo_test
+from sentry.utils import json
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+@region_silo_test
+@freeze_time("2023-11-21T10:30:30.000Z")
+class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
+    endpoint = "sentry-api-0-organization-metrics-metadata"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.redis_client = get_redis_client_for_metrics_meta()
+        self.current_time = timezone.now()
+
+    def _mock_code_location(
+        self,
+        filename: str,
+        pre_context: list[str] | None = None,
+        post_context: list[str] | None = None,
+    ) -> str:
+        code_location = {
+            "function": "foo",
+            "module": "bar",
+            "filename": filename,
+            "abs_path": f"/usr/src/foo/{filename}",
+            "lineNo": 10,
+            "context_line": "context",
+        }
+
+        if pre_context is not None:
+            code_location["pre_context"] = pre_context
+        if post_context is not None:
+            code_location["post_context"] = post_context
+
+        return json.dumps(code_location)
+
+    def _store_code_location(
+        self, organization_id: int, project_id: int, metric_mri: str, timestamp: int, value: str
+    ):
+        cache_key = get_cache_key_for_code_location(
+            organization_id, project_id, metric_mri, timestamp
+        )
+        self.redis_client.sadd(cache_key, value)
+
+    def _round_to_day(self, time: datetime) -> int:
+        return int(time.timestamp() / 86400) * 86400
+
+    def _store_code_locations(
+        self,
+        organization: Organization,
+        projects: Sequence[Project],
+        metric_mris: Sequence[str],
+        days: int,
+    ):
+        timestamps = [
+            self._round_to_day(self.current_time - timedelta(days=day)) for day in range(0, days)
+        ]
+        for project in projects:
+            for metric_mri in metric_mris:
+                for timestamp in timestamps:
+                    self._store_code_location(
+                        organization.id,
+                        project.id,
+                        metric_mri,
+                        timestamp,
+                        self._mock_code_location("script.py"),
+                    )
+                    self._store_code_location(
+                        organization.id,
+                        project.id,
+                        metric_mri,
+                        timestamp,
+                        self._mock_code_location("main.py"),
+                    )
+
+    def test_get_locations_with_stats_period(self):
+        projects = [self.create_project(name="project_1")]
+        mris = [
+            "d:custom/sentry.process_profile.track_outcome@second",
+        ]
+
+        # We specify two days, since we are querying a stats period of 1 day, thus from one day to another.
+        self._store_code_locations(self.organization, projects, mris, 2)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=mris,
+            project=[project.id for project in projects],
+            statsPeriod="1d",
+            codeLocations="true",
+        )
+        code_locations = response.data["codeLocations"]
+
+        assert len(code_locations) == 2
+
+        assert code_locations[0]["mri"] == mris[0]
+        assert code_locations[0]["timestamp"] == self._round_to_day(
+            self.current_time - timedelta(days=1)
+        )
+
+        assert code_locations[1]["mri"] == mris[0]
+        assert code_locations[1]["timestamp"] == self._round_to_day(self.current_time)
+
+        frames = code_locations[0]["frames"]
+        assert len(frames) == 2
+        for index, filename in enumerate(("main.py", "script.py")):
+            assert frames[index]["filename"] == filename
+
+        frames = code_locations[0]["frames"]
+        assert len(frames) == 2
+        for index, filename in enumerate(("main.py", "script.py")):
+            assert frames[index]["filename"] == filename
+
+    def test_get_locations_with_start_and_end(self):
+        projects = [self.create_project(name="project_1")]
+        mris = [
+            "d:custom/sentry.process_profile.track_outcome@second",
+        ]
+
+        # We specify two days, since we are querying a stats period of 1 day, thus from one day to another.
+        self._store_code_locations(self.organization, projects, mris, 2)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=mris,
+            project=[project.id for project in projects],
+            # We use an interval of 1 day but shifted by 1 day in the past.
+            start=(self.current_time - timedelta(days=2)).isoformat(),
+            end=(self.current_time - timedelta(days=1)).isoformat(),
+            codeLocations="true",
+        )
+        code_locations = response.data["codeLocations"]
+
+        assert len(code_locations) == 1
+
+        assert code_locations[0]["mri"] == mris[0]
+        assert code_locations[0]["timestamp"] == self._round_to_day(
+            self.current_time - timedelta(days=1)
+        )
+
+        frames = code_locations[0]["frames"]
+        assert len(frames) == 2
+        for index, filename in enumerate(("main.py", "script.py")):
+            assert frames[index]["filename"] == filename
+
+    def test_get_locations_with_start_and_end_and_no_data(self):
+        projects = [self.create_project(name="project_1")]
+        mris = ["d:custom/sentry.process_profile.track_outcome@second"]
+
+        # We specify two days, since we are querying a stats period of 1 day, thus from one day to another.
+        self._store_code_locations(self.organization, projects, mris, 2)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=mris,
+            project=[project.id for project in projects],
+            # We use an interval outside which we have no data.
+            start=(self.current_time - timedelta(days=3)).isoformat(),
+            end=(self.current_time - timedelta(days=2)).isoformat(),
+            codeLocations="true",
+        )
+        codeLocations = response.data["codeLocations"]
+
+        assert len(codeLocations) == 0
+
+    @patch(
+        "sentry.sentry_metrics.querying.metadata.metrics_code_locations.CodeLocationsFetcher._get_code_locations"
+    )
+    @patch(
+        "sentry.sentry_metrics.querying.metadata.metrics_code_locations.CodeLocationsFetcher.BATCH_SIZE",
+        10,
+    )
+    def test_get_locations_batching(self, get_code_locations_mock):
+        get_code_locations_mock.return_value = []
+
+        projects = [self.create_project(name="project_1")]
+        mris = ["d:custom/sentry.process_profile.track_outcome@second"]
+
+        self.get_success_response(
+            self.organization.slug,
+            metric=mris,
+            project=[project.id for project in projects],
+            statsPeriod="90d",
+            codeLocations="true",
+        )
+
+        # With a window of 90 days, it means that we are actually requesting 91 days, thus we have 10 batches of 10
+        # elements each.
+        assert len(get_code_locations_mock.mock_calls) == 10
+
+    def test_get_locations_with_incomplete_location(self):
+        project = self.create_project(name="project_1")
+        mri = "d:custom/sentry.process_profile.track_outcome@second"
+
+        self._store_code_location(
+            self.organization.id,
+            project.id,
+            mri,
+            self._round_to_day(self.current_time),
+            '{"lineno": 10}',
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=[mri],
+            project=[project.id],
+            statsPeriod="1d",
+            codeLocations="true",
+        )
+        code_locations = response.data["codeLocations"]
+
+        assert len(code_locations) == 1
+
+        assert code_locations[0]["mri"] == mri
+        assert code_locations[0]["timestamp"] == self._round_to_day(self.current_time)
+
+        frames = code_locations[0]["frames"]
+        assert len(frames) == 1
+        assert frames[0]["lineNo"] == 10
+        # We check that all the remaining elements are `None` or empty.
+        del frames[0]["lineNo"]
+        for value in frames[0].values():
+            assert value is None or value == []
+
+    def test_get_locations_with_corrupted_location(self):
+        project = self.create_project(name="project_1")
+        mri = "d:custom/sentry.process_profile.track_outcome@second"
+
+        self._store_code_location(
+            self.organization.id,
+            project.id,
+            mri,
+            self._round_to_day(self.current_time),
+            '}"invalid": "json"{',
+        )
+
+        self.get_error_response(
+            self.organization.slug,
+            metric=[mri],
+            project=[project.id],
+            statsPeriod="1d",
+            status_code=500,
+            codeLocations="true",
+        )
+
+    def test_get_pre_post_context(self):
+        project = self.create_project(name="project_1")
+        mri = "d:custom/sentry.process_profile.track_outcome@second"
+
+        self._store_code_location(
+            self.organization.id,
+            project.id,
+            mri,
+            self._round_to_day(self.current_time),
+            self._mock_code_location("script.py", ["pre"], ["post"]),
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=[mri],
+            project=[project.id],
+            statsPeriod="1d",
+            codeLocations="true",
+        )
+
+        code_locations = response.data["codeLocations"]
+
+        frame = code_locations[0]["frames"][0]
+        assert frame["preContext"] == ["pre"]
+        assert frame["postContext"] == ["post"]
+
+    def test_get_no_pre_post_context(self):
+        project = self.create_project(name="project_1")
+        mri = "d:custom/sentry.process_profile.track_outcome@second"
+
+        self._store_code_location(
+            self.organization.id,
+            project.id,
+            mri,
+            self._round_to_day(self.current_time),
+            self._mock_code_location("script.py"),
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=[mri],
+            project=[project.id],
+            statsPeriod="1d",
+            codeLocations="true",
+        )
+
+        code_locations = response.data["codeLocations"]
+
+        frame = code_locations[0]["frames"][0]
+        assert frame["preContext"] == []
+        assert frame["postContext"] == []
+
+    @patch(
+        "sentry.sentry_metrics.querying.metadata.metrics_code_locations.CodeLocationsFetcher.MAXIMUM_KEYS",
+        50,
+    )
+    def test_get_locations_with_too_many_combinations(self):
+        project = self.create_project(name="project_1")
+        mri = "d:custom/sentry.process_profile.track_outcome@second"
+
+        self.get_error_response(
+            self.organization.slug,
+            metric=[mri],
+            project=[project.id],
+            statsPeriod="90d",
+            status_code=400,
+            codeLocations="true",
+        )


### PR DESCRIPTION
This PR makes a new `/metrics/metadata` endpoint which moves the implementation of `/ddm/meta` and removes metric spans as a meta type, since it's now available through the `/metrics/samples` endpoint.

Technically, frontend should switch to this new endpoint only when the `/metrics/samples` endpoint will be on feature parity with the old endpoint.