### PR TITLE
feat(issues): Disable trace timeline for some issue types

### DIFF
--- a/static/app/utils/issueTypeConfig/cronConfig.tsx
+++ b/static/app/utils/issueTypeConfig/cronConfig.tsx
@@ -27,6 +27,7 @@ const cronConfig: IssueCategoryConfigMapping = {
     similarIssues: {enabled: false},
     userFeedback: {enabled: false},
     usesIssuePlatform: true,
+    traceTimeline: false,
   },
 };
 

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -47,6 +47,7 @@ const BASE_CONFIG: IssueTypeConfig = {
   evidence: {title: t('Evidence')},
   resources: null,
   usesIssuePlatform: true,
+  traceTimeline: true,
 };
 
 const issueTypeConfig: Config = {

--- a/static/app/utils/issueTypeConfig/replayConfig.tsx
+++ b/static/app/utils/issueTypeConfig/replayConfig.tsx
@@ -26,6 +26,7 @@ const replayConfig: IssueCategoryConfigMapping = {
     evidence: {title: t('Evidence')},
     resources: null,
     usesIssuePlatform: true,
+    traceTimeline: false,
   },
 };
 

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -86,6 +86,10 @@ export type IssueTypeConfig = {
    */
   tags: DisabledWithReasonConfig;
   /**
+   * Displays the trace timeline for this issue
+   */
+  traceTimeline: boolean;
+  /**
    * Is the User Feedback tab shown for this issue
    */
   userFeedback: DisabledWithReasonConfig;

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -86,7 +86,7 @@ export type IssueTypeConfig = {
    */
   tags: DisabledWithReasonConfig;
   /**
-   * Displays the trace timeline for this issue
+   * Displays the trace timeline and trace link for this issue
    */
   traceTimeline: boolean;
   /**

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -33,6 +33,7 @@ import {
   getShortEventId,
 } from 'sentry/utils/events';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -378,6 +379,7 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
   });
 
   const hasTraceTimeline = hasTraceTimelineFeature(organization);
+  const issueTypeConfig = getConfigForIssueType(group, group.project);
 
   return (
     <CarouselAndButtonsWrapper>
@@ -428,7 +430,9 @@ export function GroupEventCarousel({event, group, projectSlug}: GroupEventCarous
           </EventIdAndTimeContainer>
         </EventHeading>
         {hasTraceTimeline ? (
-          <TraceLink event={event} />
+          issueTypeConfig.traceTimeline ? (
+            <TraceLink event={event} />
+          ) : null
         ) : (
           <QuickTrace event={event} organization={organization} location={location} />
         )}

--- a/static/app/views/issueDetails/groupEventHeader.tsx
+++ b/static/app/views/issueDetails/groupEventHeader.tsx
@@ -4,6 +4,7 @@ import {DataSection} from 'sentry/components/events/styles';
 import GlobalAppStoreConnectUpdateAlert from 'sentry/components/globalAppStoreConnectUpdateAlert';
 import {space} from 'sentry/styles/space';
 import type {Event, Group, Project} from 'sentry/types';
+import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import useOrganization from 'sentry/utils/useOrganization';
 import {GroupEventCarousel} from 'sentry/views/issueDetails/groupEventCarousel';
 import {TraceTimeline} from 'sentry/views/issueDetails/traceTimeline/traceTimeline';
@@ -16,11 +17,12 @@ type GroupEventHeaderProps = {
 
 function GroupEventHeader({event, group, project}: GroupEventHeaderProps) {
   const organization = useOrganization();
+  const issueTypeConfig = getConfigForIssueType(group, group.project);
 
   return (
     <StyledDataSection>
       <GroupEventCarousel group={group} event={event} projectSlug={project.slug} />
-      <TraceTimeline event={event} />
+      {issueTypeConfig.traceTimeline && <TraceTimeline event={event} />}
       <StyledGlobalAppStoreConnectUpdateAlert
         project={project}
         organization={organization}


### PR DESCRIPTION
Disables the trace timeline for cron and replay issues since those won't have traces yet and we don't want to display the "No trace available" header or timeline
