### PR TITLE
feat(issues): Add a new task to validate group statuses for orgs

### DIFF
--- a/src/sentry/tasks/detect_invalid_group_status.py
+++ b/src/sentry/tasks/detect_invalid_group_status.py
@@ -1,0 +1,72 @@
+from collections import defaultdict
+from datetime import timedelta
+from logging import getLogger
+
+from django.utils import timezone
+
+from sentry.models.group import Group, GroupStatus
+from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
+from sentry.silo import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.types.group import SUBSTATUS_TO_STR, UNRESOLVED_SUBSTATUS_CHOICES, GroupSubStatus
+
+logger = getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.tasks.detect_invalid_group_status",
+    time_limit=65,
+    soft_time_limit=60,
+    silo_mode=SiloMode.REGION,
+)
+def detect_invalid_group_status(organization_id: int):
+    # Find all unresolved groups for the organization
+    three_days_ago = timezone.now() - timedelta(days=3)
+    seven_days_ago = timezone.now() - timedelta(days=7)
+    groups = Group.objects.filter(
+        status=GroupStatus.UNRESOLVED,
+        project__organization_id=organization_id,
+    ).exclude(substatus=GroupSubStatus.ONGOING)
+    invalid_groups = defaultdict(list)
+
+    # Iterate over all unresolved groups and check if they have the correct substatus
+    for group in groups:
+        if group.substatus == GroupSubStatus.NEW and group.first_seen < three_days_ago:
+            invalid_groups[group.substatus].append(group.id)
+        elif group.substatus == GroupSubStatus.REGRESSED:
+            group_history = (
+                GroupHistory.objects.filter(
+                    group=group,
+                    status=GroupHistoryStatus.REGRESSED,
+                )
+                .order_by("-date_added")
+                .first()
+            )
+
+            if not group_history or group_history.date_added < seven_days_ago:
+                invalid_groups[group.substatus].append(group.id)
+        elif group.substatus == GroupSubStatus.ESCALATING:
+            group_history = (
+                GroupHistory.objects.filter(
+                    group=group,
+                    status=GroupHistoryStatus.ESCALATING,
+                )
+                .order_by("-date_added")
+                .first()
+            )
+
+            if not group_history or group_history.date_added < seven_days_ago:
+                invalid_groups[group.substatus].append(group.id)
+        elif group.substatus not in UNRESOLVED_SUBSTATUS_CHOICES:
+            invalid_groups[group.substatus].append(group.id)
+
+    error_extra = {SUBSTATUS_TO_STR[k]: v for k, v in invalid_groups.items()}
+    if len(invalid_groups) > 0:
+        logger.error(
+            "Found groups with incorrect substatus",
+            extra={
+                "organization_id": organization_id,
+                "count": sum(len(v) for v in invalid_groups.values()),
+                **error_extra,
+            },
+        )

--- a/src/sentry/tasks/detect_invalid_group_status.py
+++ b/src/sentry/tasks/detect_invalid_group_status.py
@@ -19,13 +19,13 @@ logger = getLogger(__name__)
     soft_time_limit=60,
     silo_mode=SiloMode.REGION,
 )
-def detect_invalid_group_status(organization_id: int):
+def detect_invalid_group_status(project_id: int):
     # Find all unresolved groups for the organization
     three_days_ago = timezone.now() - timedelta(days=3)
     seven_days_ago = timezone.now() - timedelta(days=7)
     groups = Group.objects.filter(
         status=GroupStatus.UNRESOLVED,
-        project__organization_id=organization_id,
+        project_id=project_id,
     ).exclude(substatus=GroupSubStatus.ONGOING)
     invalid_groups = defaultdict(list)
 
