### PR TITLE
ref(similarity-embedding): Change FE to use cosine distance

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -211,8 +211,8 @@ describe('Issues Similar Embeddings View', function () {
   ]);
 
   const similarEmbeddingsScores = [
-    {exception: 0.9987, message: 0.3748, shouldBeGrouped: 'Yes'},
-    {exception: 0.9985, message: 0.3738, shouldBeGrouped: 'Yes'},
+    {exception: 0.01, message: 0.3748, shouldBeGrouped: 'Yes'},
+    {exception: 0.005, message: 0.3738, shouldBeGrouped: 'Yes'},
     {exception: 0.7384, message: 0.3743, shouldBeGrouped: 'No'},
     {exception: 0.3849, message: 0.4738, shouldBeGrouped: 'No'},
   ];
@@ -228,7 +228,7 @@ describe('Issues Similar Embeddings View', function () {
 
   beforeEach(function () {
     mock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/group-id/similar-issues-embeddings/?k=5&threshold=0.99',
+      url: '/organizations/org-slug/issues/group-id/similar-issues-embeddings/?k=10&threshold=0.01',
       body: mockData.simlarEmbeddings,
     });
   });
@@ -368,7 +368,7 @@ describe('Issues Similar Embeddings View', function () {
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
     mock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/group-id/similar-issues-embeddings/?k=5&threshold=0.99',
+      url: '/organizations/org-slug/issues/group-id/similar-issues-embeddings/?k=10&threshold=0.01',
       body: [],
     });
 

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -62,8 +62,8 @@ function SimilarStackTrace({params, location, project}: Props) {
       reqs.push({
         endpoint: `/organizations/${orgId}/issues/${groupId}/similar-issues-embeddings/?${qs.stringify(
           {
-            k: 5,
-            threshold: 0.99,
+            k: 10,
+            threshold: 0.01,
           }
         )}`,
         dataKey: 'similar',

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
@@ -78,7 +78,7 @@ function List({
         </Header>
       )}
       {hasSimilarityEmbeddingsFeature && (
-        <LegendSmall>0 = Not Similar, 1 = Similar</LegendSmall>
+        <LegendSmall>-1 = Not Similar, 1 = Similar</LegendSmall>
       )}
       <Panel>
         <Toolbar


### PR DESCRIPTION
Change similarity embeddings API call to use cosine distance instead of similarity and change k to 10 to match [seer](https://github.com/getsentry/timeseries-analysis-service/pull/249)