### PR TITLE
fix(metrics-extraction): Fix discover splitting code

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -26,7 +26,7 @@ from sentry.snuba import discover, metrics_enhanced_performance, metrics_perform
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.referrer import Referrer
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.utils.snuba import SnubaError
+from sentry.utils.snuba import SnubaError, SnubaTSResult
 
 logger = logging.getLogger(__name__)
 
@@ -330,8 +330,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                         split_query = scoped_query
                         if widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS:
                             split_dataset = discover
-                            split_query = f"({scoped_query}) AND event.type:error"
+                            split_query = f"({scoped_query}) AND !event.type:transaction"
                         elif widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE:
+                            # We can't add event.type:transaction for now because of on-demand.
                             split_dataset = scopedDataset
                         else:
                             split_dataset = discover
@@ -340,23 +341,44 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
                     try:
                         error_results = _data_fn(
-                            discover, offset, limit, f"({scoped_query}) AND event.type:error"
+                            discover, offset, limit, f"({scoped_query}) AND !event.type:transaction"
                         )
                         # Widget has not split the discover dataset yet, so we need to check if there are errors etc.
                         has_errors = len(error_results["data"]) > 0
                     except SnubaError:
                         has_errors = False
 
-                    if has_errors:
-                        # If we see errors, always fallback to discover to scoped_query for the user.
-                        all_results = _data_fn(discover, offset, limit, scoped_query)
+                    original_results = _data_fn(scopedDataset, offset, limit, scoped_query)
+                    if isinstance(original_results, SnubaTSResult):
+                        dataset_meta = original_results.data.get("meta", {})
                     else:
-                        all_results = _data_fn(scopedDataset, offset, limit, scoped_query)
+                        dataset_meta = list(original_results.values())[0].data.get("meta", {})
+                    using_metrics = dataset_meta.get("isMetricsData", False) or dataset_meta.get(
+                        "isMetricsExtractedData", False
+                    )
+                    has_other_data = len(original_results["data"]) > 0
 
-                    has_other_data = len(all_results["data"]) > 0
-                    self.save_split_decision(widget, has_errors, has_other_data)
+                    has_transactions = has_other_data
+                    transaction_results = None
+                    if has_errors and has_other_data and not using_metrics:
+                        # In the case that the original request was not using the metrics dataset, we cannot be certain that other data is solely transactions.
+                        sentry_sdk.set_tag("third_split_query", True)
+                        transactions_only_query = f"({scoped_query}) AND event.type:transaction"
+                        transaction_results = _data_fn(
+                            discover, offset, limit, transactions_only_query
+                        )
+                        has_transactions = len(transaction_results["data"]) > 0
 
-                    return all_results
+                    decision = self.save_split_decision(widget, has_errors, has_transactions)
+
+                    if decision == DashboardWidgetTypes.DISCOVER:
+                        return _data_fn(discover, offset, limit, scoped_query)
+                    elif decision == DashboardWidgetTypes.TRANSACTION_LIKE:
+                        return original_results
+                    elif decision == DashboardWidgetTypes.ERROR_EVENTS and error_results:
+                        return error_results
+                    else:
+                        return original_results
                 except Exception as e:
                     # Swallow the exception if it was due to the discover split, and try again one more time.
                     sentry_sdk.capture_exception(e)

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -128,6 +128,28 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
             }
         )
 
+    def flatten_results(self, results: SnubaTSResult | dict[str, SnubaTSResult]):
+        if isinstance(results, SnubaTSResult):
+            return results.data["data"]
+        else:
+            return sum(
+                [timeseries_result.data["data"] for timeseries_result in results.values()],
+                [],
+            )
+
+    def check_if_results_have_data(self, results: SnubaTSResult | dict[str, SnubaTSResult]):
+        flattened_data = self.flatten_results(results)
+        has_data = any(
+            any(
+                column_name != "time"
+                and isinstance(column_value, (int, float))
+                and column_value != 0
+                for (column_name, column_value) in row.items()
+            )
+            for row in flattened_data
+        )
+        return has_data
+
     def get(self, request: Request, organization: Organization) -> Response:
         with sentry_sdk.start_span(op="discover.endpoint", description="filter_params") as span:
             span.set_data("organization", organization)
@@ -307,12 +329,13 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         split_query = query
                         if widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS:
                             split_dataset = discover
-                            split_query = f"({query}) AND event.type:error"
+                            split_query = f"({query}) AND !event.type:transaction"
                         elif widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE:
+                            # We can't add event.type:transaction for now because of on-demand.
                             split_dataset = scoped_dataset
                         else:
                             # This is a fallback for the ambiguous case.
