### PR TITLE
feat(crons): Make a project level `MonitorCheckInAttachment` endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -620,6 +620,9 @@ from .endpoints.userroles_index import UserRolesEndpoint
 
 __all__ = ("urlpatterns",)
 
+from ..monitors.endpoints.project_monitor_checkin_attachment import (
+    ProjectMonitorCheckInAttachmentEndpoint,
+)
 from ..monitors.endpoints.project_monitor_checkin_index import ProjectMonitorCheckInIndexEndpoint
 from ..monitors.endpoints.project_monitor_environment_details import (
     ProjectMonitorEnvironmentDetailsEndpoint,
@@ -2678,6 +2681,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/statistical-detector/$",
         ProjectStatisticalDetectors.as_view(),
         name="sentry-api-0-project-statistical-detector",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/monitors/(?P<monitor_slug>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/attachment/$",
+        ProjectMonitorCheckInAttachmentEndpoint.as_view(),
+        name="sentry-api-0-project-monitor-check-in-attachment",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/monitors/(?P<monitor_slug>[^\/]+)/$",

--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -139,6 +139,31 @@ class ProjectMonitorEndpoint(ProjectEndpoint):
         return args, kwargs
 
 
+class ProjectMonitorCheckinEndpoint(ProjectMonitorEndpoint):
+    """
+    Base endpoint class for monitors which will look up a checkin
+    and convert it to a MonitorCheckin object.
+    """
+
+    def convert_args(
+        self,
+        request: Request,
+        checkin_id: str,
+        *args,
+        **kwargs,
+    ):
+        args, kwargs = super().convert_args(request, *args, **kwargs)
+        try:
+            kwargs["checkin"] = MonitorCheckIn.objects.get(
+                project_id=kwargs["project"].id,
+                guid=checkin_id,
+            )
+        except MonitorCheckIn.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        return args, kwargs
+
+
 class ProjectMonitorEnvironmentEndpoint(ProjectMonitorEndpoint):
     """
     Base endpoint class for monitor environment which will look up the monitor environment and

--- a/src/sentry/monitors/endpoints/base_monitor_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/base_monitor_checkin_attachment.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from django.http.response import FileResponse
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import BaseEndpointMixin
+from sentry.api.endpoints.event_attachment_details import EventAttachmentDetailsPermission
+from sentry.models.files.file import File
+
+from .base import ProjectMonitorPermission
+
+
+class MonitorCheckInAttachmentPermission(EventAttachmentDetailsPermission):
+    scope_map = ProjectMonitorPermission.scope_map
+
+    def has_object_permission(self, request: Request, view, project):
+        result = super().has_object_permission(request, view, project)
+
+        # Allow attachment uploads via DSN
+        if request.method == "POST":
+            return True
+
+        return result
+
+
+class BaseMonitorCheckInAttachmentEndpoint(BaseEndpointMixin):
+    def download(self, file_id):
+        file = File.objects.get(id=file_id)
+        fp = file.getfile()
+        response = FileResponse(
+            fp,
+            content_type=file.headers.get("Content-Type", "application/octet-stream"),
+        )
+        response["Content-Length"] = file.size
+        response["Content-Disposition"] = f"attachment; filename={file.name}"
+        return response
+
+    def get_monitor_checkin_attachment(
+        self, request: Request, project, monitor, checkin
+    ) -> Response:
+        if checkin.attachment_id:
+            return self.download(checkin.attachment_id)
+        else:
+            return Response({"detail": "Check-in has no attachment"}, status=404)

--- a/src/sentry/monitors/endpoints/project_monitor_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/project_monitor_checkin_attachment.py
@@ -7,7 +7,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 
-from .base import MonitorEndpoint
+from .base import ProjectMonitorCheckinEndpoint
 from .base_monitor_checkin_attachment import (
     BaseMonitorCheckInAttachmentEndpoint,
     MonitorCheckInAttachmentPermission,
@@ -15,15 +15,14 @@ from .base_monitor_checkin_attachment import (
 
 
 @region_silo_endpoint
-class OrganizationMonitorCheckInAttachmentEndpoint(
-    MonitorEndpoint, BaseMonitorCheckInAttachmentEndpoint
+class ProjectMonitorCheckInAttachmentEndpoint(
+    ProjectMonitorCheckinEndpoint, BaseMonitorCheckInAttachmentEndpoint
 ):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.CRONS
-
     permission_classes = (MonitorCheckInAttachmentPermission,)
 
-    def get(self, request: Request, organization, project, monitor, checkin) -> Response:
+    def get(self, request: Request, project, monitor, checkin) -> Response:
         return self.get_monitor_checkin_attachment(request, project, monitor, checkin)

--- a/tests/sentry/monitors/endpoints/test_base_monitor_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_checkin_attachment.py
@@ -1,0 +1,67 @@
+from django.core.files.base import ContentFile
+
+from sentry.models.files import File
+from sentry.monitors.models import CheckInStatus, MonitorCheckIn
+from sentry.testutils.cases import MonitorTestCase
+
+
+class BaseMonitorCheckInAttachmentEndpointTest(MonitorTestCase):
+    __test__ = False
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+    def test_download(self):
+        file = self.create_file(name="log.txt", type="checkin.attachment")
+        file.putfile(ContentFile(b"some data!"))
+
+        monitor = self._create_monitor()
+        monitor_environment = self._create_monitor_environment(monitor)
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            date_added=monitor.date_added,
+            status=CheckInStatus.IN_PROGRESS,
+            attachment_id=file.id,
+        )
+
+        resp = self.get_success_response(self.organization.slug, monitor.slug, checkin.guid)
+        assert resp.get("Content-Disposition") == "attachment; filename=log.txt"
+        assert b"".join(resp.streaming_content) == b"some data!"
+
+    def test_download_no_file(self):
+        monitor = self._create_monitor()
+        monitor_environment = self._create_monitor_environment(monitor)
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            date_added=monitor.date_added,
+            status=CheckInStatus.IN_PROGRESS,
+        )
+
+        resp = self.get_error_response(
+            self.organization.slug, monitor.slug, checkin.guid, status_code=404
+        )
+        assert resp.data["detail"] == "Check-in has no attachment"
+
+    def test_delete_cascade(self):
+        file = self.create_file(name="log.txt", type="checkin.attachment")
+        file.putfile(ContentFile(b"some data!"))
+
+        monitor = self._create_monitor()
+        monitor_environment = self._create_monitor_environment(monitor)
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            date_added=monitor.date_added,
+            status=CheckInStatus.IN_PROGRESS,
+            attachment_id=file.id,
+        )
+
+        checkin.delete()
+
+        assert not File.objects.filter(type="checkin.attachment").exists()

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_checkin_attachment.py
@@ -1,69 +1,10 @@
-from django.core.files.base import ContentFile
-
-from sentry.models.files import File
-from sentry.monitors.models import CheckInStatus, MonitorCheckIn
-from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.silo import region_silo_test
+from tests.sentry.monitors.endpoints.test_base_monitor_checkin_attachment import (
+    BaseMonitorCheckInAttachmentEndpointTest,
+)
 
 
 @region_silo_test
-class OrganizationMonitorCheckInAttachmentEndpointTest(MonitorTestCase):
+class OrganizationMonitorCheckInAttachmentEndpointTest(BaseMonitorCheckInAttachmentEndpointTest):
     endpoint = "sentry-api-0-organization-monitor-check-in-attachment"
-
-    def setUp(self):
-        super().setUp()
-        self.login_as(self.user)
-
-    def test_download(self):
-        file = self.create_file(name="log.txt", type="checkin.attachment")
-        file.putfile(ContentFile(b"some data!"))
-
-        monitor = self._create_monitor()
-        monitor_environment = self._create_monitor_environment(monitor)
-        checkin = MonitorCheckIn.objects.create(
-            monitor=monitor,
-            monitor_environment=monitor_environment,
-            project_id=self.project.id,
-            date_added=monitor.date_added,
-            status=CheckInStatus.IN_PROGRESS,
-            attachment_id=file.id,
-        )
-
-        resp = self.get_success_response(self.organization.slug, monitor.slug, checkin.guid)
-        assert resp.get("Content-Disposition") == "attachment; filename=log.txt"
-        assert b"".join(resp.streaming_content) == b"some data!"
-
-    def test_download_no_file(self):
-        monitor = self._create_monitor()
-        monitor_environment = self._create_monitor_environment(monitor)
-        checkin = MonitorCheckIn.objects.create(
-            monitor=monitor,
-            monitor_environment=monitor_environment,
-            project_id=self.project.id,
-            date_added=monitor.date_added,
-            status=CheckInStatus.IN_PROGRESS,
-        )
-
-        resp = self.get_error_response(
-            self.organization.slug, monitor.slug, checkin.guid, status_code=404
-        )
-        assert resp.data["detail"] == "Check-in has no attachment"
-
-    def test_delete_cascade(self):
-        file = self.create_file(name="log.txt", type="checkin.attachment")
-        file.putfile(ContentFile(b"some data!"))
-
-        monitor = self._create_monitor()
-        monitor_environment = self._create_monitor_environment(monitor)
-        checkin = MonitorCheckIn.objects.create(
-            monitor=monitor,
-            monitor_environment=monitor_environment,
-            project_id=self.project.id,
-            date_added=monitor.date_added,
-            status=CheckInStatus.IN_PROGRESS,
-            attachment_id=file.id,
-        )
-
-        checkin.delete()
-
-        assert not File.objects.filter(type="checkin.attachment").exists()
+    __test__ = True

--- a/tests/sentry/monitors/endpoints/test_project_monitor_checkin_attachment.py
+++ b/tests/sentry/monitors/endpoints/test_project_monitor_checkin_attachment.py
@@ -1,0 +1,13 @@
+from sentry.testutils.silo import region_silo_test
+from tests.sentry.monitors.endpoints.test_base import BaseProjectMonitorTest
+from tests.sentry.monitors.endpoints.test_base_monitor_checkin_attachment import (
+    BaseMonitorCheckInAttachmentEndpointTest,
+)
+
+
+@region_silo_test
+class OrganizationMonitorCheckInAttachmentEndpointTest(
+    BaseMonitorCheckInAttachmentEndpointTest, BaseProjectMonitorTest
+):
+    endpoint = "sentry-api-0-project-monitor-check-in-attachment"
+    __test__ = True


### PR DESCRIPTION
We want to make cron slugs unique per project instead of org. To support this, we need project level apis that the frontend can call.

Related to #65898
