### PR TITLE
 feat(ddm): Implement transformer abstractions in the metrics API

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -28,7 +28,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.querying.data import run_metrics_query
 from sentry.sentry_metrics.querying.data_v2 import run_metrics_queries_plan
-from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan, QueryOrder
+from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
     LatestReleaseNotFoundError,
@@ -37,6 +37,7 @@ from sentry.sentry_metrics.querying.errors import (
 )
 from sentry.sentry_metrics.querying.metadata import MetricCodeLocations, get_metric_code_locations
 from sentry.sentry_metrics.querying.samples_list import get_sample_list_executor_cls
+from sentry.sentry_metrics.querying.types import QueryOrder
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.utils import string_to_use_case_id
 from sentry.snuba.metrics import (

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -29,6 +29,7 @@ from sentry.models.project import Project
 from sentry.sentry_metrics.querying.data import run_metrics_query
 from sentry.sentry_metrics.querying.data_v2 import run_metrics_queries_plan
 from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan
+from sentry.sentry_metrics.querying.data_v2.transformation import MetricsAPIQueryTransformer
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
     LatestReleaseNotFoundError,
@@ -431,7 +432,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
                 projects=self.get_projects(request, organization),
                 environments=self.get_environments(request, organization),
                 referrer=Referrer.API_ORGANIZATION_METRICS_QUERY.value,
-            )
+            ).apply_transformer(MetricsAPIQueryTransformer())
         except InvalidMetricsQueryError as e:
             return Response(status=400, data={"detail": str(e)})
         except LatestReleaseNotFoundError as e:

