### PR TITLE
fix: Filter null user IDs before querying in get_owners

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -262,7 +262,9 @@ class RpcOrganization(RpcOrganizationSummary):
             owners = OrganizationMember.objects.filter(
                 organization_id=self.id, role__in=[roles.get_top_dog().id]
             ).values_list("user_id", flat=True)
-        return user_service.get_many(filter={"user_ids": list(owners)})
+        return user_service.get_many(
+            filter={"user_ids": [owner_id for owner_id in owners if owner_id is not None]}
+        )
 
     @property
     def default_owner_id(self):


### PR DESCRIPTION
Should fix [SENTRY-2QJZ](https://sentry.sentry.io/issues/5004584948/)