### PR TITLE
Migrate recoveryOptionsModal to use API hook instead of AsyncComponent

### DIFF
--- a/static/app/components/modals/recoveryOptionsModal.spec.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.spec.tsx
@@ -42,6 +42,7 @@ describe('RecoveryOptionsModal', function () {
 
   it('can redirect to recovery codes if user skips backup phone setup', async function () {
     renderComponent();
+    await screen.findByText('Add a Phone Number');
 
     expect(
       screen.queryByRole('button', {name: 'Get Recovery Codes'})
@@ -65,7 +66,10 @@ describe('RecoveryOptionsModal', function () {
   it('can redirect to backup phone setup', async function () {
     renderComponent();
 
-    const backupPhoneButton = screen.getByRole('button', {name: 'Add a Phone Number'});
+    const backupPhoneButton = await screen.findByRole('button', {
+      name: 'Add a Phone Number',
+    });
+
     expect(backupPhoneButton).toBeInTheDocument();
     expect(backupPhoneButton).toHaveAttribute(
       'href',
@@ -76,7 +80,7 @@ describe('RecoveryOptionsModal', function () {
     expect(closeModal).toHaveBeenCalled();
   });
 
-  it('skips backup phone setup if text message authenticator unavailable', function () {
+  it('skips backup phone setup if text message authenticator unavailable', async function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/users/me/authenticators/',
@@ -86,7 +90,9 @@ describe('RecoveryOptionsModal', function () {
 
     renderComponent();
 
-    const getCodesbutton = screen.getByRole('button', {name: 'Get Recovery Codes'});
+    const getCodesbutton = await screen.findByRole('button', {
+      name: 'Get Recovery Codes',
+    });
     expect(getCodesbutton).toBeInTheDocument();
 
     expect(getCodesbutton).toHaveAttribute(

--- a/static/app/components/modals/recoveryOptionsModal.spec.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.spec.tsx
@@ -42,14 +42,14 @@ describe('RecoveryOptionsModal', function () {
 
   it('can redirect to recovery codes if user skips backup phone setup', async function () {
     renderComponent();
-    await screen.findByText('Add a Phone Number');
+    const skipButton = await screen.findByRole('button', {name: 'Skip this step'});
 
     expect(
       screen.queryByRole('button', {name: 'Get Recovery Codes'})
     ).not.toBeInTheDocument();
 
     // skip backup phone setup
-    await userEvent.click(screen.getByRole('button', {name: 'Skip this step'}));
+    await userEvent.click(skipButton);
 
     const getCodesbutton = screen.getByRole('button', {name: 'Get Recovery Codes'});
     expect(getCodesbutton).toBeInTheDocument();

--- a/static/app/components/modals/recoveryOptionsModal.spec.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.spec.tsx
@@ -107,4 +107,32 @@ describe('RecoveryOptionsModal', function () {
       screen.queryByRole('button', {name: 'Add a Phone Number'})
     ).not.toBeInTheDocument();
   });
+
+  it('renders the LoadingIndicator while fetching authenticators', async () => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/users/me/authenticators/',
+      method: 'GET',
+      body: [],
+    });
+
+    renderComponent();
+
+    const indicator = await screen.findByTestId('loading-indicator');
+    expect(indicator).toBeInTheDocument();
+  });
+
+  it('renders the error message on API error', async () => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/users/me/authenticators/',
+      method: 'GET',
+      statusCode: 500,
+    });
+
+    renderComponent();
+
+    const error = await screen.findByText('There was an error loading authenticators.');
+    expect(error).toBeInTheDocument();
+  });
 });

--- a/static/app/components/modals/recoveryOptionsModal.spec.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.spec.tsx
@@ -108,20 +108,6 @@ describe('RecoveryOptionsModal', function () {
     ).not.toBeInTheDocument();
   });
 
-  it('renders the LoadingIndicator while fetching authenticators', async () => {
-    MockApiClient.clearMockResponses();
-    MockApiClient.addMockResponse({
-      url: '/users/me/authenticators/',
-      method: 'GET',
-      body: [],
-    });
-
-    renderComponent();
-
-    const indicator = await screen.findByTestId('loading-indicator');
-    expect(indicator).toBeInTheDocument();
-  });
-
   it('renders the error message on API error', async () => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({

--- a/static/app/components/modals/recoveryOptionsModal.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.tsx
@@ -1,118 +1,116 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
-import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Authenticator} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-type Props = DeprecatedAsyncComponent['props'] &
-  ModalRenderProps & {
-    authenticatorName: string;
-  };
-
-type State = DeprecatedAsyncComponent['state'] & {
-  authenticators: Authenticator[] | null;
-  skipSms: boolean;
+type Props = ModalRenderProps & {
+  authenticatorName: string;
 };
 
-class RecoveryOptionsModal extends DeprecatedAsyncComponent<Props, State> {
-  getDefaultState() {
-    return {...super.getDefaultState(), skipSms: false};
-  }
+function RecoveryOptionsModal({
+  authenticatorName,
+  closeModal,
+  Body,
+  Header,
+  Footer,
+}: Props) {
+  const {isLoading, data: authenticators = []} = useApiQuery<Authenticator[]>(
+    ['/users/me/authenticators/'],
+    {
+      staleTime: 5000, // expire after 5 seconds
+    }
+  );
+  const [skipSms, setSkipSms] = useState<boolean>(false);
 
-  getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    return [['authenticators', '/users/me/authenticators/']];
-  }
+  const {recovery, sms} = authenticators.reduce<{[key: string]: Authenticator}>(
+    (obj, item) => {
+      obj[item.id] = item;
+      return obj;
+    },
+    {}
+  );
 
-  handleSkipSms = () => {
-    this.setState({skipSms: true});
+  const recoveryEnrolled = recovery?.isEnrolled;
+  const displaySmsPrompt =
+    sms && !sms.isEnrolled && !skipSms && !sms.disallowNewEnrollment;
+
+  const handleSkipSms = () => {
+    setSkipSms(true);
   };
 
-  renderBody() {
-    const {authenticatorName, closeModal, Body, Header, Footer} = this.props;
-    const {authenticators, skipSms} = this.state;
+  if (isLoading) return null;
 
-    const {recovery, sms} = authenticators!.reduce<{[key: string]: Authenticator}>(
-      (obj, item) => {
-        obj[item.id] = item;
-        return obj;
-      },
-      {}
-    );
-    const recoveryEnrolled = recovery?.isEnrolled;
-    const displaySmsPrompt =
-      sms && !sms.isEnrolled && !skipSms && !sms.disallowNewEnrollment;
+  return (
+    <Fragment>
+      <Header closeButton>{t('Two-Factor Authentication Enabled')}</Header>
 
-    return (
-      <Fragment>
-        <Header closeButton>{t('Two-Factor Authentication Enabled')}</Header>
-
-        <Body>
-          <TextBlock>
-            {t('Two-factor authentication via %s has been enabled.', authenticatorName)}
-          </TextBlock>
-          <TextBlock>
-            {t('You should now set up recovery options to secure your account.')}
-          </TextBlock>
-
-          {displaySmsPrompt ? (
-            // set up backup phone number
-            <Alert type="warning">
-              {t('We recommend adding a phone number as a backup 2FA method.')}
-            </Alert>
-          ) : (
-            // get recovery codes
-            <Alert type="warning">
-              {t(
-                `Recovery codes are the only way to access your account if you lose
-                  your device and cannot receive two-factor authentication codes.`
-              )}
-            </Alert>
-          )}
-        </Body>
+      <Body>
+        <TextBlock>
+          {t('Two-factor authentication via %s has been enabled.', authenticatorName)}
+        </TextBlock>
+        <TextBlock>
+          {t('You should now set up recovery options to secure your account.')}
+        </TextBlock>
 
         {displaySmsPrompt ? (
           // set up backup phone number
-          <Footer>
-            <Button onClick={this.handleSkipSms} name="skipStep" autoFocus>
-              {t('Skip this step')}
-            </Button>
-            <Button
-              priority="primary"
-              onClick={closeModal}
-              to={`/settings/account/security/mfa/${sms.id}/enroll/`}
-              name="addPhone"
-              css={{marginLeft: space(1)}}
-              autoFocus
-            >
-              {t('Add a Phone Number')}
-            </Button>
-          </Footer>
+          <Alert type="warning">
+            {t('We recommend adding a phone number as a backup 2FA method.')}
+          </Alert>
         ) : (
           // get recovery codes
-          <Footer>
-            <Button
-              priority="primary"
-              onClick={closeModal}
-              to={
-                recoveryEnrolled
-                  ? `/settings/account/security/mfa/${recovery.authId}/`
-                  : '/settings/account/security/'
-              }
-              name="getCodes"
-              autoFocus
-            >
-              {t('Get Recovery Codes')}
-            </Button>
-          </Footer>
+          <Alert type="warning">
+            {t(
+              `Recovery codes are the only way to access your account if you lose
+                  your device and cannot receive two-factor authentication codes.`
+            )}
+          </Alert>
         )}
-      </Fragment>
-    );
-  }
+      </Body>
+
+      {displaySmsPrompt ? (
+        // set up backup phone number
+        <Footer>
+          <Button onClick={handleSkipSms} name="skipStep" autoFocus>
+            {t('Skip this step')}
+          </Button>
+          <Button
+            priority="primary"
+            onClick={closeModal}
+            to={`/settings/account/security/mfa/${sms.id}/enroll/`}
+            name="addPhone"
+            css={{marginLeft: space(1)}}
+            autoFocus
+          >
+            {t('Add a Phone Number')}
+          </Button>
+        </Footer>
+      ) : (
+        // get recovery codes
+        <Footer>
+          <Button
+            priority="primary"
+            onClick={closeModal}
+            to={
+              recoveryEnrolled
+                ? `/settings/account/security/mfa/${recovery.authId}/`
+                : '/settings/account/security/'
+            }
+            name="getCodes"
+            autoFocus
+          >
+            {t('Get Recovery Codes')}
+          </Button>
+        </Footer>
+      )}
+    </Fragment>
+  );
 }
 
 export default RecoveryOptionsModal;

--- a/static/app/components/modals/recoveryOptionsModal.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.tsx
@@ -3,6 +3,8 @@ import {Fragment, useState} from 'react';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Authenticator} from 'sentry/types';
@@ -20,12 +22,14 @@ function RecoveryOptionsModal({
   Header,
   Footer,
 }: Props) {
-  const {isLoading, data: authenticators = []} = useApiQuery<Authenticator[]>(
-    ['/users/me/authenticators/'],
-    {
-      staleTime: 5000, // expire after 5 seconds
-    }
-  );
+  const {
+    isLoading,
+    isError,
+    refetch: refetchAuthenticators,
+    data: authenticators = [],
+  } = useApiQuery<Authenticator[]>(['/users/me/authenticators/'], {
+    staleTime: 5000, // expire after 5 seconds
+  });
   const [skipSms, setSkipSms] = useState<boolean>(false);
 
   const {recovery, sms} = authenticators.reduce<{[key: string]: Authenticator}>(
@@ -44,7 +48,16 @@ function RecoveryOptionsModal({
     setSkipSms(true);
   };
 
-  if (isLoading) return null;
+  if (isLoading) return <LoadingIndicator />;
+
+  if (isError) {
+    return (
+      <LoadingError
+        message={t('There was an error loading authenticators.')}
+        onRetry={refetchAuthenticators}
+      />
+    );
+  }
 
   return (
     <Fragment>


### PR DESCRIPTION
## Description
Part of FE TSC Project to [convert DeprecatedAsyncView](https://www.notion.so/sentry/Guide-How-to-convert-AsyncComponent-and-AsyncView-to-useApiQuery-55751df48dc04df5b4b0da42ba5e4fbd) to use the `useApiQuery` hook instead.

Core changes:
- Migrated to use a functional component instead of class component
- Updated tests to use `findBy` to so they will block for the `useApiQuery` hook.

### Screen Shot
Confirmed that the component is still rendering correctly after the migration:
<img width="776" alt="Screenshot 2024-02-26 at 12 47 15 PM" src="https://github.com/getsentry/sentry/assets/1569818/c8b0d201-5ad9-45b1-be59-3cddb3660a53">
