### PR TITLE
ref(ui): Switch queryBuilder placeholder to aria-placeholder

### DIFF
--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -196,7 +196,8 @@ export const QueryBuilder = memo(function QueryBuilder({
             breakpoints.large ? (breakpoints.xlarge ? 70 : 45) : 30,
             /\.|-|_/
           )}
-          placeholder={t('Select a metric')}
+          // TODO(TS): Is this used anywhere?
+          aria-placeholder={t('Select a metric')}
           options={mriOptions}
           value={metricsQuery.mri}
           onChange={handleMRIChange}


### PR DESCRIPTION
I'm not sure that MetricSelect uses this placeholder anywhere, added a comment

part of https://github.com/getsentry/frontend-tsc/issues/22