### PR TITLE
chore(hybridcloud) Stop sending organization to send_incident_alert_notification

### DIFF
--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -74,7 +74,6 @@ def send_incident_alert_notification(
         sentry_app_id=action.sentry_app_id,
         action_id=action.id,
         incident_id=incident.id,
-        organization=organization,
         organization_id=organization.id,
         new_status=new_status.value,
         incident_attachment_json=json.dumps(incident_attachment),


### PR DESCRIPTION
Continuing work from #65736 and #65791 to stop sending organization so that we have a smaller RPC method payload.
