### PR TITLE
fix(stats): don't query for non-existent times_seen column in outcomes_raw

### DIFF
--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -107,7 +107,7 @@ class TimesSeenField(Field):
             return Function("sum", [Column("times_seen")], "times_seen")
         else:
             # RawOutcomes doesnt have times_seen, do a count instead
-            return Function("count()", [Column("times_seen")], "times_seen")
+            return Function("count()", [], "times_seen")
 
 
 class Dimension(SimpleGroupBy, ABC, Generic[T]):

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -107,7 +107,7 @@ class TimesSeenField(Field):
             return Function("sum", [Column("times_seen")], "times_seen")
         else:
             # RawOutcomes doesnt have times_seen, do a count instead
-            return Function("count()", [], "times_seen")
+            return Function("count", [], "times_seen")
 
 
 class Dimension(SimpleGroupBy, ABC, Generic[T]):

--- a/tests/sentry/snuba/test_outcomes.py
+++ b/tests/sentry/snuba/test_outcomes.py
@@ -98,7 +98,7 @@ class OutcomesQueryDefinitionTests(TestCase):
             {"organization_id": 1},
             True,
         )
-        assert Function("count()", [Column("times_seen")], "times_seen") in query.select_params
+        assert Function("count()", [], "times_seen") in query.select_params
 
         query = _make_query(
             "statsPeriod=6h&interval=1d&groupBy=category&field=sum(times_seen)",

--- a/tests/sentry/snuba/test_outcomes.py
+++ b/tests/sentry/snuba/test_outcomes.py
@@ -98,7 +98,7 @@ class OutcomesQueryDefinitionTests(TestCase):
             {"organization_id": 1},
             True,
         )
-        assert Function("count()", [], "times_seen") in query.select_params
+        assert Function("count", [], "times_seen") in query.select_params
 
         query = _make_query(
             "statsPeriod=6h&interval=1d&groupBy=category&field=sum(times_seen)",

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -704,7 +704,7 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         }
 
     @freeze_time("2021-03-14T12:27:28.303Z")
-    def test_minute_interval(self):
+    def test_minute_interval_sum_quantity(self):
         make_request = functools.partial(
             self.client.get,
             reverse("sentry-api-0-organization-stats-v2", args=[self.org.slug]),
@@ -733,6 +733,40 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
                     "by": {},
                     "totals": {"sum(quantity)": 6},
                     "series": {"sum(quantity)": [6, 0, 0, 0, 0]},
+                }
+            ],
+        }
+
+    @freeze_time("2021-03-14T12:27:28.303Z")
+    def test_minute_interval_sum_times_seen(self):
+        make_request = functools.partial(
+            self.client.get,
+            reverse("sentry-api-0-organization-stats-v2", args=[self.org.slug]),
+        )
+        response = make_request(
+            {
+                "statsPeriod": "1h",
+                "interval": "15m",
+                "field": ["sum(times_seen)"],
+                "category": "error",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert result_sorted(response.data) == {
+            "start": "2021-03-14T11:15:00Z",
+            "end": "2021-03-14T12:30:00Z",
+            "intervals": [
+                "2021-03-14T11:15:00Z",
+                "2021-03-14T11:30:00Z",
+                "2021-03-14T11:45:00Z",
+                "2021-03-14T12:00:00Z",
+                "2021-03-14T12:15:00Z",
+            ],
+            "groups": [
+                {
+                    "by": {},
+                    "totals": {"sum(times_seen)": 6},
+                    "series": {"sum(times_seen)": [6, 0, 0, 0, 0]},
                 }
             ],
         }


### PR DESCRIPTION
[This error](https://sentry.sentry.io/issues/4931943425/) is happening because we are querying for a `times_seen` column in the `outcomes_raw` Snuba table when it doesn't exist. The schema can be found [here](https://github.com/getsentry/snuba/blob/master/snuba/datasets/configuration/outcomes_raw/entities/outcomes_raw.yaml). `times_seen` _does_ exist for the `outcomes` table; see the schema [here](https://github.com/getsentry/snuba/blob/master/snuba/datasets/configuration/outcomes/entities/outcomes.yaml).

A PR 3 years ago added an extra column into the count() function for `outcomes_raw`; it should have been left empty.
https://github.com/getsentry/sentry/pull/27718/files#diff-dd1c437b7adf7a697fba2d680fad6aeb869eb384c40ed9468375383839138b68L97-R102

Fixes SENTRY-2HV7