### PR TITLE
feat(ddm): Add limit when fetching code locations from Redis

### DIFF
--- a/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
@@ -79,8 +79,10 @@ class CodeLocationsFetcher:
     BATCH_SIZE = 25
     # The maximum number of code locations we want to retrieve per Redis set.
     MAX_SET_SIZE = 10
+    # The maximum number of code locations that we actually return per Redis set.
+    MAX_LOCATIONS_SIZE = 5
 
-    # Given the limits above, we can expect, in the worst case MAXIMUM_KEYS * (MAX_SET_SIZE / 2) elements being
+    # Given the limits above, we can expect, in the worst case MAXIMUM_KEYS * MAX_LOCATIONS_SIZE elements being
     # returned because we further limit entries returned from Redis after loading them.
 
     def __init__(
@@ -157,7 +159,7 @@ class CodeLocationsFetcher:
             # size. This way, we will have consistent ordering up to MAX_SET_SIZE elements in the set, if the size
             # goes above that, we will end up having different locations returned each time (due to the random access).
             sorted_locations = sorted(parsed_locations, key=lambda value: value.filename or "")[
-                : self.MAX_SET_SIZE / 2
+                : self.MAX_LOCATIONS_SIZE
             ]
             frames.append(MetricCodeLocations(query=query, frames=sorted_locations))
 

--- a/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
@@ -152,16 +152,13 @@ class CodeLocationsFetcher:
             if not locations:
                 continue
 
+            # To maintain consistent ordering, we sort by the location representation.
+            locations = sorted(locations)[: self.MAX_LOCATIONS_SIZE]
             parsed_locations = [
                 self._parse_code_location_payload(location) for location in locations
             ]
-            # To maintain consistent ordering, we sort by filename, and we want to only get half of the maximum set
-            # size. This way, we will have consistent ordering up to MAX_SET_SIZE elements in the set, if the size
-            # goes above that, we will end up having different locations returned each time (due to the random access).
-            sorted_locations = sorted(parsed_locations, key=lambda value: value.filename or "")[
-                : self.MAX_LOCATIONS_SIZE
-            ]
-            frames.append(MetricCodeLocations(query=query, frames=sorted_locations))
+
+            frames.append(MetricCodeLocations(query=query, frames=parsed_locations))
 
         return frames
 

--- a/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
@@ -72,13 +72,15 @@ class CodeLocationsFetcher:
     # The maximum number of keys that can be fetched by the fetcher.
     #
     # The estimation was naively done by supposing at most 10 metrics with 2 projects and at most 90 timestamps.
-    MAXIMUM_KEYS = 2000
+    MAXIMUM_KEYS = 200
     # The size of the batch of keys that are fetched by endpoint.
     #
     # Batching is done via Redis pipeline and the goal is to improve the performance of the system.
     BATCH_SIZE = 25
     # The maximum number of code locations we want to retrieve per Redis set.
     MAX_SET_SIZE = 2
+
+    # Given the limits above, we can expect, in the worst case MAXIMUM_KEYS * MAX_SET_SIZE elements being returned.
 
     def __init__(
         self,

--- a/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
@@ -80,7 +80,8 @@ class CodeLocationsFetcher:
     # The maximum number of code locations we want to retrieve per Redis set.
     MAX_SET_SIZE = 10
 
-    # Given the limits above, we can expect, in the worst case MAXIMUM_KEYS * MAX_SET_SIZE elements being returned.
+    # Given the limits above, we can expect, in the worst case MAXIMUM_KEYS * (MAX_SET_SIZE / 2) elements being
+    # returned because we further limit entries returned from Redis after loading them.
 
     def __init__(
         self,

--- a/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
@@ -72,13 +72,13 @@ class CodeLocationsFetcher:
     # The maximum number of keys that can be fetched by the fetcher.
     #
     # The estimation was naively done by supposing at most 10 metrics with 2 projects and at most 90 timestamps.
-    MAXIMUM_KEYS = 200
+    MAXIMUM_KEYS = 50
     # The size of the batch of keys that are fetched by endpoint.
     #
     # Batching is done via Redis pipeline and the goal is to improve the performance of the system.
     BATCH_SIZE = 25
     # The maximum number of code locations we want to retrieve per Redis set.
-    MAX_SET_SIZE = 2
+    MAX_SET_SIZE = 5
 
     # Given the limits above, we can expect, in the worst case MAXIMUM_KEYS * MAX_SET_SIZE elements being returned.
 
@@ -165,7 +165,7 @@ class CodeLocationsFetcher:
             # de-duplication.
             code_locations += self._get_code_locations(queries)
 
-        metrics.incr("ddm.metrics_code_locations.fetched", amount=len(code_locations))
+        metrics.distribution("ddm.metrics_code_locations.fetched", value=len(code_locations))
 
         return code_locations
 

--- a/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
@@ -100,7 +100,7 @@ class CodeLocationsFetcher:
 
     def _validate(self):
         total_combinations = len(self._projects) * len(self._metric_mris) * len(self._timestamps)
-        if total_combinations >= self.MAXIMUM_KEYS:
+        if total_combinations > self.MAXIMUM_KEYS:
             raise TooManyCodeLocationsRequestedError(
                 "The request results in too many code locations to be fetched, try to reduce the number of "
                 "metrics, projects or the time interval"

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -201,13 +201,13 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             self.organization.slug,
             metric=mris,
             project=[project.id for project in projects],
-            statsPeriod="90d",
+            statsPeriod="30d",
             codeLocations="true",
         )
 
-        # With a window of 90 days, it means that we are actually requesting 91 days, thus we have 10 batches of 10
+        # With a window of 30 days, it means that we are actually requesting 31 days, thus we have 4 batches of 10
         # elements each.
-        assert len(get_code_locations_mock.mock_calls) == 10
+        assert len(get_code_locations_mock.mock_calls) == 4
 
     def test_get_locations_with_incomplete_location(self):
         project = self.create_project(name="project_1")

--- a/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_metadata.py
@@ -198,13 +198,13 @@ class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
             self.organization.slug,
             metric=mris,
             project=[project.id for project in projects],
-            statsPeriod="90d",
+            statsPeriod="30d",
             codeLocations="true",
         )
 
-        # With a window of 90 days, it means that we are actually requesting 91 days, thus we have 10 batches of 10
+        # With a window of 30 days, it means that we are actually requesting 31 days, thus we have 4 batches of 10
         # elements each.
-        assert len(get_code_locations_mock.mock_calls) == 10
+        assert len(get_code_locations_mock.mock_calls) == 4
 
     def test_get_locations_with_incomplete_location(self):
         project = self.create_project(name="project_1")


### PR DESCRIPTION
This PR adds a limit to how many code locations are fetched in each set. In addition, it adds a new metric to track the number of code locations emitted per request.

With the new limit, we are able to determine the upper bound for how many elements can be returned by the endpoint in the worst case.