### PR TITLE
chore: Add option for double write sample rate

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2111,3 +2111,10 @@ register(
     default=100_000.0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Sample rate for double writing to experimental dsn
+register(
+    "store.experimental-dsn-double-write.sample-rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
As we wait on SDKs to send us standalone spans, we can test the spans-only pipeline
by just not producing to the transactions kafka topic in relay for a project.
This will allow us to test and see what breaks when we only send spans.
I'd like to double write the `sentry` backend project to an experimental dsn and switch
that experimental project to exclusively only produce to the spans topic in relay 
(ie no transactions). Double writing so that sentry prod data doesn't break, and we
can still test on production data and compare `sentry` and `sentry_experimental`
projects product experiences.

Adding a flag that will allow us to control the rollout of the double write.
used in https://github.com/getsentry/sentry/pull/65719/files?diff=split&w=1
