### PR TITLE
meta(codeowners): Update codeowners for ingest and issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,16 +36,12 @@
 /src/sentry/coreapi.py                                   @getsentry/ingest
 /src/sentry/ingest/                                      @getsentry/ingest
 /src/sentry/interfaces/                                  @getsentry/ingest
-/src/sentry/message_filters.py                           @getsentry/ingest
 /src/sentry/quotas/                                      @getsentry/ingest
 /src/sentry/relay/                                       @getsentry/ingest
-/src/sentry/utils/data_filters.py                        @getsentry/ingest
 /src/sentry/web/api.py                                   @getsentry/ingest
 /src/sentry/scripts/quotas/                              @getsentry/ingest
 /src/sentry/scripts/tsdb/                                @getsentry/ingest
 /src/sentry/tasks/relay.py                               @getsentry/ingest
-/src/sentry/tasks/unmerge.py                             @getsentry/ingest
-/tests/sentry/event_manager/                             @getsentry/ingest
 /tests/sentry/ingest/                                    @getsentry/ingest
 /tests/sentry/relay/                                     @getsentry/ingest
 /tests/relay_integration/                                @getsentry/ingest
@@ -496,7 +492,8 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/grouping/                               @getsentry/issues
 /src/sentry/issues/                                 @getsentry/issues
 /src/sentry/tasks/post_process.py                   @getsentry/issues
-/tests/sentry/event_manager/test_event_manager.py   @getsentry/issues
+/src/sentry/tasks/unmerge.py                        @getsentry/issues
+/tests/sentry/event_manager/                        @getsentry/issues
 /tests/sentry/grouping/                             @getsentry/issues
 /tests/sentry/issues/                               @getsentry/issues
 /tests/sentry/search/                               @getsentry/issues


### PR DESCRIPTION
This PR updates the CODEOWNERS in the following way:

Transfers from Ingest to Issues:
```
/src/sentry/tasks/unmerge.py
/tests/sentry/event_manager/
```

Removes from Ingest (files don't exist anymore, so noop):
```
/src/sentry/message_filters.py
/src/sentry/utils/data_filters.py
```