### PR TITLE
feat(feedback): add additional platforms to crash report onboarding

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/useLoadFeedbackOnboardingDoc.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/useLoadFeedbackOnboardingDoc.tsx
@@ -6,6 +6,26 @@ import {feedbackOnboardingPlatforms} from 'sentry/data/platformCategories';
 import type {Organization, PlatformIntegration, ProjectKey} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
+function getPlatformPath(platform: PlatformIntegration) {
+  if (platform.type === 'framework') {
+    switch (platform.id) {
+      case 'capacitor':
+        return `capacitor/capacitor`;
+      case 'dart':
+        return `dart/dart`;
+      case 'android':
+        return `android/android`;
+      case 'flutter':
+        return `flutter/flutter`;
+      case 'unreal':
+        return `unreal/unreal`;
+      default:
+        return platform.id.replace(`${platform.language}-`, `${platform.language}/`);
+    }
+  }
+  return `${platform.language}/${platform.id}`;
+}
+
 function useLoadFeedbackOnboardingDoc({
   platform,
   organization,
@@ -23,14 +43,7 @@ function useLoadFeedbackOnboardingDoc({
     | 'none'
   >(null);
 
-  const platformPath =
-    platform?.type === 'framework'
-      ? platform?.id === 'capacitor'
-        ? `capacitor/capacitor`
-        : platform?.id === 'dart'
-          ? `dart/dart`
-          : platform?.id.replace(`${platform.language}-`, `${platform.language}/`)
-      : `${platform?.language}/${platform?.id}`;
+  const platformPath = getPlatformPath(platform);
 
   const {
     data: projectKeys,

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -380,9 +380,14 @@ export const replayJsLoaderInstructionsPlatformList: readonly PlatformKey[] = [
 ];
 
 export const feedbackOnboardingPlatforms: readonly PlatformKey[] = [
+  'android',
+  'dart',
+  'flutter',
   'java',
   'java-log4j2',
-  'dart',
+  'kotlin',
+  'react-native',
+  'unreal',
   ...replayPlatforms,
 ];
 

--- a/static/app/gettingStartedDocs/dart/dart.tsx
+++ b/static/app/gettingStartedDocs/dart/dart.tsx
@@ -158,7 +158,7 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
-export const feedbackOnboardingCrashApi: OnboardingConfig = {
+export const feedbackOnboardingCrashApiDart: OnboardingConfig = {
   introduction: () => getCrashReportApiIntroduction(),
   install: () => [
     {
@@ -196,7 +196,7 @@ Sentry.captureUserFeedback(userFeedback);`,
 
 const docs: Docs = {
   onboarding,
-  feedbackOnboardingCrashApi,
+  feedbackOnboardingCrashApi: feedbackOnboardingCrashApiDart,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -5,6 +5,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {feedbackOnboardingCrashApiDart} from 'sentry/gettingStartedDocs/dart/dart';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -176,6 +177,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  feedbackOnboardingCrashApi: feedbackOnboardingCrashApiDart,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/kotlin/kotlin.tsx
+++ b/static/app/gettingStartedDocs/kotlin/kotlin.tsx
@@ -9,6 +9,10 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportApiIntroduction,
+  getCrashReportInstallDescription,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -271,8 +275,44 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
   ],
 };
 
+const feedbackOnboardingCrashApi: OnboardingConfig = {
+  introduction: () => getCrashReportApiIntroduction(),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: getCrashReportInstallDescription(),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'Kotlin',
+              value: 'kotlin',
+              language: 'kotlin',
+              code: `import io.sentry.kotlin.multiplatform.Sentry
+import io.sentry.kotlin.multiplatform.protocol.UserFeedback
+
+val sentryId = Sentry.captureMessage("My message")
+
+val userFeedback = UserFeedback(sentryId).apply {
+  comments = "It broke."
+  email = "john.doe@example.com"
+  name = "John Doe"
+}
+Sentry.captureUserFeedback(userFeedback)`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: () => [],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs<PlatformOptions> = {
   platformOptions,
+  feedbackOnboardingCrashApi,
   onboarding,
 };
 

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -9,6 +9,10 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportApiIntroduction,
+  getCrashReportInstallDescription,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -285,8 +289,47 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const feedbackOnboardingCrashApi: OnboardingConfig = {
+  introduction: () => getCrashReportApiIntroduction(),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: getCrashReportInstallDescription(),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'TypeScript',
+              value: 'typescript',
+              language: 'typescript',
+              code: `import * as Sentry from "@sentry/react-native";
+import { UserFeedback } from "@sentry/react-native";
+
+const sentryId = Sentry.captureMessage("My Message");
+// OR: const sentryId = Sentry.lastEventId();
+
+const userFeedback: UserFeedback = {
+  event_id: sentryId,
+  name: "John Doe",
+  email: "john@doe.com",
+  comments: "Hello World!",
+};
+
+Sentry.captureUserFeedback(userFeedback);`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: () => [],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
+  feedbackOnboardingCrashApi,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/unreal/unreal.tsx
+++ b/static/app/gettingStartedDocs/unreal/unreal.tsx
@@ -9,6 +9,10 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportApiIntroduction,
+  getCrashReportInstallDescription,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -222,8 +226,48 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const feedbackOnboardingCrashApi: OnboardingConfig = {
+  introduction: () => getCrashReportApiIntroduction(),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: getCrashReportInstallDescription(),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'C++',
+              value: 'cpp',
+              language: 'cpp',
+              code: `USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
+
+USentryId* EventId = SentrySubsystem->CaptureMessage(TEXT("Message with feedback"));
+
+USentryUserFeedback* UserFeedback = NewObject<USentryUserFeedback>();
+User->Initialize(EventId);
+User->SetEmail("test@sentry.io");
+User->SetName("Name");
+User->SetComment("Some comment");
+
+SentrySubsystem->CaptureUserFeedback(UserFeedback);
+
+// OR
+
+SentrySubsystem->CaptureUserFeedbackWithParams(EventId, "test@sentry.io", "Some comment", "Name");`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: () => [],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
+  feedbackOnboardingCrashApi,
 };
 
 export default docs;


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry/issues/65728
- adds flutter, kotlin, react-native, unreal