### PR TITLE
fix: Fix billing kafka config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3465,15 +3465,13 @@ KAFKA_SUBSCRIPTION_RESULT_TOPICS = {
 
 
 # Cluster configuration for each Kafka topic by name.
-KAFKA_TOPICS: Mapping[str, TopicDefinition | None] = {
+KAFKA_TOPICS: Mapping[str, TopicDefinition] = {
     KAFKA_EVENTS: {"cluster": "default"},
     KAFKA_EVENTS_COMMIT_LOG: {"cluster": "default"},
     KAFKA_TRANSACTIONS: {"cluster": "default"},
     KAFKA_TRANSACTIONS_COMMIT_LOG: {"cluster": "default"},
     KAFKA_OUTCOMES: {"cluster": "default"},
-    # When OUTCOMES_BILLING is None, it inherits from OUTCOMES and does not
-    # create a separate producer. Check ``track_outcome`` for details.
-    KAFKA_OUTCOMES_BILLING: None,
+    KAFKA_OUTCOMES_BILLING: {"cluster": "default"},
     KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS: {"cluster": "default"},
     KAFKA_TRANSACTIONS_SUBSCRIPTIONS_RESULTS: {"cluster": "default"},
     KAFKA_GENERIC_METRICS_SUBSCRIPTIONS_RESULTS: {"cluster": "default"},

--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -96,16 +96,6 @@ def get_kafka_admin_cluster_options(
     )
 
 
-def _validate_topic_definitions() -> None:
-    for cluster, defn in settings.KAFKA_TOPICS.items():
-        # If this assertion fails on import, get_topic_definition needs to be
-        # updated with new logic.
-        assert cluster == settings.KAFKA_OUTCOMES_BILLING or defn is not None
-
-
-_validate_topic_definitions()
-
-
 def get_topic_definition(topic: str) -> TopicDefinition:
     defn = settings.KAFKA_TOPICS.get(topic)
     if defn is not None:

--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -106,11 +106,9 @@ def _validate_topic_definitions() -> None:
 _validate_topic_definitions()
 
 
-def get_topic_definition(cluster: str) -> TopicDefinition:
-    defn = settings.KAFKA_TOPICS.get(cluster)
+def get_topic_definition(topic: str) -> TopicDefinition:
+    defn = settings.KAFKA_TOPICS.get(topic)
     if defn is not None:
         return defn
-    elif cluster == settings.KAFKA_OUTCOMES_BILLING:
-        return get_topic_definition(settings.KAFKA_OUTCOMES)
     else:
-        raise ValueError(f"Unknown {cluster=}")
+        raise ValueError(f"Unknown {topic=}")

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -75,7 +75,7 @@ def track_outcome(
     outcomes_config = kafka_config.get_topic_definition(settings.KAFKA_OUTCOMES)
     billing_config = kafka_config.get_topic_definition(settings.KAFKA_OUTCOMES_BILLING)
 
-    use_billing = outcome.is_billing() and outcomes_config == billing_config
+    use_billing = outcome.is_billing()
 
     # Create a second producer instance only if the cluster differs. Otherwise,
     # reuse the same producer and just send to the other topic.

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -74,9 +74,8 @@ def track_outcome(
 
     outcomes_config = kafka_config.get_topic_definition(settings.KAFKA_OUTCOMES)
     billing_config = kafka_config.get_topic_definition(settings.KAFKA_OUTCOMES_BILLING)
-    use_billing = (
-        outcome.is_billing() and settings.KAFKA_TOPICS[settings.KAFKA_OUTCOMES_BILLING] is not None
-    )
+
+    use_billing = outcome.is_billing() and outcomes_config != billing_config
 
     # Create a second producer instance only if the cluster differs. Otherwise,
     # reuse the same producer and just send to the other topic.

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -75,7 +75,7 @@ def track_outcome(
     outcomes_config = kafka_config.get_topic_definition(settings.KAFKA_OUTCOMES)
     billing_config = kafka_config.get_topic_definition(settings.KAFKA_OUTCOMES_BILLING)
 
-    use_billing = outcome.is_billing() and outcomes_config != billing_config
+    use_billing = outcome.is_billing() and outcomes_config == billing_config
 
     # Create a second producer instance only if the cluster differs. Otherwise,
     # reuse the same producer and just send to the other topic.

--- a/tests/sentry/utils/test_outcomes.py
+++ b/tests/sentry/utils/test_outcomes.py
@@ -105,7 +105,7 @@ def test_track_outcome_default(setup):
 
 def test_track_outcome_billing(setup):
     """
-    Checks that outcomes are routed to the SHARED topic within the same cluster
+    Checks that outcomes are routed to the DEDICATED topic within the same cluster
     in default configuration.
     """
 
@@ -121,7 +121,7 @@ def test_track_outcome_billing(setup):
 
     assert outcomes.outcomes_publisher
     (topic_name, _), _ = setup.mock_publisher.return_value.publish.call_args
-    assert topic_name == settings.KAFKA_OUTCOMES
+    assert topic_name == settings.KAFKA_OUTCOMES_BILLING
 
     assert outcomes.billing_publisher is None
 


### PR DESCRIPTION
We should not special case the kafka config for this particular application feature, nor should we need to understand how the application functions in order to generate this config correctly.

The system config was effectively being used as an application feature flag, which we should avoid doing.

This means the `outcomes-billing` topic will be used for billing outcomes in all environments in the same way. There is no different behavior depending on kafka configuration in different environments.

