### PR TITLE
fix(app-start): Show both event sample tables even if no R2

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types';
+import {defined} from 'sentry/utils';
 import EventView, {fromSorts} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -24,10 +25,10 @@ const DEFAULT_SORT: Sort = {
 
 type Props = {
   cursorName: string;
-  release: string;
   sortKey: string;
   transaction: string;
   footerAlignedPagination?: boolean;
+  release?: string;
   showDeviceClassSelector?: boolean;
 };
 
@@ -92,10 +93,11 @@ export function EventSamples({
 
   const {data, isLoading, pageLinks} = useTableQuery({
     eventView,
-    enabled: true,
+    enabled: defined(release),
     limit: 4,
     cursor,
     referrer: 'api.starfish.mobile-startup-event-samples',
+    initialData: {data: []},
   });
 
   return (
@@ -103,7 +105,7 @@ export function EventSamples({
       cursorName={cursorName}
       eventIdKey="transaction.id"
       eventView={eventView}
-      isLoading={isLoading}
+      isLoading={defined(release) && isLoading}
       profileIdKey="profile_id"
       sortKey={sortKey}
       data={data}

--- a/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/samples.tsx
@@ -27,30 +27,26 @@ export function SamplesTables({transactionName}) {
       return (
         <EventSplitContainer>
           <ErrorBoundary mini>
-            {primaryRelease && (
-              <div>
-                <EventSamples
-                  cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
-                  sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
-                  release={primaryRelease}
-                  transaction={transactionName}
-                  footerAlignedPagination
-                />
-              </div>
-            )}
+            <div>
+              <EventSamples
+                cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
+                sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
+                release={primaryRelease}
+                transaction={transactionName}
+                footerAlignedPagination
+              />
+            </div>
           </ErrorBoundary>
           <ErrorBoundary mini>
-            {secondaryRelease && (
-              <div>
-                <EventSamples
-                  cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
-                  sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
-                  release={secondaryRelease}
-                  transaction={transactionName}
-                  footerAlignedPagination
-                />
-              </div>
-            )}
+            <div>
+              <EventSamples
+                cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
+                sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
+                release={secondaryRelease}
+                transaction={transactionName}
+                footerAlignedPagination
+              />
+            </div>
           </ErrorBoundary>
         </EventSplitContainer>
       );


### PR DESCRIPTION
When there isn't an R2, this would error out because the error boundary didn't receive a react node

Instead, show the table but make it show an empty state.

<img width="1487" alt="Screenshot 2024-02-27 at 3 18 12 PM" src="https://github.com/getsentry/sentry/assets/22846452/fb3c8293-4982-4fda-8691-9d5b33a9a7bb">
