### PR TITLE
fix(hybridcloud) Don't use proxy for pagerduty

### DIFF
--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -4,8 +4,8 @@ from typing import Any
 
 from sentry.api.serializers import ExternalEventSerializer, serialize
 from sentry.eventstore.models import Event, GroupEvent
+from sentry.integrations.client import ApiClient
 from sentry.shared_integrations.client.base import BaseApiResponseX
-from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 
 LEVEL_SEVERITY_MAP = {
     "debug": "info",
@@ -16,19 +16,17 @@ LEVEL_SEVERITY_MAP = {
 }
 
 
-class PagerDutyProxyClient(IntegrationProxyClient):
+class PagerDutyClient(ApiClient):
     allow_redirects = False
     integration_name = "pagerduty"
     base_url = "https://events.pagerduty.com/v2/enqueue"
 
     def __init__(
         self,
-        org_integration_id: int | None,
         integration_key: str,
-        keyid: str | None = None,
     ) -> None:
         self.integration_key = integration_key
-        super().__init__(org_integration_id=org_integration_id, keyid=keyid)
+        super().__init__()
 
     def request(self, method: str, *args: Any, **kwargs: Any) -> BaseApiResponseX:
         headers = kwargs.pop("headers", None)

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -23,8 +23,10 @@ class PagerDutyClient(ApiClient):
 
     def __init__(
         self,
-        integration_id: int,
         integration_key: str,
+        integration_id: int | None = None,  # soon to be required, depending on getsentry changes
+        keyid: str | None = None,  # deprecated but still passed by getsentry
+        org_integration_id: int | None = None,  # deprecated but still passed by getsentry
     ) -> None:
         self.integration_key = integration_key
         super().__init__(integration_id=integration_id)
@@ -69,3 +71,9 @@ class PagerDutyClient(ApiClient):
             payload = data
 
         return self.post("/", data=payload)
+
+
+class PagerDutyProxyClient(PagerDutyClient):
+    """Backwards compatibility shim for getsentry"""
+
+    pass

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -23,10 +23,11 @@ class PagerDutyClient(ApiClient):
 
     def __init__(
         self,
+        integration_id: int,
         integration_key: str,
     ) -> None:
         self.integration_key = integration_key
-        super().__init__()
+        super().__init__(integration_id=integration_id)
 
     def request(self, method: str, *args: Any, **kwargs: Any) -> BaseApiResponseX:
         headers = kwargs.pop("headers", None)

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -78,7 +78,9 @@ class PagerDutyIntegration(IntegrationInstallation):
         if not integration_key:
             raise ValueError("Cannot get client without an an integration_key.")
 
-        return PagerDutyClient(integration_key=integration_key)
+        return PagerDutyClient(
+            integration_id=org_integration.integration_id, integration_key=integration_key
+        )
 
     def get_client(self):
         raise NotImplementedError("Use get_keyring_client instead.")

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -24,7 +24,7 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
-from .client import PagerDutyProxyClient
+from .client import PagerDutyClient
 from .utils import PagerDutyServiceDict, add_service
 
 logger = logging.getLogger("sentry.integrations.pagerduty")
@@ -67,7 +67,7 @@ metadata = IntegrationMetadata(
 
 
 class PagerDutyIntegration(IntegrationInstallation):
-    def get_keyring_client(self, keyid: str) -> PagerDutyProxyClient:
+    def get_keyring_client(self, keyid: str) -> PagerDutyClient:
         org_integration = self.org_integration
         assert org_integration, "Cannot get client without an organization integration"
 
@@ -75,13 +75,10 @@ class PagerDutyIntegration(IntegrationInstallation):
         for pds in org_integration.config.get("pagerduty_services", []):
             if str(pds["id"]) == str(keyid):
                 integration_key = pds["integration_key"]
-        assert integration_key, "Cannot get client without an an integration_key"
+        if not integration_key:
+            raise ValueError("Cannot get client without an an integration_key.")
 
-        return PagerDutyProxyClient(
-            org_integration_id=self.org_integration.id,
-            integration_key=integration_key,
-            keyid=keyid,
-        )
+        return PagerDutyClient(integration_key=integration_key)
 
     def get_client(self):
         raise NotImplementedError("Use get_keyring_client instead.")

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -160,7 +160,10 @@ def send_incident_alert_notification(
 
     integration_key = service["integration_key"]
     # TODO(hybridcloud) This should use the integration.installation client workflow instead.
-    client = PagerDutyClient(integration_key=integration_key)
+    client = PagerDutyClient(
+        integration_id=integration_id,
+        integration_key=integration_key,
+    )
     attachment = build_incident_attachment(
         incident, integration_key, new_status, metric_value, notification_uuid
     )

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -15,7 +15,7 @@ from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.shared_integrations.client.proxy import infer_org_integration
 from sentry.shared_integrations.exceptions import ApiError
 
-from .client import PagerDutyProxyClient
+from .client import PagerDutyClient
 
 logger = logging.getLogger("sentry.integrations.pagerduty")
 
@@ -160,11 +160,7 @@ def send_incident_alert_notification(
 
     integration_key = service["integration_key"]
     # TODO(hybridcloud) This should use the integration.installation client workflow instead.
-    client = PagerDutyProxyClient(
-        org_integration_id=org_integration_id,
-        integration_key=integration_key,
-        keyid=str(service["id"]),
-    )
+    client = PagerDutyClient(integration_key=integration_key)
     attachment = build_incident_attachment(
         incident, integration_key, new_status, metric_value, notification_uuid
     )

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -4,18 +4,14 @@ from unittest.mock import call
 
 import pytest
 import responses
-from django.test import override_settings
 from responses import matchers
 
 from sentry.api.serializers import ExternalEventSerializer, serialize
-from sentry.integrations.pagerduty.client import PagerDutyProxyClient
 from sentry.integrations.pagerduty.utils import add_service
-from sentry.silo.base import SiloMode
-from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, region_silo_test
+from sentry.testutils.silo import control_silo_test
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
@@ -33,7 +29,7 @@ SERVICES = [
 
 
 @control_silo_test
-class PagerDutyProxyClientTest(APITestCase):
+class PagerDutyClientTest(APITestCase):
     provider = "pagerduty"
 
     @pytest.fixture(autouse=True)
@@ -126,125 +122,3 @@ class PagerDutyProxyClientTest(APITestCase):
             )
         ]
         assert self.metrics.incr.mock_calls == calls
-
-
-def assert_proxy_request(request, is_proxy=True):
-    assert (PROXY_BASE_PATH in request.url) == is_proxy
-    assert (PROXY_OI_HEADER in request.headers) == is_proxy
-    assert (PROXY_SIGNATURE_HEADER in request.headers) == is_proxy
-    # PagerDuty API does not require the Authorization header.
-    # The secret is instead passed in the body payload called routing_key/integration key
-    assert "Authorization" not in request.headers
-    if is_proxy:
-        assert request.headers[PROXY_OI_HEADER] is not None
-
-
-@region_silo_test
-class PagerDutyProxyApiClientTest(APITestCase):
-    def setUp(self):
-        self.login_as(self.user)
-
-        self.integration = self.create_integration(
-            organization=self.organization,
-            provider="pagerduty",
-            name="Example PagerDuty",
-            external_id=EXTERNAL_ID,
-            metadata={"services": SERVICES},
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.service = add_service(
-                self.integration.organizationintegration_set.first(),
-                service_name=SERVICES[0]["service_name"],
-                integration_key=SERVICES[0]["integration_key"],
-            )
-        self.installation = self.integration.get_installation(self.organization.id)
-        self.min_ago = iso_format(before_now(minutes=1))
-
-    @responses.activate
-    def test_integration_proxy_is_active(self):
-        responses.add(
-            responses.POST,
-            "https://events.pagerduty.com/v2/enqueue/",
-            body=b"{}",
-            match=[
-                matchers.header_matcher(
-                    {
-                        "Content-Type": "application/json",
-                    }
-                ),
-            ],
-        )
-
-        responses.add(
-            responses.POST,
-            "http://controlserver/api/0/internal/integration-proxy/",
-            body=b"{}",
-            match=[
-                matchers.header_matcher(
-                    {
-                        "Content-Type": "application/json",
-                    }
-                ),
-            ],
-        )
-
-        class PagerDutyProxyApiTestClient(PagerDutyProxyClient):
-            _use_proxy_url_for_tests = True
-
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "message",
-                "timestamp": self.min_ago,
-                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
-            },
-            project_id=self.project.id,
-        )
-
-        assert self.installation.org_integration is not None
-        org_integration_id = self.installation.org_integration.id
-
-        responses.calls.reset()
-        with override_settings(SILO_MODE=SiloMode.MONOLITH):
-            client = PagerDutyProxyApiTestClient(
-                org_integration_id=org_integration_id,
-                integration_key=self.service["integration_key"],
-                keyid=str(self.service["id"]),
-            )
-            client.send_trigger(event)
-
-            assert len(responses.calls) == 1
-            request = responses.calls[0].request
-            assert "https://events.pagerduty.com/v2/enqueue/" == request.url
-            assert client.base_url and (client.base_url.lower() in request.url)
-            assert_proxy_request(request, is_proxy=False)
-
-        responses.calls.reset()
-        with override_settings(SILO_MODE=SiloMode.CONTROL):
-            client = PagerDutyProxyApiTestClient(
-                org_integration_id=org_integration_id,
-                integration_key=self.service["integration_key"],
-                keyid=str(self.service["id"]),
-            )
-            client.send_trigger(event)
-
-            assert len(responses.calls) == 1
-            request = responses.calls[0].request
-            assert "https://events.pagerduty.com/v2/enqueue/" == request.url
-            assert client.base_url and (client.base_url.lower() in request.url)
-            assert_proxy_request(request, is_proxy=False)
-
-        responses.calls.reset()
-        with override_settings(SILO_MODE=SiloMode.REGION):
-            client = PagerDutyProxyApiTestClient(
-                org_integration_id=org_integration_id,
-                integration_key=self.service["integration_key"],
-                keyid=str(self.service["id"]),
-            )
-            client.send_trigger(event)
-
-            assert len(responses.calls) == 1
-            request = responses.calls[0].request
-            assert "http://controlserver/api/0/internal/integration-proxy/" == request.url
-            assert client.base_url and (client.base_url.lower() not in request.url)
-            assert_proxy_request(request, is_proxy=True)


### PR DESCRIPTION
Pagerduty doesn't use refresh tokens and gains no benefit from the integration proxy. To reduce failure points we can bypass the proxy.

Refs HC-1125