### PR TITLE
feat(github-comments): Don't comment info-level issues on merged PRs

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -21,6 +21,7 @@ from sentry.integrations.utils.commit_context import (
 from sentry.locks import locks
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
+from sentry.models.group import Group
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.project import Project
@@ -280,8 +281,10 @@ def process_commit_context(
                     extra={"organization_id": project.organization_id},
                 )
                 repo = Repository.objects.filter(id=commit.repository_id)
+                group = Group.objects.get_from_cache(id=group_id)
                 if (
-                    installation is not None
+                    group.level is not logging.INFO  # Don't comment on info level issues
+                    and installation is not None
                     and repo.exists()
                     and repo.get().provider == "integrations:github"
                 ):

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -113,6 +113,7 @@ def get_top_5_issues_by_count(issue_list: list[int], project: Project) -> list[d
                     Condition(Column("group_id"), Op.IN, issue_list),
                     Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=30)),
                     Condition(Column("timestamp"), Op.LT, datetime.now()),
+                    Condition(Column("level"), Op.NEQ, "info"),
                 ]
             )
             .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
@@ -266,6 +267,39 @@ class TestTop5IssuesByCount(TestCase, SnubaTestCase):
         ]
         res = get_top_5_issues_by_count(issue_ids, self.project)
         assert len(res) == 5
+
+    def test_ignore_info_level_issues(self):
+        group1 = [
+            self.store_event(
+                {
+                    "fingerprint": ["group-1"],
+                    "timestamp": iso_format(before_now(days=1)),
+                    "level": logging.INFO,
+                },
+                project_id=self.project.id,
+            )
+            for _ in range(3)
+        ][0].group.id
+        group2 = [
+            self.store_event(
+                {"fingerprint": ["group-2"], "timestamp": iso_format(before_now(days=1))},
+                project_id=self.project.id,
+            )
+            for _ in range(6)
+        ][0].group.id
+        group3 = [
+            self.store_event(
+                {
+                    "fingerprint": ["group-3"],
+                    "timestamp": iso_format(before_now(days=1)),
+                    "level": logging.INFO,
+                },
+                project_id=self.project.id,
+            )
+            for _ in range(4)
+        ][0].group.id
+        res = get_top_5_issues_by_count([group1, group2, group3], self.project)
+        assert [issue["group_id"] for issue in res] == [group2]
 
 
 @region_silo_test

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -301,6 +301,43 @@ class TestTop5IssuesByCount(TestCase, SnubaTestCase):
         res = get_top_5_issues_by_count([group1, group2, group3], self.project)
         assert [issue["group_id"] for issue in res] == [group2]
 
+    def test_do_not_ignore_other_issues(self):
+        group1 = [
+            self.store_event(
+                {
+                    "fingerprint": ["group-1"],
+                    "timestamp": iso_format(before_now(days=1)),
+                    "level": logging.ERROR,
+                },
+                project_id=self.project.id,
+            )
+            for _ in range(3)
+        ][0].group.id
+        group2 = [
+            self.store_event(
+                {
+                    "fingerprint": ["group-2"],
+                    "timestamp": iso_format(before_now(days=1)),
+                    "level": logging.INFO,
+                },
+                project_id=self.project.id,
+            )
+            for _ in range(6)
+        ][0].group.id
+        group3 = [
+            self.store_event(
+                {
+                    "fingerprint": ["group-3"],
+                    "timestamp": iso_format(before_now(days=1)),
+                    "level": logging.DEBUG,
+                },
+                project_id=self.project.id,
+            )
+            for _ in range(4)
+        ][0].group.id
+        res = get_top_5_issues_by_count([group1, group2, group3], self.project)
+        assert [issue["group_id"] for issue in res] == [group3, group1]
+
 
 @region_silo_test
 class TestCommentBuilderQueries(GithubCommentTestCase):

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -12,7 +12,6 @@ from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
-from sentry.models.group import Group
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import (
@@ -1009,9 +1008,7 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
         self.pull_request.save()
 
         self.add_responses()
-
-        group = Group.objects.get_from_cache(id=self.event.group_id)
-        Group.update(group, level=logging.INFO)
+        self.event.group.update(level=logging.INFO)
 
         with self.tasks():
             event_frames = get_frame_paths(self.event)
@@ -1024,9 +1021,6 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             )
             assert not mock_comment_workflow.called
             assert len(PullRequestCommit.objects.all()) == 0
-
-        # Reset group level
-        Group.update(group, level=logging.ERROR)
 
     @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate


### PR DESCRIPTION
* Added additional filter to prevent comments  for info level issues on merged issues.
* Prevented the trigger of the comment workflow
* Added additional expression in the WHERE clause of snuba query
* Wrote tests for both changes

Fixes: https://github.com/getsentry/team-core-product-foundations/issues/126