### PR TITLE
chore(slack): log full response for rule.fail.slack_post

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -109,7 +109,9 @@ class SlackNotifyServiceAction(IntegrationEventAction):
 
             client = SlackClient(integration_id=integration.id)
             try:
-                client.post("/chat.postMessage", data=payload, timeout=5)
+                client.post(
+                    "/chat.postMessage", data=payload, timeout=5, log_response_with_error=True
+                )
             except ApiError as e:
                 log_params = {
                     "error": str(e),

--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -125,6 +125,8 @@ class SlackClient(IntegrationProxyClient):
         *args: Any,
         **kwargs: Any,
     ) -> BaseApiResponse:
+        log_response_with_error = kwargs.pop("log_error", False)
+
         response = self._request(
             method,
             path,
@@ -137,7 +139,7 @@ class SlackClient(IntegrationProxyClient):
             **kwargs,
         )
         if not raw_response and not response.json.get("ok"):
-            if kwargs.get("log_response_with_error", False):
+            if log_response_with_error:
                 self.logger.info(
                     "rule.fail.slack_post.log_response", extra={"response": response.__dict__}
                 )

--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -138,6 +138,8 @@ class SlackClient(IntegrationProxyClient):
         )
         if not raw_response and not response.json.get("ok"):
             if kwargs.get("log_response_with_error", False):
-                self.logger.info("rule.fail.slack_post.log_response", extra={"response": response})
+                self.logger.info(
+                    "rule.fail.slack_post.log_response", extra={"response": response.__dict__}
+                )
             raise ApiError(response.get("error", ""))
         return response

--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -125,7 +125,7 @@ class SlackClient(IntegrationProxyClient):
         *args: Any,
         **kwargs: Any,
     ) -> BaseApiResponse:
-        log_response_with_error = kwargs.pop("log_error", False)
+        log_response_with_error = kwargs.pop("log_response_with_error", False)
 
         response = self._request(
             method,

--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -137,5 +137,7 @@ class SlackClient(IntegrationProxyClient):
             **kwargs,
         )
         if not raw_response and not response.json.get("ok"):
+            if kwargs.get("log_response_with_error", False):
+                self.logger.info("rule.fail.slack_post.log_response", extra={"response": response})
             raise ApiError(response.get("error", ""))
         return response


### PR DESCRIPTION
Sometimes the `error` field in `ApiError` in an empty string. If we log the full response we can see what is happening when we don't get an `error` field back in the response.