### PR TITLE
fix(feedback): Pass the project list when editing feedbacks

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -37,6 +37,7 @@ export default function FeedbackActions({
   const {markAsRead, resolve} = useMutateFeedback({
     feedbackIds: [feedbackItem.id],
     organization,
+    projectIds: [feedbackItem.project.id],
   });
 
   const mutationOptions = {

--- a/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
@@ -43,6 +43,7 @@ export default function FeedbackAssignedTo({feedbackIssue, feedbackEvent}: Props
   const {assign} = useMutateFeedback({
     feedbackIds: [feedbackIssue.id],
     organization,
+    projectIds: [feedbackIssue.project.id],
   });
 
   const owners = getOwnerList([], eventOwners ?? null, feedbackIssue.assignedTo);

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -11,6 +11,8 @@ import useMutateFeedback from 'sentry/components/feedback/useMutateFeedback';
 import {t, tct} from 'sentry/locale';
 import {GroupStatus} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {decodeList} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const statusToButtonLabel: Record<string, string> = {
@@ -33,9 +35,15 @@ interface Props
 
 export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) {
   const organization = useOrganization();
+  const queryView = useLocationQuery({
+    fields: {
+      project: decodeList,
+    },
+  });
   const {markAsRead, resolve} = useMutateFeedback({
     feedbackIds: selectedIds,
     organization,
+    projectIds: queryView.project,
   });
 
   const onToggleResovled = useCallback(

--- a/static/app/components/feedback/useFetchFeedbackData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackData.tsx
@@ -37,6 +37,7 @@ export default function useFetchFeedbackData({feedbackId}: Props) {
   const {markAsRead} = useMutateFeedback({
     feedbackIds: [feedbackId],
     organization,
+    projectIds: issueData ? [issueData?.project.id] : [],
   });
 
   // TODO: it would be excellent if `PUT /issues/` could return the same data

--- a/static/app/components/feedback/useMutateFeedback.tsx
+++ b/static/app/components/feedback/useMutateFeedback.tsx
@@ -17,9 +17,14 @@ type TContext = unknown;
 interface Props {
   feedbackIds: TFeedbackIds;
   organization: Organization;
+  projectIds: string[];
 }
 
-export default function useMutateFeedback({feedbackIds, organization}: Props) {
+export default function useMutateFeedback({
+  feedbackIds,
+  organization,
+  projectIds,
+}: Props) {
   const api = useApi({
     persistInFlight: false,
   });
@@ -43,7 +48,7 @@ export default function useMutateFeedback({feedbackIds, organization}: Props) {
         ? {}
         : ids === 'all'
           ? listQueryKey[1]!
-          : {query: {id: ids}};
+          : {query: {id: ids, project: projectIds}};
       return fetchMutation(api)(['PUT', url, options, payload]);
     },
     onSettled: (_resp, _error, [ids, _payload]) => {


### PR DESCRIPTION
Pass the project list when editing feedbacks, so multi-project rules can be properly applied (or skipped)

Before when we were bulk editing the `project: string[]` query param was not being passed along to the server. So the server uses the 'all projects' value as a default. When 'all projects' is selected (or assumed to be) then we need to check the `organizations:global-views` flag, which returns false for free-tier orgs. 

The problem is that free-tier orgs can only view/bulk-select feedbacks from the same project anyway. So we need to tell the server which project is selected, which will prevent it from setting 'all projects' as the default.

I made the `projectIds` a required field because all the other callsites operate on one feedback at a time, and they have the projectId readily available anyway. So it's easier to keep getting this right going forward.

Examples of the corrected request and successful response:
![SCR-20240229-mhcs](https://github.com/getsentry/sentry/assets/187460/1fec5706-2615-4279-a771-a1cd45c424b0)
![SCR-20240229-mhdd](https://github.com/getsentry/sentry/assets/187460/4f9b9267-9550-446b-af1f-87e4afa92390)


Fixes https://github.com/getsentry/sentry/issues/65945