### PR TITLE
ref: use an aware datetime for HC's DEFAULT_DATE

### DIFF
--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -26,7 +26,7 @@ OptionValue = Any
 IDEMPOTENCY_KEY_LENGTH = 48
 REGION_NAME_LENGTH = 48
 
-DEFAULT_DATE = datetime.datetime(2000, 1, 1)
+DEFAULT_DATE = datetime.datetime(2000, 1, 1, tzinfo=datetime.UTC)
 
 
 class ValueEqualityEnum(Enum):


### PR DESCRIPTION
this fixes some warning spew in django that is likely to be an error in the future

```console
$ pytest -W 'error::RuntimeWarning' --maxfail 1 -q tests/sentry/hybridcloud/test_log.py
F
================================================== FAILURES ===================================================
_______________________________________ test_audit_log_event[MONOLITH] ________________________________________
tests/sentry/hybridcloud/test_log.py:16: in test_audit_log_event
    log_service.record_audit_log(
src/sentry/services/hybrid_cloud/log/impl.py:21: in record_audit_log
    entry.save()
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
src/sentry/models/auditlogentry.py:85: in save
    super().save(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/base.py:822: in save
    self.save_base(
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/base.py:909: in save_base
    updated = self._save_table(
.venv/lib/python3.11/site-packages/django/db/models/base.py:1067: in _save_table
    results = self._do_insert(
.venv/lib/python3.11/site-packages/django/db/models/base.py:1108: in _do_insert
    return manager._insert(
.venv/lib/python3.11/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1847: in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1822: in execute_sql
    for sql, params in self.as_sql():
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1745: in as_sql
    value_rows = [
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1746: in <listcomp>
    [
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1747: in <listcomp>
    self.prepare_value(field, self.pre_save_val(field, obj))
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1686: in prepare_value
    return field.get_db_prep_save(value, connection=self.connection)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1013: in get_db_prep_save
    return self.get_db_prep_value(value, connection=connection, prepared=False)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1671: in get_db_prep_value
    value = self.get_prep_value(value)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1659: in get_prep_value
    warnings.warn(
E   RuntimeWarning: DateTimeField AuditLogEntry.datetime received a naive datetime (2000-01-01 00:00:00) while time zone support is active.
=========================================== short test summary info ===========================================
FAILED tests/sentry/hybridcloud/test_log.py::test_audit_log_event[MONOLITH] - RuntimeWarning: DateTimeField AuditLogEntry.datetime received a naive datetime (2000-01-01 00:00:00) while...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
1 failed in 3.90s
```

<!-- Describe your PR here. -->