### PR TITLE
fix(mobile-starfish): Do not retry release selector queries

### DIFF
--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -33,7 +33,7 @@ export function useReleases(searchTerm?: string) {
         },
       },
     ],
-    {staleTime: Infinity, enabled: isReady}
+    {staleTime: Infinity, enabled: isReady, retry: false}
   );
 
   const chunks = releaseResults.data?.length ? chunk(releaseResults.data, 10) : [];
@@ -67,7 +67,9 @@ export function useReleases(searchTerm?: string) {
             method: 'GET',
             query: queryKey[1]?.query,
           }) as Promise<TableData>,
-        ...{staleTime: Infinity, enabled: isReady && !releaseResults.isLoading},
+        staleTime: Infinity,
+        enabled: isReady && !releaseResults.isLoading,
+        retry: false,
       };
     }),
   });


### PR DESCRIPTION
Pass along `retry: false` because if these queries fail to load for any error case, the loading state may never change and cause an infinite loader

According to [the docs](https://tanstack.com/query/v4/docs/framework/react/reference/useQuery) for `useQuery`, if we don't define `retry: false` or cap it with a number, it will infinitely retry which means it will always be loading if there's an issue such as bad input.