### PR TITLE
feat(metrics): Support min/max params on metrics samples

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -425,6 +425,8 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
 class MetricsSamplesSerializer(serializers.Serializer):
     mri = serializers.CharField(required=True)
     field = serializers.ListField(required=True, allow_empty=False, child=serializers.CharField())
+    max = serializers.FloatField(required=False)
+    min = serializers.FloatField(required=False)
     query = serializers.CharField(required=False)
     referrer = serializers.CharField(required=False)
 
@@ -477,6 +479,8 @@ class OrganizationMetricsSamplesEndpoint(OrganizationEventsV2EndpointBase):
             snuba_params,
             serialized["field"],
             serialized.get("query", ""),
+            serialized.get("min"),
+            serialized.get("max"),
             rollup,
             Referrer.API_ORGANIZATION_METRICS_SAMPLES,
         )

--- a/src/sentry/search/events/builder/metrics_summaries.py
+++ b/src/sentry/search/events/builder/metrics_summaries.py
@@ -7,6 +7,11 @@ from sentry.snuba.dataset import Dataset
 class MetricsSummariesQueryBuilder(QueryBuilder):
     requires_organization_condition = False
 
+    def get_field_type(self, field: str) -> str | None:
+        if field in ["min_metric", "max_metric", "sum_metric", "count_metric"]:
+            return "number"
+        return None
+
     def get_snql_query(self) -> Request:
         self.validate_having_clause()
 

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -423,9 +423,9 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
             store_metrics_summary={
                 "d:custom/other@millisecond": [
                     {
-                        "min": 100.0,
-                        "max": 100.0,
-                        "sum": 100.0,
+                        "min": 21.0,
+                        "max": 21.0,
+                        "sum": 21.0,
                         "count": 1,
                         "tags": {},
                     }

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import timedelta
 from functools import partial
 from uuid import uuid4
 
@@ -161,14 +162,19 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
         }
 
     def test_span_duration_samples(self):
-        span_ids = [uuid4().hex[:16] for _ in range(10)]
-        for i, span_id in enumerate(span_ids):
+        good_span_id = uuid4().hex[:16]
+
+        for i, val in enumerate([100, 200, 300]):
+            span_id = good_span_id if val == 200 else uuid4().hex[:16]
+            ts = before_now(days=i, minutes=10).replace(microsecond=0)
+
             self.store_indexed_span(
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
                 span_id=span_id,
-                timestamp=before_now(days=i, minutes=10),
+                duration=val,
+                timestamp=ts,
                 group=uuid4().hex[:16],  # we need a non 0 group
             )
 
@@ -177,28 +183,34 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
             "field": ["id"],
             "project": [self.project.id],
             "statsPeriod": "14d",
+            "min": 150,
+            "max": 250,
         }
         response = self.do_request(query)
         assert response.status_code == 200, response.data
-        expected = {int(span_id, 16) for span_id in span_ids}
+        expected = {int(good_span_id, 16)}
         actual = {int(row["id"], 16) for row in response.data["data"]}
         assert actual == expected
 
         for row in response.data["data"]:
             assert row["summary"] == {
-                "min": 10.0,
-                "max": 10.0,
-                "sum": 10.0,
+                "min": 200.0,
+                "max": 200.0,
+                "sum": 200.0,
                 "count": 1,
             }
 
     def test_transaction_duration_samples(self):
-        span_ids = [uuid4().hex[:16] for _ in range(1)]
-        for i, span_id in enumerate(span_ids):
+        good_span_id = uuid4().hex[:16]
+
+        for i, val in enumerate([100, 200, 300]):
+            span_id = good_span_id if val == 200 else uuid4().hex[:16]
+
             ts = before_now(days=i, minutes=10).replace(microsecond=0)
+            start_ts = ts - timedelta(microseconds=val * 1000)
 
             # first write to the transactions dataset
-            data = load_data("transaction", timestamp=ts)
+            data = load_data("transaction", start_timestamp=start_ts, timestamp=ts)
             data["contexts"]["trace"]["span_id"] = span_id
             self.store_event(
                 data=data,
@@ -219,51 +231,36 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
             "field": ["id"],
             "project": [self.project.id],
             "statsPeriod": "14d",
+            "min": 150,
+            "max": 250,
         }
         response = self.do_request(query)
         assert response.status_code == 200, response.data
