### PR TITLE
chore(team-org-roles): remove HC helpers

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -114,8 +114,6 @@ default_manager.add("organizations:higher-ownership-limit", OrganizationFeature,
 default_manager.add("organizations:integrations-deployment", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:integrations-feature-flag-integration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:integrations-gh-invite", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:integrations-open-pr-comment", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:integrations-open-pr-comment-js", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:investigation-bias", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:invite-members", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
@@ -162,7 +160,6 @@ default_manager.add("organizations:on-demand-metrics-ui-widgets", OrganizationFe
 default_manager.add("organizations:on-demand-metrics-query-spec-version-two", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:onboarding-sdk-selection", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)  # Only enabled in sentry.io to enable onboarding flows.
-default_manager.add("organizations:org-roles-for-teams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:org-subdomains", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-anomaly-detection-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-calculate-score-relay", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/services/hybrid_cloud/access/impl.py
+++ b/src/sentry/services/hybrid_cloud/access/impl.py
@@ -91,7 +91,13 @@ class RegionAccessService(AccessService):
     def can_override_sso_as_owner(
         self, auth_provider: RpcAuthProvider, member: RpcOrganizationMemberSummary
     ) -> bool:
-        if member.role != roles.get_top_dog().id:
+        # get member role
+        try:
+            member_role = OrganizationMemberMapping.objects.get(id=member.id).role
+        except OrganizationMemberMapping.DoesNotExist:
+            return False
+
+        if member_role != roles.get_top_dog().id:
             return False
 
         user_ids = (

--- a/src/sentry/services/hybrid_cloud/access/impl.py
+++ b/src/sentry/services/hybrid_cloud/access/impl.py
@@ -50,7 +50,9 @@ class ControlAccessService(AccessService):
         """
         # get member role
         try:
-            member_role = OrganizationMemberMapping.objects.get(id=member.id).role
+            member_role = OrganizationMemberMapping.objects.get(
+                organizationmember_id=member.id, organization_id=member.organization_id
+            ).role
         except OrganizationMemberMapping.DoesNotExist:
             return False
 
@@ -93,8 +95,10 @@ class RegionAccessService(AccessService):
     ) -> bool:
         # get member role
         try:
-            member_role = OrganizationMemberMapping.objects.get(id=member.id).role
-        except OrganizationMemberMapping.DoesNotExist:
+            member_role = OrganizationMember.objects.get(
+                id=member.id, organization_id=member.organization_id
+            ).role
+        except OrganizationMember.DoesNotExist:
             return False
 
         if member_role != roles.get_top_dog().id:

--- a/src/sentry/services/hybrid_cloud/access/impl.py
+++ b/src/sentry/services/hybrid_cloud/access/impl.py
@@ -1,5 +1,3 @@
-from django.db.models import Q
-
 from sentry import roles
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authidentityreplica import AuthIdentityReplica
@@ -7,10 +5,6 @@ from sentry.models.authprovider import AuthProvider
 from sentry.models.authproviderreplica import AuthProviderReplica
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
-from sentry.models.team import Team
-from sentry.models.teamreplica import TeamReplica
 from sentry.services.hybrid_cloud.access.service import AccessService
 from sentry.services.hybrid_cloud.auth import RpcAuthIdentity, RpcAuthProvider
 from sentry.services.hybrid_cloud.auth.serial import (
@@ -24,37 +18,6 @@ from sentry.services.hybrid_cloud.user.service import user_service
 
 
 class ControlAccessService(AccessService):
-    def get_all_org_roles(self, member_id: int, organization_id: int) -> list[str]:
-        try:
-            member = OrganizationMemberMapping.objects.get(
-                organizationmember_id=member_id, organization_id=organization_id
-            )
-        except OrganizationMemberMapping.DoesNotExist:
-            return []
-
-        team_ids = OrganizationMemberTeamReplica.objects.filter(
-            organizationmember_id=member_id, organization_id=organization_id
-        ).values_list("team_id", flat=True)
-        all_roles: set[str] = set(
-            TeamReplica.objects.filter(team_id__in=team_ids)
-            .exclude(org_role=None)
-            .values_list("org_role", flat=True)
-        )
-        all_roles.add(member.role)
-        return list(all_roles)
-
-    def get_top_dog_team_member_ids(self, organization_id: int) -> list[int]:
-        owner_teams = list(
-            TeamReplica.objects.filter(
-                organization_id=organization_id, org_role=roles.get_top_dog().id
-            ).values_list("team_id", flat=True)
-        )
-        return list(
-            OrganizationMemberTeamReplica.objects.filter(team_id__in=owner_teams).values_list(
-                "organizationmember_id", flat=True
-            )
-        )
-
     def get_permissions_for_user(self, user_id: int) -> frozenset[str]:
         user = user_service.get_user(user_id)
         if user is None:
@@ -85,21 +48,9 @@ class ControlAccessService(AccessService):
         """If an owner is trying to gain access, allow bypassing SSO if there are no
         other owners with SSO enabled.
         """
-
-        # Get more org role related data into control to reduce this inter silo rpc stuff....
-        org_roles = self.get_all_org_roles(
-            member_id=member.id, organization_id=member.organization_id
-        )
-        if roles.get_top_dog().id not in org_roles:
-            return False
-
-        all_top_dogs_from_teams = self.get_top_dog_team_member_ids(
-            organization_id=member.organization_id
-        )
         user_ids = (
             OrganizationMemberMapping.objects.filter(
-                Q(organizationmember_id__in=all_top_dogs_from_teams)
-                | Q(role=roles.get_top_dog().id),
+                role=roles.get_top_dog().id,
                 organization_id=member.organization_id,
                 user__is_active=True,
             )
@@ -112,35 +63,6 @@ class ControlAccessService(AccessService):
 
 
 class RegionAccessService(AccessService):
-    def get_all_org_roles(self, member_id: int, organization_id: int) -> list[str]:
-        try:
-            member = OrganizationMember.objects.get(id=member_id, organization_id=organization_id)
-        except OrganizationMember.DoesNotExist:
-            return []
-
-        team_ids = OrganizationMemberTeam.objects.filter(
-            organizationmember_id=member.id
-        ).values_list("team_id", flat=True)
-        all_roles: set[str] = set(
-            Team.objects.filter(id__in=team_ids)
-            .exclude(org_role=None)
-            .values_list("org_role", flat=True)
-        )
-        all_roles.add(member.role)
-        return list(all_roles)
-
-    def get_top_dog_team_member_ids(self, organization_id: int) -> list[int]:
-        owner_teams = list(
-            Team.objects.filter(
-                organization_id=organization_id, org_role=roles.get_top_dog().id
-            ).values_list("id", flat=True)
-        )
-        return list(
-            OrganizationMemberTeam.objects.filter(team_id__in=owner_teams).values_list(
-                "organizationmember_id", flat=True
-            )
-        )
-
     def get_auth_provider(self, organization_id: int) -> RpcAuthProvider | None:
         try:
             ap = AuthProviderReplica.objects.get(organization_id=organization_id)
@@ -160,18 +82,9 @@ class RegionAccessService(AccessService):
     def can_override_sso_as_owner(
         self, auth_provider: RpcAuthProvider, member: RpcOrganizationMemberSummary
     ) -> bool:
-        org_roles = self.get_all_org_roles(
-            member_id=member.id, organization_id=member.organization_id
-        )
-        if roles.get_top_dog().id not in org_roles:
-            return False
-
-        all_top_dogs_from_teams = self.get_top_dog_team_member_ids(
-            organization_id=member.organization_id
-        )
         user_ids = (
             OrganizationMember.objects.filter(
-                Q(id__in=all_top_dogs_from_teams) | Q(role=roles.get_top_dog().id),
+                role=roles.get_top_dog().id,
                 organization_id=member.organization_id,
                 user_is_active=True,
             )

--- a/src/sentry/services/hybrid_cloud/access/impl.py
+++ b/src/sentry/services/hybrid_cloud/access/impl.py
@@ -48,6 +48,15 @@ class ControlAccessService(AccessService):
         """If an owner is trying to gain access, allow bypassing SSO if there are no
         other owners with SSO enabled.
         """
+        # get member role
+        try:
+            member_role = OrganizationMemberMapping.objects.get(id=member.id).role
+        except OrganizationMemberMapping.DoesNotExist:
+            return False
+
+        if member_role != roles.get_top_dog().id:
+            return False
+
         user_ids = (
             OrganizationMemberMapping.objects.filter(
                 role=roles.get_top_dog().id,
@@ -82,6 +91,9 @@ class RegionAccessService(AccessService):
     def can_override_sso_as_owner(
         self, auth_provider: RpcAuthProvider, member: RpcOrganizationMemberSummary
     ) -> bool:
+        if member.role != roles.get_top_dog().id:
+            return False
+
         user_ids = (
             OrganizationMember.objects.filter(
                 role=roles.get_top_dog().id,

--- a/src/sentry/services/hybrid_cloud/access/service.py
+++ b/src/sentry/services/hybrid_cloud/access/service.py
@@ -38,14 +38,6 @@ class AccessService(abc.ABC):
         """
         pass
 
-    @abc.abstractmethod
-    def get_all_org_roles(self, member_id: int, organization_id: int) -> list[str]:
-        pass
-
-    @abc.abstractmethod
-    def get_top_dog_team_member_ids(self, organization_id: int) -> list[int]:
-        pass
-
     def auth_identity_is_valid(
         self,
         auth_provider: RpcAuthProvider,


### PR DESCRIPTION
Part of an ongoing effort to remove the org roles for teams feature https://github.com/getsentry/team-core-product-foundations/issues/51

We can remove hybrid cloud helpers relating to getting all org roles since none of this logic exists anymore in the codebase save for the column on the Team model.