### PR TITLE
fix(metrics_extraction): Add function to query for on-demand metric spec

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -59,7 +59,7 @@ from sentry.snuba.metrics.extraction import (
     MetricSpecType,
     OnDemandMetricSpec,
     fetch_on_demand_metric_spec,
-    should_use_on_demand_metrics,
+    should_use_on_demand_metrics_for_querying,
 )
 from sentry.snuba.metrics.fields import histogram as metrics_histogram
 from sentry.snuba.metrics.query import (
@@ -160,12 +160,12 @@ class MetricsQueryBuilder(QueryBuilder):
 
         groupby_columns = self._get_group_bys()
 
-        if not should_use_on_demand_metrics(
-            self.dataset,
-            field,
-            self.query,
-            groupby_columns,
-            organization=Organization.objects.get_from_cache(id=self.organization_id),
+        if not should_use_on_demand_metrics_for_querying(
+            Organization.objects.get_from_cache(id=self.organization_id),
+            dataset=self.dataset,
+            aggregate=field,
+            query=self.query,
+            groupbys=groupby_columns,
         ):
             return None
 


### PR DESCRIPTION
In #65637, I introduced a way to only allow certain functions if an org had the spec two feature flag.

As I worked more on my other PRs it became clear that I had to decouple querying from mere extraction.

We want to extract the function even if the organization is not ready to query for the function.