### PR TITLE
feat(trace): Change to an iterative serialize function

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -174,6 +174,12 @@ class TraceEvent:
         self.span_serialized = span_serialized
         if span_serialized:
             self.fetched_nodestore = True
+            self.timestamp = datetime.fromisoformat(self.event["timestamp"]).timestamp()
+            self.start_timestamp = (
+                datetime.fromisoformat(self.event["timestamp"]).timestamp()
+                # duration is in ms, timestamp is in seconds
+                - self.event["transaction.duration"] / 1000
+            )
         self.load_performance_issues(light, snuba_params)
 
     @property
@@ -316,7 +322,17 @@ class TraceEvent:
             "performance_issues": self.performance_issues,
         }
 
-    def full_dict(self, detailed: bool = False) -> FullResponse:
+    def full_dict(
+        self, detailed: bool = False, visited: set[str] | None = None
+    ) -> FullResponse | None:
+        if visited is None:
+            visited = set()
+        event_id = self.event["id"]
+        # We're in a loop!
+        if event_id in visited:
+            return
+        else:
+            visited.add(self.event["id"])
         result = cast(FullResponse, self.to_dict())
         if detailed and "transaction.status" in self.event:
             result.update(
@@ -327,8 +343,9 @@ class TraceEvent:
                 }
             )
         if self.span_serialized:
