### PR TITLE
ref: pass aware datetimes in tests

### DIFF
--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from sentry.models.deploy import Deploy
@@ -156,9 +156,9 @@ class ReleaseThresholdStatusTest(APITestCase):
             {p2.slug}-{release1.version}: [threshold]
         }
         """
-        now = str(datetime.now())
-        yesterday = str(datetime.now() - timedelta(hours=24))
-        last_week = str(datetime.now() - timedelta(days=7))
+        now = datetime.now(UTC)
+        yesterday = datetime.now(UTC) - timedelta(hours=24)
+        last_week = datetime.now(UTC) - timedelta(days=7)
         release_old = Release.objects.create(
             version="old_version", organization=self.organization, date_added=last_week
         )
@@ -218,8 +218,8 @@ class ReleaseThresholdStatusTest(APITestCase):
             {p2.slug}-{release1.version}: [threshold]
         }
         """
-        now = str(datetime.now())
-        yesterday = str(datetime.now() - timedelta(hours=24))
+        now = datetime.now(UTC)
+        yesterday = datetime.now(UTC) - timedelta(hours=24)
         response = self.get_success_response(
             self.organization.slug, start=yesterday, end=now, environment=["canary"]
         )
@@ -268,8 +268,8 @@ class ReleaseThresholdStatusTest(APITestCase):
             {p2.slug}-{release1.version}: [threshold]
         }
         """
-        now = str(datetime.now())
-        yesterday = str(datetime.now() - timedelta(hours=24))
+        now = datetime.now(UTC)
+        yesterday = datetime.now(UTC) - timedelta(hours=24)
 
         # Creates a deploy for a particular Release in a particular Environment
         r1_canary_deploy = Deploy.objects.create(
@@ -330,8 +330,8 @@ class ReleaseThresholdStatusTest(APITestCase):
             {p2.slug}-{release1.version}: [threshold]
         }
         """
-        now = str(datetime.now())
-        yesterday = str(datetime.now() - timedelta(hours=24))
+        now = datetime.now(UTC)
+        yesterday = datetime.now(UTC) - timedelta(hours=24)
         response = self.get_success_response(
             self.organization.slug, start=yesterday, end=now, release=[self.release1.version]
         )
@@ -381,8 +381,8 @@ class ReleaseThresholdStatusTest(APITestCase):
             {p2.slug}-{release1.version}: [threshold]
         }
         """
-        now = str(datetime.now())
-        yesterday = str(datetime.now() - timedelta(hours=24))
+        now = datetime.now(UTC)
+        yesterday = datetime.now(UTC) - timedelta(hours=24)
         response = self.get_success_response(
             self.organization.slug, start=yesterday, end=now, projectSlug=[self.project2.slug]
         )
@@ -462,8 +462,8 @@ class ReleaseThresholdStatusTest(APITestCase):
             project=self.project4,
         )
 
-        now = str(datetime.now())
-        yesterday = str(datetime.now() - timedelta(hours=24))
+        now = datetime.now(UTC)
+        yesterday = datetime.now(UTC) - timedelta(hours=24)
 
         mock_is_error_count_healthy.return_value = True, 100
         mock_is_new_issue_count_healthy.return_value = True, 100

--- a/tests/sentry/api/endpoints/test_artifact_bundles.py
+++ b/tests/sentry/api/endpoints/test_artifact_bundles.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from django.urls import reverse
 
@@ -24,8 +24,8 @@ class ArtifactBundlesEndpointTest(APITestCase):
         artifact_bundle_1 = self.create_artifact_bundle(
             self.organization,
             artifact_count=2,
-            date_uploaded=datetime.now(),
-            date_last_modified=datetime.now(),
+            date_uploaded=datetime.now(UTC),
+            date_last_modified=datetime.now(UTC),
         )
         ProjectArtifactBundle.objects.create(
             organization_id=self.organization.id,
@@ -36,8 +36,8 @@ class ArtifactBundlesEndpointTest(APITestCase):
         artifact_bundle_2 = self.create_artifact_bundle(
             self.organization,
             artifact_count=2,
-            date_uploaded=datetime.now() + timedelta(hours=1),
-            date_last_modified=datetime.now() + timedelta(hours=1),
+            date_uploaded=datetime.now(UTC) + timedelta(hours=1),
+            date_last_modified=datetime.now(UTC) + timedelta(hours=1),
         )
         ProjectArtifactBundle.objects.create(
             organization_id=self.organization.id,
@@ -54,7 +54,7 @@ class ArtifactBundlesEndpointTest(APITestCase):
         artifact_bundle_3 = self.create_artifact_bundle(
             self.organization,
             artifact_count=2,
-            date_uploaded=datetime.now() + timedelta(hours=2),
+            date_uploaded=datetime.now(UTC) + timedelta(hours=2),
             # We also test with the date set to None.
             date_last_modified=None,
         )
@@ -206,8 +206,8 @@ class ArtifactBundlesEndpointTest(APITestCase):
         artifact_bundle = self.create_artifact_bundle(
             self.organization,
             artifact_count=2,
-            date_uploaded=datetime.now(),
-            date_last_modified=datetime.now(),
+            date_uploaded=datetime.now(UTC),
+            date_last_modified=datetime.now(UTC),
         )
         ProjectArtifactBundle.objects.create(
             organization_id=self.organization.id,
@@ -241,8 +241,8 @@ class ArtifactBundlesEndpointTest(APITestCase):
         artifact_bundle = self.create_artifact_bundle(
             self.organization,
             artifact_count=2,
-            date_uploaded=datetime.now(),
-            date_last_modified=datetime.now(),
+            date_uploaded=datetime.now(UTC),
+            date_last_modified=datetime.now(UTC),
         )
         ProjectArtifactBundle.objects.create(
             organization_id=self.organization.id,
@@ -364,7 +364,7 @@ class ArtifactBundlesEndpointTest(APITestCase):
             artifact_bundle = self.create_artifact_bundle(
                 self.organization,
                 artifact_count=2,
-                date_uploaded=datetime.now() + timedelta(hours=index),
+                date_uploaded=datetime.now(UTC) + timedelta(hours=index),
             )
             ProjectArtifactBundle.objects.create(
                 organization_id=self.organization.id,
@@ -393,8 +393,8 @@ class ArtifactBundlesEndpointTest(APITestCase):
             artifact_bundle = self.create_artifact_bundle(
                 self.organization,
                 artifact_count=2,
-                date_uploaded=datetime.now() + timedelta(hours=index),
-                date_last_modified=datetime.now() + timedelta(hours=index),
+                date_uploaded=datetime.now(UTC) + timedelta(hours=index),
+                date_last_modified=datetime.now(UTC) + timedelta(hours=index),
             )
             bundle_ids.append(str(artifact_bundle.bundle_id))
             ProjectArtifactBundle.objects.create(

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -39,7 +39,7 @@ class GroupNoteTest(APITestCase):
 
     def test_note_merge(self):
         """Test that when 2 (or more) issues with comments are merged, the chronological order of the comments are preserved."""
-        now = datetime.datetime.now()
+        now = datetime.datetime.now(datetime.UTC)
 
         project1 = self.create_project()
         event1 = self.store_event(data={}, project_id=project1.id)

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -210,7 +210,7 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
             organization=self.organization,
             email="foo@example.com",
             role="member",
-            token_expires_at="2018-10-20 00:00:00",
+            token_expires_at="2018-10-20 00:00:00+00:00",
         )
 
         self.get_error_response(self.organization.slug, member.id, reinvite=1, status_code=400)
@@ -225,7 +225,7 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
             organization=self.organization,
             email="foo@example.com",
             role="member",
-            token_expires_at="2018-10-20 00:00:00",
+            token_expires_at="2018-10-20 00:00:00+00:00",
         )
 
         self.get_success_response(self.organization.slug, member.id, reinvite=1, regenerate=1)

--- a/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.urls import reverse
 
@@ -18,7 +18,7 @@ class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
         )
 
     def test_simple_sent_first_event(self):
-        self.create_project(teams=[self.team], first_event=datetime.now())
+        self.create_project(teams=[self.team], first_event=datetime.now(UTC))
         self.create_member(organization=self.org, user=self.foo, teams=[self.team])
 
         self.login_as(user=self.foo)
@@ -40,7 +40,7 @@ class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
         assert not response.data["sentFirstEvent"]
 
     def test_first_event_in_org(self):
-        self.create_project(teams=[self.team], first_event=datetime.now())
+        self.create_project(teams=[self.team], first_event=datetime.now(UTC))
         self.create_member(organization=self.org, user=self.foo)
 
         self.login_as(user=self.foo)
@@ -51,7 +51,7 @@ class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
         assert response.data["sentFirstEvent"]
 
     def test_no_first_event_in_member_projects(self):
-        self.create_project(teams=[self.team], first_event=datetime.now())
+        self.create_project(teams=[self.team], first_event=datetime.now(UTC))
         self.create_member(organization=self.org, user=self.foo)
 
         self.login_as(user=self.foo)
@@ -62,7 +62,7 @@ class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
         assert not response.data["sentFirstEvent"]
 
     def test_first_event_from_project_ids(self):
-        project = self.create_project(teams=[self.team], first_event=datetime.now())
+        project = self.create_project(teams=[self.team], first_event=datetime.now(UTC))
         self.create_member(organization=self.org, user=self.foo)
 
         self.login_as(user=self.foo)

--- a/tests/sentry/api/endpoints/test_organization_recent_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_recent_searches.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from functools import cached_property
 from typing import Any
 
@@ -161,7 +161,7 @@ class RecentSearchesCreateTest(APITestCase):
         self.login_as(self.user)
         search_type = 1
         query = "something"
-        the_date = datetime(2019, 1, 1, 1, 1, 1)
+        the_date = datetime(2019, 1, 1, 1, 1, 1, tzinfo=UTC)
         with freeze_time(the_date):
             response = self.get_response(self.organization.slug, type=search_type, query=query)
             assert response.status_code == 201
@@ -172,7 +172,7 @@ class RecentSearchesCreateTest(APITestCase):
                 query=query,
                 last_seen=the_date,
             ).exists()
-        the_date = datetime(2019, 1, 1, 2, 2, 2)
+        the_date = datetime(2019, 1, 1, 2, 2, 2, tzinfo=UTC)
         with freeze_time(the_date):
             response = self.get_response(self.organization.slug, type=search_type, query=query)
             assert response.status_code == 204, response.content

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from django.urls import reverse
@@ -230,7 +230,7 @@ class ReleaseDetailsTest(APITestCase):
         Test that ensures that in the case we are trying to get prev and next release to a current
         release with exact same date then we fallback to id comparison
         """
