### PR TITLE
fix(feedback): allow baggage and sentry-trace headers on error embed CORS headers

### DIFF
--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -104,7 +104,9 @@ class ErrorPageEmbedView(View):
         response["Access-Control-Allow-Origin"] = request.META.get("HTTP_ORIGIN", "")
         response["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
         response["Access-Control-Max-Age"] = "1000"
-        response["Access-Control-Allow-Headers"] = "Content-Type, Authorization, X-Requested-With"
+        response[
+            "Access-Control-Allow-Headers"
+        ] = "Content-Type, Authorization, X-Requested-With, baggage, sentry-trace"
         response["Vary"] = "Accept"
         if content == "" and context:
             response["X-Sentry-Context"] = json_context


### PR DESCRIPTION
This is currently breaking crash report error page submissions on the Sentry site, as we attempt to send sentry-trace and baggage headers, which our CORS policy rejects. this PR adds these two headers to the acceptable headers.