### PR TITLE
fix(spans-indexed): Merge span duration with self time for accuracy

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -493,7 +493,8 @@ class OrganizationMetricsSamplesEndpoint(OrganizationEventsV2EndpointBase):
         if not executor_cls:
             raise ParseError(f"Unsupported MRI: {serialized['mri']}")
 
-        if (sort := serialized.get("sort")) is not None:
+        sort = serialized.get("sort")
+        if sort is not None:
             column = sort[1:] if sort.startswith("-") else sort
             if not executor_cls.supports_sort(column):
                 raise ParseError(f"Unsupported sort: {sort} for MRI")

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -50,6 +50,7 @@ class SpansIndexedDatasetConfig(DatasetConfig):
             constants.DEVICE_CLASS_ALIAS: lambda alias: field_aliases.resolve_device_class(
                 self.builder, alias
             ),
+            "span.duration": self._resolve_span_duration,
         }
 
     @property
@@ -234,6 +235,29 @@ class SpansIndexedDatasetConfig(DatasetConfig):
 
     def _resolve_span_module(self, alias: str) -> SelectType:
         return field_aliases.resolve_span_module(self.builder, alias)
+
+    def _resolve_span_duration(self, alias: str) -> SelectType:
+        # In ClickHouse, duration is an UInt32 whereas self time is a Float64.
+        # This creates a situation where a sub-millisecond duration is truncated
+        # to but the self time is not.
+        #
+        # To remedy this, we take the greater of the duration and self time as
+        # this is the only situation where the self time can be greater than
+        # the duration.
+        #
+        # Also avoids strange situations on the frontend where duration is less
+        # than the self time.
+        duration = Column("duration")
+        self_time = self.builder.column("span.self_time")
+        return Function(
+            "if",
+            [
+                Function("greater", [self_time, duration]),
+                self_time,
+                duration,
+            ],
+            alias,
+        )
 
     def _resolve_bounded_sample(
         self,

--- a/src/sentry/sentry_metrics/querying/samples_list.py
+++ b/src/sentry/sentry_metrics/querying/samples_list.py
@@ -11,7 +11,7 @@ from sentry.search.events.builder import (
     QueryBuilder,
     SpansIndexedQueryBuilder,
 )
-from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams
+from sentry.search.events.types import ParamsType, QueryBuilderConfig, SelectType, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.naming_layer.mri import (
     SpanMRI,
@@ -439,7 +439,7 @@ class SpansSamplesListExecutor(AbstractSamplesListExecutor):
 
         additional_conditions = self.get_additional_conditions(builder)
 
-        min_max_conditions = self.get_min_max_conditions(builder.column(column))
+        min_max_conditions = self.get_min_max_conditions(builder.resolve_column(column))
 
         builder.add_conditions([*additional_conditions, *min_max_conditions])
 
@@ -499,7 +499,7 @@ class SpansSamplesListExecutor(AbstractSamplesListExecutor):
 
         column = self.mri_to_column(self.mri)
         assert column is not None
-        min_max_conditions = self.get_min_max_conditions(builder.column(column))
+        min_max_conditions = self.get_min_max_conditions(builder.resolve_column(column))
 
         builder.add_conditions([*additional_conditions, *min_max_conditions])
 
@@ -519,7 +519,7 @@ class SpansSamplesListExecutor(AbstractSamplesListExecutor):
     def get_additional_conditions(self, builder: QueryBuilder) -> list[Condition]:
         raise NotImplementedError
 
-    def get_min_max_conditions(self, column: Column) -> list[Condition]:
+    def get_min_max_conditions(self, column: SelectType) -> list[Condition]:
         conditions = []
 
         if self.min is not None:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -120,7 +120,8 @@ SPAN_COLUMN_MAP = {
     "span.action": "action",
     "span.description": "description",
     "span.domain": "domain",
-    "span.duration": "duration",
+    # DO NOT directly expose span.duration, we should always use the alias
+    # "span.duration": "duration",
     "span.group": "group",
     "span.module": "module",
     "span.op": "op",

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from snuba_sdk import Column, Condition, Function, Op
+
+from sentry.search.events.builder import SpansIndexedQueryBuilder
+from sentry.snuba.dataset import Dataset
+from sentry.testutils.factories import Factories
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@pytest.fixture
+def now():
+    return datetime(2022, 10, 31, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def today(now):
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+@pytest.fixture
+def params(now, today):
+    organization = Factories.create_organization()
+    team = Factories.create_team(organization=organization)
+    project1 = Factories.create_project(organization=organization, teams=[team])
+    project2 = Factories.create_project(organization=organization, teams=[team])
+
+    user = Factories.create_user()
+    Factories.create_team_membership(team=team, user=user)
+
+    return {
+        "start": now - timedelta(days=7),
+        "end": now - timedelta(seconds=1),
+        "project_id": [project1.id, project2.id],
+        "project_objects": [project1, project2],
+        "organization_id": organization.id,
+        "user_id": user.id,
+        "team_id": [team.id],
+    }
+
+
+span_duration = Function(
+    "if",
+    [
+        Function("greater", [Column("exclusive_time"), Column("duration")]),
+        Column("exclusive_time"),
+        Column("duration"),
+    ],
+    "span.duration",
+)
+
+
+@pytest.mark.parametrize(
+    ["field", "expected"], [pytest.param("span.duration", span_duration, id="span.duration")]
+)
+@django_db_all
+def test_field_alias(params, field, expected):
+    builder = SpansIndexedQueryBuilder(
+        Dataset.SpansIndexed,
+        params,
+        selected_columns=[field],
+    )
+    assert expected in builder.columns
+
+
+@pytest.mark.parametrize(
+    ["condition", "op", "value"],
+    [
+        pytest.param("1s", Op.EQ, 1000, id="=1s"),
+        pytest.param(">1s", Op.GT, 1000, id=">1s"),
+        pytest.param("<1s", Op.LT, 1000, id="<1s"),
+        pytest.param(">=1s", Op.GTE, 1000, id=">=1s"),
+        pytest.param("<=1s", Op.LTE, 1000, id="<=1s"),
+    ],
+)
+@django_db_all
+def test_span_duration_where(params, condition, op, value):
+    builder = SpansIndexedQueryBuilder(
+        Dataset.SpansIndexed,
+        params,
+        query=f"span.duration:{condition}",
+        selected_columns=["count"],
+    )
+    assert Condition(span_duration, op, value) in builder.where


### PR DESCRIPTION
The span duration is stored as an UInt32 while the self time is stores as a Float64. This means that in the case where duration should equal self time, it can be truncated resulting in the duration being less than self time which should never happen. To remedy, we take the max of the duration and self time as the actual duration.