### PR TITLE
chore(team-org-roles): finally remove hybrid cloud helpers

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1689,8 +1689,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:on-demand-metrics-query-spec-version-two": False,
     # Enable the SDK selection feature in the onboarding
     "organizations:onboarding-sdk-selection": False,
-    # Enable the setting of org roles for team
-    "organizations:org-roles-for-teams": False,
     # Prefix host with organization ID when giving users DSNs (can be
     # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE)
     "organizations:org-subdomains": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -162,7 +162,6 @@ default_manager.add("organizations:on-demand-metrics-ui-widgets", OrganizationFe
 default_manager.add("organizations:on-demand-metrics-query-spec-version-two", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:onboarding-sdk-selection", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)  # Only enabled in sentry.io to enable onboarding flows.
-default_manager.add("organizations:org-roles-for-teams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:org-subdomains", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-anomaly-detection-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-calculate-score-relay", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/services/hybrid_cloud/access/impl.py
+++ b/src/sentry/services/hybrid_cloud/access/impl.py
@@ -5,10 +5,6 @@ from sentry.models.authprovider import AuthProvider
 from sentry.models.authproviderreplica import AuthProviderReplica
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
-from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
-from sentry.models.team import Team
-from sentry.models.teamreplica import TeamReplica
 from sentry.services.hybrid_cloud.access.service import AccessService
 from sentry.services.hybrid_cloud.auth import RpcAuthIdentity, RpcAuthProvider
 from sentry.services.hybrid_cloud.auth.serial import (
@@ -22,37 +18,6 @@ from sentry.services.hybrid_cloud.user.service import user_service
 
 
 class ControlAccessService(AccessService):
-    def get_all_org_roles(self, member_id: int, organization_id: int) -> list[str]:
-        try:
-            member = OrganizationMemberMapping.objects.get(
-                organizationmember_id=member_id, organization_id=organization_id
-            )
-        except OrganizationMemberMapping.DoesNotExist:
-            return []
-
-        team_ids = OrganizationMemberTeamReplica.objects.filter(
-            organizationmember_id=member_id, organization_id=organization_id
-        ).values_list("team_id", flat=True)
-        all_roles: set[str] = set(
-            TeamReplica.objects.filter(team_id__in=team_ids)
-            .exclude(org_role=None)
-            .values_list("org_role", flat=True)
-        )
-        all_roles.add(member.role)
-        return list(all_roles)
-
-    def get_top_dog_team_member_ids(self, organization_id: int) -> list[int]:
-        owner_teams = list(
-            TeamReplica.objects.filter(
-                organization_id=organization_id, org_role=roles.get_top_dog().id
-            ).values_list("team_id", flat=True)
-        )
-        return list(
-            OrganizationMemberTeamReplica.objects.filter(team_id__in=owner_teams).values_list(
-                "organizationmember_id", flat=True
-            )
-        )
-
     def get_permissions_for_user(self, user_id: int) -> frozenset[str]:
         user = user_service.get_user(user_id)
         if user is None:
@@ -109,35 +74,6 @@ class ControlAccessService(AccessService):
 
 
 class RegionAccessService(AccessService):
-    def get_all_org_roles(self, member_id: int, organization_id: int) -> list[str]:
-        try:
-            member = OrganizationMember.objects.get(id=member_id, organization_id=organization_id)
-        except OrganizationMember.DoesNotExist:
-            return []
-
-        team_ids = OrganizationMemberTeam.objects.filter(
-            organizationmember_id=member.id
-        ).values_list("team_id", flat=True)
-        all_roles: set[str] = set(
-            Team.objects.filter(id__in=team_ids)
-            .exclude(org_role=None)
-            .values_list("org_role", flat=True)
-        )
-        all_roles.add(member.role)
-        return list(all_roles)
-
-    def get_top_dog_team_member_ids(self, organization_id: int) -> list[int]:
-        owner_teams = list(
-            Team.objects.filter(
-                organization_id=organization_id, org_role=roles.get_top_dog().id
-            ).values_list("id", flat=True)
-        )
-        return list(
-            OrganizationMemberTeam.objects.filter(team_id__in=owner_teams).values_list(
-                "organizationmember_id", flat=True
-            )
-        )
-
     def get_auth_provider(self, organization_id: int) -> RpcAuthProvider | None:
         try:
             ap = AuthProviderReplica.objects.get(organization_id=organization_id)

--- a/src/sentry/services/hybrid_cloud/access/service.py
+++ b/src/sentry/services/hybrid_cloud/access/service.py
@@ -38,14 +38,6 @@ class AccessService(abc.ABC):
         """
         pass
 
-    @abc.abstractmethod
-    def get_all_org_roles(self, member_id: int, organization_id: int) -> list[str]:
-        pass
-
-    @abc.abstractmethod
-    def get_top_dog_team_member_ids(self, organization_id: int) -> list[int]:
-        pass
-
     def auth_identity_is_valid(
         self,
         auth_provider: RpcAuthProvider,


### PR DESCRIPTION
Part of an ongoing effort to remove the org roles for teams feature https://github.com/getsentry/team-core-product-foundations/issues/51

RE: Mark's comment here
https://github.com/getsentry/sentry/pull/65798#discussion_r1503358500
> Removing RPC methods requires two deploys.
> 
> 1. First remove all callers of an RPC method, and deploy that.
> 2. Once your callsite changes have landed you can remove the RPC method from the service and impl modules.
> 
> Doing both changes in one deployment will cause a burst of failures until all regions have been deployed which we should avoid.

This PR accomplishes part 2, and removes the feature flags for this feature.

Part 1 here https://github.com/getsentry/sentry/pull/65831