### PR TITLE
fix(feedback): refactor useCurrentProjectState to be feedback specific

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
@@ -48,12 +48,7 @@ export function FeedbackOnboardingLayout({
 
     return {
       introduction: doc.introduction?.(docParams),
-      steps: [
-        ...doc.install(docParams),
-        ...doc.configure(docParams),
-        ...doc.verify(docParams),
-      ],
-      nextSteps: doc.nextSteps?.(docParams) || [],
+      steps: [...doc.install(docParams), ...doc.configure(docParams)],
     };
   }, [
     cdn,

--- a/static/app/components/feedback/feedbackOnboarding/useCurrentProjectState.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/useCurrentProjectState.tsx
@@ -1,0 +1,96 @@
+import {useEffect, useState} from 'react';
+import partition from 'lodash/partition';
+
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
+import {
+  feedbackOnboardingPlatforms,
+  feedbackWebApiPlatforms,
+} from 'sentry/data/platformCategories';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import type {Project} from 'sentry/types';
+import useProjects from 'sentry/utils/useProjects';
+
+// Partition platforms into those with either widget/crash API docs, and those that will default to web API
+export function splitProjectsByFeedbackSupport(projects: Project[]) {
+  const [webApi, nonWebApi] = partition(projects, project =>
+    feedbackWebApiPlatforms.includes(project.platform!)
+  );
+  return {
+    webApi,
+    nonWebApi,
+  };
+}
+
+function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanelKey}) {
+  const [currentProject, setCurrentProject] = useState<Project | undefined>(undefined);
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+  const {selection, isReady} = useLegacyStore(PageFiltersStore);
+
+  const isActive = currentPanel === SidebarPanelKey.FEEDBACK_ONBOARDING;
+
+  // Projects with onboarding instructions
+  const projectsWithOnboarding = projects.filter(
+    p => p.platform && feedbackOnboardingPlatforms.includes(p.platform)
+  );
+
+  useEffect(() => {
+    if (!isActive) {
+      setCurrentProject(undefined);
+      return;
+    }
+
+    if (
+      currentProject ||
+      !projectsLoaded ||
+      !projects.length ||
+      !isReady ||
+      !projectsWithOnboarding
+    ) {
+      return;
+    }
+
+    if (selection.projects.length) {
+      const selectedProjectIds = selection.projects.map(String);
+
+      // If we selected something that has onboarding instructions, pick that first
+      const projectForOnboarding = projectsWithOnboarding.find(p =>
+        selectedProjectIds.includes(p.id)
+      );
+
+      if (projectForOnboarding) {
+        setCurrentProject(projectForOnboarding);
+        return;
+      }
+
+      // Otherwise, just pick the first selected project
+      const firstSelectedProject = projects.find(p => selectedProjectIds.includes(p.id));
+      setCurrentProject(firstSelectedProject);
+      return;
+    }
+    // We have no selection, so pick the first project with onboarding
+    setCurrentProject(projectsWithOnboarding.at(0));
+    return;
+  }, [
+    currentProject,
+    projectsLoaded,
+    projects,
+    isReady,
+    isActive,
+    selection.projects,
+    projectsWithOnboarding,
+  ]);
+
+  const {webApi, nonWebApi} = splitProjectsByFeedbackSupport(projects);
+
+  return {
+    projectsWithOnboarding,
+    projects,
+    webApi,
+    nonWebApi,
+    currentProject,
+    setCurrentProject,
+  };
+}
+
+export default useCurrentProjectState;

--- a/static/app/components/feedback/feedbackOnboarding/useCurrentProjectState.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/useCurrentProjectState.tsx
@@ -1,26 +1,11 @@
 import {useEffect, useState} from 'react';
-import partition from 'lodash/partition';
 
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
-import {
-  feedbackOnboardingPlatforms,
-  feedbackWebApiPlatforms,
-} from 'sentry/data/platformCategories';
+import {feedbackOnboardingPlatforms} from 'sentry/data/platformCategories';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Project} from 'sentry/types';
 import useProjects from 'sentry/utils/useProjects';
-
-// Partition platforms into those with either widget/crash API docs, and those that will default to web API
-export function splitProjectsByFeedbackSupport(projects: Project[]) {
-  const [webApi, nonWebApi] = partition(projects, project =>
-    feedbackWebApiPlatforms.includes(project.platform!)
-  );
-  return {
-    webApi,
-    nonWebApi,
-  };
-}
 
 function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanelKey}) {
   const [currentProject, setCurrentProject] = useState<Project | undefined>(undefined);
@@ -81,13 +66,9 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
     projectsWithOnboarding,
   ]);
 
