### PR TITLE
fix: add missing validate to base class

### DIFF
--- a/src/sentry/processing/realtime_metrics/base.py
+++ b/src/sentry/processing/realtime_metrics/base.py
@@ -17,6 +17,12 @@ class RealtimeMetricsStore(Service):
         "remove_projects_from_lpq",
     )
 
+    def validate(self) -> None:
+        """
+        Validate the current state of the metrics store.
+        """
+        raise NotImplementedError
+
     def record_project_duration(self, project_id: int, duration: float) -> None:
         """
         Records the duration of a symbolication request for the given project_id.

--- a/src/sentry/processing/realtime_metrics/dummy.py
+++ b/src/sentry/processing/realtime_metrics/dummy.py
@@ -11,6 +11,9 @@ class DummyRealtimeMetricsStore(base.RealtimeMetricsStore):
     def __init__(self, **kwargs: Any) -> None:
         pass
 
+    def validate(self) -> None:
+        pass
+
     def record_project_duration(self, project_id: int, duration: float) -> None:
         pass
 


### PR DESCRIPTION
Validate is listed in base class `__all__` but not defined.