### PR TITLE
feat(crons): Detect broken monitors

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1230,6 +1230,14 @@ CELERYBEAT_SCHEDULE_REGION = {
         "task": "sentry.tasks.on_demand_metrics.schedule_on_demand_check",
         "schedule": crontab(minute="*/5"),
     },
+    "detect_broken_monitor_envs": {
+        "task": "sentry.monitors.tasks.detect_broken_monitor_envs",
+        "schedule": crontab(
+            minute="0",
+            hour="12",  # 05:00 PDT, 09:00 EDT, 12:00 UTC
+        ),
+        "options": {"expires": 15 * 60},
+    },
 }
 
 # Assign the configuration keys celery uses based on our silo mode.

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -25,7 +25,6 @@ from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics, redis
 from sentry.utils.arroyo_producer import SingletonProducer
-from sentry.utils.iterators import chunked
 from sentry.utils.kafka_config import (
     get_kafka_admin_cluster_options,
     get_kafka_producer_cluster_options,
@@ -428,12 +427,10 @@ def detect_broken_monitor_envs():
         # TODO(davidenwang): When we want to email users, remove this filter
         monitorenvbrokendetection__isnull=True,
     )
-    for open_incidents in chunked(
-        RangeQuerySetWrapper(
-            open_incidents_qs,
-            step=1000,
-        ),
-        1000,
+    for open_incidents in RangeQuerySetWrapper(
+        open_incidents_qs,
+        order_by="starting_timestamp",
+        step=1000,
     ):
         for open_incident in open_incidents:
             try:

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 
 import msgpack
@@ -12,9 +12,12 @@ from arroyo import Topic as ArroyoTopic
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from confluent_kafka.admin import AdminClient, PartitionMetadata
 from django.conf import settings
+from django.utils import timezone as django_timezone
 
+from sentry import features
 from sentry.conf.types.kafka_definition import Topic
 from sentry.constants import ObjectStatus
+from sentry.models.organization import Organization
 from sentry.monitors.logic.mark_failed import mark_failed
 from sentry.monitors.schedule import get_prev_schedule
 from sentry.monitors.types import ClockPulseMessage
@@ -22,13 +25,23 @@ from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics, redis
 from sentry.utils.arroyo_producer import SingletonProducer
+from sentry.utils.iterators import chunked
 from sentry.utils.kafka_config import (
     get_kafka_admin_cluster_options,
     get_kafka_producer_cluster_options,
     get_topic_definition,
 )
+from sentry.utils.query import RangeQuerySetWrapper
 
-from .models import CheckInStatus, MonitorCheckIn, MonitorEnvironment, MonitorStatus, MonitorType
+from .models import (
+    CheckInStatus,
+    MonitorCheckIn,
+    MonitorEnvBrokenDetection,
+    MonitorEnvironment,
+    MonitorIncident,
+    MonitorStatus,
+    MonitorType,
+)
 
 logger = logging.getLogger("sentry")
 
@@ -49,6 +62,12 @@ MONITOR_TASKS_LAST_TRIGGERED_KEY = "sentry.monitors.last_tasks_ts"
 
 # This key is used to store the hashmap of Mapping[PartitionKey, Timestamp]
 MONITOR_TASKS_PARTITION_CLOCKS = "sentry.monitors.partition_clocks"
+
+# The number of consecutive failing checkins qualifying a monitor env as broken
+NUM_CONSECUTIVE_BROKEN_CHECKINS = 4
+
+# The number of days a monitor env has to be failing to qualify as broken
+NUM_DAYS_BROKEN_PERIOD = 3
 
 
 def _get_producer() -> KafkaProducer:
@@ -392,3 +411,57 @@ def mark_checkin_timeout(checkin_id: int, ts: datetime, **kwargs):
         )
 
         mark_failed(checkin, ts=most_recent_expected_ts)
