### PR TITLE
build: test redis-cluster on CI

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Is bigtable required?'
     required: false
     default: 'false'
+  redis_cluster:
+    description: 'Is redis cluster required?'
+    required: false
+    default: 'false'
   symbolicator:
     description: 'Is symbolicator required?'
     required: false
@@ -140,6 +144,7 @@ runs:
         NEED_CLICKHOUSE: ${{ inputs.clickhouse }}
         NEED_BIGTABLE: ${{ inputs.bigtable }}
         NEED_CHARTCUTERIE: ${{ inputs.chartcuterie }}
+        NEED_REDIS_CLUSTER: ${{ inputs.redis_cluster }}
         NEED_SYMBOLICATOR: ${{ inputs.symbolicator }}
         WORKDIR: ${{ inputs.workdir }}
         PG_VERSION: ${{ inputs.pg-version }}
@@ -165,6 +170,10 @@ runs:
 
         if [ "$NEED_CHARTCUTERIE" = "true" ]; then
           services+=(chartcuterie)
+        fi
+
+        if [ "$NEED_REDIS_CLUSTER" = "true" ]; then
+          services+=(redis-cluster)
         fi
 
         if [ "$NEED_SYMBOLICATOR" = "true" ]; then

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -92,6 +92,7 @@ jobs:
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
+          redis_cluster: true
           kafka: true
           snuba: true
           symbolicator: true

--- a/src/sentry/testutils/helpers/redis.py
+++ b/src/sentry/testutils/helpers/redis.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+
+def get_redis_cluster_default_options(id: str) -> dict[str, Any]:
+    return {
+        "redis.clusters": {
+            id: {
+                "is_redis_cluster": True,
+                "hosts": [
+                    {"host": "0.0.0.0", "port": 7000},
+                    {"host": "0.0.0.0", "port": 7001},
+                    {"host": "0.0.0.0", "port": 7002},
+                    {"host": "0.0.0.0", "port": 7003},
+                    {"host": "0.0.0.0", "port": 7004},
+                    {"host": "0.0.0.0", "port": 7005},
+                ],
+            }
+        }
+    }

--- a/tests/sentry/processing/backpressure/test_redis.py
+++ b/tests/sentry/processing/backpressure/test_redis.py
@@ -2,12 +2,28 @@ from django.test.utils import override_settings
 
 from sentry.processing.backpressure.memory import iter_cluster_memory_usage
 from sentry.processing.backpressure.monitor import Redis, load_service_definitions
+from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.redis import get_redis_cluster_default_options
 
 
-def test_returns_some_usage() -> None:
-    with override_settings(SENTRY_PROCESSING_SERVICES={"redis": {"redis": "default"}}):
-        services = load_service_definitions()
+@override_settings(SENTRY_PROCESSING_SERVICES={"redis": {"redis": "default"}})
+def test_rb_cluster_returns_some_usage() -> None:
+    services = load_service_definitions()
+    redis_service = services["redis"]
+    assert isinstance(redis_service, Redis)
 
+    usage = [usage for usage in iter_cluster_memory_usage(redis_service.cluster)]
+    assert len(usage) > 0
+    memory = usage[0]
+    assert memory.used > 0
+    assert memory.available > 0
+    assert 0.0 < memory.percentage < 1.0
+
+
+@override_settings(SENTRY_PROCESSING_SERVICES={"redis": {"redis": "cluster"}})
+@override_options(get_redis_cluster_default_options(id="cluster"))
+def test_redis_cluster_cluster_returns_some_usage() -> None:
+    services = load_service_definitions()
     redis_service = services["redis"]
     assert isinstance(redis_service, Redis)
 


### PR DESCRIPTION
Let's start testing Redis Cluster on CI and increase our coverage on it.

You need to run `sentry devservices up redis-cluster` to enable it locally.