### PR TITLE
fix(issues): Reduce whitespace at top of issues

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -1,8 +1,10 @@
+import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import EventContextSummary from 'sentry/components/events/contextSummary';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Organization, Project} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 
@@ -18,7 +20,7 @@ type Props = {
 
 function Tags({event, organization, projectSlug, location, hasEventContext}: Props) {
   return (
-    <EventDataSection
+    <StyledEventDataSection
       title={t('Tags')}
       help={t('The default and custom tags associated with this event')}
       data-test-id="event-tags"
@@ -32,8 +34,16 @@ function Tags({event, organization, projectSlug, location, hasEventContext}: Pro
         projectSlug={projectSlug}
         location={location}
       />
-    </EventDataSection>
+    </StyledEventDataSection>
   );
 }
 
 export default Tags;
+
+const StyledEventDataSection = styled(EventDataSection)`
+  padding: ${space(0.5)} ${space(2)} ${space(1)};
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(1)} ${space(4)} ${space(1.5)};
+  }
+`;

--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -79,7 +79,7 @@ export function SuspectCommits({group, eventId, project, commitRow: CommitRow}: 
   const commitHeading = tn('Suspect Commit', 'Suspect Commits (%s)', commits.length);
 
   return (
-    <DataSection>
+    <StyledDataSection>
       <SuspectCommitHeader>
         <h3 data-test-id="suspect-commit">{commitHeading}</h3>
         {commits.length > 1 && (
@@ -109,9 +109,17 @@ export function SuspectCommits({group, eventId, project, commitRow: CommitRow}: 
           />
         ))}
       </StyledPanel>
-    </DataSection>
+    </StyledDataSection>
   );
 }
+
+const StyledDataSection = styled(DataSection)`
+  padding: ${space(0.5)} ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(1)} ${space(4)};
+  }
+`;
 
 export const StyledPanel = styled(Panel)`
   margin: 0;

--- a/static/app/views/issueDetails/groupEventHeader.tsx
+++ b/static/app/views/issueDetails/groupEventHeader.tsx
@@ -18,19 +18,27 @@ function GroupEventHeader({event, group, project}: GroupEventHeaderProps) {
   const organization = useOrganization();
 
   return (
-    <DataSection>
+    <StyledDataSection>
       <GroupEventCarousel group={group} event={event} projectSlug={project.slug} />
       <TraceTimeline event={event} />
       <StyledGlobalAppStoreConnectUpdateAlert
         project={project}
         organization={organization}
       />
-    </DataSection>
+    </StyledDataSection>
   );
 }
 
 const StyledGlobalAppStoreConnectUpdateAlert = styled(GlobalAppStoreConnectUpdateAlert)`
   margin: ${space(0.5)} 0;
+`;
+
+const StyledDataSection = styled(DataSection)`
+  padding: ${space(1)} ${space(2)} 0;
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(1.5)} ${space(4)} 0;
+  }
 `;
 
 export default GroupEventHeader;

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -50,7 +50,7 @@ export function TraceTimeline({event}: TraceTimelineProps) {
     traceEvents.every(item => item.id === event.id);
   if (isError || noEvents || onlySelfEvent) {
     // display empty placeholder to reduce layout shift
-    return <div style={{height: 38}} data-test-id="trace-timeline-empty" />;
+    return <div style={{height: 36}} data-test-id="trace-timeline-empty" />;
   }
 
   return (
@@ -89,7 +89,7 @@ const TimelineWrapper = styled('div')`
   grid-template-columns: 1fr auto;
   align-items: start;
   gap: ${space(2)};
-  margin-top: ${space(0.5)};
+  margin-top: ${space(0.25)};
 `;
 
 const QuestionTooltipWrapper = styled('div')`


### PR DESCRIPTION
Reduces whitespace in the sections at the top of issues, especially near the trace timeline. Since Tags or Suspect commits can both be the top element it reduces padding in both.

before - no timeline
![Screenshot 2024-02-26 at 2 10 43 PM](https://github.com/getsentry/sentry/assets/1400464/da9b7d0b-2f04-4ad9-ac64-9c3a9c93eead)

before - with timeline
![Screenshot 2024-02-26 at 2 10 49 PM](https://github.com/getsentry/sentry/assets/1400464/843cf3f7-7f23-45a8-912b-95b2b6d2d6fb)

after - no timeline
![Screenshot 2024-02-26 at 2 10 28 PM](https://github.com/getsentry/sentry/assets/1400464/5ce71a55-72f6-4f91-9b99-4c137118c205)

after - with timeline
![Screenshot 2024-02-26 at 2 10 36 PM](https://github.com/getsentry/sentry/assets/1400464/54f6f278-7aba-41ca-be56-bb5fd3d8b323)

