### PR TITLE
chore(staff): Let staff access relocation abort

### DIFF
--- a/src/sentry/api/endpoints/relocations/abort.py
+++ b/src/sentry/api/endpoints/relocations/abort.py
@@ -7,7 +7,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import SuperuserPermission
+from sentry.api.permissions import SuperuserOrStaffFeatureFlaggedPermission
 from sentry.api.serializers import serialize
 from sentry.models.relocation import Relocation
 
@@ -25,7 +25,7 @@ class RelocationAbortEndpoint(Endpoint):
         # TODO(getsentry/team-ospo#214): Stabilize before GA.
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
-    permission_classes = (SuperuserPermission,)
+    permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def put(self, request: Request, relocation_uuid: str) -> Response:
         """

--- a/tests/sentry/api/endpoints/relocations/test_abort.py
+++ b/tests/sentry/api/endpoints/relocations/test_abort.py
@@ -2,8 +2,10 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 from sentry.api.endpoints.relocations.abort import ERR_NOT_ABORTABLE_STATUS
+from sentry.api.exceptions import StaffRequired
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.relocation import OrderedTask
 
@@ -13,15 +15,15 @@ TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 @region_silo_test
 class AbortRelocationTest(APITestCase):
     endpoint = "sentry-api-0-relocations-abort"
+    method = "put"
 
     def setUp(self):
         super().setUp()
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(
-            "superuser", is_superuser=True, is_staff=True, is_active=True
-        )
+        self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
             creator_id=self.superuser.id,
@@ -35,58 +37,103 @@ class AbortRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    def test_good_abort_in_progress(self):
-        self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/abort/")
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff_good_abort_in_progress(self):
+        self.login_as(user=self.staff_user, staff=True)
+        self.relocation.status = Relocation.Status.PAUSE.value
+        self.relocation.save()
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
-    def test_good_abort_paused(self):
+    def test_superuser_good_abort_in_progress(self):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/abort/")
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
-    def test_bad_already_succeeded(self):
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff_good_abort_paused(self):
+        self.login_as(user=self.staff_user, staff=True)
+        self.relocation.status = Relocation.Status.PAUSE.value
+        self.relocation.save()
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
+
+        assert response.data["status"] == Relocation.Status.FAILURE.name
+        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
+
+    def test_superuser_good_abort_paused(self):
+        self.login_as(user=self.superuser, superuser=True)
+        self.relocation.status = Relocation.Status.PAUSE.value
+        self.relocation.save()
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
+
+        assert response.data["status"] == Relocation.Status.FAILURE.name
+        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff_bad_already_succeeded(self):
+        self.login_as(user=self.staff_user, staff=True)
+        self.relocation.status = Relocation.Status.SUCCESS.value
+        self.relocation.save()
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
+
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
+
+    def test_superuser_bad_already_succeeded(self):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.SUCCESS.value
         self.relocation.save()
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/abort/")
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
-    def test_bad_already_failed(self):
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff_bad_already_failed(self):
+        self.login_as(user=self.staff_user, staff=True)
+        self.relocation.status = Relocation.Status.FAILURE.value
+        self.relocation.save()
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
+
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
+
+    def test_superuser_bad_already_failed(self):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/abort/")
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
-    def test_bad_not_found(self):
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff_bad_not_found(self):
+        self.login_as(user=self.staff_user, staff=True)
+        does_not_exist_uuid = uuid4().hex
+        self.get_error_response(str(does_not_exist_uuid), status_code=404)
+
+    def test_superuser_bad_not_found(self):
         self.login_as(user=self.superuser, superuser=True)
         does_not_exist_uuid = uuid4().hex
-        response = self.client.put(f"/api/0/relocations/{str(does_not_exist_uuid)}/abort/")
+        self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
-        assert response.status_code == 404
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_superuser_fails_with_flag(self):
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.get_error_response(self.relocation.uuid, status_code=403)
+
+        assert response.data["detail"]["message"] == StaffRequired.message
 
     def test_bad_no_auth(self):
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/abort/")
-
-        assert response.status_code == 401
+        self.get_error_response(self.relocation.uuid, status_code=401)
 
     def test_bad_no_superuser(self):
         self.login_as(user=self.superuser, superuser=False)
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/abort/")
-
-        assert response.status_code == 403
+        self.get_error_response(self.relocation.uuid, status_code=403)

--- a/tests/sentry/api/endpoints/relocations/test_abort.py
+++ b/tests/sentry/api/endpoints/relocations/test_abort.py
@@ -38,7 +38,7 @@ class AbortRelocationTest(APITestCase):
         )
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_staff_good_abort_in_progress(self):
+    def test_good_staff_abort_in_progress(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
@@ -47,7 +47,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
-    def test_superuser_good_abort_in_progress(self):
+    def test_good_superuser_abort_in_progress(self):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
@@ -57,7 +57,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_staff_good_abort_paused(self):
+    def test_good_staff_abort_paused(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
@@ -66,7 +66,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
-    def test_superuser_good_abort_paused(self):
+    def test_good_superuser_abort_paused(self):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
@@ -76,7 +76,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_staff_bad_already_succeeded(self):
+    def test_bad_staff_already_succeeded(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.SUCCESS.value
         self.relocation.save()
@@ -85,7 +85,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
-    def test_superuser_bad_already_succeeded(self):
+    def test_bad_superuser_already_succeeded(self):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.SUCCESS.value
         self.relocation.save()
@@ -95,7 +95,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_staff_bad_already_failed(self):
+    def test_bad_staff_already_failed(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
@@ -104,7 +104,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
-    def test_superuser_bad_already_failed(self):
+    def test_bad_superuser_already_failed(self):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
@@ -114,12 +114,12 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_staff_bad_not_found(self):
+    def test_bad_staff_not_found(self):
         self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
-    def test_superuser_bad_not_found(self):
+    def test_bad_superuser_not_found(self):
         self.login_as(user=self.superuser, superuser=True)
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)


### PR DESCRIPTION
Use `SuperuserOrStaffFeatureFlaggedPermission`, which only checks for active staff when the flag is enabled and o/w defaults to checking for active superuser.

This endpoint is only used in _admin, so we want to eventually prevent superusers from accessing it by switching the permission class to `StaffPermisison`.