### PR TITLE
fix(app-start): Increase chart padding to prevent legend overlap

### DIFF
--- a/static/app/views/starfish/views/appStartup/countChart.tsx
+++ b/static/app/views/starfish/views/appStartup/countChart.tsx
@@ -1,5 +1,6 @@
 import {getInterval} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {MultiSeriesEventsStats} from 'sentry/types';
 import type {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
@@ -134,7 +135,7 @@ export function CountChart({chartHeight}: Props) {
         grid={{
           left: '0',
           right: '0',
-          top: '8px',
+          top: space(2),
           bottom: '0',
         }}
         showLegend

--- a/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
@@ -4,6 +4,7 @@ import TransitionChart from 'sentry/components/charts/transitionChart';
 import {getInterval} from 'sentry/components/charts/utils';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {
   axisLabelFormatter,
   getDurationUnit,
@@ -168,7 +169,7 @@ function DeviceClassBreakdownBarChart({
             grid={{
               left: '0',
               right: '0',
-              top: '8px',
+              top: space(2),
               bottom: '0',
               containLabel: true,
             }}

--- a/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
@@ -1,5 +1,6 @@
 import {getInterval} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {MultiSeriesEventsStats} from 'sentry/types';
 import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
@@ -136,7 +137,7 @@ function StartDurationWidget({additionalFilters, chartHeight}: Props) {
         grid={{
           left: '0',
           right: '0',
-          top: '8px',
+          top: space(2),
           bottom: '0',
         }}
         showLegend


### PR DESCRIPTION
The legend can overlap the chart lines or bars. Increase the padding a bit to get more space.

Before:
![image](https://github.com/getsentry/sentry/assets/22846452/95a4cbb0-ad06-4548-a4dd-cb908f883c7d)

After:
<img width="1472" alt="Screenshot 2024-02-27 at 3 27 09 PM" src="https://github.com/getsentry/sentry/assets/22846452/1b9ab571-d294-434a-a9f5-2303856ed709">

It's a bit harder to tell, but if you try to hover, the tooltip will never appear when hovering the legend which means that the chart doesn't overlap there.