### PR TITLE
fix(hybridcloud) Don't use integration proxy for bitbucket

### DIFF
--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -7,12 +7,11 @@ from urllib.parse import parse_qs, urlparse, urlsplit
 
 from requests import PreparedRequest
 
+from sentry.integrations.client import ApiClient
 from sentry.integrations.utils import get_query_hash
 from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
-from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.shared_integrations.client.base import BaseApiResponseX
-from sentry.shared_integrations.client.proxy import IntegrationProxyClient, infer_org_integration
 from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
 from sentry.utils.patch_set import patch_to_file_changes
@@ -47,7 +46,7 @@ class BitbucketAPIPath:
     source = "/2.0/repositories/{repo}/src/{sha}/{path}"
 
 
-class BitbucketApiClient(IntegrationProxyClient):
+class BitbucketApiClient(ApiClient):
     """
     The API Client for the Bitbucket Integration
 
@@ -56,25 +55,19 @@ class BitbucketApiClient(IntegrationProxyClient):
 
     integration_name = "bitbucket"
 
-    def __init__(self, integration: RpcIntegration, org_integration_id: int | None = None):
+    def __init__(self, integration: RpcIntegration):
         self.base_url = integration.metadata["base_url"]
         self.shared_secret = integration.metadata["shared_secret"]
         # subject is probably the clientKey
         self.subject = integration.external_id
 
-        if not org_integration_id:
-            org_integration_id = infer_org_integration(
-                integration_id=integration.id, ctx_logger=logger
-            )
         super().__init__(
             integration_id=integration.id,
-            org_integration_id=org_integration_id,
             verify_ssl=True,
             logging_context=None,
         )
 
-    @control_silo_function
-    def authorize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
+    def finalize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
         path = prepared_request.url[len(self.base_url) :]
         url_params = dict(parse_qs(urlsplit(path).query))
         path = path.split("?")[0]

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -87,11 +87,7 @@ class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, Re
     repo_search = True
 
     def get_client(self):
-        org_integration_id = self.org_integration.id if self.org_integration else None
-        return BitbucketApiClient(
-            integration=self.model,
-            org_integration_id=org_integration_id,
-        )
+        return BitbucketApiClient(integration=self.model)
 
     @property
     def username(self):


### PR DESCRIPTION
Bitbucket doesn't use refresh tokens. Using the integration proxy is only adding operational complexity at this time.