### PR TITLE
chore(open-pr-comments): cleanup feature flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1598,10 +1598,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable interface functionality to synchronize groups between sentry and
     # issues on external services.
     "organizations:integrations-issue-sync": True,
-    # Enable comments of related issues on open PRs
-    "organizations:integrations-open-pr-comment": False,
-    # Enable comments of related issues on open PRs for Javascript
-    "organizations:integrations-open-pr-comment-js": False,
     # Enable Opsgenie integration
     "organizations:integrations-opsgenie": True,
     # Enable stacktrace linking

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -15,7 +15,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
-from sentry import analytics, features, options
+from sentry import analytics, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
@@ -25,6 +25,7 @@ from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
@@ -529,9 +530,13 @@ class PullRequestEventWebhook(Webhook):
             )
 
             if action == "opened" and created:
-                if not features.has("organizations:integrations-open-pr-comment", organization):
+                if not OrganizationOption.objects.get_value(
+                    organization=organization,
+                    key="sentry:github_open_pr_bot",
+                    default=True,
+                ):
                     logger.info(
-                        "github.open_pr_comment.flag_missing",
+                        "github.open_pr_comment.option_missing",
                         extra={"organization_id": organization.id},
                     )
                     return

--- a/src/sentry/tasks/integrations/github/language_parsers.py
+++ b/src/sentry/tasks/integrations/github/language_parsers.py
@@ -216,9 +216,15 @@ class JavascriptParser(LanguageParser):
         )
 
 
-PATCH_PARSERS: dict[str, Any] = {"py": PythonParser}
+PATCH_PARSERS: dict[str, Any] = {
+    "py": PythonParser,
+    "js": JavascriptParser,
+    "jsx": JavascriptParser,
+    "ts": JavascriptParser,
+    "tsx": JavascriptParser,
+}
 
