### PR TITLE
fix(tests): disable failing test

### DIFF
--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
+import pytest
 from django.utils import timezone
 
 from sentry.issues.grouptype import (
@@ -408,6 +409,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
         result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert result == {}
 
+    @pytest.mark.xfail(reason="fails only in CI, need to determine why")
     def test_transactions(self):
         prev_hour = timezone.now() - timedelta(hours=1)
         transaction = self.create_performance_issue(tags=[["foo", "bar"]])


### PR DESCRIPTION
unblocks master by disabling this test relating to rule firing and performance issues. no leads on why its failling, but appears to only be failing in CI, and not failing locally. may be a utc date boundary issue.

https://github.com/getsentry/sentry/actions/runs/8057281346/job/22011093979