### PR TITLE
feat(crons): Make a project level `MonitorEnvironmentDetails` endpoint

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import abc
 import functools
 import logging
 import time
@@ -162,6 +163,21 @@ def apply_cors_headers(
             response["Access-Control-Allow-Credentials"] = "true"
 
     return response
+
+
+class BaseEndpointMixin(abc.ABC):
+    """
+    Inherit from this class when adding mixin classes that call `Endpoint` methods. This allows typing to
+    work correctly
+    """
+
+    @abc.abstractmethod
+    def create_audit_entry(self, request: Request, transaction_id=None, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def respond(self, context: object | None = None, **kwargs: Any) -> Response:
+        pass
 
 
 class Endpoint(APIView):

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -619,6 +619,9 @@ from .endpoints.userroles_index import UserRolesEndpoint
 
 __all__ = ("urlpatterns",)
 
+from ..monitors.endpoints.project_monitor_environment_details import (
+    ProjectMonitorEnvironmentDetailsEndpoint,
+)
 from ..monitors.endpoints.project_monitors_details import ProjectMonitorDetailsEndpoint
 
 # issues endpoints are available both top level (by numerical ID) as well as coupled
@@ -2672,6 +2675,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/monitors/(?P<monitor_slug>[^\/]+)/$",
         ProjectMonitorDetailsEndpoint.as_view(),
         name="sentry-api-0-project-monitor-details",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/monitors/(?P<monitor_slug>[^\/]+)/environments/(?P<environment>[^\/]+)$",
+        ProjectMonitorEnvironmentDetailsEndpoint.as_view(),
+        name="sentry-api-0-project-monitor-environment-details",
     ),
 ]
 

--- a/src/sentry/monitors/endpoints/monitor_details.py
+++ b/src/sentry/monitors/endpoints/monitor_details.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import abc
-from typing import Any
-
 from django.db import router, transaction
 from django.db.models import F
 from django.db.models.functions import TruncMinute
@@ -11,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log, quotas
+from sentry.api.base import BaseEndpointMixin
 from sentry.api.exceptions import ParameterValidationError
 from sentry.api.helpers.environments import get_environments
 from sentry.api.serializers import serialize
@@ -38,15 +36,7 @@ from sentry.utils.auth import AuthenticatedHttpRequest
 from sentry.utils.outcomes import Outcome
 
 
