### PR TITLE
ref(daily summary): Move functions around

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -27,6 +27,7 @@ from sentry.utils.outcomes import Outcome
 from sentry.utils.snuba import raw_snql_query
 
 ONE_DAY = int(timedelta(days=1).total_seconds())
+COMPARISON_PERIOD = 14
 
 
 class OrganizationReportContext:
@@ -108,7 +109,7 @@ class DailySummaryProjectContext:
     key_performance_issues: list[tuple[Group, int]] = []
     escalated_today: list[Group] = []
     regressed_today: list[Group] = []
-    new_in_release: dict[str, list[Group]] = {}
+    new_in_release: dict[int, list[Group]] = {}
 
     def __init__(self, project: Project):
         self.project = project
@@ -136,9 +137,7 @@ def project_key_errors(
         return None
     # Take the 3 most frequently occuring events
     prefix = (
-        "daily_summary"
-        if referrer == Referrer.DAILY_SUMMARY_KEY_PERFORMANCE_ISSUES.value
-        else "weekly_reports"
+        "daily_summary" if referrer == Referrer.DAILY_SUMMARY_KEY_ERRORS.value else "weekly_reports"
     )
     op = f"{prefix}.project_key_errors"
 
@@ -412,3 +411,31 @@ def organization_project_issue_substatus_summaries(ctx: OrganizationReportContex
         if item["substatus"] == GroupSubStatus.REGRESSED:
             project_ctx.regression_substatus_count = item["total"]
         project_ctx.total_substatus_count += item["total"]
+
+
+def check_if_project_is_empty(project_ctx: ProjectContext) -> bool:
+    """
+    Check if this project has any content we could show in an email.
+    """
+    return (
+        not project_ctx.key_errors
+        and not project_ctx.key_transactions
+        and not project_ctx.key_performance_issues
+        and not project_ctx.accepted_error_count
+        and not project_ctx.dropped_error_count
+        and not project_ctx.accepted_transaction_count
+        and not project_ctx.dropped_transaction_count
+        and not project_ctx.accepted_replay_count
+        and not project_ctx.dropped_replay_count
+    )
+
+
+def check_if_ctx_is_empty(ctx: OrganizationReportContext) -> bool:
+    """
+    Check if the context is empty. If it is, we don't want to send an email.
+    """
+    project_ctxs = [
+        cast(ProjectContext, project_ctx) for project_ctx in ctx.projects_context_map.values()
+    ]
+
+    return all(check_if_project_is_empty(project_ctx) for project_ctx in project_ctxs)

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -27,6 +27,7 @@ from sentry.tasks.summaries.utils import (
     ONE_DAY,
     OrganizationReportContext,
     ProjectContext,
+    check_if_ctx_is_empty,
     fetch_key_error_groups,
     fetch_key_performance_issue_groups,
     organization_project_issue_substatus_summaries,
@@ -48,34 +49,6 @@ from sentry.utils.snuba import parse_snuba_datetime
 date_format = partial(dateformat.format, format_string="F jS, Y")
 
 logger = logging.getLogger(__name__)
-
-
-def check_if_project_is_empty(project_ctx: ProjectContext) -> bool:
-    """
-    Check if this project has any content we could show in an email.
-    """
-    return (
-        not project_ctx.key_errors
-        and not project_ctx.key_transactions
-        and not project_ctx.key_performance_issues
-        and not project_ctx.accepted_error_count
-        and not project_ctx.dropped_error_count
-        and not project_ctx.accepted_transaction_count
-        and not project_ctx.dropped_transaction_count
-        and not project_ctx.accepted_replay_count
-        and not project_ctx.dropped_replay_count
-    )
-
-
-def check_if_ctx_is_empty(ctx: OrganizationReportContext) -> bool:
-    """
-    Check if the context is empty. If it is, we don't want to send an email.
-    """
-    project_ctxs = [
-        cast(ProjectContext, project_ctx) for project_ctx in ctx.projects_context_map.values()
-    ]
-
-    return all(check_if_project_is_empty(project_ctx) for project_ctx in project_ctxs)
 
 
 # The entry point. This task is scheduled to run every week.

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -7,7 +7,7 @@ from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.activity import Activity
 from sentry.models.group import GroupStatus
 from sentry.services.hybrid_cloud.user_option import user_option_service
-from sentry.tasks.summaries.daily_summary import prepare_summary_data, schedule_organizations
+from sentry.tasks.summaries.daily_summary import build_summary_data, schedule_organizations
 from sentry.tasks.summaries.utils import ONE_DAY
 from sentry.testutils.cases import OutcomesSnubaTest, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
@@ -78,37 +78,9 @@ class DailySummaryTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCas
         )
         self.release = self.create_release(project=self.project, date_added=self.now)
 
-    @with_feature("organizations:daily-summary")
-    @mock.patch("sentry.tasks.summaries.daily_summary.prepare_summary_data")
-    def test_schedule_organizations(self, mock_prepare_summary_data):
-        user2 = self.create_user()
-        self.create_member(teams=[self.team], user=user2, organization=self.organization)
-        for _ in range(2):
-            self.store_event_and_outcomes(
-                self.project.id,
-                self.three_days_ago,
-                fingerprint="group-1",
-                category=DataCategory.ERROR,
-            )
-        for _ in range(2):
-            self.store_event_and_outcomes(
-                self.project.id,
-                self.now,
-                fingerprint="group-2",
-                category=DataCategory.ERROR,
-            )
-
-        with self.tasks():
-            schedule_organizations(timestamp=to_timestamp(self.now))
-
-        # user2's local timezone is UTC and therefore it isn't sent now
-        assert mock_prepare_summary_data.delay.call_count == 1
-        for call_args in mock_prepare_summary_data.delay.call_args_list:
-            assert call_args.args == (to_timestamp(self.now), ONE_DAY, self.organization.id)
-
-    def test_prepare_summary_data(self):
+    def populate_event_data(self):
         for _ in range(6):
-            group1 = self.store_event_and_outcomes(
+            self.group1 = self.store_event_and_outcomes(
                 self.project.id,
                 self.three_days_ago,
                 fingerprint="group-1",
@@ -131,7 +103,7 @@ class DailySummaryTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCas
 
         # create an issue first seen in the release and set it to regressed
         for _ in range(2):
-            group2 = self.store_event_and_outcomes(
+            self.group2 = self.store_event_and_outcomes(
                 self.project.id,
                 self.now,
                 fingerprint="group-2",
@@ -139,19 +111,19 @@ class DailySummaryTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCas
                 release=self.release.version,
                 resolve=False,
             )
-        group2.substatus = GroupSubStatus.REGRESSED
-        group2.save()
+        self.group2.substatus = GroupSubStatus.REGRESSED
+        self.group2.save()
         Activity.objects.create_group_activity(
-            group2,
+            self.group2,
             ActivityType.SET_REGRESSION,
             data={
-                "event_id": group2.get_latest_event().event_id,
+                "event_id": self.group2.get_latest_event().event_id,
                 "version": self.release.version,
             },
         )
         # create and issue and set it to escalating
         for _ in range(10):
-            group3 = self.store_event_and_outcomes(
+            self.group3 = self.store_event_and_outcomes(
                 self.project.id,
                 self.now,
                 fingerprint="group-3",
@@ -159,20 +131,20 @@ class DailySummaryTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCas
                 release=self.release.version,
                 resolve=False,
             )
-        group3.substatus = GroupSubStatus.ESCALATING
-        group3.save()
+        self.group3.substatus = GroupSubStatus.ESCALATING
+        self.group3.save()
         Activity.objects.create_group_activity(
-            group3,
+            self.group3,
             ActivityType.SET_ESCALATING,
             data={
-                "event_id": group3.get_latest_event().event_id,
+                "event_id": self.group3.get_latest_event().event_id,
                 "version": self.release.version,
             },
         )
 
         # store an event in another project to be sure they're in separate buckets
         for _ in range(2):
-            group4 = self.store_event_and_outcomes(
+            self.group4 = self.store_event_and_outcomes(
                 self.project2.id,
                 self.now,
                 fingerprint="group-4",
@@ -180,13 +152,35 @@ class DailySummaryTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCas
             )
 
         # store some performance issues
-        perf_event = self.create_performance_issue(
+        self.perf_event = self.create_performance_issue(
             fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group5"
         )
-        perf_event2 = self.create_performance_issue(
+        self.perf_event2 = self.create_performance_issue(
             fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group6"
         )
-        summary = prepare_summary_data(to_timestamp(self.now), ONE_DAY, self.organization.id)
+
+    @with_feature("organizations:daily-summary")
+    @mock.patch("sentry.tasks.summaries.daily_summary.prepare_summary_data")
+    def test_schedule_organizations(self, mock_prepare_summary_data):
+        user2 = self.create_user()
+        self.create_member(teams=[self.team], user=user2, organization=self.organization)
+
+        with self.tasks():
+            schedule_organizations(timestamp=to_timestamp(self.now))
+
+        # user2's local timezone is UTC and therefore it isn't sent now
+        assert mock_prepare_summary_data.delay.call_count == 1
+        for call_args in mock_prepare_summary_data.delay.call_args_list:
+            assert call_args.args == (to_timestamp(self.now), ONE_DAY, self.organization.id)
+
+    def test_build_summary_data(self):
+        self.populate_event_data()
+        summary = build_summary_data(
+            timestamp=to_timestamp(self.now),
+            duration=ONE_DAY,
+            organization=self.organization,
+            daily=True,
+        )
         project_id = self.project.id
 
         assert (
@@ -194,25 +188,29 @@ class DailySummaryTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCas
         )  # total outcomes from today
         assert summary.projects_context_map[project_id].comparison_period_avg == 1
         assert len(summary.projects_context_map[project_id].key_errors) == 3
-        assert (group1, None, 3) in summary.projects_context_map[project_id].key_errors
-        assert (group2, None, 2) in summary.projects_context_map[project_id].key_errors
-        assert (group3, None, 10) in summary.projects_context_map[project_id].key_errors
+        assert (self.group1, None, 3) in summary.projects_context_map[project_id].key_errors
+        assert (self.group2, None, 2) in summary.projects_context_map[project_id].key_errors
+        assert (self.group3, None, 10) in summary.projects_context_map[project_id].key_errors
         assert len(summary.projects_context_map[project_id].key_performance_issues) == 2
-        assert (perf_event.group, None, 1) in summary.projects_context_map[
+        assert (self.perf_event.group, None, 1) in summary.projects_context_map[
             project_id
         ].key_performance_issues
-        assert (perf_event2.group, None, 1) in summary.projects_context_map[
+        assert (self.perf_event2.group, None, 1) in summary.projects_context_map[
             project_id
         ].key_performance_issues
-        assert summary.projects_context_map[project_id].escalated_today == [group3]
-        assert summary.projects_context_map[project_id].regressed_today == [group2]
-        assert group2 in summary.projects_context_map[project_id].new_in_release[self.release.id]
-        assert group3 in summary.projects_context_map[project_id].new_in_release[self.release.id]
+        assert summary.projects_context_map[project_id].escalated_today == [self.group3]
+        assert summary.projects_context_map[project_id].regressed_today == [self.group2]
+        assert (
+            self.group2 in summary.projects_context_map[project_id].new_in_release[self.release.id]
+        )
+        assert (
+            self.group3 in summary.projects_context_map[project_id].new_in_release[self.release.id]
+        )
 
         project_id2 = self.project2.id
         assert summary.projects_context_map[project_id2].total_today == 2
         assert summary.projects_context_map[project_id2].comparison_period_avg == 0
-        assert summary.projects_context_map[project_id2].key_errors == [(group4, None, 2)]
+        assert summary.projects_context_map[project_id2].key_errors == [(self.group4, None, 2)]
         assert summary.projects_context_map[project_id2].key_performance_issues == []
         assert summary.projects_context_map[project_id2].escalated_today == []
         assert summary.projects_context_map[project_id2].regressed_today == []


### PR DESCRIPTION
A chunk off my large [draft](https://github.com/getsentry/sentry/pull/66044) that moves a couple functions into utils to be reused, puts building the daily summary data into a function to be called for easier testing, moves issue creation into a helper function in tests, and updates the test to use the daily summary builder function.