-# for testing the Javascript parser, feature flagged
+# for testing new parsers
 BETA_PATCH_PARSERS: dict[str, Any] = {
     "py": PythonParser,
     "js": JavascriptParser,

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -21,13 +21,10 @@ from snuba_sdk import (
 )
 from snuba_sdk import Request as SnubaRequest
 
-from sentry import features
 from sentry.constants import EXTENSION_LANGUAGE_MAP
 from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models.group import Group, GroupStatus
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.models.options.organization_option import OrganizationOption
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.pullrequest import CommentType, PullRequest
 from sentry.models.repository import Repository
@@ -42,7 +39,7 @@ from sentry.tasks.integrations.github.constants import (
     RATE_LIMITED_MESSAGE,
     STACKFRAME_COUNT,
 )
-from sentry.tasks.integrations.github.language_parsers import BETA_PATCH_PARSERS, PATCH_PARSERS
+from sentry.tasks.integrations.github.language_parsers import PATCH_PARSERS
 from sentry.tasks.integrations.github.pr_comment import format_comment_url
 from sentry.tasks.integrations.github.utils import (
     GithubAPIErrorType,
@@ -195,16 +192,8 @@ def safe_for_comment(
     changed_lines_count = 0
     filtered_pr_files = []
 
-    try:
-        organization = Organization.objects.get_from_cache(id=repository.organization_id)
-    except Organization.DoesNotExist:
-        logger.exception("github.open_pr_comment.org_missing")
-        metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_org"})
-        return []
-
     patch_parsers = PATCH_PARSERS
-    if features.has("organizations:integrations-open-pr-comment-js", organization):
-        patch_parsers = BETA_PATCH_PARSERS
+    # NOTE: if we are testing beta patch parsers, add check here
 
     for file in pr_files:
         filename = file["filename"]
@@ -285,11 +274,8 @@ def get_top_5_issues_by_count_for_file(
     if not len(projects):
         return []
 
-    organization = projects[0].organization
-
     patch_parsers = PATCH_PARSERS
-    if features.has("organizations:integrations-open-pr-comment-js", organization):
-        patch_parsers = BETA_PATCH_PARSERS
+    # NOTE: if we are testing beta patch parsers, add check here
 
     # fetches the appropriate parser for formatting the snuba query given the file extension
     # the extension is never replaced in reverse codemapping
@@ -423,22 +409,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_pr"})
         return
 
-    # check org option
     org_id = pull_request.organization_id
-    try:
-        organization = Organization.objects.get_from_cache(id=org_id)
-    except Organization.DoesNotExist:
-        logger.exception("github.open_pr_comment.org_missing")
-        metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_org"})
-        return
-
-    if not OrganizationOption.objects.get_value(
-        organization=organization,
-        key="sentry:github_open_pr_bot",
-        default=True,
-    ):
-        logger.info("github.open_pr_comment.option_missing", extra={"organization_id": org_id})
-        return
 
     # check PR repo exists to get repo name
     try:
@@ -480,8 +451,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     top_issues_per_file = []
 
     patch_parsers = PATCH_PARSERS
-    if features.has("organizations:integrations-open-pr-comment-js", organization):
-        patch_parsers = BETA_PATCH_PARSERS
+    # NOTE: if we are testing beta patch parsers, add check here
 
     file_extensions = set()
     # fetch issues related to the files

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -23,7 +23,6 @@ from sentry.tasks.integrations.github.open_pr_comment import (
 from sentry.tasks.integrations.github.utils import PullRequestFile, PullRequestIssue
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.json import JSONData
@@ -97,29 +96,6 @@ class TestSafeForComment(GithubCommentTestCase):
 
     @responses.activate
     def test_simple(self):
-        data = [
-            {"filename": "foo.py", "changes": 100, "status": "modified"},
-            {"filename": "bar.js", "changes": 100, "status": "modified"},
-            {"filename": "baz.py", "changes": 100, "status": "added"},
-            {"filename": "bee.py", "changes": 100, "status": "deleted"},
-            {"filename": "hi.py", "changes": 100, "status": "removed"},
-            {"filename": "boo.py", "changes": 0, "status": "renamed"},
-        ]
-        responses.add(
-            responses.GET,
-            self.gh_path.format(pull_number=self.pr.key),
-            status=200,
-            json=data,
-        )
-
-        pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
-        assert pr_files == [
-            {"filename": "foo.py", "changes": 100, "status": "modified"},
-        ]
-
-    @responses.activate
-    @with_feature("organizations:integrations-open-pr-comment-js")
-    def test_simple_with_javascript(self):
         data = [
             {"filename": "foo.py", "changes": 100, "status": "modified"},
             {"filename": "bar.js", "changes": 100, "status": "modified"},
@@ -401,7 +377,6 @@ class TestGetCommentIssues(CreateEventTestCase):
         assert top_5_issue_ids == [group_id, self.group_id]
         assert function_names == ["planet", "world"]
 
-    @with_feature("organizations:integrations-open-pr-comment-js")
     def test_javascript_simple(self):
         # should match function name exactly or className.functionName
         group_id_1 = [
@@ -1102,27 +1077,6 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             "github_open_pr_comment.error", tags={"type": "missing_pr"}
         )
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
-    def test_comment_workflow_missing_org(
-        self,
-        mock_metrics,
-        _,
-        mock_safe_for_comment,
-        mock_issues,
-        mock_function_names,
-        mock_reverse_codemappings,
-        mock_pr_filenames,
-    ):
-        self.pr.organization_id = 0
-        self.pr.save()
-
-        open_pr_comment_workflow(self.pr.id)
-
-        assert not mock_pr_filenames.called
-        mock_metrics.incr.assert_called_with(
-            "github_open_pr_comment.error", tags={"type": "missing_org"}
-        )
-
     def test_comment_workflow_missing_org_option(
         self,
         mock_metrics,
@@ -1200,31 +1154,3 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         mock_metrics.incr.assert_called_with(
             "github_open_pr_comment.error", tags={"type": "unsafe_for_comment"}
         )
-
-    @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
-    def test_comment_workflow_missing_javascript_feature_flag(
-        self,
-        mock_metrics,
-        _,
-        mock_safe_for_comment,
-        mock_issues,
-        mock_function_names,
-        mock_reverse_codemappings,
-        mock_pr_filenames,
-    ):
-        mock_safe_for_comment.return_value = [{"filename": "hello.js", "patch": "a"}]
-        mock_reverse_codemappings.return_value = ([self.project], ["hello.js"])
-        mock_pr_filenames.return_value = [PullRequestFile(filename="hello.js", patch="a")]
-
-        open_pr_comment_workflow(self.pr.id)
-
-        # mock safe for comment should filter out js if the org doesn't have
-        # the feature flag, but we also have a check in open_pr_comment_workflow
-
-        assert not mock_issues.called
-        # this metric is emitted inside a for loop
-        mock_metrics.incr.assert_any_call(
-            "github_open_pr_comment.missing_parser", tags={"extension": "js"}
-        )
-        # this metric is emitted in the early return after the for loop
-        mock_metrics.incr.assert_called_with("github_open_pr_comment.no_issues")

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -5,7 +5,6 @@ import responses
 from django.utils import timezone
 
 from sentry.models.group import Group, GroupStatus
-from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.integrations.github.constants import STACKFRAME_COUNT
@@ -1076,22 +1075,6 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         mock_metrics.incr.assert_called_with(
             "github_open_pr_comment.error", tags={"type": "missing_pr"}
         )
-
-    def test_comment_workflow_missing_org_option(
-        self,
-        mock_metrics,
-        mock_safe_for_comment,
-        mock_issues,
-        mock_function_names,
-        mock_reverse_codemappings,
-        mock_pr_filenames,
-    ):
-        OrganizationOption.objects.set_value(
-            organization=self.organization, key="sentry:github_open_pr_bot", value=False
-        )
-        open_pr_comment_workflow(self.pr.id)
-
-        assert not mock_pr_filenames.called
 
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
     def test_comment_workflow_missing_repo(


### PR DESCRIPTION
Cleans up feature flags for Open PR Comments.

When a PR is opened, we now check for whether the org has the open PR bot org option enabled instead of the feature flag. I've also added notes on how to add new languages if we decide to roll out new languages to a beta cohort.