### PR TITLE
ref: use an aware datetime for backups

### DIFF
--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import tempfile
 from copy import deepcopy
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from functools import cached_property, cmp_to_key
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -14,7 +14,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.apps import apps
 from django.db import connections, router
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 from sentry_relay.auth import generate_key_pair
 
 from sentry.backup.crypto import (
@@ -348,8 +348,8 @@ class BackupTestCase(TransactionTestCase):
         UserIP.objects.create(
             user=user,
             ip_address="127.0.0.2",
-            first_seen=datetime(2012, 4, 5, 3, 29, 45, tzinfo=timezone.utc),
-            last_seen=datetime(2012, 4, 5, 3, 29, 45, tzinfo=timezone.utc),
+            first_seen=datetime(2012, 4, 5, 3, 29, 45, tzinfo=UTC),
+            last_seen=datetime(2012, 4, 5, 3, 29, 45, tzinfo=UTC),
         )
         Authenticator.objects.create(user=user, type=1)
 
@@ -423,14 +423,14 @@ class BackupTestCase(TransactionTestCase):
         NeglectedRule.objects.create(
             rule=rule,
             organization=org,
-            disable_date=datetime.now(),
-            sent_initial_email_date=datetime.now(),
-            sent_final_email_date=datetime.now(),
+            disable_date=timezone.now(),
+            sent_initial_email_date=timezone.now(),
+            sent_final_email_date=timezone.now(),
         )
         CustomDynamicSamplingRule.update_or_create(
             condition={"op": "equals", "name": "environment", "value": "prod"},
-            start=django_timezone.now(),
-            end=django_timezone.now() + timedelta(hours=1),
+            start=timezone.now(),
+            end=timezone.now() + timedelta(hours=1),
             project_ids=[project.id],
             organization_id=org.id,
             num_samples=100,
@@ -478,8 +478,8 @@ class BackupTestCase(TransactionTestCase):
         IncidentSnapshot.objects.create(
             incident=incident,
             event_stats_snapshot=TimeSeriesSnapshot.objects.create(
-                start=datetime.utcnow() - timedelta(hours=24),
-                end=datetime.utcnow(),
+                start=timezone.now() - timedelta(hours=24),
+                end=timezone.now(),
                 values=[[1.0, 2.0, 3.0], [1.5, 2.5, 3.5]],
                 period=1,
             ),
@@ -495,7 +495,7 @@ class BackupTestCase(TransactionTestCase):
 
         # *Snapshot
         PendingIncidentSnapshot.objects.create(
-            incident=incident, target_run_date=datetime.utcnow() + timedelta(hours=4)
+            incident=incident, target_run_date=timezone.now() + timedelta(hours=4)
         )
 
         # Dashboard
@@ -599,7 +599,7 @@ class BackupTestCase(TransactionTestCase):
         ApiGrant.objects.create(
             user=owner,
             application=app.application,
-            expires_at="2022-01-01 11:11",
+            expires_at="2022-01-01 11:11+00:00",
             redirect_uri="https://example.com",
             scope_list=["openid", "profile", "email"],
         )

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -4,7 +4,7 @@ import io
 import os
 import tarfile
 import tempfile
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -123,7 +123,9 @@ class SanitizationTests(ImportTestCase):
             assert UserEmail.objects.count() == 4
             assert UserEmail.objects.filter(is_verified=True).count() == 0
             assert (
-                UserEmail.objects.filter(date_hash_added__lt=datetime(2023, 7, 1, 0, 0)).count()
+                UserEmail.objects.filter(
+                    date_hash_added__lt=datetime(2023, 7, 1, 0, 0, tzinfo=UTC)
+                ).count()
                 == 0
             )
             assert (
@@ -162,7 +164,9 @@ class SanitizationTests(ImportTestCase):
             assert UserEmail.objects.count() == 4
             assert UserEmail.objects.filter(is_verified=True).count() == 0
             assert (
-                UserEmail.objects.filter(date_hash_added__lt=datetime(2023, 7, 1, 0, 0)).count()
+                UserEmail.objects.filter(
+                    date_hash_added__lt=datetime(2023, 7, 1, 0, 0, tzinfo=UTC)
+                ).count()
                 == 0
             )
             assert (
@@ -211,7 +215,9 @@ class SanitizationTests(ImportTestCase):
             assert UserEmail.objects.count() == 4
             assert UserEmail.objects.filter(is_verified=True).count() == 0
             assert (
-                UserEmail.objects.filter(date_hash_added__lt=datetime(2023, 7, 1, 0, 0)).count()
+                UserEmail.objects.filter(
+                    date_hash_added__lt=datetime(2023, 7, 1, 0, 0, tzinfo=UTC)
+                ).count()
                 == 0
             )
             assert (
@@ -257,7 +263,9 @@ class SanitizationTests(ImportTestCase):
             assert UserEmail.objects.count() == 4
             assert UserEmail.objects.filter(is_verified=True).count() == 4
             assert (
-                UserEmail.objects.filter(date_hash_added__lt=datetime(2023, 7, 1, 0, 0)).count()
+                UserEmail.objects.filter(
+                    date_hash_added__lt=datetime(2023, 7, 1, 0, 0, tzinfo=UTC)
+                ).count()
                 == 4
             )
             assert (
@@ -409,8 +417,12 @@ class SanitizationTests(ImportTestCase):
             assert UserIP.objects.filter(region_code="CA").exists()
 
             # Unlike global scope, this time must be reset.
-            assert UserIP.objects.filter(last_seen__gt=datetime(2023, 7, 1, 0, 0)).exists()
-            assert UserIP.objects.filter(first_seen__gt=datetime(2023, 7, 1, 0, 0)).exists()
+            assert UserIP.objects.filter(
+                last_seen__gt=datetime(2023, 7, 1, 0, 0, tzinfo=UTC)
+            ).exists()
+            assert UserIP.objects.filter(
+                first_seen__gt=datetime(2023, 7, 1, 0, 0, tzinfo=UTC)
+            ).exists()
 
     @patch("sentry.models.userip.geo_by_addr")
     def test_good_regional_user_ip_in_global_scope(self, mock_geo_by_addr):
@@ -441,8 +453,12 @@ class SanitizationTests(ImportTestCase):
             assert UserIP.objects.filter(region_code="CA").exists()
 
             # Unlike org/user scope, this must NOT be reset.
-            assert not UserIP.objects.filter(last_seen__gt=datetime(2023, 7, 1, 0, 0)).exists()
-            assert not UserIP.objects.filter(first_seen__gt=datetime(2023, 7, 1, 0, 0)).exists()
+            assert not UserIP.objects.filter(
+                last_seen__gt=datetime(2023, 7, 1, 0, 0, tzinfo=UTC)
+            ).exists()
+            assert not UserIP.objects.filter(
+                first_seen__gt=datetime(2023, 7, 1, 0, 0, tzinfo=UTC)
+            ).exists()
 
     # Regression test for getsentry/self-hosted#2468.
     @patch("sentry.models.userip.geo_by_addr")


### PR DESCRIPTION
this fixes some warning spew in django that is likely to be an error in the future

```
$ pytest -W 'error::RuntimeWarning' --maxfail 1 -q tests/sentry/backup/test_imports.py 
.........F
================================================== FAILURES ===================================================
________________________ SanitizationTests.test_good_regional_user_ip_in_global_scope _________________________
tests/sentry/backup/test_imports.py:444: in test_good_regional_user_ip_in_global_scope
    assert not UserIP.objects.filter(last_seen__gt=datetime(2023, 7, 1, 0, 0)).exists()
.venv/lib/python3.11/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1476: in filter
    return self._filter_or_exclude(False, args, kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1494: in _filter_or_exclude
    clone._filter_or_exclude_inplace(negate, args, kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1501: in _filter_or_exclude_inplace
    self._query.add_q(Q(*args, **kwargs))
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1613: in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1645: in _add_q
    child_clause, needed_inner = self.build_filter(
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1559: in build_filter
    condition = self.build_lookup(lookups, col, value)
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1389: in build_lookup
    lookup = lookup_class(lhs, rhs)
.venv/lib/python3.11/site-packages/django/db/models/lookups.py:30: in __init__
    self.rhs = self.get_prep_lookup()
.venv/lib/python3.11/site-packages/django/db/models/lookups.py:88: in get_prep_lookup
    return self.lhs.output_field.get_prep_value(self.rhs)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1659: in get_prep_value
    warnings.warn(
E   RuntimeWarning: DateTimeField UserIP.last_seen received a naive datetime (2023-07-01 00:00:00) while time zone support is active.
=========================================== short test summary info ===========================================
FAILED tests/sentry/backup/test_imports.py::SanitizationTests::test_good_regional_user_ip_in_global_scope - RuntimeWarning: DateTimeField UserIP.last_seen received a naive datetime (2023-07-01 00:00:00) while time ...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
1 failed, 9 passed in 24.08s
```

<!-- Describe your PR here. -->