### PR TITLE
fix: merge get_cluster_routing_client redis calls

### DIFF
--- a/src/sentry/cache/redis.py
+++ b/src/sentry/cache/redis.py
@@ -1,5 +1,5 @@
 from sentry.utils import json
-from sentry.utils.redis import get_cluster_from_options, is_instance_rb_cluster, redis_clusters
+from sentry.utils.redis import get_cluster_from_options, get_cluster_routing_client, redis_clusters
 
 from .base import BaseCache
 
@@ -55,10 +55,7 @@ class CommonRedisCache(BaseCache):
 class RbCache(CommonRedisCache):
     def __init__(self, **options: object) -> None:
         cluster, options = get_cluster_from_options("SENTRY_CACHE_OPTIONS", options)
-        if is_instance_rb_cluster(cluster, False):
-            client = cluster.get_routing_client()
-        else:
-            raise AssertionError("unreachable")
+        client = get_cluster_routing_client(cluster, False)
         # XXX: rb does not have a "raw" client -- use the default client
         super().__init__(client=client, raw_client=client, **options)
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -266,6 +266,17 @@ def get_dynamic_cluster_from_options(
     return False, cluster, config
 
 
+def get_cluster_routing_client(
+    cluster: RedisCluster | rb.Cluster, is_redis_cluster: bool
+) -> RedisCluster | rb.RoutingClient:
+    if is_instance_redis_cluster(cluster, is_redis_cluster):
+        return cluster
+    elif is_instance_rb_cluster(cluster, is_redis_cluster):
+        return cluster.get_routing_client()
+    else:
+        raise AssertionError("unreachable")
+
+
 def is_instance_redis_cluster(
     val: rb.Cluster | RedisCluster, is_redis_cluster: bool
 ) -> TypeGuard[RedisCluster]:

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -12,7 +12,11 @@ from sentry.models.project import Project
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
-from sentry.utils.redis import is_instance_rb_cluster, is_instance_redis_cluster
+from sentry.utils.redis import (
+    get_cluster_routing_client,
+    is_instance_rb_cluster,
+    is_instance_redis_cluster,
+)
 
 
 class TestRedisBuffer:
@@ -37,31 +41,31 @@ class TestRedisBuffer:
     @mock.patch("sentry.buffer.redis.process_incr")
     def test_process_pending_one_batch(self, process_incr):
         self.buf.incr_batch_size = 5
-        client = self.buf.get_routing_client()
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
         client.zadd("b:p", {"foo": 1, "bar": 2})
         self.buf.process_pending()
         assert len(process_incr.apply_async.mock_calls) == 1
         process_incr.apply_async.assert_any_call(kwargs={"batch_keys": ["foo", "bar"]})
-        client = self.buf.get_routing_client()
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
         assert client.zrange("b:p", 0, -1) == []
 
     @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
     @mock.patch("sentry.buffer.redis.process_incr")
     def test_process_pending_multiple_batches(self, process_incr):
         self.buf.incr_batch_size = 2
-        client = self.buf.get_routing_client()
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
         client.zadd("b:p", {"foo": 1, "bar": 2, "baz": 3})
         self.buf.process_pending()
         assert len(process_incr.apply_async.mock_calls) == 2
         process_incr.apply_async.assert_any_call(kwargs={"batch_keys": ["foo", "bar"]})
         process_incr.apply_async.assert_any_call(kwargs={"batch_keys": ["baz"]})
-        client = self.buf.get_routing_client()
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
         assert client.zrange("b:p", 0, -1) == []
 
     @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
     @mock.patch("sentry.buffer.base.Buffer.process")
     def test_process_does_bubble_up_json(self, process):
-        client = self.buf.get_routing_client()
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
 
         client.hmset(
             "foo",
@@ -86,7 +90,7 @@ class TestRedisBuffer:
     @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
     @mock.patch("sentry.buffer.base.Buffer.process")
     def test_process_does_bubble_up_pickle(self, process):
-        client = self.buf.get_routing_client()
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
 
         client.hmset(
             "foo",
@@ -135,7 +139,7 @@ class TestRedisBuffer:
 
     def test_incr_saves_to_redis(self):
         now = datetime.datetime(2017, 5, 3, 6, 6, 6, tzinfo=datetime.UTC)
-        client = self.buf.get_routing_client()
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
         model = mock.Mock()
         model.__name__ = "Mock"
         columns = {"times_seen": 1}
@@ -220,7 +224,7 @@ class TestRedisBuffer:
         ]
 
         # Confirm that we've only processed the unpartitioned buffer
-        client = self.buf.get_routing_client()
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
 
         assert client.zrange("b:p", 0, -1) == []
         assert client.zrange("b:p:0", 0, -1) != []
@@ -247,7 +251,7 @@ class TestRedisBuffer:
     @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
     @mock.patch("sentry.buffer.base.Buffer.process")
     def test_process_uses_signal_only(self, process):
-        client = self.buf.get_routing_client()
+        client = get_cluster_routing_client(self.buf.cluster, self.buf.is_redis_cluster)
 
         client.hmset(
             "foo",


### PR DESCRIPTION
Merge routing_client calls and move it to `utils/redis.py`