### PR TITLE
ref: before_now() returns aware datetimes

### DIFF
--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -1,5 +1,3 @@
-from datetime import timezone
-
 from django.utils import timezone as django_timezone
 
 from sentry.incidents.logic import update_incident_status
@@ -10,7 +8,7 @@ from sentry.testutils.silo import no_silo_test
 
 FEATURE_NAME = ["organizations:incidents", "organizations:performance-view"]
 
-event_time = before_now(days=3).replace(tzinfo=timezone.utc)
+event_time = before_now(days=3)
 
 
 @no_silo_test

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -1,5 +1,5 @@
 import copy
-from datetime import timedelta, timezone
+from datetime import timedelta
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -181,7 +181,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_all_events_query(self, mock_now):
-        now = before_now().replace(tzinfo=timezone.utc)
+        now = before_now()
         mock_now.return_value = now
         five_mins_ago = iso_format(now - timedelta(minutes=5))
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
@@ -236,7 +236,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_errors_query(self, mock_now):
-        now = before_now().replace(tzinfo=timezone.utc)
+        now = before_now()
         mock_now.return_value = now
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
         self.store_event(
@@ -289,7 +289,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transactions_query(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         event_data = generate_transaction()
 
@@ -304,7 +304,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_all_events(self, mock_now):
-        now = before_now().replace(tzinfo=timezone.utc)
+        now = before_now()
         mock_now.return_value = now
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
 
@@ -340,7 +340,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_errors_view(self, mock_now):
-        now = before_now().replace(tzinfo=timezone.utc)
+        now = before_now()
         mock_now.return_value = now
 
         event_data = load_data("javascript")
@@ -374,7 +374,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_transactions_query(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
@@ -420,7 +420,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_transactions_query_siblings(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
 
@@ -496,7 +496,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transaction_event_detail_view_ops_filtering(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
@@ -644,7 +644,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @pytest.mark.skip(reason="causing timeouts in github actions and travis")
     @patch("django.utils.timezone.now")
     def test_drilldown_result(self, mock_now):
-        now = before_now().replace(tzinfo=timezone.utc)
+        now = before_now()
         mock_now.return_value = now
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
         events = (
@@ -683,7 +683,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @pytest.mark.skip(reason="not done")
     @patch("django.utils.timezone.now")
     def test_usage(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         # TODO: load events
 

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -10,7 +10,7 @@ from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import no_silo_test
 
-event_time = before_now(days=3).replace(tzinfo=timezone.utc)
+event_time = before_now(days=3)
 
 
 @no_silo_test

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -11,7 +11,7 @@ from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import no_silo_test
 
-event_time = before_now(days=3).replace(tzinfo=timezone.utc)
+event_time = before_now(days=3)
 
 
 @no_silo_test

--- a/tests/acceptance/test_performance_issues.py
+++ b/tests/acceptance/test_performance_issues.py
@@ -1,6 +1,6 @@
 import random
 import string
-from datetime import timedelta, timezone
+from datetime import timedelta
 from unittest import mock
 from unittest.mock import patch
 
@@ -67,7 +67,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
 
     @patch("django.utils.timezone.now")
     def test_with_one_performance_issue(self, mock_now):
-        mock_now.return_value = before_now(minutes=5).replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now(minutes=5)
         event_data = self.create_sample_event(
             "n-plus-one-in-django-new-view", mock_now.return_value.timestamp()
         )
@@ -89,7 +89,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
 
     @patch("django.utils.timezone.now")
     def test_multiple_events_with_one_cause_are_grouped(self, mock_now):
-        mock_now.return_value = before_now(minutes=5).replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now(minutes=5)
         event_data = self.create_sample_event(
             "n-plus-one-in-django-new-view", mock_now.return_value.timestamp()
         )
@@ -100,7 +100,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
 
     @patch("django.utils.timezone.now")
     def test_n_one_api_call_performance_issue(self, mock_now):
-        mock_now.return_value = before_now(minutes=5).replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now(minutes=5)
         event_data = self.create_sample_event(
             "n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream",
             mock_now.return_value.timestamp(),
@@ -124,7 +124,7 @@ class PerformanceIssuesTest(AcceptanceTestCase, SnubaTestCase, PerformanceIssueT
 
     @patch("django.utils.timezone.now")
     def test_multiple_events_with_multiple_causes_are_not_grouped(self, mock_now):
-        mock_now.return_value = before_now(minutes=5).replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now(minutes=5)
 
         # Create identical events with different parent spans
         for _ in range(3):

--- a/tests/acceptance/test_performance_landing.py
+++ b/tests/acceptance/test_performance_landing.py
@@ -1,4 +1,3 @@
-from datetime import timezone
 from unittest.mock import patch
 
 from django.db.models import F
@@ -33,7 +32,7 @@ class PerformanceLandingTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)
@@ -51,7 +50,7 @@ class PerformanceLandingTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data_and_new_widget_designs(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -1,4 +1,3 @@
-from datetime import timezone
 from unittest.mock import patch
 
 from django.db.models import F
@@ -33,7 +32,7 @@ class PerformanceOverviewTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_onboarding(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)
@@ -41,7 +40,7 @@ class PerformanceOverviewTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -1,4 +1,3 @@
-from datetime import timezone
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -42,7 +41,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         # Create a transaction
         event = make_event(load_data("transaction", timestamp=before_now(minutes=3)))
@@ -66,7 +65,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_view_details_from_summary(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         event = make_event(
             load_data(
@@ -85,7 +84,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_tags_page(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         tags_path = "/organizations/{}/performance/summary/tags/?{}".format(
             self.org.slug,
@@ -104,7 +103,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transaction_vitals(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         vitals_path = "/organizations/{}/performance/summary/vitals/?{}".format(
             self.org.slug,
@@ -125,7 +124,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transaction_vitals_filtering(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         vitals_path = "/organizations/{}/performance/summary/vitals/?{}".format(
             self.org.slug,
@@ -185,7 +184,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_transaction_threshold_modal(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         # Create a transaction
         event = make_event(load_data("transaction", timestamp=before_now(minutes=3)))

--- a/tests/acceptance/test_performance_trace_detail.py
+++ b/tests/acceptance/test_performance_trace_detail.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, timezone
+from datetime import timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -189,7 +189,7 @@ class PerformanceTraceDetailTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)

--- a/tests/acceptance/test_performance_trends.py
+++ b/tests/acceptance/test_performance_trends.py
@@ -1,4 +1,3 @@
-from datetime import timezone
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -59,7 +58,7 @@ class PerformanceTrendsTest(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
         values = range(1, 100, 5)
 
         self.make_trend("improvement", [v for v in reversed(values)])

--- a/tests/acceptance/test_performance_vital_detail.py
+++ b/tests/acceptance/test_performance_vital_detail.py
@@ -1,4 +1,3 @@
-from datetime import timezone
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -35,7 +34,7 @@ class PerformanceVitalDetailsTest(AcceptanceTestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_with_data(self, mock_now):
 
-        mock_now.return_value = before_now().replace(tzinfo=timezone.utc)
+        mock_now.return_value = before_now()
 
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -5,7 +5,7 @@ from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import no_silo_test
 
-event_time = before_now(days=3).replace(tzinfo=timezone.utc)
+event_time = before_now(days=3)
 current_time = datetime.now(timezone.utc)
 
 

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -69,14 +69,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             name="alert rule",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=6).replace(tzinfo=timezone.utc),
+            date_added=before_now(minutes=6),
             owner=self.team.actor.get_actor_tuple(),
         )
         self.other_alert_rule = self.create_alert_rule(
             name="other alert rule",
             organization=self.org,
             projects=[self.project2],
-            date_added=before_now(minutes=5).replace(tzinfo=timezone.utc),
+            date_added=before_now(minutes=5),
             owner=self.team.actor.get_actor_tuple(),
         )
         self.issue_rule = self.create_issue_alert_rule(
@@ -86,14 +86,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=4).replace(tzinfo=timezone.utc),
+                "date_added": before_now(minutes=4),
             }
         )
         self.yet_another_alert_rule = self.create_alert_rule(
             name="yet another alert rule",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=3).replace(tzinfo=timezone.utc),
+            date_added=before_now(minutes=3),
             owner=self.team2.actor.get_actor_tuple(),
         )
         self.combined_rules_url = f"/api/0/organizations/{self.org.slug}/combined-rules/"
@@ -169,14 +169,14 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             name="!1?",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=6).replace(tzinfo=timezone.utc),
+            date_added=before_now(minutes=6),
             owner=self.team.actor.get_actor_tuple(),
         )
         alert_rule1 = self.create_alert_rule(
             name="!1?zz",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=6).replace(tzinfo=timezone.utc),
+            date_added=before_now(minutes=6),
             owner=self.team.actor.get_actor_tuple(),
         )
 
@@ -394,7 +394,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=4).replace(tzinfo=timezone.utc),
+                "date_added": before_now(minutes=4),
             }
         )
 
@@ -464,7 +464,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.an_unassigned_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=3).replace(tzinfo=timezone.utc),
+            date_added=before_now(minutes=3),
             owner=None,
         )
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -512,7 +512,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=4).replace(tzinfo=timezone.utc),
+                "date_added": before_now(minutes=4),
                 "owner": self.team.actor,
             }
         )
@@ -542,7 +542,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             name="alert rule",
             organization=another_org,
             projects=[another_project],
-            date_added=before_now(minutes=6).replace(tzinfo=timezone.utc),
+            date_added=before_now(minutes=6),
             owner=another_org_team.actor.get_actor_tuple(),
         )
 
@@ -553,7 +553,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=4).replace(tzinfo=timezone.utc),
+                "date_added": before_now(minutes=4),
                 "owner": another_org_team.actor,
             }
         )
