### PR TITLE
ref(ddm): Pass blocked metric tags to search bar

### DIFF
--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -28,7 +28,6 @@ import type {
   MRI,
   UseCase,
 } from 'sentry/types/metrics';
-import {statsPeriodToDays} from 'sentry/utils/dates';
 import {isMeasurement as isMeasurementName} from 'sentry/utils/discover/fields';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import {getMeasurements} from 'sentry/utils/measurements/measurements';
@@ -224,7 +223,7 @@ export function useClearQuery() {
   }, [routerRef]);
 }
 
-export function formatMetricsFormula(formula: string) {
+export function unescapeMetricsFormula(formula: string) {
   // Remove the $ from variable names
   return formula.replaceAll('$', '');
 }
@@ -236,7 +235,7 @@ export function getMetricsSeriesName(
 ) {
   let name = '';
   if (isMetricFormula(query)) {
-    name = formatMetricsFormula(query.formula);
+    name = unescapeMetricsFormula(query.formula);
   } else {
     name = formatMRIField(MRIToField(query.mri, query.op));
   }
@@ -420,9 +419,6 @@ export function getMetricsCorrelationSpanUrl(
 
 export function getMetaDateTimeParams(datetime?: PageFilters['datetime']) {
   if (datetime?.period) {
-    if (statsPeriodToDays(datetime.period) < 14) {
-      return {statsPeriod: '14d'};
-    }
     return {statsPeriod: datetime.period};
   }
   if (datetime?.start && datetime?.end) {

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -28,6 +28,7 @@ import type {
   MRI,
   UseCase,
 } from 'sentry/types/metrics';
+import {statsPeriodToDays} from 'sentry/utils/dates';
 import {isMeasurement as isMeasurementName} from 'sentry/utils/discover/fields';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import {getMeasurements} from 'sentry/utils/measurements/measurements';
@@ -419,6 +420,9 @@ export function getMetricsCorrelationSpanUrl(
 
 export function getMetaDateTimeParams(datetime?: PageFilters['datetime']) {
   if (datetime?.period) {
+    if (statsPeriodToDays(datetime.period) < 14) {
+      return {statsPeriod: '14d'};
+    }
     return {statsPeriod: datetime.period};
   }
   if (datetime?.start && datetime?.end) {

--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -53,7 +53,8 @@ function useMetaUseCase(
 export function useMetricsMeta(
   pageFilters: Partial<PageFilters>,
   useCases?: UseCase[],
-  filterBlockedMetrics = true
+  filterBlockedMetrics = true,
+  enabled: boolean = true
 ): {data: MetricMeta[]; isLoading: boolean} {
   const enabledUseCases = useCases ?? DEFAULT_USE_CASES;
 
@@ -61,17 +62,17 @@ export function useMetricsMeta(
     'sessions',
     pageFilters,
     {
-      enabled: enabledUseCases.includes('sessions'),
+      enabled: enabled && enabledUseCases.includes('sessions'),
     }
   );
   const {data: txnsMeta = [], ...txnsReq} = useMetaUseCase('transactions', pageFilters, {
-    enabled: enabledUseCases.includes('transactions'),
+    enabled: enabled && enabledUseCases.includes('transactions'),
   });
   const {data: customMeta = [], ...customReq} = useMetaUseCase('custom', pageFilters, {
-    enabled: enabledUseCases.includes('custom'),
+    enabled: enabled && enabledUseCases.includes('custom'),
   });
   const {data: spansMeta = [], ...spansReq} = useMetaUseCase('spans', pageFilters, {
-    enabled: enabledUseCases.includes('spans'),
+    enabled: enabled && enabledUseCases.includes('spans'),
   });
 
   const isLoading =

--- a/static/app/utils/metrics/useMetricsTags.tsx
+++ b/static/app/utils/metrics/useMetricsTags.tsx
@@ -10,7 +10,8 @@ import {getMetaDateTimeParams} from './index';
 export function useMetricsTags(
   mri: MRI | undefined,
   pageFilters: Partial<PageFilters>,
-  filterBlockedTags = true
+  filterBlockedTags = true,
+  blockedTags?: string[]
 ) {
   const {slug} = useOrganization();
   const useCase = getUseCaseFromMRI(mri) ?? 'custom';
@@ -41,11 +42,13 @@ export function useMetricsTags(
     }
   );
 
-  const metricMeta = useMetricsMeta(pageFilters, [useCase], false);
-  const blockedTags =
-    metricMeta.data
-      ?.find(meta => meta.mri === mri)
-      ?.blockingStatus?.flatMap(s => s.blockedTags) ?? [];
+  const metricMeta = useMetricsMeta(pageFilters, [useCase], false, !blockedTags);
+  const blockedTagsData =
+    (blockedTags ||
+      metricMeta.data
+        ?.find(meta => meta.mri === mri)
+        ?.blockingStatus?.flatMap(s => s.blockedTags)) ??
+    [];
 
   if (!filterBlockedTags) {
     return tagsQuery;
@@ -53,6 +56,6 @@ export function useMetricsTags(
 
   return {
     ...tagsQuery,
-    data: tagsQuery.data?.filter(tag => !blockedTags.includes(tag.key)) ?? [],
+    data: tagsQuery.data?.filter(tag => !blockedTagsData.includes(tag.key)) ?? [],
   };
 }

--- a/static/app/views/ddm/formulaInput.tsx
+++ b/static/app/views/ddm/formulaInput.tsx
@@ -4,6 +4,7 @@ import debounce from 'lodash/debounce';
 
 import Input, {inputStyles} from 'sentry/components/input';
 import {t} from 'sentry/locale';
+import {unescapeMetricsFormula} from 'sentry/utils/metrics';
 import {FormularFormatter} from 'sentry/views/ddm/formulaParser/formatter';
 import {joinTokens, parseFormula} from 'sentry/views/ddm/formulaParser/parser';
 import {type TokenList, TokenType} from 'sentry/views/ddm/formulaParser/types';
@@ -27,10 +28,6 @@ function escapeVariables(tokens: TokenList): TokenList {
   });
 }
 
-function unescapeVariables(formula: string): string {
-  return formula.replaceAll('$', '');
-}
-
 function equalizeWhitespace(formula: TokenList): TokenList {
   return formula.map(token => {
     // Ensure equal spacing
@@ -49,7 +46,7 @@ export function FormulaInput({
 }: Props) {
   const [errors, setErrors] = useState<any>([]);
   const [showErrors, setIsValidationEnabled] = useState(false);
-  const [value, setValue] = useState<string>(() => unescapeVariables(valueProp));
+  const [value, setValue] = useState<string>(() => unescapeMetricsFormula(valueProp));
 
   const validateVariable = useCallback(
     (variable: string): string | null => {

--- a/static/app/views/ddm/metricSearchBar.tsx
+++ b/static/app/views/ddm/metricSearchBar.tsx
@@ -23,6 +23,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 
 interface MetricSearchBarProps extends Partial<SmartSearchBarProps> {
   onChange: (value: string) => void;
+  blockedTags?: string[];
   disabled?: boolean;
   mri?: MRI;
   projectIds?: string[];
@@ -63,6 +64,7 @@ export function ensureQuotedTextFilters(
 
 export function MetricSearchBar({
   mri,
+  blockedTags,
   disabled,
   onChange,
   query,
@@ -77,10 +79,15 @@ export function MetricSearchBar({
     [projectIds]
   );
 
-  const {data: tags = EMPTY_ARRAY, isLoading} = useMetricsTags(mri, {
-    ...selection,
-    projects: projectIdNumbers,
-  });
+  const {data: tags = EMPTY_ARRAY, isLoading} = useMetricsTags(
+    mri,
+    {
+      ...selection,
+      projects: projectIdNumbers,
+    },
+    true,
+    blockedTags
+  );
 
   const supportedTags: TagCollection = useMemo(
     () => tags.reduce((acc, tag) => ({...acc, [tag.key]: tag}), {}),

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -242,6 +242,7 @@ export const QueryBuilder = memo(function QueryBuilder({
           disabled={!metricsQuery.mri}
           onChange={handleQueryChange}
           query={metricsQuery.query}
+          blockedTags={selectedMeta?.blockingStatus?.flatMap(s => s.blockedTags) ?? []}
         />
       </SearchBarWrapper>
     </QueryBuilderWrapper>

--- a/static/app/views/ddm/scratchpad.tsx
+++ b/static/app/views/ddm/scratchpad.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import * as echarts from 'echarts/core';
 
 import {space} from 'sentry/styles/space';
-import {formatMetricsFormula, getMetricsCorrelationSpanUrl} from 'sentry/utils/metrics';
+import {getMetricsCorrelationSpanUrl, unescapeMetricsFormula} from 'sentry/utils/metrics';
 import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
 import type {MetricsQueryApiQueryParams} from 'sentry/utils/metrics/useMetricsQuery';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -110,7 +110,7 @@ export function MetricScratchpad() {
       let tokens: TokenList = [];
 
       try {
-        tokens = parseFormula(formatMetricsFormula(formula));
+        tokens = parseFormula(unescapeMetricsFormula(formula));
       } catch {
         // We should not end up here, but if we do, we should not crash the UI
         return {dependencies: [], isError: true};

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -20,12 +20,12 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {MetricsQueryApiResponse, PageFilters} from 'sentry/types';
 import {
-  formatMetricsFormula,
   getDefaultMetricDisplayType,
   getFormattedMQL,
   getMetricsSeriesId,
   getMetricsSeriesName,
   isCumulativeOp,
+  unescapeMetricsFormula,
 } from 'sentry/utils/metrics';
 import {metricDisplayTypeOptions} from 'sentry/utils/metrics/constants';
 import {formatMRIField, MRIToField, parseMRI} from 'sentry/utils/metrics/mri';
@@ -102,7 +102,7 @@ export function getWidgetTitle(queries: MetricsQueryApiQueryParams[]) {
     if (isMetricFormula(firstQuery)) {
       return (
         <Fragment>
-          <FormularFormatter formula={formatMetricsFormula(firstQuery.formula)} />
+          <FormularFormatter formula={unescapeMetricsFormula(firstQuery.formula)} />
         </Fragment>
       );
     }
@@ -112,7 +112,7 @@ export function getWidgetTitle(queries: MetricsQueryApiQueryParams[]) {
   return filteredQueries
     .map(q =>
       isMetricFormula(q)
-        ? formatMetricsFormula(q.formula)
+        ? unescapeMetricsFormula(q.formula)
         : formatMRIField(MRIToField(q.mri, q.op))
     )
     .join(', ');


### PR DESCRIPTION
- Pass blocked metrics to search bar instead of fetching them again
- Renaming