-class MonitorDetailsMixin(abc.ABC):
-    @abc.abstractmethod
-    def create_audit_entry(self, request: Request, transaction_id=None, **kwargs):
-        pass
-
-    @abc.abstractmethod
-    def respond(self, context: object | None = None, **kwargs: Any) -> Response:
-        pass
-
+class MonitorDetailsMixin(BaseEndpointMixin):
     def get_monitor(self, request: Request, project: Project, monitor: Monitor) -> Response:
         """
         Retrieves details for a monitor.

--- a/src/sentry/monitors/endpoints/monitor_environment_details.py
+++ b/src/sentry/monitors/endpoints/monitor_environment_details.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import audit_log
+from sentry.api.base import BaseEndpointMixin
+from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
+from sentry.models.scheduledeletion import RegionScheduledDeletion
+from sentry.monitors.models import MonitorEnvironment, MonitorStatus
+
+
+class MonitorEnvironmentDetailsMixin(BaseEndpointMixin):
+    def update_monitor_environment(
+        self, request: Request, project, monitor, monitor_environment
+    ) -> Response:
+        """
+        Update a monitor environment.
+        """
+        # Only support muting/unmuting monitor environments
+        is_muted = request.data.get("isMuted")
+        if type(is_muted) is bool:
+            monitor_environment.update(is_muted=is_muted)
+
+        self.create_audit_entry(
+            request=request,
+            organization=project.organization,
+            target_object=monitor_environment.id,
+            event=audit_log.get_event_id("MONITOR_ENVIRONMENT_EDIT"),
+            data=monitor_environment.get_audit_log_data(),
+        )
+
+        return self.respond(serialize(monitor, request.user))
+
+    def delete_monitor_environment(
+        self, request: Request, project, monitor, monitor_environment
+    ) -> Response:
+        """
+        Delete a monitor environment.
+        """
+        active_monitor_environment = (
+            MonitorEnvironment.objects.filter(id=monitor_environment.id)
+            .exclude(
+                monitor__status__in=[
+                    ObjectStatus.PENDING_DELETION,
+                    ObjectStatus.DELETION_IN_PROGRESS,
+                ]
+            )
+            .exclude(
+                status__in=[
+                    MonitorStatus.PENDING_DELETION,
+                    MonitorStatus.DELETION_IN_PROGRESS,
+                ]
+            )
+            .first()
+        )
+
+        if not active_monitor_environment or not active_monitor_environment.update(
+            status=MonitorStatus.PENDING_DELETION
+        ):
+            return self.respond(status=404)
+
+        schedule = RegionScheduledDeletion.schedule(
+            active_monitor_environment, days=0, actor=request.user
+        )
+        self.create_audit_entry(
+            request=request,
+            organization=project.organization,
+            target_object=active_monitor_environment.id,
+            event=audit_log.get_event_id("MONITOR_ENVIRONMENT_EDIT"),
+            data=active_monitor_environment.get_audit_log_data(),
+            transaction_id=schedule.guid,
+        )
+
+        return self.respond(status=202)

--- a/src/sentry/monitors/endpoints/project_monitor_environment_details.py
+++ b/src/sentry/monitors/endpoints/project_monitor_environment_details.py
@@ -15,15 +15,15 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams, MonitorParams
-from sentry.monitors.endpoints.base import MonitorEndpoint
+from sentry.monitors.endpoints.base import ProjectMonitorEnvironmentEndpoint
 from sentry.monitors.endpoints.monitor_environment_details import MonitorEnvironmentDetailsMixin
 from sentry.monitors.serializers import MonitorSerializer
 
 
 @region_silo_endpoint
 @extend_schema(tags=["Crons"])
-class OrganizationMonitorEnvironmentDetailsEndpoint(
-    MonitorEndpoint, MonitorEnvironmentDetailsMixin
+class ProjectMonitorEnvironmentDetailsEndpoint(
+    ProjectMonitorEnvironmentEndpoint, MonitorEnvironmentDetailsMixin
 ):
     publish_status = {
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
@@ -32,9 +32,10 @@ class OrganizationMonitorEnvironmentDetailsEndpoint(
     owner = ApiOwner.CRONS
 
     @extend_schema(
-        operation_id="Update a Monitor Environment",
+        operation_id="Update a Monitor Environment for a Project",
         parameters=[
             GlobalParams.ORG_SLUG,
+            GlobalParams.PROJECT_SLUG,
             MonitorParams.MONITOR_SLUG,
             MonitorParams.ENVIRONMENT,
         ],
@@ -46,18 +47,17 @@ class OrganizationMonitorEnvironmentDetailsEndpoint(
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def put(
-        self, request: Request, organization, project, monitor, monitor_environment
-    ) -> Response:
+    def put(self, request: Request, project, monitor, monitor_environment) -> Response:
         """
         Update a monitor environment.
         """
         return self.update_monitor_environment(request, project, monitor, monitor_environment)
 
     @extend_schema(
-        operation_id="Delete a Monitor Environments",
+        operation_id="Delete a Monitor Environment for a Project",
         parameters=[
             GlobalParams.ORG_SLUG,
+            GlobalParams.PROJECT_SLUG,
             MonitorParams.MONITOR_SLUG,
             MonitorParams.ENVIRONMENT,
         ],
@@ -68,7 +68,5 @@ class OrganizationMonitorEnvironmentDetailsEndpoint(
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def delete(
-        self, request: Request, organization, project, monitor, monitor_environment
-    ) -> Response:
+    def delete(self, request: Request, project, monitor, monitor_environment) -> Response:
         return self.delete_monitor_environment(request, project, monitor, monitor_environment)

--- a/tests/sentry/monitors/endpoints/test_base.py
+++ b/tests/sentry/monitors/endpoints/test_base.py
@@ -1,0 +1,10 @@
+from sentry.testutils.cases import APITestCase
+
+
+class BaseProjectMonitorDetailsTest(APITestCase):
+    __test__ = False
+
+    def get_response(self, *args, **params):
+        list_args = list(args)
+        list_args.insert(1, self.project.slug)
+        return super().get_response(*list_args, **params)

--- a/tests/sentry/monitors/endpoints/test_monitor_environment_details.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_environment_details.py
@@ -1,0 +1,101 @@
+from sentry.constants import ObjectStatus
+from sentry.models.scheduledeletion import RegionScheduledDeletion
+from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus
+from sentry.testutils.cases import MonitorTestCase
+from sentry.testutils.helpers.datetime import freeze_time
+
+
+@freeze_time()
+class BaseUpdateMonitorEnvironmentTest(MonitorTestCase):
+    __test__ = False
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def test_simple(self):
+        monitor = self._create_monitor(status=MonitorStatus.ACTIVE)
+        monitor_environment = self._create_monitor_environment(monitor)
+        # Test disable
+        resp = self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            monitor_environment.get_environment().name,
+            method="PUT",
+            **{"isMuted": True},
+        )
+        assert resp.data["slug"] == monitor.slug
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == ObjectStatus.ACTIVE
+
+        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
+        assert monitor_environment.is_muted is True
+
+        # Test activate
+        resp = self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            monitor_environment.get_environment().name,
+            method="PUT",
+            **{"isMuted": False},
+        )
+        assert resp.data["slug"] == monitor.slug
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == ObjectStatus.ACTIVE
+
+        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
+        assert monitor_environment.is_muted is False
+
+        # Test other status
+        resp = self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            monitor_environment.get_environment().name,
+            method="PUT",
+            **{"status": "error"},
+        )
+        assert resp.data["slug"] == monitor.slug
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == ObjectStatus.ACTIVE
+
+        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
+        assert monitor_environment.status == MonitorStatus.ACTIVE
+
+
+class BaseDeleteMonitorTest(MonitorTestCase):
+    __test__ = False
+
+    def setUp(self):
+        self.login_as(user=self.user)
+        super().setUp()
+
+    def test_simple(self):
+        monitor = self._create_monitor(status=MonitorStatus.ACTIVE)
+        monitor_environment = self._create_monitor_environment(monitor)
+        monitor_environment_2 = self._create_monitor_environment(monitor, name="second")
+
+        self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            monitor_environment.get_environment().name,
+            method="DELETE",
+            status_code=202,
+        )
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == ObjectStatus.ACTIVE
+
+        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
+        assert monitor_environment.status == MonitorStatus.PENDING_DELETION
+        assert RegionScheduledDeletion.objects.filter(
+            object_id=monitor_environment.id, model_name="MonitorEnvironment"
+        ).exists()
+
+        monitor_environment_2 = MonitorEnvironment.objects.get(id=monitor_environment_2.id)
+        assert monitor_environment_2.status == MonitorStatus.ACTIVE
+        assert not RegionScheduledDeletion.objects.filter(
+            object_id=monitor_environment_2.id, model_name="MonitorEnvironment"
+        ).exists()

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_environment_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_environment_details.py
@@ -1,104 +1,17 @@
-from sentry.constants import ObjectStatus
-from sentry.models.scheduledeletion import RegionScheduledDeletion
-from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus
-from sentry.testutils.cases import MonitorTestCase
-from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
+from tests.sentry.monitors.endpoints.test_monitor_environment_details import (
+    BaseDeleteMonitorTest,
+    BaseUpdateMonitorEnvironmentTest,
+)
 
 
 @region_silo_test
-@freeze_time()
-class UpdateMonitorEnvironmentTest(MonitorTestCase):
+class UpdateMonitorEnvironmentTest(BaseUpdateMonitorEnvironmentTest):
     endpoint = "sentry-api-0-organization-monitor-environment-details"
-
-    def setUp(self):
-        super().setUp()
-        self.login_as(user=self.user)
-
-    def test_simple(self):
-        monitor = self._create_monitor(status=MonitorStatus.ACTIVE)
-        monitor_environment = self._create_monitor_environment(monitor)
-        # Test disable
-        resp = self.get_success_response(
-            self.organization.slug,
-            monitor.slug,
-            monitor_environment.get_environment().name,
-            method="PUT",
-            **{"isMuted": True},
-        )
-        assert resp.data["slug"] == monitor.slug
-
-        monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == ObjectStatus.ACTIVE
-
-        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
-        assert monitor_environment.is_muted is True
-
-        # Test activate
-        resp = self.get_success_response(
-            self.organization.slug,
-            monitor.slug,
-            monitor_environment.get_environment().name,
-            method="PUT",
-            **{"isMuted": False},
-        )
-        assert resp.data["slug"] == monitor.slug
-
-        monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == ObjectStatus.ACTIVE
-
-        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
-        assert monitor_environment.is_muted is False
-
-        # Test other status
-        resp = self.get_success_response(
-            self.organization.slug,
-            monitor.slug,
-            monitor_environment.get_environment().name,
-            method="PUT",
-            **{"status": "error"},
-        )
-        assert resp.data["slug"] == monitor.slug
-
-        monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == ObjectStatus.ACTIVE
-
-        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
-        assert monitor_environment.status == MonitorStatus.ACTIVE
+    __test__ = True
 
 
 @region_silo_test()
-class DeleteMonitorTest(MonitorTestCase):
+class DeleteMonitorTest(BaseDeleteMonitorTest):
     endpoint = "sentry-api-0-organization-monitor-environment-details"
-
-    def setUp(self):
-        self.login_as(user=self.user)
-        super().setUp()
-
-    def test_simple(self):
-        monitor = self._create_monitor(status=MonitorStatus.ACTIVE)
-        monitor_environment = self._create_monitor_environment(monitor)
-        monitor_environment_2 = self._create_monitor_environment(monitor, name="second")
-
-        self.get_success_response(
-            self.organization.slug,
-            monitor.slug,
-            monitor_environment.get_environment().name,
-            method="DELETE",
-            status_code=202,
-        )
-
-        monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == ObjectStatus.ACTIVE
-
-        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
-        assert monitor_environment.status == MonitorStatus.PENDING_DELETION
-        assert RegionScheduledDeletion.objects.filter(
-            object_id=monitor_environment.id, model_name="MonitorEnvironment"
-        ).exists()
-
-        monitor_environment_2 = MonitorEnvironment.objects.get(id=monitor_environment_2.id)
-        assert monitor_environment_2.status == MonitorStatus.ACTIVE
-        assert not RegionScheduledDeletion.objects.filter(
-            object_id=monitor_environment_2.id, model_name="MonitorEnvironment"
-        ).exists()
+    __test__ = True

--- a/tests/sentry/monitors/endpoints/test_project_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_project_monitor_details.py
@@ -1,20 +1,11 @@
-from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
+from tests.sentry.monitors.endpoints.test_base import BaseProjectMonitorDetailsTest
 from tests.sentry.monitors.endpoints.test_monitor_details import (
     BaseDeleteMonitorTest,
     BaseMonitorDetailsTest,
     BaseUpdateMonitorTest,
 )
-
-
-class BaseProjectMonitorDetailsTest(APITestCase):
-    __test__ = False
-
-    def get_response(self, *args, **params):
-        list_args = list(args)
-        list_args.insert(1, self.project.slug)
-        return super().get_response(*list_args, **params)
 
 
 @region_silo_test

--- a/tests/sentry/monitors/endpoints/test_project_monitor_environment_details.py
+++ b/tests/sentry/monitors/endpoints/test_project_monitor_environment_details.py
@@ -1,0 +1,20 @@
+from sentry.testutils.silo import region_silo_test
+from tests.sentry.monitors.endpoints.test_base import BaseProjectMonitorDetailsTest
+from tests.sentry.monitors.endpoints.test_monitor_environment_details import (
+    BaseDeleteMonitorTest,
+    BaseUpdateMonitorEnvironmentTest,
+)
+
+
+@region_silo_test
+class ProjectUpdateMonitorEnvironmentTest(
+    BaseUpdateMonitorEnvironmentTest, BaseProjectMonitorDetailsTest
+):
+    endpoint = "sentry-api-0-project-monitor-environment-details"
+    __test__ = True
+
+
+@region_silo_test()
+class ProjectDeleteMonitorTest(BaseDeleteMonitorTest, BaseProjectMonitorDetailsTest):
+    endpoint = "sentry-api-0-project-monitor-environment-details"
+    __test__ = True


### PR DESCRIPTION
We want to make cron slugs unique per project instead of org. To support this, we need project level apis that the frontend can call.

Related to #65898
Depends on https://github.com/getsentry/sentry/pull/65900
