### PR TITLE
chore(inbound-filters): Make disabled state for legacy browsers better

### DIFF
--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -262,7 +262,9 @@ class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
       <div>
         <div>
           <BulkFilter>
-            <FieldLabel>{t('Filter out legacy browsers')}:</FieldLabel>
+            <FieldLabel disabled={disabled}>
+              {t('Filter out legacy browsers')}:
+            </FieldLabel>
             <ButtonBar gap={1}>
               <Button
                 priority="link"

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -260,35 +260,34 @@ class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
     const {disabled} = this.props;
     return (
       <div>
-        {!disabled && (
-          <div>
-            <BulkFilter>
-              <FieldLabel>{t('Filter out legacy browsers')}:</FieldLabel>
-              <ButtonBar gap={1}>
-                <Button
-                  priority="link"
-                  borderless
-                  onClick={this.handleToggleSubfilters.bind(this, true)}
-                >
-                  {t('All')}
-                </Button>
-                <Button
-                  priority="link"
-                  borderless
-                  onClick={this.handleToggleSubfilters.bind(this, false)}
-                >
-                  {t('None')}
-                </Button>
-              </ButtonBar>
-            </BulkFilter>
-            <FieldHelp>
-              {t(
-                'The browser versions filtered out will be periodically evaluated and updated.'
-              )}
-            </FieldHelp>
-          </div>
-        )}
-
+        <div>
+          <BulkFilter>
+            <FieldLabel>{t('Filter out legacy browsers')}:</FieldLabel>
+            <ButtonBar gap={1}>
+              <Button
+                priority="link"
+                borderless
+                onClick={this.handleToggleSubfilters.bind(this, true)}
+                disabled={disabled}
+              >
+                {t('All')}
+              </Button>
+              <Button
+                priority="link"
+                borderless
+                onClick={this.handleToggleSubfilters.bind(this, false)}
+                disabled={disabled}
+              >
+                {t('None')}
+              </Button>
+            </ButtonBar>
+          </BulkFilter>
+          <FieldHelp>
+            {t(
+              'The browser versions filtered out will be periodically evaluated and updated.'
+            )}
+          </FieldHelp>
+        </div>
         <FilterGrid>
           {Object.keys(LEGACY_BROWSER_SUBFILTERS)
             .filter(key => {


### PR DESCRIPTION
this pr updates how we handle the disabled state for the legacy browser filters. Right now, when disabled, you can't toggle the settings but the header is also not shown. Now the header is shown, but the all/none buttons are disabled.

before: 
<img width="1159" alt="Screenshot 2024-02-26 at 10 58 37 AM" src="https://github.com/getsentry/sentry/assets/46740234/aae526a1-4c43-4bd9-9f4a-abb25896682d">


after:
<img width="1159" alt="Screenshot 2024-02-26 at 11 11 35 AM" src="https://github.com/getsentry/sentry/assets/46740234/198ffbf0-76d8-49ed-b722-05daf3d06c7f">

