### PR TITLE
fix: utilize created rather than releaseproject created

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -478,6 +478,7 @@ class OrganizationReleasesEndpoint(
 
                 # release creation is idempotent to simplify user
                 # experiences
+                created = False
                 try:
                     release, created = Release.objects.get_or_create(
                         organization_id=organization.id,
@@ -555,7 +556,7 @@ class OrganizationReleasesEndpoint(
                         scope.set_tag("failure_reason", "InvalidRepository")
                         return Response({"refs": [str(e)]}, status=400)
 
-                if not releaseproject_created and not new_releaseprojects:
+                if not created and not new_releaseprojects:
                     # This is the closest status code that makes sense, and we want
                     # a unique 2xx response code so people can understand when
                     # behavior differs.


### PR DESCRIPTION
addresses https://sentry.sentry.io/issues/5017563989/?notification_uuid=4ce99b56-569b-4058-9381-fdcb0e183e93&project=1&referrer=assigned_activity-slack