### PR TITLE
test(ui): Fix act warnings in projects dashboard tests

### DIFF
--- a/static/app/actionCreators/projects.tsx
+++ b/static/app/actionCreators/projects.tsx
@@ -58,7 +58,7 @@ export function loadStats(api: Client, params: StatsParams) {
 
 // This is going to queue up a list of project ids we need to fetch stats for
 // Will be cleared when debounced function fires
-const _projectStatsToFetch: Set<string> = new Set();
+export const _projectStatsToFetch: Set<string> = new Set();
 
 // Max projects to query at a time, otherwise if we fetch too many in the same request
 // it can timeout

--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -55,11 +55,12 @@ describe('ProjectsDashboard', function () {
   });
 
   afterEach(function () {
+    projectsActions._projectStatsToFetch.clear();
     MockApiClient.clearMockResponses();
   });
 
   describe('empty state', function () {
-    it('renders with no projects', function () {
+    it('renders with no projects', async function () {
       const noProjectTeams = [TeamFixture({isMember: false, projects: []})];
 
       render(
@@ -73,10 +74,12 @@ describe('ProjectsDashboard', function () {
         />
       );
 
-      expect(screen.getByRole('button', {name: 'Join a Team'})).toBeInTheDocument();
+      expect(
+        await screen.findByRole('button', {name: 'Join a Team'})
+      ).toBeInTheDocument();
     });
 
-    it('renders with 1 project, with no first event', function () {
+    it('renders with 1 project, with no first event', async function () {
       const projects = [ProjectFixture({teams, firstEvent: null})];
       ProjectsStore.loadInitialData(projects);
 
@@ -93,7 +96,7 @@ describe('ProjectsDashboard', function () {
         />
       );
 
-      expect(screen.getByTestId('join-team')).toBeInTheDocument();
+      expect(await screen.findByTestId('join-team')).toBeInTheDocument();
       expect(screen.getByTestId('create-project')).toBeInTheDocument();
       expect(
         screen.getByPlaceholderText('Search for projects by name')
@@ -105,7 +108,7 @@ describe('ProjectsDashboard', function () {
   });
 
   describe('with projects', function () {
-    it('renders with two projects', function () {
+    it('renders with two projects', async function () {
       const teamA = TeamFixture({slug: 'team1', isMember: true});
       const projects = [
         ProjectFixture({
@@ -136,11 +139,11 @@ describe('ProjectsDashboard', function () {
           {...RouteComponentPropsFixture()}
         />
       );
-      expect(screen.getByText('My Teams')).toBeInTheDocument();
+      expect(await screen.findByText('My Teams')).toBeInTheDocument();
       expect(screen.getAllByTestId('badge-display-name')).toHaveLength(2);
     });
 
-    it('renders correct project with selected team', function () {
+    it('renders correct project with selected team', async function () {
       const teamC = TeamFixture({
         id: '1',
         slug: 'teamC',
@@ -227,7 +230,7 @@ describe('ProjectsDashboard', function () {
         />
       );
 
-      expect(screen.getByText('project3')).toBeInTheDocument();
+      expect(await screen.findByText('project3')).toBeInTheDocument();
       expect(screen.queryByText('project2')).not.toBeInTheDocument();
     });
 
@@ -276,7 +279,7 @@ describe('ProjectsDashboard', function () {
       });
     });
 
-    it('renders bookmarked projects first in team list', function () {
+    it('renders bookmarked projects first in team list', async function () {
       const teamA = TeamFixture({slug: 'team1', isMember: true});
       const projects = [
         ProjectFixture({
@@ -339,7 +342,6 @@ describe('ProjectsDashboard', function () {
         ],
       });
 
-      jest.useFakeTimers();
       render(
         <Dashboard
           api={api}
@@ -351,10 +353,10 @@ describe('ProjectsDashboard', function () {
         />
       );
 
-      jest.runAllTimers();
-      jest.useRealTimers();
       // check that all projects are displayed
-      expect(screen.getAllByTestId('badge-display-name')).toHaveLength(6);
+      await waitFor(() =>
+        expect(screen.getAllByTestId('badge-display-name')).toHaveLength(6)
+      );
 
       const projectName = screen.getAllByTestId('badge-display-name');
       // check that projects are in the correct order - alphabetical with bookmarked projects in front


### PR DESCRIPTION
- removes unnecessary fake timers
- adds findBy to fix act warnings for react 18 since there is async parts of this component that haven't finished yet.
- properly clears the funky _projectStatsToFetch global set between tests

part of https://github.com/getsentry/frontend-tsc/issues/22