### PR TITLE
ref: make ParamsType a TypedDict

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -28,7 +28,7 @@ from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.search.events.constants import DURATION_UNITS, SIZE_UNITS
 from sentry.search.events.fields import get_function_alias
-from sentry.search.events.types import SnubaParams
+from sentry.search.events.types import ParamsType, SnubaParams
 from sentry.snuba import discover
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.utils import DATASET_LABELS, DATASET_OPTIONS, get_dataset
@@ -125,7 +125,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
     def get_snuba_params(
         self, request: Request, organization: Organization, check_global_views: bool = True
-    ) -> dict[str, Any]:
+    ) -> ParamsType:
         with sentry_sdk.start_span(op="discover.endpoint", description="filter_params"):
             if (
                 len(self.get_field_list(organization, request))
@@ -136,7 +136,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                     detail=f"You can view up to {MAX_FIELDS} fields at a time. Please delete some and try again."
                 )
 
-            params: dict[str, Any] = self.get_filter_params(request, organization)
+            params: ParamsType = self.get_filter_params(request, organization)
             params = self.quantize_date_params(request, params)
             params["user_id"] = request.user.id if request.user else None
             params["team_id"] = self.get_team_ids(request, organization)
@@ -350,7 +350,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         ],
         top_events: int = 0,
         query_column: str = "count()",
-        params: dict[str, Any] | None = None,
+        params: ParamsType | None = None,
         query: str | None = None,
         allow_partial_buckets: bool = False,
         zerofill_results: bool = True,

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -87,7 +87,7 @@ SPAN_PERFORMANCE_COLUMNS: dict[str, SpanPerformanceColumn] = {
 class OrganizationEventsSpansEndpointBase(OrganizationEventsV2EndpointBase):
     def get_snuba_params(
         self, request: Request, organization: Organization, check_global_views: bool = True
-    ) -> dict[str, Any]:
+    ) -> ParamsType:
         params = super().get_snuba_params(request, organization, check_global_views)
 
         if len(params.get("project_id", [])) != 1:

--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -369,15 +369,18 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
 
             return Response(data=aggregated_tree)
 
-        conditions = [["transaction", "=", transaction]]
+        conditions: list[list[object]] = [["transaction", "=", transaction]]
         if http_method is not None:
             conditions.append(["http.method", "=", http_method])
 
         environments = params.get("environment", None)
