### PR TITLE
fix(issues): Move issue action taken out of state

### DIFF
--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -1203,7 +1203,7 @@ describe('IssueList', function () {
         }),
       });
 
-      expect(screen.getByTestId('awaiting-events')).toBeInTheDocument();
+      expect(await screen.findByTestId('awaiting-events')).toBeInTheDocument();
     });
 
     it('does not display when no projects selected and any projects have a first event', async function () {

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -108,7 +108,6 @@ type Props = {
   WithRouteAnalyticsProps;
 
 type State = {
-  actionTaken: boolean;
   error: string | null;
   groupIds: string[];
   issuesLoading: boolean;
@@ -125,7 +124,6 @@ type State = {
   queryMaxCount: number;
   realtimeActive: boolean;
   selectAllActive: boolean;
-  undo: boolean;
   // Will be set to true if there is valid session data from issue-stats api call
   query?: string;
 };
@@ -163,7 +161,6 @@ class IssueListOverview extends Component<Props, State> {
     return {
       groupIds: [],
       actionTaken: false,
-      undo: false,
       selectAllActive: false,
       realtimeActive,
       pageLinks: '',
@@ -312,6 +309,8 @@ class IssueListOverview extends Component<Props, State> {
   private _lastRequest: any;
   private _lastStatsRequest: any;
   private _lastFetchCountsRequest: any;
+  private actionTaken = false;
+  private undo = false;
 
   getQueryFromSavedSearchOrLocation({
     savedSearch,
@@ -577,7 +576,7 @@ class IssueListOverview extends Component<Props, State> {
     const query = this.getQuery();
 
     if (!this.state.realtimeActive) {
-      if (!this.state.actionTaken && !this.state.undo) {
+      if (!this.actionTaken && !this.undo) {
         GroupStore.loadInitialData([]);
 
         this.setState({
@@ -691,7 +690,7 @@ class IssueListOverview extends Component<Props, State> {
           return;
         }
 
-        if (this.state.undo) {
+        if (this.undo) {
           GroupStore.loadInitialData(data);
         }
         GroupStore.add(data);
@@ -744,7 +743,8 @@ class IssueListOverview extends Component<Props, State> {
         this.resumePolling();
 
         if (!this.state.realtimeActive) {
-          this.setState({actionTaken: false, undo: false});
+          this.actionTaken = false;
+          this.undo = false;
         }
       },
     });
@@ -994,7 +994,7 @@ class IssueListOverview extends Component<Props, State> {
   };
 
   onDelete = () => {
-    this.setState({actionTaken: true});
+    this.actionTaken = true;
     this.fetchData(true);
   };
 
@@ -1032,7 +1032,7 @@ class IssueListOverview extends Component<Props, State> {
         if (!query.includes('is:ignored') && !isForReviewQuery(query)) {
           GroupStore.add(groups);
         }
-        this.setState({undo: true});
+        this.undo = true;
       },
       error: err => {
         this.setState({
@@ -1142,10 +1142,8 @@ class IssueListOverview extends Component<Props, State> {
     GroupStore.remove(itemIds);
 
     const queryCount = this.state.queryCount - itemIds.length;
-    this.setState({
-      actionTaken: true,
-      queryCount,
-    });
+    this.actionTaken = true;
+    this.setState({queryCount});
 
     if (GroupStore.getAllItemIds().length === 0) {
       // If we run out of issues on the last page, navigate back a page to


### PR DESCRIPTION
Moves the actionTaken and undo booleans out of state and into the component, more like a ref. In react 18 setting the state and using the state creates a race since the state may not yet be updated by the time its checked. These were not used to change the dom and do not need to be in state.

fixes the only act warning for 18 in test

part of https://github.com/getsentry/frontend-tsc/issues/22
