### PR TITLE
ref: add date_to_utc_datetime

### DIFF
--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -1,7 +1,7 @@
 import re
 import zoneinfo
 from collections.abc import Mapping
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, overload
 
 from dateutil.parser import parse
@@ -65,10 +65,13 @@ def to_datetime(value: float | int | None) -> datetime | None:
     return epoch + timedelta(seconds=value)
 
 
+def date_to_utc_datetime(d: date) -> datetime:
+    """Convert a `date` to an aware `datetime`."""
+    return datetime(d.year, d.month, d.day, tzinfo=UTC)
+
+
 def floor_to_utc_day(value: datetime) -> datetime:
-    """
-    Floors a given datetime to UTC midnight.
-    """
+    """Floors a given datetime to UTC midnight."""
     return value.astimezone(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
 
 

--- a/tests/sentry/utils/test_dates.py
+++ b/tests/sentry/utils/test_dates.py
@@ -1,11 +1,10 @@
 import datetime
-from datetime import timezone
 
-from sentry.utils.dates import parse_stats_period, to_datetime, to_timestamp
+from sentry.utils.dates import date_to_utc_datetime, parse_stats_period, to_datetime, to_timestamp
 
 
 def test_timestamp_conversions():
-    value = datetime.datetime(2015, 10, 1, 21, 19, 5, 648517, tzinfo=timezone.utc)
+    value = datetime.datetime(2015, 10, 1, 21, 19, 5, 648517, tzinfo=datetime.UTC)
     assert int(to_timestamp(value)) == int(value.strftime("%s"))
     assert to_datetime(to_timestamp(value)) == value
 
@@ -19,3 +18,9 @@ def test_parse_stats_period():
     assert parse_stats_period("-1s") is None
     assert parse_stats_period("4w") == datetime.timedelta(weeks=4)
     assert parse_stats_period("900000000000d") is datetime.timedelta.max
+
+
+def test_date_to_utc_datetime():
+    d = datetime.date(2024, 7, 5)
+    dt = date_to_utc_datetime(d)
+    assert dt == datetime.datetime(2024, 7, 5, tzinfo=datetime.UTC)


### PR DESCRIPTION
this function helps avoid naive datetime warnings.  for now it's only used in getsentry

<!-- Describe your PR here. -->