### PR TITLE
fix(hybridcloud) Don't retry 400 or 401 responses

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -272,7 +272,7 @@ def perform_request(payload: WebhookPayload) -> None:
         # Other ApiErrors should be retried
         metrics.incr(
             "hybridcloud.deliver_webhooks.failure",
-            tags={"reason": "discard", "destination_region": region.name},
+            tags={"reason": "api_error", "destination_region": region.name},
         )
         logger.warning(
             "hybridcloud.deliver_webhooks.api_error",


### PR DESCRIPTION
These response outcomes are persistent and retrying will not solve the deliverability issue.
