### PR TITLE
ref(feedback): close sidebar upon page refresh

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
@@ -48,12 +48,7 @@ export function FeedbackOnboardingLayout({
 
     return {
       introduction: doc.introduction?.(docParams),
-      steps: [
-        ...doc.install(docParams),
-        ...doc.configure(docParams),
-        ...doc.verify(docParams),
-      ],
-      nextSteps: doc.nextSteps?.(docParams) || [],
+      steps: [...doc.install(docParams), ...doc.configure(docParams)],
     };
   }, [
     cdn,

--- a/static/app/components/feedback/feedbackSetupPanel.tsx
+++ b/static/app/components/feedback/feedbackSetupPanel.tsx
@@ -7,6 +7,7 @@ import {Button, LinkButton} from 'sentry/components/button';
 import {useFeedbackOnboardingSidebarPanel} from 'sentry/components/feedback/useFeedbackOnboarding';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
+import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -20,6 +21,7 @@ export default function FeedbackSetupPanel() {
     trackAnalytics('feedback.index-setup-viewed', {
       organization,
     });
+    SidebarPanelStore.hidePanel('feedback-sidequest');
   }, [organization]);
 
   return (

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -564,7 +564,10 @@ function Sidebar() {
           <FeedbackOnboardingSidebar
             currentPanel={activePanel}
             onShowPanel={() => togglePanel(SidebarPanelKey.FEEDBACK_ONBOARDING)}
-            hidePanel={hidePanel}
+            hidePanel={() => {
+              hidePanel();
+              window.location.hash = '';
+            }}
             {...sidebarItemProps}
           />
           <ReplaysOnboardingSidebar


### PR DESCRIPTION
- Close the sidebar when user refreshes the page
- Don't render the verify step or next steps (we don't need it)

https://github.com/getsentry/sentry/assets/56095982/844db4e0-c423-430a-80dc-bbf345959fbd

