### PR TITLE
chore(hybridcloud) Remove unused parameter from sent_incident_alert_notification

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -32,7 +32,6 @@ from sentry.services.hybrid_cloud.integration.serial import (
     serialize_integration_external_project,
     serialize_organization_integration,
 )
-from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.pagination import RpcPaginationArgs, RpcPaginationResult
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import json, metrics
@@ -357,15 +356,10 @@ class DatabaseBackedIntegrationService(IntegrationService):
         incident_id: int,
         new_status: int,
         incident_attachment_json: str,
-        organization: RpcOrganizationSummary | None = None,  # deprecated
-        organization_id: int | None = None,
+        organization_id: int,
         metric_value: str | None = None,
         notification_uuid: str | None = None,
     ) -> bool:
-        if organization_id is None and organization is not None:
-            organization_id = organization.id
-        assert organization_id is not None, "organization or organization_id is required"
-
         sentry_app = SentryApp.objects.get(id=sentry_app_id)
 
         metrics.incr("notifications.sent", instance=sentry_app.slug, skip_internal=False)

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -12,7 +12,6 @@ from sentry.services.hybrid_cloud.integration.model import (
     RpcIntegrationExternalProject,
     RpcIntegrationIdentityContext,
 )
-from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.pagination import RpcPaginationArgs, RpcPaginationResult
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.silo import SiloMode
@@ -238,8 +237,7 @@ class IntegrationService(RpcService):
         incident_id: int,
         new_status: int,
         incident_attachment_json: str,
-        organization: RpcOrganizationSummary | None = None,
-        organization_id: int | None = None,
+        organization_id: int,
         metric_value: str | None = None,
         notification_uuid: str | None = None,
     ) -> bool:


### PR DESCRIPTION
Complete work started in #65736, #65791, and #65883 to remove a parameter from the send_incident_alert_notification RPC method.

Fixes HC-1123
Fixes SENTRY-2QAG