### PR TITLE
chore(hybridcloud) Remove shims for getsentry

### DIFF
--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -20,13 +20,7 @@ OpsgeniePriority = Literal["P1", "P2", "P3", "P4", "P5"]
 class OpsgenieClient(ApiClient):
     integration_name = "opsgenie"
 
-    def __init__(
-        self,
-        integration: RpcIntegration | Integration,
-        integration_key: str,
-        org_integration_id: int | None = None,  # deprecated but still passed by getsentry
-        keyid: str | None = None,  # deprecated but still passed by getsentry
-    ) -> None:
+    def __init__(self, integration: RpcIntegration | Integration, integration_key: str) -> None:
         self.integration = integration
         self.base_url = f"{self.metadata['base_url']}{OPSGENIE_API_VERSION}"
         self.integration_key = integration_key

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -21,13 +21,7 @@ class PagerDutyClient(ApiClient):
     integration_name = "pagerduty"
     base_url = "https://events.pagerduty.com/v2/enqueue"
 
-    def __init__(
-        self,
-        integration_key: str,
-        integration_id: int | None = None,  # soon to be required, depending on getsentry changes
-        keyid: str | None = None,  # deprecated but still passed by getsentry
-        org_integration_id: int | None = None,  # deprecated but still passed by getsentry
-    ) -> None:
+    def __init__(self, integration_key: str, integration_id: int) -> None:
         self.integration_key = integration_key
         super().__init__(integration_id=integration_id)
 
@@ -71,9 +65,3 @@ class PagerDutyClient(ApiClient):
             payload = data
 
         return self.post("/", data=payload)
-
-
-class PagerDutyProxyClient(PagerDutyClient):
-    """Backwards compatibility shim for getsentry"""
-
-    pass


### PR DESCRIPTION
Getsentry is no longer relying on these parameters/names.

