### PR TITLE
ref: use aware datetimes in api endpoints

### DIFF
--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -89,7 +89,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
             defaults={
                 "owner_id": request.user.id,
                 "until": data.get("until"),
-                "date_added": datetime.datetime.now(),
+                "date_added": datetime.datetime.now(datetime.UTC),
             },
             **kwargs,
         )

--- a/src/sentry/api/endpoints/team_groups_old.py
+++ b/src/sentry/api/endpoints/team_groups_old.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from django.db.models import Q
 from rest_framework.request import Request
@@ -35,7 +35,7 @@ class TeamGroupsOldEndpoint(TeamEndpoint, EnvironmentMixin):
             .filter(
                 group_environment_filter,
                 status=GroupStatus.UNRESOLVED,
-                last_seen__gt=datetime.now() - timedelta(days=90),
+                last_seen__gt=datetime.now(UTC) - timedelta(days=90),
             )
             .order_by("first_seen")[:limit]
         )

--- a/src/sentry/api/endpoints/team_unresolved_issue_age.py
+++ b/src/sentry/api/endpoints/team_unresolved_issue_age.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from django.db.models import Case, Count, Q, TextField, Value, When
 from django.utils import timezone
@@ -52,7 +52,7 @@ class TeamUnresolvedIssueAgeEndpoint(TeamEndpoint, EnvironmentMixin):
             .filter(
                 group_environment_filter,
                 status=GroupStatus.UNRESOLVED,
-                last_seen__gt=datetime.now() - timedelta(days=90),
+                last_seen__gt=datetime.now(UTC) - timedelta(days=90),
             )
             .annotate(
                 bucket=Case(


### PR DESCRIPTION
this fixes some warnings related to timezones which will eventually be errors

for example:

```console
$ pytest -W 'error::RuntimeWarning' --maxfail 1 -q tests/sentry/api/endpoints/test_rule_snooze.py 
F
================================================== FAILURES ===================================================
________________________________ PostRuleSnoozeTest.test_edit_issue_alert_mute ________________________________
tests/sentry/api/endpoints/test_rule_snooze.py:184: in test_edit_issue_alert_mute
    assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
E   AssertionError: assert False
E    +  where False = <bound method QuerySet.exists of <BaseQuerySet []>>()
E    +    where <bound method QuerySet.exists of <BaseQuerySet []>> = <BaseQuerySet []>.exists
E    +      where <BaseQuerySet []> = <bound method QuerySet.filter of <sentry.db.models.manager.base.RuleSnoozeManager object at 0x10bf0b710>>(rule=2)
E    +        where <bound method QuerySet.filter of <sentry.db.models.manager.base.RuleSnoozeManager object at 0x10bf0b710>> = <sentry.db.models.manager.base.RuleSnoozeManager object at 0x10bf0b710>.filter
E    +          where <sentry.db.models.manager.base.RuleSnoozeManager object at 0x10bf0b710> = RuleSnooze.objects
E    +        and   2 = <Rule at 0x138e9bb50: id=2, project_id=4553568299319298, label='test rule'>.id
E    +          where <Rule at 0x138e9bb50: id=2, project_id=4553568299319298, label='test rule'> = <sentry.testutils.silo.PostRuleSnoozeTest testMethod=test_edit_issue_alert_mute>.issue_alert_rule
-------------------------------------------- Captured stdout call ---------------------------------------------
18:50:26 [ERROR] django.request: Internal Server Error: /api/0/projects/baz/bar/rules/2/snooze/ (status_code=500 request=<WSGIRequest: POST '/api/0/projects/baz/bar/rules/2/snooze/'>)
-------------------------------------------- Captured stderr call ---------------------------------------------
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 948, in get_or_create
    return self.get(**kwargs), False
           ^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 649, in get
    raise self.model.DoesNotExist(
sentry.models.rulesnooze.RuleSnooze.DoesNotExist: RuleSnooze matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/src/sentry/api/base.py", line 273, in handle_exception
    response = super().handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/Users/asottile/workspace/sentry/src/sentry/api/base.py", line 399, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/src/sentry/api/endpoints/rule_snooze.py", line 87, in post
    rule_snooze, created = RuleSnooze.objects.get_or_create(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/src/sentry/silo/base.py", line 146, in override
    return original_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/src/sentry/silo/base.py", line 146, in override
    return original_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 955, in get_or_create
    return self.create(**params), True
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/src/sentry/silo/base.py", line 146, in override
    return original_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 679, in create
    obj.save(force_insert=True, using=self.db)
  File "/Users/asottile/workspace/sentry/src/sentry/silo/base.py", line 146, in override
    return original_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/base.py", line 822, in save
    self.save_base(
  File "/Users/asottile/workspace/sentry/src/sentry/silo/base.py", line 146, in override
    return original_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/base.py", line 909, in save_base
    updated = self._save_table(
              ^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/base.py", line 1067, in _save_table
    results = self._do_insert(
              ^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/base.py", line 1108, in _do_insert
    return manager._insert(
           ^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 1847, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1822, in execute_sql
    for sql, params in self.as_sql():
                       ^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1745, in as_sql
    value_rows = [
                 ^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1746, in <listcomp>
    [
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1747, in <listcomp>
    self.prepare_value(field, self.pre_save_val(field, obj))
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1686, in prepare_value
    return field.get_db_prep_save(value, connection=self.connection)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py", line 1013, in get_db_prep_save
    return self.get_db_prep_value(value, connection=connection, prepared=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py", line 1671, in get_db_prep_value
    value = self.get_prep_value(value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py", line 1659, in get_prep_value
    warnings.warn(
RuntimeWarning: DateTimeField RuleSnooze.date_added received a naive datetime (2024-02-27 18:50:26.148119) while time zone support is active.
=========================================== short test summary info ===========================================
FAILED tests/sentry/api/endpoints/test_rule_snooze.py::PostRuleSnoozeTest::test_edit_issue_alert_mute - AssertionError: assert False
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
1 failed in 4.77s
```

<!-- Describe your PR here. -->