-        expected = {int(span_id, 16) for span_id in span_ids}
+        expected = {int(good_span_id, 16)}
         actual = {int(row["id"], 16) for row in response.data["data"]}
         assert actual == expected
 
         for row in response.data["data"]:
             assert row["summary"] == {
-                "min": 3000,
-                "max": 3000,
-                "sum": 3000,
+                "min": 200,
+                "max": 200,
+                "sum": 200,
                 "count": 1,
             }
 
     def test_transaction_measurement_samples(self):
-        good_span_ids = [uuid4().hex[:16] for _ in range(1)]
-        bad_span_ids = [uuid4().hex[:16] for _ in range(1)]
-        for i, (good_span_id, bad_span_id) in enumerate(zip(good_span_ids, bad_span_ids)):
+        good_span_id = uuid4().hex[:16]
+
+        for i, val in enumerate([100, 200, 300]):
+            span_id = good_span_id if val == 200 else uuid4().hex[:16]
+
             ts = before_now(days=i, minutes=10).replace(microsecond=0)
 
             # first write to the transactions dataset
             data = load_data("transaction", timestamp=ts)
-            # bad span ids will not have the measurement
-            data["measurements"] = {}
-            data["contexts"]["trace"]["span_id"] = bad_span_id
-            self.store_event(
-                data=data,
-                project_id=self.project.id,
-            )
-
-            # next write to the spans dataset
-            self.store_segment(
-                self.project.id,
-                uuid4().hex,
-                uuid4().hex,
-                span_id=bad_span_id,
-                timestamp=ts,
-            )
-
-            # first write to the transactions dataset
-            data = load_data("transaction", timestamp=ts)
             # good span ids will have the measurement
-            data["measurements"] = {"lcp": {"value": 10}}
-            data["contexts"]["trace"]["span_id"] = good_span_id
+            data["measurements"] = {"lcp": {"value": val}}
+            data["contexts"]["trace"]["span_id"] = span_id
             self.store_event(
                 data=data,
                 project_id=self.project.id,
@@ -274,46 +271,68 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=good_span_id,
+                span_id=span_id,
                 timestamp=ts,
             )
+
+        span_id = uuid4().hex[:16]
+        ts = before_now(days=10, minutes=10).replace(microsecond=0)
+
+        # first write to the transactions dataset
+        data = load_data("transaction", timestamp=ts)
+        # bad span ids will not have the measurement
+        data["measurements"] = {}
+        data["contexts"]["trace"]["span_id"] = span_id
+        self.store_event(
+            data=data,
+            project_id=self.project.id,
+        )
+
+        # next write to the spans dataset
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            span_id=span_id,
+            timestamp=ts,
+        )
 
         query = {
             "mri": "d:transactions/measurements.lcp@millisecond",
             "field": ["id"],
             "project": [self.project.id],
             "statsPeriod": "14d",
+            "min": 150.0,
+            "max": 250.0,
         }
         response = self.do_request(query)
         assert response.status_code == 200, response.data
-        expected = {int(span_id, 16) for span_id in good_span_ids}
+        expected = {int(good_span_id, 16)}
         actual = {int(row["id"], 16) for row in response.data["data"]}
         assert actual == expected
 
         for row in response.data["data"]:
             assert row["summary"] == {
-                "min": 10.0,
-                "max": 10.0,
-                "sum": 10.0,
+                "min": 200.0,
+                "max": 200.0,
+                "sum": 200.0,
                 "count": 1,
             }
 
     def test_span_measurement_samples(self):
-        good_span_ids = [uuid4().hex[:16] for _ in range(1)]
-        bad_span_ids = [uuid4().hex[:16] for _ in range(1)]
-        for i, (good_span_id, bad_span_id) in enumerate(zip(good_span_ids, bad_span_ids)):
-            ts = before_now(days=i, minutes=10).replace(microsecond=0)
+        good_span_id = uuid4().hex[:16]
 
