### PR TITLE
ref: use tz-aware datetimes in the rest of the apidocs tests

### DIFF
--- a/tests/apidocs/endpoints/releases/test_organization_release_details.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_details.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.test.client import RequestFactory
 from django.urls import reverse
@@ -27,7 +27,9 @@ class OrganizationReleaseDetailsDocsTest(APIDocsTestCase):
 
         self.login_as(user=user)
         release = self.create_release(
-            project=self.project1, version="1", date_added=datetime(2013, 8, 13, 3, 8, 24, 880386)
+            project=self.project1,
+            version="1",
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=UTC),
         )
 
         self.url = reverse(

--- a/tests/apidocs/endpoints/releases/test_organization_releases.py
+++ b/tests/apidocs/endpoints/releases/test_organization_releases.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.test.client import RequestFactory
 from django.urls import reverse
@@ -27,12 +27,16 @@ class OrganizationReleasesDocsTest(APIDocsTestCase):
         self.login_as(user=user)
 
         release1 = Release.objects.create(
-            organization_id=org.id, version="1", date_added=datetime(2013, 8, 13, 3, 8, 24, 880386)
+            organization_id=org.id,
+            version="1",
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release1.add_project(self.project1)
 
         release2 = Release.objects.create(
-            organization_id=org2.id, version="2", date_added=datetime(2013, 8, 14, 3, 8, 24, 880386)
+            organization_id=org2.id,
+            version="2",
+            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release2.add_project(self.project2)
 


### PR DESCRIPTION
this warning is currently disabled, I'm slowly working to turn it on and fix the things

<!-- Describe your PR here. -->