### PR TITLE
feat(new-trace-view): Adding the trace footer with trace level webvitals and tag summary

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -33,6 +33,7 @@ import Trace from './trace';
 import TraceHeader from './traceHeader';
 import {TraceTree} from './traceTree';
 import TraceWarnings from './traceWarnings';
+import {TraceFooter} from './traceFooter';
 
 const DOCUMENT_TITLE = [t('Trace Details'), t('Performance')].join(' — ');
 
@@ -204,6 +205,13 @@ function TraceViewContent(props: TraceViewContentProps) {
             traces={props.traceSplitResult}
           />
           <Trace trace={tree} trace_id={props.traceSlug} />
+          <TraceFooter
+            rootEventResults={rootEventResults}
+            organization={props.organization}
+            location={props.location}
+            traces={props.traceSplitResult}
+            traceEventView={props.traceEventView}
+          />
         </Layout.Main>
       </Layout.Body>
     </Fragment>

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -30,10 +30,10 @@ import useProjects from 'sentry/utils/useProjects';
 import Breadcrumb from '../breadcrumb';
 
 import Trace from './trace';
+import {TraceFooter} from './traceFooter';
 import TraceHeader from './traceHeader';
 import {TraceTree} from './traceTree';
 import TraceWarnings from './traceWarnings';
-import {TraceFooter} from './traceFooter';
 
 const DOCUMENT_TITLE = [t('Trace Details'), t('Performance')].join(' — ');
 

--- a/static/app/views/performance/newTraceDetails/traceFooter.tsx
+++ b/static/app/views/performance/newTraceDetails/traceFooter.tsx
@@ -1,0 +1,163 @@
+import type {EventTransaction, Organization} from 'sentry/types';
+import type EventView from 'sentry/utils/discover/eventView';
+import type {Location} from 'history';
+import type {
+  TraceFullDetailed,
+  TraceSplitResults,
+} from 'sentry/utils/performance/quickTrace/types';
+import type {UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import EventVitals from 'sentry/components/events/eventVitals';
+import {generateQueryWithTag} from 'sentry/utils';
+import {formatTagKey} from 'sentry/utils/discover/fields';
+import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
+import styled from '@emotion/styled';
+import {space} from 'sentry/styles/space';
+import {getTraceInfo} from '../traceDetails/utils';
+import Tags from 'sentry/views/discover/tags';
+import {SectionHeading} from 'sentry/components/charts/styles';
+import {t} from 'sentry/locale';
+import Placeholder from 'sentry/components/placeholder';
+import Panel from 'sentry/components/panels/panel';
+import {Fragment} from 'react';
+
+type TraceFooterProps = {
+  traceEventView: EventView;
+  organization: Organization;
+  location: Location;
+  traces: TraceSplitResults<TraceFullDetailed> | null;
+  rootEventResults: UseApiQueryResult<EventTransaction, RequestError>;
+};
+
+function NoWebVitals() {
+  return (
+    <div style={{flex: 1}}>
+      <SectionHeading>{t('WebVitals')}</SectionHeading>
+      <WebVitalsWrapper>
+        {[
+          WEB_VITAL_DETAILS['measurements.cls'],
+          WEB_VITAL_DETAILS['measurements.lcp'],
+          WEB_VITAL_DETAILS['measurements.ttfb'],
+          WEB_VITAL_DETAILS['measurements.fcp'],
+          WEB_VITAL_DETAILS['measurements.fid'],
+        ].map(detail => (
+          <StyledPanel>
+            <div>{detail.name}</div>
+            <div>{' \u2014 '}</div>
+          </StyledPanel>
+        ))}
+      </WebVitalsWrapper>
+    </div>
+  );
+}
+
+function TraceFooterLoading() {
+  return (
+    <TraceFooterWrapper>
+      <div style={{flex: 1}}>
+        <SectionHeading>{t('WebVitals')}</SectionHeading>
+        <Fragment>
+          <StyledPlaceholderVital key="title-1" />
+          <StyledPlaceholderVital key="title-2" />
+          <StyledPlaceholderVital key="title-3" />
+          <StyledPlaceholderVital key="title-4" />
+          <StyledPlaceholderVital key="title-5" />
+        </Fragment>
+      </div>
+      <div style={{flex: 1}}>
+        <SectionHeading>{t('Tag Summary')}</SectionHeading>
+        <Fragment>
+          <StyledPlaceholderTagTitle key="title-1" />
+          <StyledPlaceholderTag key="bar-1" />
+          <StyledPlaceholderTagTitle key="title-2" />
+          <StyledPlaceholderTag key="bar-2" />
+          <StyledPlaceholderTagTitle key="title-3" />
+          <StyledPlaceholderTag key="bar-3" />
+        </Fragment>
+      </div>
+    </TraceFooterWrapper>
+  );
+}
+
+export function TraceFooter(props: TraceFooterProps) {
+  if (!props.traces) {
+    return <TraceFooterLoading />;
+  }
+
+  const {data: rootEvent} = props.rootEventResults;
+  const {transactions, orphan_errors} = props.traces;
+  const traceInfo = getTraceInfo(transactions, orphan_errors);
+  const orphanErrorsCount = traceInfo.trailingOrphansCount ?? 0;
+  const transactionsCount = traceInfo.transactions.size ?? 0;
+  const totalNumOfEvents = transactionsCount + orphanErrorsCount;
+  const webVitals = Object.keys(rootEvent?.measurements ?? {})
+    .filter(name => Boolean(WEB_VITAL_DETAILS[`measurements.${name}`]))
+    .sort();
+
+  return rootEvent ? (
+    <TraceFooterWrapper>
+      {webVitals.length > 0 ? (
+        <div style={{flex: 1}}>
+          <EventVitals event={rootEvent} />
+        </div>
+      ) : (
+        <NoWebVitals />
+      )}
+      <div style={{flex: 1}}>
+        <Tags
+          generateUrl={(key: string, value: string) => {
+            const url = props.traceEventView.getResultsViewUrlTarget(
+              props.organization.slug,
+              false
+            );
+            url.query = generateQueryWithTag(url.query, {
+              key: formatTagKey(key),
+              value,
+            });
+            return url;
+          }}
+          totalValues={totalNumOfEvents}
+          eventView={props.traceEventView}
+          organization={props.organization}
+          location={props.location}
+        />
+      </div>
+    </TraceFooterWrapper>
+  ) : null;
+}
+
+const TraceFooterWrapper = styled('div')`
+  display: flex;
+  gap: ${space(2)};
+  margin-top: ${space(2)};
+`;
+
+const StyledPlaceholderTag = styled(Placeholder)`
+  border-radius: ${p => p.theme.borderRadius};
+  height: 16px;
+  margin-bottom: ${space(1.5)};
+`;
+
+const StyledPlaceholderTagTitle = styled(Placeholder)`
+  width: 100px;
+  height: 12px;
+  margin-bottom: ${space(0.5)};
+`;
+
+const StyledPlaceholderVital = styled(StyledPlaceholderTagTitle)`
+  width: 100%;
+  height: 50px;
+  margin-bottom: ${space(0.5)};
+`;
+
+const StyledPanel = styled(Panel)`
+  padding: ${space(1)} ${space(1.5)};
+  margin-bottom: ${space(1)};
+  width: 100%;
+`;
+
+const WebVitalsWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+`;

--- a/static/app/views/performance/newTraceDetails/traceFooter.tsx
+++ b/static/app/views/performance/newTraceDetails/traceFooter.tsx
@@ -1,32 +1,34 @@
-import type {EventTransaction, Organization} from 'sentry/types';
-import type EventView from 'sentry/utils/discover/eventView';
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
 import type {Location} from 'history';
+
+import {SectionHeading} from 'sentry/components/charts/styles';
+import EventVitals from 'sentry/components/events/eventVitals';
+import Panel from 'sentry/components/panels/panel';
+import Placeholder from 'sentry/components/placeholder';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {EventTransaction, Organization} from 'sentry/types';
+import {generateQueryWithTag} from 'sentry/utils';
+import type EventView from 'sentry/utils/discover/eventView';
+import {formatTagKey} from 'sentry/utils/discover/fields';
 import type {
   TraceFullDetailed,
   TraceSplitResults,
 } from 'sentry/utils/performance/quickTrace/types';
+import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
-import EventVitals from 'sentry/components/events/eventVitals';
-import {generateQueryWithTag} from 'sentry/utils';
-import {formatTagKey} from 'sentry/utils/discover/fields';
-import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
-import styled from '@emotion/styled';
-import {space} from 'sentry/styles/space';
-import {getTraceInfo} from '../traceDetails/utils';
 import Tags from 'sentry/views/discover/tags';
-import {SectionHeading} from 'sentry/components/charts/styles';
-import {t} from 'sentry/locale';
-import Placeholder from 'sentry/components/placeholder';
-import Panel from 'sentry/components/panels/panel';
-import {Fragment} from 'react';
+
+import {getTraceInfo} from '../traceDetails/utils';
 
 type TraceFooterProps = {
-  traceEventView: EventView;
-  organization: Organization;
   location: Location;
-  traces: TraceSplitResults<TraceFullDetailed> | null;
+  organization: Organization;
   rootEventResults: UseApiQueryResult<EventTransaction, RequestError>;
+  traceEventView: EventView;
+  traces: TraceSplitResults<TraceFullDetailed> | null;
 };
 
 function NoWebVitals() {
@@ -41,7 +43,7 @@ function NoWebVitals() {
           WEB_VITAL_DETAILS['measurements.fcp'],
           WEB_VITAL_DETAILS['measurements.fid'],
         ].map(detail => (
-          <StyledPanel>
+          <StyledPanel key={detail.name}>
             <div>{detail.name}</div>
             <div>{' \u2014 '}</div>
           </StyledPanel>


### PR DESCRIPTION
<img width="1267" alt="Screenshot 2024-02-23 at 10 53 11 AM" src="https://github.com/getsentry/sentry/assets/60121741/86e14c79-49ef-434e-a27b-dee2205d2ce9">
<img width="1275" alt="Screenshot 2024-02-23 at 10 54 27 AM" src="https://github.com/getsentry/sentry/assets/60121741/e06cfdb6-1103-4876-a36a-dad15f8e46f0">
