### PR TITLE
feat(crons): Ensure that org level monitor endpoints will continue working if there are multiple monitors with the same slug

### DIFF
--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -76,8 +76,8 @@ class MonitorEndpoint(Endpoint):
         monitors = list(Monitor.objects.filter(organization_id=organization.id, slug=monitor_slug))
         if not monitors:
             raise ResourceDoesNotExist
-        monitors.sort(key=lambda monitor: monitor.id)
-        monitor = monitors[0]
+
+        monitor = min(monitors, key=lambda m: m.id)
 
         project = Project.objects.get_from_cache(id=monitor.project_id)
         if project.status != ObjectStatus.ACTIVE:


### PR DESCRIPTION
Since we're making the constraint for monitor slug on (project, slug) we might end up with multiple potential monitors in the org level endpoints. This puts in a temporary fix so that we just return the oldest monitor.

I can't write a test for this yet since we still have the old constraint in place.

Fixes https://github.com/getsentry/sentry/issues/65954
