### PR TITLE
fix(issue-priority): Only update priority and activity if priority changes

### DIFF
--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -116,5 +116,5 @@ def auto_update_priority(group: Group, reason: PriorityChangeReason) -> None:
     elif reason == PriorityChangeReason.ONGOING:
         new_priority = get_priority_for_ongoing_group(group)
 
-    if new_priority is not None:
+    if new_priority is not None and new_priority != group.priority:
         update_priority(group, new_priority, reason)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -456,7 +456,7 @@ class GroupManager(BaseManager["Group"]):
             group.substatus = substatus
             if should_update_priority:
                 priority = get_priority_for_ongoing_group(group)
-                if priority:
+                if priority and group.priority != priority:
                     group.priority = priority
                     updated_priority[group.id] = priority
 

--- a/tests/sentry/issues/test_priority.py
+++ b/tests/sentry/issues/test_priority.py
@@ -56,9 +56,12 @@ class TestUpdatesPriority(TestCase):
         )
         auto_update_priority(self.group, PriorityChangeReason.ESCALATING)
         assert self.group.priority == PriorityLevel.HIGH
-        self.assert_activity_grouphistory_set(
-            self.group, PriorityLevel.HIGH, PriorityChangeReason.ESCALATING
-        )
+        assert not Activity.objects.filter(
+            group=self.group, type=ActivityType.SET_PRIORITY.value
+        ).exists()
+        assert not GroupHistory.objects.filter(
+            group=self.group, status=GroupHistoryStatus.PRIORITY_HIGH
+        ).exists()
 
     def test_skips_if_priority_locked(self) -> None:
         self.group = self.create_group(
@@ -115,8 +118,14 @@ class TestUpdatesPriority(TestCase):
         )
         auto_update_priority(self.group, PriorityChangeReason.ONGOING)
         assert self.group.priority == PriorityLevel.HIGH
-        self.assert_activity_grouphistory_set(
-            self.group, PriorityLevel.HIGH, PriorityChangeReason.ONGOING
+        assert not Activity.objects.filter(
+            group=self.group, type=ActivityType.SET_PRIORITY.value
+        ).exists()
+        assert (
+            GroupHistory.objects.filter(
+                group=self.group, status=GroupHistoryStatus.PRIORITY_HIGH
+            ).count()
+            == 1
         )
 
     def test_updates_priority_ongoing_no_history(self) -> None:


### PR DESCRIPTION
Checks the current priority when updating, to only write to GroupHistory/Activity tables if the priority is changed. 

Fixes https://github.com/getsentry/sentry/issues/65663