### PR TITLE
fix(profiling): Use `ProfilerOnRenderCallback` type

### DIFF
--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react';
+import type {ProfilerOnRenderCallback, ReactNode} from 'react';
 import {Fragment, Profiler, useEffect, useRef} from 'react';
 import type {IdleTransaction} from '@sentry/core';
 import {captureMessage, setExtra, setTag} from '@sentry/react';
@@ -35,11 +35,7 @@ export function getPerformanceTransaction(): IdleTransaction | Transaction | und
 /**
  * Callback for React Profiler https://reactjs.org/docs/profiler.html
  */
-export function onRenderCallback(
-  id: string,
-  phase: 'mount' | 'update',
-  actualDuration: number
-) {
+export const onRenderCallback: ProfilerOnRenderCallback = (id, phase, actualDuration) => {
   try {
     const transaction = getPerformanceTransaction();
     if (transaction && actualDuration > MIN_UPDATE_SPAN_TIME) {
@@ -54,7 +50,7 @@ export function onRenderCallback(
   } catch (_) {
     // Add defensive catch since this wraps all of App
   }
-}
+};
 
 export class PerformanceInteraction {
   private static interactionTransaction: Transaction | null = null;


### PR DESCRIPTION
Use the ProfilerOnRenderCallback type directly since its different in 17 and 18. I think there's a new phase 'nested-update' and the types were angry in 18

part of https://github.com/getsentry/frontend-tsc/issues/22