-            result["timestamp"] = datetime.fromisoformat(self.event["timestamp"]).timestamp()
-            result["start_timestamp"] = (
+            result["timestamp"] = self.timestamp
+            result["start_timestamp"] = self.start_timestamp
+            (
                 datetime.fromisoformat(self.event["timestamp"]).timestamp()
                 # duration is in ms, timestamp is in seconds
                 - self.event["transaction.duration"] / 1000
@@ -348,9 +365,12 @@ class TraceEvent:
                 result["_meta"] = {}
                 result["tags"], result["_meta"]["tags"] = get_tags_with_meta(self.nodestore_event)
         # Only add children that have nodestore events, which may be missing if we're pruning for trace navigator
-        result["children"] = [
-            child.full_dict(detailed) for child in self.children if child.fetched_nodestore
-        ]
+        result["children"] = []
+        for child in self.children:
+            if child.fetched_nodestore:
+                child_dict = child.full_dict(detailed, visited)
+                if child_dict is not None:
+                    result["children"].append(child_dict)
         return result
 
 
@@ -390,6 +410,13 @@ def child_sort_key(item: TraceEvent) -> list[int]:
         return [
             item.nodestore_event.data["start_timestamp"],
             item.nodestore_event.data["timestamp"],
+        ]
+    elif item.span_serialized:
+        return [
+            item.start_timestamp,
+            item.timestamp,
+            item.event["transaction"],
+            item.event["id"],
         ]
     else:
         return [
@@ -1261,149 +1288,80 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
     ) -> Sequence[FullResponse]:
         root_traces: list[TraceEvent] = []
         orphans: list[TraceEvent] = []
-        visited_transactions: set[str] = set()
-        visited_errors: set[str] = set()
+        orphan_errors: list[SnubaError] = []
         if not allow_orphan_errors:
             raise ParseError("Must allow orphan errors to useSpans")
         if detailed:
             raise ParseError("Cannot return a detailed response using Spans")
 
-        # A trace can have multiple roots, so we want to visit
-        # all roots in a trace and build their children.
-        # A root segment is one that doesn't have a parent span id
-        # but here is identified by the attribute "root" = 1 on
-        # a SnubaTransaction object.
-        with sentry_sdk.start_span(op="serialize", description="visit root transactions"):
-            root_traces = self.visit_transactions(
-                roots,
-                transactions,
-                errors,
-                visited_transactions,
-                visited_errors,
-            )
-
-        # At this point all the roots have their tree built. Remaining
-        # transactions are either orphan transactions or children of
-        # orphan transactions. Orphan transactions (unlike roots) have
-        # a parent_id but the parent_id wasn't found (dropped span).
-        # We get a sorted list of these transactions by start timestamp.
-        with sentry_sdk.start_span(op="serialize", description="orphans"):
-            remaining_transactions = self.calculate_remaining_transactions(
-                transactions, visited_transactions
-            )
-
-            # Determine orphan transactions. `trace.parent_transaction` on a
-            # transaction is set when the indexed spans dataset has a row for
-            # the parent span id for this transaction. Since we already considered
-            # the root spans cases, the remaining spans with no parent transaction
-            # id are orphan transactions.
-            orphan_roots = [
-                orphan
-                for orphan in remaining_transactions
-                if orphan["trace.parent_transaction"] is None
-            ]
-
-            # Build the trees for all the orphan transactions.
-            orphans = self.visit_transactions(
-                orphan_roots,
-                remaining_transactions,
-                errors,
-                visited_transactions,
-                visited_errors,
-            )
-
-        with sentry_sdk.start_span(op="nodestore", description="remaining orphans"):
-            # Remaining are transactions with parent transactions but those
-            # parents don't map to any of the existing transactions.
-            remaining_transactions = self.calculate_remaining_transactions(
-                transactions, visited_transactions
-            )
-            orphans.extend(
-                self.visit_transactions(
-                    remaining_transactions,
-                    remaining_transactions,
-                    errors,
-                    visited_transactions,
-                    visited_errors,
+        with sentry_sdk.start_span(op="serialize", description="create parent map"):
+            parent_event_map = defaultdict(list)
+            serialized_transactions = []
+            for transaction in transactions:
+                parent_id = transaction["trace.parent_transaction"]
+                serialized_transaction = TraceEvent(
+                    transaction, parent_id, -1, span_serialized=True
                 )
-            )
+                if parent_id is None:
+                    if transaction["trace.parent_span"]:
+                        orphans.append(serialized_transaction)
+                    else:
+                        root_traces.append(serialized_transaction)
+                else:
+                    parent_event_map[parent_id].append(serialized_transaction)
+                serialized_transactions.append(serialized_transaction)
+
+        parent_error_map = defaultdict(list)
+        for error in errors:
+            if "trace.transaction" in error:
+                parent_error_map[error["trace.transaction"]].append(self.serialize_error(error))
+            else:
+                orphan_errors.append(error)
+
+        with sentry_sdk.start_span(op="serialize", description="associate children"):
+            visited_transactions: set[str] = {
+                transaction.event["id"] for transaction in root_traces
+            }
+            for transaction in serialized_transactions:
+                event_id = transaction.event["id"]
+                if event_id in parent_event_map:
+                    children_events = parent_event_map.pop(event_id)
+                    transaction.children = sorted(children_events, key=child_sort_key)
+                if event_id in parent_error_map:
+                    transaction.errors = sorted(
+                        parent_error_map.pop(event_id), key=lambda k: k["timestamp"]
+                    )
+
+        with sentry_sdk.start_span(op="serialize", description="more orphans"):
+            for transaction in sorted(serialized_transactions, key=child_sort_key):
+                if transaction.event["id"] not in visited_transactions:
+                    if transaction not in orphans:
+                        orphans.append(transaction)
+                    visited_transactions.add(transaction.event["id"])
+                    for child in transaction.children:
+                        visited_transactions.add(child.event["id"])
 
         with sentry_sdk.start_span(op="serialize", description="sort"):
             # Sort the results so they're consistent
-            orphan_errors = sorted(
-                [error for error in errors if error["id"] not in visited_errors],
-                key=lambda k: k["timestamp"],
-            )
+            orphan_errors.sort(key=lambda k: k["timestamp"])
             root_traces.sort(key=child_sort_key)
             orphans.sort(key=child_sort_key)
 
+        visited_transactions = set()
         with sentry_sdk.start_span(op="serialize", description="to dict"):
             return {
-                "transactions": [trace.full_dict(detailed) for trace in root_traces]
-                + [orphan.full_dict(detailed) for orphan in orphans],
+                "transactions": [
+                    trace.full_dict(detailed, visited_transactions)
+                    for trace in root_traces
+                    if trace.event["id"] not in visited_transactions
+                ]
+                + [
+                    orphan.full_dict(detailed, visited_transactions)
+                    for orphan in orphans
+                    if orphan.event["id"] not in visited_transactions
+                ],
                 "orphan_errors": [self.serialize_error(error) for error in orphan_errors],
             }
-
-    @sentry_sdk.trace
-    def calculate_remaining_transactions(self, transactions, visited_transactions):
-        return sorted(
-            [
-                transaction
-                for transaction in transactions
-                if transaction["id"] not in visited_transactions
-            ],
-            key=lambda k: -datetime.fromisoformat(k["timestamp"]).timestamp(),
-        )
-
-    @sentry_sdk.trace
-    def visit_transactions(
-        self, to_visit, transactions, errors, visited_transactions, visited_errors
-    ):
-        serialized_events: list[TraceEvent] = []
-        for transaction in to_visit:
-            if transaction["id"] in visited_transactions:
-                continue
-            visited_transactions.add(transaction["id"])
-            root_event = TraceEvent(transaction, None, 0, span_serialized=True)
-            self.add_children(
-                root_event, transactions, visited_transactions, errors, visited_errors, 1
-            )
-            serialized_events.append(root_event)
-        return serialized_events
-
-    def add_children(
-        self, parent, transactions, visited_transactions, errors, visited_errors, generation
-    ):
-        for error in errors:
-            if error["id"] in visited_errors:
-                continue
-            if "trace.transaction" in error and error["trace.transaction"] == parent.event["id"]:
-                visited_errors.add(error["id"])
-                parent.errors.append(self.serialize_error(error))
-
-        # Loop through all the transactions to see if any of them are
-        # children.
-        for transaction in transactions:
-            if transaction["id"] in visited_transactions:
-                continue
-            if transaction["trace.parent_transaction"] == parent.event["id"]:
-                # If transaction is a child, establish that relationship and add it
-                # to visited_transactions.
-                visited_transactions.add(transaction["id"])
-                new_child = TraceEvent(
-                    transaction, parent.event["id"], generation, span_serialized=True
-                )
-                # Repeat adding children until there are none.
-                self.add_children(
-                    new_child,
-                    transactions,
-                    visited_transactions,
-                    errors,
-                    visited_errors,
-                    generation + 1,
-                )
-                parent.children.append(new_child)
-        parent.children.sort(key=child_sort_key)
 
 
 @region_silo_endpoint

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -316,20 +316,21 @@ class BaseQueryBuilder:
         equations: list[str] | None = None,
         orderby: list[str] | str | None = None,
     ) -> None:
-        with sentry_sdk.start_span(op="QueryBuilder", description="resolve_time_conditions"):
-            # Has to be done early, since other conditions depend on start and end
-            self.resolve_time_conditions()
-        with sentry_sdk.start_span(op="QueryBuilder", description="resolve_conditions"):
-            self.where, self.having = self.resolve_conditions(query)
-        with sentry_sdk.start_span(op="QueryBuilder", description="resolve_params"):
-            # params depends on parse_query, and conditions being resolved first since there may be projects in conditions
-            self.where += self.resolve_params()
-        with sentry_sdk.start_span(op="QueryBuilder", description="resolve_columns"):
-            self.columns = self.resolve_select(selected_columns, equations)
-        with sentry_sdk.start_span(op="QueryBuilder", description="resolve_orderby"):
-            self.orderby = self.resolve_orderby(orderby)
-        with sentry_sdk.start_span(op="QueryBuilder", description="resolve_groupby"):
-            self.groupby = self.resolve_groupby(groupby_columns)
+        with sentry_sdk.start_span(op="QueryBuilder", description="resolve_query"):
+            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_time_conditions"):
+                # Has to be done early, since other conditions depend on start and end
+                self.resolve_time_conditions()
+            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_conditions"):
+                self.where, self.having = self.resolve_conditions(query)
+            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_params"):
+                # params depends on parse_query, and conditions being resolved first since there may be projects in conditions
+                self.where += self.resolve_params()
+            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_columns"):
+                self.columns = self.resolve_select(selected_columns, equations)
+            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_orderby"):
+                self.orderby = self.resolve_orderby(orderby)
+            with sentry_sdk.start_span(op="QueryBuilder", description="resolve_groupby"):
+                self.groupby = self.resolve_groupby(groupby_columns)
 
     def load_config(
         self,

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -38,9 +38,12 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase):
         span_id=None,
         measurements=None,
         file_io_performance_issue=False,
+        start_timestamp=None,
         **kwargs,
     ):
         start, end = self.get_start_end(duration)
+        if start_timestamp is not None:
+            start = start_timestamp
         data = load_data(
             "transaction",
             trace=trace,
@@ -609,7 +612,7 @@ class OrganizationEventsTraceLightEndpointTest(OrganizationEventsTraceEndpointBa
                 spans=[],
                 project_id=self.create_project(organization=self.organization).id,
                 parent_span_id=self.gen2_span_ids[1],
-                duration=525,
+                duration=1500,
             ).event_id,
         ]
 
@@ -790,6 +793,7 @@ class OrganizationEventsTraceLightEndpointTest(OrganizationEventsTraceEndpointBa
 @region_silo_test
 class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
     url_name = "sentry-api-0-organization-events-trace"
+    check_generation = True
 
     def assert_event(self, result, event_data, message):
         assert result["transaction"] == event_data.transaction, message
@@ -803,7 +807,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         self.assert_event(root, self.root_event, "root")
         assert root["parent_event_id"] is None
         assert root["parent_span_id"] is None
-        assert root["generation"] == 0
+        if self.check_generation:
+            assert root["generation"] == 0
         assert root["transaction.duration"] == 3000
         assert len(root["children"]) == 3
         assert len(root["performance_issues"]) == 1
@@ -813,7 +818,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             self.assert_event(gen1, self.gen1_events[i], f"gen1_{i}")
             assert gen1["parent_event_id"] == self.root_event.event_id
             assert gen1["parent_span_id"] == self.root_span_ids[i]
-            assert gen1["generation"] == 1
+            if self.check_generation:
+                assert gen1["generation"] == 1
             assert gen1["transaction.duration"] == 2000
             assert len(gen1["children"]) == 1
 
@@ -821,7 +827,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             self.assert_event(gen2, self.gen2_events[i], f"gen2_{i}")
             assert gen2["parent_event_id"] == self.gen1_events[i].event_id
             assert gen2["parent_span_id"] == self.gen1_span_ids[i]
-            assert gen2["generation"] == 2
+            if self.check_generation:
+                assert gen2["generation"] == 2
             assert gen2["transaction.duration"] == 1000
 
             # Only the first gen2 descendent has a child
@@ -831,7 +838,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
                 self.assert_event(gen3, self.gen3_event, f"gen3_{i}")
                 assert gen3["parent_event_id"] == self.gen2_events[i].event_id
                 assert gen3["parent_span_id"] == self.gen2_span_id
-                assert gen3["generation"] == 3
+                if self.check_generation:
+                    assert gen3["generation"] == 3
                 assert gen3["transaction.duration"] == 500
                 assert len(gen3["children"]) == 0
             elif gen2_no_children:
@@ -1012,6 +1020,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             parent_span_id=root_parent_span,
             project_id=self.project.id,
             duration=3000,
+            start_timestamp=self.day_ago - timedelta(minutes=1),
         )
         orphan_child = self.create_event(
             trace=self.trace_id,
@@ -1087,7 +1096,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
                 spans=[],
                 project_id=self.create_project(organization=self.organization).id,
                 parent_span_id=self.gen2_span_ids[1],
-                duration=500,
+                duration=1000,
             ).event_id,
             self.create_event(
                 trace=self.trace_id,
@@ -1095,7 +1104,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
                 spans=[],
                 project_id=self.create_project(organization=self.organization).id,
                 parent_span_id=self.gen2_span_ids[1],
-                duration=525,
+                duration=2000,
             ).event_id,
         ]
 
