### PR TITLE
ref(dynamic-sampling): Improve handling of sample rates

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -568,7 +568,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         if sample_rate is not None:
             context["planSampleRate"] = sample_rate
 
-        desired_sample_rate = get_sliding_window_org_sample_rate(
+        desired_sample_rate, _ = get_sliding_window_org_sample_rate(
             org_id=obj.id, default_sample_rate=sample_rate
         )
         if desired_sample_rate is not None:

--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -70,7 +70,7 @@ def get_guarded_blended_sample_rate(organization: Organization, project: Project
 
     # When using the boosted project sample rate, we want to fall back to the blended sample rate in case there are
     # any issues.
-    sample_rate = get_boost_low_volume_projects_sample_rate(
+    sample_rate, _ = get_boost_low_volume_projects_sample_rate(
         org_id=organization.id, project_id=project.id, error_sample_rate_fallback=sample_rate
     )
 

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -263,12 +263,17 @@ def adjust_sample_rates_of_projects(
 
     # If we have the sliding window org enabled, we use that and fall back to the blended sample rate in case of issues.
     if organization is not None and is_sliding_window_org_enabled(organization):
-        sample_rate = get_sliding_window_org_sample_rate(
-            org_id=org_id, default_sample_rate=sample_rate, notify_missing=True
+        sample_rate, success = get_sliding_window_org_sample_rate(
+            org_id=org_id, default_sample_rate=sample_rate
         )
-        log_sample_rate_source(
-            org_id, None, "boost_low_volume_projects", "sliding_window_org", sample_rate
-        )
+        if success:
+            log_sample_rate_source(
+                org_id, None, "boost_low_volume_projects", "sliding_window_org", sample_rate
+            )
+        else:
+            log_sample_rate_source(
+                org_id, None, "boost_low_volume_projects", "blended_sample_rate", sample_rate
+            )
     else:
         log_sample_rate_source(
             org_id, None, "boost_low_volume_projects", "blended_sample_rate", sample_rate

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -171,13 +171,14 @@ def boost_low_volume_transactions_of_project(project_transactions: ProjectTransa
         log_skipped_job(org_id, "boost_low_volume_transactions")
         return
 
-    # By default, we use the blended sample rate.
-    sample_rate = quotas.backend.get_blended_sample_rate(organization_id=org_id)
-
-    if organization is not None and is_sliding_window_org_enabled(organization):
-        sample_rate = get_boost_low_volume_projects_sample_rate(
-            org_id=org_id, project_id=project_id, error_sample_rate_fallback=sample_rate
-        )
+    # We try to use the sample rate that was individually computed for each project, but if we don't find it, we will
+    # resort to the blended sample rate of the org.
+    sample_rate, success = get_boost_low_volume_projects_sample_rate(
+        org_id=org_id,
+        project_id=project_id,
+        error_sample_rate_fallback=quotas.backend.get_blended_sample_rate(organization_id=org_id),
+    )
+    if success:
         log_sample_rate_source(
             org_id,
             project_id,

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -23,7 +23,6 @@ from sentry.dynamic_sampling.models.base import ModelType
 from sentry.dynamic_sampling.models.common import RebalancedItem, guarded_run
 from sentry.dynamic_sampling.models.factory import model_factory
 from sentry.dynamic_sampling.models.transactions_rebalancing import TransactionsRebalancingInput
-from sentry.dynamic_sampling.rules.base import is_sliding_window_org_enabled
 from sentry.dynamic_sampling.tasks.common import GetActiveOrgs, TimedIterator
 from sentry.dynamic_sampling.tasks.constants import (
     BOOST_LOW_VOLUME_TRANSACTIONS_QUERY_INTERVAL,

--- a/src/sentry/dynamic_sampling/tasks/helpers/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/boost_low_volume_projects.py
@@ -10,28 +10,28 @@ def generate_boost_low_volume_projects_cache_key(org_id: int) -> str:
 
 
 def get_boost_low_volume_projects_sample_rate(
-    org_id: int, project_id: int, error_sample_rate_fallback: float
-) -> float:
+    org_id: int, project_id: int, error_sample_rate_fallback: float | None
+) -> tuple[float | None, bool]:
     redis_client = get_redis_client_for_ds()
     cache_key = generate_boost_low_volume_projects_cache_key(org_id=org_id)
 
     try:
-        return float(redis_client.hget(cache_key, project_id))
+        return float(redis_client.hget(cache_key, project_id)), True
     # Thrown if the input is not a string or a float (e.g., None).
     except TypeError:
         # In case there is no value in cache, we want to check if the sliding window org was executed. If it was
         # executed, but we didn't have this project boosted, it means that the entire org didn't have traffic in the
         # last hour which resulted in the system not considering it at all.
         if was_sliding_window_org_executed():
-            return 1.0
+            return 1.0, False
 
         # In the other case were the sliding window was not run, maybe because of an issue, we will just fall back to
         # blended sample rate, to avoid oversampling.
         sentry_sdk.capture_message(
             "Sliding window org value not stored in cache and sliding window org not executed"
         )
-        return error_sample_rate_fallback
+        return error_sample_rate_fallback, False
     # Thrown if the input is not a valid float.
     except ValueError:
         sentry_sdk.capture_message("Invalid boosted project sample rate value stored in cache")
-        return error_sample_rate_fallback
+        return error_sample_rate_fallback, False

--- a/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
@@ -40,18 +40,15 @@ def generate_sliding_window_org_cache_key(org_id: int) -> str:
 
 
 def get_sliding_window_org_sample_rate(
-    org_id: int, default_sample_rate: float | None = None, notify_missing: bool = False
-) -> float | None:
+    org_id: int, default_sample_rate: float | None
+) -> tuple[float | None, bool]:
     redis_client = get_redis_client_for_ds()
     cache_key = generate_sliding_window_org_cache_key(org_id)
 
     try:
-        return float(redis_client.get(cache_key))
+        return float(redis_client.get(cache_key)), True
     except (TypeError, ValueError):
-        if notify_missing:
-            sentry_sdk.capture_message("Missing or invalid sliding window org sample rate in cache")
-
-        return default_sample_rate
+        return default_sample_rate, False
 
 
 def get_sliding_window_size() -> int | None:

--- a/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
@@ -1,8 +1,6 @@
 from calendar import IllegalMonthError, monthrange
 from datetime import datetime, timezone
 
-import sentry_sdk
-
 from sentry import options
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -115,7 +115,6 @@ def recalibrate_org(org_id: int, total: int, indexed: int) -> None:
                 target_sample_rate,
             )
         else:
-            # TODO: log error.
             log_sample_rate_source(
                 org_id,
                 None,

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -102,18 +102,27 @@ def recalibrate_org(org_id: int, total: int, indexed: int) -> None:
     # If we have the sliding window org enabled, we use that and fall back to the blended sample rate in case
     # of issues.
     if organization is not None and is_sliding_window_org_enabled(organization):
-        target_sample_rate = get_sliding_window_org_sample_rate(
+        target_sample_rate, success = get_sliding_window_org_sample_rate(
             org_id=org_id,
             default_sample_rate=target_sample_rate,
-            notify_missing=True,
         )
-        log_sample_rate_source(
-            org_id,
-            None,
-            "recalibrate_orgs",
-            "sliding_window_org",
-            target_sample_rate,
-        )
+        if success:
+            log_sample_rate_source(
+                org_id,
+                None,
+                "recalibrate_orgs",
+                "sliding_window_org",
+                target_sample_rate,
+            )
+        else:
+            # TODO: log error.
+            log_sample_rate_source(
+                org_id,
+                None,
+                "recalibrate_orgs",
+                "blended_sample_rate",
+                target_sample_rate,
+            )
     else:
         log_sample_rate_source(
             org_id,


### PR DESCRIPTION
This PR improves the handling of the sample rate in two ways:
* The functions to return the sample rate from cache, now communicate success via a boolean to have better error handling on the caller side.
* The boost transactions bias now tries to fetch the boosted project sample rate irrespectively of the sliding window org, since that sample rate can also be computed based on the blended sample rate, in case the sliding window org is disabled.