### PR TITLE
ref: make before_now return aware datetimes

### DIFF
--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import time_machine
 
@@ -12,8 +12,8 @@ def iso_format(date):
     return date.isoformat()[:19]
 
 
-def before_now(**kwargs):
-    date = datetime.utcnow() - timedelta(**kwargs)
+def before_now(**kwargs: float) -> datetime:
+    date = datetime.now(UTC) - timedelta(**kwargs)
     return date - timedelta(microseconds=date.microsecond % 1000)
 
 
@@ -25,7 +25,7 @@ class MockClock:
     """Returns a distinct, increasing timestamp each time it is called."""
 
     def __init__(self, initial=None):
-        self.time = initial or datetime.now(timezone.utc)
+        self.time = initial or datetime.now(UTC)
 
     def __call__(self):
         self.time += timedelta(seconds=1)
@@ -34,5 +34,5 @@ class MockClock:
 
 def freeze_time(t: str | datetime | None = None) -> time_machine.travel:
     if t is None:
-        t = datetime.now(timezone.utc)
+        t = datetime.now(UTC)
     return time_machine.travel(t, tick=False)

--- a/tests/sentry/utils/test_eventuser.py
+++ b/tests/sentry/utils/test_eventuser.py
@@ -12,7 +12,7 @@ from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_forma
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.eventuser import EventUser
 
-now = before_now(days=1).replace(minute=10).replace(second=0).replace(microsecond=0)
+now = before_now(days=1).replace(minute=10, second=0, microsecond=0, tzinfo=None)
 
 
 @region_silo_test


### PR DESCRIPTION
this fixes the majority of incorrectly naive datetime warnings in our tests

<!-- Describe your PR here. -->