-        if environments and len(environments) > 1:
-            conditions.append(["environment", "IN", environments])
-        elif environments and len(environments) == 1:
-            conditions.append(["environment", "=", environments[0]])
+        if environments:
+            if isinstance(environments, str):
+                conditions.append(["environment", "=", environments])
+            elif len(environments) == 1:
+                conditions.append(["environment", "=", environments[0]])
+            elif len(environments) > 1:
+                conditions.append(["environment", "IN", environments])
 
         events = eventstore.backend.get_events(
             filter=eventstore.Filter(

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -11,6 +10,7 @@ from sentry.api.serializers import serialize
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import GroupCategory
 from sentry.search.events.builder import QueryBuilder
+from sentry.search.events.types import ParamsType
 from sentry.snuba.dataset import Dataset
 from sentry.utils.validators import normalize_event_id
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 def get_direct_hit_response(
     request: Request,
     query: str | None,
-    snuba_params: Mapping[str, Any],
+    snuba_params: ParamsType,
     referrer: str,
     group: Group,
 ) -> Response | None:
@@ -52,7 +52,7 @@ def get_direct_hit_response(
 
 
 def get_query_builder_for_group(
-    query: str, snuba_params: Mapping[str, Any], group: Group, limit: int, offset: int
+    query: str, snuba_params: ParamsType, group: Group, limit: int, offset: int
 ) -> QueryBuilder:
     dataset = Dataset.IssuePlatform
     if group.issue_category == GroupCategory.ERROR:

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -24,7 +24,7 @@ from sentry.models.dashboard_widget import (
 from sentry.relay.config.metric_extraction import get_current_widget_specs, widget_exceeds_max_specs
 from sentry.search.events.builder import UnresolvedQuery
 from sentry.search.events.fields import is_function
-from sentry.search.events.types import QueryBuilderConfig
+from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.tasks.on_demand_metrics import (
     _get_widget_on_demand_specs,
@@ -195,12 +195,12 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
             # Subtract one because the equation is injected to fields
             orderby = f"{orderby_prefix}equation[{len(equations) - 1}]"
 
-        params = {
+        params: ParamsType = {
             "start": datetime.now() - timedelta(days=1),
             "end": datetime.now(),
             "project_id": [p.id for p in self.context["projects"]],
             "organization_id": self.context["organization"].id,
-            "environment": self.context.get("environment"),
+            "environment": self.context.get("environment", []),
         }
 
         try:

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -90,7 +90,7 @@ def default_start_end_dates(
 
 @overload
 def get_date_range_from_params(
-    params: dict[str, Any],
+    params: Mapping[str, Any],
     optional: Literal[False] = ...,
     default_stats_period: datetime.timedelta = ...,
 ) -> tuple[datetime.datetime, datetime.datetime]:
@@ -99,7 +99,7 @@ def get_date_range_from_params(
 
 @overload
 def get_date_range_from_params(
-    params: dict[str, Any],
+    params: Mapping[str, Any],
     optional: bool = ...,
     default_stats_period: datetime.timedelta = ...,
 ) -> tuple[None, None] | tuple[datetime.datetime, datetime.datetime]:
@@ -107,7 +107,7 @@ def get_date_range_from_params(
 
 
 def get_date_range_from_params(
-    params: dict[str, Any],
+    params: Mapping[str, Any],
     optional: bool = False,
     default_stats_period: datetime.timedelta = MAX_STATS_PERIOD,
 ) -> tuple[None, None] | tuple[datetime.datetime, datetime.datetime]:
@@ -133,7 +133,15 @@ def get_date_range_from_params(
     :return: A length 2 tuple containing start/end or raises an `InvalidParams`
     exception
     """
-    mutable_params = params.copy()
+    mutable_params = {
+        k: params[k]
+        for k in (
+            *("timeframe", "timeframeStart", "timeframeEnd"),
+            *("statsPeriod", "statsPeriodStart", "statsPeriodEnd"),
+            *("start", "end"),
+        )
+        if k in params
+    }
     timeframe = mutable_params.get("timeframe")
     timeframe_start = mutable_params.get("timeframeStart")
     timeframe_end = mutable_params.get("timeframeEnd")

--- a/src/sentry/data_export/processors/discover.py
+++ b/src/sentry/data_export/processors/discover.py
@@ -7,6 +7,7 @@ from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.search.events.fields import get_function_alias
+from sentry.search.events.types import ParamsType
 from sentry.snuba import discover
 from sentry.snuba.utils import get_dataset
 
@@ -24,7 +25,7 @@ class DiscoverProcessor:
         self.projects = self.get_projects(organization_id, discover_query)
         self.environments = self.get_environments(organization_id, discover_query)
         self.start, self.end = get_date_range_from_params(discover_query)
-        self.params = {
+        self.params: ParamsType = {
             "organization_id": organization_id,
             "project_id": [project.id for project in self.projects],
             "start": self.start,

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -30,7 +30,7 @@ from sentry.models.transaction_threshold import (
 )
 from sentry.search.events import fields
 from sentry.search.events.builder import QueryBuilder
-from sentry.search.events.types import QueryBuilderConfig
+from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import (
     MetricSpec,
@@ -590,7 +590,7 @@ def _is_widget_query_low_cardinality(widget_query: DashboardWidgetQuery, project
 
     New queries will be checked upon creation and not allowed at that time.
     """
-    params: dict[str, Any] = {
+    params: ParamsType = {
         "statsPeriod": "30m",
         "project_objects": [project],
         "organization_id": project.organization_id,  # Organization id has to be specified to not violate allocation policy.

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -149,7 +149,7 @@ class BaseQueryBuilder:
                         organization_id=organization.id, name__in=params["environment"]
                     )
                 )
-                if "" in cast(list[str], params["environment"]):
+                if "" in params["environment"]:
                     environments.append(None)
             elif isinstance(params["environment"], str):
                 environments = list(

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -18,8 +18,22 @@ from sentry.models.team import Team
 from sentry.services.hybrid_cloud.user import RpcUser
 
 WhereType = Union[Condition, BooleanCondition]
+
+
 # Replaced by SnubaParams
-ParamsType = Mapping[str, Union[Sequence[int], int, str, datetime]]
+class ParamsType(TypedDict, total=False):
+    project_id: list[int]
+    projects: list[Project]
+    project_objects: list[Project]
+    start: datetime
+    end: datetime
+    environment: str | list[str]
+    organization_id: int
+    use_case_id: str
+    environment_objects: list[Environment]
+    statsPeriod: str
+
+
 SelectType = Union[AliasedExpression, Column, Function, CurriedFunction]
 
 NormalizedArg = Optional[Union[str, float]]

--- a/src/sentry/sentry_metrics/querying/samples_list.py
+++ b/src/sentry/sentry_metrics/querying/samples_list.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, TypedDict, cast
+from typing import TypedDict, cast
 
 from snuba_sdk import And, Column, Condition, Function, Op, Or
 
@@ -10,7 +10,7 @@ from sentry.search.events.builder import (
     QueryBuilder,
     SpansIndexedQueryBuilder,
 )
-from sentry.search.events.types import QueryBuilderConfig, SnubaParams
+from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.naming_layer.mri import (
     SpanMRI,
@@ -33,7 +33,7 @@ class AbstractSamplesListExecutor(ABC):
     def __init__(
         self,
         mri: str,
-        params: dict[str, Any],
+        params: ParamsType,
         snuba_params: SnubaParams,
         fields: list[str],
         query: str | None,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -270,7 +270,7 @@ def query(
 def timeseries_query(
     selected_columns: Sequence[str],
     query: str,
-    params: dict[str, Any],
+    params: ParamsType,
     rollup: int,
     referrer: str | None = None,
     zerofill_results: bool = True,
@@ -599,7 +599,7 @@ def get_facets(
     Returns Sequence[FacetResult]
     """
     sample = len(params["project_id"]) > 2
-    fetch_projects = len(params.get("project_id", [])) > 1
+    fetch_projects = len(params["project_id"]) > 1
 
     with sentry_sdk.start_span(op="discover.discover", description="facets.frequent_tags"):
         key_name_builder = QueryBuilder(

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -13,7 +13,7 @@ from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, CRASH_RATE_ALERT_
 from sentry.exceptions import InvalidQuerySubscription, UnsupportedQuerySubscription
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
-from sentry.search.events.types import QueryBuilderConfig
+from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.utils import (
     MetricIndexNotFound,
@@ -140,9 +140,9 @@ class BaseEntitySubscription(ABC, _EntitySubscription):
     def build_query_builder(
         self,
         query: str,
-        project_ids: Sequence[int],
+        project_ids: list[int],
         environment: Environment | None,
-        params: MutableMapping[str, Any] | None = None,
+        params: ParamsType | None = None,
         skip_field_validation_for_entity_subscription_deletion: bool = False,
     ) -> QueryBuilder:
         raise NotImplementedError
@@ -161,9 +161,9 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
     def build_query_builder(
         self,
         query: str,
-        project_ids: Sequence[int],
+        project_ids: list[int],
         environment: Environment | None,
-        params: MutableMapping[str, Any] | None = None,
+        params: ParamsType | None = None,
         skip_field_validation_for_entity_subscription_deletion: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import ErrorsQueryBuilder, QueryBuilder
@@ -257,9 +257,9 @@ class SessionsEntitySubscription(BaseEntitySubscription):
     def build_query_builder(
         self,
         query: str,
-        project_ids: Sequence[int],
+        project_ids: list[int],
         environment: Environment | None,
-        params: MutableMapping[str, Any] | None = None,
+        params: ParamsType | None = None,
         skip_field_validation_for_entity_subscription_deletion: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import SessionsQueryBuilder
@@ -368,9 +368,9 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
     def build_query_builder(
         self,
         query: str,
-        project_ids: Sequence[int],
+        project_ids: list[int],
         environment: Environment | None,
-        params: MutableMapping[str, Any] | None = None,
+        params: ParamsType | None = None,
         skip_field_validation_for_entity_subscription_deletion: bool = False,
     ) -> QueryBuilder:
         from sentry.search.events.builder import AlertMetricsQueryBuilder

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -9,6 +9,7 @@ import sentry_sdk
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.models.organization import Organization
+from sentry.search.events.types import ParamsType
 from sentry.snuba import discover
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.metrics_performance import histogram_query as metrics_histogram_query
@@ -111,7 +112,7 @@ def query(
 def timeseries_query(
     selected_columns: Sequence[str],
     query: str,
-    params: dict[str, str],
+    params: ParamsType,
     rollup: int,
     referrer: str,
     zerofill_results: bool = True,

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -17,7 +17,7 @@ from sentry.search.events.builder import (
     TopMetricsQueryBuilder,
 )
 from sentry.search.events.fields import get_function_alias
-from sentry.search.events.types import EventsResponse, QueryBuilderConfig
+from sentry.search.events.types import EventsResponse, ParamsType, QueryBuilderConfig
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import MetricSpecType
@@ -90,7 +90,7 @@ def query(
 def bulk_timeseries_query(
     selected_columns: Sequence[str],
     queries: list[str],
-    params: dict[str, str],
+    params: ParamsType,
     rollup: int,
     referrer: str,
     zerofill_results: bool = True,
@@ -191,7 +191,7 @@ def bulk_timeseries_query(
 def timeseries_query(
     selected_columns: Sequence[str],
     query: str,
-    params: dict[str, Any],
+    params: ParamsType,
     rollup: int,
     referrer: str,
     zerofill_results: bool = True,
@@ -211,7 +211,7 @@ def timeseries_query(
     equations, columns = categorize_columns(selected_columns)
     metrics_compatible = not equations
 
-    def run_metrics_query(inner_params: dict[str, Any]):
+    def run_metrics_query(inner_params: ParamsType):
         with sentry_sdk.start_span(op="mep", description="TimeseriesMetricQueryBuilder"):
             metrics_query = TimeseriesMetricQueryBuilder(
                 inner_params,

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import MutableMapping, Sequence
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from django.utils import timezone
 
 from sentry import features
 from sentry.models.environment import Environment
+from sentry.search.events.types import ParamsType
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.entity_subscription import (
     BaseEntitySubscription,
@@ -195,9 +195,9 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
 def build_query_builder(
     entity_subscription: BaseEntitySubscription,
     query: str,
-    project_ids: Sequence[int],
+    project_ids: list[int],
     environment: Environment | None,
-    params: MutableMapping[str, Any] | None = None,
+    params: ParamsType | None = None,
 ) -> QueryBuilder:
     return entity_subscription.build_query_builder(query, project_ids, environment, params)
 

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import Any
 
 import sentry_sdk
 from celery.exceptions import SoftTimeLimitExceeded
@@ -25,7 +24,7 @@ from sentry.relay.config.metric_extraction import (
 )
 from sentry.search.events import fields
 from sentry.search.events.builder import QueryBuilder
-from sentry.search.events.types import EventsResponse, QueryBuilderConfig
+from sentry.search.events.types import EventsResponse, ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
 from sentry.snuba.referrer import Referrer
@@ -466,7 +465,7 @@ def _query_cardinality(
     # Restrict period down to an allowlist so we're not slamming snuba with giant queries
     if period not in [TASK_QUERY_PERIOD, DASHBOARD_QUERY_PERIOD]:
         raise Exception("Cardinality can only be queried with 1h or 30m")
-    params: dict[str, Any] = {
+    params: ParamsType = {
         "statsPeriod": period,
         "organization_id": organization.id,
         "projects": Project.objects.filter(organization=organization),

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -34,6 +34,7 @@ from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.models.statistical_detectors import RegressionType
 from sentry.profiles.utils import get_from_profiling_service
+from sentry.search.events.types import ParamsType
 from sentry.seer.utils import BreakpointData
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -502,7 +503,7 @@ def emit_function_regression_issue(
     project_ids = [int(regression["project"]) for regression in regressions]
     projects = [projects_by_id[project_id] for project_id in project_ids]
 
-    params: dict[str, Any] = {
+    params: ParamsType = {
         "start": start,
         "end": start + timedelta(minutes=1),
         "project_id": project_ids,
@@ -877,7 +878,7 @@ def query_functions(projects: list[Project], start: datetime) -> list[DetectorPa
     # we just need to query for the 1 minute of data.
     start = start - timedelta(hours=1)
     start = start.replace(minute=0, second=0, microsecond=0)
-    params: dict[str, Any] = {
+    params: ParamsType = {
         "start": start,
         "end": start + timedelta(minutes=1),
         "project_id": [project.id for project in projects],
@@ -927,7 +928,7 @@ def query_functions_timeseries(
 
     # take the last 14 days as our window
     end = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
-    params: dict[str, Any] = {
+    params: ParamsType = {
         "start": end - timedelta(days=14),
         "end": end,
         "project_id": project_ids,

--- a/tests/sentry/api/endpoints/test_project_key_stats.py
+++ b/tests/sentry/api/endpoints/test_project_key_stats.py
@@ -158,8 +158,8 @@ class ProjectKeyStatsTest(OutcomesSnubaTest, SnubaTestCase, APITestCase):
         response = self.client.get(
             self.path,
             data={
-                "since": before_now(days=1).timestamp(),
-                "until": before_now().timestamp(),
+                "since": int(before_now(days=1).timestamp()),
+                "until": int(before_now().timestamp()),
             },
         )
         assert response.status_code == 200, response.content

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import re
 from datetime import timezone
-from typing import Any
 
 import pytest
 from snuba_sdk.aliased_expression import AliasedExpression
@@ -15,7 +14,7 @@ from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events import constants
 from sentry.search.events.builder import QueryBuilder
-from sentry.search.events.types import QueryBuilderConfig
+from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
 from sentry.utils.snuba import QueryOutsideRetentionError
@@ -31,7 +30,7 @@ class QueryBuilderTest(TestCase):
         ) - datetime.timedelta(days=2)
         self.end = self.start + datetime.timedelta(days=1)
         self.projects = [self.project.id, self.create_project().id, self.create_project().id]
-        self.params: dict[str, Any] = {
+        self.params: ParamsType = {
             "project_id": self.projects,
             "start": self.start,
             "end": self.end,
@@ -447,7 +446,7 @@ class QueryBuilderTest(TestCase):
     def test_retention(self):
         old_start = datetime.datetime(2015, 5, 18, 10, 15, 1, tzinfo=timezone.utc)
         old_end = datetime.datetime(2015, 5, 19, 10, 15, 1, tzinfo=timezone.utc)
-        old_params = {**self.params, "start": old_start, "end": old_end}
+        old_params: ParamsType = {**self.params, "start": old_start, "end": old_end}
         with self.options({"system.event-retention-days": 10}):
             with pytest.raises(QueryOutsideRetentionError):
                 QueryBuilder(

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -17,7 +17,7 @@ from sentry.search.events.builder import (
     TimeseriesMetricQueryBuilder,
     TopMetricsQueryBuilder,
 )
-from sentry.search.events.types import HistogramParams, QueryBuilderConfig
+from sentry.search.events.types import HistogramParams, ParamsType, QueryBuilderConfig
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.aggregation_option_registry import AggregationOption
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -105,7 +105,7 @@ class MetricBuilderBaseTest(MetricsEnhancedPerformanceTestCase):
             hour=10, minute=0, second=0, microsecond=0
         )
         self.projects = [self.project.id]
-        self.params = {
+        self.params: ParamsType = {
             "organization_id": self.organization.id,
             "project_id": self.projects,
             "start": self.start,
@@ -1639,13 +1639,15 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_granularity(self):
         # Need to pick granularity based on the period and interval for timeseries
         def get_granularity(start, end, interval):
-            params = {
-                "organization_id": self.organization.id,
-                "project_id": self.projects,
-                "start": start,
-                "end": end,
-            }
-            query = TimeseriesMetricQueryBuilder(params, interval=interval)
+            query = TimeseriesMetricQueryBuilder(
+                {
+                    "organization_id": self.organization.id,
+                    "project_id": self.projects,
+                    "start": start,
+                    "end": end,
+                },
+                interval=interval,
+            )
             return query.granularity.granularity
 
         # If we're doing atleast day and its midnight we should use the daily bucket
@@ -2127,7 +2129,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             )
 
         query = TimeseriesMetricQueryBuilder(
-            {**self.params, "environment": ["prod"]},  # type:ignore
+            {**self.params, "environment": ["prod"]},
             dataset=Dataset.PerformanceMetrics,
             interval=3600,
             query=query_s,

--- a/tests/sentry/snuba/test_discover_facets_query.py
+++ b/tests/sentry/snuba/test_discover_facets_query.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sentry.exceptions import InvalidSearchQuery
+from sentry.search.events.types import ParamsType
 from sentry.snuba import discover
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -49,8 +50,11 @@ class GetFacetsTest(SnubaTestCase, TestCase):
             },
             project_id=self.project.id,
         )
-        params = {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago}
-        result = discover.get_facets("", params, "testing.get-facets-test")
+        result = discover.get_facets(
+            "",
+            {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago},
+            "testing.get-facets-test",
+        )
         assert len(result) == 5
         assert {r.key for r in result} == {"color", "paying", "level"}
         assert {r.value for r in result} == {"red", "blue", "1", "0", "error"}
@@ -76,7 +80,11 @@ class GetFacetsTest(SnubaTestCase, TestCase):
             },
             project_id=other_project.id,
         )
-        params = {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago}
+        params: ParamsType = {
+            "project_id": [self.project.id],
+            "start": self.day_ago,
+            "end": self.min_ago,
+        }
         result = discover.get_facets("", params, "testing.get-facets-test")
         keys = {r.key for r in result}
         assert keys == {"color", "level"}
@@ -105,8 +113,11 @@ class GetFacetsTest(SnubaTestCase, TestCase):
                 },
                 project_id=self.project.id,
             )
-        params = {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago}
-        result = discover.get_facets("", params, "testing.get-facets-test")
+        result = discover.get_facets(
+            "",
+            {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago},
+            "testing.get-facets-test",
+        )
         keys = {r.key for r in result}
         assert keys == {"environment", "level"}
         assert {None, "prod", "staging"} == {f.value for f in result if f.key == "environment"}
@@ -131,7 +142,11 @@ class GetFacetsTest(SnubaTestCase, TestCase):
             },
             project_id=self.project.id,
         )
-        params = {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago}
+        params: ParamsType = {
+            "project_id": [self.project.id],
+            "start": self.day_ago,
+            "end": self.min_ago,
+        }
         result = discover.get_facets("bad", params, "testing.get-facets-test")
         keys = {r.key for r in result}
         assert "color" in keys
@@ -161,7 +176,11 @@ class GetFacetsTest(SnubaTestCase, TestCase):
             },
             project_id=self.project.id,
         )
-        params = {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago}
+        params: ParamsType = {
+            "project_id": [self.project.id],
+            "start": self.day_ago,
+            "end": self.min_ago,
+        }
         result = discover.get_facets("bad", params, "testing.get-facets-test")
         keys = {r.key for r in result}
         assert "color" in keys
@@ -191,8 +210,11 @@ class GetFacetsTest(SnubaTestCase, TestCase):
             },
             project_id=self.project.id,
         )
-        params = {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago}
-        result = discover.get_facets("", params, "testing.get-facets-test")
+        result = discover.get_facets(
+            "",
+            {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago},
+            "testing.get-facets-test",
+        )
         keys = {r.key for r in result}
         assert "color" in keys
         assert "toy" not in keys
@@ -218,8 +240,11 @@ class GetFacetsTest(SnubaTestCase, TestCase):
             },
             project_id=self.project.id,
         )
-        params = {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago}
-        result = discover.get_facets("", params, "testing.get-facets-test")
+        result = discover.get_facets(
+            "",
+            {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago},
+            "testing.get-facets-test",
+        )
         first = result[0]
         assert first.key == "color"
         assert first.value == "zzz"

--- a/tests/sentry/snuba/test_metrics_performance.py
+++ b/tests/sentry/snuba/test_metrics_performance.py
@@ -4,6 +4,7 @@ from datetime import timezone
 import pytest
 
 from sentry.exceptions import IncompatibleMetricsQuery
+from sentry.search.events.types import ParamsType
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics_performance import timeseries_query
@@ -26,7 +27,7 @@ class TimeseriesQueryTest(MetricsEnhancedPerformanceTestCase):
         )
         self.default_interval = 3600
         self.projects = [self.project.id]
-        self.params = {
+        self.params: ParamsType = {
             "organization_id": self.organization.id,
             "project_id": self.projects,
             "start": self.start,

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -588,7 +588,7 @@ class BuildSnqlQueryTest(TestCase):
             query_builder = build_query_builder(
                 entity_subscription,
                 query,
-                (self.project.id,),
+                [self.project.id],
                 environment=environment,
                 params={
                     "organization_id": self.organization.id,

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -1371,7 +1371,7 @@ class FunctionsTasksTest(ProfilesSnubaTestCase):
                 "trend_percentage": 1.23,
                 "absolute_percentage_change": 1.23,
                 "trend_difference": 1.23,
-                "breakpoint": (self.hour_ago - timedelta(hours=12)).timestamp(),
+                "breakpoint": int((self.hour_ago - timedelta(hours=12)).timestamp()),
             }
             for project in self.projects
         ]


### PR DESCRIPTION
it isn't actually a well defined dict -- but this helps with unpacking it inside the events code

there's definitely some problematic dict stuffing happening here -- it's wild that this sometimes has `project_id` (list of int???), `projects` (list of Project), and project_objects (list of Project) -- but hopefully that can be cleaned up later with an actual type

<!-- Describe your PR here. -->