### PR TITLE
feat(trace): Chunk span ids

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -611,6 +611,7 @@ def augment_transactions_with_spans(
         spans_params["project_id"] = list(projects.union(set(problem_project_map.keys())))
 
     # If we're querying over 100 span ids, lets split the query into 3
+    sentry_sdk.set_tag("trace_view.use_spans.span_len", len(query_spans))
     if len(query_spans) > 100:
         list_spans = list(query_spans)
         chunks = [


### PR DESCRIPTION
- This list of span ids can hit up to 10k, lets chunk this query for two reasons
  1. Snuba needs to parse this giant list, it can take 100s of ms when its such a big list splitting it up means we can parallelize that work
  2. This is still the slowest part of the trace endpoint, hopefully parallelizing the query means that clickhouse can return faster too