### PR TITLE
fix(slack): strip whitespace and new lines in code block

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -589,7 +589,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
     def build(self, notification_uuid: str | None = None) -> SlackBlock | SlackAttachment:
         # XXX(dcramer): options are limited to 100 choices, even when nested
-        text = build_attachment_text(self.group, self.event) or ""
+        text = build_attachment_text(self.group, self.event).strip(" \n") or ""
 
         if self.use_improved_block_kit:
             text = escape_slack_markdown_text(text)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -589,7 +589,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
     def build(self, notification_uuid: str | None = None) -> SlackBlock | SlackAttachment:
         # XXX(dcramer): options are limited to 100 choices, even when nested
-        text = build_attachment_text(self.group, self.event).strip(" \n") or ""
+        text = build_attachment_text(self.group, self.event) or ""
+        text = text.strip(" \n")
 
         if self.use_improved_block_kit:
             text = escape_slack_markdown_text(text)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -908,7 +908,8 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             data={"message": "Hello world", "level": "error"}, project_id=self.project.id
         )
         group_event = event.for_group(event.groups[0])
-        text = "<bye> ```asdf```"
+        # should also trim whitespace
+        text = "\n\n\n      <bye> ```asdf```      "
         escaped_text = "<bye> `asdf`"
 
         occurrence = self.build_occurrence(


### PR DESCRIPTION
This looks weird. We should strip whitespace and new lines from the front and back of the text we're putting into the code block.

<img width="494" alt="Screenshot 2024-02-29 at 09 21 53" src="https://github.com/getsentry/sentry/assets/70817427/1c4f8770-db7b-4856-bb3f-f53b3b698a3e">