### PR TITLE
feat: hash support for user auth token middleware

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -319,17 +319,10 @@ class UserAuthTokenAuthentication(StandardAuthentication):
             except ApiTokenReplica.DoesNotExist:
                 try:
                     # If we can't find it by hash, use the plaintext string
-                    api_token_replica = ApiTokenReplica.objects.get(token=token_str)
+                    return ApiTokenReplica.objects.get(token=token_str)
                 except ApiTokenReplica.DoesNotExist:
                     # If the token does not exist by plaintext either, it is not a valid token
                     raise AuthenticationFailed("Invalid token")
-                else:
-                    # If found by plaintext, update the ApiToken with the hashed value
-                    # which will replicate back to the region
-                    api_token = ApiToken.objects.get(token=token_str)
-                    api_token.hashed_token = hashed_token
-                    api_token.save(update_fields=["hashed_token"])
-                    return api_token_replica
         else:
             try:
                 # Try to find the token by its hashed value first

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -320,7 +320,7 @@ class UserAuthTokenAuthentication(StandardAuthentication):
                 # If we can't find it by hash, use the plaintext string
                 api_token = ApiToken.objects.get(token=token_str)
             except ApiToken.DoesNotExist:
-                # If the token does not exist by plaintext either, return None
+                # If the token does not exist by plaintext either, it is not a valid token
                 raise AuthenticationFailed("Invalid token")
             else:
                 # Update it with the hashed value if found by plaintext

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -366,12 +366,15 @@ class UserAuthTokenAuthentication(StandardAuthentication):
         application_is_inactive = False
 
         if not token:
-            at = token = self._find_or_update_token_by_hash(token_str)
 
             if SiloMode.get_current_mode() == SiloMode.REGION:
-                user = user_service.get_user(user_id=at.user_id)
-                application_is_inactive = not at.application_is_active
+                atr: ApiTokenReplica = self._find_or_update_token_by_hash(token_str)
+                token = atr
+                user = user_service.get_user(user_id=atr.user_id)
+                application_is_inactive = not atr.application_is_active
             else:
