### PR TITLE
fix(trace): Start timestamp calculation

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -329,7 +329,8 @@ class TraceEvent:
             result["timestamp"] = datetime.fromisoformat(self.event["timestamp"]).timestamp()
             result["start_timestamp"] = (
                 datetime.fromisoformat(self.event["timestamp"]).timestamp()
-                - self.event["transaction.duration"]
+                # duration is in ms, timestamp is in seconds
+                - self.event["transaction.duration"] / 1000
             )
         if self.nodestore_event:
             result["timestamp"] = self.nodestore_event.data.get("timestamp")

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -793,9 +793,10 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
 
     def assert_event(self, result, event_data, message):
         assert result["transaction"] == event_data.transaction, message
-        assert result["event_id"] == event_data.event_id, message
-        # assert result["timestamp"] == event_data.data["timestamp"], message
-        # assert result["start_timestamp"] == event_data.data["start_timestamp"], message
+        assert result["event_id"] == pytest.approx(event_data.event_id), message
+        assert result["start_timestamp"] == pytest.approx(
+            event_data.data["start_timestamp"]
+        ), message
 
     def assert_trace_data(self, root, gen2_no_children=True):
         """see the setUp docstring for an idea of what the response structure looks like"""


### PR DESCRIPTION
- The start timestamp calculation was using transaction.duration (ms) as-is when timestamps are in seconds which meant that start timestamp would be off by magnitudes
- because of the different datasets, start_timestamp and timestamp are now approximate. But given we just need to render these in the trace view a few ms off should be okay