### PR TITLE
perf: enable dogstatsd buffering

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1455,6 +1455,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "auth:enterprise-superuser-read-write": False,
     # Enables user registration.
     "auth:register": True,
+    # Enables datadog buffering
+    "datadog:enable-buffering": False,
     # Enable advanced search features, like negation and wildcard matching.
     "organizations:advanced-search": True,
     # Enables alert creation on indexed events in UI (use for PoC/testing only)

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -3,6 +3,8 @@ from typing import Any
 from datadog import initialize
 from datadog.dogstatsd.base import statsd
 
+from sentry import features
+
 from .base import MetricsBackend, Tags
 
 __all__ = ["DogStatsdMetricsBackend"]
@@ -14,6 +16,8 @@ class DogStatsdMetricsBackend(MetricsBackend):
         self.tags = kwargs.pop("tags", None)
         initialize(**kwargs)
         statsd.disable_telemetry()
+        if features.has("datadog:enable-buffering"):
+            statsd.disable_buffering = False
         super().__init__(prefix=prefix)
 
     def incr(


### PR DESCRIPTION
All dogstatsd calls are right now sync. This is causing performance issues since all REST API calls are blocked until the execution of stats end. Refer to https://github.com/getsentry/sentry/pull/66032 for performance implications of `not-buffering`

@wedamija thank you for finding it!