### PR TITLE
feat(replay): adds feature flag for playing a replay from the replay tab

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1943,6 +1943,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:view-hierarchies-options-dev": False,
     # Enable minimap in the widget viewer modal in dashboards
     "organizations:widget-viewer-modal-minimap": False,
+    # Enable playing replays from the replay tab
+    "organizations:replay-play-from-replay-tab": False,
     # Enable AI Autofix feture on the Issue Details page.
     "projects:ai-autofix": False,
     # Adds additional filters and a new section to issue alert rules.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -286,6 +286,7 @@ default_manager.add("organizations:user-feedback-ui", OrganizationFeature, Featu
 default_manager.add("organizations:user-feedback-onboarding", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:widget-viewer-modal-minimap", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:replay-play-from-replay-tab", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.
 


### PR DESCRIPTION
This feature flag will be used to render the replay viewer from the replay tab as shown below


<img width="538" alt="Screenshot 2024-02-28 at 12 42 42 PM" src="https://github.com/getsentry/sentry/assets/8533851/040c4feb-ead3-4ccc-8b68-9ebf85ec20c6">
