### PR TITLE
fix(metrics-extraction): Add try/catch around events query

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -233,6 +233,14 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         # Covers cases of !A && !B and A && B
         return DashboardWidgetTypes.ERROR_EVENTS
 
+    def save_split_decision(self, widget, has_errors, has_other_data):
+        """This can be removed once the discover dataset has been fully split"""
+        new_discover_widget_split = self.get_split_decision(has_errors, has_other_data)
+
+        if widget.discover_widget_split != new_discover_widget_split:
+            widget.discover_widget_split = new_discover_widget_split
+            widget.save()
+
     def handle_unit_meta(
         self, meta: dict[str, str]
     ) -> tuple[dict[str, str], dict[str, str | None]]:

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -236,7 +236,6 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
     def save_split_decision(self, widget, has_errors, has_other_data):
         """This can be removed once the discover dataset has been fully split"""
         new_discover_widget_split = self.get_split_decision(has_errors, has_other_data)
-
         if widget.discover_widget_split != new_discover_widget_split:
             widget.discover_widget_split = new_discover_widget_split
             widget.save()

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3263,14 +3263,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         user_misery_field = "user_misery(300)"
         query = "transaction.duration:>=100"
 
-        _, widget, __ = create_widget(
-            ["epm()"],
-            "transaction.duration:>=100",
-            self.project,
-            title="Dashboard 123",
-            columns=["user.id", "release", "count()"],
-            discover_widget_split=None,
-        )
+        _, widget, __ = create_widget(["count()"], "", self.project, discover_widget_split=None)
 
         # We store data for both specs, however, when the query builders try to query
         # for the data it will not query on-demand data
@@ -3305,12 +3298,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         query = "transaction.duration:>=100"
 
         _, widget, __ = create_widget(
-            ["epm()"],
-            "transaction.duration:>=100",
+            ["count()"],
+            "",
             self.project,
-            title="Dashboard 123",
-            columns=["user.id", "release", "count()"],
-            discover_widget_split=DashboardWidgetTypes.TRANSACTION_LIKE,  # Transaction-like tries to use on-demand
+            discover_widget_split=DashboardWidgetTypes.TRANSACTION_LIKE,  # Transactions like uses on-demand
         )
 
         # We store data for both specs, however, when the query builders try to query

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -15,6 +15,7 @@ from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.on_demand import create_widget
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.samples import load_data
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -1176,7 +1177,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             assert response.data[group][agg]["meta"]["isMetricsExtractedData"]
             assert response.data[group]["isMetricsExtractedData"]
 
-    def test_top_events_with_transaction_on_demand_passing_widget_id_unsaved(self):
+    def test_top_events_with_transaction_on_demand_passing_widget_id_unsaved_transaction_only(self):
         field = "count()"
         field_two = "count_web_vitals(measurements.lcp, good)"
         groupbys = ["customtag1", "customtag2"]
@@ -1189,11 +1190,9 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
         )
 
         _, widget, __ = create_widget(
-            ["epm()"],
-            "transaction.duration:>=100",
+            ["count()"],
+            "",
             self.project,
-            title="Dashboard 123",
-            columns=["user.id", "release", "count()"],
             discover_widget_split=None,
         )
 
@@ -1231,12 +1230,86 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                     "orderby": ["-count()"],
                     "query": query,
                     "yAxis": yAxis,
