### PR TITLE
ref: use start / end as datetimes instead of naive dates

### DIFF
--- a/src/sentry/api/endpoints/team_time_to_resolution.py
+++ b/src/sentry/api/endpoints/team_time_to_resolution.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from datetime import timedelta
 
@@ -14,6 +16,7 @@ from sentry.api.bases.team import TeamEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.api.utils import get_date_range_from_params
 from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
+from sentry.utils.dates import floor_to_utc_day
 
 
 @region_silo_endpoint
@@ -31,8 +34,8 @@ class TeamTimeToResolutionEndpoint(TeamEndpoint, EnvironmentMixin):
             return Response({"detail": "You do not have the insights feature enabled"}, status=400)
 
         start, end = get_date_range_from_params(request.GET)
-        end = end.date() + timedelta(days=1)
-        start = start.date() + timedelta(days=1)
+        end = floor_to_utc_day(end) + timedelta(days=1)
+        start = floor_to_utc_day(start) + timedelta(days=1)
         environments = [e.id for e in get_environments(request, team.organization)]
         grouphistory_environment_filter = (
             Q(group__groupenvironment__environment_id=environments[0]) if environments else Q()
@@ -62,8 +65,9 @@ class TeamTimeToResolutionEndpoint(TeamEndpoint, EnvironmentMixin):
             sums[key]["count"] += 1
 
         avgs = {}
-        current_day = start
-        while current_day < end:
+        current_day = start.date()
+        end_date = end.date()
+        while current_day < end_date:
             key = str(current_day)
             if key in sums:
                 avg = int((sums[key]["sum"] / sums[key]["count"]).total_seconds())

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -1,7 +1,7 @@
 import re
 import zoneinfo
 from collections.abc import Mapping
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any, overload
 
 from dateutil.parser import parse
@@ -11,7 +11,7 @@ from django.utils.timezone import is_aware, make_aware
 from sentry import quotas
 from sentry.constants import MAX_ROLLUP_POINTS
 
-epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+epoch = datetime(1970, 1, 1, tzinfo=UTC)
 
 # Factory is an obscure GMT alias
 AVAILABLE_TIMEZONES = frozenset(zoneinfo.available_timezones() - {"Factory"})
@@ -69,7 +69,7 @@ def floor_to_utc_day(value: datetime) -> datetime:
     """
     Floors a given datetime to UTC midnight.
     """
-    return value.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    return value.astimezone(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 def parse_date(datestr: str, timestr: str) -> datetime | None:
@@ -94,7 +94,7 @@ def parse_timestamp(value: Any) -> datetime | None:
     if isinstance(value, datetime):
         return value
     elif isinstance(value, (int, float)):
-        return datetime.fromtimestamp(value, timezone.utc)
+        return datetime.fromtimestamp(value, UTC)
     value = (value or "").rstrip("Z").encode("ascii", "replace").split(b".", 1)
     if not value:
         return None
@@ -107,7 +107,7 @@ def parse_timestamp(value: Any) -> datetime | None:
             rv = rv.replace(microsecond=int(value[1].ljust(6, b"0")[:6]))
         except ValueError:
             return None
-    return rv.replace(tzinfo=timezone.utc)
+    return rv.replace(tzinfo=UTC)
 
 
 def parse_stats_period(period: str) -> timedelta | None:
@@ -196,7 +196,7 @@ def outside_retention_with_modified_start(
 
     # Need to support timezone-aware and naive datetimes since
     # Snuba API only deals in naive UTC
-    now = datetime.now(timezone.utc) if start.tzinfo else datetime.utcnow()
+    now = datetime.now(UTC) if start.tzinfo else datetime.utcnow()
     start = max(start, now - timedelta(days=retention))
 
     return start > end, start


### PR DESCRIPTION
this fixes a django warning about missing timezone information which will become an error

<!-- Describe your PR here. -->