### PR TITLE
ref(issue-priority): Remove Priority sort constants from backend

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -42,9 +42,7 @@ COMMIT_RANGE_DELIMITER = ".."
 # semver constants
 SEMVER_FAKE_PACKAGE = "__sentry_fake__"
 
-# TODO(snigdha): we will need to remove priority from here once we have renamed all instances to trends
 SORT_OPTIONS = {
-    "priority": _("Priority"),
     "trends": _("Trends"),
     "date": _("Last Seen"),
     "new": _("First Seen"),

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -185,10 +185,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                 result = inbox_search(**query_kwargs)
             else:
                 query_kwargs["referrer"] = "search.group_index"
-                # TODO(snigdha): remove this once we've migrated saved searches to replace priority with trends
-                if query_kwargs["sort_by"] == "priority":
-                    query_kwargs["sort_by"] = "trends"
-
                 result = search.query(**query_kwargs)
             return result, query_kwargs
 

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -17,7 +17,6 @@ from sentry.models.search_common import SearchType
 class SortOptions:
     DATE = "date"
     NEW = "new"
-    PRIORITY = "priority"
     TRENDS = "trends"
     FREQ = "freq"
     USER = "user"
@@ -28,7 +27,6 @@ class SortOptions:
         return (
             (cls.DATE, _("Last Seen")),
             (cls.NEW, _("First Seen")),
-            (cls.PRIORITY, _("Priority")),
             (cls.TRENDS, _("Trends")),
             (cls.FREQ, _("Events")),
             (cls.USER, _("Users")),

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -694,13 +694,11 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
     dependency_aggregations = {"trends": ["last_seen", "times_seen"]}
     postgres_only_fields = {*SKIP_SNUBA_FIELDS, "regressed_in_release"}
     # add specific fields here on top of skip_snuba_fields from the serializer
-    # TODO(snigdha): we will need to remove priority from here once we have renamed all instances to trends
     sort_strategies = {
         "date": "last_seen",
         "freq": "times_seen",
         "new": "first_seen",
         "trends": "trends",
-        "priority": "priority",
         "user": "user_count",
         # We don't need a corresponding snuba field here, since this sort only happens
         # in Postgres
@@ -712,12 +710,10 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         "first_seen": ["multiply(toUInt64(min(timestamp)), 1000)", ""],
         "last_seen": ["multiply(toUInt64(max(timestamp)), 1000)", ""],
         "trends": trends_aggregation,
-        "priority": trends_aggregation,
         # Only makes sense with WITH TOTALS, returns 1 for an individual group.
         "total": ["uniq", ISSUE_FIELD_NAME],
         "user_count": ["uniq", "tags[sentry:user]"],
         "trends_issue_platform": trends_issue_platform_aggregation,
-        "priority_issue_platform": trends_issue_platform_aggregation,
     }
 
     @property
@@ -1121,8 +1117,6 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "date": "last_seen",
         "freq": "times_seen",
         "new": "first_seen",
-        # TODO(snigdha): we will need to remove priority from here once we have renamed all instances to trends
-        "priority": "priority",
         "trends": "trends",
         "user": "user_count",
     }
@@ -1171,27 +1165,6 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "last_seen": last_seen_aggregation,
         # https://github.com/getsentry/sentry/blob/804c85100d0003cfdda91701911f21ed5f66f67c/src/sentry/event_manager.py#L241-L271
         "trends": Function(
-            "toUInt64",
-            [
-                Function(
-                    "plus",
-                    [
-                        Function(
-                            "multiply",
-                            [
-                                Function(
-                                    "log",
-                                    [times_seen_aggregation],
-                                ),
-                                600,
-                            ],
-                        ),
-                        last_seen_aggregation,
-                    ],
-                )
-            ],
-        ),
-        "priority": Function(
             "toUInt64",
             [
                 Function(

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -170,66 +170,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 2
         assert [item["id"] for item in response.data] == [str(group.id), str(group_2.id)]
 
-    def test_sort_by_priority(self):
-        group = self.store_event(
-            data={
-                "timestamp": iso_format(before_now(seconds=10)),
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        ).group
-        self.store_event(
-            data={
-                "timestamp": iso_format(before_now(seconds=10)),
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={
-                "timestamp": iso_format(before_now(hours=13)),
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        )
-
-        group_2 = self.store_event(
-            data={
-                "timestamp": iso_format(before_now(seconds=5)),
-                "fingerprint": ["group-2"],
-            },
-            project_id=self.project.id,
-        ).group
-        self.store_event(
-            data={
-                "timestamp": iso_format(before_now(hours=13)),
-                "fingerprint": ["group-2"],
-            },
-            project_id=self.project.id,
-        )
-        self.login_as(user=self.user)
-
-        aggregate_kwargs: dict = {
-            "log_level": "3",
-            "has_stacktrace": "5",
-            "relative_volume": "1",
-            "event_halflife_hours": "4",
-            "issue_halflife_hours": "4",
-            "v2": "true",
-            "norm": "False",
-        }
-
-        response = self.get_success_response(
-            sort="priority",
-            query="is:unresolved",
-            limit=25,
-            start=iso_format(before_now(days=1)),
-            end=iso_format(before_now(seconds=1)),
-            **aggregate_kwargs,
-        )
-        assert len(response.data) == 2
-        assert [item["id"] for item in response.data] == [str(group.id), str(group_2.id)]
-
     def test_sort_by_inbox(self):
         group_1 = self.store_event(
             data={

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3982,15 +3982,6 @@ class CdcEventsSnubaSearchTest(TestCase, SharedSnubaMixin):
             date_from=self.base_datetime - timedelta(days=30),
         )
 
-    def test_sort_priority(self):
-        self.run_test(
-            "is:unresolved",
-            [self.group1, self.group2],
-            None,
-            sort_by="priority",
-            date_from=self.base_datetime - timedelta(days=30),
-        )
-
     def test_cursor(self):
         group3 = self.store_event(
             data={


### PR DESCRIPTION
Step 4/4 for the priority sort -> trends rename.

We've renamed the sort in the SavedSearch table and update the frontend to send 'trends' for the sort name. We can now drop support for 'priority'. 

Fixes https://github.com/getsentry/sentry/issues/65208