@@ -823,7 +823,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             name="the best rule",
             organization=self.org,
             projects=[self.project],
-            date_added=before_now(minutes=1).replace(tzinfo=timezone.utc),
+            date_added=before_now(minutes=1),
             owner=team.actor.get_actor_tuple(),
         )
         self.create_issue_alert_rule(
@@ -833,7 +833,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",
-                "date_added": before_now(minutes=2).replace(tzinfo=timezone.utc),
+                "date_added": before_now(minutes=2),
                 "owner": team.actor,
             }
         )

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -1,4 +1,3 @@
-from datetime import timezone
 from unittest.mock import patch
 
 import responses
@@ -16,7 +15,7 @@ from sentry.utils import json
 
 pytestmark = [requires_snuba]
 
-event_time = before_now(days=3).replace(tzinfo=timezone.utc)
+event_time = before_now(days=3)
 # external_id is the account name in pagerduty
 EXTERNAL_ID = "example-pagerduty"
 SERVICES = [

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, timezone
+from datetime import timedelta
 
 from django.utils import timezone as django_timezone
 
@@ -502,7 +502,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            before_now(hours=1).replace(tzinfo=timezone.utc),
+            before_now(hours=1),
         )
         assert group_info is not None
         event_2, _, _ = self.store_search_issue(
@@ -510,7 +510,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            before_now(hours=1).replace(tzinfo=timezone.utc),
+            before_now(hours=1),
         )
 
         self.login_as(user=self.user)

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, timezone
+from datetime import timedelta
 
 from sentry.models.rule import Rule
 from sentry.models.rulefirehistory import RuleFireHistory
