### PR TITLE
feat(metrics): ALways return metric summary per sample

### DIFF
--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1002,8 +1002,9 @@ class DiscoverDatasetConfig(DatasetConfig):
                 ),
                 SnQLFunction(
                     "example",
+                    required_args=[NumericColumn("column")],
                     snql_aggregate=lambda args, alias: function_aliases.resolve_random_sample(
-                        ["timestamp", "span_id"], alias
+                        ["timestamp", "span_id", args["column"].name], alias
                     ),
                     private=True,
                 ),

--- a/src/sentry/search/events/datasets/metrics_summaries.py
+++ b/src/sentry/search/events/datasets/metrics_summaries.py
@@ -41,7 +41,16 @@ class MetricsSummariesDatasetConfig(DatasetConfig):
                 SnQLFunction(
                     "example",
                     snql_aggregate=lambda args, alias: function_aliases.resolve_random_sample(
-                        ["group", "end_timestamp", "span_id"], alias
+                        [
+                            "group",
+                            "end_timestamp",
+                            "span_id",
+                            "min",
+                            "max",
+                            "sum",
+                            "count",
+                        ],
+                        alias,
                     ),
                     private=True,
                 ),

--- a/src/sentry/sentry_metrics/querying/samples_list.py
+++ b/src/sentry/sentry_metrics/querying/samples_list.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any
+from typing import Any, TypedDict, cast
 
 from snuba_sdk import And, Column, Condition, Function, Op, Or
 
