### PR TITLE
ref: use aware datetimes in tasks

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from django.db.models import Value
@@ -286,8 +286,8 @@ def get_top_5_issues_by_count_for_file(
 
     group_ids = list(
         Group.objects.filter(
-            first_seen__gte=datetime.now() - timedelta(days=90),
-            last_seen__gte=datetime.now() - timedelta(days=14),
+            first_seen__gte=datetime.now(UTC) - timedelta(days=90),
+            last_seen__gte=datetime.now(UTC) - timedelta(days=14),
             status=GroupStatus.UNRESOLVED,
             project__in=projects,
         )

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from string import Template
 from typing import Any
@@ -862,7 +862,7 @@ def validating_poll(uuid: str, build_id: str) -> None:
             if relocation_validation_attempt.date_added is not None
             else datetime.fromtimestamp(0)
         )
-        timeout_limit = datetime.now(tz=timezone.utc) - DEFAULT_VALIDATION_TIMEOUT
+        timeout_limit = datetime.now(UTC) - DEFAULT_VALIDATION_TIMEOUT
 
         if build.status == Build.Status.SUCCESS:
             next_task = NextTask(
@@ -1186,7 +1186,7 @@ def notifying_users(uuid: str) -> None:
             hash = lost_password_hash_service.get_or_create(user_id=user.id).hash
             LostPasswordHash.send_relocate_account_email(user, hash, relocation.want_org_slugs)
 
-        relocation.latest_unclaimed_emails_sent_at = datetime.now()
+        relocation.latest_unclaimed_emails_sent_at = datetime.now(UTC)
         relocation.save()
 
     notifying_owner.apply_async(args=[uuid])

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TypedDict
 
 from sentry_sdk.crons.decorator import monitor
@@ -67,7 +67,7 @@ def generate_forecasts_for_projects(project_ids: list[int]) -> None:
                 status=GroupStatus.IGNORED,
                 substatus=GroupSubStatus.UNTIL_ESCALATING,
                 project_id__in=project_ids,
-                last_seen__gte=datetime.now() - timedelta(days=7),
+                last_seen__gte=datetime.now(UTC) - timedelta(days=7),
             ).select_related(
                 "project", "project__organization"
             ),  # TODO: Remove this once the feature flag is removed


### PR DESCRIPTION
this fixes a warning which will eventually be an error


for example:

```console
$ pytest -W 'error::RuntimeWarning' --maxfail 1 -q tests/sentry/tasks/test_relocation.py 
......................................................F
================================================== FAILURES ===================================================
_______________________________________ NotifyingUsersTest.test_success _______________________________________
tests/sentry/tasks/test_relocation.py:1888: in test_success
    notifying_users(self.uuid)
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/celery/local.py:182: in __call__
    return self._get_current_object()(*a, **kw)
.venv/lib/python3.11/site-packages/celery/app/task.py:411: in __call__
    return self.run(*args, **kwargs)
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/celery/app/autoretry.py:60: in run
    ret = task.retry(exc=exc, **retry_kwargs)
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/celery/app/task.py:720: in retry
    raise_with_context(exc or Retry('Task can be retried', None))
.venv/lib/python3.11/site-packages/celery/app/autoretry.py:38: in run
    return task._orig_run(*args, **kwargs)
src/sentry/tasks/base.py:117: in _wrapped
    result = func(*args, **kwargs)
src/sentry/tasks/relocation.py:1190: in notifying_users
    relocation.save()
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/base.py:822: in save
    self.save_base(
src/sentry/silo/base.py:146: in override
    return original_method(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/base.py:909: in save_base
    updated = self._save_table(
.venv/lib/python3.11/site-packages/django/db/models/base.py:1036: in _save_table
    updated = self._do_update(
.venv/lib/python3.11/site-packages/django/db/models/base.py:1101: in _do_update
    return filtered._update(values) > 0
.venv/lib/python3.11/site-packages/django/db/models/query.py:1278: in _update
    return query.get_compiler(self.db).execute_sql(CURSOR)
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1990: in execute_sql
    cursor = super().execute_sql(result_type)
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1549: in execute_sql
    sql, params = self.as_sql()
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1953: in as_sql
    val = field.get_db_prep_save(val, connection=self.connection)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1013: in get_db_prep_save
    return self.get_db_prep_value(value, connection=connection, prepared=False)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1671: in get_db_prep_value
    value = self.get_prep_value(value)
.venv/lib/python3.11/site-packages/django/db/models/fields/__init__.py:1659: in get_prep_value
    warnings.warn(
E   RuntimeWarning: DateTimeField Relocation.latest_unclaimed_emails_sent_at received a naive datetime (2024-02-27 19:08:40.007639) while time zone support is active.
=========================================== short test summary info ===========================================
FAILED tests/sentry/tasks/test_relocation.py::NotifyingUsersTest::test_success - RuntimeWarning: DateTimeField Relocation.latest_unclaimed_emails_sent_at received a naive datetime (2024-0...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
1 failed, 54 passed in 28.82s
```

<!-- Describe your PR here. -->