### PR TITLE
fix(hybridcloud) Don't use proxy for opsgenie

### DIFF
--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -4,11 +4,11 @@ from typing import Literal
 from urllib.parse import quote
 
 from sentry.eventstore.models import Event, GroupEvent
+from sentry.integrations.client import ApiClient
 from sentry.models.group import Group
 from sentry.models.integrations.integration import Integration
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.shared_integrations.client.base import BaseApiResponseX
-from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 
 OPSGENIE_API_VERSION = "v2"
 # Defaults to P3 if null, but we can be explicit - https://docs.opsgenie.com/docs/alert-api
@@ -17,20 +17,18 @@ OPSGENIE_DEFAULT_PRIORITY = "P3"
 OpsgeniePriority = Literal["P1", "P2", "P3", "P4", "P5"]
 
 
-class OpsgenieClient(IntegrationProxyClient):
+class OpsgenieClient(ApiClient):
     integration_name = "opsgenie"
 
     def __init__(
         self,
         integration: RpcIntegration | Integration,
         integration_key: str,
-        org_integration_id: int | None,
-        keyid: str | None = None,
     ) -> None:
         self.integration = integration
         self.base_url = f"{self.metadata['base_url']}{OPSGENIE_API_VERSION}"
         self.integration_key = integration_key
-        super().__init__(org_integration_id=org_integration_id, keyid=keyid)
+        super().__init__()
 
     @property
     def metadata(self):

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -28,7 +28,7 @@ class OpsgenieClient(ApiClient):
         self.integration = integration
         self.base_url = f"{self.metadata['base_url']}{OPSGENIE_API_VERSION}"
         self.integration_key = integration_key
-        super().__init__()
+        super().__init__(integration_id=self.integration.id)
 
     @property
     def metadata(self):

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -24,6 +24,8 @@ class OpsgenieClient(ApiClient):
         self,
         integration: RpcIntegration | Integration,
         integration_key: str,
+        org_integration_id: int | None = None,  # deprecated but still passed by getsentry
+        keyid: str | None = None,  # deprecated but still passed by getsentry
     ) -> None:
         self.integration = integration
         self.base_url = f"{self.metadata['base_url']}{OPSGENIE_API_VERSION}"

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -122,8 +122,6 @@ class OpsgenieIntegration(IntegrationInstallation):
         return OpsgenieClient(
             integration=self.model,
             integration_key=team["integration_key"],
-            org_integration_id=org_integration.id,
-            keyid=keyid,
         )
 
     def get_client(self) -> Any:  # type: ignore


### PR DESCRIPTION
Opsgenie doesn't use refresh tokens and gains no benefit from the integration proxy. To reduce failure points we can bypass the proxy.

Refs HC-1125