### PR TITLE
fix(trace-view): restoring detailed param for old trace query.

### DIFF
--- a/static/app/utils/performance/quickTrace/traceFullQuery.spec.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.spec.tsx
@@ -56,6 +56,29 @@ describe('TraceFullQuery', function () {
     expect(getMock).toHaveBeenCalledTimes(1);
   });
 
+  it('fetches data on mount with detailed param', async function () {
+    const getMock = MockApiClient.addMockResponse({
+      url: `/organizations/test-org/events-trace/${traceId}/`,
+      body: [],
+      match: [MockApiClient.matchQuery({detailed: '1'})],
+    });
+    render(
+      <TraceFullDetailedQuery
+        detailed
+        traceId={traceId}
+        eventId={eventId}
+        location={location}
+        orgSlug="test-org"
+        statsPeriod="24h"
+      >
+        {renderTraceFull}
+      </TraceFullDetailedQuery>
+    );
+
+    expect(await screen.findByTestId('type')).toHaveTextContent('full');
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
   it('fetches data on mount with useSpans param', async function () {
     const getMock = MockApiClient.addMockResponse({
       url: `/organizations/test-org/events-trace/${traceId}/`,
@@ -64,6 +87,7 @@ describe('TraceFullQuery', function () {
     });
     render(
       <TraceFullDetailedQuery
+        useSpans
         traceId={traceId}
         eventId={eventId}
         location={location}

--- a/static/app/utils/performance/quickTrace/traceFullQuery.spec.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.spec.tsx
@@ -64,7 +64,7 @@ describe('TraceFullQuery', function () {
     });
     render(
       <TraceFullDetailedQuery
-        detailed
+        type="detailed"
         traceId={traceId}
         eventId={eventId}
         location={location}
@@ -87,7 +87,7 @@ describe('TraceFullQuery', function () {
     });
     render(
       <TraceFullDetailedQuery
-        useSpans
+        type="spans"
         traceId={traceId}
         eventId={eventId}
         location={location}

--- a/static/app/utils/performance/quickTrace/traceFullQuery.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.tsx
@@ -120,9 +120,7 @@ export function TraceFullQuery(
 }
 
 export function TraceFullDetailedQuery(
-  props: Omit<QueryProps<TraceSplitResults<TraceFullDetailed>>, 'detailed'>
+  props: QueryProps<TraceSplitResults<TraceFullDetailed>>
 ) {
-  return (
-    <GenericTraceFullQuery<TraceSplitResults<TraceFullDetailed>> {...props} useSpans />
-  );
+  return <GenericTraceFullQuery<TraceSplitResults<TraceFullDetailed>> {...props} />;
 }

--- a/static/app/utils/performance/quickTrace/traceFullQuery.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.tsx
@@ -16,10 +16,9 @@ import {
 } from 'sentry/utils/performance/quickTrace/utils';
 
 type AdditionalQueryProps = {
-  detailed?: boolean;
+  type?: 'detailed' | 'spans';
   eventId?: string;
   limit?: number;
-  useSpans?: boolean;
 };
 
 type TraceFullQueryChildrenProps<T> = BaseTraceChildrenProps &
@@ -37,18 +36,17 @@ type QueryProps<T> = Omit<TraceRequestProps, 'eventView'> &
   };
 
 function getTraceFullRequestPayload({
-  detailed = false,
-  useSpans = false,
+  type,
   eventId,
   limit,
   ...props
 }: DiscoverQueryProps & AdditionalQueryProps) {
   const additionalApiPayload: any = getTraceRequestPayload(props);
 
-  if (useSpans) {
-    additionalApiPayload.useSpans = useSpans ? '1' : '0';
+  if (type === 'spans') {
+    additionalApiPayload.useSpans = '1';
   } else {
-    additionalApiPayload.detailed = detailed ? '1' : '0';
+    additionalApiPayload.detailed = '1';
   }
 
   if (eventId) {
@@ -114,9 +112,7 @@ function GenericTraceFullQuery<T>({
 export function TraceFullQuery(
   props: Omit<QueryProps<TraceSplitResults<TraceFull>>, 'detailed'>
 ) {
-  return (
-    <GenericTraceFullQuery<TraceSplitResults<TraceFull>> {...props} detailed={false} />
-  );
+  return <GenericTraceFullQuery<TraceSplitResults<TraceFull>> {...props} />;
 }
 
 export function TraceFullDetailedQuery(

--- a/static/app/utils/performance/quickTrace/traceFullQuery.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.tsx
@@ -16,9 +16,9 @@ import {
 } from 'sentry/utils/performance/quickTrace/utils';
 
 type AdditionalQueryProps = {
-  type?: 'detailed' | 'spans';
   eventId?: string;
   limit?: number;
+  type?: 'detailed' | 'spans';
 };
 
 type TraceFullQueryChildrenProps<T> = BaseTraceChildrenProps &

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -81,6 +81,7 @@ export function TraceView() {
       <Layout.Page>
         <NoProjectMessage organization={organization}>
           <TraceFullDetailedQuery
+            useSpans
             location={location}
             orgSlug={organization.slug}
             traceId={traceSlug}

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -81,7 +81,7 @@ export function TraceView() {
       <Layout.Page>
         <NoProjectMessage organization={organization}>
           <TraceFullDetailedQuery
-            useSpans
+            type="spans"
             location={location}
             orgSlug={organization.slug}
             traceId={traceSlug}

--- a/static/app/views/performance/traceDetails/index.tsx
+++ b/static/app/views/performance/traceDetails/index.tsx
@@ -147,7 +147,7 @@ class TraceSummary extends Component<Props> {
 
     return (
       <TraceFullDetailedQuery
-        detailed
+        type="detailed"
         location={location}
         orgSlug={organization.slug}
         traceId={traceSlug}

--- a/static/app/views/performance/traceDetails/index.tsx
+++ b/static/app/views/performance/traceDetails/index.tsx
@@ -147,6 +147,7 @@ class TraceSummary extends Component<Props> {
 
     return (
       <TraceFullDetailedQuery
+        detailed
         location={location}
         orgSlug={organization.slug}
         traceId={traceSlug}


### PR DESCRIPTION
Old trace view code requires detailed param to be passed to load measurements and tags for txn details.