### PR TITLE
fix(hybridcloud) Don't forward no-op webhooks

### DIFF
--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -74,6 +74,8 @@ class JiraServerIssueUpdatedWebhook(Endpoint):
 
         data = request.data
 
+        # Note: If we ever process more webhooks from jira server
+        # we also need to update JiraServerRequestParser
         if not data.get("changelog"):
             logger.info("missing-changelog", extra=extra)
             return self.respond()

--- a/src/sentry/middleware/integrations/parsers/jira_server.py
+++ b/src/sentry/middleware/integrations/parsers/jira_server.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import logging
 
+from django.http import HttpResponse
+
 from sentry.integrations.jira_server.webhooks import (
     JiraServerIssueUpdatedWebhook,
     get_integration_from_token,
 )
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.outbox import WebhookProviderIdentifier
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +25,21 @@ class JiraServerRequestParser(BaseRequestParser):
             integration = get_integration_from_token(token)
         except ValueError as e:
             logger.info("%s.no_integration", self.provider, extra={"error": str(e)})
-            return self.get_response_from_control_silo()
+            return HttpResponse(status=200)
+
         organizations = self.get_organizations_from_integration(integration=integration)
         regions = self.get_regions_from_organizations(organizations=organizations)
+
+        try:
+            data = json.loads(self.request.body)
+        except ValueError:
+            data = {}
+
+        # We only process webhooks with changelogs
+        if not data.get("changelog"):
+            logger.info("missing-changelog", extra={"integration_id": integration.id})
+            return HttpResponse(status=200)
+
         return self.get_response_from_outbox_creation_for_integration(
             regions=regions, integration=integration
         )
@@ -32,4 +47,5 @@ class JiraServerRequestParser(BaseRequestParser):
     def get_response(self):
         if self.view_class == JiraServerIssueUpdatedWebhook:
             return self.get_response_from_issue_update_webhook()
+
         return self.get_response_from_control_silo()

--- a/tests/sentry/middleware/integrations/parsers/test_jira_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira_server.py
@@ -5,6 +5,7 @@ from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
 
+from fixtures.integrations.stub_service import StubService
 from sentry.middleware.integrations.parsers.jira_server import JiraServerRequestParser
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.silo.base import SiloMode
@@ -23,6 +24,9 @@ region = Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT)
 
 region_config = (region,)
 
+issue_updated_payload = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
+no_changelog = {}
+
 
 @control_silo_test
 class JiraServerRequestParserTest(TestCase):
@@ -33,9 +37,6 @@ class JiraServerRequestParserTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.path = reverse(
-            "sentry-extensions-bitbucket-webhook", kwargs={"organization_id": self.organization.id}
-        )
         self.integration = self.create_integration(
             organization=self.organization, external_id="jira_server:1", provider="jira_server"
         )
@@ -54,7 +55,7 @@ class JiraServerRequestParserTest(TestCase):
 
         assert isinstance(response, HttpResponse)
         assert response.status_code == 200
-        assert response.content == b"passthrough"
+        assert response.content == b""
         assert len(responses.calls) == 0
         assert_no_webhook_outboxes()
 
@@ -63,7 +64,10 @@ class JiraServerRequestParserTest(TestCase):
     @responses.activate
     def test_routing_endpoint_with_integration(self):
         route = reverse("sentry-extensions-jiraserver-issue-updated", kwargs={"token": "TOKEN"})
-        request = self.factory.post(route)
+
+        request = self.factory.post(
+            route, data=issue_updated_payload, content_type="application/json"
+        )
         parser = JiraServerRequestParser(request=request, response_handler=self.get_response)
 
         OrganizationMapping.objects.get(organization_id=self.organization.id).update(
@@ -90,7 +94,9 @@ class JiraServerRequestParserTest(TestCase):
     @responses.activate
     def test_routing_endpoint_with_integration_webhookpayload(self):
         route = reverse("sentry-extensions-jiraserver-issue-updated", kwargs={"token": "TOKEN"})
-        request = self.factory.post(route)
+        request = self.factory.post(
+            route, data=issue_updated_payload, content_type="application/json"
+        )
         parser = JiraServerRequestParser(request=request, response_handler=self.get_response)
 
         OrganizationMapping.objects.get(organization_id=self.organization.id).update(
@@ -110,6 +116,29 @@ class JiraServerRequestParserTest(TestCase):
             mailbox_name=f"jira_server:{self.integration.id}",
             region_names=[region.name],
         )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    @override_options({"hybridcloud.webhookpayload.rollout": 1.0})
+    @responses.activate
+    def test_drop_request_without_changelog(self):
+        route = reverse("sentry-extensions-jiraserver-issue-updated", kwargs={"token": "TOKEN"})
+        request = self.factory.post(route, data=no_changelog, content_type="application/json")
+        parser = JiraServerRequestParser(request=request, response_handler=self.get_response)
+
+        OrganizationMapping.objects.get(organization_id=self.organization.id).update(
+            region_name="us"
+        )
+        with mock.patch(
+            "sentry.middleware.integrations.parsers.jira_server.get_integration_from_token"
+        ) as mock_get_token:
+            mock_get_token.return_value = self.integration
+            response = parser.get_response()
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 200
+        assert response.content == b""
+        assert len(responses.calls) == 0
+        assert_no_webhook_outboxes()
 
     @responses.activate
     @override_settings(SILO_MODE=SiloMode.CONTROL)

--- a/tests/sentry/middleware/integrations/parsers/test_jira_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira_server.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest import mock
 
 import responses
@@ -25,7 +26,7 @@ region = Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT)
 region_config = (region,)
 
 issue_updated_payload = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
-no_changelog = {}
+no_changelog: dict[str, Any] = {}
 
 
 @control_silo_test


### PR DESCRIPTION
There are a few high-volume jira-server integrations in production. These integrations generate large volumes of webhooks that result in no-ops as they don't contain the `changelog` attribute we rely on.

Instead of storing these payloads and forwarding them to the region we can acknowledge and drop them in control silo.