### PR TITLE
fix(mobile-starfish): Update breadcrumbs in module headers

### DIFF
--- a/static/app/views/starfish/modules/mobile/appStartup.tsx
+++ b/static/app/views/starfish/modules/mobile/appStartup.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
 import Feature from 'sentry/components/acl/feature';
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
@@ -12,11 +13,13 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
 import Onboarding from 'sentry/views/performance/onboarding';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
@@ -64,6 +67,20 @@ export default function InitializationModule() {
           <PageAlertProvider>
             <Layout.Header>
               <Layout.HeaderContent>
+                <Breadcrumbs
+                  crumbs={[
+                    {
+                      label: t('Performance'),
+                      to: normalizeUrl(
+                        `/organizations/${organization.slug}/performance/`
+                      ),
+                      preservePageFilters: true,
+                    },
+                    {
+                      label: ROUTE_NAMES['app-startup'],
+                    },
+                  ]}
+                />
                 <Layout.Title>{ROUTE_NAMES['app-startup']}</Layout.Title>
               </Layout.HeaderContent>
             </Layout.Header>

--- a/static/app/views/starfish/modules/mobile/pageload.tsx
+++ b/static/app/views/starfish/modules/mobile/pageload.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -16,9 +17,11 @@ import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pa
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
 import Onboarding from 'sentry/views/performance/onboarding';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
+import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import {ScreensView, YAxis} from 'sentry/views/starfish/views/screens';
 import {PlatformSelector} from 'sentry/views/starfish/views/screens/platformSelector';
 import {isCrossPlatform} from 'sentry/views/starfish/views/screens/utils';
@@ -42,6 +45,18 @@ export default function PageloadModule() {
         <PageAlertProvider>
           <Layout.Header>
             <Layout.HeaderContent>
+              <Breadcrumbs
+                crumbs={[
+                  {
+                    label: t('Performance'),
+                    to: normalizeUrl(`/organizations/${organization.slug}/performance/`),
+                    preservePageFilters: true,
+                  },
+                  {
+                    label: ROUTE_NAMES.pageload,
+                  },
+                ]}
+              />
               <HeaderWrapper>
                 <Layout.Title>{t('Screen Loads')}</Layout.Title>
                 {organization.features.includes(

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -19,6 +19,7 @@ import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pa
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {
   PRIMARY_RELEASE_ALIAS,
   ReleaseComparisonSelector,
@@ -90,6 +91,11 @@ function ScreenSummary() {
   };
 
   const crumbs: Crumb[] = [
+    {
+      label: t('Performance'),
+      to: normalizeUrl(`/organizations/${organization.slug}/performance/`),
+      preservePageFilters: true,
+    },
     {
       to: startupModule,
       label: t('App Starts'),

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -19,6 +19,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {
   PRIMARY_RELEASE_ALIAS,
   ReleaseComparisonSelector,
@@ -74,6 +75,11 @@ function ScreenLoadSpans() {
   };
 
   const crumbs: Crumb[] = [
+    {
+      label: t('Performance'),
+      to: normalizeUrl(`/organizations/${organization.slug}/performance/`),
+      preservePageFilters: true,
+    },
     {
       to: screenLoadModule,
       label: t('Screen Loads'),


### PR DESCRIPTION
The breadcrumbs should start at Performance for consistency with other modules and appear even in the overview page