### PR TITLE
feat(new-trace): Passing useSpans to trace query.

### DIFF
--- a/static/app/utils/performance/quickTrace/traceFullQuery.spec.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.spec.tsx
@@ -56,11 +56,11 @@ describe('TraceFullQuery', function () {
     expect(getMock).toHaveBeenCalledTimes(1);
   });
 
-  it('fetches data on mount with detailed param', async function () {
+  it('fetches data on mount with useSpans param', async function () {
     const getMock = MockApiClient.addMockResponse({
       url: `/organizations/test-org/events-trace/${traceId}/`,
       body: [],
-      match: [MockApiClient.matchQuery({detailed: '1'})],
+      match: [MockApiClient.matchQuery({useSpans: '1'})],
     });
     render(
       <TraceFullDetailedQuery

--- a/static/app/utils/performance/quickTrace/traceFullQuery.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.tsx
@@ -17,9 +17,9 @@ import {
 
 type AdditionalQueryProps = {
   detailed?: boolean;
-  useSpans?: boolean;
   eventId?: string;
   limit?: number;
+  useSpans?: boolean;
 };
 
 type TraceFullQueryChildrenProps<T> = BaseTraceChildrenProps &

--- a/static/app/utils/performance/quickTrace/traceFullQuery.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.tsx
@@ -17,6 +17,7 @@ import {
 
 type AdditionalQueryProps = {
   detailed?: boolean;
+  useSpans?: boolean;
   eventId?: string;
   limit?: number;
 };
@@ -36,13 +37,20 @@ type QueryProps<T> = Omit<TraceRequestProps, 'eventView'> &
   };
 
 function getTraceFullRequestPayload({
-  detailed,
+  detailed = false,
+  useSpans = false,
   eventId,
   limit,
   ...props
 }: DiscoverQueryProps & AdditionalQueryProps) {
   const additionalApiPayload: any = getTraceRequestPayload(props);
-  additionalApiPayload.detailed = detailed ? '1' : '0';
+
+  if (useSpans) {
+    additionalApiPayload.useSpans = useSpans ? '1' : '0';
+  } else {
+    additionalApiPayload.detailed = detailed ? '1' : '0';
+  }
+
   if (eventId) {
     additionalApiPayload.event_id = eventId;
   }
@@ -115,6 +123,6 @@ export function TraceFullDetailedQuery(
   props: Omit<QueryProps<TraceSplitResults<TraceFullDetailed>>, 'detailed'>
 ) {
   return (
-    <GenericTraceFullQuery<TraceSplitResults<TraceFullDetailed>> {...props} detailed />
+    <GenericTraceFullQuery<TraceSplitResults<TraceFullDetailed>> {...props} useSpans />
   );
 }


### PR DESCRIPTION
Passing useSpans to trace query, instead of detailed query param.