### PR TITLE
ref: use aware datetime.min for org_auth_tokens lookup

### DIFF
--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.core.exceptions import ValidationError
 from django.db.models import Value
@@ -49,7 +49,7 @@ class OrgAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
         organization: RpcOrganization,
     ) -> Response:
         # We want to sort by date_last_used, but sort NULLs last
-        the_past = datetime.min
+        the_past = datetime.min.replace(tzinfo=UTC)
 
         token_list = list(
             OrgAuthToken.objects.filter(


### PR DESCRIPTION
fixes this warning:

```console
$ pytest -W 'error::RuntimeWarning' --maxfail 1 -q tests/sentry/api/endpoints/test_org_auth_tokens.py
F
================================================== FAILURES ===================================================
___________________________________ OrgAuthTokensListTest.test_never_cache ____________________________________
tests/sentry/api/endpoints/test_org_auth_tokens.py:92: in test_never_cache
    response = self.get_success_response(self.organization.slug, status_code=status.HTTP_200_OK)
src/sentry/testutils/cases.py:734: in get_success_response
    assert_status_code(response, status_code)
src/sentry/testutils/asserts.py:42: in assert_status_code
    assert minimum <= response.status_code < maximum, (
E   AssertionError: (500, b'{"detail":"Internal Error","errorId":null}')
E   assert 500 < 201
E    +  where 500 = <Response status_code=500, "application/json">.status_code
-------------------------------------------- Captured stdout call ---------------------------------------------
18:39:20 [ERROR] django.request: Internal Server Error: /api/0/organizations/baz/org-auth-tokens/ (status_code=500 request=<WSGIRequest: GET '/api/0/organizations/baz/org-auth-tokens/'>)
-------------------------------------------- Captured stderr call ---------------------------------------------
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/src/sentry/api/base.py", line 273, in handle_exception
    response = super().handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/Users/asottile/workspace/sentry/src/sentry/api/base.py", line 399, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/utils/decorators.py", line 48, in _wrapper
    return bound_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/views/decorators/cache.py", line 80, in _view_wrapper
    response = view_func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/src/sentry/api/endpoints/org_auth_tokens.py", line 54, in get
    token_list = list(
                 ^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 400, in __iter__
    self._fetch_all()
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 1928, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 91, in __iter__
    results = compiler.execute_sql(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1549, in execute_sql
    sql, params = self.as_sql()
                  ^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 736, in as_sql
    extra_select, order_by, group_by = self.pre_sql_setup(
                                       ^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 84, in pre_sql_setup
    self.setup_query(with_col_aliases=with_col_aliases)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 73, in setup_query
    self.select, self.klass_info, self.annotation_col_map = self.get_select(
                                                            ^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 296, in get_select
    sql, params = self.compile(col)
                  ^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 546, in compile
    sql, params = node.as_sql(self, self.connection)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/expressions.py", line 994, in as_sql
    arg_sql, arg_params = compiler.compile(arg)
                          ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 546, in compile
    sql, params = node.as_sql(self, self.connection)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/expressions.py", line 1062, in as_sql
    val = output_field.get_db_prep_value(val, connection=connection)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py", line 1671, in get_db_prep_value
    value = self.get_prep_value(value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py", line 1659, in get_prep_value
    warnings.warn(
RuntimeWarning: DateTimeField (unbound) received a naive datetime (0001-01-01 00:00:00) while time zone support is active.
=========================================== short test summary info ===========================================
FAILED tests/sentry/api/endpoints/test_org_auth_tokens.py::OrgAuthTokensListTest::test_never_cache - AssertionError: (500, b'{"detail":"Internal Error","errorId":null}')
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
1 failed in 4.86s
```

<!-- Describe your PR here. -->