-        date_now = datetime.utcnow()
+        date_now = datetime.now(UTC)
         release_1 = Release.objects.create(
             date_added=date_now, organization_id=self.organization.id, version="foobar@1.0.0"
         )
@@ -416,7 +416,7 @@ class ReleaseDetailsTest(APITestCase):
         )
         release_2.add_project(self.project1)
 
-        date_added_from_8d = datetime.utcnow() - timedelta(days=8)
+        date_added_from_8d = datetime.now(UTC) - timedelta(days=8)
         release_3 = Release.objects.create(
             organization_id=self.organization.id,
             version="foobar@3.0.0",
@@ -472,7 +472,7 @@ class ReleaseDetailsTest(APITestCase):
         retrieved correctly in the case when all releases have the same exact datetime and we
         need to fallback to comparison with id
         """
-        date_now = datetime.utcnow()
+        date_now = datetime.now(UTC)
         release_2 = self.create_release(
             project=self.project1, version="foobar@2.0.0", date_added=date_now
         )
@@ -606,7 +606,9 @@ class ReleaseDetailsTest(APITestCase):
         self.create_member(teams=[team1], user=user, organization=org)
         self.login_as(user=user)
         release1 = Release.objects.create(
-            organization_id=org.id, version="1", date_added=datetime(2013, 8, 13, 3, 8, 24, 880386)
+            organization_id=org.id,
+            version="1",
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release1.add_project(project1)
         url = reverse(
@@ -984,7 +986,7 @@ class UpdateReleaseDetailsTest(APITestCase):
             "sentry-api-0-organization-release-details",
             kwargs={"organization_slug": org.slug, "version": release.version},
         )
-        response = self.client.put(url, data={"dateReleased": datetime.utcnow().isoformat() + "Z"})
+        response = self.client.put(url, data={"dateReleased": datetime.now(UTC).isoformat()})
 
         assert response.status_code == 200, (response.status_code, response.content)
 
@@ -1018,7 +1020,7 @@ class UpdateReleaseDetailsTest(APITestCase):
             "sentry-api-0-organization-release-details",
             kwargs={"organization_slug": org.slug, "version": release.version},
         )
-        response = self.client.put(url, data={"dateReleased": datetime.utcnow().isoformat() + "Z"})
+        response = self.client.put(url, data={"dateReleased": datetime.now(UTC).isoformat()})
 
         assert response.status_code == 200, (response.status_code, response.content)
 
@@ -1267,7 +1269,7 @@ class ReleaseSerializerTest(unittest.TestCase):
         result = serializer.validated_data
         assert result["ref"] == self.ref
         assert result["url"] == self.url
-        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=timezone.utc)
+        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=UTC)
         assert result["commits"] == self.commits
         assert result["headCommits"] == self.headCommits
         assert result["refs"] == self.refs

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
 from sentry.ingest.userreport import save_userreport
@@ -64,7 +64,7 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
             comments="Hello world",
             group_id=self.group_1.id,
             environment_id=self.env_2.id,
-            date_added=datetime.now() - timedelta(days=7),
+            date_added=datetime.now(UTC) - timedelta(days=7),
         )
 
     def run_test(self, expected, **params):
@@ -88,13 +88,13 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
     def test_date_filter(self):
         self.run_test(
             [self.report_1],
-            start=(datetime.now() - timedelta(days=1)).isoformat() + "Z",
-            end=datetime.now().isoformat() + "Z",
+            start=(datetime.now(UTC) - timedelta(days=1)).isoformat(),
+            end=datetime.now(UTC).isoformat(),
         )
         self.run_test(
             [self.report_1, self.report_2],
-            start=(datetime.now() - timedelta(days=8)).isoformat() + "Z",
-            end=datetime.now().isoformat() + "Z",
+            start=(datetime.now(UTC) - timedelta(days=8)).isoformat(),
+            end=datetime.now(UTC).isoformat(),
         )
         self.run_test([self.report_1, self.report_2], statsPeriod="14d")
 

--- a/tests/sentry/api/endpoints/test_project_release_stats.py
+++ b/tests/sentry/api/endpoints/test_project_release_stats.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.urls import reverse
 
@@ -20,7 +20,7 @@ class ProjectReleaseStatsTest(APITestCase):
         release = Release.objects.create(
             organization_id=project.organization_id,
             version="1",
-            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release.add_project(project)
 

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from functools import cached_property
 
 from django.urls import reverse
@@ -36,7 +36,7 @@ class ProjectReleaseListTest(APITestCase):
         release1 = Release.objects.create(
             organization_id=project1.organization_id,
             version="1",
-            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release1.add_project(project1)
 
@@ -45,15 +45,15 @@ class ProjectReleaseListTest(APITestCase):
         release2 = Release.objects.create(
             organization_id=project1.organization_id,
             version="2",
-            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386),
+            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release2.add_project(project1)
 
         release3 = Release.objects.create(
             organization_id=project1.organization_id,
             version="3",
-            date_added=datetime(2013, 8, 12, 3, 8, 24, 880386),
-            date_released=datetime(2013, 8, 15, 3, 8, 24, 880386),
+            date_added=datetime(2013, 8, 12, 3, 8, 24, 880386, tzinfo=UTC),
+            date_released=datetime(2013, 8, 15, 3, 8, 24, 880386, tzinfo=UTC),
             user_agent="my_agent",
         )
         release3.add_project(project1)
@@ -84,7 +84,7 @@ class ProjectReleaseListTest(APITestCase):
         release = Release.objects.create(
             organization_id=project.organization_id,
             version="foobar",
-            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386),
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release.add_project(project)
 
@@ -106,7 +106,7 @@ class ProjectReleaseListTest(APITestCase):
         release = Release.objects.create(
             organization_id=project.organization_id,
             version="foo.bar-1.0.0",
-            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386),
+            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release.add_project(project)
 
@@ -121,7 +121,7 @@ class ProjectReleaseListEnvironmentsTest(APITestCase):
     def setUp(self):
         self.login_as(user=self.user)
 
-        self.datetime = datetime(2013, 8, 13, 3, 8, 24, tzinfo=timezone.utc)
+        self.datetime = datetime(2013, 8, 13, 3, 8, 24, tzinfo=UTC)
         team = self.create_team()
         project1 = self.create_project(teams=[team], name="foo")
         project2 = self.create_project(teams=[team], name="bar")
@@ -495,7 +495,9 @@ class ProjectReleaseCreateTest(APITestCase):
         team1 = self.create_team(organization=org)
         project1 = self.create_project(teams=[team1], organization=org)
         release1 = Release.objects.create(
-            organization_id=org.id, version="1", date_added=datetime(2013, 8, 13, 3, 8, 24, 880386)
+            organization_id=org.id,
+            version="1",
+            date_added=datetime(2013, 8, 13, 3, 8, 24, 880386, tzinfo=UTC),
         )
         release1.add_project(project1)
 
@@ -734,7 +736,7 @@ class ReleaseSerializerTest(TestCase):
         assert result["owner"].username == self.user.username
         assert result["ref"] == self.ref
         assert result["url"] == self.url
-        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=timezone.utc)
+        assert result["dateReleased"] == datetime(1000, 10, 10, 6, 6, tzinfo=UTC)
         assert result["commits"] == self.commits
 
     def test_fields_not_required(self):

--- a/tests/sentry/api/endpoints/test_release_deploys.py
+++ b/tests/sentry/api/endpoints/test_release_deploys.py
@@ -27,7 +27,7 @@ class ReleaseDeploysListTest(APITestCase):
             environment_id=production_env.id,
             organization_id=project.organization_id,
             release=release,
-            date_finished=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            date_finished=datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1),
         )
 
         staging_env = Environment.objects.create(
@@ -90,7 +90,7 @@ class ReleaseDeploysListTest(APITestCase):
             environment_id=production_env.id,
             organization_id=project.organization_id,
             release=release,
-            date_finished=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            date_finished=datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1),
         )
 
         ReleaseProjectEnvironment.objects.create(

--- a/tests/sentry/api/endpoints/test_team_groups_old.py
+++ b/tests/sentry/api/endpoints/test_team_groups_old.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from sentry.models.group import GroupStatus
 from sentry.models.groupassignee import GroupAssignee
@@ -19,11 +19,11 @@ class TeamGroupsOldTest(APITestCase):
         project2 = self.create_project(teams=[self.team], slug="bar")
         group1 = self.create_group(
             project=project1,
-            first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+            first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=UTC),
         )
         group2 = self.create_group(
             project=project2,
-            first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+            first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=UTC),
         )
         resolved_group = self.create_group(project=project2, status=GroupStatus.RESOLVED)
         GroupAssignee.objects.assign(group1, self.user)
@@ -33,19 +33,19 @@ class TeamGroupsOldTest(APITestCase):
         other_user = self.create_user()
         assigned_to_other = self.create_group(
             project=project2,
-            first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+            first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=UTC),
         )
         GroupAssignee.objects.assign(assigned_to_other, other_user)
         self.create_group(
             project=project2,
-            first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+            first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=UTC),
         )
 
         # Should be excluded since it hasn't been seen for over 90 days.
         last_seen_too_old_group = self.create_group(
             project=project1,
-            first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
-            last_seen=datetime.now() - timedelta(days=91),
+            first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=UTC),
+            last_seen=datetime.now(UTC) - timedelta(days=91),
         )
         GroupAssignee.objects.assign(last_seen_too_old_group, self.user)
 
@@ -59,7 +59,7 @@ class TeamGroupsOldTest(APITestCase):
         self.create_environment(name="dev", project=project1)
         group1 = self.create_group(
             project=project1,
-            first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+            first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=UTC),
         )
         GroupAssignee.objects.assign(group1, self.user)
         GroupEnvironment.objects.create(group_id=group1.id, environment_id=environment.id)

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -194,20 +194,22 @@ class UpdateGroupsTest(TestCase):
         for data in [
             {
                 "group": self.create_group(
-                    status=GroupStatus.IGNORED, first_seen=datetime.now() - timedelta(days=8)
+                    status=GroupStatus.IGNORED, first_seen=datetime.now(UTC) - timedelta(days=8)
                 ),
                 "request_data": {"status": "unresolved"},
                 "expected_substatus": GroupSubStatus.ONGOING,
             },
             {
                 "group": self.create_group(
-                    status=GroupStatus.IGNORED, first_seen=datetime.now() - timedelta(days=8)
+                    status=GroupStatus.IGNORED, first_seen=datetime.now(UTC) - timedelta(days=8)
                 ),
                 "request_data": {"status": "unresolved", "substatus": "ongoing"},
                 "expected_substatus": GroupSubStatus.ONGOING,
             },
             {
-                "group": self.create_group(status=GroupStatus.IGNORED, first_seen=datetime.now()),
+                "group": self.create_group(
+                    status=GroupStatus.IGNORED, first_seen=datetime.now(UTC)
+                ),
                 "request_data": {"status": "unresolved"},
                 "expected_substatus": GroupSubStatus.NEW,
             },

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest import mock
 
 from sentry.api.serializers import SimpleEventSerializer, serialize
@@ -501,7 +501,7 @@ class SqlFormatEventSerializerTest(TestCase):
         release = Release.objects.create(
             version="internal@1.0.0",
             organization=self.organization,
-            date_released=datetime(2023, 1, 1),
+            date_released=datetime(2023, 1, 1, tzinfo=UTC),
         )
         release.add_project(self.project)
         release.set_commits(

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import patch
 from uuid import uuid4
@@ -93,7 +93,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         assert result["versionInfo"]["buildHash"] == release_version
         assert result["versionInfo"]["description"] == release_version[:12]
 
-        current_formatted_datetime = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        current_formatted_datetime = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S+00:00")
         current_project_meta = {
             "prev_release_version": "foobar@1.0.0",
             "next_release_version": "foobar@2.0.0",
@@ -534,7 +534,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
             release_id=release.id,
             environment_id=env2.id,
             new_issues_count=1,
-            adopted=datetime.utcnow(),
+            adopted=datetime.now(UTC),
         )
 
         result = serialize(release, user, with_adoption_stages=True)
@@ -558,13 +558,13 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
             release_id=release.id,
             environment_id=env.id,
             new_issues_count=1,
-            adopted=datetime.utcnow(),
+            adopted=datetime.now(UTC),
         )
         result = serialize(release, user, with_adoption_stages=True)
         assert result["adoptionStages"][project.slug]["stage"] == ReleaseStages.ADOPTED
         assert result["adoptionStages"][project2.slug]["stage"] == ReleaseStages.ADOPTED
 
-        rpe.update(unadopted=datetime.utcnow())
+        rpe.update(unadopted=datetime.now(UTC))
         result = serialize(release, user, with_adoption_stages=True)
         assert result["adoptionStages"][project.slug]["stage"] == ReleaseStages.REPLACED
         assert result["adoptionStages"][project2.slug]["stage"] == ReleaseStages.ADOPTED

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from django.http import HttpRequest
@@ -162,7 +162,7 @@ class TestOrgAuthTokenAuthentication(TestCase):
             self.auth.authenticate(request)
 
     def test_inactive_key(self):
-        self.org_auth_token.update(date_deactivated=datetime.now())
+        self.org_auth_token.update(date_deactivated=datetime.now(UTC))
         request = HttpRequest()
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {self.token}"
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -910,8 +910,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
             project_id=self.project.id,
         )
-        before_now_300_seconds = iso_format(before_now(seconds=300))
-        before_now_350_seconds = iso_format(before_now(seconds=350))
+        before_now_300_seconds = before_now(seconds=300).isoformat()
+        before_now_350_seconds = before_now(seconds=350).isoformat()
         event2 = self.store_event(
             data={"timestamp": before_now_300_seconds, "fingerprint": ["group-2"]},
             project_id=self.project.id,

--- a/tests/sentry/issues/test_attributes.py
+++ b/tests/sentry/issues/test_attributes.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.utils import timezone
@@ -90,14 +90,14 @@ class GroupAttributesTest(TestCase):
             group=group,
             project=group.project,
             user_id=self.user.id,
-            date_added=datetime.now(),
+            date_added=timezone.now(),
         )
         group_2 = self.create_group()
         GroupAssignee.objects.create(
             group=group_2,
             project=group.project,
             team_id=self.team.id,
-            date_added=datetime.now(),
+            date_added=timezone.now(),
         )
 
         snapshot_values = _bulk_retrieve_snapshot_values([group, group_2], False)

--- a/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
+++ b/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -57,7 +57,7 @@ class TestGrantExchanger(TestCase):
             self.grant_exchanger.call()
 
     def test_grant_must_be_active(self):
-        self.orm_install.api_grant.update(expires_at=(datetime.utcnow() - timedelta(hours=1)))
+        self.orm_install.api_grant.update(expires_at=(datetime.now(UTC) - timedelta(hours=1)))
 
         with pytest.raises(APIUnauthorized):
             self.grant_exchanger.call()

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -279,12 +279,12 @@ class GroupTest(TestCase, SnubaTestCase):
         last_release = Release.objects.create(
             organization_id=self.organization.id,
             version="100",
-            date_added=iso_format(now - timedelta(seconds=10)),
+            date_added=now - timedelta(seconds=10),
         )
         first_release = Release.objects.create(
             organization_id=self.organization.id,
             version="200",
-            date_added=iso_format(now - timedelta(seconds=100)),
+            date_added=now - timedelta(seconds=100),
         )
         GroupRelease.objects.create(
             project_id=project.id,

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -286,7 +286,7 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
             role="member",
             user=user,
             token="abc-def",
-            token_expires_at="2018-01-01 10:00:00",
+            token_expires_at="2018-01-01 10:00:00+00:00",
         )
         with outbox_runner():
             OrganizationMember.objects.delete_expired(timezone.now())

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -363,7 +363,7 @@ class SetCommitsTestCase(TestCase):
             organization_id=org.id,
             key="b" * 40,
             author=author,
-            date_added="2019-03-01 12:00:00",
+            date_added="2019-03-01 12:00:00+00:00",
             message="fixed a thing",
         )
 
@@ -1281,7 +1281,7 @@ class ClearCommitsTestCase(TestCase):
             organization_id=org.id,
             repository_id=repo.id,
             author=author,
-            date_added="2019-03-01 12:00:00",
+            date_added="2019-03-01 12:00:00+00:00",
             message="fixes %s" % (group.qualified_short_id),
             key="alksdflskdfjsldkfajsflkslk",
         )
@@ -1289,7 +1289,7 @@ class ClearCommitsTestCase(TestCase):
             organization_id=org.id,
             repository_id=repo.id,
             author=author2,
-            date_added="2019-03-01 12:02:00",
+            date_added="2019-03-01 12:02:00+00:00",
             message="i fixed something",
             key="lskfslknsdkcsnlkdflksfdkls",
         )

--- a/tests/sentry/models/test_rulesnooze.py
+++ b/tests/sentry/models/test_rulesnooze.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from django.db import IntegrityError, router, transaction
@@ -24,12 +24,12 @@ class RuleSnoozeTest(APITestCase):
             user_id=self.user.id,
             owner_id=self.user.id,
             rule=self.issue_alert_rule,
-            until=datetime.now() + timedelta(days=10),
+            until=datetime.now(UTC) + timedelta(days=10),
         )
         issue_alert_rule_snooze_all = self.snooze_rule(
             owner_id=self.user2.id,
             rule=self.issue_alert_rule,
-            until=datetime.now() + timedelta(days=1),
+            until=datetime.now(UTC) + timedelta(days=1),
         )
         assert RuleSnooze.objects.filter(id=issue_alert_rule_snooze_user.id).exists()
         assert RuleSnooze.objects.filter(id=issue_alert_rule_snooze_all.id).exists()
@@ -39,7 +39,7 @@ class RuleSnoozeTest(APITestCase):
             user_id=self.user.id,
             owner_id=self.user.id,
             rule=self.issue_alert_rule,
-            until=datetime.now() + timedelta(days=1),
+            until=datetime.now(UTC) + timedelta(days=1),
         )
         assert RuleSnooze.objects.filter(id=issue_alert_rule_snooze_user_until.id).exists()
 
@@ -56,7 +56,7 @@ class RuleSnoozeTest(APITestCase):
             user_id=self.user.id,
             owner_id=self.user.id,
             alert_rule=self.metric_alert_rule,
-            until=datetime.now() + timedelta(days=1),
+            until=datetime.now(UTC) + timedelta(days=1),
         )
         assert RuleSnooze.objects.filter(id=metric_alert_rule_snooze_user.id).exists()
 
@@ -105,4 +105,4 @@ class RuleSnoozeTest(APITestCase):
             )
 
         with pytest.raises(IntegrityError), transaction.atomic(router.db_for_write(RuleSnooze)):
-            self.snooze_rule(owner_id=self.user.id, until=datetime.now() + timedelta(days=1))
+            self.snooze_rule(owner_id=self.user.id, until=datetime.now(UTC) + timedelta(days=1))

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from django.conf import settings
@@ -45,8 +45,8 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         self.check_valid_response(response, [monitor])
 
     def test_sort_status(self):
-        last_checkin = datetime.now() - timedelta(minutes=1)
-        last_checkin_older = datetime.now() - timedelta(minutes=5)
+        last_checkin = datetime.now(UTC) - timedelta(minutes=1)
+        last_checkin_older = datetime.now(UTC) - timedelta(minutes=5)
 
         def add_status_monitor(
             env_status_key: str,
@@ -243,7 +243,7 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
     def test_monitor_environment_include_new(self):
         monitor = self._create_monitor()
         self._create_monitor_environment(
-            monitor, status=MonitorStatus.OK, last_checkin=datetime.now() - timedelta(minutes=1)
+            monitor, status=MonitorStatus.OK, last_checkin=datetime.now(UTC) - timedelta(minutes=1)
         )
 
         monitor_visible = self._create_monitor(name="visible")
@@ -265,13 +265,13 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         self._create_monitor_environment(
             monitor,
             status=MonitorStatus.OK,
-            last_checkin=datetime.now() - timedelta(minutes=1),
+            last_checkin=datetime.now(UTC) - timedelta(minutes=1),
         )
         self._create_monitor_environment(
             monitor,
             status=MonitorStatus.PENDING_DELETION,
             name="deleted_environment",
-            last_checkin=datetime.now() - timedelta(minutes=1),
+            last_checkin=datetime.now(UTC) - timedelta(minutes=1),
         )
 
         response = self.get_success_response(self.organization.slug)

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import collections
 from collections.abc import Iterable, Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
 from django.utils import timezone
@@ -428,7 +428,7 @@ class GetSendToOwnersTest(_ParticipantsTest):
             group=event.group,
             project=event.group.project,
             team_id=team.id,
-            date_added=datetime.now(),
+            date_added=timezone.now(),
         )
 
         self.assert_recipients_are(
@@ -453,7 +453,7 @@ class GetSendToOwnersTest(_ParticipantsTest):
             group=event.group,
             project=event.group.project,
             user_id=self.user.id,
-            date_added=datetime.now(),
+            date_added=timezone.now(),
         )
 
         self.assert_recipients_are(
@@ -474,7 +474,7 @@ class GetSendToOwnersTest(_ParticipantsTest):
             group=event.group,
             project=event.group.project,
             user_id=member.id,
-            date_added=datetime.now(),
+            date_added=timezone.now(),
         )
 
         self.assert_recipients_are(

--- a/tests/sentry/rules/filters/test_latest_adopted_release.py
+++ b/tests/sentry/rules/filters/test_latest_adopted_release.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sentry.rules.filters.latest_adopted_release_filter import LatestAdoptedReleaseFilter
 from sentry.testutils.cases import RuleTestCase
@@ -9,7 +9,7 @@ class LatestAdoptedReleaseFilterTest(RuleTestCase):
 
     def test_semver(self):
         event = self.get_event()
-        now = datetime.now()
+        now = datetime.now(UTC)
         prod = self.create_environment(name="prod")
         test = self.create_environment(name="test")
         newest_release = self.create_release(
@@ -79,7 +79,7 @@ class LatestAdoptedReleaseFilterTest(RuleTestCase):
 
     def test_date(self):
         event = self.get_event()
-        now = datetime.now()
+        now = datetime.now(UTC)
         prod = self.create_environment(name="prod")
         test = self.create_environment(name="test")
         oldest_release = self.create_release(

--- a/tests/sentry/rules/filters/test_latest_release.py
+++ b/tests/sentry/rules/filters/test_latest_release.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sentry.models.release import Release
 from sentry.models.rule import Rule
@@ -18,14 +18,14 @@ class LatestReleaseFilterTest(RuleTestCase):
         oldRelease = Release.objects.create(
             organization_id=self.organization.id,
             version="1",
-            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386, tzinfo=UTC),
         )
         oldRelease.add_project(self.project)
 
         newRelease = Release.objects.create(
             organization_id=self.organization.id,
             version="2",
-            date_added=datetime(2020, 9, 2, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 2, 3, 8, 24, 880386, tzinfo=UTC),
         )
         newRelease.add_project(self.project)
 
@@ -38,14 +38,14 @@ class LatestReleaseFilterTest(RuleTestCase):
         oldRelease = Release.objects.create(
             organization_id=self.organization.id,
             version="1",
-            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386, tzinfo=UTC),
         )
         oldRelease.add_project(self.project)
 
         newRelease = Release.objects.create(
             organization_id=self.organization.id,
             version="2",
-            date_added=datetime(2020, 9, 2, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 2, 3, 8, 24, 880386, tzinfo=UTC),
         )
         newRelease.add_project(self.project)
 
@@ -58,7 +58,7 @@ class LatestReleaseFilterTest(RuleTestCase):
         oldRelease = Release.objects.create(
             organization_id=self.organization.id,
             version="1",
-            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386, tzinfo=UTC),
         )
         oldRelease.add_project(self.project)
         event.data["tags"] = (("release", oldRelease.version),)
@@ -68,7 +68,7 @@ class LatestReleaseFilterTest(RuleTestCase):
         newRelease = Release.objects.create(
             organization_id=self.organization.id,
             version="2",
-            date_added=datetime(2020, 9, 2, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 2, 3, 8, 24, 880386, tzinfo=UTC),
         )
         newRelease.add_project(self.project)
 
@@ -91,21 +91,21 @@ class LatestReleaseFilterTest(RuleTestCase):
         self.create_release(
             project=event.group.project,
             version="1",
-            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386, tzinfo=UTC),
             environments=[self.environment],
         )
 
         new_release = self.create_release(
             project=event.group.project,
             version="2",
-            date_added=datetime(2020, 9, 2, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 2, 3, 8, 24, 880386, tzinfo=UTC),
             environments=[self.environment],
         )
 
         other_env_release = self.create_release(
             project=event.group.project,
             version="4",
-            date_added=datetime(2020, 9, 3, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 3, 3, 8, 24, 880386, tzinfo=UTC),
         )
 
         event.data["tags"] = (("release", new_release.version),)

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest import mock
 from unittest.mock import patch
 
@@ -626,7 +626,7 @@ class RuleProcessorTestFilters(TestCase):
         release = self.create_release(
             project=self.project,
             version="2021-02.newRelease",
-            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
+            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386, tzinfo=UTC),
             environments=[self.environment],
         )
 

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -1,7 +1,7 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.models.group import GroupStatus
 from sentry.models.release import Release, ReleaseProject
@@ -185,49 +185,49 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
     # TODO: update docs to include minutes, days, and weeks suffixes
     @freeze_time("2016-01-01")
     def test_age_tag_negative_value(self):
-        start = datetime.now(timezone.utc)
+        start = timezone.now()
         expected = start - timedelta(hours=12)
         result = self.parse_query("age:-12h")
         assert result == {"tags": {}, "query": "", "age_from": expected, "age_from_inclusive": True}
 
     @freeze_time("2016-01-01")
     def test_age_tag_positive_value(self):
-        start = datetime.now(timezone.utc)
+        start = timezone.now()
         expected = start - timedelta(hours=12)
         result = self.parse_query("age:+12h")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
     @freeze_time("2016-01-01")
     def test_age_tag_weeks(self):
-        start = datetime.now(timezone.utc)
+        start = timezone.now()
         expected = start - timedelta(days=35)
         result = self.parse_query("age:+5w")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
     @freeze_time("2016-01-01")
     def test_age_tag_days(self):
-        start = datetime.now(timezone.utc)
+        start = timezone.now()
         expected = start - timedelta(days=10)
         result = self.parse_query("age:+10d")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
     @freeze_time("2016-01-01")
     def test_age_tag_hours(self):
-        start = datetime.now(timezone.utc)
+        start = timezone.now()
         expected = start - timedelta(hours=10)
         result = self.parse_query("age:+10h")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
     @freeze_time("2016-01-01")
     def test_age_tag_minutes(self):
-        start = datetime.now(timezone.utc)
+        start = timezone.now()
         expected = start - timedelta(minutes=30)
         result = self.parse_query("age:+30m")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
     @freeze_time("2016-01-01")
     def test_two_age_tags(self):
-        start = datetime.now(timezone.utc)
+        start = timezone.now()
         expected_to = start - timedelta(hours=12)
         expected_from = start - timedelta(hours=24)
         result = self.parse_query("age:+12h age:-24h")
@@ -244,9 +244,9 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
         result = self.parse_query("event.timestamp:2016-01-02")
         assert result == {
             "query": "",
-            "date_from": datetime(2016, 1, 2, tzinfo=timezone.utc),
+            "date_from": datetime(2016, 1, 2, tzinfo=UTC),
             "date_from_inclusive": True,
-            "date_to": datetime(2016, 1, 3, tzinfo=timezone.utc),
+            "date_to": datetime(2016, 1, 3, tzinfo=UTC),
             "date_to_inclusive": False,
             "tags": {},
         }
@@ -264,7 +264,7 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
             "query": "",
             "times_seen_lower": 10,
             "times_seen_lower_inclusive": False,
-            "date_from": datetime(2016, 1, 2, tzinfo=timezone.utc),
+            "date_from": datetime(2016, 1, 2, tzinfo=UTC),
             "date_from_inclusive": False,
         }
 
@@ -275,7 +275,7 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
             "query": "",
             "times_seen_lower": 10,
             "times_seen_lower_inclusive": True,
-            "date_from": datetime(2016, 1, 2, tzinfo=timezone.utc),
+            "date_from": datetime(2016, 1, 2, tzinfo=UTC),
             "date_from_inclusive": True,
         }
 
@@ -286,7 +286,7 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
             "query": "",
             "times_seen_upper": 10,
             "times_seen_upper_inclusive": False,
-            "date_to": datetime(2016, 1, 2, tzinfo=timezone.utc),
+            "date_to": datetime(2016, 1, 2, tzinfo=UTC),
             "date_to_inclusive": False,
         }
 
@@ -299,7 +299,7 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
             "query": "",
             "times_seen_upper": 10,
             "times_seen_upper_inclusive": True,
-            "date_to": datetime(2016, 1, 2, tzinfo=timezone.utc),
+            "date_to": datetime(2016, 1, 2, tzinfo=UTC),
             "date_to_inclusive": True,
         }
 
@@ -405,12 +405,12 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
         release = self.create_release(
             project=self.project,
             version="older_release",
-            date_added=datetime.now() - timedelta(days=1),
+            date_added=timezone.now() - timedelta(days=1),
         )
         result = self.parse_query("first-release:latest")
         assert result == {"first_release": [release.version], "tags": {}, "query": ""}
         release = self.create_release(
-            project=self.project, version="new_release", date_added=datetime.now()
+            project=self.project, version="new_release", date_added=timezone.now()
         )
         result = self.parse_query("first-release:latest")
         assert result == {"first_release": [release.version], "tags": {}, "query": ""}
@@ -426,12 +426,12 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
         release = self.create_release(
             project=self.project,
             version="older_release",
-            date_added=datetime.now() - timedelta(days=1),
+            date_added=timezone.now() - timedelta(days=1),
         )
         result = self.parse_query("release:latest")
         assert result == {"tags": {"sentry:release": [release.version]}, "query": ""}
         release = self.create_release(
-            project=self.project, version="new_release", date_added=datetime.now()
+            project=self.project, version="new_release", date_added=timezone.now()
         )
         result = self.parse_query("release:latest")
         assert result == {"tags": {"sentry:release": [release.version]}, "query": ""}
@@ -453,7 +453,7 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
         assert result["tags"]["sentry:user"] == "xxxxxx:example"
 
     def test_user_lookup_with_dot_query(self):
-        self.project.date_added = django_timezone.now() - timedelta(minutes=10)
+        self.project.date_added = timezone.now() - timedelta(minutes=10)
         self.project.save()
 
         self.store_event(
@@ -476,7 +476,7 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
         assert result["tags"]["sentry:user"] == "email:fake@example.com"
 
     def test_user_lookup_legacy_syntax(self):
-        self.project.date_added = django_timezone.now() - timedelta(minutes=10)
+        self.project.date_added = timezone.now() - timedelta(minutes=10)
         self.project.save()
 
         self.store_event(
@@ -516,64 +516,64 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
 
     def test_age_from(self):
         result = self.parse_query("age:-24h")
-        assert result["age_from"] > django_timezone.now() - timedelta(hours=25)
-        assert result["age_from"] < django_timezone.now() - timedelta(hours=23)
+        assert result["age_from"] > timezone.now() - timedelta(hours=25)
+        assert result["age_from"] < timezone.now() - timedelta(hours=23)
         assert not result.get("age_to")
 
     def test_age_to(self):
         result = self.parse_query("age:+24h")
-        assert result["age_to"] > django_timezone.now() - timedelta(hours=25)
-        assert result["age_to"] < django_timezone.now() - timedelta(hours=23)
+        assert result["age_to"] > timezone.now() - timedelta(hours=25)
+        assert result["age_to"] < timezone.now() - timedelta(hours=23)
         assert not result.get("age_from")
 
     def test_age_range(self):
         result = self.parse_query("age:-24h age:+12h")
-        assert result["age_from"] > django_timezone.now() - timedelta(hours=25)
-        assert result["age_from"] < django_timezone.now() - timedelta(hours=23)
-        assert result["age_to"] > django_timezone.now() - timedelta(hours=13)
-        assert result["age_to"] < django_timezone.now() - timedelta(hours=11)
+        assert result["age_from"] > timezone.now() - timedelta(hours=25)
+        assert result["age_from"] < timezone.now() - timedelta(hours=23)
+        assert result["age_to"] > timezone.now() - timedelta(hours=13)
+        assert result["age_to"] < timezone.now() - timedelta(hours=11)
 
     def test_first_seen_range(self):
         result = self.parse_query("firstSeen:-24h firstSeen:+12h")
-        assert result["age_from"] > django_timezone.now() - timedelta(hours=25)
-        assert result["age_from"] < django_timezone.now() - timedelta(hours=23)
-        assert result["age_to"] > django_timezone.now() - timedelta(hours=13)
-        assert result["age_to"] < django_timezone.now() - timedelta(hours=11)
+        assert result["age_from"] > timezone.now() - timedelta(hours=25)
+        assert result["age_from"] < timezone.now() - timedelta(hours=23)
+        assert result["age_to"] > timezone.now() - timedelta(hours=13)
+        assert result["age_to"] < timezone.now() - timedelta(hours=11)
 
     def test_date_range(self):
         result = self.parse_query("event.timestamp:>2016-01-01 event.timestamp:<2016-01-02")
-        assert result["date_from"] == datetime(2016, 1, 1, tzinfo=timezone.utc)
+        assert result["date_from"] == datetime(2016, 1, 1, tzinfo=UTC)
         assert result["date_from_inclusive"] is False
-        assert result["date_to"] == datetime(2016, 1, 2, tzinfo=timezone.utc)
+        assert result["date_to"] == datetime(2016, 1, 2, tzinfo=UTC)
         assert result["date_to_inclusive"] is False
 
     def test_date_range_with_timezone(self):
         result = self.parse_query(
             "event.timestamp:>2016-01-01T10:00:00-03:00 event.timestamp:<2016-01-02T10:00:00+02:00"
         )
-        assert result["date_from"] == datetime(2016, 1, 1, 13, 0, 0, tzinfo=timezone.utc)
+        assert result["date_from"] == datetime(2016, 1, 1, 13, 0, 0, tzinfo=UTC)
         assert result["date_from_inclusive"] is False
-        assert result["date_to"] == datetime(2016, 1, 2, 8, 0, tzinfo=timezone.utc)
+        assert result["date_to"] == datetime(2016, 1, 2, 8, 0, tzinfo=UTC)
         assert result["date_to_inclusive"] is False
 
     def test_date_range_with_z_timezone(self):
         result = self.parse_query(
             "event.timestamp:>2016-01-01T10:00:00Z event.timestamp:<2016-01-02T10:00:00Z"
         )
-        assert result["date_from"] == datetime(2016, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        assert result["date_from"] == datetime(2016, 1, 1, 10, 0, 0, tzinfo=UTC)
         assert result["date_from_inclusive"] is False
-        assert result["date_to"] == datetime(2016, 1, 2, 10, 0, tzinfo=timezone.utc)
+        assert result["date_to"] == datetime(2016, 1, 2, 10, 0, tzinfo=UTC)
         assert result["date_to_inclusive"] is False
 
     def test_date_range_inclusive(self):
         result = self.parse_query("event.timestamp:>=2016-01-01 event.timestamp:<=2016-01-02")
-        assert result["date_from"] == datetime(2016, 1, 1, tzinfo=timezone.utc)
+        assert result["date_from"] == datetime(2016, 1, 1, tzinfo=UTC)
         assert result["date_from_inclusive"] is True
-        assert result["date_to"] == datetime(2016, 1, 2, tzinfo=timezone.utc)
+        assert result["date_to"] == datetime(2016, 1, 2, tzinfo=UTC)
         assert result["date_to_inclusive"] is True
 
     def test_date_approx_day(self):
-        date_value = datetime(2016, 1, 1, tzinfo=timezone.utc)
+        date_value = datetime(2016, 1, 1, tzinfo=UTC)
         result = self.parse_query("event.timestamp:2016-01-01")
         assert result["date_from"] == date_value
         assert result["date_from_inclusive"]
@@ -581,7 +581,7 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
         assert not result["date_to_inclusive"]
 
     def test_date_approx_precise(self):
-        date_value = datetime(2016, 1, 1, tzinfo=timezone.utc)
+        date_value = datetime(2016, 1, 1, tzinfo=UTC)
         result = self.parse_query("event.timestamp:2016-01-01T00:00:00")
         assert result["date_from"] == date_value - timedelta(minutes=5)
         assert result["date_from_inclusive"]
@@ -589,7 +589,7 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
         assert not result["date_to_inclusive"]
 
     def test_date_approx_precise_with_timezone(self):
-        date_value = datetime(2016, 1, 1, 5, 0, 0, tzinfo=timezone.utc)
+        date_value = datetime(2016, 1, 1, 5, 0, 0, tzinfo=UTC)
         result = self.parse_query("event.timestamp:2016-01-01T00:00:00-05:00")
         assert result["date_from"] == date_value - timedelta(minutes=5)
         assert result["date_from_inclusive"]
@@ -598,10 +598,10 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
 
     def test_last_seen_range(self):
         result = self.parse_query("lastSeen:-24h lastSeen:+12h")
-        assert result["last_seen_from"] > django_timezone.now() - timedelta(hours=25)
-        assert result["last_seen_from"] < django_timezone.now() - timedelta(hours=23)
-        assert result["last_seen_to"] > django_timezone.now() - timedelta(hours=13)
-        assert result["last_seen_to"] < django_timezone.now() - timedelta(hours=11)
+        assert result["last_seen_from"] > timezone.now() - timedelta(hours=25)
+        assert result["last_seen_from"] < timezone.now() - timedelta(hours=23)
+        assert result["last_seen_to"] > timezone.now() - timedelta(hours=13)
+        assert result["last_seen_to"] < timezone.now() - timedelta(hours=11)
 
     def test_has_tag(self):
         result = self.parse_query("has:foo")
@@ -737,7 +737,7 @@ class GetLatestReleaseTest(TestCase):
 
         ReleaseProjectEnvironment.objects.filter(
             release__in=[new, other_project_env_release]
-        ).update(adopted=datetime.now())
+        ).update(adopted=timezone.now())
 
         assert get_latest_release([self.project, project_2], [environment], adopted=True) == [
             new.version,
@@ -766,7 +766,7 @@ class GetLatestReleaseTest(TestCase):
             get_latest_release([project_2, self.project], [self.environment, env_2], adopted=True)
 
         ReleaseProjectEnvironment.objects.filter(release__in=[release_3, release_1]).update(
-            adopted=datetime.now()
+            adopted=timezone.now()
         )
         assert get_latest_release(
             [project_2, self.project], [self.environment, env_2], adopted=True
@@ -779,7 +779,7 @@ class GetLatestReleaseTest(TestCase):
         ]
         # Make sure unadopted releases are ignored
         ReleaseProjectEnvironment.objects.filter(release__in=[release_3]).update(
-            unadopted=datetime.now()
+            unadopted=timezone.now()
         )
         assert get_latest_release(
             [project_2, self.project], [self.environment, env_2], adopted=True
@@ -787,7 +787,7 @@ class GetLatestReleaseTest(TestCase):
             release_1.version,
         ]
 
-        ReleaseProject.objects.filter(release__in=[release_1]).update(adopted=datetime.now())
+        ReleaseProject.objects.filter(release__in=[release_1]).update(adopted=timezone.now())
         assert get_latest_release([project_2, self.project], None, adopted=True) == [
             release_1.version,
         ]

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_token_creator.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_token_creator.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
@@ -71,7 +71,7 @@ class TestCreatorExternal(TestCreatorBase):
         ).run(user=self.user, request=None)
 
     def test_create_token(self):
-        today = date.today()
+        today = datetime.now(UTC)
         api_token = SentryAppInstallationTokenCreator(
             sentry_app_installation=self.sentry_app_installation, expires_at=today
         ).run(user=self.user, request=None)

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -107,7 +107,7 @@ class GithubCommentTestCase(IntegrationTestCase):
 
     def add_pr_to_commit(self, commit: Commit, date_added=None):
         if date_added is None:
-            date_added = iso_format(before_now(minutes=1))
+            date_added = before_now(minutes=1)
         pr = PullRequest.objects.create(
             organization_id=commit.organization_id,
             repository_id=commit.repository_id,

--- a/tests/sentry/tasks/test_app_store_connect.py
+++ b/tests/sentry/tasks/test_app_store_connect.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from django.utils import timezone
@@ -171,7 +171,7 @@ class TestUpdateDsyms:
 
     @django_db_all
     def test_get_persisted_build(self, default_project, config, build):
-        seen = datetime(2020, 2, 20)
+        seen = datetime(2020, 2, 20, tzinfo=UTC)
 
         AppConnectBuild.objects.create(
             project=default_project,
@@ -198,7 +198,7 @@ class TestUpdateDsyms:
 
     @django_db_all
     def test_get_persisted_build_preserves_existing_fetched(self, default_project, config, build):
-        seen = datetime(2020, 2, 20)
+        seen = datetime(2020, 2, 20, tzinfo=UTC)
 
         AppConnectBuild.objects.create(
             project=default_project,

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -1,6 +1,6 @@
 import io
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from hashlib import sha1
 from unittest import mock
 from unittest.mock import patch
@@ -397,9 +397,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
 
         # Since we are uploading the same bundle 3 times, we expect that all of them will result with the same
         # `date_added` or the last upload.
-        expected_updated_date = datetime.fromisoformat("2023-05-31T12:00:00").replace(
-            tzinfo=timezone.utc
-        )
+        expected_updated_date = datetime.fromisoformat("2023-05-31T12:00:00+00:00")
 
         artifact_bundles = ArtifactBundle.objects.filter(bundle_id=bundle_id)
         assert len(artifact_bundles) == 1
@@ -927,7 +925,7 @@ class ArtifactBundleIndexingTest(TestCase):
             dist=dist,
             bundle_id="2c5b367b-4fef-4db8-849d-b9e79607d630",
             indexing_state=ArtifactBundleIndexingState.NOT_INDEXED.value,
-            date=datetime.now() - timedelta(hours=1),
+            date=datetime.now(UTC) - timedelta(hours=1),
         )
 
         with ArtifactBundlePostAssembler(
@@ -957,7 +955,7 @@ class ArtifactBundleIndexingTest(TestCase):
             dist=dist,
             bundle_id="2c5b367b-4fef-4db8-849d-b9e79607d630",
             indexing_state=ArtifactBundleIndexingState.NOT_INDEXED.value,
-            date=datetime.now() - timedelta(hours=2),
+            date=datetime.now(UTC) - timedelta(hours=2),
         )
 
         self._create_bundle_and_bind_to_release(
@@ -965,7 +963,7 @@ class ArtifactBundleIndexingTest(TestCase):
             dist=dist,
             bundle_id="0cf678f2-0771-4e2f-8ace-d6cea8493f0c",
             indexing_state=ArtifactBundleIndexingState.NOT_INDEXED.value,
-            date=datetime.now() - timedelta(hours=1),
+            date=datetime.now(UTC) - timedelta(hours=1),
         )
 
         artifact_bundle_3 = self._create_bundle_and_bind_to_release(
@@ -973,7 +971,7 @@ class ArtifactBundleIndexingTest(TestCase):
             dist=dist,
             bundle_id="0cf678f2-0771-4e2f-8ace-d6cea8493f0d",
             indexing_state=ArtifactBundleIndexingState.NOT_INDEXED.value,
-            date=datetime.now() - timedelta(hours=1),
+            date=datetime.now(UTC) - timedelta(hours=1),
         )
 
         with ArtifactBundlePostAssembler(
@@ -1004,7 +1002,7 @@ class ArtifactBundleIndexingTest(TestCase):
             dist=dist,
             bundle_id="2c5b367b-4fef-4db8-849d-b9e79607d630",
             indexing_state=ArtifactBundleIndexingState.WAS_INDEXED.value,
-            date=datetime.now() - timedelta(hours=2),
+            date=datetime.now(UTC) - timedelta(hours=2),
         )
 
         self._create_bundle_and_bind_to_release(
@@ -1012,7 +1010,7 @@ class ArtifactBundleIndexingTest(TestCase):
             dist=dist,
             bundle_id="0cf678f2-0771-4e2f-8ace-d6cea8493f0d",
             indexing_state=ArtifactBundleIndexingState.WAS_INDEXED.value,
-            date=datetime.now() - timedelta(hours=1),
+            date=datetime.now(UTC) - timedelta(hours=1),
         )
 
         with ArtifactBundlePostAssembler(
@@ -1038,7 +1036,7 @@ class ArtifactBundleIndexingTest(TestCase):
             dist=dist,
             bundle_id="2c5b367b-4fef-4db8-849d-b9e79607d630",
             indexing_state=ArtifactBundleIndexingState.NOT_INDEXED.value,
-            date=datetime.now() - timedelta(hours=1),
+            date=datetime.now(UTC) - timedelta(hours=1),
         )
 
         self._create_bundle_and_bind_to_release(
@@ -1046,7 +1044,7 @@ class ArtifactBundleIndexingTest(TestCase):
             dist=dist,
             bundle_id="2c5b367b-4fef-4db8-849d-b9e79607d630",
             indexing_state=ArtifactBundleIndexingState.NOT_INDEXED.value,
-            date=datetime.now() - timedelta(hours=2),
+            date=datetime.now(UTC) - timedelta(hours=2),
         )
 
         self._create_bundle_and_bind_to_release(
@@ -1056,7 +1054,7 @@ class ArtifactBundleIndexingTest(TestCase):
             indexing_state=ArtifactBundleIndexingState.NOT_INDEXED.value,
             # We simulate that this bundle is into the database but was created after the assembling of bundle 1 started
             # its progress but did not finish.
-            date=datetime.now() + timedelta(hours=1),
+            date=datetime.now(UTC) + timedelta(hours=1),
         )
 
         with ArtifactBundlePostAssembler(

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -805,15 +805,15 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             message="foo",
             title="bar",
             merge_commit_sha=self.commit.key,
-            date_added=iso_format(before_now(days=1)),
+            date_added=before_now(days=1),
         )
         self.repo.provider = "integrations:github"
         self.repo.save()
         self.pull_request_comment = PullRequestComment.objects.create(
             pull_request=self.pull_request,
             external_id=1,
-            created_at=iso_format(before_now(days=1)),
-            updated_at=iso_format(before_now(days=1)),
+            created_at=before_now(days=1),
+            updated_at=before_now(days=1),
             group_ids=[],
         )
         self.blame = FileBlameInfo(
@@ -979,7 +979,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
     def test_gh_comment_pr_too_old(self, get_jwt, mock_comment_workflow, mock_get_commit_context):
         """No comment on pr that's older than PR_COMMENT_WINDOW"""
         mock_get_commit_context.return_value = [self.blame]
-        self.pull_request.date_added = iso_format(before_now(days=PR_COMMENT_WINDOW + 1))
+        self.pull_request.date_added = before_now(days=PR_COMMENT_WINDOW + 1)
         self.pull_request.save()
 
         self.add_responses()
@@ -1175,8 +1175,8 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
         PullRequestComment.objects.create(
             external_id=1,
             pull_request=self.pull_request,
-            created_at=iso_format(before_now(days=1)),
-            updated_at=iso_format(before_now(days=1)),
+            created_at=before_now(days=1),
+            updated_at=before_now(days=1),
             group_ids=[],
             comment_type=CommentType.OPEN_PR,
         )

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -161,7 +161,7 @@ class OAuthTokenCodeTest(TestCase):
             user=self.user,
             application=self.application,
             redirect_uri="https://example.com",
-            expires_at="2022-01-01 11:11",
+            expires_at="2022-01-01 11:11+00:00",
         )
         resp = self.client.post(
             self.path,


### PR DESCRIPTION
this is currently a warning but will likely be an error in the future

```
.venv/lib/python3.11/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1476: in filter
    return self._filter_or_exclude(False, args, kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1494: in _filter_or_exclude
    clone._filter_or_exclude_inplace(negate, args, kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1501: in _filter_or_exclude_inplace
    self._query.add_q(Q(*args, **kwargs))
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1613: in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1645: in _add_q
    child_clause, needed_inner = self.build_filter(
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1559: in build_filter
    condition = self.build_lookup(lookups, col, value)
.venv/lib/python3.11/site-packages/django/db/models/sql/query.py:1389: in build_lookup
    lookup = lookup_class(lhs, rhs)
.venv/lib/python3.11/site-packages/django/db/models/lookups.py:30: in __init__
    self.rhs = self.get_prep_lookup()
.venv/lib/python3.11/site-packages/django/db/models/lookups.py:88: in get_prep_lookup
    return self.lhs.output_field.get_prep_value(self.rhs)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1659: in get_prep_value
    warnings.warn(
E   RuntimeWarning: DateTimeField UserIP.last_seen received a naive datetime (2023-07-01 00:00:00) while time zone support is active.
```

<!-- Describe your PR here. -->