### PR TITLE
ref(weekly reports): Filter only perf issues on issue platform dataset

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -156,6 +156,7 @@ def project_key_performance_issues(ctx, project):
                 Function("count", []),
             ],
             where=[
+                Condition(Column("group_id"), Op.IN, list(group_id_to_group.keys())),
                 Condition(Column("timestamp"), Op.GTE, ctx.start),
                 Condition(Column("timestamp"), Op.LT, ctx.end + timedelta(days=1)),
                 Condition(Column("project_id"), Op.EQ, project.id),

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -10,7 +10,7 @@ from django.db.models import F
 from django.utils import timezone as django_timezone
 
 from sentry.constants import DataCategory
-from sentry.issues.grouptype import PerformanceNPlusOneGroupType
+from sentry.issues.grouptype import MonitorCheckInFailure, PerformanceNPlusOneGroupType
 from sentry.models.group import GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus
 from sentry.models.notificationsettingoption import NotificationSettingOption
@@ -349,6 +349,9 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         group2.save()
         self.create_performance_issue(fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group1")
         self.create_performance_issue(fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group2")
+
+        # store a crons issue just to make sure it's not counted in key_performance_issues
+        self.create_group(type=MonitorCheckInFailure.type_id)
         prepare_organization_report(to_timestamp(now), ONE_DAY * 7, self.organization.id)
 
         for call_args in message_builder.call_args_list:


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/65681 to make sure we're only returning results for performance issues, and not other things on the issue platform dataset.