### PR TITLE
fix(issue-details): Fix structured data styling for multiline strings

### DIFF
--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -261,7 +261,6 @@ const ValueBoolean = styled('span')`
 `;
 
 const ValueMultiLineString = styled('span')`
-  color: var(--prism-selector);
   display: block;
   overflow: auto;
   border-radius: 4px;


### PR DESCRIPTION
Tiny fix, mistakenly added this color to multiline string values which we don't want (yet)