### PR TITLE
fix(ddm): Fix issues with metrics API

### DIFF
--- a/src/sentry/sentry_metrics/querying/data_v2/transformation.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation.py
@@ -85,7 +85,7 @@ def _generate_full_series(
     for time, value in series:
         time_seconds = parse_datetime_string(time).timestamp()
         index = int((time_seconds - start_seconds) / interval)
-        full_series[index] = value
+        full_series[index] = nan_to_none(value)
 
     return full_series
 

--- a/src/sentry/sentry_metrics/querying/visitors/query_expression.py
+++ b/src/sentry/sentry_metrics/querying/visitors/query_expression.py
@@ -201,7 +201,7 @@ class QueriedMetricsVisitor(QueryExpressionVisitor[set[str]]):
         metrics: set[str] = set()
 
         for parameter in formula.parameters:
-            metrics.union(self.visit(parameter))
+            metrics = metrics.union(self.visit(parameter))
 
         return metrics
 
@@ -227,7 +227,7 @@ class UsedGroupBysVisitor(QueryExpressionVisitor[set[str]]):
         group_bys: set[str] = set()
 
         for parameter in formula.parameters:
-            group_bys.union(self.visit(parameter))
+            group_bys = group_bys.union(self.visit(parameter))
 
         return group_bys.union(self._group_bys_as_string(formula.groupby))
 


### PR DESCRIPTION
This PR fixes two issues with the metrics API, namely:
* Two visitors were not correctly using the new set obtained from the `union` of other sets.
* The transformation logic was not converting nans to `None` in series.