### PR TITLE
fix return for add_project

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -504,7 +504,7 @@ class OrganizationReleasesEndpoint(
 
                 new_releaseprojects = []
                 for project in projects:
-                    obj, releaseproject_created = release.add_project(project)
+                    _, releaseproject_created = release.add_project(project)
                     if releaseproject_created:
                         new_releaseprojects.append(project)
 

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -502,14 +502,14 @@ class OrganizationReleasesEndpoint(
                     release.status = new_status
                     release.save()
 
-                new_projects = []
+                new_releaseprojects = []
                 for project in projects:
-                    created = release.add_project(project)
-                    if created:
-                        new_projects.append(project)
+                    obj, releaseproject_created = release.add_project(project)
+                    if releaseproject_created:
+                        new_releaseprojects.append(project)
 
                 if release.date_released:
-                    for project in new_projects:
+                    for project in new_releaseprojects:
                         Activity.objects.create(
                             type=ActivityType.RELEASE.value,
                             project=project,
@@ -555,7 +555,7 @@ class OrganizationReleasesEndpoint(
                         scope.set_tag("failure_reason", "InvalidRepository")
                         return Response({"refs": [str(e)]}, status=400)
 
-                if not created and not new_projects:
+                if not releaseproject_created and not new_releaseprojects:
                     # This is the closest status code that makes sense, and we want
                     # a unique 2xx response code so people can understand when
                     # behavior differs.

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -162,7 +162,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                     release.status = new_status
                     release.save()
 
-                obj, releaseproject_created = release.add_project(project)
+                _, releaseproject_created = release.add_project(project)
 
                 commit_list = result.get("commits")
                 if commit_list:

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -162,7 +162,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                     release.status = new_status
                     release.save()
 
-                created = release.add_project(project)
+                obj, releaseproject_created = release.add_project(project)
 
                 commit_list = result.get("commits")
                 if commit_list:
@@ -179,7 +179,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                         datetime=release.date_released,
                     )
 
-                if not created:
+                if not releaseproject_created:
                     # This is the closest status code that makes sense, and we want
                     # a unique 2xx response code so people can understand when
                     # behavior differs.

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -839,14 +839,17 @@ class Release(Model):
 
         try:
             with atomic_transaction(using=router.db_for_write(ReleaseProject)):
-                created = ReleaseProject.objects.get_or_create(project=project, release=self)[1]
+                obj, created = ReleaseProject.objects.get_or_create(project=project, release=self)[
+                    1
+                ]
                 if not project.flags.has_releases:
                     project.flags.has_releases = True
                     project.update(flags=F("flags").bitor(Project.flags.has_releases))
         except IntegrityError:
+            obj = None
             created = False
 
-        return created
+        return obj, created
 
     def handle_commit_ranges(self, refs):
         """

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -839,9 +839,7 @@ class Release(Model):
 
         try:
             with atomic_transaction(using=router.db_for_write(ReleaseProject)):
-                obj, created = ReleaseProject.objects.get_or_create(project=project, release=self)[
-                    1
-                ]
+                obj, created = ReleaseProject.objects.get_or_create(project=project, release=self)
                 if not project.flags.has_releases:
                     project.flags.has_releases = True
                     project.update(flags=F("flags").bitor(Project.flags.has_releases))


### PR DESCRIPTION
previous implementation was returning the created status from `ReleaseProject.objects.get_or_create` from the `add_project` helper.

this is not entirely clear _what_ was being created.

This PR renames the variables and makes it more clear what the response is