### PR TITLE
ref(slack): update logic to show context

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -383,6 +383,7 @@ class PerformanceDurationRegressionGroupType(GroupType):
     enable_auto_resolve = False
     enable_escalation_detection = False
     default_priority = PriorityLevel.LOW
+    notification_config = NotificationConfig(context=["Approx. Start Time"])
 
 
 @dataclass(frozen=True)
@@ -395,7 +396,7 @@ class PerformanceP95EndpointRegressionGroupType(GroupType):
     enable_escalation_detection = False
     default_priority = PriorityLevel.MEDIUM
     released = True
-    notification_config = NotificationConfig(context=["Users Affected", "State", "Regressed Date"])
+    notification_config = NotificationConfig(context=["Approx. Start Time"])
 
 
 # experimental
@@ -495,6 +496,7 @@ class ProfileFunctionRegressionExperimentalType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
     default_priority = PriorityLevel.LOW
+    notification_config = NotificationConfig(context=["Approx. Start Time"])
 
 
 @dataclass(frozen=True)
@@ -506,7 +508,7 @@ class ProfileFunctionRegressionType(GroupType):
     enable_auto_resolve = False
     released = True
     default_priority = PriorityLevel.MEDIUM
-    notification_config = NotificationConfig(context=[])
+    notification_config = NotificationConfig(context=["Approx. Start Time"])
 
 
 @dataclass(frozen=True)
@@ -559,6 +561,7 @@ class ReplayRageClickType(ReplayGroupTypeDefaults, GroupType):
     description = "Rage Click Detected"
     category = GroupCategory.REPLAY.value
     default_priority = PriorityLevel.MEDIUM
+    notification_config = NotificationConfig()
 
 
 @dataclass(frozen=True)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1653,6 +1653,8 @@ class SlackNotificationConfigTest(TestCase, PerformanceIssueTestCase):
             assert_no_errors=False,
         )
         group = event.group
+        assert group
+
         context_without_error_user_count = get_context(group)
         assert (
             context_without_error_user_count


### PR DESCRIPTION
Changes:
- All regression performance type issues will have `Approx. Start Time: date+time` (representing the regressed date)
- User Feedback and Crons will not have context
- Update logic to show context if all 4 defaults can possibly be shown (see below)

For error, non-regression performance, and replay rage click issues, we can show either all 4 of `Events`, `Users Affected`, `State`, `First Seen`, or just `State` and `First Seen`.
- We always show `State` and `First Seen`
- We only show `Event Count` and `User Count` if the event count > 1 or if the state != `New`

NOTE: We also don't show values in context that are non-truthy. So if `User Count` is `None` or `0` we don't show it.

Resolves https://github.com/getsentry/team-core-product-foundations/issues/83