@@ -1130,7 +1139,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             spans=[],
             parent_span_id=parent_span_id,
             project_id=self.project.id,
-            duration=1250,
+            duration=2000,
         )
 
         with self.feature(self.FEATURES):
@@ -1171,7 +1180,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             parent_span_id=uuid4().hex[:16],
             span_id=orphan_span_ids["root"],
             project_id=self.project.id,
-            duration=1000,
+            duration=3000,
+            start_timestamp=self.day_ago - timedelta(minutes=1),
         )
         child_event = self.create_event(
             trace=self.trace_id,
@@ -1190,7 +1200,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             project_id=self.gen1_project.id,
             # Because the snuba query orders based is_root then timestamp, this causes grandchild1-0 to be added to
             # results first before child1-0
-            duration=2500,
+            duration=2000,
         )
         grandchild_event = self.create_event(
             trace=self.trace_id,
@@ -1207,7 +1217,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             parent_span_id=orphan_span_ids["child_span"],
             span_id=orphan_span_ids["grandchild"],
             project_id=self.gen1_project.id,
-            duration=1500,
+            duration=1000,
         )
 
         with self.feature(self.FEATURES):
@@ -1222,16 +1232,19 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         self.assert_trace_data(main)
         self.assert_event(orphans, root_event, "orphan-root")
         assert len(orphans["children"]) == 1
