### PR TITLE
chore(ui): remove UI for org roles from team

### DIFF
--- a/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
@@ -138,11 +138,10 @@ function TeamRow({
   organization: Organization;
   team: Team;
 }) {
-  const hasOrgAdmin = organization.access.includes('org:admin');
   const isIdpProvisioned = team.flags['idp:provisioned'];
-  const isRemoveDisabled = disabled || isIdpProvisioned || !hasOrgAdmin;
+  const isRemoveDisabled = disabled || isIdpProvisioned;
 
-  const buttonHelpText = getButtonHelpText(isIdpProvisioned, !hasOrgAdmin);
+  const buttonHelpText = getButtonHelpText(isIdpProvisioned);
 
   return (
     <TeamPanelItem data-test-id="team-row-for-member">

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -72,7 +72,6 @@ export function DropdownAddTeam({
       renderDropdownOption({
         isAddingTeamToMember,
         isAddingTeamToProject,
-        organization,
         team,
         index,
         disabled,
@@ -112,27 +111,23 @@ function renderDropdownOption({
   disabled,
   index,
   isAddingTeamToMember,
-  organization,
   team,
 }: {
   disabled: boolean;
   index: number;
   isAddingTeamToMember: boolean;
   isAddingTeamToProject: boolean;
-  organization: Organization;
   team: Team;
 }) {
-  const hasOrgAdmin = organization.access.includes('org:admin');
   const isIdpProvisioned = isAddingTeamToMember && team.flags['idp:provisioned'];
-  const isPermissionGroup = isAddingTeamToMember && !hasOrgAdmin;
-  const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);
+  const buttonHelpText = getButtonHelpText(isIdpProvisioned);
 
   return {
     index,
     value: team.slug,
     searchKey: team.slug,
     label: () => {
-      if (isIdpProvisioned || isPermissionGroup) {
+      if (isIdpProvisioned) {
         return (
           <Tooltip title={buttonHelpText}>
             <DropdownTeamBadgeDisabled avatarSize={18} team={team} />
@@ -142,7 +137,7 @@ function renderDropdownOption({
 
       return <DropdownTeamBadge avatarSize={18} team={team} />;
     },
-    disabled: disabled || isIdpProvisioned || isPermissionGroup,
+    disabled: disabled || isIdpProvisioned,
   };
 }
 

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -176,17 +176,13 @@ class AllTeamsRow extends Component<Props, State> {
 
   render() {
     const {team, openMembership, organization} = this.props;
-    const {access} = organization;
     const urlPrefix = `/settings/${organization.slug}/teams/`;
-    const canEditTeam = access.includes('org:write') || access.includes('team:admin');
 
     // TODO(team-roles): team admins can also manage membership
     // org:admin is a unique scope that only org owners have
-    const isOrgOwner = access.includes('org:admin');
-    const isPermissionGroup = !canEditTeam || !isOrgOwner;
     const isIdpProvisioned = team.flags['idp:provisioned'];
 
-    const buttonHelpText = getButtonHelpText(isIdpProvisioned, isPermissionGroup);
+    const buttonHelpText = getButtonHelpText(isIdpProvisioned);
 
     const display = (
       <IdBadge
@@ -201,7 +197,7 @@ class AllTeamsRow extends Component<Props, State> {
     const canViewTeam = team.hasAccess;
 
     const teamRoleName = this.getTeamRoleName();
-    const isDisabled = isIdpProvisioned || isPermissionGroup;
+    const isDisabled = isIdpProvisioned;
 
     return (
       <TeamPanelItem>

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -310,10 +310,7 @@ class TeamMembers extends DeprecatedAsyncView<Props, State> {
 
   renderMembers(isTeamAdmin: boolean) {
     const {config, organization, team} = this.props;
-    const {access} = organization;
 
-    // org:admin is a unique scope that only org owners have
-    const isOrgOwner = access.includes('org:admin');
     const {teamMembers, loading} = this.state;
 
     if (loading) {
@@ -325,7 +322,6 @@ class TeamMembers extends DeprecatedAsyncView<Props, State> {
           <TeamMembersRow
             key={member.id}
             hasWriteAccess={isTeamAdmin}
-            isOrgOwner={isOrgOwner}
             organization={organization}
             team={team}
             member={member}

--- a/static/app/views/settings/organizationTeams/teamMembersRow.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembersRow.tsx
@@ -12,7 +12,6 @@ import {getButtonHelpText} from 'sentry/views/settings/organizationTeams/utils';
 
 interface Props {
   hasWriteAccess: boolean;
-  isOrgOwner: boolean;
   member: TeamMember;
   organization: Organization;
   removeMember: (member: Member) => void;
@@ -27,7 +26,6 @@ function TeamMembersRow({
   member,
   user,
   hasWriteAccess,
-  isOrgOwner,
   removeMember,
   updateMemberRole,
 }: Props) {
@@ -50,7 +48,6 @@ function TeamMembersRow({
       <div>
         <RemoveButton
           hasWriteAccess={hasWriteAccess}
-          isOrgOwner={isOrgOwner}
           isSelf={isSelf}
           onClick={() => removeMember(member)}
           member={member}
@@ -62,12 +59,11 @@ function TeamMembersRow({
 
 function RemoveButton(props: {
   hasWriteAccess: boolean;
-  isOrgOwner: boolean;
   isSelf: boolean;
   member: TeamMember;
   onClick: () => void;
 }) {
-  const {member, hasWriteAccess, isOrgOwner, isSelf, onClick} = props;
+  const {member, hasWriteAccess, isSelf, onClick} = props;
 
   const canRemoveMember = hasWriteAccess || isSelf;
   if (!canRemoveMember) {
@@ -85,7 +81,7 @@ function RemoveButton(props: {
   }
 
   const isIdpProvisioned = member.flags['idp:provisioned'];
-  const buttonHelpText = getButtonHelpText(isIdpProvisioned, !isOrgOwner);
+  const buttonHelpText = getButtonHelpText(isIdpProvisioned);
 
   const buttonRemoveText = isSelf ? t('Leave') : t('Remove');
   return (

--- a/static/app/views/settings/organizationTeams/utils.tsx
+++ b/static/app/views/settings/organizationTeams/utils.tsx
@@ -1,17 +1,10 @@
 import {t} from 'sentry/locale';
 
-export function getButtonHelpText(
-  isIdpProvisioned: boolean = false,
-  isPermissionGroup: boolean = false
-) {
+export function getButtonHelpText(isIdpProvisioned: boolean = false) {
   if (isIdpProvisioned) {
     return t(
       "Membership to this team is managed through your organization's identity provider."
     );
-  }
-
-  if (isPermissionGroup) {
-    return t('Membership to a team with an organization role is managed by org owners.');
   }
 
   return undefined;


### PR DESCRIPTION
The second argument to `getButtonHelpText` was only used to determine whether we should show tooltip text about org roles for teams. Since this feature is not being used anymore, we can remove the second argument.