@@ -76,7 +76,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         )
         RuleFireHistory.objects.bulk_create(history)
 
-        base_triggered_date = before_now(days=1).replace(tzinfo=timezone.utc)
+        base_triggered_date = before_now(days=1)
 
         self.run_test(
             rule,
@@ -151,7 +151,7 @@ class FetchRuleGroupsPaginatedTest(BasePostgresRuleHistoryBackendTest):
                 event_id=i,
             )
 
-        base_triggered_date = before_now(days=1).replace(tzinfo=timezone.utc)
+        base_triggered_date = before_now(days=1)
         self.run_test(
             rule,
             before_now(days=3),

--- a/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sentry.api.serializers import serialize
 from sentry.models.rule import Rule
@@ -61,7 +61,7 @@ class ProjectRuleGroupHistoryIndexEndpointTest(APITestCase):
             start=iso_format(before_now(days=6)),
             end=iso_format(before_now(days=0)),
         )
-        base_triggered_date = before_now(days=1).replace(tzinfo=timezone.utc)
+        base_triggered_date = before_now(days=1)
         assert resp.data == serialize(
             [
                 RuleGroupHistory(self.group, 3, base_triggered_date),

--- a/tests/sentry/snuba/test_discover_query.py
+++ b/tests/sentry/snuba/test_discover_query.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta, timezone
+from datetime import timedelta
 
 import pytest
 from django.utils import timezone as django_timezone
@@ -34,9 +34,9 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         super().setUp()
         self.environment = self.create_environment(self.project, name="prod")
         self.release = self.create_release(self.project, version="first-release")
-        self.now = before_now().replace(tzinfo=timezone.utc)
-        self.one_min_ago = before_now(minutes=1).replace(tzinfo=timezone.utc)
-        self.two_min_ago = before_now(minutes=2).replace(tzinfo=timezone.utc)
+        self.now = before_now()
+        self.one_min_ago = before_now(minutes=1)
+        self.two_min_ago = before_now(minutes=2)
 
         self.event_time = self.one_min_ago
         self.event = self.store_event(
@@ -54,7 +54,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         self.params = {
             "organization_id": self.organization.id,
             "project_id": [self.project.id],
-            "start": before_now(days=1).replace(tzinfo=timezone.utc),
+            "start": before_now(days=1),
             "end": self.now,
         }
 
@@ -386,9 +386,9 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         assert [item["timestamp.to_day"] for item in data] == [f"{iso_format(day)}+00:00"]
 
     def test_timestamp_rounding_filters(self):
-        one_day_ago = before_now(days=1).replace(tzinfo=timezone.utc)
-        two_day_ago = before_now(days=2).replace(tzinfo=timezone.utc)
-        three_day_ago = before_now(days=3).replace(tzinfo=timezone.utc)
+        one_day_ago = before_now(days=1)
+        two_day_ago = before_now(days=2)
+        three_day_ago = before_now(days=3)
         self.params["start"] = three_day_ago
 
         self.store_event(
@@ -3145,7 +3145,7 @@ class ArithmeticTest(SnubaTestCase, TestCase):
         super().setUp()
 
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
-        self.now = before_now().replace(tzinfo=timezone.utc)
+        self.now = before_now()
         event_data = load_data("transaction")
         # Half of duration so we don't get weird rounding differences when comparing the results
         event_data["breakdowns"]["span_ops"]["ops.http"]["value"] = 1500

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2372,7 +2372,7 @@ class PostProcessGroupPerformanceTest(
         run_post_process_job_mock,
         generic_metrics_backend_mock,
     ):
-        min_ago = before_now(minutes=1).replace(tzinfo=timezone.utc)
+        min_ago = before_now(minutes=1)
         event = self.store_transaction(
             project_id=self.project.id,
             user_id=self.create_user(name="user1").name,
@@ -2508,7 +2508,7 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
         self,
         mock_store_transaction_name,
     ):
-        min_ago = before_now(minutes=1).replace(tzinfo=timezone.utc)
+        min_ago = before_now(minutes=1)
         event = process_event(
             data={
                 "project": self.project.id,

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -1,6 +1,6 @@
 import math
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
 from uuid import uuid4
@@ -4126,7 +4126,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
     @mock.patch("sentry.utils.snuba.quantize_time")
     def test_quantize_dates(self, mock_quantize):
         self.create_project()
-        mock_quantize.return_value = before_now(days=1).replace(tzinfo=timezone.utc)
+        mock_quantize.return_value = before_now(days=1)
 
         # Don't quantize short time periods
         query = {"statsPeriod": "1h", "query": "", "field": ["id", "timestamp"]}
@@ -5898,7 +5898,7 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            before_now(hours=1).replace(tzinfo=timezone.utc),
+            before_now(hours=1),
             user=user_data,
         )
         event, _, group_info = self.store_search_issue(
@@ -5906,7 +5906,7 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group2"],
             "prod",
-            before_now(hours=1).replace(tzinfo=timezone.utc),
+            before_now(hours=1),
             user=user_data,
         )
         assert group_info is not None
@@ -5980,7 +5980,7 @@ class OrganizationEventsIssuePlatformDatasetEndpointTest(
             1,
             ["group1-fingerprint"],
             None,
-            before_now(hours=1).replace(tzinfo=timezone.utc),
+            before_now(hours=1),
             user=user_data,
         )
         assert group_info is not None

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, timezone
+from datetime import timedelta
 from unittest import mock
 from uuid import uuid4
 
@@ -602,7 +602,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
 
     @mock.patch("sentry.utils.snuba.quantize_time")
     def test_quantize_dates(self, mock_quantize):
-        mock_quantize.return_value = before_now(days=1).replace(tzinfo=timezone.utc)
+        mock_quantize.return_value = before_now(days=1)
         with self.feature("organizations:discover-basic"):
             # Don't quantize short time periods
             self.client.get(

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -1,4 +1,3 @@
-from datetime import timezone
 from unittest import mock
 
 import pytest
@@ -128,7 +127,7 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase, SearchIssueTest
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            before_now(hours=1).replace(tzinfo=timezone.utc),
+            before_now(hours=1),
         )
         assert group_info is not None
         url = reverse(
@@ -214,7 +213,7 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase, SearchIssueTest
 
     @mock.patch("sentry.utils.snuba.quantize_time")
     def test_quantize_dates(self, mock_quantize):
-        mock_quantize.return_value = before_now(days=1).replace(tzinfo=timezone.utc)
+        mock_quantize.return_value = before_now(days=1)
         with self.feature(self.features):
             # Don't quantize short time periods
             self.client.get(

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -867,7 +867,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
 
     @mock.patch("sentry.utils.snuba.quantize_time")
     def test_quantize_dates(self, mock_quantize):
-        mock_quantize.return_value = before_now(days=1).replace(tzinfo=timezone.utc)
+        mock_quantize.return_value = before_now(days=1)
         # Don't quantize short time periods
         self.do_request(
             data={"statsPeriod": "1h", "query": "", "interval": "30m", "yAxis": "count()"},

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, timezone
+from datetime import timedelta
 from unittest import mock
 
 from django.utils import timezone as django_timezone
@@ -439,7 +439,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
 
     def test_get_start_from_seen_stats(self):
         for days, expected in [(None, 30), (0, 14), (1000, 90)]:
-            last_seen = None if days is None else before_now(days=days).replace(tzinfo=timezone.utc)
+            last_seen = None if days is None else before_now(days=days)
             start = GroupSerializerSnuba._get_start_from_seen_stats(
                 {
                     mock.sentinel.group: {
@@ -460,22 +460,22 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
                 SearchFilter(
                     SearchKey("timestamp"),
                     ">",
-                    SearchValue(before_now(hours=1).replace(tzinfo=timezone.utc)),
+                    SearchValue(before_now(hours=1)),
                 ),
                 SearchFilter(
                     SearchKey("timestamp"),
                     "<",
-                    SearchValue(before_now(seconds=1).replace(tzinfo=timezone.utc)),
+                    SearchValue(before_now(seconds=1)),
                 ),
                 SearchFilter(
                     SearchKey("date"),
                     ">",
-                    SearchValue(before_now(hours=1).replace(tzinfo=timezone.utc)),
+                    SearchValue(before_now(hours=1)),
                 ),
                 SearchFilter(
                     SearchKey("date"),
                     "<",
-                    SearchValue(before_now(seconds=1).replace(tzinfo=timezone.utc)),
+                    SearchValue(before_now(seconds=1)),
                 ),
             ]
         )

--- a/tests/snuba/api/serializers/test_group_stream.py
+++ b/tests/snuba/api/serializers/test_group_stream.py
@@ -1,5 +1,5 @@
 import time
-from datetime import timedelta, timezone
+from datetime import timedelta
 from unittest import mock
 
 from django.utils import timezone as django_timezone
@@ -261,22 +261,22 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
                 SearchFilter(
                     SearchKey("timestamp"),
                     ">",
-                    SearchValue(before_now(hours=1).replace(tzinfo=timezone.utc)),
+                    SearchValue(before_now(hours=1)),
                 ),
                 SearchFilter(
                     SearchKey("timestamp"),
                     "<",
-                    SearchValue(before_now(seconds=1).replace(tzinfo=timezone.utc)),
+                    SearchValue(before_now(seconds=1)),
                 ),
                 SearchFilter(
                     SearchKey("date"),
                     ">",
-                    SearchValue(before_now(hours=1).replace(tzinfo=timezone.utc)),
+                    SearchValue(before_now(hours=1)),
                 ),
                 SearchFilter(
                     SearchKey("date"),
                     "<",
-                    SearchValue(before_now(seconds=1).replace(tzinfo=timezone.utc)),
+                    SearchValue(before_now(seconds=1)),
                 ),
             ]
         )

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -175,7 +175,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
     @with_feature("projects:similarity-indexing")
     @mock.patch("sentry.analytics.record")
     def test_unmerge(self, mock_record):
-        now = before_now(minutes=5).replace(microsecond=0, tzinfo=timezone.utc)
+        now = before_now(minutes=5).replace(microsecond=0)
 
         def time_from_now(offset=0):
             return now + timedelta(seconds=offset)


### PR DESCRIPTION
so no need for re-attaching utc

since #65800

<!-- Describe your PR here. -->