@@ -22,7 +22,14 @@ from sentry.snuba.metrics.naming_layer.mri import (
 from sentry.snuba.referrer import Referrer
 
 
-class SamplesListExecutor(ABC):
+class Summary(TypedDict):
+    min: float
+    max: float
+    sum: float
+    count: int
+
+
+class AbstractSamplesListExecutor(ABC):
     def __init__(
         self,
         mri: str,
@@ -50,9 +57,15 @@ class SamplesListExecutor(ABC):
     def execute(self, offset, limit):
         raise NotImplementedError
 
-    def get_spans_by_key(self, span_ids: list[tuple[str, str, str]]):
+    def get_spans_by_key(
+        self, span_ids: list[tuple[str, str, str]], additional_fields: list[str] | None = None
+    ):
         if not span_ids:
             return {"data": []}
+
+        fields = self.fields
+        if additional_fields is not None:
+            fields += additional_fields
 
         builder = SpansIndexedQueryBuilder(
             Dataset.SpansIndexed,
@@ -105,10 +118,10 @@ class SamplesListExecutor(ABC):
         return builder.process_results(query_results)
 
 
-class SegmentsSamplesListExecutor(SamplesListExecutor):
+class SegmentsSamplesListExecutor(AbstractSamplesListExecutor):
     @classmethod
     @abstractmethod
-    def mri_to_column(cls, mri) -> str | None:
+    def mri_to_column(cls, mri: str) -> str | None:
         raise NotImplementedError
 
     @classmethod
@@ -116,12 +129,22 @@ class SegmentsSamplesListExecutor(SamplesListExecutor):
         return cls.mri_to_column(mri) is not None
 
     def execute(self, offset, limit):
-        span_keys = self.get_span_keys(offset, limit)
-        return self.get_spans_by_key(span_keys)
+        span_keys, summaries = self.get_span_keys(offset, limit)
+        result = self.get_spans_by_key(span_keys)
 
-    def get_span_keys(self, offset: int, limit: int) -> list[tuple[str, str, str]]:
-        rounded_timestamp = f"rounded_timestamp({self.rollup})"
+        should_pop_id = "id" not in self.fields
 
+        for row in result["data"]:
+            span_id = row.pop("id") if should_pop_id else row["id"]
+            row["summary"] = summaries[span_id]
+
+        return result
+
+    def get_span_keys(
+        self,
+        offset: int,
+        limit: int,
+    ) -> tuple[list[tuple[str, str, str]], dict[str, Summary]]:
         """
         When getting examples for a segment, it's actually much faster to read it
         from the transactions dataset compared to the spans dataset as it's a much
@@ -137,7 +160,10 @@ class SegmentsSamplesListExecutor(SamplesListExecutor):
             self.params,
             snuba_params=self.snuba_params,
             query=self.query,
-            selected_columns=[rounded_timestamp, "example()"],
+            selected_columns=[
+                f"rounded_timestamp({self.rollup})",
+                f"example({self.mri_to_column(self.mri)}) AS example",
+            ],
             limit=limit,
             offset=offset,
             sample_rate=options.get("metrics.sample-list.sample-rate"),
@@ -149,7 +175,7 @@ class SegmentsSamplesListExecutor(SamplesListExecutor):
         query_results = builder.run_query(self.referrer.value)
         result = builder.process_results(query_results)
 
-        return [
+        span_keys = [
             (
                 "00",  # all segments have a group of `00` currently
                 row["example"][0],  # timestamp
@@ -158,6 +184,33 @@ class SegmentsSamplesListExecutor(SamplesListExecutor):
             for row in result["data"]
         ]
 
+        """
+        Because transaction level measurements currently do not get
+        propagated to the spans dataset, we have to query them here,
+        generate the summary for it here, and propagate it to the
+        results of the next stage.
+
+        Once we start writing transaction level measurements to the
+        indexed spans dataset, we can stop doing this and read the
+        value directly from the indexed spans dataset.
+
+        For simplicity, all transaction based metrics use this approach.
+        """
+        summaries = {
+            cast(str, row["example"][1]): cast(
+                Summary,
+                {
+                    "min": row["example"][2],
+                    "max": row["example"][2],
+                    "sum": row["example"][2],
+                    "count": 1,
+                },
+            )
+            for row in result["data"]
+        }
+
+        return span_keys, summaries
+
     @abstractmethod
     def get_additional_conditions(self, builder: QueryBuilder) -> list[Condition]:
         raise NotImplementedError
@@ -165,9 +218,11 @@ class SegmentsSamplesListExecutor(SamplesListExecutor):
 
 class TransactionDurationSamplesListExecutor(SegmentsSamplesListExecutor):
     @classmethod
-    def mri_to_column(cls, mri) -> str | None:
+    def mri_to_column(cls, mri: str) -> str | None:
         if mri == TransactionMRI.DURATION.value:
-            return "duration"
+            # Because we read this from the transactions dataset,
+            # we use the name for the transactions dataset instead.
+            return "transaction.duration"
         return None
 
     def get_additional_conditions(self, builder: QueryBuilder) -> list[Condition]:
@@ -179,7 +234,7 @@ class TransactionMeasurementsSamplesListExecutor(SegmentsSamplesListExecutor):
     def mri_to_column(cls, mri) -> str | None:
         name = cls.measurement_name(mri)
         if name is not None:
-            return f"measurements[{name}]"
+            return f"measurements.{name}"
 
         return None
 
@@ -195,7 +250,7 @@ class TransactionMeasurementsSamplesListExecutor(SegmentsSamplesListExecutor):
         return [Condition(Function("has", [Column("measurements.key"), name]), Op.EQ, 1)]
 
 
-class SpansSamplesListExecutor(SamplesListExecutor):
+class SpansSamplesListExecutor(AbstractSamplesListExecutor):
     @classmethod
     @abstractmethod
     def mri_to_column(cls, mri) -> str | None:
@@ -207,7 +262,22 @@ class SpansSamplesListExecutor(SamplesListExecutor):
 
     def execute(self, offset, limit):
         span_keys = self.get_span_keys(offset, limit)
-        return self.get_spans_by_key(span_keys)
+
+        column = self.mri_to_column(self.mri)
+        assert column is not None
+
+        result = self.get_spans_by_key(span_keys, additional_fields=[column])
+
+        for row in result["data"]:
+            value = row.pop(column)
+            row["summary"] = {
+                "min": value,
+                "max": value,
+                "sum": value,
+                "count": 1,
+            }
+
+        return result
 
     def get_span_keys(self, offset: int, limit: int) -> list[tuple[str, str, str]]:
         rounded_timestamp = f"rounded_timestamp({self.rollup})"
@@ -278,7 +348,7 @@ class SpansMeasurementsSamplesListExecutor(SpansSamplesListExecutor):
     def mri_to_column(cls, mri) -> str | None:
         name = cls.measurement_name(mri)
         if name is not None:
-            return f"measurements[{name}]"
+            return f"measurements.{name}"
 
         return None
 
@@ -303,7 +373,7 @@ class SpansMeasurementsSamplesListExecutor(SpansSamplesListExecutor):
         return [Condition(Function("has", [Column("measurements.key"), name]), Op.EQ, 1)]
 
 
-class CustomSamplesListExecutor(SamplesListExecutor):
+class CustomSamplesListExecutor(AbstractSamplesListExecutor):
     @classmethod
     def supports(cls, mri: str) -> bool:
         parsed_mri = parse_mri(mri)
@@ -312,10 +382,22 @@ class CustomSamplesListExecutor(SamplesListExecutor):
         return False
 
     def execute(self, offset, limit):
-        span_keys = self.get_span_keys(offset, limit)
-        return self.get_spans_by_key(span_keys)
+        span_keys, summaries = self.get_span_keys(offset, limit)
+        result = self.get_spans_by_key(span_keys, additional_fields=["id"])
 
-    def get_span_keys(self, offset: int, limit: int) -> list[tuple[str, str, str]]:
+        should_pop_id = "id" not in self.fields
+
+        for row in result["data"]:
+            span_id = row.pop("id") if should_pop_id else row["id"]
+            row["summary"] = summaries[span_id]
+
+        return result
+
+    def get_span_keys(
+        self,
+        offset: int,
+        limit: int,
+    ) -> tuple[list[tuple[str, str, str]], dict[str, Summary]]:
         rounded_timestamp = f"rounded_timestamp({self.rollup})"
 
         query = " ".join(q for q in [self.query, f"metric:{self.mri}"] if q)
@@ -336,14 +418,34 @@ class CustomSamplesListExecutor(SamplesListExecutor):
         query_results = builder.run_query(self.referrer.value)
         result = builder.process_results(query_results)
 
-        return [
+        span_keys = [
             (
-                row["example"][0],  # group
-                row["example"][1],  # timestamp
-                row["example"][2],  # span_id
+                cast(str, row["example"][0]),  # group
+                cast(str, row["example"][1]),  # timestamp
+                cast(str, row["example"][2]),  # span_id
             )
             for row in result["data"]
         ]
+
+        """
+        The indexed spans dataset does not contain any metric related
+        data. To propagate these values, we read it from the metric
+        summaries table, and copy them to the results in the next step.
+        """
+        summaries = {
+            cast(str, row["example"][2]): cast(
+                Summary,
+                {
+                    "min": row["example"][3],
+                    "max": row["example"][4],
+                    "sum": row["example"][5],
+                    "count": row["example"][6],
+                },
+            )
+            for row in result["data"]
+        }
+
+        return span_keys, summaries
 
 
 SAMPLE_LIST_EXECUTORS = [
@@ -355,7 +457,7 @@ SAMPLE_LIST_EXECUTORS = [
 ]
 
 
-def get_sample_list_executor_cls(mri) -> type[SamplesListExecutor] | None:
+def get_sample_list_executor_cls(mri) -> type[AbstractSamplesListExecutor] | None:
     for executor_cls in SAMPLE_LIST_EXECUTORS:
         if executor_cls.supports(mri):
             return executor_cls

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -156,6 +156,10 @@ METRICS_SUMMARIES_COLUMN_MAP = {
     "segment.id": "segment_id",
     "span.duration": "duration",
     "span.group": "group",
+    "min_metric": "min",
+    "max_metric": "max",
+    "sum_metric": "sum",
+    "count_metric": "count",
 }
 
 SPAN_COLUMN_MAP.update(

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -184,6 +184,14 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
         actual = {int(row["id"], 16) for row in response.data["data"]}
         assert actual == expected
 
+        for row in response.data["data"]:
+            assert row["summary"] == {
+                "min": 10.0,
+                "max": 10.0,
+                "sum": 10.0,
+                "count": 1,
+            }
+
     def test_transaction_duration_samples(self):
         span_ids = [uuid4().hex[:16] for _ in range(1)]
         for i, span_id in enumerate(span_ids):
@@ -218,7 +226,15 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
         actual = {int(row["id"], 16) for row in response.data["data"]}
         assert actual == expected
 
-    def test_measurement_samples(self):
+        for row in response.data["data"]:
+            assert row["summary"] == {
+                "min": 3000,
+                "max": 3000,
+                "sum": 3000,
+                "count": 1,
+            }
+
+    def test_transaction_measurement_samples(self):
         good_span_ids = [uuid4().hex[:16] for _ in range(1)]
         bad_span_ids = [uuid4().hex[:16] for _ in range(1)]
         for i, (good_span_id, bad_span_id) in enumerate(zip(good_span_ids, bad_span_ids)):
@@ -274,6 +290,14 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
         actual = {int(row["id"], 16) for row in response.data["data"]}
         assert actual == expected
 
+        for row in response.data["data"]:
+            assert row["summary"] == {
+                "min": 10.0,
+                "max": 10.0,
+                "sum": 10.0,
+                "count": 1,
+            }
+
     def test_span_measurement_samples(self):
         good_span_ids = [uuid4().hex[:16] for _ in range(1)]
         bad_span_ids = [uuid4().hex[:16] for _ in range(1)]
@@ -288,12 +312,17 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 timestamp=ts,
                 group=uuid4().hex[:16],  # we need a non 0 group
                 measurements={
-                    "score.total": 1,
-                    "score.inp": 2,
-                    "score.weight.inp": 3,
-                    "http.response_content_length": 4,
-                    "http.decoded_response_content_length": 5,
-                    "http.response_transfer_size": 6,
+                    measurement: i + 1
+                    for i, measurement in enumerate(
+                        [
+                            "score.total",
+                            "score.inp",
+                            "score.weight.inp",
+                            "http.response_content_length",
+                            "http.decoded_response_content_length",
+                            "http.response_transfer_size",
+                        ]
+                    )
                 },
             )
             self.store_indexed_span(
@@ -305,14 +334,16 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 group=uuid4().hex[:16],  # we need a non 0 group
             )
 
-        for mri in [
-            "d:spans/http.response_content_length@byte",
-            "d:spans/http.decoded_response_content_length@byte",
-            "d:spans/http.response_transfer_size@byte",
-            "d:spans/webvital.score.total@ratio",
-            "d:spans/webvital.score.inp@ratio",
-            "d:spans/webvital.score.weight.inp@ratio",
-        ]:
+        for i, mri in enumerate(
+            [
+                "d:spans/webvital.score.total@ratio",
+                "d:spans/webvital.score.inp@ratio",
+                "d:spans/webvital.score.weight.inp@ratio",
+                "d:spans/http.response_content_length@byte",
+                "d:spans/http.decoded_response_content_length@byte",
+                "d:spans/http.response_transfer_size@byte",
+            ]
+        ):
             query = {
                 "mri": mri,
                 "field": ["id"],
@@ -323,7 +354,15 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
             assert response.status_code == 200, response.data
             expected = {int(span_id, 16) for span_id in good_span_ids}
             actual = {int(row["id"], 16) for row in response.data["data"]}
-            assert actual == expected
+            assert actual == expected, mri
+
+            for row in response.data["data"]:
+                assert row["summary"] == {
+                    "min": i + 1,
+                    "max": i + 1,
+                    "sum": i + 1,
+                    "count": 1,
+                }, mri
 
     def test_custom_samples(self):
         mri = "d:custom/value@millisecond"
@@ -361,10 +400,10 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 store_metrics_summary={
                     "d:custom/other@millisecond": [
                         {
-                            "min": 10.0,
-                            "max": 100.0,
-                            "sum": 110.0,
-                            "count": 2,
+                            "min": 20.0,
+                            "max": 200.0,
+                            "sum": 220.0,
+                            "count": 3,
                             "tags": {},
                         }
                     ]
@@ -382,3 +421,11 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
         expected = {int(span_id, 16) for span_id in good_span_ids}
         actual = {int(row["id"], 16) for row in response.data["data"]}
         assert actual == expected
+
+        for row in response.data["data"]:
+            assert row["summary"] == {
+                "min": 10.0,
+                "max": 100.0,
+                "sum": 110.0,
+                "count": 2,
+            }


### PR DESCRIPTION
To better provide context as to why a particular sample was shown, always include a metric summary for each sample returned.