### PR TITLE
fix(slack): remove integration provider check from proxy logger

### DIFF
--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -188,9 +188,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             self.log_extra["silo_mode"] = SiloMode.get_current_mode().value
             logger.info(
                 "integration_proxy.bad_request",
-                extra={
-                    **self.log_extra,
-                },
+                extra=self.log_extra,
             )
             return HttpResponseBadRequest()
 

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -183,6 +183,14 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         self.log_extra["host"] = request.headers.get("Host")
 
         if not self._should_operate(request):
+            self.log_extra["silo_mode"] = SiloMode.get_current_mode().value
+            logger.info(
+                "integration_proxy.bad_request",
+                extra={
+                    **self.log_extra,
+                    "integration_id": self.integration.id,
+                },
+            )
             return HttpResponseBadRequest()
 
         metrics.incr("hybrid_cloud.integration_proxy.initialize", sample_rate=1.0)

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -134,6 +134,8 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         """
         is_correct_silo = SiloMode.get_current_mode() == SiloMode.CONTROL
         if not is_correct_silo:
+            self.log_extra["silo_mode"] = SiloMode.get_current_mode().value
+            logger.info("integration_proxy.incorrect_silo_mode", extra=self.log_extra)
             return False
 
         is_valid_sender = self._validate_sender(request=request)
@@ -188,7 +190,6 @@ class InternalIntegrationProxyEndpoint(Endpoint):
                 "integration_proxy.bad_request",
                 extra={
                     **self.log_extra,
-                    "integration_id": self.integration.id,
                 },
             )
             return HttpResponseBadRequest()


### PR DESCRIPTION
Fixes SENTRY-2S2H

Sometimes `self.integration` is not initialized.