-                            split_dataset = scoped_dataset
+                            split_dataset = discover
 
                         return _get_event_stats(
                             split_dataset,
@@ -325,7 +348,8 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         )
 
                     # Widget has not split the discover dataset yet, so we need to check if there are errors etc.
-                    errors_only_query = f"({query}) AND event.type:error"
+                    errors_only_query = f"({query}) AND !event.type:transaction"
+                    error_results = None
                     try:
                         error_results = _get_event_stats(
                             discover,
@@ -336,27 +360,51 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                             zerofill_results,
                             comparison_delta,
                         )
-                        sum_error_results = error_results.data["data"]
-                        has_errors = any(
-                            any("(" in column and ")" in column for column in row.keys())
-                            for row in sum_error_results
-                        )
+                        has_errors = self.check_if_results_have_data(error_results)
                     except SnubaError:
                         has_errors = False
 
-                    if has_errors:
-                        # If we see errors, always fallback to discover to scopedQuery for the user.
-                        all_results = _get_event_stats(
-                            scoped_dataset,
+                    original_results = _get_event_stats(
+                        scoped_dataset,
+                        query_columns,
+                        query,
+                        params,
+                        rollup,
+                        zerofill_results,
+                        comparison_delta,
+                    )
+                    has_other_data = self.check_if_results_have_data(original_results)
+                    if isinstance(original_results, SnubaTSResult):
+                        dataset_meta = original_results.data.get("meta", {})
+                    else:
+                        dataset_meta = list(original_results.values())[0].data.get("meta", {})
+
+                    using_metrics = dataset_meta.get("isMetricsData", False) or dataset_meta.get(
+                        "isMetricsExtractedData", False
+                    )
+
+                    has_transactions = has_other_data
+                    transaction_results = None
+                    if has_errors and has_other_data and not using_metrics:
+                        # In the case that the original request was not using the metrics dataset, we cannot be certain that other data is solely transactions.
+                        sentry_sdk.set_tag("third_split_query", True)
+                        transactions_only_query = f"({query}) AND event.type:transaction"
+                        transaction_results = _get_event_stats(
+                            discover,
                             query_columns,
-                            query,
+                            transactions_only_query,
                             params,
                             rollup,
                             zerofill_results,
                             comparison_delta,
                         )
-                    else:
-                        all_results = _get_event_stats(
+                        has_transactions = self.check_if_results_have_data(transaction_results)
+
+                    decision = self.save_split_decision(widget, has_errors, has_transactions)
+
+                    if decision == DashboardWidgetTypes.DISCOVER:
+                        # The user needs to be warned to split in this case.
+                        return _get_event_stats(
                             discover,
                             query_columns,
                             query,
@@ -365,30 +413,12 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                             zerofill_results,
                             comparison_delta,
                         )
-
-                    if isinstance(all_results, SnubaTSResult):
-                        other_data = all_results.data["data"]
+                    elif decision == DashboardWidgetTypes.TRANSACTION_LIKE:
+                        return original_results
+                    elif decision == DashboardWidgetTypes.ERROR_EVENTS and error_results:
+                        return error_results
                     else:
-                        other_data = sum(
-                            [
-                                timeseries_result.data["data"]
-                                for timeseries_result in all_results.values()
-                            ],
-                            [],
-                        )
-
-                    has_other_data = any(
-                        any(
-                            column_name != "time"
-                            and isinstance(column_value, (int, float))
-                            and column_value != 0
-                            for (column_name, column_value) in row.items()
-                        )
-                        for row in other_data
-                    )
-                    self.save_split_decision(widget, has_errors, has_other_data)
-
-                    return all_results
+                        return original_results
 
                 except Exception as e:
                     # Swallow the exception if it was due to discover split, and try again one more time.


### PR DESCRIPTION
### Summary
The logic in the discover splitting code wasn't quite right and had some troubles when there were mixtures of SnubaTSResult as well as the grouped dict of SnubaTSResult.


#### Other
- Switched `ERROR_EVENTS` to contain `event.type:default` etc. by flipping the conditions to `event.type:transaction` since they don't really belong anywhere else at the moment and we don't need to split them since they don't require all the MEP / metrics / on-demand code.
- Made sure the case of 0 data on both sides doesn't save as `DISCOVER` because on-demand takes a while before data arrives, the first refresh of those widgets would otherwise set it to `DISCOVER` forever. 
- Behind a feature flag which is currently off.

#### Future notes
- We may need refine querying for `DashboardWidgetTypes.TRANSACTION_LIKE` to not use metricsEnhanced
   - We might be able to save these values on-save for a dashboard widget, but it won't work with MetricsEnhanced when it requires on-demand since on-demand only kicks in a bit after dashboard widget creation. 
- GA: Pre-fill these so we don't make multiple queries even if it's only once.