--- a/src/sentry/sentry_metrics/querying/data_v2/api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/api.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -8,7 +9,7 @@ from sentry import features
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.sentry_metrics.querying.data_v2.execution import QueryExecutor
+from sentry.sentry_metrics.querying.data_v2.execution import QueryExecutor, QueryResult
 from sentry.sentry_metrics.querying.data_v2.parsing import QueryParser
 from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan
 from sentry.sentry_metrics.querying.data_v2.preparation import (
@@ -18,6 +19,11 @@ from sentry.sentry_metrics.querying.data_v2.preparation import (
 )
 from sentry.sentry_metrics.querying.data_v2.transformation import QueryTransformer
 from sentry.utils import metrics
+
+
+@dataclass(frozen=True)
+class QueryResults:
+    results: Sequence[QueryResult]
 
 
 def _time_equal_within_bound(time_1: datetime, time_2: datetime, bound: timedelta) -> bool:

--- a/src/sentry/sentry_metrics/querying/data_v2/api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/api.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import cast
 
@@ -18,11 +17,6 @@ from sentry.sentry_metrics.querying.data_v2.preparation import (
     run_preparation_steps,
 )
 from sentry.utils import metrics
-
-
-@dataclass(frozen=True)
-class QueryResults:
-    results: Sequence[QueryResult]
 
 
 def _time_equal_within_bound(time_1: datetime, time_2: datetime, bound: timedelta) -> bool:

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -11,11 +11,10 @@ from snuba_sdk.conditions import BooleanCondition, BooleanOp, Condition, Op
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.querying.common import SNUBA_QUERY_LIMIT
-from sentry.sentry_metrics.querying.data_v2.plan import QueryOrder
 from sentry.sentry_metrics.querying.data_v2.preparation import IntermediateQuery
 from sentry.sentry_metrics.querying.data_v2.units import MeasurementUnit, UnitFamily
 from sentry.sentry_metrics.querying.errors import MetricsQueryExecutionError
-from sentry.sentry_metrics.querying.types import GroupKey, GroupsCollection
+from sentry.sentry_metrics.querying.types import GroupKey, GroupsCollection, QueryOrder
 from sentry.sentry_metrics.querying.visitors import (
     QueriedMetricsVisitor,
     TimeseriesConditionInjectionVisitor,

--- a/src/sentry/sentry_metrics/querying/data_v2/parsing.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/parsing.py
@@ -5,9 +5,9 @@ from snuba_sdk.mql.mql import InvalidMQLQueryError, parse_mql
 
 from sentry.models.environment import Environment
 from sentry.models.project import Project
-from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan, QueryOrder
+from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan
 from sentry.sentry_metrics.querying.errors import InvalidMetricsQueryError
-from sentry.sentry_metrics.querying.types import QueryExpression
+from sentry.sentry_metrics.querying.types import QueryExpression, QueryOrder
 from sentry.sentry_metrics.querying.visitors import (
     EnvironmentsInjectionVisitor,
     LatestReleaseTransformationVisitor,

--- a/src/sentry/sentry_metrics/querying/data_v2/plan.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/plan.py
@@ -1,35 +1,9 @@
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass, replace
-from enum import Enum
-from typing import Union
 
-from snuba_sdk import Direction
-
-from sentry.sentry_metrics.querying.errors import InvalidMetricsQueryError
-
-# TODO: move these types in the right folder.
-
-
-class QueryOrder(Enum):
-    ASC = "asc"
-    DESC = "desc"
-
-    @classmethod
-    # Used `Union` because `|` conflicts with the parser.
-    def from_string(cls, value: str) -> Union["QueryOrder", None]:
-        for v in cls:
-            if v.value == value:
-                return v
-
-        return None
-
-    def to_snuba_order(self) -> Direction:
-        if self == QueryOrder.ASC:
-            return Direction.ASC
-        elif self == QueryOrder.DESC:
-            return Direction.DESC
-
-        raise InvalidMetricsQueryError(f"Ordering {self} does not exist is snuba")
+from sentry.sentry_metrics.querying.data_v2.execution import QueryResult
+from sentry.sentry_metrics.querying.types import QueryOrder
 
 
 @dataclass(frozen=True)
@@ -92,3 +66,8 @@ class MetricsQueriesPlan:
         A query plan is defined to be empty is no formulas have been applied on it.
         """
         return not self._formulas
+
+
+@dataclass(frozen=True)
+class MetricsQueriesPlanResult:
+    results: Sequence[QueryResult]

--- a/src/sentry/sentry_metrics/querying/data_v2/plan.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/plan.py
@@ -1,8 +1,11 @@
 import re
-from collections.abc import Sequence
 from dataclasses import dataclass, replace
 
 from sentry.sentry_metrics.querying.data_v2.execution import QueryResult
+from sentry.sentry_metrics.querying.data_v2.transformation.base import (
+    QueryTransformer,
+    QueryTransformerResult,
+)
 from sentry.sentry_metrics.querying.types import QueryOrder
 
 
@@ -70,4 +73,12 @@ class MetricsQueriesPlan:
 
 @dataclass(frozen=True)
 class MetricsQueriesPlanResult:
-    results: Sequence[QueryResult]
+    results: list[QueryResult]
+
+    def apply_transformer(
+        self, transformer: QueryTransformer[QueryTransformerResult]
+    ) -> QueryTransformerResult:
+        """
+        Applies a transformer on the `results` and returns the value of the transformation.
+        """
+        return transformer.transform(self.results)

--- a/src/sentry/sentry_metrics/querying/data_v2/preparation.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/preparation.py
@@ -3,12 +3,12 @@ from dataclasses import dataclass, replace
 
 from snuba_sdk import MetricsQuery, Timeseries
 
-from sentry.sentry_metrics.querying.data_v2.plan import QueryOrder
 from sentry.sentry_metrics.querying.data_v2.units import (
     MeasurementUnit,
     UnitFamily,
     get_unit_family_and_unit,
 )
+from sentry.sentry_metrics.querying.types import QueryOrder
 from sentry.snuba.metrics import parse_mri
 
 

--- a/src/sentry/sentry_metrics/querying/data_v2/transformation/__init__.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation/__init__.py
@@ -1,0 +1,3 @@
+from .metrics_api import MetricsAPIQueryTransformer
+
+__all__ = ["MetricsAPIQueryTransformer"]

--- a/src/sentry/sentry_metrics/querying/data_v2/transformation/base.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation/base.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+from sentry.sentry_metrics.querying.data_v2.execution import QueryResult
+
+QueryTransformerResult = TypeVar("QueryTransformerResult")
+
+
+class QueryTransformer(ABC, Generic[QueryTransformerResult]):
+    @abstractmethod
+    def transform(self, query_results: list[QueryResult]) -> QueryTransformerResult:
+        raise NotImplementedError

--- a/src/sentry/sentry_metrics/querying/data_v2/transformation/metrics_api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation/metrics_api.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from sentry.search.utils import parse_datetime_string
 from sentry.sentry_metrics.querying.data_v2.execution import QueryResult
+from sentry.sentry_metrics.querying.data_v2.transformation.base import QueryTransformer
 from sentry.sentry_metrics.querying.data_v2.utils import nan_to_none
 from sentry.sentry_metrics.querying.errors import MetricsQueryExecutionError
 from sentry.sentry_metrics.querying.types import GroupKey, ResultValue, Series, Totals
@@ -90,10 +91,8 @@ def _generate_full_series(
     return full_series
 
 
-class QueryTransformer:
-    def __init__(self, query_results: Sequence[QueryResult]):
-        self._query_results = query_results
-
+class MetricsAPIQueryTransformer(QueryTransformer[Mapping[str, Any]]):
+    def __init__(self):
         self._start: datetime | None = None
         self._end: datetime | None = None
         self._interval: int | None = None
@@ -103,7 +102,7 @@ class QueryTransformer:
         return self._start, self._end, self._interval
 
     def _build_intermediate_results(
-        self,
+        self, query_results: list[QueryResult]
     ) -> tuple[list[OrderedDict[GroupKey, GroupValue]], list[list[QueryMeta]]]:
         """
         Builds a tuple of intermediate groups and metadata which is used to efficiently transform the query results.
@@ -126,7 +125,7 @@ class QueryTransformer:
                 group_value = query_groups.setdefault(tuple(grouped_values), GroupValue.empty())
                 add_to_group(row, group_value)
 
-        for query_result in self._query_results:
+        for query_result in query_results:
             # All queries must have the same timerange, so under this assumption we take the first occurrence of each.
             if self._start is None:
                 self._start = query_result.modified_start
@@ -185,16 +184,16 @@ class QueryTransformer:
 
         return queries_groups, queries_meta
 
-    def transform(self) -> Mapping[str, Any]:
+    def transform(self, query_results: list[QueryResult]) -> Mapping[str, Any]:
         """
         Transforms the query results into the Sentry's API format.
         """
         # If we have not run any queries, we won't return anything back.
-        if not self._query_results:
+        if not query_results:
             return {}
 
         # We first build intermediate results that we can work efficiently with.
-        queries_groups, queries_meta = self._build_intermediate_results()
+        queries_groups, queries_meta = self._build_intermediate_results(query_results)
 
         # We assert that all the data we require for the transformation has been found during the building of
         # intermediate results.

--- a/src/sentry/sentry_metrics/querying/types.py
+++ b/src/sentry/sentry_metrics/querying/types.py
@@ -21,7 +21,7 @@ GroupKey = tuple[Group, ...]
 # Type representing a sequence of groups [[(`key_1`, `value_1`), (`key_2`, `value_2`), ...], ...]
 GroupsCollection = Sequence[Sequence[Group]]
 # Type representing the possible expressions for a query.
-QueryExpression = Union[Timeseries, Formula, float, str]
+QueryExpression = Union[Timeseries, Formula, int, float, str]
 # Type representing the possible conditions for a query.
 QueryCondition = Union[BooleanCondition, Condition]
 

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -4,12 +4,13 @@ import pytest
 from django.utils import timezone as django_timezone
 
 from sentry.sentry_metrics.querying.data_v2 import run_metrics_queries_plan
-from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan, QueryOrder
+from sentry.sentry_metrics.querying.data_v2.plan import MetricsQueriesPlan
 from sentry.sentry_metrics.querying.data_v2.units import MeasurementUnit, get_unit_family_and_unit
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
     MetricsQueryExecutionError,
 )
+from sentry.sentry_metrics.querying.types import QueryOrder
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.visibility import block_metric
 from sentry.snuba.metrics.naming_layer import TransactionMRI


### PR DESCRIPTION
This PR implements a new `QueryTransformer` API which allows people to implement their transformations given the basic data type returned by the API. Before this PR, we returned a basic `Mapping[str, Any]` in a format that is used exclusively for the REST endpoint, limiting the capabilities of the users of the API.

The need for different transformation logics arises since the API might eventually be used not only in the rest endpoints but by internal consumers.

The implementation is relatively straightforward, now the `run_metrics_queries_plan` function returns a special data type `MetricsQueriesPlanResult` which encapsulates the logic to run a `QueryTransformer` on the results. In the future, it might also expose external iterators over series and totals.