### PR TITLE
fix(metrics-layer): Change how interval calculation is handled

### DIFF
--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -386,7 +386,7 @@ class MetricsQuery(MetricsQueryValidationRunner):
 
         if self.start and self.end and self.include_series:
             # For this calculation, we decided to round down to the integer since if we get 10.000,x we prefer to allow
-            # the query and lose some data points.
+            # the query and lose some data points. On the other hand, if we get 11.000,x we will not allow the query.
             if int((self.end - self.start).total_seconds() / interval) > MAX_POINTS:
                 raise InvalidParams(
                     "Your interval and date range would create too many results. "

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -385,7 +385,9 @@ class MetricsQuery(MetricsQueryValidationRunner):
             interval = self.interval
 
         if self.start and self.end and self.include_series:
-            if (self.end - self.start).total_seconds() / interval > MAX_POINTS:
+            # For this calculation, we decided to round down to the integer since if we get 10.000,x we prefer to allow
+            # the query and lose some data points.
+            if int((self.end - self.start).total_seconds() / interval) > MAX_POINTS:
                 raise InvalidParams(
                     "Your interval and date range would create too many results. "
                     "Use a larger interval, or a smaller date range."


### PR DESCRIPTION
This PR changes how the interval check in the old metrics layer is performed by rounding to integer the resulting value. 

The rationale behind rounding is to avoid throwing an error in case we will have a fraction of an interval more to "theoretically" return. As an example, if we get back that we would return 10000,6 intervals, we will just return 10000 and the 60% of the other interval will be omitted.