### PR TITLE
fix(slack): Ensure infer_org_integration only filters ACTIVE

### DIFF
--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -136,18 +136,22 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         if not is_correct_silo:
             self.log_extra["silo_mode"] = SiloMode.get_current_mode().value
             logger.info("integration_proxy.incorrect_silo_mode", extra=self.log_extra)
+            metrics.incr("hybrid_cloud.integration_proxy.failure.invalid_mode", sample_rate=1.0)
             return False
 
         is_valid_sender = self._validate_sender(request=request)
         if not is_valid_sender:
+            logger.info("integration_proxy.failure.invalid_sender", extra=self.log_extra)
             metrics.incr("hybrid_cloud.integration_proxy.failure.invalid_sender", sample_rate=1.0)
             return False
 
         is_valid_request = self._validate_request(request=request)
         if not is_valid_request:
+            logger.info("integration_proxy.failure.invalid_request", extra=self.log_extra)
             metrics.incr("hybrid_cloud.integration_proxy.failure.invalid_request", sample_rate=1.0)
             return False
 
+        logger.info("integration_proxy.valid_request", extra=self.log_extra)
         return True
 
     def _call_third_party_api(self, request, full_url: str, headers) -> HttpResponse:
@@ -185,11 +189,6 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         self.log_extra["host"] = request.headers.get("Host")
 
         if not self._should_operate(request):
-            self.log_extra["silo_mode"] = SiloMode.get_current_mode().value
-            logger.info(
-                "integration_proxy.bad_request",
-                extra=self.log_extra,
-            )
             return HttpResponseBadRequest()
 
         metrics.incr("hybrid_cloud.integration_proxy.initialize", sample_rate=1.0)

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -16,6 +16,7 @@ from requests import PreparedRequest
 from requests.adapters import Retry
 
 from sentry import options
+from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.http import build_session
 from sentry.integrations.client import ApiClient
@@ -81,7 +82,12 @@ def infer_org_integration(
     org_integration_id = None
     with in_test_hide_transaction_boundary():
         org_integrations = integration_service.get_organization_integrations(
-            integration_id=integration_id
+            integration_id=integration_id,
+            # NOTE: This is to resolve #inc-649, but will allow organizations with disabled slack
+            # integrations to use the existing credentials if another organization has it
+            # enabled. A true fix would be to remove usage of infer_org_integration, and ensure
+            # all callers pass in an organization_id/organization_integration_id.
+            status=ObjectStatus.ACTIVE,
         )
     if len(org_integrations) > 0:
         org_integration_id = org_integrations[0].id

--- a/tests/sentry/shared_integrations/client/test_proxy.py
+++ b/tests/sentry/shared_integrations/client/test_proxy.py
@@ -5,16 +5,18 @@ from django.test import override_settings
 from pytest import raises
 from requests import Request
 
+from sentry.constants import ObjectStatus
 from sentry.net.http import Session
 from sentry.shared_integrations.client.proxy import (
     IntegrationProxyClient,
     get_control_silo_ip_address,
+    infer_org_integration,
 )
 from sentry.shared_integrations.exceptions import ApiHostError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_OI_HEADER, PROXY_PATH, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 control_address = "http://controlserver"
 
@@ -33,6 +35,30 @@ class IntegrationProxyClientTest(TestCase):
             _use_proxy_url_for_tests = True
 
         self.client_cls = TestClient
+
+    def test_infer_organization_is_active(self):
+        integration = self.create_provider_integration(provider="slack", external_id="workspace:1")
+        # Share the slack workspace across two organizations
+        organization_invalid = self.create_organization()
+        organization_valid = self.create_organization()
+        # Create a valid one, and an invalid one
+        org_integration_invalid = self.create_organization_integration(
+            integration_id=integration.id,
+            organization_id=organization_invalid.id,
+            status=ObjectStatus.DISABLED,
+        )
+        org_integration_valid = self.create_organization_integration(
+            integration_id=integration.id,
+            organization_id=organization_valid.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        # Infer should always look for the first ACTIVE organization_integration
+        assert infer_org_integration(integration_id=integration.id) == org_integration_valid.id
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            org_integration_valid.delete()
+        second_inference = infer_org_integration(integration_id=integration.id)
+        assert second_inference is not org_integration_invalid.id
+        assert second_inference is None
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_authorize_request_noop(self):


### PR DESCRIPTION
This PR hopefully will address some of the inconsistencies we've seen across integration requests sent through the proxy. It'd be most likely occurring for integrations that are often shared, which is why it was so frequent with Slack. 

In the future, we should ensure that all call sites for integration clients pass in an organization when initialized so we can skip this inference altogether.