-                    "field": [
-                        "count()",
-                        "count_web_vitals(measurements.lcp, good)",
-                        "customtag1",
-                        "customtag2",
-                    ],
+                    "field": [field, field_two] + groupbys,
+                    "topEvents": 5,
+                    "dataset": "metricsEnhanced",
+                    "useOnDemandMetrics": "true",
+                    "onDemandType": "dynamic_query",
+                    "dashboardWidgetId": widget.id,
+                },
+            )
+            assert bool(mock_widget_save.assert_called_once)
+
+        assert response.status_code == 200, response.content
+        # Fell back to discover data which is empty for this test (empty group of '').
+        assert len(response.data.keys()) == 1
+        assert bool(response.data[""])
+
+    def test_top_events_with_transaction_on_demand_passing_widget_id_unsaved_error(self):
+        field = "count()"
+        field_two = "count()"
+        groupbys = ["customtag1", "customtag2"]
+        query = "query.dataset:foo"
+        spec = OnDemandMetricSpec(
+            field=field, groupbys=groupbys, query=query, spec_type=MetricSpecType.DYNAMIC_QUERY
+        )
+        spec_two = OnDemandMetricSpec(
+            field=field_two, groupbys=groupbys, query=query, spec_type=MetricSpecType.DYNAMIC_QUERY
+        )
+
+        _, widget, __ = create_widget(
+            ["count()"],
+            "",
+            self.project,
+            discover_widget_split=None,
+        )
+
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "very bad",
+                "type": "error",
+                "timestamp": iso_format(self.day_ago + timedelta(hours=1)),
+                "tags": {"customtag1": "error_value", "query.dataset": "foo"},
+            },
+            project_id=self.project.id,
+        )
+
+        for hour in range(0, 5):
+            self.store_on_demand_metric(
+                hour * 62 * 24,
+                spec=spec,
+                additional_tags={
+                    "customtag1": "foo",
+                    "customtag2": "red",
+                    "environment": "production",
+                },
+                timestamp=self.day_ago + timedelta(hours=hour),
+            )
+            self.store_on_demand_metric(
+                hour * 60 * 24,
+                spec=spec_two,
+                additional_tags={
+                    "customtag1": "bar",
+                    "customtag2": "blue",
+                    "environment": "production",
+                },
+                timestamp=self.day_ago + timedelta(hours=hour),
+            )
+
+        yAxis = ["count()"]
+
+        with mock.patch.object(widget, "save") as mock_widget_save:
+            response = self.do_request(
+                data={
+                    "project": self.project.id,
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "interval": "1h",
+                    "orderby": ["-count()"],
+                    "query": query,
+                    "yAxis": yAxis,
+                    "field": [field, field_two, "customtag1", "customtag2"],
                     "topEvents": 5,
                     "dataset": "metricsEnhanced",
                     "useOnDemandMetrics": "true",
@@ -1248,20 +1321,102 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
 
         assert response.status_code == 200, response.content
 
-        groups = [
-            ("foo,red", "count()", 0.0, 1488.0),
-            ("foo,red", "count_web_vitals(measurements.lcp, good)", 0.0, 0.0),
-            ("bar,blue", "count()", 0.0, 0.0),
-            ("bar,blue", "count_web_vitals(measurements.lcp, good)", 0.0, 1440.0),
-        ]
-        assert len(response.data.keys()) == 2
-        for group_count in groups:
-            group, agg, row1, row2 = group_count
-            row_data = response.data[group][agg]["data"][:2]
-            assert [attrs for time, attrs in row_data] == [[{"count": row1}], [{"count": row2}]]
+        assert response.status_code == 200, response.content
+        # Fell back to discover data which is empty for this test (empty group of '').
+        assert len(response.data.keys()) == 1
+        assert bool(response.data["error_value,"])
 
-            assert response.data[group][agg]["meta"]["isMetricsExtractedData"]
-            assert response.data[group]["isMetricsExtractedData"]
+    def test_top_events_with_transaction_on_demand_passing_widget_id_unsaved_discover(self):
+        field = "count()"
+        field_two = "count()"
+        groupbys = ["customtag1", "customtag2"]
+        query = "query.dataset:foo"
+        spec = OnDemandMetricSpec(
+            field=field, groupbys=groupbys, query=query, spec_type=MetricSpecType.DYNAMIC_QUERY
+        )
+        spec_two = OnDemandMetricSpec(
+            field=field_two, groupbys=groupbys, query=query, spec_type=MetricSpecType.DYNAMIC_QUERY
+        )
+
+        _, widget, __ = create_widget(
+            ["count()"],
+            "",
+            self.project,
+            discover_widget_split=None,
+        )
+
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "very bad",
+                "type": "error",
+                "timestamp": iso_format(self.day_ago + timedelta(hours=1)),
+                "tags": {"customtag1": "error_value", "query.dataset": "foo"},
+            },
+            project_id=self.project.id,
+        )
+
+        transaction = load_data("transaction")
+        transaction["timestamp"] = iso_format(self.day_ago + timedelta(hours=1))
+        transaction["start_timestamp"] = iso_format(self.day_ago + timedelta(hours=1))
+        transaction["tags"] = {"customtag1": "transaction_value", "query.dataset": "foo"}
+
+        self.store_event(
+            data=transaction,
+            project_id=self.project.id,
+        )
+
+        for hour in range(0, 5):
+            self.store_on_demand_metric(
+                hour * 62 * 24,
+                spec=spec,
+                additional_tags={
+                    "customtag1": "foo",
+                    "customtag2": "red",
+                    "environment": "production",
+                },
+                timestamp=self.day_ago + timedelta(hours=hour),
+            )
+            self.store_on_demand_metric(
+                hour * 60 * 24,
+                spec=spec_two,
+                additional_tags={
+                    "customtag1": "bar",
+                    "customtag2": "blue",
+                    "environment": "production",
+                },
+                timestamp=self.day_ago + timedelta(hours=hour),
+            )
+
+        yAxis = ["count()"]
+
+        with mock.patch.object(widget, "save") as mock_widget_save:
+            response = self.do_request(
+                data={
+                    "project": self.project.id,
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "interval": "1h",
+                    "orderby": ["-count()"],
+                    "query": query,
+                    "yAxis": yAxis,
+                    "field": [field, field_two, "customtag1", "customtag2"],
+                    "topEvents": 5,
+                    "dataset": "metricsEnhanced",
+                    "useOnDemandMetrics": "true",
+                    "onDemandType": "dynamic_query",
+                    "dashboardWidgetId": widget.id,
+                },
+            )
+            assert bool(mock_widget_save.assert_called_once)
+
+        assert response.status_code == 200, response.content
+
+        assert response.status_code == 200, response.content
+        # Fell back to discover data which is empty for this test (empty group of '').
+        assert len(response.data.keys()) == 2
+        assert bool(response.data["error_value,"])
+        assert bool(response.data["transaction_value,"])
 
     def test_top_events_with_transaction_on_demand_passing_widget_id_saved(self):
         field = "count()"
@@ -1276,11 +1431,9 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
         )
 
         _, widget, __ = create_widget(
-            ["epm()"],
-            "transaction.duration:>=100",
+            ["count()"],
+            "",
             self.project,
-            title="Dashboard 123",
-            columns=["user.id", "release", "count()"],
             discover_widget_split=DashboardWidgetTypes.TRANSACTION_LIKE,  # Transactions like uses on-demand
         )
 


### PR DESCRIPTION
### Summary
The `/events` endpoint was missing the same try/catch for `SnubaError` that is in `/event-stats`. Snuba can reject the error-sided query if you send something like 'measurements', in which case we can tell that the query should not be error-based
