### PR TITLE
fix(crons): Correctly return groups associated with a checkin

### DIFF
--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -235,7 +235,7 @@ class MonitorCheckInSerializer(Serializer):
                 )
 
             for checkin in item_list:
-                attrs[item]["groups"] = (
+                attrs[checkin]["groups"] = (
                     trace_groups.get(checkin.trace_id.hex, []) if checkin.trace_id else []
                 )
 


### PR DESCRIPTION
We were just returning groups on a single checkin, and they might have been unrelated to the checkin.
