### PR TITLE
fix: Filter null user IDs from RuleActivity objects before querying

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -89,7 +89,10 @@ class RuleSerializer(Serializer):
         )
 
         users = {
-            u.id: u for u in user_service.get_many(filter=dict(user_ids=[ra.user_id for ra in ras]))
+            u.id: u
+            for u in user_service.get_many(
+                filter=dict(user_ids=[ra.user_id for ra in ras if ra.user_id is not None])
+            )
         }
 
         for rule_activity in ras:


### PR DESCRIPTION
Should fix [SENTRY-2K63](https://sentry.sentry.io/issues/4949407924/).