### PR TITLE
fix(metrics-extraction): Fix highlighting on widget viewer as well

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -41,8 +41,10 @@ import {
   isEquation,
   isEquationAlias,
 } from 'sentry/utils/discover/fields';
-import {createOnDemandFilterWarning} from 'sentry/utils/onDemandMetrics';
-import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
+import {
+  createOnDemandFilterWarning,
+  shouldDisplayOnDemandWidgetWarning,
+} from 'sentry/utils/onDemandMetrics';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -394,7 +396,8 @@ function WidgetViewerModal(props: Props) {
     )
   );
 
-  const queryOptions = sortedQueries.map(({name, conditions}, index) => {
+  const queryOptions = sortedQueries.map((query, index) => {
+    const {name, conditions} = query;
     // Creates the highlighted query elements to be used in the Query Select
     const dashboardFiltersString = dashboardFiltersToString(dashboardFilters);
     const parsedQuery =
@@ -403,7 +406,11 @@ function WidgetViewerModal(props: Props) {
             conditions +
               (dashboardFiltersString === '' ? '' : ` ${dashboardFiltersString}`),
             {
-              getFilterTokenWarning: hasOnDemandMetricWidgetFeature(organization)
+              getFilterTokenWarning: shouldDisplayOnDemandWidgetWarning(
+                query,
+                widget.widgetType ?? WidgetType.DISCOVER,
+                organization
+              )
                 ? getOnDemandFilterWarning
                 : undefined,
             }


### PR DESCRIPTION
### Summary
The modal widget viewer on the dashboard itself should also have the highlighting updated.

#### Screenshots

|before|after|
|----|----|
|![Screenshot 2024-02-23 at 10 50 12 AM](https://github.com/getsentry/sentry/assets/6111995/12ef5890-ae81-49f9-86ca-f92df5c775c8) | ![Screenshot 2024-02-23 at 10 52 58 AM](https://github.com/getsentry/sentry/assets/6111995/2694b07b-2185-4ca5-8552-90dc6727e105) |