### PR TITLE
Remove rollout options for Rust Enhancers

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -19,7 +19,7 @@ from parsimonious.nodes import NodeVisitor
 from sentry_ophio.enhancers import Cache as RustCache
 from sentry_ophio.enhancers import Enhancements as RustEnhancements
 
-from sentry import options, projectoptions
+from sentry import projectoptions
 from sentry.features.rollout import in_random_rollout
 from sentry.grouping.component import GroupingComponent
 from sentry.stacktraces.functions import set_in_app
@@ -150,37 +150,25 @@ def merge_rust_enhancements(
 
 
 def parse_rust_enhancements(
-    source: Literal["config_structure", "config_string"], input: str | bytes, force_parsing=False
+    source: Literal["config_structure", "config_string"], input: str | bytes
 ) -> RustEnhancements | None:
     """
     Parses ``RustEnhancements`` from either a msgpack-encoded `config_structure`,
     or from the text representation called `config_string`.
-
-    Parsing itself is controlled via an option, but can be forced via `force_parsing`.
     """
     rust_enhancements = None
 
-    parse_rust_enhancements = force_parsing
-    if not force_parsing:
-        try:
-            parse_rust_enhancements = random.random() < options.get(
-                "grouping.rust_enhancers.parse_rate"
-            )
-        except Exception:
-            parse_rust_enhancements = False
+    try:
+        if source == "config_structure":
+            assert isinstance(input, bytes)
+            rust_enhancements = RustEnhancements.from_config_structure(input, RUST_CACHE)
+        else:
+            assert isinstance(input, str)
+            rust_enhancements = RustEnhancements.parse(input, RUST_CACHE)
 
-    if parse_rust_enhancements:
-        try:
-            if source == "config_structure":
-                assert isinstance(input, bytes)
-                rust_enhancements = RustEnhancements.from_config_structure(input, RUST_CACHE)
-            else:
-                assert isinstance(input, str)
-                rust_enhancements = RustEnhancements.parse(input, RUST_CACHE)
-
-            metrics.incr("rust_enhancements.parsing_performed", tags={"source": source})
-        except Exception:
-            logger.exception("failed parsing Rust Enhancements from `%s`", source)
+        metrics.incr("rust_enhancements.parsing_performed", tags={"source": source})
+    except Exception:
+        logger.exception("failed parsing Rust Enhancements from `%s`", source)
 
     return rust_enhancements
 
@@ -199,13 +187,6 @@ def apply_rust_enhancements(
     returning a tuple of `(modified category, modified in_app)` for each frame.
     """
     if not rust_enhancements:
-        return None
-
-    try:
-        use_rust_enhancements = in_random_rollout("grouping.rust_enhancers.modify_frames_rate")
-    except Exception:
-        use_rust_enhancements = False
-    if not use_rust_enhancements:
         return None
 
     try:
@@ -299,13 +280,15 @@ class Enhancements:
             self.rust_enhancements, match_frames, exception_data
         )
 
-        if rust_enhanced_frames and prefer_rust_enhancers():
+        if rust_enhanced_frames:
             for frame, (category, in_app) in zip(frames, rust_enhanced_frames):
                 if in_app is not None:
                     set_in_app(frame, in_app)
                 if category is not None:
                     set_path(frame, "data", "category", value=category)
             return
+        else:
+            logger.error("Rust enhancements were not applied successfully")
 
         in_memory_cache: dict[str, str] = {}
 
@@ -476,8 +459,8 @@ class Enhancements:
 
     @classmethod
     @sentry_sdk.tracing.trace
-    def from_config_string(self, s, bases=None, id=None, force_rust_parsing=False) -> Enhancements:
-        rust_enhancements = parse_rust_enhancements("config_string", s, force_rust_parsing)
+    def from_config_string(self, s, bases=None, id=None) -> Enhancements:
+        rust_enhancements = parse_rust_enhancements("config_string", s)
 
         try:
             tree = enhancements_grammar.parse(s)
@@ -815,9 +798,7 @@ def _load_configs() -> dict[str, Enhancements]:
                 fn = fn.replace("@", ":")
                 # NOTE: we want to force parsing the `RustEnhancements` here, as the base rules
                 # are required for inheritance, and because they are well tested.
-                enhancements = Enhancements.from_config_string(
-                    f.read(), id=fn[:-4], force_rust_parsing=True
-                )
+                enhancements = Enhancements.from_config_string(f.read(), id=fn[:-4])
                 rv[fn[:-4]] = enhancements
     return rv
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import logging
 import os
-import random
 import zlib
 from collections.abc import Sequence
 from hashlib import md5

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -19,7 +19,6 @@ from sentry_ophio.enhancers import Cache as RustCache
 from sentry_ophio.enhancers import Enhancements as RustEnhancements
 
 from sentry import projectoptions
-from sentry.features.rollout import in_random_rollout
 from sentry.grouping.component import GroupingComponent
 from sentry.stacktraces.functions import set_in_app
 from sentry.utils import metrics
@@ -227,13 +226,6 @@ def compare_rust_enhancers(
                 scope.set_extra("python_frames", python_frames)
                 scope.set_extra("rust_enhanced_frames", rust_enhanced_frames)
                 sentry_sdk.capture_message("Rust Enhancements mismatch")
-
-
-def prefer_rust_enhancers():
-    try:
-        return in_random_rollout("grouping.rust_enhancers.prefer_rust_result")
-    except Exception:
-        return False
 
 
 class Enhancements:

--- a/tests/sentry/grouping/test_categorization.py
+++ b/tests/sentry/grouping/test_categorization.py
@@ -43,6 +43,7 @@ else like actual grouping happens elsewhere like test_variants.py.
    If you push any intermediate step into master or even just a PR, you just
    leaked PII to the public and all of this will have been for nothing.
 """
+
 from __future__ import annotations
 
 import contextlib
@@ -58,8 +59,6 @@ from sentry.grouping.api import get_default_grouping_config_dict, load_grouping_
 from sentry.grouping.enhancer.actions import VarAction
 from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
-from sentry.testutils.helpers.options import override_options
-from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils.safe import get_path
 
 _fixture_path = os.path.join(os.path.dirname(__file__), "categorization_inputs")
@@ -130,10 +129,6 @@ INPUTS = [
 
 
 @pytest.mark.parametrize("input", INPUTS, ids=lambda x: x.filename[:-5].replace("-", "_"))
-@django_db_all
-@override_options(
-    {"grouping.rust_enhancers.parse_rate": 1.0, "grouping.rust_enhancers.modify_frames_rate": 1.0}
-)
 def test_categorization(input: CategorizationInput, insta_snapshot, track_enhancers_coverage):
     # XXX: In-process re-runs using pytest-watch or whatever will behave
     # wrongly because input.data is reused between tests, we do this for perf.

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -8,7 +8,6 @@ from sentry.grouping.component import GroupingComponent
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.enhancer.matchers import create_match_frame
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -53,14 +52,10 @@ family:native                                   max-frames=3
 
     insta_snapshot(dump_obj(enhancement))
 
-    rust_parsing = 1.0 if version == 2 else 0.0
-    with override_options({"grouping.rust_enhancers.parse_rate": rust_parsing}):
-        dumped = enhancement.dumps()
-        assert Enhancements.loads(dumped).dumps() == dumped
-        assert (
-            Enhancements.loads(dumped)._to_config_structure() == enhancement._to_config_structure()
-        )
-        assert isinstance(dumped, str)
+    dumped = enhancement.dumps()
+    assert Enhancements.loads(dumped).dumps() == dumped
+    assert Enhancements.loads(dumped)._to_config_structure() == enhancement._to_config_structure()
+    assert isinstance(dumped, str)
 
 
 def test_parsing_errors():
@@ -80,10 +75,6 @@ def test_callee_recursion():
         Enhancements.from_config_string(" category:foo | [ category:bar ] | [ category:baz ] +app")
 
 
-@django_db_all
-@override_options(
-    {"grouping.rust_enhancers.parse_rate": 1.0, "grouping.rust_enhancers.modify_frames_rate": 1.0}
-)
 def test_flipflop_inapp():
     enhancement = Enhancements.from_config_string(
         """
@@ -487,10 +478,6 @@ def test_sentinel_and_prefix(action, type):
     assert getattr(component, f"is_{type}_frame") is expected
 
 
-@django_db_all
-@override_options(
-    {"grouping.rust_enhancers.parse_rate": 1.0, "grouping.rust_enhancers.modify_frames_rate": 1.0}
-)
 @pytest.mark.parametrize(
     "frame",
     [


### PR DESCRIPTION
We have fully enabled these, so lets remove all the options usage related to it.

This is pretty much a followup from #65533.