### PR TITLE
Add a new `--reprocess-only-stuck-events` option to ingest(-events) consumer

### DIFF
--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -33,6 +33,10 @@ class EventProcessingStore(Service):
     def __get_unprocessed_key(self, key: str) -> str:
         return key + ":u"
 
+    def exists(self, event: Event) -> bool:
+        key = cache_key_for_event(event)
+        return self.get(key) is not None
+
     def store(self, event: Event, unprocessed: bool = False) -> str:
         with sentry_sdk.start_span(op="eventstore.processing.store"):
             key = cache_key_for_event(event)

--- a/src/sentry/ingest/consumer/attachment_event.py
+++ b/src/sentry/ingest/consumer/attachment_event.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def decode_and_process_chunks(
-    raw_message: Message[KafkaPayload], consumer_type: str
+    raw_message: Message[KafkaPayload], consumer_type: str, reprocess_only_stuck_events: bool
 ) -> IngestMessage | None:
     """
     The first pass for the `attachments` topic:
@@ -40,13 +40,16 @@ def decode_and_process_chunks(
     message: IngestMessage = msgpack.unpackb(raw_payload, use_list=False)
 
     if message["type"] == "attachment_chunk":
-        process_attachment_chunk(message)
+        if not reprocess_only_stuck_events:
+            process_attachment_chunk(message)
         return None
 
     return message
 
 
-def process_attachments_and_events(raw_message: Message[IngestMessage]) -> None:
+def process_attachments_and_events(
+    raw_message: Message[IngestMessage], reprocess_only_stuck_events: bool
+) -> None:
     """
     The second pass for the `attachments` topic processes *individual* `attachments`
     which are not needed for event processing, and the `event` itself,
@@ -71,9 +74,10 @@ def process_attachments_and_events(raw_message: Message[IngestMessage]) -> None:
         return None
 
     if message_type == "attachment":
-        process_individual_attachment(message, project)
+        if not reprocess_only_stuck_events:
+            process_individual_attachment(message, project)
     elif message_type == "event":
-        process_event(message, project)
+        process_event(message, project, reprocess_only_stuck_events)
     elif message_type == "user_report":
         process_userreport(message, project)
     else:

--- a/src/sentry/ingest/consumer/factory.py
+++ b/src/sentry/ingest/consumer/factory.py
@@ -62,6 +62,7 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     def __init__(
         self,
         consumer_type: str,
+        reprocess_only_stuck_events: bool,
         num_processes: int,
         max_batch_size: int,
         max_batch_time: int,
@@ -70,6 +71,7 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     ):
         self.consumer_type = consumer_type
         self.is_attachment_topic = consumer_type == ConsumerType.Attachments
+        self.reprocess_only_stuck_events = reprocess_only_stuck_events
 
         self.multi_process = None
         self._pool = MultiprocessingPool(num_processes)
@@ -97,7 +99,11 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         final_step = CommitOffsets(commit)
 
         if not self.is_attachment_topic:
-            event_function = partial(process_simple_event_message, consumer_type=self.consumer_type)
+            event_function = partial(
+                process_simple_event_message,
+                consumer_type=self.consumer_type,
+                reprocess_only_stuck_events=self.reprocess_only_stuck_events,
+            )
             next_step = maybe_multiprocess_step(mp, event_function, final_step, self._pool)
             return create_backpressure_step(health_checker=self.health_checker, next_step=next_step)
 
@@ -112,8 +118,12 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         # later step.
 
         assert self._attachments_pool is not None
+        processing_function = partial(
+            process_attachments_and_events,
+            reprocess_only_stuck_events=self.reprocess_only_stuck_events,
+        )
         step_2 = maybe_multiprocess_step(
-            mp, process_attachments_and_events, final_step, self._attachments_pool
+            mp, processing_function, final_step, self._attachments_pool
         )
         # This `FilterStep` will skip over processing `None` (aka already handled attachment chunks)
         # in the second step. We filter this here explicitly,
@@ -123,7 +133,11 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         # As the steps are defined (and types inferred) in reverse order, we would get a type error here,
         # as `step_1` outputs an `| None`, but the `filter_step` does not mention that in its type,
         # as it is inferred from the `step_2` input type which does not mention `| None`.
-        attachment_function = partial(decode_and_process_chunks, consumer_type=self.consumer_type)
+        attachment_function = partial(
+            decode_and_process_chunks,
+            consumer_type=self.consumer_type,
+            reprocess_only_stuck_events=self.reprocess_only_stuck_events,
+        )
         step_1 = maybe_multiprocess_step(
             mp, attachment_function, filter_step, self._pool  # type:ignore
         )

--- a/src/sentry/ingest/consumer/factory.py
+++ b/src/sentry/ingest/consumer/factory.py
@@ -138,9 +138,7 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             consumer_type=self.consumer_type,
             reprocess_only_stuck_events=self.reprocess_only_stuck_events,
         )
-        step_1 = maybe_multiprocess_step(
-            mp, attachment_function, filter_step, self._pool  # type:ignore
-        )
+        step_1 = maybe_multiprocess_step(mp, attachment_function, filter_step, self._pool)
 
         return create_backpressure_step(health_checker=self.health_checker, next_step=step_1)
 

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -49,7 +49,9 @@ def trace_func(**span_kwargs):
 
 @trace_func(name="ingest_consumer.process_event")
 @metrics.wraps("ingest_consumer.process_event")
