### PR TITLE
test(ui): Fix various act warnings for react 18

### DIFF
--- a/static/app/components/assistant/guideAnchor.spec.tsx
+++ b/static/app/components/assistant/guideAnchor.spec.tsx
@@ -1,7 +1,7 @@
 import {ConfigFixture} from 'sentry-fixture/config';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import ConfigStore from 'sentry/stores/configStore';
@@ -32,7 +32,7 @@ describe('GuideAnchor', function () {
       </div>
     );
 
-    GuideStore.fetchSucceeded(serverGuide);
+    act(() => GuideStore.fetchSucceeded(serverGuide));
     expect(await screen.findByText('Identify Your Issues')).toBeInTheDocument();
 
     // XXX(epurkhiser): Skip pointer event checks due to a bug with how Popper
@@ -75,7 +75,7 @@ describe('GuideAnchor', function () {
       </div>
     );
 
-    GuideStore.fetchSucceeded(serverGuide);
+    act(() => GuideStore.fetchSucceeded(serverGuide));
     expect(await screen.findByText('Identify Your Issues')).toBeInTheDocument();
 
     const dismissMock = MockApiClient.addMockResponse({
@@ -129,11 +129,11 @@ describe('GuideAnchor', function () {
       </div>
     );
 
-    GuideStore.fetchSucceeded(serverGuide);
+    act(() => GuideStore.fetchSucceeded(serverGuide));
     expect(await screen.findByText('Identify Your Issues')).toBeInTheDocument();
-    GuideStore.setForceHide(true);
+    act(() => GuideStore.setForceHide(true));
     expect(screen.queryByText('Identify Your Issues')).not.toBeInTheDocument();
-    GuideStore.setForceHide(false);
+    act(() => GuideStore.setForceHide(false));
     expect(await screen.findByText('Identify Your Issues')).toBeInTheDocument();
   });
 });

--- a/static/app/components/autoComplete.spec.tsx
+++ b/static/app/components/autoComplete.spec.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 
-import {fireEvent, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, fireEvent, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {AutoCompleteProps} from 'sentry/components/autoComplete';
 import AutoComplete from 'sentry/components/autoComplete';
@@ -134,7 +134,7 @@ describe('AutoComplete', function () {
       fireEvent.focus(input);
       fireEvent.blur(input);
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
 
       expect(screen.queryByTestId('test-autocomplete')).not.toBeInTheDocument();
       expect(mocks.onClose).toHaveBeenCalledTimes(1);
@@ -152,11 +152,11 @@ describe('AutoComplete', function () {
     it('can open and close dropdown menu using injected actions', function () {
       createWrapper();
       const [injectedProps] = autoCompleteState;
-      injectedProps.actions.open();
+      act(() => injectedProps.actions.open());
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
       expect(mocks.onOpen).toHaveBeenCalledTimes(1);
 
-      injectedProps.actions.close();
+      act(() => injectedProps.actions.close());
       expect(screen.queryByTestId('test-autocomplete')).not.toBeInTheDocument();
       expect(mocks.onClose).toHaveBeenCalledTimes(1);
     });
@@ -311,7 +311,7 @@ describe('AutoComplete', function () {
       expect(input).toHaveValue('a');
 
       fireEvent.blur(input);
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
       expect(screen.queryByTestId('test-autocomplete')).not.toBeInTheDocument();
       expect(input).toHaveValue('');
     });
@@ -352,7 +352,7 @@ describe('AutoComplete', function () {
       jest.useFakeTimers();
       fireEvent.focus(input);
       fireEvent.blur(input);
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
 
       // This still gets called even though menu is open
@@ -372,12 +372,12 @@ describe('AutoComplete', function () {
     it('does not open and close dropdown menu using injected actions', function () {
       createWrapper({isOpen: true});
       const [injectedProps] = autoCompleteState;
-      injectedProps.actions.open();
+      act(() => injectedProps.actions.open());
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
 
       expect(mocks.onOpen).toHaveBeenCalledTimes(1);
 
-      injectedProps.actions.close();
+      act(() => injectedProps.actions.close());
       expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
 
       expect(mocks.onClose).toHaveBeenCalledTimes(1);
@@ -528,7 +528,7 @@ describe('AutoComplete', function () {
       expect(input).toHaveValue('a');
 
       fireEvent.blur(input);
-      jest.runAllTimers();
+      act(() => jest.runAllTimers());
       expect(input).toHaveValue('');
     });
   });

--- a/static/app/components/charts/eventsRequest.spec.tsx
+++ b/static/app/components/charts/eventsRequest.spec.tsx
@@ -72,7 +72,7 @@ describe('EventsRequest', function () {
       expect(doEventsRequest).toHaveBeenCalled();
     });
 
-    it('makes a new request if projects prop changes', function () {
+    it('makes a new request if projects prop changes', async function () {
       const {rerender} = render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
       (doEventsRequest as jest.Mock).mockClear();
 
@@ -81,6 +81,7 @@ describe('EventsRequest', function () {
           {mock}
         </EventsRequest>
       );
+      await waitFor(() => expect(doEventsRequest).toHaveBeenCalledTimes(1));
       expect(doEventsRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -89,7 +90,7 @@ describe('EventsRequest', function () {
       );
     });
 
-    it('makes a new request if environments prop changes', function () {
+    it('makes a new request if environments prop changes', async function () {
       const {rerender} = render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
       (doEventsRequest as jest.Mock).mockClear();
 
@@ -98,6 +99,7 @@ describe('EventsRequest', function () {
           {mock}
         </EventsRequest>
       );
+      await waitFor(() => expect(doEventsRequest).toHaveBeenCalledTimes(1));
       expect(doEventsRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -106,7 +108,7 @@ describe('EventsRequest', function () {
       );
     });
 
-    it('makes a new request if period prop changes', function () {
+    it('makes a new request if period prop changes', async function () {
       const {rerender} = render(<EventsRequest {...DEFAULTS}>{mock}</EventsRequest>);
       (doEventsRequest as jest.Mock).mockClear();
 
@@ -116,6 +118,7 @@ describe('EventsRequest', function () {
         </EventsRequest>
       );
 
+      await waitFor(() => expect(doEventsRequest).toHaveBeenCalledTimes(1));
       expect(doEventsRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({

--- a/static/app/components/charts/onDemandMetricRequest.spec.tsx
+++ b/static/app/components/charts/onDemandMetricRequest.spec.tsx
@@ -67,7 +67,7 @@ describe('OnDemandMetricRequest', function () {
       expect(doEventsRequest).toHaveBeenCalled();
     });
 
-    it('makes a new request if projects prop changes', function () {
+    it('makes a new request if projects prop changes', async function () {
       const {rerender} = render(
         <OnDemandMetricRequest {...DEFAULTS}>{mock}</OnDemandMetricRequest>
       );
@@ -79,7 +79,7 @@ describe('OnDemandMetricRequest', function () {
         </OnDemandMetricRequest>
       );
 
-      expect(doEventsRequest).toHaveBeenCalledTimes(2);
+      await waitFor(() => expect(doEventsRequest).toHaveBeenCalledTimes(2));
       expect(doEventsRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -88,7 +88,7 @@ describe('OnDemandMetricRequest', function () {
       );
     });
 
-    it('makes a new request if environments prop changes', function () {
+    it('makes a new request if environments prop changes', async function () {
       const {rerender} = render(
         <OnDemandMetricRequest {...DEFAULTS}>{mock}</OnDemandMetricRequest>
       );
@@ -100,7 +100,7 @@ describe('OnDemandMetricRequest', function () {
         </OnDemandMetricRequest>
       );
 
-      expect(doEventsRequest).toHaveBeenCalledTimes(2);
+      await waitFor(() => expect(doEventsRequest).toHaveBeenCalledTimes(2));
       expect(doEventsRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -109,7 +109,7 @@ describe('OnDemandMetricRequest', function () {
       );
     });
 
-    it('makes a new request if period prop changes', function () {
+    it('makes a new request if period prop changes', async function () {
       const {rerender} = render(
         <OnDemandMetricRequest {...DEFAULTS}>{mock}</OnDemandMetricRequest>
       );
@@ -121,7 +121,7 @@ describe('OnDemandMetricRequest', function () {
         </OnDemandMetricRequest>
       );
 
-      expect(doEventsRequest).toHaveBeenCalledTimes(2);
+      await waitFor(() => expect(doEventsRequest).toHaveBeenCalledTimes(2));
       expect(doEventsRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({

--- a/static/app/components/charts/optionSelector.spec.tsx
+++ b/static/app/components/charts/optionSelector.spec.tsx
@@ -56,9 +56,9 @@ describe('Charts > OptionSelector (Multiple)', function () {
     return render(<TestComponent />, {context: initialData.routerContext});
   };
 
-  it('renders yAxisOptions with yAxisValue selected', function () {
+  it('renders yAxisOptions with yAxisValue selected', async function () {
     renderComponent();
-    expect(screen.getByRole('option', {name: 'count()'})).toHaveAttribute(
+    expect(await screen.findByRole('option', {name: 'count()'})).toHaveAttribute(
       'aria-selected',
       'true'
     );

--- a/static/app/components/charts/releaseSeries.spec.tsx
+++ b/static/app/components/charts/releaseSeries.spec.tsx
@@ -163,7 +163,7 @@ describe('ReleaseSeries', function () {
     );
   });
 
-  it('fetches on property updates', function () {
+  it('fetches on property updates', async function () {
     const wrapper = render(
       <ReleaseSeries {...baseSeriesProps} period="14d">
         {renderFunc}
@@ -186,9 +186,11 @@ describe('ReleaseSeries', function () {
 
       expect(releasesMock).toHaveBeenCalled();
     }
+
+    await waitFor(() => expect(releasesMock).toHaveBeenCalledTimes(1));
   });
 
-  it('doesnt not refetch releases with memoize enabled', function () {
+  it('doesnt not refetch releases with memoize enabled', async function () {
     const originalPeriod = '14d';
     const updatedPeriod = '7d';
     const wrapper = render(
@@ -197,7 +199,7 @@ describe('ReleaseSeries', function () {
       </ReleaseSeries>
     );
 
-    expect(releasesMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(releasesMock).toHaveBeenCalledTimes(1));
 
     wrapper.rerender(
       <ReleaseSeries {...baseSeriesProps} period={updatedPeriod} memoized>
@@ -205,7 +207,7 @@ describe('ReleaseSeries', function () {
       </ReleaseSeries>
     );
 
-    expect(releasesMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(releasesMock).toHaveBeenCalledTimes(2));
 
     wrapper.rerender(
       <ReleaseSeries {...baseSeriesProps} period={originalPeriod} memoized>
@@ -213,7 +215,7 @@ describe('ReleaseSeries', function () {
       </ReleaseSeries>
     );
 
-    expect(releasesMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(releasesMock).toHaveBeenCalledTimes(2));
   });
 
   it('generates an eCharts `markLine` series from releases', async function () {

--- a/static/app/components/compactSelect/composite.spec.tsx
+++ b/static/app/components/compactSelect/composite.spec.tsx
@@ -64,7 +64,7 @@ describe('CompactSelect', function () {
     );
   });
 
-  it('renders disabled trigger button', function () {
+  it('renders disabled trigger button', async function () {
     render(
       <CompositeSelect disabled>
         <CompositeSelect.Region
@@ -77,7 +77,7 @@ describe('CompactSelect', function () {
         />
       </CompositeSelect>
     );
-    expect(screen.getByRole('button')).toBeDisabled();
+    expect(await screen.findByRole('button')).toBeDisabled();
   });
 
   // CompositeSelect renders a series of separate list boxes, each of which has its own

--- a/static/app/components/compactSelect/index.spec.tsx
+++ b/static/app/components/compactSelect/index.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {CompactSelect} from 'sentry/components/compactSelect';
 
 describe('CompactSelect', function () {
-  it('renders', function () {
+  it('renders', async function () {
     render(
       <CompactSelect
         options={[
@@ -14,9 +14,10 @@ describe('CompactSelect', function () {
         ]}
       />
     );
+    expect(await screen.findByRole('button', {name: 'None'})).toBeEnabled();
   });
 
-  it('renders disabled', function () {
+  it('renders disabled', async function () {
     render(
       <CompactSelect
         disabled
@@ -26,7 +27,7 @@ describe('CompactSelect', function () {
         ]}
       />
     );
-    expect(screen.getByRole('button')).toBeDisabled();
+    expect(await screen.findByRole('button', {name: 'None'})).toBeDisabled();
   });
 
   it('renders with menu title', async function () {
@@ -174,7 +175,7 @@ describe('CompactSelect', function () {
       ]);
     });
 
-    it('displays trigger button with prefix', function () {
+    it('displays trigger button with prefix', async function () {
       render(
         <CompactSelect
           triggerProps={{prefix: 'Prefix'}}
@@ -185,7 +186,9 @@ describe('CompactSelect', function () {
           ]}
         />
       );
-      expect(screen.getByRole('button', {name: 'Prefix Option One'})).toBeInTheDocument();
+      expect(
+        await screen.findByRole('button', {name: 'Prefix Option One'})
+      ).toBeInTheDocument();
     });
 
     it('can search', async function () {
@@ -472,7 +475,7 @@ describe('CompactSelect', function () {
       ]);
     });
 
-    it('displays trigger button with prefix', function () {
+    it('displays trigger button with prefix', async function () {
       render(
         <CompactSelect
           grid
@@ -484,7 +487,9 @@ describe('CompactSelect', function () {
           ]}
         />
       );
-      expect(screen.getByRole('button', {name: 'Prefix Option One'})).toBeInTheDocument();
+      expect(
+        await screen.findByRole('button', {name: 'Prefix Option One'})
+      ).toBeInTheDocument();
     });
 
     it('can search', async function () {

--- a/static/app/components/events/contextSummary/index.spec.tsx
+++ b/static/app/components/events/contextSummary/index.spec.tsx
@@ -82,7 +82,7 @@ describe('ContextSummary', function () {
       render(<ContextSummary event={event} />);
     });
 
-    it('renders at least three contexts', function () {
+    it('renders at least three contexts', async function () {
       const event = EventFixture({
         id: '',
         user: CONTEXT_USER,
@@ -92,6 +92,9 @@ describe('ContextSummary', function () {
       });
 
       render(<ContextSummary event={event} />);
+      expect((await screen.findAllByTestId('context-item'))[0]).toHaveTextContent(
+        'Mmail@example.orgID:1'
+      );
     });
 
     it('renders up to four contexts', function () {
@@ -171,7 +174,7 @@ describe('ContextSummary', function () {
 
 describe('OsSummary', function () {
   describe('render()', function () {
-    it('renders the version string', function () {
+    it('renders the version string', async function () {
       render(
         <ContextSummaryOS
           data={{
@@ -181,6 +184,9 @@ describe('OsSummary', function () {
           }}
           meta={{}}
         />
+      );
+      expect(await screen.findByTestId('context-item')).toHaveTextContent(
+        'Mac OS XVersion:10.13.4'
       );
     });
 
@@ -265,7 +271,7 @@ describe('OsSummary', function () {
 
 describe('GpuSummary', function () {
   describe('render()', function () {
-    it('renders name and vendor', function () {
+    it('renders name and vendor', async function () {
       render(
         <ContextSummaryGPU
           data={{
@@ -275,9 +281,12 @@ describe('GpuSummary', function () {
           meta={{}}
         />
       );
+      expect(await screen.findByTestId('context-item')).toHaveTextContent(
+        'Mali-T880Vendor:ARM'
+      );
     });
 
-    it('renders unknown when no vendor', function () {
+    it('renders unknown when no vendor', async function () {
       render(
         <ContextSummaryGPU
           data={{
@@ -285,6 +294,9 @@ describe('GpuSummary', function () {
           }}
           meta={{}}
         />
+      );
+      expect(await screen.findByTestId('context-item')).toHaveTextContent(
+        'Apple A8 GPUVendor:Unknown'
       );
     });
 

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -185,7 +185,7 @@ describe('EventTagsAndScreenshot', function () {
       });
     });
 
-    it('not shared event - without attachments', function () {
+    it('not shared event - without attachments', async function () {
       render(
         <EventTagsAndScreenshot
           event={EventFixture({...event, tags, contexts})}
@@ -196,13 +196,13 @@ describe('EventTagsAndScreenshot', function () {
         {organization}
       );
 
-      // Screenshot Container
-      expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
-
       // Tags Container
-      expect(screen.getByText('Tags')).toBeInTheDocument();
+      expect(await screen.findByText('Tags')).toBeInTheDocument();
       const contextItems = screen.getAllByTestId('context-item');
       expect(contextItems).toHaveLength(Object.keys(contexts).length);
+
+      // Screenshot Container
+      expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
 
       // Context Item 1
       const contextItem1 = within(contextItems[0]);
@@ -413,9 +413,9 @@ describe('EventTagsAndScreenshot', function () {
         `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${moreAttachments[1].id}/?download`
       );
 
-      screen.getByRole('button', {name: 'Next Screenshot'}).click();
+      await userEvent.click(screen.getByRole('button', {name: 'Next Screenshot'}));
 
-      expect(screen.getByTestId('screenshot-data-section')?.textContent).toContain(
+      expect(await screen.findByTestId('screenshot-data-section')).toHaveTextContent(
         '2 of 2'
       );
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -148,13 +148,13 @@ describe('Breadcrumbs', () => {
   });
 
   describe('render', function () {
-    it('should display the correct number of crumbs with no filter', function () {
+    it('should display the correct number of crumbs with no filter', async function () {
       props.data.values = props.data.values.slice(0, 4);
 
       render(<Breadcrumbs {...props} />);
 
       // data.values + virtual crumb
-      expect(screen.getAllByTestId('crumb')).toHaveLength(4);
+      expect(await screen.findAllByTestId('crumb')).toHaveLength(4);
 
       expect(screen.getByTestId('last-crumb')).toBeInTheDocument();
     });
@@ -173,7 +173,7 @@ describe('Breadcrumbs', () => {
       expect(screen.getByTestId('last-crumb')).toBeInTheDocument();
     });
 
-    it('should not crash if data contains a toString attribute', function () {
+    it('should not crash if data contains a toString attribute', async function () {
       // Regression test: A "toString" property in data should not falsely be
       // used to coerce breadcrumb data to string. This would cause a TypeError.
       const data = {nested: {toString: 'hello'}};
@@ -191,7 +191,7 @@ describe('Breadcrumbs', () => {
       render(<Breadcrumbs {...props} />);
 
       // data.values + virtual crumb
-      expect(screen.getByTestId('crumb')).toBeInTheDocument();
+      expect(await screen.findByTestId('crumb')).toBeInTheDocument();
 
       expect(screen.getByTestId('last-crumb')).toBeInTheDocument();
     });

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
@@ -3,7 +3,7 @@ import {EntryDebugMetaFixture} from 'sentry-fixture/eventEntry';
 import {ImageFixture} from 'sentry-fixture/image';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {DebugImageDetails} from 'sentry/components/events/interfaces/debugMeta/debugImageDetails';
@@ -30,7 +30,7 @@ describe('Debug Meta - Image Details', function () {
     });
   });
 
-  it('Candidates correctly sorted', function () {
+  it('Candidates correctly sorted', async function () {
     renderGlobalModal();
 
     act(() =>
@@ -44,6 +44,10 @@ describe('Debug Meta - Image Details', function () {
           onReprocessEvent={jest.fn()}
         />
       ))
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument()
     );
 
     // Check status order.

--- a/static/app/components/events/interfaces/searchBarAction.spec.tsx
+++ b/static/app/components/events/interfaces/searchBarAction.spec.tsx
@@ -98,7 +98,7 @@ describe('SearchBarAction', () => {
     expect(screen.getAllByText('Error')[1]).toBeInTheDocument();
   });
 
-  it('Without Options', () => {
+  it('Without Options', async () => {
     render(
       <SearchBarAction
         filterOptions={[]}
@@ -109,6 +109,7 @@ describe('SearchBarAction', () => {
       />
     );
 
+    expect(await screen.findByTestId('input-trailing-items')).toBeInTheDocument();
     expect(screen.queryByText('Types')).not.toBeInTheDocument();
     expect(screen.queryByText('Levels')).not.toBeInTheDocument();
   });

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -228,13 +228,15 @@ describe('Threads', function () {
         organization,
       };
 
-      it('renders', function () {
+      it('renders', async function () {
         render(<Threads {...props} />, {
           organization,
         });
 
         // Title
-        expect(screen.getByRole('heading', {name: 'Stack Trace'})).toBeInTheDocument();
+        expect(
+          await screen.findByRole('heading', {name: 'Stack Trace'})
+        ).toBeInTheDocument();
 
         // Actions
         expect(screen.getByRole('radio', {name: 'Full Stack Trace'})).toBeInTheDocument();
@@ -879,10 +881,10 @@ describe('Threads', function () {
         organization,
       };
 
-      it('renders', function () {
+      it('renders', async function () {
         render(<Threads {...props} />, {organization});
         // Title
-        const threadSelector = screen.getByTestId('thread-selector');
+        const threadSelector = await screen.findByTestId('thread-selector');
         expect(threadSelector).toBeInTheDocument();
         within(threadSelector).getByText('main');
 
@@ -907,7 +909,7 @@ describe('Threads', function () {
         expect(screen.queryAllByTestId('stack-trace-frame')).toHaveLength(3);
       });
 
-      it('renders thread state and lock reason', function () {
+      it('renders thread state and lock reason', async function () {
         const newOrg = {
           ...organization,
           features: ['anr-improvements'],
@@ -915,7 +917,7 @@ describe('Threads', function () {
         const newProps = {...props, organization: newOrg};
         render(<Threads {...newProps} />, {organization: newOrg});
         // Title
-        expect(screen.getByTestId('thread-selector')).toBeInTheDocument();
+        expect(await screen.findByTestId('thread-selector')).toBeInTheDocument();
 
         expect(screen.getByText('Threads')).toBeInTheDocument();
         expect(screen.getByText('Thread State')).toBeInTheDocument();
@@ -942,7 +944,7 @@ describe('Threads', function () {
         expect(screen.queryAllByTestId('stack-trace-frame')).toHaveLength(3);
       });
 
-      it('hides thread tag event entry if none', function () {
+      it('hides thread tag event entry if none', async function () {
         const newOrg = {
           ...organization,
           features: ['anr-improvements'],
@@ -992,10 +994,11 @@ describe('Threads', function () {
           organization: newOrg,
         };
         render(<Threads {...newProps} />, {organization: newOrg});
+        expect(await screen.findByTestId('event-section-threads')).toBeInTheDocument();
         expect(screen.queryByText('Thread Tags')).not.toBeInTheDocument();
       });
 
-      it('maps android vm states to java vm states', function () {
+      it('maps android vm states to java vm states', async function () {
         const newEvent = {...event};
         const threadsEntry = newEvent.entries[1].data as React.ComponentProps<
           typeof Threads
@@ -1050,7 +1053,7 @@ describe('Threads', function () {
         const newProps = {...props, event: newEvent, organization: newOrg};
         render(<Threads {...newProps} />, {organization: newOrg});
         // Title
-        expect(screen.getByTestId('thread-selector')).toBeInTheDocument();
+        expect(await screen.findByTestId('thread-selector')).toBeInTheDocument();
 
         expect(screen.getByText('Threads')).toBeInTheDocument();
         expect(screen.getByText('Thread State')).toBeInTheDocument();
@@ -1201,7 +1204,7 @@ describe('Threads', function () {
         expect(screen.getByRole('option', {name: 'Raw stack trace'})).toBeInTheDocument();
       });
 
-      it('uses thread label in selector if name not available', function () {
+      it('uses thread label in selector if name not available', async function () {
         const newEvent = {...event};
         const threadsEntry = newEvent.entries[1].data as React.ComponentProps<
           typeof Threads
@@ -1250,7 +1253,7 @@ describe('Threads', function () {
         const newProps = {...props, event: newEvent};
         render(<Threads {...newProps} />, {organization});
         // Title
-        const threadSelector = screen.getByTestId('thread-selector');
+        const threadSelector = await screen.findByTestId('thread-selector');
         expect(threadSelector).toBeInTheDocument();
         within(threadSelector).getByText('ViewController.causeCrash');
       });

--- a/static/app/utils/eventWaiter.spec.tsx
+++ b/static/app/utils/eventWaiter.spec.tsx
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render} from 'sentry-test/reactTestingLibrary';
+import {act, render} from 'sentry-test/reactTestingLibrary';
 
 import EventWaiter from 'sentry/utils/eventWaiter';
 
@@ -58,19 +58,19 @@ describe('EventWaiter', function () {
     child.mockClear();
 
     // Advanced time for the first setInterval tick to occur
-    jest.advanceTimersByTime(1);
+    act(() => jest.advanceTimersByTime(1));
 
     // We have to await *two* API calls. We could normally do this using tick(),
     // however since we have enabled fake timers, we cannot tick.
-    await Promise.resolve();
-    await Promise.resolve();
+    await act(() => Promise.resolve());
+    await act(() => Promise.resolve());
 
     expect(child).toHaveBeenCalledWith({firstIssue: events[0]});
 
     // Check that the polling has stopped
     projectApiMock.mockClear();
 
-    jest.advanceTimersByTime(10);
+    act(() => jest.advanceTimersByTime(10));
     expect(projectApiMock).not.toHaveBeenCalled();
   });
 
@@ -109,8 +109,8 @@ describe('EventWaiter', function () {
 
     // We have to await *two* API calls. We could normally do this using tick(),
     // however since we have enabled fake timers, we cannot tick.
-    await Promise.resolve();
-    await Promise.resolve();
+    await act(() => Promise.resolve());
+    await act(() => Promise.resolve());
 
     expect(child).toHaveBeenCalledWith({firstIssue: true});
   });

--- a/static/app/utils/performance/quickTrace/quickTraceQuery.spec.tsx
+++ b/static/app/utils/performance/quickTrace/quickTraceQuery.spec.tsx
@@ -62,7 +62,7 @@ describe('TraceLiteQuery', function () {
     });
   });
 
-  it('fetches data on mount and passes the event id', function () {
+  it('fetches data on mount and passes the event id', async function () {
     render(
       <QuickTraceQuery event={event} location={location} orgSlug="test-org">
         {renderQuickTrace}
@@ -71,9 +71,10 @@ describe('TraceLiteQuery', function () {
 
     expect(traceLiteMock).toHaveBeenCalledTimes(1);
     expect(traceFullMock).toHaveBeenCalledTimes(1);
+    expect(await screen.findByTestId('type')).toHaveTextContent('partial');
   });
 
-  it('doesnt fetch meta when not needed', function () {
+  it('doesnt fetch meta when not needed', async function () {
     render(
       <QuickTraceQuery event={event} location={location} orgSlug="test-org">
         {renderQuickTrace}
@@ -83,6 +84,7 @@ describe('TraceLiteQuery', function () {
     expect(traceLiteMock).toHaveBeenCalledTimes(1);
     expect(traceFullMock).toHaveBeenCalledTimes(1);
     expect(traceMetaMock).toHaveBeenCalledTimes(0);
+    expect(await screen.findByTestId('type')).toHaveTextContent('partial');
   });
 
   it('uses lite results when it cannot find current event in full results', async function () {

--- a/static/app/utils/performance/suspectSpans/spanOpsQuery.spec.tsx
+++ b/static/app/utils/performance/suspectSpans/spanOpsQuery.spec.tsx
@@ -1,4 +1,4 @@
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import EventView from 'sentry/utils/discover/eventView';
 import SpanOpsQuery from 'sentry/utils/performance/suspectSpans/spanOpsQuery';
@@ -24,7 +24,7 @@ describe('SuspectSpansQuery', function () {
     };
   });
 
-  it('fetches data on mount', function () {
+  it('fetches data on mount', async function () {
     const getMock = MockApiClient.addMockResponse({
       url: '/organizations/test-org/events-span-ops/',
       // just asserting that the data is being fetched, no need for actual data here
@@ -37,6 +37,6 @@ describe('SuspectSpansQuery', function () {
       </SpanOpsQuery>
     );
 
-    expect(getMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
   });
 });

--- a/static/app/utils/performance/suspectSpans/suspectSpansQuery.spec.tsx
+++ b/static/app/utils/performance/suspectSpans/suspectSpansQuery.spec.tsx
@@ -1,4 +1,4 @@
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import EventView from 'sentry/utils/discover/eventView';
 import SuspectSpansQuery from 'sentry/utils/performance/suspectSpans/suspectSpansQuery';
@@ -24,7 +24,7 @@ describe('SuspectSpansQuery', function () {
     };
   });
 
-  it('fetches data on mount', function () {
+  it('fetches data on mount', async function () {
     const getMock = MockApiClient.addMockResponse({
       url: '/organizations/test-org/events-spans-performance/',
       // just asserting that the data is being fetched, no need for actual data here
@@ -42,10 +42,10 @@ describe('SuspectSpansQuery', function () {
       </SuspectSpansQuery>
     );
 
-    expect(getMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
   });
 
-  it('fetches data with the right op filter', function () {
+  it('fetches data with the right op filter', async function () {
     const getMock = MockApiClient.addMockResponse({
       url: '/organizations/test-org/events-spans-performance/',
       // just asserting that the data is being fetched, no need for actual data here
@@ -64,10 +64,10 @@ describe('SuspectSpansQuery', function () {
       </SuspectSpansQuery>
     );
 
-    expect(getMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
   });
 
-  it('fetches data with the right group filter', function () {
+  it('fetches data with the right group filter', async function () {
     const getMock = MockApiClient.addMockResponse({
       url: '/organizations/test-org/events-spans-performance/',
       // just asserting that the data is being fetched, no need for actual data here
@@ -86,10 +86,10 @@ describe('SuspectSpansQuery', function () {
       </SuspectSpansQuery>
     );
 
-    expect(getMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
   });
 
-  it('fetches data with the right per suspect param', function () {
+  it('fetches data with the right per suspect param', async function () {
     const getMock = MockApiClient.addMockResponse({
       url: '/organizations/test-org/events-spans-performance/',
       // just asserting that the data is being fetched, no need for actual data here
@@ -108,6 +108,6 @@ describe('SuspectSpansQuery', function () {
       </SuspectSpansQuery>
     );
 
-    expect(getMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
   });
 });

--- a/static/app/utils/profiling/hooks/useProfileEvents.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.spec.tsx
@@ -73,7 +73,7 @@ describe('useProfileEvents', function () {
     });
 
     await waitFor(() => result.current.isError);
-    expect(result.current.status).toEqual('error');
+    await waitFor(() => expect(result.current.status).toEqual('error'));
   });
 });
 

--- a/static/app/utils/useMembers.spec.tsx
+++ b/static/app/utils/useMembers.spec.tsx
@@ -41,10 +41,7 @@ describe('useMembers', function () {
     const {onSearch} = result.current;
 
     // Works with append
-    const onSearchPromise = reactHooks.act(() => onSearch('test'));
-
-    expect(result.current.fetching).toBe(true);
-    await onSearchPromise;
+    await reactHooks.act(() => onSearch('test'));
     expect(result.current.fetching).toBe(false);
 
     // Wait for state to be reflected from the store

--- a/static/app/utils/useProjects.spec.tsx
+++ b/static/app/utils/useProjects.spec.tsx
@@ -38,10 +38,8 @@ describe('useProjects', function () {
     const {onSearch} = result.current;
 
     // Works with append
-    const onSearchPromise = reactHooks.act(() => onSearch('test'));
+    await reactHooks.act(() => onSearch('test'));
 
-    expect(result.current.fetching).toBe(true);
-    await onSearchPromise;
     expect(result.current.fetching).toBe(false);
 
     // Wait for state to be reflected from the store

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -566,7 +566,7 @@ describe('ProjectAlertsCreate', function () {
         'A new issue is created',
       ]);
       expect(
-        screen.getByText('Preview is not supported for these conditions')
+        await screen.findByText('Preview is not supported for these conditions')
       ).toBeInTheDocument();
     });
 

--- a/static/app/views/settings/account/accountIdentities.spec.tsx
+++ b/static/app/views/settings/account/accountIdentities.spec.tsx
@@ -3,6 +3,7 @@ import {
   renderGlobalModal,
   screen,
   userEvent,
+  waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
 import AccountIdentities from 'sentry/views/settings/account/accountIdentities';
@@ -54,7 +55,9 @@ describe('AccountIdentities', function () {
 
     render(<AccountIdentities />);
 
-    expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument()
+    );
 
     expect(await screen.findByText('GitHub')).toBeInTheDocument();
     expect(await screen.findByText('Google')).toBeInTheDocument();

--- a/static/app/views/settings/account/accountSecurity/accountSecurityDetails.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityDetails.spec.tsx
@@ -209,7 +209,7 @@ describe('AccountSecurityDetails', function () {
       });
     });
 
-    it('has enrolled circle indicator', function () {
+    it('has enrolled circle indicator', async function () {
       const params = {
         authId: '16',
       };
@@ -231,6 +231,7 @@ describe('AccountSecurityDetails', function () {
         {context: routerContext}
       );
 
+      expect(await screen.findByTestId('auth-status-enabled')).toBeInTheDocument();
       // does not have remove button
       expect(screen.queryByRole('button', {name: 'Remove'})).not.toBeInTheDocument();
     });

--- a/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.spec.tsx
@@ -46,7 +46,7 @@ describe('TwoFactorRequired', function () {
     ...routerProps,
   };
 
-  it('renders empty', function () {
+  it('renders empty', async function () {
     MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: [],
@@ -59,10 +59,11 @@ describe('TwoFactorRequired', function () {
       {context: routerContext}
     );
 
+    expect(await screen.findByText('Your current password')).toBeInTheDocument();
     expect(screen.queryByTestId('require-2fa')).not.toBeInTheDocument();
   });
 
-  it('does not render when 2FA is disabled and no pendingInvite cookie', function () {
+  it('does not render when 2FA is disabled and no pendingInvite cookie', async function () {
     render(
       <AccountSecurityWrapper {...routerProps} params={{authId: ''}}>
         <TwoFactorRequired {...baseProps} />
@@ -70,10 +71,11 @@ describe('TwoFactorRequired', function () {
       {context: routerContext}
     );
 
+    expect(await screen.findByText('Your current password')).toBeInTheDocument();
     expect(screen.queryByTestId('require-2fa')).not.toBeInTheDocument();
   });
 
-  it('does not render when 2FA is enrolled and no pendingInvite cookie', function () {
+  it('does not render when 2FA is enrolled and no pendingInvite cookie', async function () {
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [AuthenticatorsFixture().Totp({isEnrolled: true})],
@@ -86,10 +88,11 @@ describe('TwoFactorRequired', function () {
       {context: routerContext}
     );
 
+    expect(await screen.findByText('Your current password')).toBeInTheDocument();
     expect(screen.queryByTestId('require-2fa')).not.toBeInTheDocument();
   });
 
-  it('does not render when 2FA is enrolled and has pendingInvite cookie', function () {
+  it('does not render when 2FA is enrolled and has pendingInvite cookie', async function () {
     const cookieData = {
       memberId: 5,
       token: 'abcde',
@@ -112,6 +115,7 @@ describe('TwoFactorRequired', function () {
       {context: routerContext}
     );
 
+    expect(await screen.findByText('Your current password')).toBeInTheDocument();
     expect(screen.queryByTestId('require-2fa')).not.toBeInTheDocument();
     Cookies.remove(INVITE_COOKIE);
   });

--- a/static/app/views/settings/account/accountSettingsLayout.spec.tsx
+++ b/static/app/views/settings/account/accountSettingsLayout.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {BreadcrumbContextProvider} from 'sentry-test/providers/breadcrumbContextProvider';
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as OrgActions from 'sentry/actionCreators/organizations';
 import AccountSettingsLayout from 'sentry/views/settings/account/accountSettingsLayout';
@@ -27,7 +27,7 @@ describe('AccountSettingsLayout', function () {
     });
   });
 
-  it('fetches org details for SidebarDropdown', function () {
+  it('fetches org details for SidebarDropdown', async function () {
     const {rerender} = render(
       <BreadcrumbContextProvider>
         <AccountSettingsLayout {...routerProps}>content</AccountSettingsLayout>
@@ -43,11 +43,11 @@ describe('AccountSettingsLayout', function () {
       </BreadcrumbContextProvider>
     );
 
+    await waitFor(() => expect(api).toHaveBeenCalledTimes(1));
     expect(spy).toHaveBeenCalledWith(expect.anything(), organization.slug, {
       setActive: true,
       loadProjects: true,
     });
-    expect(api).toHaveBeenCalledTimes(1);
   });
 
   it('does not fetch org details for SidebarDropdown', function () {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
@@ -70,18 +70,18 @@ describe('Sentry Application Dashboard', function () {
       });
     });
 
-    it('shows the total install/uninstall stats', () => {
+    it('shows the total install/uninstall stats', async () => {
       render(
         <SentryApplicationDashboard
           {...RouteComponentPropsFixture()}
           params={{appSlug: sentryApp.slug}}
         />
       );
-      expect(screen.getByTestId('installs')).toHaveTextContent('Total installs5');
+      expect(await screen.findByTestId('installs')).toHaveTextContent('Total installs5');
       expect(screen.getByTestId('uninstalls')).toHaveTextContent('Total uninstalls2');
     });
 
-    it('shows the request log', () => {
+    it('shows the request log', async () => {
       render(
         <SentryApplicationDashboard
           {...RouteComponentPropsFixture()}
@@ -89,7 +89,7 @@ describe('Sentry Application Dashboard', function () {
         />
       );
       // The mock response has 1 request
-      expect(screen.getByTestId('request-item')).toBeInTheDocument();
+      expect(await screen.findByTestId('request-item')).toBeInTheDocument();
       const requestLog = within(screen.getByTestId('request-item'));
       // Make sure that all the info is displayed
       expect(requestLog.getByText('https://example.com/webhook')).toBeInTheDocument();
@@ -98,7 +98,7 @@ describe('Sentry Application Dashboard', function () {
       expect(requestLog.getByText('Test Org')).toBeInTheDocument();
     });
 
-    it('shows an empty message if there are no requests', () => {
+    it('shows an empty message if there are no requests', async () => {
       MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/requests/`,
         body: [],
@@ -112,11 +112,11 @@ describe('Sentry Application Dashboard', function () {
       );
 
       expect(
-        screen.getByText('No requests found in the last 30 days.')
+        await screen.findByText('No requests found in the last 30 days.')
       ).toBeInTheDocument();
     });
 
-    it('shows integration and interactions chart', () => {
+    it('shows integration and interactions chart', async () => {
       render(
         <SentryApplicationDashboard
           {...RouteComponentPropsFixture()}
@@ -124,7 +124,7 @@ describe('Sentry Application Dashboard', function () {
         />
       );
 
-      expect(screen.getAllByTestId('chart')).toHaveLength(3);
+      expect(await screen.findAllByTestId('chart')).toHaveLength(3);
     });
   });
 
@@ -169,7 +169,7 @@ describe('Sentry Application Dashboard', function () {
       });
     });
 
-    it('shows the request log', () => {
+    it('shows the request log', async () => {
       render(
         <SentryApplicationDashboard
           {...RouteComponentPropsFixture()}
@@ -177,7 +177,7 @@ describe('Sentry Application Dashboard', function () {
         />
       );
       // The mock response has 1 request
-      expect(screen.getByTestId('request-item')).toBeInTheDocument();
+      expect(await screen.findByTestId('request-item')).toBeInTheDocument();
       const requestLog = within(screen.getByTestId('request-item'));
       // Make sure that all the info is displayed
       expect(requestLog.getByText('https://example.com/webhook')).toBeInTheDocument();
@@ -188,7 +188,7 @@ describe('Sentry Application Dashboard', function () {
       expect(screen.queryByText('Integration Views')).not.toBeInTheDocument();
     });
 
-    it('shows an empty message if there are no requests', () => {
+    it('shows an empty message if there are no requests', async () => {
       MockApiClient.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/requests/`,
         body: [],
@@ -201,11 +201,11 @@ describe('Sentry Application Dashboard', function () {
         />
       );
       expect(
-        screen.getByText('No requests found in the last 30 days.')
+        await screen.findByText('No requests found in the last 30 days.')
       ).toBeInTheDocument();
     });
 
-    it('shows the component interactions in a line chart', () => {
+    it('shows the component interactions in a line chart', async () => {
       render(
         <SentryApplicationDashboard
           {...RouteComponentPropsFixture()}
@@ -213,7 +213,7 @@ describe('Sentry Application Dashboard', function () {
         />
       );
 
-      expect(screen.getByTestId('chart')).toBeInTheDocument();
+      expect(await screen.findByTestId('chart')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as indicatorActions from 'sentry/actionCreators/indicator';
 import Indicators from 'sentry/components/indicators';
@@ -78,14 +78,18 @@ describe('OrganizationSettingsForm', function () {
 
     // Test "undo" call undo directly
     expect(model.getValue('name')).toBe('New Name');
-    model.undo();
+    act(() => {
+      model.undo();
+    });
     expect(model.getValue('name')).toBe('Organization Name');
 
     // `saveOnBlurUndoMessage` saves the new field, so reimplement this
-    await model.saveField('name', 'Organization Name');
+    act(() => {
+      model.saveField('name', 'Organization Name');
+    });
 
     // Initial data should be updated to original name
-    expect(model.initialData.name).toBe('Organization Name');
+    await waitFor(() => expect(model.initialData.name).toBe('Organization Name'));
 
     putMock.mockReset();
 

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
@@ -44,7 +44,7 @@ describe('IntegrationListDirectory', function () {
       ]);
     });
 
-    it('shows installed integrations at the top in order of weight', function () {
+    it('shows installed integrations at the top in order of weight', async function () {
       render(
         <IntegrationListDirectory
           {...routerProps}
@@ -57,7 +57,7 @@ describe('IntegrationListDirectory', function () {
         }
       );
 
-      expect(screen.getByRole('textbox', {name: 'Filter'})).toBeInTheDocument();
+      expect(await screen.findByRole('textbox', {name: 'Filter'})).toBeInTheDocument();
 
       [
         'bitbucket',
@@ -70,7 +70,7 @@ describe('IntegrationListDirectory', function () {
       ].map(testId => expect(screen.getByTestId(testId)).toBeInTheDocument());
     });
 
-    it('does not show legacy plugin that has a First Party Integration if not installed', function () {
+    it('does not show legacy plugin that has a First Party Integration if not installed', async function () {
       render(
         <IntegrationListDirectory
           {...routerProps}
@@ -81,10 +81,11 @@ describe('IntegrationListDirectory', function () {
         {context: routerContext}
       );
 
+      expect(await screen.findByRole('textbox', {name: 'Filter'})).toBeInTheDocument();
       expect(screen.queryByText('GitHub (Legacy)')).not.toBeInTheDocument();
     });
 
-    it('shows legacy plugin that has a First Party Integration if installed', function () {
+    it('shows legacy plugin that has a First Party Integration if installed', async function () {
       render(
         <IntegrationListDirectory
           {...routerProps}
@@ -95,7 +96,7 @@ describe('IntegrationListDirectory', function () {
         {context: routerContext}
       );
 
-      expect(screen.getByText('PagerDuty (Legacy)')).toBeInTheDocument();
+      expect(await screen.findByText('PagerDuty (Legacy)')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -448,7 +448,7 @@ describe('OrganizationMembersList', function () {
       teams: [],
     });
 
-    it('disable buttons for no access', function () {
+    it('disable buttons for no access', async function () {
       const org = OrganizationFixture({
         status: {
           id: 'active',
@@ -469,7 +469,7 @@ describe('OrganizationMembersList', function () {
         context: RouterContextFixture([{organization: org}]),
       });
 
-      expect(screen.getByText('Pending Members')).toBeInTheDocument();
+      expect(await screen.findByText('Pending Members')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Approve'})).toBeDisabled();
     });
 

--- a/static/app/views/settings/organizationRateLimits/organizationRateLimits.spec.tsx
+++ b/static/app/views/settings/organizationRateLimits/organizationRateLimits.spec.tsx
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {OrganizationRateLimitProps} from 'sentry/views/settings/organizationRateLimits/organizationRateLimits';
 import OrganizationRateLimits from 'sentry/views/settings/organizationRateLimits/organizationRateLimits';
@@ -68,7 +68,7 @@ describe('Organization Rate Limits', function () {
     expect(mock).not.toHaveBeenCalled();
 
     // Change Account Limit
-    screen.getByRole('slider', {name: 'Account Limit'}).focus();
+    act(() => screen.getByRole('slider', {name: 'Account Limit'}).focus());
     await userEvent.keyboard('{ArrowLeft>5}');
     await userEvent.tab();
 
@@ -95,7 +95,7 @@ describe('Organization Rate Limits', function () {
     expect(mock).not.toHaveBeenCalled();
 
     // Change Project Rate Limit
-    screen.getByRole('slider', {name: 'Per-Project Limit'}).focus();
+    act(() => screen.getByRole('slider', {name: 'Per-Project Limit'}).focus());
     await userEvent.keyboard('{ArrowRight>5}');
     await userEvent.tab();
 

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
@@ -323,7 +323,7 @@ describe('TeamMembers', function () {
     expect(deleteMock).toHaveBeenCalled();
   });
 
-  it('renders team-level roles without flag', function () {
+  it('renders team-level roles without flag', async function () {
     const owner = MemberFixture({
       id: '123',
       email: 'foo@example.com',
@@ -345,13 +345,13 @@ describe('TeamMembers', function () {
       />
     );
 
-    const admins = screen.queryAllByText('Team Admin');
+    const admins = await screen.findAllByText('Team Admin');
     expect(admins).toHaveLength(3);
     const contributors = screen.queryAllByText('Contributor');
     expect(contributors).toHaveLength(2);
   });
 
-  it('renders team-level roles with flag', function () {
+  it('renders team-level roles with flag', async function () {
     const manager = MemberFixture({
       id: '123',
       email: 'foo@example.com',
@@ -375,7 +375,7 @@ describe('TeamMembers', function () {
       />
     );
 
-    const admins = screen.queryAllByText('Team Admin');
+    const admins = await screen.findAllByText('Team Admin');
     expect(admins).toHaveLength(3);
     const contributors = screen.queryAllByText('Contributor');
     expect(contributors).toHaveLength(2);

--- a/static/app/views/settings/projectPlugins/projectPluginDetails.spec.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginDetails.spec.tsx
@@ -50,7 +50,7 @@ describe('ProjectPluginDetails', function () {
     });
   });
 
-  it('renders', function () {
+  it('renders', async function () {
     render(
       <ProjectPluginDetailsContainer
         {...routerProps}
@@ -62,6 +62,7 @@ describe('ProjectPluginDetails', function () {
         }}
       />
     );
+    expect(await screen.findByRole('heading', {name: 'Amazon SQS'})).toBeInTheDocument();
   });
 
   it('resets plugin', async function () {

--- a/static/app/views/settings/settingsIndex.spec.tsx
+++ b/static/app/views/settings/settingsIndex.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {BreadcrumbContextProvider} from 'sentry-test/providers/breadcrumbContextProvider';
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as OrgActions from 'sentry/actionCreators/organizations';
 import ConfigStore from 'sentry/stores/configStore';
@@ -71,7 +71,7 @@ describe('SettingsIndex', function () {
       });
     });
 
-    it('fetches org details for SidebarDropdown', function () {
+    it('fetches org details for SidebarDropdown', async function () {
       const {rerender} = render(
         <BreadcrumbContextProvider>
           <SettingsIndex {...props} params={{}} organization={null} />
@@ -85,11 +85,11 @@ describe('SettingsIndex', function () {
         </BreadcrumbContextProvider>
       );
 
+      await waitFor(() => expect(orgApi).toHaveBeenCalledTimes(1));
       expect(spy).toHaveBeenCalledWith(expect.anything(), organization.slug, {
         setActive: true,
         loadProjects: true,
       });
-      expect(orgApi).toHaveBeenCalledTimes(1);
     });
 
     it('does not fetch org details for SidebarDropdown', function () {

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.spec.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.spec.tsx
@@ -199,7 +199,7 @@ describe('EventSamplesTable', function () {
     );
   });
 
-  it('uses a custom sort key for sortable headers', function () {
+  it('uses a custom sort key for sortable headers', async function () {
     mockQuery = {
       name: '',
       fields: ['transaction.id', 'duration'],
@@ -227,7 +227,7 @@ describe('EventSamplesTable', function () {
     );
 
     // Ascending sort in transaction ID because the default is descending
-    expect(screen.getByRole('link', {name: 'Event ID'})).toHaveAttribute(
+    expect(await screen.findByRole('link', {name: 'Event ID'})).toHaveAttribute(
       'href',
       '/mock-pathname/?customSortKey=transaction.id'
     );


### PR DESCRIPTION
- fixes a bunch of act warnings on components that use fetch or change state in an effect and are not async
- fixes a few act warnings where we directly modify stores
- mostly just change things from getBy to findBy to silence act warnings

this is touching a lot of files, but there's about ~100 of these files to change and its all the same problem.

part of https://github.com/getsentry/frontend-tsc/issues/22