+        for i, value in enumerate([100, 200, 300]):
             self.store_indexed_span(
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=good_span_id,
-                timestamp=ts,
+                span_id=good_span_id if value == 200 else uuid4().hex[:16],
+                timestamp=before_now(days=i, minutes=10).replace(microsecond=0),
                 group=uuid4().hex[:16],  # we need a non 0 group
                 measurements={
-                    measurement: i + 1
-                    for i, measurement in enumerate(
+                    measurement: value + j + 1
+                    for j, measurement in enumerate(
                         [
                             "score.total",
                             "score.inp",
@@ -329,8 +348,8 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=bad_span_id,
-                timestamp=ts,
+                span_id=uuid4().hex[:16],
+                timestamp=before_now(days=10, minutes=10).replace(microsecond=0),
                 group=uuid4().hex[:16],  # we need a non 0 group
             )
 
@@ -349,83 +368,89 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 "field": ["id"],
                 "project": [self.project.id],
                 "statsPeriod": "14d",
+                "min": 150.0,
+                "max": 250.0,
             }
             response = self.do_request(query)
             assert response.status_code == 200, response.data
-            expected = {int(span_id, 16) for span_id in good_span_ids}
+            expected = {int(good_span_id, 16)}
             actual = {int(row["id"], 16) for row in response.data["data"]}
             assert actual == expected, mri
 
             for row in response.data["data"]:
                 assert row["summary"] == {
-                    "min": i + 1,
-                    "max": i + 1,
-                    "sum": i + 1,
+                    "min": 201 + i,
+                    "max": 201 + i,
+                    "sum": 201 + i,
                     "count": 1,
                 }, mri
 
     def test_custom_samples(self):
         mri = "d:custom/value@millisecond"
-        good_span_ids = [uuid4().hex[:16] for _ in range(1)]
-        bad_span_ids = [uuid4().hex[:16] for _ in range(1)]
-        for i, (good_span_id, bad_span_id) in enumerate(zip(good_span_ids, bad_span_ids)):
-            ts = before_now(days=i, minutes=10).replace(microsecond=0)
+        good_span_id = uuid4().hex[:16]
 
+        # 10 is below the min
+        # 20 is within bounds
+        # 30 is above the max
+        for i, val in enumerate([10.0, 20.0, 30.0]):
             self.store_indexed_span(
                 self.project.id,
                 uuid4().hex,
                 uuid4().hex,
-                span_id=good_span_id,
-                timestamp=ts,
+                span_id=good_span_id if val == 20.0 else uuid4().hex[:16],
+                timestamp=before_now(days=i, minutes=10).replace(microsecond=0),
                 group=uuid4().hex[:16],  # we need a non 0 group
                 store_metrics_summary={
                     mri: [
                         {
-                            "min": 10.0,
-                            "max": 100.0,
-                            "sum": 110.0,
-                            "count": 2,
+                            "min": val,
+                            "max": val,
+                            "sum": val,
+                            "count": 1,
                             "tags": {},
                         }
                     ]
                 },
             )
-            self.store_indexed_span(
-                self.project.id,
-                uuid4().hex,
-                uuid4().hex,
-                span_id=bad_span_id,
-                timestamp=ts,
-                group=uuid4().hex[:16],  # we need a non 0 group
-                store_metrics_summary={
-                    "d:custom/other@millisecond": [
-                        {
-                            "min": 20.0,
-                            "max": 200.0,
-                            "sum": 220.0,
-                            "count": 3,
-                            "tags": {},
-                        }
-                    ]
-                },
-            )
+
+        self.store_indexed_span(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            span_id=uuid4().hex[:16],
+            timestamp=before_now(days=10, minutes=10).replace(microsecond=0),
+            group=uuid4().hex[:16],  # we need a non 0 group
+            store_metrics_summary={
+                "d:custom/other@millisecond": [
+                    {
+                        "min": 100.0,
+                        "max": 100.0,
+                        "sum": 100.0,
+                        "count": 1,
+                        "tags": {},
+                    }
+                ]
+            },
+        )
 
         query = {
             "mri": mri,
             "field": ["id"],
             "project": [self.project.id],
             "statsPeriod": "14d",
+            "min": 15.0,
+            "max": 25.0,
         }
         response = self.do_request(query)
         assert response.status_code == 200, response.data
-        expected = {int(span_id, 16) for span_id in good_span_ids}
+        expected = {int(good_span_id, 16)}
         actual = {int(row["id"], 16) for row in response.data["data"]}
         assert actual == expected
 
         for row in response.data["data"]:
             assert row["summary"] == {
-                "min": 10.0,
-                "max": 100.0,
-                "sum": 110.0,
-                "count": 2,
+                "min": 20.0,
+                "max": 20.0,
+                "sum": 20.0,
+                "count": 1,
             }


### PR DESCRIPTION
When the user selects a focus area, we want to narrow the search to just values within the focus area. This will be done by adjusting the data params and adding a new min/max param to specify the bounds. This PR adds support for this.