### PR TITLE
feat(assignment): Allow settings to determine organizations exempt from rate limit

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3786,6 +3786,7 @@ SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS = {
     "path": "sentry.utils.locking.backends.redis.RedisLockBackend",
     "options": {"cluster": "default"},
 }
+SENTRY_POST_PROCESS_CONFIGURATION: Mapping[str, Any] = {"org_ids_exempt_from_ratelimit": {}}
 
 # maximum number of projects allowed to query snuba with for the organization_vitals_overview endpoint
 ORGANIZATION_VITALS_OVERVIEW_PROJECT_LIMIT = 300

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3786,7 +3786,9 @@ SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS = {
     "path": "sentry.utils.locking.backends.redis.RedisLockBackend",
     "options": {"cluster": "default"},
 }
-SENTRY_POST_PROCESS_CONFIGURATION: Mapping[str, Any] = {"org_ids_with_increased_ratelimit": {}}
+SENTRY_POST_PROCESS_CONFIGURATION: Mapping[str, Any] = {
+    "org_ids_with_increased_issue_owners_ratelimit": set()
+}
 
 # maximum number of projects allowed to query snuba with for the organization_vitals_overview endpoint
 ORGANIZATION_VITALS_OVERVIEW_PROJECT_LIMIT = 300

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3786,7 +3786,7 @@ SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS = {
     "path": "sentry.utils.locking.backends.redis.RedisLockBackend",
     "options": {"cluster": "default"},
 }
-SENTRY_POST_PROCESS_CONFIGURATION: Mapping[str, Any] = {"org_ids_exempt_from_ratelimit": {}}
+SENTRY_POST_PROCESS_CONFIGURATION: Mapping[str, Any] = {"org_ids_with_increased_ratelimit": {}}
 
 # maximum number of projects allowed to query snuba with for the organization_vitals_overview endpoint
 ORGANIZATION_VITALS_OVERVIEW_PROJECT_LIMIT = 300

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -179,7 +179,7 @@ def should_issue_owners_ratelimit(project_id: int, group_id: int, organization_i
     """
     enforced_limit = ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT
     if organization_id and organization_id in configuration.get(
-        "org_ids_with_increased_ratelimit", {}
+        "org_ids_with_increased_issue_owners_ratelimit", set()
     ):
         enforced_limit = HIGHER_ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -358,11 +358,9 @@ def handle_group_owners(
 
     lock = locks.get(f"groupowner-bulk:{group.id}", duration=10, name="groupowner_bulk")
     try:
-        with (
-            metrics.timer("post_process.handle_group_owners"),
-            sentry_sdk.start_span(op="post_process.handle_group_owners"),
-            lock.acquire(),
-        ):
+        with metrics.timer("post_process.handle_group_owners"), sentry_sdk.start_span(
+            op="post_process.handle_group_owners"
+        ), lock.acquire():
             current_group_owners = GroupOwner.objects.filter(
                 group=group,
                 type__in=[GroupOwnerType.OWNERSHIP_RULE.value, GroupOwnerType.CODEOWNERS.value],
@@ -739,17 +737,14 @@ def run_post_process_job(job: PostProcessJob):
 
     for pipeline_step in pipeline:
         try:
-            with (
-                metrics.timer(
-                    "tasks.post_process.run_post_process_job.pipeline.duration",
-                    tags={
-                        "pipeline": pipeline_step.__name__,
-                        "issue_category": issue_category_metric,
-                        "is_reprocessed": job["is_reprocessed"],
-                    },
-                ),
-                sentry_sdk.start_span(op=f"tasks.post_process_group.{pipeline_step.__name__}"),
-            ):
+            with metrics.timer(
+                "tasks.post_process.run_post_process_job.pipeline.duration",
+                tags={
+                    "pipeline": pipeline_step.__name__,
+                    "issue_category": issue_category_metric,
+                    "is_reprocessed": job["is_reprocessed"],
+                },
+            ), sentry_sdk.start_span(op=f"tasks.post_process_group.{pipeline_step.__name__}"):
                 pipeline_step(job)
         except Exception:
             metrics.incr(

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1352,6 +1352,23 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
         )
 
+        mock_config = {"org_ids_exempt_from_ratelimit": {self.project.organization_id}}
+        with patch.dict("sentry.tasks.post_process.configuration", mock_config):
+            self.call_post_process_group(
+                is_new=False,
+                is_regression=False,
+                is_new_group_environment=False,
+                event=event,
+            )
+            logger.info.assert_any_call(
+                "should_issue_owners_ratelimit.exemption",
+                extra={
+                    "project_id": self.project.id,
+                    "group_id": event.group_id,
+                    "organization_id": self.project.organization_id,
+                },
+            )
+
 
 class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
     github_blame_return_value = {

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1354,7 +1354,9 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         mock_logger.reset_mock()
 
         # Raise this organization's ratelimit
-        mock_config = {"org_ids_with_increased_ratelimit": {self.project.organization_id}}
+        mock_config = {
+            "org_ids_with_increased_issue_owners_ratelimit": {self.project.organization_id}
+        }
         with patch.dict("sentry.tasks.post_process.configuration", mock_config):
             self.call_post_process_group(
                 is_new=False,
@@ -1376,7 +1378,9 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
                 datetime.now(),
             ),
         )
-        mock_config = {"org_ids_with_increased_ratelimit": {self.project.organization_id}}
+        mock_config = {
+            "org_ids_with_increased_issue_owners_ratelimit": {self.project.organization_id}
+        }
         with patch.dict("sentry.tasks.post_process.configuration", mock_config):
             self.call_post_process_group(
                 is_new=False,


### PR DESCRIPTION
This PR will allow organizations specified in settings to ~~be exempt from~~ use an increased value for internal assignment rate limits during post_process.

Nothing is specified but the plan is to overwrite it in getsentry.