### PR TITLE
chore: Add discard transaction feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1991,6 +1991,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "projects:span-metrics-extraction-ga-modules": False,
     "projects:span-metrics-extraction-all-modules": False,
     "projects:span-metrics-extraction-resource": False,
+    "projects:discard-transaction": False,
     # Enable suspect resolutions feature
     "projects:suspect-resolutions": False,
     # Controls whether or not the relocation endpoints can be used.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -310,6 +310,7 @@ default_manager.add("projects:span-metrics-extraction-ga-modules", ProjectFeatur
 default_manager.add("projects:span-metrics-extraction-resource", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:span-metrics-extraction", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:suspect-resolutions", ProjectFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("projects:discard-transaction", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 
 
 # Project plugin features

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -59,6 +59,7 @@ EXPOSABLE_FEATURES = [
     "organizations:custom-metrics",
     "organizations:metric-meta",
     "organizations:standalone-span-ingestion",
+    "projects:discard-transaction",
 ]
 
 EXTRACT_METRICS_VERSION = 1
@@ -432,9 +433,11 @@ def _get_project_config(
 
     if features.has("organizations:metrics-extraction", project.organization):
         config["sessionMetrics"] = {
-            "version": EXTRACT_ABNORMAL_MECHANISM_VERSION
-            if _should_extract_abnormal_mechanism(project)
-            else EXTRACT_METRICS_VERSION,
+            "version": (
+                EXTRACT_ABNORMAL_MECHANISM_VERSION
+                if _should_extract_abnormal_mechanism(project)
+                else EXTRACT_METRICS_VERSION
+            ),
             "drop": features.has(
                 "organizations:release-health-drop-sessions", project.organization
             ),


### PR DESCRIPTION
As we wait on SDKs to send us standalone spans, we can test the spans-only pipeline
by just not producing to the transactions kafka topic in relay for a project. This flag
will control which projects we stop writing transactions for in relay.

Related to https://github.com/getsentry/getsentry/pull/13062