### PR TITLE
feat(crons): Show project information in details area for crons

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -71,7 +71,7 @@ export function TimelineTableRow({
           {isDisabled && <Tag>{t('Disabled')}</Tag>}
         </DetailsHeadline>
         <ProjectScheduleDetails>
-          <Schedule>{scheduleAsText(monitor.config)}</Schedule>
+          <DetailsText>{scheduleAsText(monitor.config)}</DetailsText>
           <ProjectDetails>
             <ProjectBadge
               project={monitor.project}
@@ -79,7 +79,7 @@ export function TimelineTableRow({
               disableLink
               hideName
             />
-            <Schedule>{trimSlug(monitor.project.slug)}</Schedule>
+            <DetailsText>{trimSlug(monitor.project.slug)}</DetailsText>
           </ProjectDetails>
         </ProjectScheduleDetails>
       </DetailsLink>
@@ -249,7 +249,7 @@ const Name = styled('h3')`
   word-break: break-word;
 `;
 
-const Schedule = styled('small')`
+const DetailsText = styled('small')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Tag from 'sentry/components/tag';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis} from 'sentry/icons';
@@ -13,6 +14,7 @@ import {t, tct} from 'sentry/locale';
 import {fadeIn} from 'sentry/styles/animations';
 import {space} from 'sentry/styles/space';
 import type {ObjectStatus} from 'sentry/types';
+import {trimSlug} from 'sentry/utils/trimSlug';
 import useOrganization from 'sentry/utils/useOrganization';
 import {StatusToggleButton} from 'sentry/views/monitors/components/statusToggleButton';
 import type {Monitor} from 'sentry/views/monitors/types';
@@ -68,7 +70,18 @@ export function TimelineTableRow({
           <Name>{monitor.name}</Name>
           {isDisabled && <Tag>{t('Disabled')}</Tag>}
         </DetailsHeadline>
-        <Schedule>{scheduleAsText(monitor.config)}</Schedule>
+        <ProjectScheduleDetails>
+          <Schedule>{scheduleAsText(monitor.config)}</Schedule>
+          <ProjectDetails>
+            <ProjectBadge
+              project={monitor.project}
+              avatarSize={12}
+              disableLink
+              hideName
+            />
+            <Schedule>{trimSlug(monitor.project.slug)}</Schedule>
+          </ProjectDetails>
+        </ProjectScheduleDetails>
       </DetailsLink>
       <DetailsActions>
         {onToggleStatus && (
@@ -217,6 +230,17 @@ const DetailsHeadline = styled('div')`
 
   /* We always leave at least enough room for the status toggle button */
   grid-template-columns: 1fr minmax(30px, max-content);
+`;
+
+const ProjectScheduleDetails = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  flex-wrap: wrap;
+`;
+
+const ProjectDetails = styled('div')`
+  display: flex;
+  gap: ${space(0.5)};
 `;
 
 const Name = styled('h3')`


### PR DESCRIPTION
As we transition to a state where monitor slugs are unique to the project and not the org, we need to have project slug information in the crons listing page to differentiate duplicate cron slugs within an org.

<img width="1246" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/f31e4f75-cdc0-41d3-820e-a2928562fe73">

If the project + schedule text gets too long, then it wraps to the next line. We have a good amount of space in the details area so opted for wrapping vs. ellipsizing