### PR TITLE
fix(ddm): Fix metrics API not working with integers

### DIFF
--- a/src/sentry/sentry_metrics/querying/data_v2/units.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/units.py
@@ -54,9 +54,9 @@ class Unit:
     """
 
     name: MeasurementUnit
-    scaling_factor: float
+    scaling_factor: float | int
 
-    def convert(self, value: float | int) -> float:
+    def convert(self, value: float | int) -> float | int:
         return value * (self.scaling_factor or 1)
 
     def apply_on_timeseries(self, timeseries: Timeseries) -> Formula:

--- a/src/sentry/sentry_metrics/querying/data_v2/units.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/units.py
@@ -57,9 +57,13 @@ class Unit:
     scaling_factor: float | int
 
     def convert(self, value: float | int) -> float | int:
-        return value * (self.scaling_factor or 1)
+        return value * self.scaling_factor
 
-    def apply_on_timeseries(self, timeseries: Timeseries) -> Formula:
+    def apply_on_timeseries(self, timeseries: Timeseries) -> Timeseries | Formula:
+        # In case the factor is the identity of the multiplication, we do not apply any formula.
+        if self.scaling_factor in {1.0, 1}:
+            return timeseries
+
         # We represent the scaling factor as a multiplicative factor, so that we can just multiply.
         return Formula(
             function_name=ArithmeticOperator.MULTIPLY.value,

--- a/src/sentry/sentry_metrics/querying/visitors/base.py
+++ b/src/sentry/sentry_metrics/querying/visitors/base.py
@@ -26,7 +26,9 @@ class QueryExpressionVisitor(ABC, Generic[TVisited]):
         elif isinstance(query_expression, str):
             return self._visit_string(query_expression)
 
-        raise AssertionError(f"Unhandled query expression {query_expression}")
+        raise AssertionError(
+            f"Unhandled query expression {query_expression} of type {type(query_expression)}"
+        )
 
     def _visit_formula(self, formula: Formula) -> TVisited:
         # The default implementation just mutates the parameters of the `Formula`.
@@ -70,7 +72,9 @@ class QueryConditionVisitor(ABC, Generic[TVisited]):
         elif isinstance(query_condition, Condition):
             return self._visit_condition(query_condition)
 
-        raise AssertionError(f"Unhandled query condition {query_condition}")
+        raise AssertionError(
+            f"Unhandled query condition {query_condition} of type {type(query_condition)}"
+        )
 
     def _visit_boolean_condition(self, boolean_condition: BooleanCondition) -> TVisited:
         conditions = []

--- a/src/sentry/sentry_metrics/querying/visitors/base.py
+++ b/src/sentry/sentry_metrics/querying/visitors/base.py
@@ -19,8 +19,10 @@ class QueryExpressionVisitor(ABC, Generic[TVisited]):
             return self._visit_formula(query_expression)
         elif isinstance(query_expression, Timeseries):
             return self._visit_timeseries(query_expression)
+        elif isinstance(query_expression, int):
+            return self._visit_int(query_expression)
         elif isinstance(query_expression, float):
-            return self._visit_number(query_expression)
+            return self._visit_float(query_expression)
         elif isinstance(query_expression, str):
             return self._visit_string(query_expression)
 
@@ -37,8 +39,11 @@ class QueryExpressionVisitor(ABC, Generic[TVisited]):
     def _visit_timeseries(self, timeseries: Timeseries) -> TVisited:
         raise timeseries
 
-    def _visit_number(self, number: float):
-        return number
+    def _visit_int(self, int_number: float):
+        return int_number
+
+    def _visit_float(self, float_number: float):
+        return float_number
 
     def _visit_string(self, string: str):
         return string

--- a/src/sentry/sentry_metrics/querying/visitors/query_expression.py
+++ b/src/sentry/sentry_metrics/querying/visitors/query_expression.py
@@ -211,7 +211,10 @@ class QueriedMetricsVisitor(QueryExpressionVisitor[set[str]]):
 
         return {timeseries.metric.mri}
 
-    def _visit_number(self, number: float) -> set[str]:
+    def _visit_int(self, int_number: float):
+        return set()
+
+    def _visit_float(self, float_number: float) -> set[str]:
         return set()
 
     def _visit_string(self, string: str) -> set[str]:
@@ -234,7 +237,10 @@ class UsedGroupBysVisitor(QueryExpressionVisitor[set[str]]):
     def _visit_timeseries(self, timeseries: Timeseries) -> set[str]:
         return self._group_bys_as_string(timeseries.groupby)
 
-    def _visit_number(self, number: float) -> set[str]:
+    def _visit_int(self, int_number: float):
+        return set()
+
+    def _visit_float(self, float_number: float) -> set[str]:
         return set()
 
     def _visit_string(self, string: str) -> set[str]:

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -778,7 +778,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     def test_query_with_one_metric_blocked_for_one_project(self):
-        mri = "d:custom/page_load@millisecond"
+        mri = "d:custom/page_size@byte"
 
         project_1 = self.create_project()
         project_2 = self.create_project()
@@ -813,8 +813,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [None, self.to_reference_unit(15.0), None]
-        assert data[0][0]["totals"] == self.to_reference_unit(15.0)
+        assert data[0][0]["series"] == [None, self.to_reference_unit(15.0, "byte"), None]
+        assert data[0][0]["totals"] == self.to_reference_unit(15.0, "byte")
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     def test_query_with_one_metric_blocked_for_all_projects(self):


### PR DESCRIPTION
This PR fixes a bug in the metrics API which didn't support integer values in formulas. In addition, it adds better exception formatting for missing visitor branches.