### PR TITLE
chore(staff): Let staff access relocation pause

### DIFF
--- a/src/sentry/api/endpoints/relocations/pause.py
+++ b/src/sentry/api/endpoints/relocations/pause.py
@@ -14,7 +14,7 @@ from sentry.api.endpoints.relocations import (
     ERR_UNKNOWN_RELOCATION_STEP,
 )
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import SuperuserPermission
+from sentry.api.permissions import SuperuserOrStaffFeatureFlaggedPermission
 from sentry.api.serializers import serialize
 from sentry.models.relocation import Relocation
 
@@ -36,7 +36,7 @@ class RelocationPauseEndpoint(Endpoint):
         # TODO(getsentry/team-ospo#214): Stabilize before GA.
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
-    permission_classes = (SuperuserPermission,)
+    permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def put(self, request: Request, relocation_uuid: str) -> Response:
         """

--- a/tests/sentry/api/endpoints/relocations/test_pause.py
+++ b/tests/sentry/api/endpoints/relocations/test_pause.py
@@ -11,6 +11,7 @@ from sentry.api.endpoints.relocations.pause import (
 )
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.relocation import OrderedTask
 
@@ -20,15 +21,15 @@ TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
 @region_silo_test
 class PauseRelocationTest(APITestCase):
     endpoint = "sentry-api-0-relocations-pause"
+    method = "put"
 
     def setUp(self):
         super().setUp()
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(
-            "superuser", is_superuser=True, is_staff=True, is_active=True
-        )
+        self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
             creator_id=self.superuser.id,
@@ -42,35 +43,39 @@ class PauseRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_staff_good_pause_asap(self):
+        self.login_as(user=self.staff_user, staff=True)
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
+
+        assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
+        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
+        assert response.data["scheduledPauseAtStep"] == Relocation.Step.VALIDATING.name
+
     def test_good_pause_asap(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/pause/")
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledPauseAtStep"] == Relocation.Step.VALIDATING.name
 
     def test_good_pause_at_next_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/pause/",
-            {"atStep": Relocation.Step.VALIDATING.name},
+        response = self.get_success_response(
+            self.relocation.uuid, atStep=Relocation.Step.VALIDATING.name, status_code=200
         )
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledPauseAtStep"] == Relocation.Step.VALIDATING.name
 
     def test_good_pause_at_future_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/pause/",
-            {"atStep": Relocation.Step.NOTIFYING.name},
+        response = self.get_success_response(
+            self.relocation.uuid, atStep=Relocation.Step.NOTIFYING.name, status_code=200
         )
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledPauseAtStep"] == Relocation.Step.NOTIFYING.name
@@ -79,12 +84,10 @@ class PauseRelocationTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.PAUSE.value
         self.relocation.save()
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/pause/",
-            {"atStep": Relocation.Step.IMPORTING.name},
+        response = self.get_success_response(
+            self.relocation.uuid, atStep=Relocation.Step.IMPORTING.name, status_code=200
         )
 
-        assert response.status_code == 200
         assert response.data["status"] == Relocation.Status.PAUSE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
         assert response.data["scheduledPauseAtStep"] == Relocation.Step.IMPORTING.name
@@ -100,9 +103,8 @@ class PauseRelocationTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/pause/")
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_PAUSABLE_STATUS.substitute(
             status=Relocation.Status.FAILURE.name
@@ -110,12 +112,10 @@ class PauseRelocationTest(APITestCase):
 
     def test_bad_invalid_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/pause/",
-            {"atStep": "nonexistent"},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep="nonexistent", status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_UNKNOWN_RELOCATION_STEP.substitute(
             step="nonexistent"
@@ -123,12 +123,10 @@ class PauseRelocationTest(APITestCase):
 
     def test_bad_unknown_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/pause/",
-            {"atStep": Relocation.Step.UNKNOWN.name},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep=Relocation.Step.UNKNOWN.name, status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP.substitute(
             step=Relocation.Step.UNKNOWN.name
@@ -136,12 +134,10 @@ class PauseRelocationTest(APITestCase):
 
     def test_bad_current_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/pause/",
-            {"atStep": Relocation.Step.PREPROCESSING.name},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep=Relocation.Step.PREPROCESSING.name, status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP.substitute(
             step=Relocation.Step.PREPROCESSING.name
@@ -149,12 +145,10 @@ class PauseRelocationTest(APITestCase):
 
     def test_bad_past_step(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/pause/",
-            {"atStep": Relocation.Step.UPLOADING.name},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep=Relocation.Step.UPLOADING.name, status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP.substitute(
             step=Relocation.Step.UPLOADING.name
@@ -162,12 +156,10 @@ class PauseRelocationTest(APITestCase):
 
     def test_bad_last_step_specified(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.put(
-            f"/api/0/relocations/{str(self.relocation.uuid)}/pause/",
-            {"atStep": Relocation.Step.COMPLETED.name},
+        response = self.get_error_response(
+            self.relocation.uuid, atStep=Relocation.Step.COMPLETED.name, status_code=400
         )
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP.substitute(
             step=Relocation.Step.COMPLETED.name
@@ -177,19 +169,14 @@ class PauseRelocationTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         self.relocation.step = Relocation.Step.NOTIFYING.value
         self.relocation.save()
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/pause/")
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-        assert response.status_code == 400
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_COULD_NOT_PAUSE_RELOCATION
 
     def test_bad_no_auth(self):
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/pause/")
-
-        assert response.status_code == 401
+        self.get_error_response(self.relocation.uuid, status_code=401)
 
     def test_bad_no_superuser(self):
         self.login_as(user=self.superuser, superuser=False)
-        response = self.client.put(f"/api/0/relocations/{str(self.relocation.uuid)}/pause/")
-
-        assert response.status_code == 403
+        self.get_error_response(self.relocation.uuid, status_code=403)

--- a/tests/sentry/api/endpoints/relocations/test_pause.py
+++ b/tests/sentry/api/endpoints/relocations/test_pause.py
@@ -44,7 +44,7 @@ class PauseRelocationTest(APITestCase):
         )
 
     @with_feature("auth:enterprise-staff-cookie")
-    def test_staff_good_pause_asap(self):
+    def test_good_staff_pause_asap(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)
 


### PR DESCRIPTION
Use `SuperuserOrStaffFeatureFlaggedPermission`, which only checks for active staff when the flag is enabled and o/w defaults to checking for active superuser.

This endpoint is only used in _admin, so we want to eventually prevent superusers from accessing it by switching the permission class to `StaffPermisison`.

I only included 1 simple staff test in code, but manually checked that all tests passed with active staff locally