### PR TITLE
test(ui): Prevent another projects dashboard flake

### DIFF
--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -50,6 +50,10 @@ describe('ProjectsDashboard', function () {
       url: `/teams/${org.slug}/${team.slug}/members/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
     ProjectsStatsStore.reset();
     ProjectsStore.loadInitialData([]);
   });
@@ -158,10 +162,12 @@ describe('ProjectsDashboard', function () {
           ProjectFixture({
             id: '1',
             slug: 'project1',
+            stats: [],
           }),
           ProjectFixture({
             id: '2',
             slug: 'project2',
+            stats: [],
           }),
         ],
       });


### PR DESCRIPTION
still flaking, just mock it https://github.com/getsentry/sentry/actions/runs/8088618112/job/22103012729?pr=66024 the debounce needs to be cleared but is also mocked