### PR TITLE
chore(relocation): Hide relocation link from org create page if feature is not enabled

### DIFF
--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -56,12 +56,16 @@ describe('OrganizationCreate', function () {
     ConfigStore.set('termsUrl', 'https://example.com/terms');
     ConfigStore.set('privacyUrl', 'https://example.com/privacy');
     ConfigStore.set('isSelfHosted', false);
+    ConfigStore.set('features', new Set(['relocation:enabled']));
     render(<OrganizationCreate />);
     expect(screen.getByText('Create a New Organization')).toBeInTheDocument();
     expect(
       screen.getByText('Relocating from self-hosted?', {exact: false})
     ).toBeInTheDocument();
-    expect(screen.getByText('here')).toHaveAttribute('href', '/relocation/');
+    expect(screen.getByText('Relocating from self-hosted?')).toHaveAttribute(
+      'href',
+      '/relocation/'
+    );
 
     await userEvent.type(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
     await userEvent.click(

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -130,9 +130,9 @@ function OrganizationCreate() {
               required
             />
           )}
-          {!isSelfHosted && (
+          {!isSelfHosted && ConfigStore.get('features').has('relocation:enabled') && (
             <div>
-              {tct('Relocating from self-hosted? Click [relocationLink:here]', {
+              {tct('[relocationLink:Relocating from self-hosted?]', {
                 relocationLink: <a href={relocationUrl} />,
               })}
             </div>


### PR DESCRIPTION
rewords the relocation onboarding link and hides it when feature is not enabled