### PR TITLE
fix(issues): sort values by last_seen on Tag Details page

### DIFF
--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -227,7 +227,14 @@ class TagStorage(Service):
         raise NotImplementedError
 
     def get_group_tag_value_iter(
-        self, group, environment_ids, key, callbacks=(), offset=0, tenant_ids=None
+        self,
+        group,
+        environment_ids,
+        key,
+        callbacks=(),
+        orderby="-first_seen",
+        offset=0,
+        tenant_ids=None,
     ):
         """
         >>> get_group_tag_value_iter(group, 2, 3, 'environment')

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1422,7 +1422,7 @@ class SnubaTagStorage(TagStorage):
                 ["min", "timestamp", "first_seen"],
                 ["max", "timestamp", "last_seen"],
             ],
-            orderby="-first_seen",  # Closest thing to pre-existing `-id` order
+            orderby="-last_seen",
             limit=limit,
             referrer="tagstore.get_group_tag_value_iter",
             offset=offset,

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1402,7 +1402,15 @@ class SnubaTagStorage(TagStorage):
         )
 
     def get_group_tag_value_iter(
-        self, group, environment_ids, key, callbacks=(), limit=1000, offset=0, tenant_ids=None
+        self,
+        group,
+        environment_ids,
+        key,
+        callbacks=(),
+        orderby="-first_seen",
+        limit=1000,
+        offset=0,
+        tenant_ids=None,
     ):
         filters = {
             "project_id": get_project_list(group.project_id),
@@ -1422,7 +1430,7 @@ class SnubaTagStorage(TagStorage):
                 ["min", "timestamp", "first_seen"],
                 ["max", "timestamp", "last_seen"],
             ],
-            orderby="-last_seen",
+            orderby=orderby,
             limit=limit,
             referrer="tagstore.get_group_tag_value_iter",
             offset=offset,
@@ -1453,7 +1461,7 @@ class SnubaTagStorage(TagStorage):
             raise ValueError("Unsupported order_by: %s" % order_by)
 
         group_tag_values = self.get_group_tag_value_iter(
-            group, environment_ids, key, tenant_ids=tenant_ids
+            group, environment_ids, key, orderby="-last_seen", tenant_ids=tenant_ids
         )
 
         desc = order_by.startswith("-")


### PR DESCRIPTION
Current behavior on the tag details page (for example, https://sentry.sentry.io/issues/4981240586/tags/url/?project=1267915):
1. Get first 1000 values of specified tag (in my case, `url`) ordered by `first_seen`, descending.
2. Sort them by count.

This way, tag values that were first seen long time ago and still having recent events (and potentially having a large count), are not represented on the Tag Details page. Only "new" values are represented. This contradicts the top list of tag values from this page: https://sentry.sentry.io/issues/4981240586/tags/?project=1267915

After this fix:
1. Get first 1000 values of specified tag ordered by `last_seen`, descending.
2. Sort them by count.

This way, if there is an old tag (small `first_seen`) that has recent events (`last_seen`), it will be represented in the first 1000 of tags.

Keeping the default behavior for `get_group_tag_value_iter` (order by `-first_seen`) since this method is also used by data export.