### PR TITLE
fix[replay]: handle non-dict payload in ingest/dom_index

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -190,9 +190,12 @@ def get_user_actions(
         if tag == "options" and random.randint(0, 499) < 1:
             _handle_options_logging_event(project_id, replay_id, event)
         # log large dom mutation breadcrumb events 1/100 times
+
+        payload = event.get("data", {}).get("payload", {})
         if (
-            tag == "breadcrumb"
-            and event.get("data", {}).get("payload", {}).get("category") == "replay.mutations"
+            isinstance(payload, dict)
+            and tag == "breadcrumb"
+            and payload.get("category") == "replay.mutations"
             and random.randint(0, 99) < 1
         ):
             _handle_mutations_event(project_id, replay_id, event)
@@ -362,6 +365,9 @@ def _handle_breadcrumb(
     click = None
 
     payload = event["data"].get("payload", {})
+    if not isinstance(payload, dict):
+        return None
+
     category = payload.get("category")
     if category == "ui.slowClickDetected":
         is_timeout_reason = payload["data"].get("endReason") == "timeout"

--- a/tests/sentry/replays/unit/test_ingest_dom_index.py
+++ b/tests/sentry/replays/unit/test_ingest_dom_index.py
@@ -80,6 +80,23 @@ def test_get_user_actions():
     assert len(user_actions[0]["event_hash"]) == 36
 
 
+def test_get_user_actions_str_payload():
+    """Test "get_user_actions" function."""
+    events = [
+        {
+            "type": 5,
+            "timestamp": 1674298825,
+            "data": {
+                "tag": "breadcrumb",
+                "payload": "hello world",
+            },
+        }
+    ]
+
+    user_actions = get_user_actions(1, uuid.uuid4().hex, events, None)
+    assert len(user_actions) == 0
+
+
 def test_get_user_actions_missing_node():
     """Test "get_user_actions" function."""
     events = [


### PR DESCRIPTION
Handle the case where replay_event had a string (ex: "**not serializable") payload
[Sentry issue](https://sentry.sentry.io/issues/4958309698/?project=1&query=is%3Aunresolved+assigned%3A%5Bme%2C+my_teams%5D&referrer=issue-stream&sort=date&statsPeriod=7d&stream_index=4)

Fixes [SENTRY-2KVD](https://sentry.sentry.io/issues/?project=1&query=SENTRY-2KVD)