### PR TITLE
feat(feedback): add project option for enabling AI spam detection

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -822,6 +822,11 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                     "sentry:feedback_user_report_notification",
                     bool(options["sentry:feedback_user_report_notification"]),
                 )
+            if "sentry:feedback_ai_spam_detection" in options:
+                project.update_option(
+                    "sentry:feedback_ai_spam_detection",
+                    bool(options["sentry:feedback_ai_spam_detection"]),
+                )
             if "sentry:reprocessing_active" in options:
                 project.update_option(
                     "sentry:reprocessing_active",

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -232,6 +232,7 @@ def format_options(attrs: dict[str, Any]) -> dict[str, Any]:
         "sentry:feedback_user_report_notification": bool(
             options.get("sentry:feedback_user_report_notification")
         ),
+        "sentry:feedback_ai_spam_detection": bool(options.get("sentry:feedback_ai_spam_detection")),
         "sentry:replay_rage_click_issues": options.get("sentry:replay_rage_click_issues"),
         "quotas:spike-protection-disabled": options.get("quotas:spike-protection-disabled"),
     }

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -42,6 +42,7 @@ OPTION_KEYS = frozenset(
         "sentry:recap_server_token",
         "sentry:replay_rage_click_issues",
         "sentry:feedback_user_report_notifications",
+        "sentry:feedback_ai_spam_detection",
         "sentry:token",
         "sentry:token_header",
         "sentry:verify_ssl",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -141,6 +141,11 @@ register(
     epoch_defaults={12: True},
 )
 
+register(
+    key="sentry:feedback_ai_spam_detection",
+    default=False,
+)
+
 
 # Replacement rules for transaction names discovered by the transaction clusterer.
 # Contains a mapping from rule to last seen timestamp,

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -611,6 +611,7 @@ class ProjectUpdateTest(APITestCase):
             "sentry:verify_ssl": False,
             "sentry:replay_rage_click_issues": True,
             "sentry:feedback_user_report_notification": True,
+            "sentry:feedback_ai_spam_detection": True,
             "feedback:branding": False,
             "filters:react-hydration-errors": True,
             "filters:chunk-load-error": True,
@@ -726,6 +727,7 @@ class ProjectUpdateTest(APITestCase):
         assert project.get_option("feedback:branding") == "0"
         assert project.get_option("sentry:replay_rage_click_issues") is True
         assert project.get_option("sentry:feedback_user_report_notification") is True
+        assert project.get_option("sentry:feedback_ai_spam_detection") is True
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert AuditLogEntry.objects.filter(


### PR DESCRIPTION
- Create new project option `sentry:feedback_ai_spam_detection`, and default it to `false`
- Add to project model