### PR TITLE
chore(staff): Let staff access relocation cancel

### DIFF
--- a/src/sentry/api/endpoints/relocations/cancel.py
+++ b/src/sentry/api/endpoints/relocations/cancel.py
@@ -11,7 +11,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.relocations import ERR_UNKNOWN_RELOCATION_STEP
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import SuperuserPermission
+from sentry.api.permissions import SuperuserOrStaffFeatureFlaggedPermission
 from sentry.api.serializers import serialize
 from sentry.models.relocation import Relocation
 
@@ -36,7 +36,7 @@ class RelocationCancelEndpoint(Endpoint):
         # TODO(getsentry/team-ospo#214): Stabilize before GA.
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
-    permission_classes = (SuperuserPermission,)
+    permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def put(self, request: Request, relocation_uuid: str) -> Response:
         """

--- a/tests/sentry/api/endpoints/relocations/test_cancel.py
+++ b/tests/sentry/api/endpoints/relocations/test_cancel.py
@@ -41,7 +41,7 @@ class CancelRelocationTest(APITestCase):
         )
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_staff_good_cancel_in_progress_at_next_step(self):
+    def test_good_staff_cancel_in_progress_at_next_step(self):
         staff_user = self.create_user(is_staff=True)
         self.login_as(user=staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)

--- a/tests/sentry/api/endpoints/relocations/test_cancel.py
+++ b/tests/sentry/api/endpoints/relocations/test_cancel.py
@@ -9,6 +9,7 @@ from sentry.api.endpoints.relocations.cancel import (
 )
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.relocation import OrderedTask
 
@@ -18,15 +19,14 @@ TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 @region_silo_test
 class CancelRelocationTest(APITestCase):
     endpoint = "sentry-api-0-relocations-cancel"
+    method = "put"
 
     def setUp(self):
         super().setUp()
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(
-            "superuser", is_superuser=True, is_staff=True, is_active=True
-        )
+        self.superuser = self.create_user(is_superuser=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
             creator_id=self.superuser.id,
@@ -40,11 +40,20 @@ class CancelRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff_good_cancel_in_progress_at_next_step(self):
+        staff_user = self.create_user(is_staff=True)
+        self.login_as(user=staff_user, staff=True)
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
+
+        assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
+        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
+        assert response.data["scheduledCancelAtStep"] == Relocation.Step.VALIDATING.name
+
     def test_good_cancel_in_progress_at_next_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/")
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.VALIDATING.name
@@ -53,21 +62,18 @@ class CancelRelocationTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/")
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.PAUSE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.VALIDATING.name
 
     def test_good_cancel_in_progress_at_specified_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": Relocation.Step.IMPORTING.name},
+        response = self.get_success_response(
+            self.relocation.uuid, atStep=Relocation.Step.IMPORTING.name, status_code=200
         )
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.IMPORTING.name
@@ -76,24 +82,20 @@ class CancelRelocationTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": Relocation.Step.IMPORTING.name},
+        response = self.get_success_response(
+            self.relocation.uuid, atStep=Relocation.Step.IMPORTING.name, status_code=200
         )
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.PAUSE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.IMPORTING.name
 
     def test_good_cancel_at_future_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": Relocation.Step.NOTIFYING.name},
+        response = self.get_success_response(
+            self.relocation.uuid, atStep=Relocation.Step.NOTIFYING.name, status_code=200
         )
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.NOTIFYING.name
@@ -102,12 +104,10 @@ class CancelRelocationTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.scheduled_cancel_at_step = Relocation.Step.IMPORTING.value
         self.relocation.save()
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": Relocation.Step.IMPORTING.name},
+        response = self.get_success_response(
+            self.relocation.uuid, atStep=Relocation.Step.IMPORTING.name, status_code=200
         )
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledCancelAtStep"] == Relocation.Step.IMPORTING.name
@@ -116,12 +116,10 @@ class CancelRelocationTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": Relocation.Step.PREPROCESSING.name},
+        response = self.get_success_response(
+            self.relocation.uuid, atStep=Relocation.Step.PREPROCESSING.name, status_code=200
         )
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert not response.data["scheduledCancelAtStep"]
@@ -129,28 +127,23 @@ class CancelRelocationTest(APITestCase):
     def test_bad_not_found(self):
         self.login_as(user=self.superuser, superuser=True)
         does_not_exist_uuid = uuid4().hex
-        response = self.client.put(f"/api/0/relocations/{str(does_not_exist_uuid)}/cancel/")
-
-        assert response.status_code == 404
+        self.get_error_response(does_not_exist_uuid, status_code=404)
 
     def test_bad_already_succeeded(self):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.SUCCESS.value
         self.relocation.save()
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/")
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_CANCELLABLE_STATUS
 
     def test_bad_invalid_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": "nonexistent"},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep="nonexistent", status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_UNKNOWN_RELOCATION_STEP.substitute(
             step="nonexistent"
@@ -158,12 +151,10 @@ class CancelRelocationTest(APITestCase):
 
     def test_bad_unknown_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": Relocation.Step.UNKNOWN.name},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep=Relocation.Step.UNKNOWN.name, status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_CANCEL_RELOCATION_AT_STEP.substitute(
             step=Relocation.Step.UNKNOWN.name
@@ -171,23 +162,19 @@ class CancelRelocationTest(APITestCase):
 
     def test_bad_current_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": Relocation.Step.PREPROCESSING.name},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep=Relocation.Step.PREPROCESSING.name, status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_CANCEL_RELOCATION
 
     def test_bad_past_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": Relocation.Step.UPLOADING.name},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep=Relocation.Step.UPLOADING.name, status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_CANCEL_RELOCATION_AT_STEP.substitute(
             step=Relocation.Step.UPLOADING.name
@@ -195,12 +182,10 @@ class CancelRelocationTest(APITestCase):
 
     def test_bad_last_step_specified(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/",
-            {"atStep": Relocation.Step.COMPLETED.name},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep=Relocation.Step.COMPLETED.name, status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_CANCEL_RELOCATION_AT_STEP.substitute(
             step=Relocation.Step.COMPLETED.name
@@ -210,19 +195,14 @@ class CancelRelocationTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.step = Relocation.Step.NOTIFYING.value
         self.relocation.save()
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/")
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_CANCEL_RELOCATION
 
     def test_bad_no_auth(self):
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/")
-
-        assert response.status_code == 401
+        self.get_error_response(self.relocation.uuid, status_code=401)
 
     def test_bad_no_superuser(self):
         self.login_as(user=self.superuser, superuser=False)
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/cancel/")
-
-        assert response.status_code == 403
+        self.get_error_response(self.relocation.uuid, status_code=403)


### PR DESCRIPTION
Use `SuperuserOrStaffFeatureFlaggedPermission`, which only checks for active staff when the flag is enabled and o/w defaults to checking for active superuser.

This endpoint is only used in _admin, so we want to eventually prevent superusers from accessing it by switching the permission class to `StaffPermisison`.

I only included 1 simple staff test in code, but manually checked that all tests passed with active staff locally