### PR TITLE
fix: handle redis cluster types correctly

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.db import router
 from django.db.models import Count
 from django.utils import timezone
+from rediscluster import RedisCluster
 
 from sentry import options
 from sentry.models.artifactbundle import (
@@ -41,9 +42,9 @@ INDEXING_CACHE_TIMEOUT = 600
 # ===== Indexing of Artifact Bundles =====
 
 
-def get_redis_cluster_for_artifact_bundles():
+def get_redis_cluster_for_artifact_bundles() -> RedisCluster:
     cluster_key = settings.SENTRY_ARTIFACT_BUNDLES_INDEXING_REDIS_CLUSTER
-    return redis.redis_clusters.get(cluster_key)
+    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
 
 
 def get_refresh_key() -> str:
@@ -67,7 +68,7 @@ def set_artifact_bundle_being_indexed_if_null(
     #
     # For now the state will just contain one, since it's unary but in case we would like to expand it, it will be
     # straightforward by just using a set of integers.
-    return redis_client.set(cache_key, 1, ex=INDEXING_CACHE_TIMEOUT, nx=True)
+    return redis_client.set(cache_key, 1, ex=INDEXING_CACHE_TIMEOUT, nx=True) or False
 
 
 def remove_artifact_bundle_indexing_state(organization_id: int, artifact_bundle_id: int) -> None:

--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any, Literal, NotRequired, TypedDict, Union
 
 from django.conf import settings
+from rediscluster import RedisCluster
 
 from sentry.models.dynamicsampling import CUSTOM_RULE_START
 from sentry.utils import json, redis
@@ -226,6 +227,6 @@ def apply_dynamic_factor(base_sample_rate: float, x: float) -> float:
     return float(x / x**base_sample_rate)
 
 
-def get_redis_client_for_ds() -> Any:
+def get_redis_client_for_ds() -> RedisCluster:
     cluster_key = settings.SENTRY_DYNAMIC_SAMPLING_RULES_REDIS_CLUSTER
-    return redis.redis_clusters.get(cluster_key)
+    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]

--- a/src/sentry/dynamic_sampling/tasks/helpers/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/boost_low_volume_projects.py
@@ -16,9 +16,11 @@ def get_boost_low_volume_projects_sample_rate(
     cache_key = generate_boost_low_volume_projects_cache_key(org_id=org_id)
 
     try:
-        return float(redis_client.hget(cache_key, project_id)), True
+        value = redis_client.hget(name=cache_key, key=str(project_id))
+        assert value is not None
+        return float(value), True
     # Thrown if the input is not a string or a float (e.g., None).
-    except TypeError:
+    except (TypeError, AssertionError):
         # In case there is no value in cache, we want to check if the sliding window org was executed. If it was
         # executed, but we didn't have this project boosted, it means that the entire org didn't have traffic in the
         # last hour which resulted in the system not considering it at all.

--- a/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/recalibrate_orgs.py
@@ -26,12 +26,15 @@ def get_adjusted_factor(org_id: int) -> float:
     cache_key = generate_recalibrate_orgs_cache_key(org_id)
 
     try:
-        return float(redis_client.get(cache_key))
+        value = redis_client.get(cache_key)
+        if value is not None:
+            return float(value)
     except (TypeError, ValueError):
         # By default, the previous factor is equal to the identity of the multiplication and this is done because
         # the recalibration rule will be a factor rule and thus multiplied with the first sample rate rule that will
         # match after this.
-        return 1.0
+        pass
+    return 1.0
 
 
 def delete_adjusted_factor(org_id: int) -> None:

--- a/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
+++ b/src/sentry/dynamic_sampling/tasks/helpers/sliding_window.py
@@ -44,7 +44,12 @@ def get_sliding_window_org_sample_rate(
     cache_key = generate_sliding_window_org_cache_key(org_id)
 
     try:
-        return float(redis_client.get(cache_key)), True
+        value = redis_client.get(cache_key)
+
+        if value is not None:
+            return float(value), True
+
+        return default_sample_rate, False
     except (TypeError, ValueError):
         return default_sample_rate, False
 

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 import sentry_sdk
 from django.conf import settings
+from rediscluster import RedisCluster
 
 from sentry import features
 from sentry.features.rollout import in_random_rollout
@@ -45,10 +46,10 @@ def _get_projects_key(namespace: ClustererNamespace) -> str:
     return f"{prefix}:projects"
 
 
-def get_redis_client() -> Any:
+def get_redis_client() -> RedisCluster:
     # XXX(iker): we may want to revisit the decision of having a single Redis cluster.
     cluster_key = settings.SENTRY_TRANSACTION_NAMES_REDIS_CLUSTER
-    return redis.redis_clusters.get(cluster_key)
+    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
 
 
 def _get_all_keys(namespace: ClustererNamespace) -> Iterator[str]:

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -63,7 +63,7 @@ class RedisRuleStore:
             # to be consistent with other stores, clear previous hash entries:
             p.delete(key)
             if len(rules) > 0:
-                p.hmset(key, rules)
+                p.hmset(name=key, mapping=rules)  # type: ignore[arg-type]
             p.execute()
 
     def update_rule(self, project: Project, rule: str, last_used: int) -> None:

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -11,6 +11,7 @@ import jsonschema
 import sentry_sdk
 from django.conf import settings
 from django.urls import reverse
+from rediscluster import RedisCluster
 
 from sentry import features, options
 from sentry.auth.system import get_system_token
@@ -178,9 +179,9 @@ REDACTED_SOURCES_SCHEMA = {
 LAST_UPLOAD_TTL = 24 * 3600
 
 
-def _get_cluster():
+def _get_cluster() -> RedisCluster:
     cluster_key = settings.SENTRY_DEBUG_FILES_REDIS_CLUSTER
-    return redis.redis_clusters.get(cluster_key)
+    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
 
 
 def _last_upload_key(project_id: int) -> str:

--- a/src/sentry/models/files/utils.py
+++ b/src/sentry/models/files/utils.py
@@ -8,6 +8,7 @@ from hashlib import sha1
 
 from django.conf import settings
 from django.utils import timezone
+from rediscluster import RedisCluster
 
 from sentry import options
 from sentry.locks import locks
@@ -64,9 +65,9 @@ def lock_blob(checksum: str, name: str, metric_instance: str | None = None):
         yield
 
 
-def _get_redis_for_blobs():
+def _get_redis_for_blobs() -> RedisCluster:
     cluster_key = settings.SENTRY_DEBUG_FILES_REDIS_CLUSTER
-    return redis.redis_clusters.get(cluster_key)
+    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
 
 
 def _redis_key_for_blob(file_blob_model, checksum):

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -90,6 +90,7 @@ import redis
 import sentry_sdk
 from django.conf import settings
 from django.db import router
+from rediscluster import RedisCluster
 
 from sentry import eventstore, models, nodestore, options
 from sentry.attachments import CachedAttachment, attachment_cache
@@ -439,8 +440,9 @@ def _get_original_issue_id(data):
     return get_path(data, "contexts", "reprocessing", "original_issue_id")
 
 
-def _get_sync_redis_client():
-    return redis_clusters.get(settings.SENTRY_REPROCESSING_SYNC_REDIS_CLUSTER)
+def _get_sync_redis_client() -> RedisCluster:
+    id = settings.SENTRY_REPROCESSING_SYNC_REDIS_CLUSTER
+    return redis_clusters.get(id)  # type: ignore[return-value]
 
 
 def _get_sync_counter_key(group_id):

--- a/src/sentry/sentry_metrics/querying/utils.py
+++ b/src/sentry/sentry_metrics/querying/utils.py
@@ -1,17 +1,17 @@
 import re
-from typing import Any
 
 from django.conf import settings
+from rediscluster import RedisCluster
 
 from sentry.utils import redis
 
 
-def get_redis_client_for_metrics_meta() -> Any:
+def get_redis_client_for_metrics_meta() -> RedisCluster:
     """
     Returns the redis client which is used for the Redis cluster that stores metrics metadata.
     """
     cluster_key = settings.SENTRY_METRIC_META_REDIS_CLUSTER
-    return redis.redis_clusters.get(cluster_key)
+    return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
 
 
 def fnv1a_32(data: bytes) -> int:

--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -675,12 +675,16 @@ def get_check_status(org_id):
     redis_client = get_redis_client_for_ds()
     cache_key = generate_cache_key_for_async_progress(org_id)
 
-    cached_status = redis_client.get(cache_key)
     try:
-        float_cached_status = float(cached_status)
-        return CheckStatus(float_cached_status)
+        cached_status = redis_client.get(cache_key)
+        if cached_status:
+            float_cached_status = float(cached_status)
+            return CheckStatus(float_cached_status)
+
     except (TypeError, ValueError):
-        return None
+        pass
+
+    return None
 
 
 def set_check_results(org_id, results):

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -11,7 +11,7 @@ from typing import Any, Generic, TypeGuard, TypeVar, overload
 import rb
 from django.utils.functional import SimpleLazyObject
 from rb.clients import LocalClient
-from redis.client import Script
+from redis.client import Script, StrictRedis
 from redis.connection import ConnectionPool
 from rediscluster import RedisCluster
 from sentry_redis_tools.failover_redis import FailoverRedis
@@ -155,7 +155,7 @@ class _RedisCluster:
         return "Redis Cluster"
 
 
-TCluster = TypeVar("TCluster", rb.Cluster, RedisCluster)
+TCluster = TypeVar("TCluster", rb.Cluster, RedisCluster | StrictRedis)
 
 
 class ClusterManager(Generic[TCluster]):
@@ -165,7 +165,7 @@ class ClusterManager(Generic[TCluster]):
 
     @overload
     def __init__(
-        self: ClusterManager[RedisCluster],
+        self: ClusterManager[RedisCluster | StrictRedis],
         options_manager: OptionsManager,
         cluster_type: type[Any],
     ) -> None:
@@ -205,7 +205,7 @@ class ClusterManager(Generic[TCluster]):
 # completed, remove the rb ``clusters`` module variable and rename
 # redis_clusters to clusters.
 clusters: ClusterManager[rb.Cluster] = ClusterManager(options.default_manager)
-redis_clusters: ClusterManager[RedisCluster] = ClusterManager(
+redis_clusters: ClusterManager[RedisCluster | StrictRedis] = ClusterManager(
     options.default_manager, _RedisCluster
 )
 
@@ -214,7 +214,7 @@ def get_cluster_from_options(
     setting: str,
     options: dict[str, Any],
     cluster_manager: ClusterManager = clusters,
-) -> tuple[rb.Cluster | RedisCluster, dict[str, Any]]:
+) -> tuple[rb.Cluster | RedisCluster | StrictRedis, dict[str, Any]]:
     cluster_option_name = "cluster"
     default_cluster_name = "default"
     cluster_constructor_option_names = frozenset(("hosts",))
@@ -252,13 +252,13 @@ def get_cluster_from_options(
 
 def get_dynamic_cluster_from_options(
     setting: str, config: dict[str, Any]
-) -> tuple[bool, RedisCluster | rb.Cluster, dict[str, Any]]:
+) -> tuple[bool, RedisCluster | StrictRedis | rb.Cluster, dict[str, Any]]:
     cluster_name = config.get("cluster", "default")
     cluster_opts: dict[str, Any] | None = options.default_manager.get("redis.clusters").get(
         cluster_name
     )
     if cluster_opts is not None and cluster_opts.get("is_redis_cluster"):
-        # RedisCluster
+        # RedisCluster, StrictRedis
         return True, redis_clusters.get(cluster_name), config
 
     # RBCluster

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -105,7 +105,9 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
     def add_sample_rate_per_project(org_id: int, project_id: int, sample_rate: float):
         redis_client = get_redis_client_for_ds()
         redis_client.hset(
-            generate_boost_low_volume_projects_cache_key(org_id), project_id, sample_rate
+            name=generate_boost_low_volume_projects_cache_key(org_id),
+            key=str(project_id),
+            value=sample_rate,
         )
 
     @staticmethod
@@ -374,7 +376,7 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
     def set_boost_low_volume_projects_cache_entry(org_id: int, project_id: int, value: str):
         redis = get_redis_client_for_ds()
         cache_key = generate_boost_low_volume_projects_cache_key(org_id=org_id)
-        redis.hset(cache_key, project_id, value)
+        redis.hset(name=cache_key, key=str(project_id), value=value)
 
     def set_boost_low_volume_projects_sample_rate(
         self, org_id: int, project_id: int, sample_rate: float
@@ -643,12 +645,14 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
             val = redis_client.get(cache_key)
 
             if idx == 0:
+                assert val is not None
                 # we sampled at 10% half of what we want so we should adjust by 2
                 assert float(val) == 2.0
             elif idx == 1:
                 # we sampled at 20% we should be spot on (no adjustment)
                 assert val is None
             elif idx == 2:
+                assert val is not None
                 # we sampled at 40% twice as much as we wanted we should adjust by 0.5
                 assert float(val) == 0.5
 
@@ -662,6 +666,7 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
             val = redis_client.get(cache_key)
 
             if idx == 0:
+                assert val is not None
                 # we sampled at 10% when already having a factor of two half of what we want so we
                 # should double the current factor to 4
                 assert float(val) == 4.0
@@ -669,6 +674,7 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
                 # we sampled at 20% we should be spot on (no adjustment)
                 assert val is None
             elif idx == 2:
+                assert val is not None
                 # we sampled at 40% twice as much as we wanted we already have a factor of 0.5
                 # half it again to 0.25
                 assert float(val) == 0.25


### PR DESCRIPTION
Previously we had this assumption that `redis_clusters.get()` will always return `RedisCluster` but in reality it can also return `StrictRedis` instance. This pull request ensures that this case is handled properly.

`ratelimits/sliding_windows.py` has this assertion:

```
assert isinstance(self._client, (StrictRedis, RedisCluster)), self._client
```