### PR TITLE
ref(similarity-embedding): Change BE to use cosine distance

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -77,13 +77,16 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
     def get_formatted_results(
         self, responses: Sequence[SimilarIssuesEmbeddingsData | None], user: User | AnonymousUser
     ) -> Sequence[tuple[Mapping[str, Any], Mapping[str, Any]] | None]:
-        """Format the responses using to be used by the frontend."""
+        """
+        Format the responses using to be used by the frontend by changing the  field names and
+        changing the cosine distances into cosine similarities.
+        """
         group_data = {}
         for response in responses:
             if response:
                 formatted_response: FormattedSimilarIssuesEmbeddingsData = {
-                    "message": response["message_similarity"],
-                    "exception": response["stacktrace_similarity"],
+                    "message": 1 - response["message_distance"],
+                    "exception": 1 - response["stacktrace_distance"],
                     "shouldBeGrouped": "Yes" if response["should_group"] else "No",
                 }
                 group_data.update({response["parent_group_id"]: formatted_response})
@@ -141,9 +144,9 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
             group_id=group.id,
             count_over_threshold=len(
                 [
-                    result["stacktrace_similarity"]  # type: ignore
+                    result["stacktrace_distance"]  # type: ignore
                     for result in results["responses"]
-                    if result["stacktrace_similarity"] > 0.99  # type: ignore
+                    if result["stacktrace_distance"] <= 0.01  # type: ignore
                 ]
             )
             if results["responses"]

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -69,8 +69,8 @@ class SimilarIssuesEmbeddingsRequest(SimilarIssuesEmbeddingsRequestNotRequired):
 
 class SimilarIssuesEmbeddingsData(TypedDict):
     parent_group_id: int
-    stacktrace_similarity: float
-    message_similarity: float
+    stacktrace_distance: float
+    message_distance: float
     should_group: bool
 
 

--- a/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
+++ b/tests/sentry/api/endpoints/test_group_similar_issues_embeddings.py
@@ -102,8 +102,8 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     def get_expected_response(
         self,
         group_ids: Sequence[int],
-        message_similarities: Sequence[float],
-        exception_similarities: Sequence[float],
+        message_distances: Sequence[float],
+        exception_distances: Sequence[float],
         should_be_grouped: Sequence[str],
     ) -> Sequence[tuple[Any, Mapping[str, Any]]]:
         serialized_groups = serialize(
@@ -115,8 +115,8 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
                 (
                     group,
                     {
-                        "message": message_similarities[i],
-                        "exception": exception_similarities[i],
+                        "message": message_distances[i],
+                        "exception": exception_distances[i],
                         "shouldBeGrouped": should_be_grouped[i],
                     },
                 )
@@ -204,23 +204,23 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
     def test_get_formatted_results(self):
         new_group = self.create_group(project=self.project)
         response_1: SimilarIssuesEmbeddingsData = {
-            "message_similarity": 0.95,
+            "message_distance": 0.05,
             "parent_group_id": self.similar_group.id,
             "should_group": True,
-            "stacktrace_similarity": 0.99,
+            "stacktrace_distance": 0.01,
         }
         response_2: SimilarIssuesEmbeddingsData = {
-            "message_similarity": 0.51,
+            "message_distance": 0.49,
             "parent_group_id": new_group.id,
             "should_group": False,
-            "stacktrace_similarity": 0.23,
+            "stacktrace_distance": 0.23,
         }
         group_similar_endpoint = GroupSimilarIssuesEmbeddingsEndpoint()
         formatted_results = group_similar_endpoint.get_formatted_results(
             responses=[response_1, response_2], user=self.user
         )
         assert formatted_results == self.get_expected_response(
-            [self.similar_group.id, new_group.id], [0.95, 0.51], [0.99, 0.23], ["Yes", "No"]
+            [self.similar_group.id, new_group.id], [0.95, 0.51], [0.99, 0.77], ["Yes", "No"]
         )
 
     def test_no_feature_flag(self):
@@ -235,10 +235,10 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
-                    "message_similarity": 0.95,
+                    "message_distance": 0.05,
                     "parent_group_id": self.similar_group.id,
                     "should_group": True,
-                    "stacktrace_similarity": 0.99,
+                    "stacktrace_distance": 0.01,
                 }
             ]
         }
@@ -283,22 +283,22 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
-                    "message_similarity": 0.95,
+                    "message_distance": 0.05,
                     "parent_group_id": self.similar_group.id,
                     "should_group": True,
-                    "stacktrace_similarity": 0.998,  # Over threshold
+                    "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
-                    "message_similarity": 0.95,
+                    "message_distance": 0.05,
                     "parent_group_id": similar_group_over_threshold.id,
                     "should_group": True,
-                    "stacktrace_similarity": 0.998,
+                    "stacktrace_distance": 0.002,  # Over threshold
                 },
                 {
-                    "message_similarity": 0.95,
+                    "message_distance": 0.05,
                     "parent_group_id": similar_group_under_threshold.id,
                     "should_group": False,
-                    "stacktrace_similarity": 0.95,
+                    "stacktrace_distance": 0.05,  # Under threshold
                 },
             ]
         }
@@ -306,7 +306,7 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
 
         response = self.client.get(
             self.path,
-            data={"k": "1", "threshold": "0.99"},
+            data={"k": "1", "threshold": "0.01"},
         )
 
         assert response.data == self.get_expected_response(
@@ -339,16 +339,16 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
-                    "message_similarity": 0.95,
+                    "message_distance": 0.05,
                     "parent_group_id": self.similar_group.id,
                     "should_group": True,
-                    "stacktrace_similarity": 0.99,
+                    "stacktrace_distance": 0.01,
                 },
                 {
-                    "message_similarity": 0.95,
+                    "message_distance": 0.05,
                     "parent_group_id": 10000000,  # An arbitrarily large group ID that will not exist
                     "should_group": True,
-                    "stacktrace_similarity": 0.99,
+                    "stacktrace_distance": 0.01,
                 },
             ]
         }
@@ -436,10 +436,10 @@ class GroupSimilarIssuesEmbeddingsTest(APITestCase):
         seer_return_value: SimilarIssuesEmbeddingsResponse = {
             "responses": [
                 {
-                    "message_similarity": 0.95,
+                    "message_distance": 0.05,
                     "parent_group_id": self.similar_group.id,
                     "should_group": True,
-                    "stacktrace_similarity": 0.99,
+                    "stacktrace_distance": 0.01,
                 }
             ]
         }


### PR DESCRIPTION
Change similarity embeddings API call to use cosine distance instead of similarity to match [seer](https://github.com/getsentry/timeseries-analysis-service/pull/249)