### PR TITLE
ref(ui): Add explicit types to withSentryRouter

### DIFF
--- a/static/app/utils/withSentryRouter.tsx
+++ b/static/app/utils/withSentryRouter.tsx
@@ -14,7 +14,7 @@ import {CUSTOMER_DOMAIN, USING_CUSTOMER_DOMAIN} from 'sentry/constants';
  */
 function withSentryRouter<P extends WithRouterProps>(
   WrappedComponent: React.ComponentType<P>
-) {
+): React.ComponentType<Omit<P, keyof WithRouterProps>> {
   function WithSentryRouterWrapper(props: P) {
     const {params} = props;
     if (USING_CUSTOMER_DOMAIN) {


### PR DESCRIPTION
The changes to ClassComponent types is doing something in 18 here. Add an explicit return type of what the props will be.

Things wrapped in withSentryRouter had all their props broken.

Part of https://github.com/getsentry/frontend-tsc/issues/22

