### PR TITLE
fix(issue-details): Ensure that filtered data inside objects/arrays are annotated correctly 

### DIFF
--- a/static/app/components/events/interfaces/frame/frameVariables.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.tsx
@@ -31,7 +31,7 @@ export function FrameVariables({data, meta}: Props) {
             return v;
           })
         : data[key],
-      meta: meta?.[key]?.[''],
+      meta: meta?.[key],
     });
   }
 

--- a/static/app/components/events/interfaces/request/index.spec.tsx
+++ b/static/app/components/events/interfaces/request/index.spec.tsx
@@ -53,48 +53,50 @@ describe('Request entry', function () {
               url: null,
               query: null,
               data: {
-                a: {
-                  '': {
-                    rem: [['organization:0', 's', 0, 0]],
-                    len: 1,
-                    chunks: [
-                      {
-                        type: 'redaction',
-                        text: '',
-                        rule_id: 'organization:0',
-                        remark: 's',
-                      },
-                    ],
-                  },
-                },
-                c: {
-                  0: {
-                    d: {
-                      '': {
-                        rem: [['organization:0', 's', 0, 0]],
-                        len: 1,
-                        chunks: [
-                          {
-                            type: 'redaction',
-                            text: '',
-                            rule_id: 'organization:0',
-                            remark: 's',
-                          },
-                        ],
-                      },
+                0: {
+                  a: {
+                    '': {
+                      rem: [['organization:0', 's', 0, 0]],
+                      len: 1,
+                      chunks: [
+                        {
+                          type: 'redaction',
+                          text: '',
+                          rule_id: 'organization:0',
+                          remark: 's',
+                        },
+                      ],
                     },
-                    f: {
-                      '': {
-                        rem: [['organization:0', 's', 0, 0]],
-                        len: 1,
-                        chunks: [
-                          {
-                            type: 'redaction',
-                            text: '',
-                            rule_id: 'organization:0',
-                            remark: 's',
-                          },
-                        ],
+                  },
+                  c: {
+                    0: {
+                      d: {
+                        '': {
+                          rem: [['organization:0', 's', 0, 0]],
+                          len: 1,
+                          chunks: [
+                            {
+                              type: 'redaction',
+                              text: '',
+                              rule_id: 'organization:0',
+                              remark: 's',
+                            },
+                          ],
+                        },
+                      },
+                      f: {
+                        '': {
+                          rem: [['organization:0', 's', 0, 0]],
+                          len: 1,
+                          chunks: [
+                            {
+                              type: 'redaction',
+                              text: '',
+                              rule_id: 'organization:0',
+                              remark: 's',
+                            },
+                          ],
+                        },
                       },
                     },
                   },


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/65985

The issue was that `meta` was not being passed correctly in multiple locations. For objects/arrays it was falling back to the initial meta object when a key did not exist which is not correct.

Before:

![CleanShot 2024-02-28 at 10 34 41@2x](https://github.com/getsentry/sentry/assets/10888943/5d03b252-65aa-4aa6-8204-88722d460f2d)

After:

![CleanShot 2024-02-28 at 10 34 32@2x](https://github.com/getsentry/sentry/assets/10888943/2e1564fe-e626-4631-afaf-c7f8a40b7559)
