### PR TITLE
feat(feedback): add crash report banner to dotnet platforms

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/feedback/altCrashReportCallout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/feedback/altCrashReportCallout.tsx
@@ -1,0 +1,18 @@
+import Alert from 'sentry/components/alert';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {tct} from 'sentry/locale';
+
+export default function altCrashReportCallout() {
+  return (
+    <Alert type="info" showIcon>
+      {tct(
+        `Want to add an embeddable, JavaScript-based, crash-report modal to your website instead? [link:Read the docs] to learn how.`,
+        {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/platforms/dotnet/user-feedback/#crash-report-modal" />
+          ),
+        }
+      )}
+    </Alert>
+  );
+}

--- a/static/app/gettingStartedDocs/dotnet/dotnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet.tsx
@@ -3,6 +3,7 @@ import {Fragment} from 'react';
 import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
+import altCrashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/altCrashReportCallout';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {
   Docs,
@@ -235,6 +236,7 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
           ],
         },
       ],
+      additionalInfo: altCrashReportCallout(),
     },
   ],
   configure: () => [],

--- a/static/app/gettingStartedDocs/unity/unity.tsx
+++ b/static/app/gettingStartedDocs/unity/unity.tsx
@@ -135,9 +135,7 @@ export const feedbackOnboarding: OnboardingConfig = {
               label: 'C#',
               value: 'csharp',
               language: 'csharp',
-              code: `using Sentry;
-
-var eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.");
+              code: `var eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.");
 
 SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User");`,
             },
@@ -145,9 +143,7 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
               label: 'F#',
               value: 'fsharp',
               language: 'fsharp',
-              code: `open Sentry
-
-let eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.")
+              code: `let eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.")
 
 SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User")`,
             },

--- a/static/app/gettingStartedDocs/unity/unity.tsx
+++ b/static/app/gettingStartedDocs/unity/unity.tsx
@@ -8,7 +8,10 @@ import type {
   Docs,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
+import {
+  getCrashReportApiIntroduction,
+  getCrashReportInstallDescription,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -119,9 +122,48 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+export const feedbackOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportApiIntroduction(),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: getCrashReportInstallDescription(),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'C#',
+              value: 'csharp',
+              language: 'csharp',
+              code: `using Sentry;
+
+var eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.");
+
+SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User");`,
+            },
+            {
+              label: 'F#',
+              value: 'fsharp',
+              language: 'fsharp',
+              code: `open Sentry
+
+let eventId = SentrySdk.CaptureMessage("An event that will receive user feedback.")
+
+SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The User")`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: () => [],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
-  feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
+  feedbackOnboardingCrashApi: feedbackOnboarding,
 };
 
 export default docs;


### PR DESCRIPTION
Add a callout for dotnet platforms, where it's possible to have both crash report modal & use the crash report API:

<img width="457" alt="SCR-20240229-mcrv" src="https://github.com/getsentry/sentry/assets/56095982/964f2ad3-7d0c-4638-908a-a0dd3f7db784">

Previously, Unity was reusing the Dotnet onboarding. However, Unity doesn't allow the modal, so I made a separate onboarding config for that instead of reusing the dotnet one