### PR TITLE
Update statistical detector issues default priority

### DIFF
--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -6,6 +6,7 @@ from sentry.issues.grouptype import GroupType, PerformanceP95EndpointRegressionG
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.seer.utils import BreakpointData
+from sentry.types.group import PriorityLevel
 from sentry.utils import metrics
 
 
@@ -56,6 +57,7 @@ def send_regression_to_platform(regression: BreakpointData):
         ],
         detection_time=current_timestamp,
         level="info",
+        initial_issue_priority=PriorityLevel.MEDIUM,
     )
 
     event_data = {

--- a/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
+++ b/tests/sentry/statistical_detectors/test_issue_platform_adapter.py
@@ -3,6 +3,7 @@ from unittest import mock
 from sentry.issues.grouptype import PerformanceP95EndpointRegressionGroupType
 from sentry.seer.utils import BreakpointData
 from sentry.statistical_detectors.issue_platform_adapter import send_regression_to_platform
+from sentry.types.group import PriorityLevel
 
 
 @mock.patch("sentry.statistical_detectors.issue_platform_adapter.produce_occurrence_to_kafka")
@@ -52,6 +53,7 @@ def test_send_regressions_to_plaform(
             "type": PerformanceP95EndpointRegressionGroupType.type_id,
             "level": "info",
             "culprit": "foo",
+            "initial_issue_priority": PriorityLevel.MEDIUM,
         },
     ) == dict(occurrence)
 


### PR DESCRIPTION
Currently the default priority of statistical detector (endpoint and function regression) issues is `Low`. But, given they represent an active and likely important issue, we're updating that to `Medium`. (The guideline for Medium priority issues is "you should look at this in < 1 week", which seems about right for this kind of issue).

Note that further regressions (the slowdown getting even worse) may already cause the issue to escalate, which could further increase the priority later.