-        assert orphans["generation"] == 0
+        if self.check_generation:
+            assert orphans["generation"] == 0
         assert orphans["parent_event_id"] is None
         child = orphans["children"][0]
         self.assert_event(child, child_event, "orphan-child")
         assert len(child["children"]) == 1
-        assert child["generation"] == 1
+        if self.check_generation:
+            assert child["generation"] == 1
         assert child["parent_event_id"] == root_event.event_id
         grandchild = child["children"][0]
         self.assert_event(grandchild, grandchild_event, "orphan-grandchild")
-        assert grandchild["generation"] == 2
+        if self.check_generation:
+            assert grandchild["generation"] == 2
         assert grandchild["parent_event_id"] == child_event.event_id
 
     def test_with_errors(self):
@@ -1540,6 +1553,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
 
 @region_silo_test
 class OrganizationEventsTraceEndpointTestUsingSpans(OrganizationEventsTraceEndpointTest):
+    check_generation = False
+
     def client_get(self, data, url=None):
         data["useSpans"] = 1
         return super().client_get(data, url)


### PR DESCRIPTION
- This also fixes a bug with timestamp not being used as part of the sort
- This should prevent the risk of hitting a max recursion depth error too
- Frontend doesn't use generation anymore, setting to -1 for now until we remove it entirely (Most of the serialization is still shared)