@@ -65,7 +65,7 @@ def detect_invalid_group_status(organization_id: int):
         logger.error(
             "Found groups with incorrect substatus",
             extra={
-                "organization_id": organization_id,
+                "project_id": project_id,
                 "count": sum(len(v) for v in invalid_groups.values()),
                 **error_extra,
             },

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1472,22 +1472,22 @@ def detect_new_escalation(job: PostProcessJob):
         return
 
 
-GROUP_VALIDATION_CACHE_KEY = lambda org_id: f"detect-invalid-group-status-{org_id}"
+GROUP_VALIDATION_CACHE_KEY = lambda project_id: f"detect-invalid-group-status-{project_id}"
 GROUP_VALIDATION_CACHE_DURATION = 60 * 60 * 24 * 3  # 3 days
 
 
 def detect_invalid_group_status(job: PostProcessJob):
     from sentry.tasks.detect_invalid_group_status import detect_invalid_group_status
 
-    org = job["event"].project.organization_id
-    cache_key = GROUP_VALIDATION_CACHE_KEY(org)
+    project_id = job["event"].project.id
+    cache_key = GROUP_VALIDATION_CACHE_KEY(project_id)
 
     if cache.get(cache_key):
         return
 
     try:
         cache.set(cache_key, True, GROUP_VALIDATION_CACHE_DURATION)
-        detect_invalid_group_status.delay(organization=org)
+        detect_invalid_group_status.delay(project_id=project_id)
     except Exception as e:
         logger.exception("tasks.detect_invalid_group_status.failed", extra={"error": str(e)})
 

--- a/tests/sentry/tasks/test_detect_invalid_groups.py
+++ b/tests/sentry/tasks/test_detect_invalid_groups.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from sentry.models.group import GroupStatus
+from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
+from sentry.tasks.detect_invalid_group_status import detect_invalid_group_status
+from sentry.testutils.cases import TestCase
+from sentry.types.group import GroupSubStatus
+
+
+class DetectInvalidGroupStatusTest(TestCase):
+    def setUp(
+        self,
+    ):
+        self.new_group = self.create_group(substatus=GroupSubStatus.NEW)
+        self.ongoing_group = self.create_group(substatus=GroupSubStatus.ONGOING)
+        self.regressed_group = self.create_group(substatus=GroupSubStatus.REGRESSED)
+        self.regressed_grouphistory = GroupHistory.objects.create(
+            group=self.regressed_group,
+            status=GroupHistoryStatus.REGRESSED,
+            date_added=datetime.now() - timedelta(days=3),
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+        )
+        self.escalating_group = self.create_group(substatus=GroupSubStatus.ESCALATING)
+        self.escalating_grouphistory = GroupHistory.objects.create(
+            group=self.escalating_group,
+            status=GroupHistoryStatus.ESCALATING,
+            date_added=datetime.now() - timedelta(days=3),
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+        )
+
+    @patch("sentry.tasks.detect_invalid_group_status.logger.error")
+    def test_no_bad_groups(self, mock_logger):
+        detect_invalid_group_status(self.organization.id)
+        assert not mock_logger.called
+
+    @patch("sentry.tasks.detect_invalid_group_status.logger.error")
+    def test_bad_new_group(self, mock_logger):
+        self.new_group.update(
+            first_seen=datetime.now() - timedelta(days=4), substatus=GroupSubStatus.NEW
+        )
+        detect_invalid_group_status(self.organization.id)
+        assert mock_logger.called
+        assert mock_logger.call_args[0][0] == "Found groups with incorrect substatus"
+        assert mock_logger.call_args.kwargs["extra"]["count"] == 1
+        assert mock_logger.call_args.kwargs["extra"]["new"] == [self.new_group.id]
+
+    @patch("sentry.tasks.detect_invalid_group_status.logger.error")
+    def test_bad_regressed_group(self, mock_logger):
+        self.regressed_grouphistory.update(
+            date_added=datetime.now() - timedelta(days=8),
+        )
+        detect_invalid_group_status(self.organization.id)
+        assert mock_logger.called
+        assert mock_logger.call_args.kwargs["extra"]["count"] == 1
+        assert mock_logger.call_args.kwargs["extra"]["regressed"] == [self.regressed_group.id]
+
+    @patch("sentry.tasks.detect_invalid_group_status.logger.error")
+    def test_bad_escalating_group(self, mock_logger):
+        self.escalating_grouphistory.update(
+            date_added=datetime.now() - timedelta(days=8),
+        )
+        detect_invalid_group_status(self.organization.id)
+        assert mock_logger.called
+        assert mock_logger.call_args.kwargs["extra"]["count"] == 1
+        assert mock_logger.call_args.kwargs["extra"]["escalating"] == [self.escalating_group.id]
+
+    @patch("sentry.tasks.detect_invalid_group_status.logger.error")
+    def test_unsupported_status(self, mock_logger):
+        bad_group = self.create_group()
+        bad_group.update(
+            status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.UNTIL_CONDITION_MET
+        )
+        detect_invalid_group_status(self.organization.id)
+        assert mock_logger.called
+        assert mock_logger.call_args.kwargs["extra"]["count"] == 1
+        assert mock_logger.call_args.kwargs["extra"]["archived_until_condition_met"] == [
+            bad_group.id
+        ]

--- a/tests/sentry/tasks/test_detect_invalid_groups.py
+++ b/tests/sentry/tasks/test_detect_invalid_groups.py
@@ -33,7 +33,7 @@ class DetectInvalidGroupStatusTest(TestCase):
 
     @patch("sentry.tasks.detect_invalid_group_status.logger.error")
     def test_no_bad_groups(self, mock_logger):
-        detect_invalid_group_status(self.organization.id)
+        detect_invalid_group_status(self.project.id)
         assert not mock_logger.called
 
     @patch("sentry.tasks.detect_invalid_group_status.logger.error")
@@ -41,7 +41,7 @@ class DetectInvalidGroupStatusTest(TestCase):
         self.new_group.update(
             first_seen=datetime.now() - timedelta(days=4), substatus=GroupSubStatus.NEW
         )
-        detect_invalid_group_status(self.organization.id)
+        detect_invalid_group_status(self.project.id)
         assert mock_logger.called
         assert mock_logger.call_args[0][0] == "Found groups with incorrect substatus"
         assert mock_logger.call_args.kwargs["extra"]["count"] == 1
@@ -52,7 +52,7 @@ class DetectInvalidGroupStatusTest(TestCase):
         self.regressed_grouphistory.update(
             date_added=datetime.now() - timedelta(days=8),
         )
-        detect_invalid_group_status(self.organization.id)
+        detect_invalid_group_status(self.project.id)
         assert mock_logger.called
         assert mock_logger.call_args.kwargs["extra"]["count"] == 1
         assert mock_logger.call_args.kwargs["extra"]["regressed"] == [self.regressed_group.id]
@@ -62,7 +62,7 @@ class DetectInvalidGroupStatusTest(TestCase):
         self.escalating_grouphistory.update(
             date_added=datetime.now() - timedelta(days=8),
         )
-        detect_invalid_group_status(self.organization.id)
+        detect_invalid_group_status(self.project.id)
         assert mock_logger.called
         assert mock_logger.call_args.kwargs["extra"]["count"] == 1
         assert mock_logger.call_args.kwargs["extra"]["escalating"] == [self.escalating_group.id]
@@ -73,7 +73,7 @@ class DetectInvalidGroupStatusTest(TestCase):
         bad_group.update(
             status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.UNTIL_CONDITION_MET
         )
-        detect_invalid_group_status(self.organization.id)
+        detect_invalid_group_status(self.project.id)
         assert mock_logger.called
         assert mock_logger.call_args.kwargs["extra"]["count"] == 1
         assert mock_logger.call_args.kwargs["extra"]["archived_until_condition_met"] == [


### PR DESCRIPTION
This is a followup from iNC-624, where issues had the wrong substatus when the auto-transition task stopped running.

This cron will check the group statuses for inconsistencies at most once every 3 days for projects that are sending events to Sentry. Currently, this only checks for inconsistencies that could be a result of the auto-transition task not working. We could extend this to check for ignored issues that should have been marked unresolved, but that's pretty redundant with `sentry/tasks/clear_expired_snoozes.py`. 

If the scope of this is limited to auto-transition failures, this check _could_ call the run_auto_transition_issues task with the specific group IDs. 

Discussions/Thoughts:
It might make more sense to increment a metric here and alert via DD instead, but open to suggestions. Alternatively, the transition task could emit a metric and we alert if the number of issues transitioned falls below a threshold. 

TODO:
- [ ] add a test to test_post_process.py
- [ ] add a test with multiple types of incorrect groups

Fixes https://github.com/getsentry/team-issues/issues/16