### PR TITLE
chore(slack): log bad request in integration proxy

### DIFF
--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -186,6 +186,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
 
         if not self._should_operate(request):
             if self.integration.provider == "slack":
+                self.log_extra["silo_mode"] = SiloMode.get_current_mode().value
                 logger.info(
                     "integration_proxy.slack.bad_request",
                     extra={

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -134,6 +134,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         """
         is_correct_silo = SiloMode.get_current_mode() == SiloMode.CONTROL
         if not is_correct_silo:
+            self.log_extra["silo_mode"] = SiloMode.get_current_mode()
             logger.info("integration_proxy.incorrect_silo_mode", extra=self.log_extra)
             return False
 

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -134,7 +134,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         """
         is_correct_silo = SiloMode.get_current_mode() == SiloMode.CONTROL
         if not is_correct_silo:
-            self.log_extra["silo_mode"] = SiloMode.get_current_mode()
+            self.log_extra["silo_mode"] = SiloMode.get_current_mode().value
             logger.info("integration_proxy.incorrect_silo_mode", extra=self.log_extra)
             return False
 

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -134,6 +134,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         """
         is_correct_silo = SiloMode.get_current_mode() == SiloMode.CONTROL
         if not is_correct_silo:
+            logger.info("integration_proxy.incorrect_silo_mode", extra=self.log_extra)
             return False
 
         is_valid_sender = self._validate_sender(request=request)
@@ -183,6 +184,14 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         self.log_extra["host"] = request.headers.get("Host")
 
         if not self._should_operate(request):
+            if self.integration.provider == "slack":
+                logger.info(
+                    "integration_proxy.slack.bad_request",
+                    extra={
+                        **self.log_extra,
+                        "integration_id": self.integration.id,
+                    },
+                )
             return HttpResponseBadRequest()
 
         metrics.incr("hybrid_cloud.integration_proxy.initialize", sample_rate=1.0)


### PR DESCRIPTION
We're seeing a lot of 400s come back when we try to hit a Slack API, but none of those look to be coming from Slack itself. Adding more logging to see if our theory is right about something in the proxy being the culprit.