### PR TITLE
ref(dynamic-sampling): Cleanup sliding window org feature flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1545,10 +1545,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:discover-query": True,
     # Enable the org recalibration
     "organizations:ds-org-recalibration": False,
-    # Enable the sliding window per project
-    "organizations:ds-sliding-window": False,
-    # Enable the sliding window per org
-    "organizations:ds-sliding-window-org": False,
     # Enable the new opinionated dynamic sampling
     "organizations:dynamic-sampling": False,
     # Enables data secrecy mode

--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 import sentry_sdk
 
-from sentry import features, quotas
+from sentry import quotas
 from sentry.db.models import Model
 from sentry.dynamic_sampling.rules.biases.base import Bias
 from sentry.dynamic_sampling.rules.combine import get_relay_biases_combinator
@@ -42,12 +42,6 @@ def is_recently_added(model: Model) -> bool:
         return bool(model.date_added >= ten_minutes_ago)
 
     return False
-
-
-def is_sliding_window_org_enabled(organization: Organization) -> bool:
-    return features.has(
-        "organizations:ds-sliding-window-org", organization, actor=None
-    ) and not features.has("organizations:ds-sliding-window", organization, actor=None)
 
 
 def get_guarded_blended_sample_rate(organization: Organization, project: Project) -> float:

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -98,8 +98,6 @@ default_manager.add("organizations:device-classification", OrganizationFeature, 
 default_manager.add("organizations:discover-events-rate-limit", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:ds-sliding-window-org", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:ds-sliding-window", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:enterprise-data-secrecy", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:escalating-issues-msteams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:escalating-issues-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -216,7 +216,6 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         assert generate_rules(proj_e)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
 
     @with_feature("organizations:dynamic-sampling")
-    @with_feature("organizations:ds-sliding-window-org")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     @patch("sentry.quotas.backend.get_transaction_sampling_tier_for_volume")
     @patch("sentry.dynamic_sampling.tasks.common.extrapolate_monthly_volume")
@@ -258,7 +257,6 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         assert generate_rules(proj_d)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
 
     @with_feature("organizations:dynamic-sampling")
-    @with_feature("organizations:ds-sliding-window-org")
     @patch(
         "sentry.dynamic_sampling.tasks.boost_low_volume_projects.schedule_invalidate_project_config"
     )
@@ -291,7 +289,6 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         assert schedule_invalidate_project_config.call_count == 2
 
     @with_feature("organizations:dynamic-sampling")
-    @with_feature("organizations:ds-sliding-window-org")
     @patch(
         "sentry.dynamic_sampling.tasks.boost_low_volume_projects.schedule_invalidate_project_config"
     )
@@ -450,7 +447,6 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
                 assert global_rate == BLENDED_RATE
 
     @with_feature("organizations:dynamic-sampling")
-    @with_feature("organizations:ds-sliding-window-org")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_boost_low_volume_transactions_with_sliding_window_org(self, get_blended_sample_rate):
         """
@@ -624,7 +620,6 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
         computed_adjusted_factor.assert_not_called()
 
     @with_feature("organizations:dynamic-sampling")
-    @with_feature("organizations:ds-sliding-window-org")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_rebalance_orgs_with_sliding_window_org(self, get_blended_sample_rate):
         """


### PR DESCRIPTION
This PR removes all the feature flags and conditionals around the sliding window org and cleans up the sliding window flag too.

We should now finally have dynamic sampling in a simpler and cleaner state.