### PR TITLE
feat(trace): Add timestamp optimization to trace

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -24,6 +24,7 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.search.events.builder import QueryBuilder, SpansIndexedQueryBuilder
 from sentry.search.events.types import ParamsType, QueryBuilderConfig
+from sentry.search.utils import parse_datetime_string
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
@@ -721,6 +722,19 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
         # Detailed is deprecated now that we want to use spans instead
         detailed: bool = request.GET.get("detailed", "0") == "1"
         use_spans: bool = request.GET.get("useSpans", "0") == "1"
+        # during the transition this is optional but it will become required
+        if "timestamp" in request.GET:
+            example_timestamp: datetime | None = parse_datetime_string(request.GET["timestamp"])
+            # While possible, the majority of traces shouldn't take more than a week
+            # Starting with 3d for now, but potentially something we can increase if this becomes a problem
+            example_start = example_timestamp - timedelta(days=1, hours=12)
+            example_end = example_timestamp + timedelta(days=1, hours=12)
+            # If timestamp is being passed it should always overwrite the statsperiod or start & end
+            # the client should just not pass a timestamp if we need to overwrite this logic for any reason
+            params["start"] = max(params["start"], example_start)
+            params["end"] = min(params["end"], example_end)
+        else:
+            example_timestamp = None
         sentry_sdk.set_tag("trace_view.using_spans", str(use_spans))
         if detailed and use_spans:
             raise ParseError("Cannot return a detailed response while using spans")
@@ -1301,6 +1315,7 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
                 "orphan_errors": [self.serialize_error(error) for error in orphan_errors],
             }
 
+    @sentry_sdk.trace
     def calculate_remaining_transactions(self, transactions, visited_transactions):
         return sorted(
             [
@@ -1311,6 +1326,7 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
             key=lambda k: -datetime.fromisoformat(k["timestamp"]).timestamp(),
         )
 
+    @sentry_sdk.trace
     def visit_transactions(
         self, to_visit, transactions, errors, visited_transactions, visited_errors
     ):

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1502,6 +1502,41 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             else:
                 assert len(gen1["children"]) == 0
 
+    @mock.patch("sentry.api.endpoints.organization_events_trace.query_trace_data")
+    def test_timestamp_optimization(self, mock_query):
+        """When timestamp is passed we'll ignore the statsPeriod and make a query with a smaller start & end"""
+        self.load_trace()
+        with self.feature(self.FEATURES):
+            self.client_get(
+                data={
+                    "project": -1,
+                    "timestamp": self.root_event.timestamp,
+                    "statsPeriod": "90d",
+                },
+            )
+        mock_query.assert_called_once()
+        params = mock_query.call_args.args[1]
+        assert abs((params["end"] - params["start"]).days) <= 7
+
+    def test_timestamp_optimization_without_mock(self):
+        """Make sure that even if the params are smaller the query still works"""
+        self.load_trace()
+        with self.feature(self.FEATURES):
+            response = self.client_get(
+                data={
+                    "project": -1,
+                    "timestamp": self.root_event.timestamp,
+                    "statsPeriod": "90d",
+                },
+            )
+        assert response.status_code == 200, response.content
+        trace_transaction = response.data["transactions"][0]
+        self.assert_trace_data(trace_transaction)
+        # We shouldn't have detailed fields here
+        assert "transaction.status" not in trace_transaction
+        assert "tags" not in trace_transaction
+        assert "measurements" not in trace_transaction
+
 
 @region_silo_test
 class OrganizationEventsTraceEndpointTestUsingSpans(OrganizationEventsTraceEndpointTest):


### PR DESCRIPTION
- The frontend will start passing a timestamp param as part of the new trace view rewrite, which we can then use to narrow the timerange of the query significantly