### PR TITLE
test(ui): Catch error in hook using try/catch

### DIFF
--- a/static/app/utils/useLocalStorageState.spec.tsx
+++ b/static/app/utils/useLocalStorageState.spec.tsx
@@ -1,5 +1,3 @@
-import {Component} from 'react';
-
 import {reactHooks, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import localStorageWrapper from 'sentry/utils/localStorage';
@@ -17,25 +15,15 @@ describe('useLocalStorageState', () => {
   it('throws if key is not a string', async () => {
     let errorResult!: TypeError;
 
-    class ErrorBoundary extends Component<{children: any}> {
-      static getDerivedStateFromError(err) {
-        errorResult = err;
-        return null;
-      }
-
-      render() {
-        return !errorResult && this.props.children;
-      }
-    }
-
-    reactHooks.renderHook(
-      () =>
+    reactHooks.renderHook(() => {
+      try {
         // @ts-expect-error force incorrect usage
-        useLocalStorageState({}, 'default value'),
-      {
-        wrapper: ErrorBoundary,
+        // biome-ignore lint/correctness/useHookAtTopLevel: <explanation>
+        useLocalStorageState({}, 'default value');
+      } catch (err) {
+        errorResult = err;
       }
-    );
+    });
 
     await waitFor(() => expect(errorResult).toBeInstanceOf(TypeError));
     expect(errorResult.message).toBe('useLocalStorage: key must be a string');


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/66036 I attempted to use an error boundary figuring react 18 would be fine with it. It hates it. throws an error. I'm not sure if hooks should even throw errors like this.

part of https://github.com/getsentry/frontend-tsc/issues/22