+
+
+@instrumented_task(
+    name="sentry.monitors.tasks.detect_broken_monitor_envs",
+    max_retries=0,
+    time_limit=15 * 60,
+    soft_time_limit=10 * 60,
+    record_timing=True,
+)
+def detect_broken_monitor_envs():
+    current_time = django_timezone.now()
+    # TODO(davidenwang): When we start muting environments filter those broken detections out of this query
+    open_incidents_qs = MonitorIncident.objects.select_related("monitor").filter(
+        resolving_checkin=None,
+        starting_timestamp__lte=(current_time - timedelta(days=NUM_DAYS_BROKEN_PERIOD)),
+    )
+    for open_incidents in chunked(
+        RangeQuerySetWrapper(
+            open_incidents_qs,
+            step=1000,
+        ),
+        1000,
+    ):
+        for open_incident in open_incidents:
+            try:
+                organization = Organization.objects.get_from_cache(
+                    id=open_incident.monitor.organization_id
+                )
+                if not features.has(
+                    "organizations:crons-broken-monitor-detection", organization=organization
+                ):
+                    continue
+            except Organization.DoesNotExist:
+                continue
+
+            # verify that the most recent check-ins have been failing
+            recent_checkins = (
+                MonitorCheckIn.objects.filter(monitor_environment=open_incident.monitor_environment)
+                .order_by("-date_added")
+                .values("status")[:NUM_CONSECUTIVE_BROKEN_CHECKINS]
+            )
+            if len(recent_checkins) != NUM_CONSECUTIVE_BROKEN_CHECKINS or not all(
+                checkin["status"]
+                in [CheckInStatus.ERROR, CheckInStatus.TIMEOUT, CheckInStatus.MISSED]
+                for checkin in recent_checkins
+            ):
+                continue
+
+            detection, _ = MonitorEnvBrokenDetection.objects.get_or_create(
+                monitor_incident=open_incident, defaults={"detection_timestamp": current_time}
+            )
+            if not detection.user_notified_timestamp:
+                # TODO(davidenwang): This is where we would implement email sending logic
+                pass

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -1189,7 +1189,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
         return (monitor, monitor_environment)
 
     @with_feature("organizations:crons-broken-monitor-detection")
-    def test_creates_broken_detection(self):
+    def test_creates_broken_detection_no_duplicates(self):
         monitor, monitor_environment = self.create_monitor_and_env()
 
         first_checkin = MonitorCheckIn.objects.create(
@@ -1216,6 +1216,10 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 date_added=django_timezone.now() - timedelta(days=i),
             )
 
+        detect_broken_monitor_envs()
+        assert len(MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)) == 1
+
+        # running the task again shouldn't create duplicates
         detect_broken_monitor_envs()
         assert len(MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)) == 1
 

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -1,3 +1,4 @@
+import uuid
 import zoneinfo
 from collections.abc import MutableMapping
 from datetime import timedelta, timezone
@@ -12,11 +13,14 @@ from django.test import override_settings
 from django.utils import timezone as django_timezone
 
 from sentry.constants import ObjectStatus
