### PR TITLE
ref(typing): fix all strong types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -629,9 +629,9 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = [
   "sentry.utils.redis",
-  "src.sentry.tasks.on_demand_metrics",
-  "src.sentry.relay.config.metric_extraction",
-  "src.sentry.snuba.metrics.extraction",
+  "sentry.tasks.on_demand_metrics",
+  "sentry.relay.config.metric_extraction",
+  "sentry.snuba.metrics.extraction",
   "tests.sentry.tasks.test_on_demand_metrics",
   "tests.sentry.relay.config.test_metric_extraction",
 ]

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -567,12 +567,12 @@ def _widget_query_stateful_extraction_enabled(widget_query: DashboardWidgetQuery
     return on_demand_entry.extraction_enabled()
 
 
-def _get_widget_cardinality_query_ttl():
+def _get_widget_cardinality_query_ttl() -> int:
     # Add ttl + 25% jitter to query so queries aren't all made at once.
     return int(random.uniform(_WIDGET_QUERY_CARDINALITY_TTL, _WIDGET_QUERY_CARDINALITY_TTL * 1.5))
 
 
-def _get_widget_cardinality_softdeadline_ttl():
+def _get_widget_cardinality_softdeadline_ttl() -> int:
     # This is a much shorter deadline than the main cardinality TTL in the case softdeadline is hit
     # We want to query again soon, but still avoid thundering herd problems.
     return int(
@@ -583,7 +583,7 @@ def _get_widget_cardinality_softdeadline_ttl():
     )
 
 
-def _is_widget_query_low_cardinality(widget_query: DashboardWidgetQuery, project: Project):
+def _is_widget_query_low_cardinality(widget_query: DashboardWidgetQuery, project: Project) -> bool:
     """
     Checks cardinality of existing widget queries before allowing the metric spec, so that
     group by clauses with high-cardinality tags are not added to the on_demand metric.
@@ -1438,7 +1438,7 @@ def _produce_histogram_outliers(query_results: Any) -> Sequence[MetricConditiona
     return rules
 
 
-def get_current_widget_specs(organization):
+def get_current_widget_specs(organization: Organization) -> set[str]:
     current_version = OnDemandMetricSpecVersioning.get_query_spec_version(organization.id)
     widget_specs = DashboardWidgetQueryOnDemand.objects.filter(
         spec_version=current_version.version,
@@ -1451,7 +1451,11 @@ def get_current_widget_specs(organization):
     return current_widget_specs
 
 
-def widget_exceeds_max_specs(new_specs, current_widget_specs, organization) -> bool:
+def widget_exceeds_max_specs(
+    new_specs: Sequence[tuple[str, MetricSpec, SpecVersion]],
+    current_widget_specs: set[str],
+    organization: Organization,
+) -> bool:
     current_version = OnDemandMetricSpecVersioning.get_query_spec_version(organization.id)
     new_widget_specs = {
         widget_hash for widget_hash, _, spec_version in new_specs if spec_version == current_version

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -6,7 +6,18 @@ import os
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Literal, NamedTuple, NotRequired, Optional, TypedDict, TypeVar, Union, cast
+from typing import (
+    Any,
+    Literal,
+    NamedTuple,
+    NotRequired,
+    Optional,
+    Self,
+    TypedDict,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import sentry_sdk
 from django.utils.functional import cached_property
@@ -565,22 +576,22 @@ class SupportedBy:
     on_demand_metrics: bool
 
     @classmethod
-    def neither(cls):
+    def neither(cls) -> Self:
         return cls(standard_metrics=False, on_demand_metrics=False)
 
     @classmethod
-    def both(cls):
+    def both(cls) -> Self:
         return cls(standard_metrics=True, on_demand_metrics=True)
 
     @classmethod
-    def combine(cls, *supported_by):
+    def combine(cls, *supported_by: Self) -> Self:
         return cls(
             standard_metrics=all(s.standard_metrics for s in supported_by),
             on_demand_metrics=all(s.on_demand_metrics for s in supported_by),
         )
 
 
-def should_use_on_demand_metrics_for_querying(organization: Organization, **kwargs) -> bool:
+def should_use_on_demand_metrics_for_querying(organization: Organization, **kwargs: Any) -> bool:
     """Helper function to check if an organization can query an specific on-demand function"""
     components = _extract_aggregate_components(kwargs["aggregate"])
     if components is None:
@@ -1196,7 +1207,7 @@ class OnDemandMetricSpec:
         self._arguments = []
         self._eager_process()
 
-    def _eager_process(self):
+    def _eager_process(self) -> None:
         op, metric_type, arguments = self._process_field()
 
         self.op = op
@@ -1204,7 +1215,7 @@ class OnDemandMetricSpec:
         self._arguments = arguments or []
 
     @property
-    def field_to_extract(self):
+    def field_to_extract(self) -> str | None:
         if self.op in ("on_demand_apdex", "on_demand_count_web_vitals"):
             return None
 
@@ -1278,7 +1289,7 @@ class OnDemandMetricSpec:
         # In case we have `None` condition, we will use `None` string for hashing, so it's a sentinel value.
         return str(_deep_sorted(self.condition))
 
-    def _groupbys_for_hash(self):
+    def _groupbys_for_hash(self) -> str:
         # A sorted list of group-bys for the hash, since groupbys will be unique per on_demand metric.
         return str(sorted(self.groupbys))
 

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -182,7 +182,7 @@ def schedule_on_demand_check() -> None:
     time_limit=120,
     expires=180,
 )
-def process_widget_specs(widget_query_ids: list[int], *args, **kwargs) -> None:
+def process_widget_specs(widget_query_ids: list[int], *args: object, **kwargs: object) -> None:
     """
     Child task spawned from :func:`schedule_on_demand_check`.
     """
@@ -277,7 +277,7 @@ def _set_widget_on_demand_state(
     specs: Sequence[HashedMetricSpec],
     is_low_cardinality: bool | None,
     enabled_features: set[str],
-):
+) -> None:
     specs_per_version: dict[int, list[HashedMetricSpec]] = {}
     for hash, spec, spec_version in specs:
         specs_per_version.setdefault(spec_version.version, [])
@@ -315,8 +315,8 @@ def set_or_create_on_demand_state(
     organization: Organization,
     is_low_cardinality: bool,
     feature_enabled: bool,
-    current_widget_specs,
-):
+    current_widget_specs: set[str],
+) -> None:
     specs = _get_widget_on_demand_specs(widget_query, organization)
 
     specs_per_version: dict[int, list[HashedMetricSpec]] = {}


### PR DESCRIPTION
The definitions for stronger types are wrong. It should not start with `src.` prefix.

Pinging @armenzg for visibility 

cc @getsentry/python-typing 