### PR TITLE
fix(perf): Fix HTTP widget documentation link

### DIFF
--- a/static/app/utils/docs.tsx
+++ b/static/app/utils/docs.tsx
@@ -61,7 +61,7 @@ export function getDocsPlatform(
   return null;
 }
 
-export function getConfigureTracingDocsLink(
+export function getConfigurePerformanceDocsLink(
   project: AvatarProject | undefined
 ): string | null {
   const platform = project?.platform ?? null;

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -126,7 +126,7 @@ export function WidgetAddInstrumentationWarning({type}: {type: 'db' | 'http'}) {
       <PrimaryMessage>{t('No results found')}</PrimaryMessage>
       <SecondaryMessage>
         {tct(
-          'No transactions with [spanCategory] spans found. Please check your [link].',
+          'No transactions with [spanCategory] spans found. You may need to add integrations to your [link] to capture these spans.',
           {
             spanCategory: type === 'db' ? t('Database') : t('HTTP'),
             link: (

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -10,7 +10,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {getConfigureIntegrationsDocsLink} from 'sentry/utils/docs';
+import {getConfigurePerformanceDocsLink} from 'sentry/utils/docs';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {NoDataMessage} from 'sentry/views/performance/database/noDataMessage';
@@ -115,9 +115,9 @@ export function WidgetAddInstrumentationWarning({type}: {type: 'db' | 'http'}) {
   }
 
   const project = fullProjects.projects.find(p => p.id === '' + projects[0]);
-  const url = getConfigureIntegrationsDocsLink(project);
+  const docsLink = getConfigurePerformanceDocsLink(project);
 
-  if (!url) {
+  if (!docsLink) {
     return <WidgetEmptyStateWarning />;
   }
 
@@ -126,10 +126,14 @@ export function WidgetAddInstrumentationWarning({type}: {type: 'db' | 'http'}) {
       <PrimaryMessage>{t('No results found')}</PrimaryMessage>
       <SecondaryMessage>
         {tct(
-          'No transactions with [spanCategory] spans found, you may need to [added].',
+          'No transactions with [spanCategory] spans found. Please check your [link].',
           {
             spanCategory: type === 'db' ? t('Database') : t('HTTP'),
-            added: <ExternalLink href={url}>{t('add integrations')}</ExternalLink>,
+            link: (
+              <ExternalLink href={docsLink}>
+                {t('performance monitoring setup')}
+              </ExternalLink>
+            ),
           }
         )}
       </SecondaryMessage>

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -10,7 +10,7 @@ import QuickTrace from 'sentry/components/quickTrace';
 import {t} from 'sentry/locale';
 import type {AvatarProject} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
-import {getConfigureTracingDocsLink} from 'sentry/utils/docs';
+import {getConfigurePerformanceDocsLink} from 'sentry/utils/docs';
 import type {
   QuickTraceQueryChildrenProps,
   TraceMeta,
@@ -45,7 +45,7 @@ export default function QuickTraceMeta({
 
   const noFeatureMessage = t('Requires performance monitoring.');
 
-  const docsLink = getConfigureTracingDocsLink(project);
+  const docsLink = getConfigurePerformanceDocsLink(project);
 
   const traceId = event.contexts?.trace?.trace_id ?? null;
   let body: React.ReactNode;


### PR DESCRIPTION
Fixes #65071

Directs users with no HTTP span to the "Set Up Performance" page rather than the "Integrations" page which doesn't even exist for a lot of platforms.

Maybe the widget copy is a little awkward?

**e.g.,**
![Screenshot 2024-02-28 at 3 29 21 PM](https://github.com/getsentry/sentry/assets/989898/f08024b0-8ac2-4387-98eb-81f60cc31f36)
