### PR TITLE
feat(crons): Make sure checkin attachment endpoints will continue working if there are multiple monitors with the same slug

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -9,22 +9,27 @@ from sentry_sdk import configure_scope
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, region_silo_endpoint
-from sentry.api.serializers import serialize
-from sentry.models.files.file import File
-
-from ...api.authentication import (
+from sentry.api.authentication import (
     ApiKeyAuthentication,
     DSNAuthentication,
     OrgAuthTokenAuthentication,
     UserAuthTokenAuthentication,
 )
-from ...api.exceptions import ParameterValidationError, ResourceDoesNotExist
-from ...constants import ObjectStatus
-from ...models import Organization, Project, ProjectKey
-from ...utils.sdk import bind_organization_context
-from ..models import Monitor, MonitorCheckIn
-from .base import ProjectMonitorPermission, get_monitor_by_org_slug, try_checkin_lookup
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.exceptions import ParameterValidationError, ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
+from sentry.models.files.file import File
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.projectkey import ProjectKey
+from sentry.monitors.endpoints.base import (
+    ProjectMonitorPermission,
+    get_monitor_by_org_slug,
+    try_checkin_lookup,
+)
+from sentry.monitors.models import Monitor, MonitorCheckIn
+from sentry.utils.sdk import bind_organization_context
 
 MAX_ATTACHMENT_SIZE = 1024 * 100  # 100kb
 

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -1,28 +1,149 @@
 from __future__ import annotations
 
+from uuid import UUID
+
 from django.core.files.uploadedfile import UploadedFile
 from rest_framework.request import Request
 from rest_framework.response import Response
+from sentry_sdk import configure_scope
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import region_silo_endpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.serializers import serialize
 from sentry.models.files.file import File
 
-from .base import MonitorIngestEndpoint
+from ...api.authentication import (
+    ApiKeyAuthentication,
+    DSNAuthentication,
+    OrgAuthTokenAuthentication,
+    UserAuthTokenAuthentication,
+)
+from ...api.exceptions import ParameterValidationError, ResourceDoesNotExist
+from ...constants import ObjectStatus
+from ...models import Organization, Project, ProjectKey
+from ...utils.sdk import bind_organization_context
+from ..models import Monitor, MonitorCheckIn
+from .base import ProjectMonitorPermission, get_monitor_by_org_slug, try_checkin_lookup
 
 MAX_ATTACHMENT_SIZE = 1024 * 100  # 100kb
 
 
 @region_silo_endpoint
-class MonitorIngestCheckinAttachmentEndpoint(MonitorIngestEndpoint):
+class MonitorIngestCheckinAttachmentEndpoint(Endpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.CRONS
 
-    def post(self, request: Request, project, monitor, checkin) -> Response:
+    authentication_classes = (
+        DSNAuthentication,
+        UserAuthTokenAuthentication,
+        OrgAuthTokenAuthentication,
+        ApiKeyAuthentication,
+    )
+    permission_classes = (ProjectMonitorPermission,)
+
+    """
+    Loosens the base endpoint such that a monitor with the provided monitor_slug
+    does not need to exist. This is used for initial checkin creation with
+    monitor upsert.
+
+    [!!]: This will ONLY work when using DSN auth.
+    """
+
+    def convert_args(
+        self,
+        request: Request,
+        monitor_slug: str,
+        checkin_id: str,
+        organization_slug: str | None = None,
+        *args,
+        **kwargs,
+    ):
+        monitor = None
+
+        using_dsn_auth = isinstance(request.auth, ProjectKey)
+        if checkin_id != "latest":
+            # We require a checkin for this endpoint. If one doesn't exist then error. If the
+            # checkin_id is `latest` we'll need to resolve the monitor before we can get it.
+            try:
+                UUID(checkin_id)
+            except ValueError:
+                raise ParameterValidationError("Invalid check-in UUID")
+
+            try:
+                checkin = MonitorCheckIn.objects.select_related("monitor").get(guid=checkin_id)
+                monitor = checkin.monitor
+                project = Project.objects.select_related("organization").get(id=monitor.project_id)
+            except (MonitorCheckIn.DoesNotExist, Project.DoesNotExist):
+                raise ResourceDoesNotExist
+        else:
+
+            # When using DSN auth we're able to infer the organization slug
+            if not organization_slug and using_dsn_auth:
+                organization_slug = request.auth.project.organization.slug
+
+            # The only monitor endpoints that do not have the org slug in their
+            # parameters are the GUID-style checkin endpoints
+            if organization_slug:
+                try:
+                    # Try lookup by slug first. This requires organization context.
+                    organization = Organization.objects.get_from_cache(slug=organization_slug)
+                    monitor = get_monitor_by_org_slug(organization, monitor_slug)
+                except (Organization.DoesNotExist, Monitor.DoesNotExist):
+                    pass
+
+            # Try lookup by GUID
+            if not monitor:
+                # Validate GUIDs
+                try:
+                    UUID(monitor_slug)
+                    # When looking up by guid we don't include the org conditional
+                    # (since GUID lookup allows orgless routes), we will validate
+                    # permissions later in this function
+                    try:
+                        monitor = Monitor.objects.get(guid=monitor_slug)
+                    except Monitor.DoesNotExist:
+                        monitor = None
+                except ValueError:
+                    # This error is a bit confusing, because this may also mean
+                    # that we've failed to look up their monitor by slug.
+                    raise ParameterValidationError("Invalid monitor UUID")
+
+            if not monitor:
+                raise ResourceDoesNotExist
+
+            project = Project.objects.get_from_cache(id=monitor.project_id)
+            checkin = try_checkin_lookup(monitor, checkin_id)
+
+        if project.status != ObjectStatus.ACTIVE:
+            raise ResourceDoesNotExist
+
+        # Validate that the authenticated project matches the monitor. This is
+        # used for DSN style authentication
+        if using_dsn_auth and project.id != request.auth.project_id:
+            raise ResourceDoesNotExist
+
+        # When looking up via GUID we do not check the organization slug,
+        # validate that the slug matches the org of the monitors project
+        if organization_slug and project.organization.slug != organization_slug:
+            raise ResourceDoesNotExist
+
+        # Check project permission. Required for Token style authentication
+        self.check_object_permissions(request, project)
+
+        with configure_scope() as scope:
+            scope.set_tag("project", project.id)
+
+        bind_organization_context(project.organization)
+
+        request._request.organization = project.organization
+        kwargs["checkin"] = checkin
+
+        return args, kwargs
+
+    def post(self, request: Request, checkin) -> Response:
         """
         Uploads a check-in attachment file.
 


### PR DESCRIPTION
This just focuses on fixing the attachment ingest endpoint. We're killing the other ingest endpoints next week, so not doing anything to make them compatible.

I just moved convert_args into the endpoint itself and modified it to fit the requirements of this endpoint. We try to use the checkin id to directly look up the checkin and related data if possible. If `latest` was used, we use our standard logic to attempt to get a useful monitor to determine the latest checkin.
