### PR TITLE
chore(staff): Let staff access relocation details

### DIFF
--- a/src/sentry/api/endpoints/relocations/details.py
+++ b/src/sentry/api/endpoints/relocations/details.py
@@ -7,7 +7,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import SuperuserPermission
+from sentry.api.permissions import SuperuserOrStaffFeatureFlaggedPermission
 from sentry.api.serializers import serialize
 from sentry.models.relocation import Relocation
 
@@ -22,7 +22,7 @@ class RelocationDetailsEndpoint(Endpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     # TODO(getsentry/team-ospo#214): Open up permissions before GA.
-    permission_classes = (SuperuserPermission,)
+    permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def get(self, request: Request, relocation_uuid: str) -> Response:
         """

--- a/tests/sentry/api/endpoints/relocations/test_details.py
+++ b/tests/sentry/api/endpoints/relocations/test_details.py
@@ -37,30 +37,30 @@ class GetRelocationDetailsTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    def test_superuser_good_found(self):
+    def test_good_superuser_found(self):
         self.login_as(user=self.superuser, superuser=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)
         assert response.data["uuid"] == str(self.relocation.uuid)
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_staff_good_found_with_flag(self):
+    def test_good_staff_found_with_flag(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)
         assert response.data["uuid"] == str(self.relocation.uuid)
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_superuser_fails_with_flag(self):
+    def test_bad_superuser_fails_with_flag(self):
         self.login_as(user=self.superuser, superuser=True)
         response = self.get_error_response(self.relocation.uuid, status_code=403)
         assert response.data["detail"]["message"] == StaffRequired.message
 
-    def test_superuser_bad_not_found(self):
+    def test_bad_superuser_not_found(self):
         self.login_as(user=self.superuser, superuser=True)
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_staff_bad_not_found(self):
+    def test_bad_staff_not_found(self):
         self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)

--- a/tests/sentry/api/endpoints/relocations/test_details.py
+++ b/tests/sentry/api/endpoints/relocations/test_details.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from sentry.api.exceptions import StaffRequired
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.relocation import OrderedTask
 
@@ -19,9 +21,8 @@ class GetRelocationDetailsTest(APITestCase):
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(
-            "superuser", is_superuser=True, is_staff=True, is_active=True
-        )
+        self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
             creator_id=self.superuser.id,
@@ -36,23 +37,29 @@ class GetRelocationDetailsTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    def test_good_found(self):
+    def test_superuser_good_found(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.get(f"/api/0/relocations/{str(self.relocation.uuid)}/")
-
-        assert response.status_code == 200
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
         assert response.data["uuid"] == str(self.relocation.uuid)
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff_good_found_with_flag(self):
+        self.login_as(user=self.staff_user, staff=True)
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
+        assert response.data["uuid"] == str(self.relocation.uuid)
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_superuser_bad_not_found_with_flag(self):
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.get_error_response(self.relocation.uuid, status_code=403)
+        assert response.data["detail"]["message"] == StaffRequired.message
 
     def test_bad_not_found(self):
         self.login_as(user=self.superuser, superuser=True)
         does_not_exist_uuid = uuid4().hex
-        response = self.client.get(f"/api/0/relocations/{str(does_not_exist_uuid)}/")
-
-        assert response.status_code == 404
+        self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
     # TODO(getsentry/team-ospo#214): Add test for non-superusers to view their own relocations, but
     # not other owners'.
     def test_bad_no_auth(self):
-        response = self.client.get(f"/api/0/relocations/{str(self.relocation.uuid)}/")
-
-        assert response.status_code == 401
+        self.get_error_response(self.relocation.uuid, status_code=401)

--- a/tests/sentry/api/endpoints/relocations/test_details.py
+++ b/tests/sentry/api/endpoints/relocations/test_details.py
@@ -49,13 +49,19 @@ class GetRelocationDetailsTest(APITestCase):
         assert response.data["uuid"] == str(self.relocation.uuid)
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_superuser_bad_not_found_with_flag(self):
+    def test_superuser_fails_with_flag(self):
         self.login_as(user=self.superuser, superuser=True)
         response = self.get_error_response(self.relocation.uuid, status_code=403)
         assert response.data["detail"]["message"] == StaffRequired.message
 
-    def test_bad_not_found(self):
+    def test_superuser_bad_not_found(self):
         self.login_as(user=self.superuser, superuser=True)
+        does_not_exist_uuid = uuid4().hex
+        self.get_error_response(str(does_not_exist_uuid), status_code=404)
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff_bad_not_found(self):
+        self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)
 


### PR DESCRIPTION
Use `SuperuserOrStaffFeatureFlaggedPermission`, which only checks for active staff when the flag is enabled and o/w defaults to checking for active superuser.

This endpoint is only used in _admin, so we want to eventually prevent superusers from accessing it by switching the permission class to `StaffPermisison`.