-def process_event(message: IngestMessage, project: Project) -> None:
+def process_event(
+    message: IngestMessage, project: Project, reprocess_only_stuck_events: bool
+) -> None:
     """
     Perform some initial filtering and deserialize the message payload.
     """
@@ -123,6 +125,12 @@ def process_event(message: IngestMessage, project: Project) -> None:
             "event_id": event_id,
         },
     ):
+        return
+
+    # If we only want to reprocess "stuck" events, we check if this event is already in the
+    # `processing_store`. We only continue here if the event *is* present, as that will eventually
+    # process and consume the event from the `processing_store`, whereby getting it "unstuck".
+    if reprocess_only_stuck_events and not event_processing_store.exists(data):
         return
 
     with metrics.timer("ingest_consumer._store_event"):

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -50,7 +50,7 @@ def trace_func(**span_kwargs):
 @trace_func(name="ingest_consumer.process_event")
 @metrics.wraps("ingest_consumer.process_event")
 def process_event(
-    message: IngestMessage, project: Project, reprocess_only_stuck_events: bool
+    message: IngestMessage, project: Project, reprocess_only_stuck_events: bool = False
 ) -> None:
     """
     Perform some initial filtering and deserialize the message payload.

--- a/src/sentry/ingest/consumer/simple_event.py
+++ b/src/sentry/ingest/consumer/simple_event.py
@@ -12,7 +12,9 @@ from .processors import IngestMessage, process_event
 logger = logging.getLogger(__name__)
 
 
-def process_simple_event_message(raw_message: Message[KafkaPayload], consumer_type: str) -> None:
+def process_simple_event_message(
+    raw_message: Message[KafkaPayload], consumer_type: str, reprocess_only_stuck_events: bool
+) -> None:
     """
     Processes a single Kafka Message containing a "simple" Event payload.
 
@@ -49,4 +51,4 @@ def process_simple_event_message(raw_message: Message[KafkaPayload], consumer_ty
         logger.exception("Project for ingested event does not exist: %s", project_id)
         return
 
-    return process_event(message, project)
+    return process_event(message, project, reprocess_only_stuck_events)

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from sentry import eventstore
 from sentry.consumers import get_stream_processor
 from sentry.event_manager import EventManager
+from sentry.eventstore.processing import event_processing_store
 from sentry.ingest.types import ConsumerType
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_kafka, requires_snuba
@@ -60,7 +61,12 @@ def get_test_message(default_project):
                 },
             }
         elif type == "event":
-            event = {"message": message_text, "extra": {"the_id": event_id}, "event_id": event_id}
+            event = {
+                "message": message_text,
+                "extra": {"the_id": event_id},
+                "project": project_id,
+                "event_id": event_id,
+            }
         else:
             raise ValueError(type)
 
@@ -140,3 +146,63 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
     assert transaction_message.data["event_id"] == transaction_event_id
     assert transaction_message.data["spans"] == []
     assert transaction_message.data["contexts"]["trace"]
+
+
+@django_db_all(transaction=True)
+def test_ingest_consumer_gets_event_unstuck(
+    task_runner,
+    kafka_producer,
+    kafka_admin,
+    default_project,
+    get_test_message,
+    random_group_id,
+):
+    topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)
+
+    admin = kafka_admin(settings)
+    admin.delete_topic(topic_event_name)
+    producer = kafka_producer(settings)
+
+    create_topics("default", [topic_event_name])
+
+    message1, event_id1 = get_test_message(type="event")
+    producer.produce(topic_event_name, message1)
+
+    message2, event_id2 = get_test_message(type="event")
+    producer.produce(topic_event_name, message2)
+
+    # an event is "stuck" when it is in the processing store, so lets fake that:
+    event_processing_store.store({"project": default_project.id, "event_id": event_id2})
+
+    consumer = get_stream_processor(
+        "ingest-events",
+        consumer_args=[
+            "--max-batch-size=2",
+            "--max-batch-time-ms=5000",
+            "--processes=10",
+            "--reprocess-only-stuck-events",
+        ],
+        topic=None,
+        cluster=None,
+        group_id=random_group_id,
+        auto_offset_reset="earliest",
+        strict_offset_reset=False,
+    )
+
+    with task_runner():
+        i = 0
+        while i < MAX_POLL_ITERATIONS:
+            message = eventstore.backend.get_event_by_id(default_project.id, event_id2)
+
+            if message:
+                break
+
+            consumer._run_once()
+            i += 1
+
+    # check that we got the messages
+    assert message.data["event_id"] == event_id2
+    assert message.data["extra"]["the_id"] == event_id2
+
+    # the first event was never "stuck", so we expect it to be skipped
+    assert not eventstore.backend.get_event_by_id(default_project.id, event_id1)


### PR DESCRIPTION
This should fix #63876 by adding the requested option.

When passed, the option will only process events that *are* already in the processing store (presumably stuck), and it will ignore other events and attachments.