+from sentry.grouping.utils import hash_from_values
 from sentry.monitors.models import (
     CheckInStatus,
     Monitor,
     MonitorCheckIn,
+    MonitorEnvBrokenDetection,
     MonitorEnvironment,
+    MonitorIncident,
     MonitorStatus,
     MonitorType,
     ScheduleType,
@@ -25,11 +29,13 @@ from sentry.monitors.tasks import (
     check_missing,
     check_timeout,
     clock_pulse,
+    detect_broken_monitor_envs,
     mark_checkin_timeout,
     mark_environment_missing,
     try_monitor_tasks_trigger,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 
 
 def make_ref_time(**kwargs):
@@ -1158,3 +1164,149 @@ def test_monitor_task_trigger_partition_tick_skip(dispatch_tasks):
 
     assert dispatch_tasks.call_count == 2
     assert dispatch_tasks.mock_calls[1] == mock.call(now + timedelta(minutes=2))
+
+
+class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
+    def create_monitor_and_env(self):
+        monitor = Monitor.objects.create(
+            name="test monitor",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            type=MonitorType.CRON_JOB,
+            config={
+                "schedule": [1, "day"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "failure_issue_threshold": 1,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
+        )
+        monitor_environment = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment_id=self.environment.id,
+            status=MonitorStatus.OK,
+        )
+        return (monitor, monitor_environment)
+
+    @with_feature("organizations:crons-broken-monitor-detection")
+    def test_creates_broken_detection(self):
+        monitor, monitor_environment = self.create_monitor_and_env()
+
+        first_checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.ERROR,
+            date_added=django_timezone.now() - timedelta(days=4),
+        )
+        incident = MonitorIncident.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            starting_checkin=first_checkin,
+            starting_timestamp=first_checkin.date_added,
+            grouphash=hash_from_values([uuid.uuid4()]),
+        )
+
+        for i in range(3, -1, -1):
+            MonitorCheckIn.objects.create(
+                monitor=monitor,
+                monitor_environment=monitor_environment,
+                project_id=self.project.id,
+                status=CheckInStatus.ERROR,
+                date_added=django_timezone.now() - timedelta(days=i),
+            )
+
+        detect_broken_monitor_envs()
+        assert len(MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)) == 1
+
+    @with_feature("organizations:crons-broken-monitor-detection")
+    def test_does_not_create_broken_detection_insufficient_duration(self):
+        monitor, monitor_environment = self.create_monitor_and_env()
+
+        first_checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.ERROR,
+            date_added=django_timezone.now() - timedelta(days=2),
+        )
+        incident = MonitorIncident.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            starting_checkin=first_checkin,
+            starting_timestamp=first_checkin.date_added,
+            grouphash=hash_from_values([uuid.uuid4()]),
+        )
+
+        for i in range(4):
+            MonitorCheckIn.objects.create(
+                monitor=monitor,
+                monitor_environment=monitor_environment,
+                project_id=self.project.id,
+                status=CheckInStatus.ERROR,
+                date_added=django_timezone.now() - timedelta(days=1),
+            )
+
+        detect_broken_monitor_envs()
+        assert len(MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)) == 0
+
+    @with_feature("organizations:crons-broken-monitor-detection")
+    def test_does_not_create_broken_detection_insufficient_checkins(self):
+        monitor, monitor_environment = self.create_monitor_and_env()
+
+        first_checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.ERROR,
+            date_added=django_timezone.now() - timedelta(days=4),
+        )
+        incident = MonitorIncident.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            starting_checkin=first_checkin,
+            starting_timestamp=first_checkin.date_added,
+            grouphash=hash_from_values([uuid.uuid4()]),
+        )
+
+        for i in range(1, -1, -1):
+            MonitorCheckIn.objects.create(
+                monitor=monitor,
+                monitor_environment=monitor_environment,
+                project_id=self.project.id,
+                status=CheckInStatus.ERROR,
+                date_added=django_timezone.now() - timedelta(days=i),
+            )
+
+        detect_broken_monitor_envs()
+        assert len(MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)) == 0
+
+    def test_does_not_create_broken_detection_no_feature(self):
+        monitor, monitor_environment = self.create_monitor_and_env()
+
+        first_checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.ERROR,
+            date_added=django_timezone.now() - timedelta(days=4),
+        )
+        incident = MonitorIncident.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            starting_checkin=first_checkin,
+            starting_timestamp=first_checkin.date_added,
+            grouphash=hash_from_values([uuid.uuid4()]),
+        )
+
+        for i in range(3, -1, -1):
+            MonitorCheckIn.objects.create(
+                monitor=monitor,
+                monitor_environment=monitor_environment,
+                project_id=self.project.id,
+                status=CheckInStatus.ERROR,
+                date_added=django_timezone.now() - timedelta(days=i),
+            )
+
+        detect_broken_monitor_envs()
+        assert len(MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)) == 0

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -1197,7 +1197,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
-            date_added=django_timezone.now() - timedelta(days=4),
+            date_added=django_timezone.now() - timedelta(days=14),
         )
         incident = MonitorIncident.objects.create(
             monitor=monitor,
@@ -1228,7 +1228,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
-            date_added=django_timezone.now() - timedelta(days=2),
+            date_added=django_timezone.now() - timedelta(days=10),
         )
         incident = MonitorIncident.objects.create(
             monitor=monitor,
@@ -1259,7 +1259,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
-            date_added=django_timezone.now() - timedelta(days=4),
+            date_added=django_timezone.now() - timedelta(days=14),
         )
         incident = MonitorIncident.objects.create(
             monitor=monitor,
@@ -1289,7 +1289,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
-            date_added=django_timezone.now() - timedelta(days=4),
+            date_added=django_timezone.now() - timedelta(days=14),
         )
         incident = MonitorIncident.objects.create(
             monitor=monitor,


### PR DESCRIPTION
This PR lays down the logic for detecting that a monitor environment is broken.

- Created new table MonitorEnvBrokenDetection which has a relation to MonitorIncident and keeps tracks of when we've detected a monitor env to be broken
- Establishes logic for detecting brokenness based on a parameter of duration (3 days failing) and # of consecutive failing check-ins (4 failing check-ins)
    - May choose to lengthen this parameter depending on how annoying this may feel to customers
- Locked behind `organizations:crons-broken-monitor-detection` flag