### PR TITLE
feat(issue-details): Add special formatting to python local variable strings

### DIFF
--- a/static/app/components/events/attachmentViewers/jsonViewer.tsx
+++ b/static/app/components/events/attachmentViewers/jsonViewer.tsx
@@ -5,7 +5,7 @@ import type {ViewerProps} from 'sentry/components/events/attachmentViewers/utils
 import {getAttachmentUrl} from 'sentry/components/events/attachmentViewers/utils';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import StructuredEventData from 'sentry/components/structuredEventData';
+import {JsonEventData} from 'sentry/components/structuredEventData/jsonEventData';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -49,7 +49,7 @@ export default function JsonViewer(props: ViewerProps) {
 
   return (
     <PreviewPanelItem>
-      <StyledStructuredData data={json} maxDefaultDepth={4} preserveQuotes />
+      <StyledJsonData data={json} maxDefaultDepth={4} />
     </PreviewPanelItem>
   );
 }
@@ -60,7 +60,7 @@ const LoadingContainer = styled('div')`
   padding: ${space(1)};
 `;
 
-const StyledStructuredData = styled(StructuredEventData)`
+const StyledJsonData = styled(JsonEventData)`
   margin-bottom: 0;
   width: 100%;
 `;

--- a/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
@@ -106,6 +106,8 @@ describe('Frame Variables', function () {
         data={{
           null: 'None',
           bool: 'True',
+          str: "'string'",
+          other: '<Class at 0x12345>',
         }}
         platform="python"
       />
@@ -117,6 +119,12 @@ describe('Frame Variables', function () {
     expect(
       within(screen.getByTestId('value-boolean')).getByText('True')
     ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('value-string')).getByText('"string"')
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('value-unformatted')).getByText('<Class at 0x12345>')
+    ).toBeInTheDocument();
   });
 
   it('renders node variables correctly', function () {
@@ -126,6 +134,7 @@ describe('Frame Variables', function () {
           null: '<null>',
           undefined: '<undefined>',
           bool: true,
+          str: 'string',
         }}
         platform="node"
       />
@@ -138,6 +147,9 @@ describe('Frame Variables', function () {
     expect(
       within(screen.getByTestId('value-boolean')).getByText('true')
     ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('value-unformatted')).getByText('string')
+    ).toBeInTheDocument();
   });
 
   it('renders ruby variables correctly', function () {
@@ -146,6 +158,7 @@ describe('Frame Variables', function () {
         data={{
           null: 'nil',
           bool: 'true',
+          str: 'string',
         }}
         platform="ruby"
       />
@@ -155,6 +168,9 @@ describe('Frame Variables', function () {
     expect(
       within(screen.getByTestId('value-boolean')).getByText('true')
     ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('value-unformatted')).getByText('string')
+    ).toBeInTheDocument();
   });
 
   it('renders php variables correctly', function () {
@@ -163,6 +179,7 @@ describe('Frame Variables', function () {
         data={{
           null: 'null',
           bool: 'true',
+          str: 'string',
         }}
         platform="php"
       />
@@ -173,6 +190,9 @@ describe('Frame Variables', function () {
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('value-boolean')).getByText('true')
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('value-unformatted')).getByText('string')
     ).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/interfaces/frame/frameVariables.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.tsx
@@ -12,6 +12,8 @@ type Props = {
   platform?: PlatformKey;
 };
 
+const PYTHON_STRING_REGEX = /^['"](.*)['"]$/;
+
 const renderPythonBoolean = (value: unknown) => {
   if (typeof value === 'string') {
     return value;
@@ -45,6 +47,8 @@ const getStructuredDataConfig = ({
         isNull: value => value === null || value === 'None',
         renderBoolean: renderPythonBoolean,
         renderNull: () => 'None',
+        isString: value => typeof value === 'string' && PYTHON_STRING_REGEX.test(value),
+        renderString: value => value.replace(PYTHON_STRING_REGEX, '$1'),
       };
     case 'ruby':
       return {

--- a/static/app/components/events/interfaces/request/richHttpContentClippedBoxBodySection.tsx
+++ b/static/app/components/events/interfaces/request/richHttpContentClippedBoxBodySection.tsx
@@ -2,6 +2,7 @@ import ClippedBox from 'sentry/components/clippedBox';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import StructuredEventData from 'sentry/components/structuredEventData';
+import {JsonEventData} from 'sentry/components/structuredEventData/jsonEventData';
 import {t} from 'sentry/locale';
 import type {EntryRequest} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
@@ -27,11 +28,7 @@ export function RichHttpContentClippedBoxBodySection({
     switch (inferredContentType) {
       case 'application/json':
         return (
-          <StructuredEventData
-            data-test-id="rich-http-content-body-context-data"
-            data={data}
-            preserveQuotes
-          />
+          <JsonEventData data-test-id="rich-http-content-body-context-data" data={data} />
         );
       case 'application/x-www-form-urlencoded':
       case 'multipart/form-data': {

--- a/static/app/components/structuredEventData/jsonEventData.tsx
+++ b/static/app/components/structuredEventData/jsonEventData.tsx
@@ -1,0 +1,15 @@
+import StructuredEventData, {
+  type StructedEventDataConfig,
+  type StructuredEventDataProps,
+} from 'sentry/components/structuredEventData';
+
+type JsonEventDataProps = Omit<StructuredEventDataProps, 'config'>;
+
+const config: StructedEventDataConfig = {
+  isString: value => typeof value === 'string',
+  renderObjectKeys: value => `"${value}"`,
+};
+
+export function JsonEventData(props: JsonEventDataProps) {
+  return <StructuredEventData {...props} config={config} />;
+}

--- a/static/app/components/structuredEventData/utils.tsx
+++ b/static/app/components/structuredEventData/utils.tsx
@@ -1,3 +1,5 @@
+const STRIPPED_VALUE_REGEX = /^['"]?\*{8,}['"]?$/;
+
 export function looksLikeObjectRepr(value: string) {
   const a = value[0];
   const z = value[value.length - 1];
@@ -48,25 +50,6 @@ export function naturalCaseInsensitiveSort(a: string, b: string) {
   return a === b ? 0 : a < b ? -1 : 1;
 }
 
-export function analyzeStringForRepr(value: string) {
-  const rv = {
-    repr: value,
-    isString: true,
-    isMultiLine: false,
-    isStripped: false,
-  };
-
-  // stripped for security reasons
-  if (value.match(/^['"]?\*{8,}['"]?$/)) {
-    rv.isStripped = true;
-    return rv;
-  }
-
-  if (looksLikeObjectRepr(value)) {
-    rv.isString = false;
-    return rv;
-  }
-
-  rv.isMultiLine = looksLikeMultiLineString(value);
-  return rv;
+export function looksLikeStrippedValue(value: string) {
+  return STRIPPED_VALUE_REGEX.test(value);
 }


### PR DESCRIPTION
Because local variables for Python include single quotes for string values, we can know for sure that it is a string value and apply special formatting. I'm replacing the single quotes with double quotes and coloring it in the same way that we syntax highlight strings in the source code.

For now, I'm only doing this in the local variables UI. We could apply this formatting to many other places on the page that use this component, but in other places it's hard to know if something is _actually_ a string and not some sort of class/object representation.

Before/After Python:

![CleanShot 2024-02-29 at 10 57 16](https://github.com/getsentry/sentry/assets/10888943/4358ba91-fece-4820-92bd-7fa1140cc83f)![CleanShot 2024-02-29 at 10 57 29](https://github.com/getsentry/sentry/assets/10888943/d97180e0-6042-4615-994a-e7abcab10c5d)

The JSON viewer also looks nicer with string formatting:

![CleanShot 2024-02-29 at 10 54 39](https://github.com/getsentry/sentry/assets/10888943/bde25ed1-9707-406f-9e0b-4b9b40f561c4)
