### PR TITLE
fix(issues): Skip coverage api when codecov is disabled

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -159,7 +159,9 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     }
   );
   const coverageEnabled =
-    isQueryEnabled && organization.features.includes('codecov-integration');
+    isQueryEnabled &&
+    organization.codecovAccess &&
+    organization.features.includes('codecov-integration');
   const {data: coverage, isLoading: isLoadingCoverage} = useStacktraceCoverage(
     {
       event,
@@ -248,9 +250,10 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
   }
 
   if (isLoading || !match) {
+    const placeholderWidth = coverageEnabled ? '40px' : '14px';
     return (
       <StacktraceLinkWrapper>
-        <Placeholder height="14px" width="40px" />
+        <Placeholder height="14px" width={placeholderWidth} />
       </StacktraceLinkWrapper>
     );
   }


### PR DESCRIPTION
Needed to have checked `organization.codecovAccess` before calling the coverage api. Leading to some api calls for no reason.

Shrinks the placeholder if the query is never going to show the codecov link
