### PR TITLE
fix(ddm): Fix query substitution algorithm with overlapping query names

### DIFF
--- a/src/sentry/sentry_metrics/querying/data_v2/plan.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/plan.py
@@ -40,7 +40,9 @@ class FormulaDefinition:
 
     def replace_variables(self, queries: dict[str, str]) -> "FormulaDefinition":
         replaced_mql_formula = self.mql
-        for query_name in queries.keys():
+        # We sort query names by length and content with the goal of trying to always match the longest queries first.
+        sorted_query_names = sorted(queries.keys(), key=lambda q: (len(q), q), reverse=True)
+        for query_name in sorted_query_names:
             replaced_mql_formula = re.sub(
                 rf"\${query_name}", queries.get(query_name, ""), replaced_mql_formula
             )

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_plan.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_plan.py
@@ -1,0 +1,27 @@
+import pytest
+
+from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan
+
+
+@pytest.mark.parametrize(
+    "formula, queries, expected_formula",
+    [
+        ("$a + $b", {"a": "query_1", "b": "query_2"}, "query_1 + query_2"),
+        ("$a + $b + $c", {"a": "query_1", "b": "query_2"}, "query_1 + query_2 + $c"),
+        (
+            "$a / $aa + $ab * $b",
+            {"a": "query_1", "b": "query_2", "aa": "query_3", "ab": "query_4"},
+            "query_1 / query_3 + query_4 * query_2",
+        ),
+    ],
+)
+def test_get_replaced_formulas(formula, queries, expected_formula):
+    plan = MetricsQueriesPlan()
+    for query_name, query in queries.items():
+        plan.declare_query(query_name, query)
+
+    plan.apply_formula(formula)
+
+    replaced_formulas = plan.get_replaced_formulas()
+    assert len(replaced_formulas) == 1
+    assert replaced_formulas[0].mql == expected_formula


### PR DESCRIPTION
This PR fixes the replacement algorithm for formulas when query names are substrings of each other. The fix involves trying to match the longest queries first.