### PR TITLE
fix(perf): Don't use `.last()` when fetching `ApiTokenReplica`.

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -321,8 +321,9 @@ class UserAuthTokenAuthentication(StandardAuthentication):
 
         if not token:
             if SiloMode.get_current_mode() == SiloMode.REGION:
-                atr = token = ApiTokenReplica.objects.filter(token=token_str).last()
-                if not atr:
+                try:
+                    atr = token = ApiTokenReplica.objects.get(token=token_str)
+                except ApiTokenReplica.DoesNotExist:
                     raise AuthenticationFailed("Invalid token")
                 user = user_service.get_user(user_id=atr.user_id)
                 application_is_inactive = not atr.application_is_active


### PR DESCRIPTION
We had an incident where postgres started using the index on `id` to get `ApiTokenReplica` instead of the index on `token`. It was likely that this was triggered by some ddl on the token column, but testing this query shows that it runs as expected if we remove the sort on `id`, which I believe is confusing the query planner

There's a unique index on `ApiToken.token`, so we can rely on the column being unique here too