-  const {webApi, nonWebApi} = splitProjectsByFeedbackSupport(projects);
-
   return {
     projectsWithOnboarding,
     projects,
-    webApi,
-    nonWebApi,
     currentProject,
     setCurrentProject,
   };

--- a/static/app/components/feedback/feedbackOnboarding/useCurrentProjectState.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/useCurrentProjectState.tsx
@@ -53,7 +53,7 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
       setCurrentProject(firstSelectedProject);
       return;
     }
-    // We have no selection, so pick the first project with onboarding
+    // No selection, so pick the first project with onboarding
     setCurrentProject(projectsWithOnboarding.at(0));
     return;
   }, [

--- a/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
+++ b/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
@@ -13,9 +13,7 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const {selection, isReady} = useLegacyStore(PageFiltersStore);
 
-  const isActive =
-    currentPanel === SidebarPanelKey.REPLAYS_ONBOARDING ||
-    currentPanel === SidebarPanelKey.FEEDBACK_ONBOARDING;
+  const isActive = currentPanel === SidebarPanelKey.REPLAYS_ONBOARDING;
 
   // Projects where we have the onboarding instructions ready:
   const projectsWithOnboarding = useMemo(

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -386,7 +386,7 @@ export const feedbackNpmPlatforms: readonly PlatformKey[] = [
 ];
 
 // Feedback platforms that show widget instructions (both NPM & loader)
-const feedbackWidgetPlatforms: readonly PlatformKey[] = [
+export const feedbackWidgetPlatforms: readonly PlatformKey[] = [
   ...feedbackNpmPlatforms,
   ...replayBackendPlatforms,
 ];
@@ -405,32 +405,8 @@ export const feedbackCrashApiPlatforms: readonly PlatformKey[] = [
   'unreal',
 ];
 
-// Feedback platforms that default to the web API
-export const feedbackWebApiPlatforms: readonly PlatformKey[] = [
-  'cordova',
-  'ruby-rack',
-  'ruby',
-  'native',
-  'native-qt',
-  'native',
-  'minidump',
-  'python-asgi',
-  'python-awslambda',
-  'python-celery',
-  'python-chalice',
-  'python-gcpfunctions',
-  'python-pymongo',
-  'python-pylons',
-  'python',
-  'python-rq',
-  'python-serverless',
-  'python-tryton',
-  'python-wsgi',
-];
-
 // All feedback onboarding platforms
 export const feedbackOnboardingPlatforms: readonly PlatformKey[] = [
-  ...feedbackWebApiPlatforms,
   ...feedbackWidgetPlatforms,
   ...feedbackCrashApiPlatforms,
 ];

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -405,8 +405,32 @@ export const feedbackCrashApiPlatforms: readonly PlatformKey[] = [
   'unreal',
 ];
 
+// Feedback platforms that default to the web API
+export const feedbackWebApiPlatforms: readonly PlatformKey[] = [
+  'cordova',
+  'ruby-rack',
+  'ruby',
+  'native',
+  'native-qt',
+  'native',
+  'minidump',
+  'python-asgi',
+  'python-awslambda',
+  'python-celery',
+  'python-chalice',
+  'python-gcpfunctions',
+  'python-pymongo',
+  'python-pylons',
+  'python',
+  'python-rq',
+  'python-serverless',
+  'python-tryton',
+  'python-wsgi',
+];
+
 // All feedback onboarding platforms
 export const feedbackOnboardingPlatforms: readonly PlatformKey[] = [
+  ...feedbackWebApiPlatforms,
   ...feedbackWidgetPlatforms,
   ...feedbackCrashApiPlatforms,
 ];


### PR DESCRIPTION
cleaning up various things:

- create a new file `useCurrentProjectState` that is specific for feedback onboarding
- fix a bug where we were erroneously loading in some project that wasn't selected, leading the onboarding content to differ from the platform selected
- main change here is that we removed this line: 

`const selectedProject = currentProject ?? projects[0] ?? allProjects[0];`

this bit,`projects[0] ?? allProjects[0]`, was leading other projects to be loaded in too eagerly. in this PR we remove this line in favor of always trusting `currentProject`.

- remove verify & next steps from onboarding layout; we don't need these