### PR TITLE
ref: use aware datetimes in monitors api endpoints

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import OrderedDict, defaultdict
 from collections.abc import MutableMapping
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from django.db.models import Count, DateTimeField, Func
 from django.db.models.functions import Extract
@@ -124,7 +124,7 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
         bucket = Func(
             timedelta(seconds=args["rollup"]),
             "date_added",
-            datetime.fromtimestamp(start),
+            datetime.fromtimestamp(start, UTC),
             function="date_bin",
             output_field=DateTimeField(),
         )

--- a/src/sentry/monitors/endpoints/organization_monitor_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_stats.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from django.db.models import Avg, Count, DateTimeField, Func
 from django.db.models.functions import Extract
@@ -68,7 +68,7 @@ class OrganizationMonitorStatsEndpoint(MonitorEndpoint, StatsMixin):
         bucket = Func(
             timedelta(seconds=args["rollup"]),
             "date_added",
-            datetime.fromtimestamp(end),
+            datetime.fromtimestamp(end, UTC),
             function="date_bin",
             output_field=DateTimeField(),
         )


### PR DESCRIPTION
this fixes some warnings related to timezones which will eventually be errors

for example:

```console
$ pytest -W 'error::RuntimeWarning' --maxfail 1 -q tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py 
F
================================================== FAILURES ===================================================
__________________________ OrganizationMonitorIndexStatsTest.test_custom_resolution ___________________________
tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py:134: in test_custom_resolution
    resp = self.get_success_response(
src/sentry/testutils/cases.py:736: in get_success_response
    assert_status_code(response, status.HTTP_200_OK)
src/sentry/testutils/asserts.py:42: in assert_status_code
    assert minimum <= response.status_code < maximum, (
E   AssertionError: (500, b'{"detail":"Internal Error","errorId":null}')
E   assert 500 < 201
E    +  where 500 = <Response status_code=500, "application/json">.status_code
-------------------------------------------- Captured stdout call ---------------------------------------------
07:57:00 [ERROR] django.request: Internal Server Error: /api/0/organizations/baz/monitors-stats/ (status_code=500 request=<WSGIRequest: GET '/api/0/organizations/baz/monitors-stats/?monitor=dfcd77ea1c44&since=1647849420.0&until=1647849540.0&resolution=1m'>)
-------------------------------------------- Captured stderr call ---------------------------------------------
Traceback (most recent call last):
  File "/Users/asottile/workspace/sentry/src/sentry/api/base.py", line 273, in handle_exception
    response = super().handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/Users/asottile/workspace/sentry/src/sentry/api/base.py", line 399, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/src/sentry/monitors/endpoints/organization_monitor_index_stats.py", line 181, in get
    list(history), key=lambda k: (monitor_map[k[0]], k[1])
    ^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 400, in __iter__
    self._fetch_all()
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 1928, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/query.py", line 244, in __iter__
    compiler.results_iter(
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1513, in results_iter
    results = self.execute_sql(
              ^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1549, in execute_sql
    sql, params = self.as_sql()
                  ^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 736, in as_sql
    extra_select, order_by, group_by = self.pre_sql_setup(
                                       ^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 84, in pre_sql_setup
    self.setup_query(with_col_aliases=with_col_aliases)
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 73, in setup_query
    self.select, self.klass_info, self.annotation_col_map = self.get_select(
                                                            ^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 296, in get_select
    sql, params = self.compile(col)
                  ^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 546, in compile
    sql, params = node.as_sql(self, self.connection)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/functions/datetime.py", line 54, in as_sql
    sql, params = compiler.compile(self.lhs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 546, in compile
    sql, params = node.as_sql(self, self.connection)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/expressions.py", line 994, in as_sql
    arg_sql, arg_params = compiler.compile(arg)
                          ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 546, in compile
    sql, params = node.as_sql(self, self.connection)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/expressions.py", line 1062, in as_sql
    val = output_field.get_db_prep_value(val, connection=connection)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py", line 1671, in get_db_prep_value
    value = self.get_prep_value(value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py", line 1659, in get_prep_value
    warnings.warn(
RuntimeWarning: DateTimeField (unbound) received a naive datetime (2022-03-21 07:57:00) while time zone support is active.
=========================================== short test summary info ===========================================
FAILED tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py::OrganizationMonitorIndexStatsTest::test_custom_resolution - AssertionError: (500, b'{"detail":"Internal Error","errorId":null}')
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
1 failed in 5.45s
```

<!-- Describe your PR here. -->