+                at: ApiToken = self._find_or_update_token_by_hash(token_str)
+                token = at
                 user = at.user
                 application_is_inactive = (
                     at.application is not None and not at.application.is_active

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -299,7 +299,7 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
 class UserAuthTokenAuthentication(StandardAuthentication):
     token_name = b"bearer"
 
-    def _find_or_update_token_by_hash(self, token_str: str) -> ApiToken:
+    def _find_or_update_token_by_hash(self, token_str: str) -> ApiToken | ApiTokenReplica:
         """
         Find token by hash or update token's hash value if only found via plaintext.
         1. Hash provided plaintext token.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -271,6 +271,12 @@ register(
     type=Bool,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "apitoken.save-hash-on-create",
+    default=True,
+    type=Bool,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "api.rate-limit.org-create",

--- a/src/sentry/services/hybrid_cloud/auth/model.py
+++ b/src/sentry/services/hybrid_cloud/auth/model.py
@@ -34,6 +34,7 @@ class RpcApiToken(RpcModel):
     application_id: int | None = None
     application_is_active: bool = False
     token: str = ""
+    hashed_token: str | None = None
     expires_at: datetime.datetime | None = None
     allowed_origins: list[str] = Field(default_factory=list)
     scope_list: list[str] = Field(default_factory=list)

--- a/src/sentry/services/hybrid_cloud/auth/serial.py
+++ b/src/sentry/services/hybrid_cloud/auth/serial.py
@@ -87,6 +87,7 @@ def serialize_api_token(at: ApiToken) -> RpcApiToken:
         organization_id=at.organization_id,
         application_is_active=at.application_id is None or at.application.is_active,
         token=at.token,
+        hashed_token=at.hashed_token,
         expires_at=at.expires_at,
         allowed_origins=list(at.get_allowed_origins()),
         scope_list=at.get_scopes(),

--- a/src/sentry/services/hybrid_cloud/replica/impl.py
+++ b/src/sentry/services/hybrid_cloud/replica/impl.py
@@ -160,6 +160,7 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
             organization=organization,
             application_is_active=api_token.application_is_active,
             token=api_token.token,
+            hashed_token=api_token.hashed_token,
             expires_at=api_token.expires_at,
             apitoken_id=api_token.id,
             scope_list=api_token.scope_list,

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -397,11 +397,6 @@ class TestRpcSignatureAuthentication(TestCase):
 
 @no_silo_test
 class TestAuthTokens(TestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.auth = UserAuthTokenAuthentication()
-
     def test_system_tokens(self):
         sys_token = SystemToken()
         auth_token = AuthenticatedToken.from_token(sys_token)

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -32,6 +32,7 @@ from sentry.services.hybrid_cloud.rpc import (
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, no_silo_test
 from sentry.types.token import AuthTokenType
@@ -353,6 +354,11 @@ class TestRpcSignatureAuthentication(TestCase):
 
 @no_silo_test
 class TestAuthTokens(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.auth = UserAuthTokenAuthentication()
+
     def test_system_tokens(self):
         sys_token = SystemToken()
         auth_token = AuthenticatedToken.from_token(sys_token)
@@ -389,6 +395,45 @@ class TestAuthTokens(TestCase):
             assert auth_token.allowed_origins == token.get_allowed_origins()
             assert auth_token.scopes == token.get_scopes()
             assert auth_token.audit_log_data == token.get_audit_log_data()
+
+    @override_options({"apitoken.save-hash-on-create": False})
+    def test_user_auth_token_hashed_with_option_off(self):
+        # see https://github.com/getsentry/sentry/pull/65941
+        # the UserAuthTokenAuthentication middleware was updated to hash tokens as
+        # they were used, this test verifies the hash
+        api_token = ApiToken.objects.create(user=self.user, token_type=AuthTokenType.USER)
+        expected_hash = hashlib.sha256(api_token.token.encode()).hexdigest()
+
+        # we haven't authenticated to the API endpoint yet, so this value should be empty
+        assert api_token.hashed_token is None
+
+        request = HttpRequest()
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {api_token.token}"
+
+        with outbox_runner():
+            with assume_test_silo_mode(SiloMode.REGION):
+                # make sure the token was replicated
+                api_token_replica = ApiTokenReplica.objects.get(apitoken_id=api_token.id)
+                assert api_token.token == api_token_replica.token
+                assert (
+                    api_token_replica.hashed_token is None
+                )  # we don't expect to have a hashed value yet
+
+                # trigger the authentication middleware, and thus the hashing backfill
+                result = self.auth.authenticate(request)
+                assert result is not None
+
+                # check for the expected hash value
+                # it should upsert the hashed_token to ApiToken
+                api_token.refresh_from_db()
+                assert api_token.hashed_token == expected_hash
+
+                # after updating ApiToken, ApiTokenReplica should also be updated
+                api_token_replica.refresh_from_db()
+                assert api_token_replica.hashed_token == expected_hash
+
+                # just for good measure
+                assert api_token.hashed_token == api_token_replica.hashed_token
 
     def test_api_keys(self):
         ak = self.create_api_key(organization=self.organization, scope_list=["projects:read"])

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -424,11 +424,10 @@ class TestAuthTokens(TestCase):
                 assert result is not None
 
                 # check for the expected hash value
-                # it should upsert the hashed_token to ApiToken
                 api_token.refresh_from_db()
                 assert api_token.hashed_token == expected_hash
 
-                # after updating ApiToken, ApiTokenReplica should also be updated
+                # ApiTokenReplica should also be updated
                 api_token_replica.refresh_from_db()
                 assert api_token_replica.hashed_token == expected_hash
 

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1,3 +1,4 @@
+import hashlib
 import uuid
 from datetime import UTC, datetime
 
@@ -30,8 +31,10 @@ from sentry.services.hybrid_cloud.rpc import (
 )
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, no_silo_test
+from sentry.types.token import AuthTokenType
 from sentry.utils.security.orgauthtoken_token import hash_token
 
 
@@ -201,6 +204,28 @@ class TestTokenAuthentication(TestCase):
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
+
+    @override_options({"apitoken.save-hash-on-create": False})
+    def test_token_hashed_with_option_off(self):
+        # see https://github.com/getsentry/sentry/pull/65941
+        # the UserAuthTokenAuthentication middleware was updated to hash tokens as
+        # they were used, this test verifies the hash
+        api_token = ApiToken.objects.create(user=self.user, token_type=AuthTokenType.USER)
+        expected_hash = hashlib.sha256(api_token.token.encode()).hexdigest()
+
+        # we haven't authenticated to the API endpoint yet, so this value should be empty
+        assert api_token.hashed_token is None
+
+        request = HttpRequest()
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {api_token.token}"
+
+        # trigger the authentication middleware, and thus the hashing
+        result = self.auth.authenticate(request)
+        assert result is not None
+
+        # check for the expected hash value
+        api_token.refresh_from_db()
+        assert api_token.hashed_token == expected_hash
 
 
 @django_db_all


### PR DESCRIPTION
- Update the `UserAuthTokenAuthentication` middleware to support hashed token values. As tokens are used, it will store the appropriate hash value.
- Introduce a temporary option, `apitoken.save-hash-on-create`. This will be used in the model logic and in pre and post backfill migration tests in the future.