### PR TITLE
chore(ai-autofix): Update autofix payload + use code mapping repos

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -144,6 +145,11 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
 
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="You must be authenticated to perform this action.")
+
+        if not features.has("projects:ai-autofix", group.project):
+            return self._respond_with_error(
+                group, metadata, "AI Autofix is not enabled for this project.", 403
+            )
 
         event_entries = self._get_event_entries(group, request.user)
 

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 import requests
 from django.conf import settings
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from sentry import features
@@ -57,12 +56,12 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
             repo: Repository = repo_config.repository
             repo_name_sections = repo.name.split("/")
 
-            if len(repo_name_sections) == 2:
+            if len(repo_name_sections) > 1:
                 repos.append(
                     {
                         "provider": repo.provider,
                         "owner": repo_name_sections[0],
-                        "name": repo_name_sections[1],
+                        "name": "/".join(repo_name_sections[1:]),
                     }
                 )
 
@@ -142,9 +141,6 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
                 }
             ],
         }
-
-        if not request.user.is_authenticated:
-            raise PermissionDenied(detail="You must be authenticated to perform this action.")
 
         if not features.has("projects:ai-autofix", group.project):
             return self._respond_with_error(

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -53,9 +53,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             name="getsentry/sentry",
             provider="integrations:github",
         )
-        repo.save()
-
-        self.create_commit(project=self.project, release=release, key="1234", repo=repo)
+        self.create_code_mapping(project=self.project, repo=repo)
 
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(
@@ -80,7 +78,13 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             response = self.client.post(url, data={"additional_context": "Yes"}, format="json")
             mock_call.assert_called_with(
                 ANY,
-                "1234",
+                [
+                    {
+                        "provider": "integrations:github",
+                        "owner": "getsentry",
+                        "name": "sentry",
+                    }
+                ],
                 ANY,
                 "Yes",
             )
@@ -97,16 +101,12 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert "autofix" in group.data["metadata"]
         assert group.data["metadata"]["autofix"]["status"] == "PROCESSING"
 
-    def test_ai_autofix_with_invalid_repo(self):
+    def test_ai_autofix_without_code_mapping(self):
         release = self.create_release(project=self.project, version="1.0.0")
 
-        # Creating a repository with a name that is not 'getsentry/sentry'
-        invalid_repo = self.create_repo(
-            project=self.project, name="invalid/repo", provider="integrations:github"
+        self.create_repo(
+            project=self.project, name="invalid-repo", provider="integrations:someotherprovider"
         )
-        invalid_repo.save()
-
-        self.create_commit(project=self.project, release=release, key="1234", repo=invalid_repo)
 
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(
@@ -134,7 +134,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         group = Group.objects.get(id=group.id)
 
-        error_msg = "No valid base commit from the public sentry repo found associated through issue's releases; only the public sentry repo is supported right now."
+        error_msg = "No valid repositories found."
 
         assert response.status_code == 400  # Expecting a Bad Request response for invalid repo
         assert response.data["detail"] == error_msg

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, patch
 from sentry.models.group import Group
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.samples import load_data
@@ -11,6 +12,7 @@ pytestmark = [requires_snuba]
 
 
 @region_silo_test
+@apply_feature_flag_on_cls("projects:ai-autofix")
 class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
     def test_ai_autofix_get_endpoint_with_autofix(self):
         group = self.create_group()


### PR DESCRIPTION
Update the ai autofix request payload to send the organization, project, list of repos associated, and remove the hardcoded support for only `getsentry/sentry`

Retrieves relevant repos for a project from the code mappings.

Adds a feature flag in lieu of the hardcode.