### PR TITLE
fix(issues): fix xfailed test

### DIFF
--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
-import pytest
 from django.utils import timezone
 
 from sentry.issues.grouptype import (
@@ -409,7 +408,6 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
         result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert result == {}
 
-    @pytest.mark.xfail(reason="fails only in CI, need to determine why")
     def test_transactions(self):
         prev_hour = timezone.now() - timedelta(hours=1)
         transaction = self.create_performance_issue(tags=[["foo", "bar"]])
@@ -445,7 +443,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
             {
                 "id": "sentry.rules.filters.event_attribute.EventAttributeFilter",
                 "attribute": "message",
-                "match": "eq",
+                "match": "co",
                 "value": "N+1 Query",
             }
         ]


### PR DESCRIPTION
we noticed prod CI start failing here:
https://github.com/getsentry/sentry/actions/runs/8058942260/job/22012542947?pr=65859

we xfailed the test in order to unblock master.
https://github.com/getsentry/sentry/pull/65858

it was determined that this test failure was due to an update made to snuba:
https://github.com/getsentry/snuba/pull/4391

where we changed how the message parameter mapped to a clickhouse search column.

We change the operator to contains instead of equals, as now the "message" column is filled with additional things. the test should work correctly now.


We should do a post-mortem as to why the snuba CI did not catch this test failure. For posterity, developers looking to replicate issues in CI should make sure their local snuba image is up to date with what's in prod (sentry devservices down snuba && sentry devservices up snuba)



