### PR TITLE
feat(metrics): Support focus area in metrics samples list

### DIFF
--- a/static/app/utils/metrics/useMetricsSamples.tsx
+++ b/static/app/utils/metrics/useMetricsSamples.tsx
@@ -1,5 +1,5 @@
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import type {MRI} from 'sentry/types';
+import type {MRI, PageFilters} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {parseMRI} from 'sentry/utils/metrics/mri';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -9,8 +9,11 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 interface UseMetricSamplesOptions<F extends string> {
   fields: F[];
   referrer: string;
+  datetime?: PageFilters['datetime'];
   enabled?: boolean;
   limit?: number;
+  max?: number;
+  min?: number;
   mri?: MRI;
   query?: string;
 }
@@ -23,9 +26,12 @@ export interface MetricsSamplesResults<F extends string> {
 }
 
 export function useMetricsSamples<F extends string>({
+  datetime,
   enabled,
   fields,
   limit,
+  max,
+  min,
   mri,
   referrer,
   query,
@@ -39,8 +45,10 @@ export function useMetricsSamples<F extends string>({
     query: {
       project: selection.projects,
       environment: selection.environments,
-      ...normalizeDateTimeParams(selection.datetime),
+      ...(datetime ?? normalizeDateTimeParams(selection.datetime)),
       field: fields,
+      max,
+      min,
       mri,
       query,
       referrer,

--- a/static/app/views/ddm/widgetDetails.tsx
+++ b/static/app/views/ddm/widgetDetails.tsx
@@ -127,7 +127,11 @@ export function MetricDetails({
           <TabPanels>
             <TabPanels.Item key={Tab.SAMPLES}>
               {organization.features.includes('metrics-samples-list') ? (
-                <MetricSamplesTable mri={mri} query={queryWithFocusedSeries} />
+                <MetricSamplesTable
+                  focusArea={focusArea?.selection?.range}
+                  mri={mri}
+                  query={queryWithFocusedSeries}
+                />
               ) : (
                 <SampleTable
                   mri={mri}


### PR DESCRIPTION
This adds support for passing the focus area from the chart into the samples list. The min/max selection does not work yet and is currently a no-op.