### PR TITLE
chore(team-org-roles): remove remaining references to team.org_role

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -6,12 +6,10 @@ from django.db.models import Prefetch, prefetch_related_objects
 
 from sentry import roles
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.api.serializers.models.role import OrganizationRoleSerializer
 from sentry.models.integrations.external_actor import ExternalActor
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.models.user import User
-from sentry.roles import organization_roles
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 
@@ -23,28 +21,6 @@ from .utils import get_organization_id
 class OrganizationMemberSerializer(Serializer):
     def __init__(self, expand: Sequence[str] | None = None) -> None:
         self.expand = expand or []
-
-    def __sorted_org_roles_for_user(self, item: OrganizationMember) -> Sequence[Mapping[str, Any]]:
-        org_roles = [
-            (team.slug, organization_roles.get(team.org_role)) for team in item.team_role_prefetch
-        ]
-
-        sorted_org_roles = sorted(
-            org_roles,
-            key=lambda r: r[1].priority,
-            reverse=True,
-        )
-
-        return [
-            {
-                "teamSlug": slug,
-                "role": serialize(
-                    role,
-                    serializer=OrganizationRoleSerializer(organization=item.organization),
-                ),
-            }
-            for slug, role in sorted_org_roles
-        ]
 
     def get_attrs(
         self, item_list: Sequence[OrganizationMember], user: User, **kwargs: Any

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -283,8 +283,6 @@ class BaseTeamSerializer(Serializer):
             # Teams only have letter avatars.
             "avatar": {"avatarType": "letter_avatar", "avatarUuid": None},
         }
-        if obj.org_role:
-            result["orgRole"] = obj.org_role
 
         return result
 

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -244,7 +244,6 @@ class Team(ReplicatedRegionModel, SnowflakeIdMixin):
             "slug": self.slug,
             "name": self.name,
             "status": self.status,
-            "org_role": self.org_role,
         }
 
     def get_projects(self):

--- a/src/sentry/models/teamreplica.py
+++ b/src/sentry/models/teamreplica.py
@@ -33,5 +33,4 @@ class TeamReplica(Model):
             "slug": self.slug,
             "name": self.name,
             "status": self.status,
-            "org_role": self.org_role,
         }

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -65,7 +65,6 @@ class RpcTeam(RpcModel):
             "slug": self.slug,
             "name": self.name,
             "status": self.status,
-            "org_role": self.org_role,
         }
 
 

--- a/src/sentry/services/hybrid_cloud/organization/serial.py
+++ b/src/sentry/services/hybrid_cloud/organization/serial.py
@@ -97,7 +97,6 @@ def serialize_rpc_team(team: Team) -> RpcTeam:
         status=team.status,
         organization_id=team.organization_id,
         slug=team.slug,
-        org_role=team.org_role,
         name=team.name,
     )
 

--- a/src/sentry/services/hybrid_cloud/replica/impl.py
+++ b/src/sentry/services/hybrid_cloud/replica/impl.py
@@ -163,9 +163,9 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
             expires_at=api_token.expires_at,
             apitoken_id=api_token.id,
             scope_list=api_token.scope_list,
-            allowed_origins="\n".join(api_token.allowed_origins)
-            if api_token.allowed_origins
-            else None,
+            allowed_origins=(
+                "\n".join(api_token.allowed_origins) if api_token.allowed_origins else None
+            ),
             user_id=api_token.user_id,
         )
         handle_replication(ApiToken, destination)
@@ -326,7 +326,6 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
             slug=team.slug,
             name=team.name,
             status=team.status,
-            org_role=team.org_role,
         )
 
         handle_replication(Team, destination)

--- a/tests/sentry/hybridcloud/test_replica.py
+++ b/tests/sentry/hybridcloud/test_replica.py
@@ -218,16 +218,6 @@ def test_replicate_team():
     assert replicated.slug == team.slug
     assert replicated.name == team.name
     assert replicated.status == team.status
-    assert replicated.org_role == team.org_role
-
-    with assume_test_silo_mode(SiloMode.REGION):
-        team.org_role = "boo"
-        team.save()
-
-    with assume_test_silo_mode(SiloMode.CONTROL):
-        replicated = TeamReplica.objects.get(team_id=team.id)
-
-    assert replicated.org_role == team.org_role
 
     with assume_test_silo_mode(SiloMode.REGION):
         teams = [


### PR DESCRIPTION
[This PR](https://github.com/getsentry/sentry/pull/65923) to drop the org_role column on the Team model is failing. There are a couple of instances referring team.org_role that still need to be cleaned up.

This is part of an ongoing effort to remove the org roles for teams feature https://github.com/getsentry/team-core-product-foundations/issues/51