### PR TITLE
feat(hc): Add break-glass options for disabling RPCs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1655,7 +1655,6 @@ register("hybridcloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.integrationproxy.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Break glass controls
-register("hybrid_cloud.rpc.disabled", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybrid_cloud.rpc.disabled-service-methods", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 # == End hybrid cloud subsystem
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1653,6 +1653,10 @@ register("hybrid_cloud.region-user-allow-list", default=[], flags=FLAG_AUTOMATOR
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.integrationproxy.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
+# Break glass controls
+register("hybrid_cloud.rpc.disabled", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("hybrid_cloud.rpc.disabled-service-methods", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 # == End hybrid cloud subsystem
 
 # Decides whether an incoming transaction triggers an update of the clustering rule applied to it.

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -592,9 +592,6 @@ class _RemoteSiloCall:
             raise self._remote_exception(f"Timeout of {settings.RPC_TIMEOUT} exceeded") from e
 
     def _check_disabled(self):
-        if options.get("hybrid_cloud.rpc.disabled"):
-            raise RpcDisabledException("RPC disabled")
-
         if disabled_service_methods := options.get("hybrid_cloud.rpc.disabled-service-methods"):
             service_method = f"{self.service_name}.{self.method_name}"
             if service_method in disabled_service_methods:

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -484,6 +484,7 @@ class _RemoteSiloCall:
             tags=self._metrics_tags(),
         )
         with self._open_request_context():
+            self._check_disabled()
             if use_test_client:
                 response = self._fire_test_request(headers, data)
             else:
@@ -589,6 +590,18 @@ class _RemoteSiloCall:
             raise self._remote_exception("RPC failed, max retries reached.") from e
         except requests.exceptions.Timeout as e:
             raise self._remote_exception(f"Timeout of {settings.RPC_TIMEOUT} exceeded") from e
+
+    def _check_disabled(self) -> bool:
+        if options.get("hybrid_cloud.rpc.disabled"):
+            raise RpcDisabledException("RPC disabled")
+
+        service_method_name = f"{self.service_name}.{self.method_name}"
+        if service_method_name in options.get("hybrid_cloud.rpc.disabled-service-methods"):
+            raise RpcDisabledException(f"RPC {service_method_name} disabled")
+
+
+class RpcDisabledException(Exception):
+    """Indicates that an RPC method has been disabled and a request has not been made."""
 
 
 class RpcAuthenticationSetupException(Exception):

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -591,7 +591,7 @@ class _RemoteSiloCall:
         except requests.exceptions.Timeout as e:
             raise self._remote_exception(f"Timeout of {settings.RPC_TIMEOUT} exceeded") from e
 
-    def _check_disabled(self) -> bool:
+    def _check_disabled(self):
         if options.get("hybrid_cloud.rpc.disabled"):
             raise RpcDisabledException("RPC disabled")
 

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -595,9 +595,10 @@ class _RemoteSiloCall:
         if options.get("hybrid_cloud.rpc.disabled"):
             raise RpcDisabledException("RPC disabled")
 
-        service_method_name = f"{self.service_name}.{self.method_name}"
-        if service_method_name in options.get("hybrid_cloud.rpc.disabled-service-methods"):
-            raise RpcDisabledException(f"RPC {service_method_name} disabled")
+        if disabled_service_methods := options.get("hybrid_cloud.rpc.disabled-service-methods"):
+            service_method = f"{self.service_name}.{self.method_name}"
+            if service_method in disabled_service_methods:
+                raise RpcDisabledException(f"RPC {service_method} disabled")
 
 
 class RpcDisabledException(Exception):

--- a/tests/sentry/hybridcloud/test_rpc.py
+++ b/tests/sentry/hybridcloud/test_rpc.py
@@ -198,11 +198,6 @@ class DispatchRemoteCallTest(TestCase):
         result = org_service_delgn.get_org_by_slug(slug="this_is_not_a_valid_slug")
         assert result is None
 
-    @override_options({"hybrid_cloud.rpc.disabled": True})
-    def test_disable_rpc(self):
-        with pytest.raises(RpcDisabledException):
-            dispatch_remote_call(None, "organization", "get_organization_by_id", {"id": 0})
-
     @override_options(
         {"hybrid_cloud.rpc.disabled-service-methods": ["organization.get_organization_by_id"]}
     )

--- a/tests/sentry/hybridcloud/test_rpc.py
+++ b/tests/sentry/hybridcloud/test_rpc.py
@@ -19,6 +19,7 @@ from sentry.services.hybrid_cloud.organization import (
 from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organization
 from sentry.services.hybrid_cloud.rpc import (
     RpcAuthenticationSetupException,
+    RpcDisabledException,
     dispatch_remote_call,
     dispatch_to_local_service,
 )
@@ -26,6 +27,7 @@ from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.silo import SiloMode, unguarded_write
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import assume_test_silo_mode, no_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -195,3 +197,15 @@ class DispatchRemoteCallTest(TestCase):
             org_service_delgn = OrganizationService.create_delegation(use_test_client=False)
         result = org_service_delgn.get_org_by_slug(slug="this_is_not_a_valid_slug")
         assert result is None
+
+    @override_options({"hybrid_cloud.rpc.disabled": True})
+    def test_disable_rpc(self):
+        with pytest.raises(RpcDisabledException):
+            dispatch_remote_call(None, "organization", "get_organization_by_id", {"id": 0})
+
+    @override_options(
+        {"hybrid_cloud.rpc.disabled-service-methods": ["organization.get_organization_by_id"]}
+    )
+    def test_disable_rpc_method(self):
+        with pytest.raises(RpcDisabledException):
+            dispatch_remote_call(None, "organization", "get_organization_by_id", {"id": 0})


### PR DESCRIPTION
These will hopefully never be needed but will give us a way to quickly disable RPC requests or on an individual service/method basis using options automator.

- Adding to `hybrid_cloud.rpc.disabled-service-methods` will disable outbound RPC requests for an individual service/method (ex: `["organization.get_organization_by_id"]`)