### PR TITLE
fix(replay): Allow transactionReplays to bypass global-views when fetch replays

### DIFF
--- a/src/sentry/replays/blueprints/api.md
+++ b/src/sentry/replays/blueprints/api.md
@@ -31,7 +31,7 @@ This document is structured by resource with each resource having actions that c
   - offset (optional, number)
     Default: 0
   - query (optional, string) - Search query with space-separated field/value pairs. ie: `?query=count_errors:>2 AND duration:<1h`.
-  - queryReferrer(optional, string) - Specify the page which this query is being made from. Used for cross project query on issue replays page. Pass `queryReferrer=issueReplays` for this query.
+  - queryReferrer(optional, string) - Specify the page which this query is being made from. Used for cross project query on issue replays page & transaction replays page. Pass `queryReferrer=issueReplays` or `queryReferrer=transactionReplays` for this query.
     Some fields in the API response have their own dedicated parameters, or are otherwide not supported in the `query` param. They are:
 
     | Response Field      | Parameter       |

--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -40,6 +40,7 @@ class OrganizationReplayIndexEndpoint(OrganizationEndpoint):
         has_global_views = (
             features.has("organizations:global-views", organization, actor=request.user)
             or query_referrer == "issueReplays"
+            or query_referrer == "transactionReplays"
         )
 
         if not has_global_views and len(filter_params.get("project_id", [])) > 1:


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/issues/65888