### PR TITLE
fix(devenv): no sync in direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -194,8 +194,6 @@ fi
 # (in that it would be automatically deactivated) virtualenv active.
 deactivate 2>/dev/null || true
 
-"$DEVENV" sync
-
 # shellcheck disable=SC1091
 source .venv/bin/activate
 


### PR DESCRIPTION
so in `22cac362062` i assumed that `if grep -Eq "^devenv($|>)" "${SENTRY_ROOT}/requirements-dev.txt";` was working so i moved `devenv sync` to the happy path, surprise it never worked

people do not like `devenv sync` on cd as it's just too slow and i agree