### PR TITLE
fix(dashboards): Move router calls after clearing editing state

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
@@ -124,7 +124,7 @@ interface QueryData {
 
 interface Props extends RouteComponentProps<RouteParams, {}> {
   dashboard: DashboardDetails;
-  onSave: (widgets: Widget[]) => void;
+  onSave: (widgets: Widget[], callback?: () => void) => void;
   organization: Organization;
   selection: PageFilters;
   tags: TagCollection;
@@ -216,7 +216,7 @@ function WidgetBuilder({
 
   const api = useApi();
 
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
 
   const [datasetConfig, setDataSetConfig] = useState<ReturnType<typeof getDatasetConfig>>(
     getDatasetConfig(DATA_SET_TO_WIDGET_TYPE[dataSet])
@@ -355,14 +355,14 @@ function WidgetBuilder({
 
   useEffect(() => {
     const onUnload = () => {
-      if (!isSubmitting && state.userHasModified) {
+      if (!isSubmittingRef.current && state.userHasModified) {
         return t('You have unsaved changes, are you sure you want to leave?');
       }
       return undefined;
     };
 
     router.setRouteLeaveHook(route, onUnload);
-  }, [isSubmitting, state.userHasModified, route, router]);
+  }, [state.userHasModified, route, router]);
 
   const widgetType = DATA_SET_TO_WIDGET_TYPE[state.dataSet];
 
@@ -773,7 +773,7 @@ function WidgetBuilder({
       return;
     }
 
-    setIsSubmitting(true);
+    isSubmittingRef.current = true;
     let nextWidgetList = [...dashboard.widgets];
     const updateWidgetIndex = getUpdateWidgetIndex();
     nextWidgetList.splice(updateWidgetIndex, 1);
@@ -813,7 +813,7 @@ function WidgetBuilder({
       });
     }
 
-    setIsSubmitting(true);
+    isSubmittingRef.current = true;
     if (notDashboardsOrigin) {
       submitFromSelectedDashboard(widgetData);
       return;

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -124,7 +124,7 @@ interface QueryData {
 
 interface Props extends RouteComponentProps<RouteParams, {}> {
   dashboard: DashboardDetails;
-  onSave: (widgets: Widget[], callback?: () => void) => void;
+  onSave: (widgets: Widget[]) => void;
   organization: Organization;
   selection: PageFilters;
   tags: TagCollection;


### PR DESCRIPTION
The dashboard editors protect the user from losing information when navigating away. "You have unsaved changes". This is usually checking something in state. In react 18 this becomes a race condition between the batched state updates and router.push getting blocked by the "You have unsaved changes" function.

See acceptance test failure in react 18 https://github.com/getsentry/sentry/actions/runs/8069058337/job/22043271549?pr=65632#step:11:150

part of https://github.com/getsentry/frontend-tsc/issues/22
