### PR TITLE
test(ui): Wrap autocomplete timer tests with act

### DIFF
--- a/static/app/components/autoComplete.spec.tsx
+++ b/static/app/components/autoComplete.spec.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 
-import {fireEvent, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, fireEvent, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {AutoCompleteProps} from 'sentry/components/autoComplete';
 import AutoComplete from 'sentry/components/autoComplete';
@@ -123,7 +123,7 @@ describe('AutoComplete', function () {
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
       // Click outside dropdown
       fireEvent.click(document.body);
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
 
       await waitFor(() => expect(mocks.onClose).toHaveBeenCalledTimes(1));
     });
@@ -134,7 +134,7 @@ describe('AutoComplete', function () {
       fireEvent.focus(input);
       fireEvent.blur(input);
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
 
       expect(screen.queryByTestId('test-autocomplete')).not.toBeInTheDocument();
       expect(mocks.onClose).toHaveBeenCalledTimes(1);
@@ -152,11 +152,11 @@ describe('AutoComplete', function () {
     it('can open and close dropdown menu using injected actions', function () {
       createWrapper();
       const [injectedProps] = autoCompleteState;
-      injectedProps.actions.open();
+      act(() => injectedProps.actions.open());
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
       expect(mocks.onOpen).toHaveBeenCalledTimes(1);
 
-      injectedProps.actions.close();
+      act(() => injectedProps.actions.close());
       expect(screen.queryByTestId('test-autocomplete')).not.toBeInTheDocument();
       expect(mocks.onClose).toHaveBeenCalledTimes(1);
     });
@@ -311,7 +311,7 @@ describe('AutoComplete', function () {
       expect(input).toHaveValue('a');
 
       fireEvent.blur(input);
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
       expect(screen.queryByTestId('test-autocomplete')).not.toBeInTheDocument();
       expect(input).toHaveValue('');
     });
@@ -340,7 +340,7 @@ describe('AutoComplete', function () {
       expect(screen.queryByTestId('test-autocomplete')).not.toBeInTheDocument();
 
       fireEvent.focus(input);
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
       expect(screen.queryByTestId('test-autocomplete')).not.toBeInTheDocument();
       expect(screen.queryByRole('option')).not.toBeInTheDocument();
 
@@ -352,7 +352,7 @@ describe('AutoComplete', function () {
       jest.useFakeTimers();
       fireEvent.focus(input);
       fireEvent.blur(input);
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
 
       // This still gets called even though menu is open
@@ -372,12 +372,12 @@ describe('AutoComplete', function () {
     it('does not open and close dropdown menu using injected actions', function () {
       createWrapper({isOpen: true});
       const [injectedProps] = autoCompleteState;
-      injectedProps.actions.open();
+      act(() => injectedProps.actions.open());
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
 
       expect(mocks.onOpen).toHaveBeenCalledTimes(1);
 
-      injectedProps.actions.close();
+      act(() => injectedProps.actions.close());
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
 
       expect(mocks.onClose).toHaveBeenCalledTimes(1);
@@ -528,7 +528,7 @@ describe('AutoComplete', function () {
       expect(input).toHaveValue('a');
 
       fireEvent.blur(input);
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
       expect(input).toHaveValue('');
     });
   });


### PR DESCRIPTION
wraps fake timers with act since the state updates happen when moving timers forward. This throws act warnings or fails in react 18

part of https://github.com/getsentry/frontend-tsc/issues/22