### PR TITLE
chore(hybridcloud) Reduce number of metric tags

### DIFF
--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -462,8 +462,7 @@ class _RemoteSiloCall:
     def _metrics_tags(self, **additional_tags: str | int) -> Mapping[str, str | int | None]:
         return dict(
             rpc_destination_region=self.region.name if self.region else None,
-            rpc_service=self.service_name,
-            rpc_method=self.method_name,
+            rpc_method=f"{self.service_name}.{self.method_name}",
             **additional_tags,
         )
 


### PR DESCRIPTION
The combinator of service name and method is what we care about. Even if method names are shared across services the performance and behavior of those methods will not have anything in common.