### PR TITLE
test(hc): Account for SENTRY_USE_MONOLITH_DBS when validating silo mode

### DIFF
--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -33,10 +33,13 @@ TEST_ROOT = os.path.normpath(
 TEST_REDIS_DB = 9
 
 
+def _use_monolith_dbs() -> bool:
+    return os.environ.get("SENTRY_USE_MONOLITH_DBS", "0") == "1"
+
+
 def configure_split_db() -> None:
-    SENTRY_USE_MONOLITH_DBS = os.environ.get("SENTRY_USE_MONOLITH_DBS", "0") == "1"
     already_configured = "control" in settings.DATABASES
-    if already_configured or SENTRY_USE_MONOLITH_DBS:
+    if already_configured or _use_monolith_dbs():
         return
 
     # Add connections for the region & control silo databases.
@@ -50,14 +53,13 @@ def configure_split_db() -> None:
     settings.DATABASE_ROUTERS = ("sentry.db.router.SiloRouter",)
 
 
-DEFAULT_SILO_MODE_FOR_TEST_CASES = SiloMode.MONOLITH
+def get_default_silo_mode_for_test_cases() -> SiloMode:
+    general_default_mode = SiloMode.MONOLITH  # to be changed to REGION
+    return SiloMode.MONOLITH if _use_monolith_dbs() else general_default_mode
 
 
 def _configure_test_env_regions() -> None:
-    SENTRY_USE_MONOLITH_DBS = os.environ.get("SENTRY_USE_MONOLITH_DBS", "0") == "1"
-    settings.SILO_MODE = (
-        DEFAULT_SILO_MODE_FOR_TEST_CASES if not SENTRY_USE_MONOLITH_DBS else SiloMode.MONOLITH
-    )
+    settings.SILO_MODE = get_default_silo_mode_for_test_cases()
 
     # Assign a random name on every test run, as a reminder that test setup and
     # assertions should not depend on this value. If you need to test behavior that

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import responses
 from django.db import connections
 
 from sentry.silo import SiloMode
-from sentry.testutils.pytest.sentry import DEFAULT_SILO_MODE_FOR_TEST_CASES
+from sentry.testutils.pytest.sentry import get_default_silo_mode_for_test_cases
 
 pytest_plugins = ["sentry.testutils.pytest"]
 
@@ -112,7 +112,7 @@ def validate_silo_mode():
     # during tests.  It depends upon `override_settings` using the correct contextmanager behaviors and correct
     # thread handling in acceptance tests.  If you hit one of these, it's possible either that cleanup logic has
     # a bug, or you may be using a contextmanager incorrectly.  Let us know and we can help!
-    expected = DEFAULT_SILO_MODE_FOR_TEST_CASES
+    expected = get_default_silo_mode_for_test_cases()
     message = (
         f"Possible test leak bug!  SiloMode was not reset to {expected} between tests.  "
         "Please read the comment for validate_silo_mode() in tests/conftest.py."


### PR DESCRIPTION
Prevents a mismatch to the expected silo mode in `validate_silo_mode` when `SENTRY_USE_MONOLITH_DBS` is set.