### PR TITLE
perf: remove `metrics.incr` from killswitch match

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -15,7 +15,6 @@ from typing import Any, Optional, Union
 import click
 
 from sentry import options
-from sentry.utils import metrics
 
 Condition = dict[str, Optional[str]]
 KillswitchConfig = list[Condition]
@@ -255,13 +254,7 @@ def killswitch_matches_context(killswitch_name: str, context: Context) -> bool:
     assert killswitch_name in ALL_KILLSWITCH_OPTIONS
     assert set(ALL_KILLSWITCH_OPTIONS[killswitch_name].fields) == set(context)
     option_value = options.get(killswitch_name)
-    rv = _value_matches(killswitch_name, option_value, context)
-    metrics.incr(
-        "killswitches.run",
-        tags={"killswitch_name": killswitch_name, "decision": "matched" if rv else "passed"},
-    )
-
-    return rv
+    return _value_matches(killswitch_name, option_value, context)
 
 
 def _value_matches(


### PR DESCRIPTION
`metrics.incr` calls are effecting hot paths because of datadog `dogstats`. therefore, I recommend removing them until we find a performant solution.

<img width="1283" alt="Screenshot 2024-02-28 at 7 14 23 PM" src="https://github.com/getsentry/sentry/assets/1935246/2decaf28-72bf-4a26-86e2-f4b6a9bd9b8f">


Ref trace: https://sentry.sentry.io/profiling/profile/sentry/d009c25cb7a2442fb418389a458775a9/flamegraph/?colorCoding=by+system+vs+application+frame&fov=0%2C89%2C3041446912%2C24&query=&sorting=call+order&tid=138257113913088&view=top+down