### PR TITLE
fix(slack): don't escape and only modify multiple backticks in mrkdwn block

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -576,6 +576,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.skip_fallback = skip_fallback
         self.notes = notes
         self.commits = commits
+        self.use_improved_block_kit = features.has(
+            "organizations:slack-block-kit-improvements", group.project.organization
+        )
 
     @property
     def escape_text(self) -> bool:
@@ -587,7 +590,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
     def build(self, notification_uuid: str | None = None) -> SlackBlock | SlackAttachment:
         # XXX(dcramer): options are limited to 100 choices, even when nested
         text = build_attachment_text(self.group, self.event) or ""
-        if self.escape_text:
+        if not self.use_improved_block_kit and self.escape_text:
             text = escape_slack_text(text)
             # XXX(scefali): Not sure why we actually need to do this just for unfurled messages.
             # If we figure out why this is required we should note it here because it's quite strange
@@ -659,21 +662,18 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         # build title block
         title_text = f"<{title_link}|*{escape_slack_text(title)}*>"
 
-        use_improved_block_kit = features.has(
-            "organizations:slack-block-kit-improvements", self.group.project.organization
-        )
         if self.group.issue_category == GroupCategory.ERROR:
             level_text = None
             for k, v in LOG_LEVELS_MAP.items():
                 if self.group.level == v:
                     level_text = k
 
-            if use_improved_block_kit:
+            if self.use_improved_block_kit:
                 title_emoji = LEVEL_TO_EMOJI_V2.get(level_text)
             else:
                 title_emoji = LEVEL_TO_EMOJI.get(level_text)
         else:
-            if use_improved_block_kit:
+            if self.use_improved_block_kit:
                 title_emoji = CATEGORY_TO_EMOJI_V2.get(self.group.issue_category)
             else:
                 title_emoji = CATEGORY_TO_EMOJI.get(self.group.issue_category)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -35,7 +35,7 @@ from sentry.integrations.slack.message_builder import (
     SlackBlock,
 )
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
-from sentry.integrations.slack.utils.escape import escape_slack_text
+from sentry.integrations.slack.utils.escape import escape_slack_markdown_text, escape_slack_text
 from sentry.issues.grouptype import (
     GroupCategory,
     PerformanceP95EndpointRegressionGroupType,
@@ -590,6 +590,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
     def build(self, notification_uuid: str | None = None) -> SlackBlock | SlackAttachment:
         # XXX(dcramer): options are limited to 100 choices, even when nested
         text = build_attachment_text(self.group, self.event) or ""
+
+        if self.use_improved_block_kit:
+            text = escape_slack_markdown_text(text)
         if not self.use_improved_block_kit and self.escape_text:
             text = escape_slack_text(text)
             # XXX(scefali): Not sure why we actually need to do this just for unfurled messages.

--- a/src/sentry/integrations/slack/utils/escape.py
+++ b/src/sentry/integrations/slack/utils/escape.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 # TODO(scttcper): Might need to handle "*" bold, and "_" italics
 translator = str.maketrans({"&": "&amp;", "<": "&lt;", ">": "&gt;"})
 
@@ -14,3 +16,16 @@ def escape_slack_text(txt: str | None) -> str:
     if not txt:
         return ""
     return txt.translate(translator)
+
+
+def escape_slack_markdown_text(txt: str | None) -> str:
+    """
+    Reduces runs of multiple backticks to a single backtick.
+    This prevents the "mrkdwn" code block from ending early and leaving the rest of the text out of the code block.
+    """
+    if not txt:
+        return ""
+
+    backtick_pattern = re.compile(r"`+")
+
+    return backtick_pattern.sub("`", txt)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -908,10 +908,13 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             data={"message": "Hello world", "level": "error"}, project_id=self.project.id
         )
         group_event = event.for_group(event.groups[0])
+        text = "<bye> ```asdf```"
+        escaped_text = "<bye> `asdf`"
+
         occurrence = self.build_occurrence(
             level="info",
             evidence_display=[
-                {"name": "hi", "value": "<bye> `asdf`", "important": True},
+                {"name": "hi", "value": text, "important": True},
                 {"name": "what", "value": "where", "important": False},
             ],
         )
@@ -928,9 +931,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
                 assert occurrence.issue_title in section["text"]["text"]
 
         # no escaping
-        assert (
-            blocks["blocks"][1]["text"]["text"] == f"```{occurrence.evidence_display[0].value}```"
-        )
+        assert blocks["blocks"][1]["text"]["text"] == f"```{escaped_text}```"
         assert blocks["text"] == f"[{self.project.slug}] {occurrence.issue_title}"
 
     @with_feature("organizations:slack-block-kit")

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -902,6 +902,39 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
     @with_feature("organizations:slack-block-kit")
     @with_feature("organizations:slack-block-kit-improvements")
+    def test_build_group_generic_issue_block_no_escaping(self):
+        """Test that a generic issue type's Slack alert contains the expected values"""
+        event = self.store_event(
+            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
+        )
+        group_event = event.for_group(event.groups[0])
+        occurrence = self.build_occurrence(
+            level="info",
+            evidence_display=[
+                {"name": "hi", "value": "<bye> `asdf`", "important": True},
+                {"name": "what", "value": "where", "important": False},
+            ],
+        )
+        occurrence.save()
+        group_event.occurrence = occurrence
+
+        group_event.group.type = ProfileFileIOGroupType.type_id
+
+        blocks = SlackIssuesMessageBuilder(group=group_event.group, event=group_event).build()
+
+        assert isinstance(blocks, dict)
+        for section in blocks["blocks"]:
+            if section["type"] == "text":
+                assert occurrence.issue_title in section["text"]["text"]
+
+        # no escaping
+        assert (
+            blocks["blocks"][1]["text"]["text"] == f"```{occurrence.evidence_display[0].value}```"
+        )
+        assert blocks["text"] == f"[{self.project.slug}] {occurrence.issue_title}"
+
+    @with_feature("organizations:slack-block-kit")
+    @with_feature("organizations:slack-block-kit-improvements")
     def test_build_group_generic_issue_block_title_emojis(self):
         """Test that a generic issue type's Slack alert contains the expected values"""
         event = self.store_event(


### PR DESCRIPTION
`< >` characters are being escaped in the markdown text block. This is because we are currently purposefully escaping them, although there's no need to if we use a markdown block.

The only character we need to be worried about is the backtick `. This is because we indicate the start of the codeblock with 3 backticks, so if 3 backticks appear in a row we will exit out of the code block and the rest of the text will be rendered as normal text.

My solution to this is to reduce runs of multiple backticks into a single backtick.

Resolves https://github.com/getsentry/team-core-product-foundations/issues/103