### PR TITLE
feat(feedback): add LazyServiceWrapper for spam detection

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2341,6 +2341,11 @@ SENTRY_RELEASE_MONITOR_OPTIONS: dict[str, Any] = {}
 SENTRY_CHART_RENDERER = "sentry.charts.chartcuterie.Chartcuterie"
 SENTRY_CHART_RENDERER_OPTIONS: dict[str, Any] = {}
 
+# User Feedback Spam Detection
+SENTRY_USER_FEEDBACK_SPAM = ""
+SENTRY_USER_FEEDBACK_SPAM_OPTIONS: dict[str, str] = {}
+
+
 # URI Prefixes for generating DSN URLs
 # (Defaults to URL_PREFIX by default)
 SENTRY_ENDPOINT: str | None = None

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2342,7 +2342,7 @@ SENTRY_CHART_RENDERER = "sentry.charts.chartcuterie.Chartcuterie"
 SENTRY_CHART_RENDERER_OPTIONS: dict[str, Any] = {}
 
 # User Feedback Spam Detection
-SENTRY_USER_FEEDBACK_SPAM = ""
+SENTRY_USER_FEEDBACK_SPAM = "sentry.feedback.spam.stub.StubFeedbackSpamDetection"
 SENTRY_USER_FEEDBACK_SPAM_OPTIONS: dict[str, str] = {}
 
 

--- a/src/sentry/feedback/spam/__init__.py
+++ b/src/sentry/feedback/spam/__init__.py
@@ -2,10 +2,10 @@ from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
 
-from .base import StubFeedbackSpamDetection
+from .base import FeedbackSpamDetectionBase
 
 backend = LazyServiceWrapper(
-    StubFeedbackSpamDetection,
+    FeedbackSpamDetectionBase,
     settings.SENTRY_USER_FEEDBACK_SPAM,
     settings.SENTRY_USER_FEEDBACK_SPAM_OPTIONS,
 )

--- a/src/sentry/feedback/spam/__init__.py
+++ b/src/sentry/feedback/spam/__init__.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+
+from sentry.utils.services import LazyServiceWrapper
+
+from .base import StubFeedbackSpamDetection
+
+backend = LazyServiceWrapper(
+    StubFeedbackSpamDetection,
+    settings.SENTRY_USER_FEEDBACK_SPAM,
+    settings.SENTRY_USER_FEEDBACK_SPAM_OPTIONS,
+)
+
+backend.expose(locals())

--- a/src/sentry/feedback/spam/base.py
+++ b/src/sentry/feedback/spam/base.py
@@ -1,0 +1,6 @@
+from sentry.utils.services import Service
+
+
+class StubFeedbackSpamDetection(Service):
+    def __init__(self, **options):
+        pass

--- a/src/sentry/feedback/spam/base.py
+++ b/src/sentry/feedback/spam/base.py
@@ -1,6 +1,9 @@
 from sentry.utils.services import Service
 
 
-class StubFeedbackSpamDetection(Service):
+class FeedbackSpamDetectionBase(Service):
     def __init__(self, **options):
         pass
+
+    def spam_detection(self, text: str):
+        raise NotImplementedError

--- a/src/sentry/feedback/spam/stub.py
+++ b/src/sentry/feedback/spam/stub.py
@@ -1,0 +1,9 @@
+from sentry.feedback.spam.base import FeedbackSpamDetectionBase
+
+
+class StubFeedbackSpamDetection(FeedbackSpamDetectionBase):
+    def __init__(self, **options):
+        pass
+
+    def spam_detection(self, text):
+        return False

--- a/tests/sentry/feedback/spam/test_stub.py
+++ b/tests/sentry/feedback/spam/test_stub.py
@@ -4,5 +4,6 @@ from sentry.feedback.spam.stub import StubFeedbackSpamDetection
 
 class TestStubFeedbackSpamDetection(BaseTestCase):
     def test_spam_detection(self):
-        res = StubFeedbackSpamDetection.spam_detection(self, "great website!")
+        stub = StubFeedbackSpamDetection()
+        res = stub.spam_detection("great website!")
         assert res is False

--- a/tests/sentry/feedback/spam/test_stub.py
+++ b/tests/sentry/feedback/spam/test_stub.py
@@ -1,0 +1,8 @@
+from fixtures.sudo_testutils import BaseTestCase
+from sentry.feedback.spam.stub import StubFeedbackSpamDetection
+
+
+class TestStubFeedbackSpamDetection(BaseTestCase):
+    def test_spam_detection(self):
+        res = StubFeedbackSpamDetection.spam_detection(self, "great website!")
+        assert res is False


### PR DESCRIPTION
- in `sentry`, create a new `LazyServiceWrapper` for feedback spam detection, and a stub function which inherits from a base class, which `sentry` by default will use.

- create a new settings variable in `server.py` which will determine which service Sentry should use for spam detection. by default, it should be the stub. We'll override this in `getsentry` when we're ready to deploy in prod

- add a test for the stub