### PR TITLE
ref(ui): Swap `React.Key` for our own type in Select components

### DIFF
--- a/static/app/components/compactSelect/composite.tsx
+++ b/static/app/components/compactSelect/composite.tsx
@@ -11,12 +11,12 @@ import {Control} from './control';
 import type {MultipleListProps, SingleListProps} from './list';
 import {List} from './list';
 import {EmptyMessage} from './styles';
-import type {SelectOption} from './types';
+import type {SelectKey, SelectOption} from './types';
 import {getItemsWithKeys} from './utils';
 
-interface BaseCompositeSelectRegion<Value extends React.Key> {
+interface BaseCompositeSelectRegion<Value extends SelectKey> {
   options: SelectOption<Value>[];
-  key?: React.Key;
+  key?: SelectKey;
   label?: React.ReactNode;
 }
 
@@ -26,7 +26,7 @@ interface BaseCompositeSelectRegion<Value extends React.Key> {
  * renders as a `ul` with its own list state) whose selection values don't interfere
  * with one another.
  */
-export interface SingleCompositeSelectRegion<Value extends React.Key>
+export interface SingleCompositeSelectRegion<Value extends SelectKey>
   extends BaseCompositeSelectRegion<Value>,
     Omit<
       SingleListProps<Value>,
@@ -39,7 +39,7 @@ export interface SingleCompositeSelectRegion<Value extends React.Key>
  * list (each renders as a `ul` with its own list state) whose selection values don't
  * interfere with one another.
  */
-export interface MultipleCompositeSelectRegion<Value extends React.Key>
+export interface MultipleCompositeSelectRegion<Value extends SelectKey>
   extends BaseCompositeSelectRegion<Value>,
     Omit<
       MultipleListProps<Value>,
@@ -51,7 +51,7 @@ export interface MultipleCompositeSelectRegion<Value extends React.Key>
  * selectable list (each renders as a `ul` with its own list state) whose selection
  * values don't interfere with one another.
  */
-export type CompositeSelectRegion<Value extends React.Key> =
+export type CompositeSelectRegion<Value extends SelectKey> =
   | SingleCompositeSelectRegion<Value>
   | MultipleCompositeSelectRegion<Value>;
 
@@ -60,7 +60,7 @@ export type CompositeSelectRegion<Value extends React.Key> =
  * allowed inside CompositeSelect is CompositeSelect.Region
  */
 type CompositeSelectChild =
-  | React.ReactElement<CompositeSelectRegion<React.Key>>
+  | React.ReactElement<CompositeSelectRegion<SelectKey>>
   | false
   | null
   | undefined;
@@ -113,7 +113,7 @@ function CompositeSelect({
  * selectable list (each renders as a `ul` with its own list state) whose selection
  * values don't interfere with one another.
  */
-CompositeSelect.Region = function <Value extends React.Key>(
+CompositeSelect.Region = function <Value extends SelectKey>(
   _props: CompositeSelectRegion<Value>
 ) {
   // This pseudo-component not meant to be rendered. It only functions as a props vessel
@@ -124,13 +124,13 @@ CompositeSelect.Region = function <Value extends React.Key>(
 
 export {CompositeSelect};
 
-type RegionProps<Value extends React.Key> = CompositeSelectRegion<Value> & {
+type RegionProps<Value extends SelectKey> = CompositeSelectRegion<Value> & {
   compositeIndex: SingleListProps<Value>['compositeIndex'];
   grid: SingleListProps<Value>['grid'];
   size: SingleListProps<Value>['size'];
 };
 
-function Region<Value extends React.Key>({
+function Region<Value extends SelectKey>({
   options,
   value,
   defaultValue,

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -31,7 +31,7 @@ import useOverlay from 'sentry/utils/useOverlay';
 import usePrevious from 'sentry/utils/usePrevious';
 
 import type {SingleListProps} from './list';
-import type {SelectOption} from './types';
+import type {SelectKey, SelectOption} from './types';
 
 // autoFocus react attribute is sync called on render, this causes
 // layout thrashing and is bad for performance. This thin wrapper function
@@ -63,7 +63,7 @@ export interface SelectContextValue {
    */
   saveSelectedOptions: (
     index: number,
-    newSelectedOptions: SelectOption<React.Key> | SelectOption<React.Key>[]
+    newSelectedOptions: SelectOption<SelectKey> | SelectOption<SelectKey>[]
   ) => void;
   /**
    * Search string to determine whether an option should be rendered in the select list.
@@ -88,7 +88,7 @@ export interface ControlProps
       React.BaseHTMLAttributes<HTMLDivElement>,
       // omit keys from SingleListProps because those will be passed to <List /> instead
       keyof Omit<
-        SingleListProps<React.Key>,
+        SingleListProps<Key>,
         'children' | 'items' | 'grid' | 'compositeIndex' | 'label'
       >
     >,
@@ -402,7 +402,7 @@ export function Control({
    * trigger label.
    */
   const [selectedOptions, setSelectedOptions] = useState<
-    Array<SelectOption<React.Key> | SelectOption<React.Key>[]>
+    Array<SelectOption<SelectKey> | SelectOption<SelectKey>[]>
   >([]);
   const saveSelectedOptions = useCallback<SelectContextValue['saveSelectedOptions']>(
     (index, newSelectedOptions) => {

--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -88,7 +88,7 @@ export interface ControlProps
       React.BaseHTMLAttributes<HTMLDivElement>,
       // omit keys from SingleListProps because those will be passed to <List /> instead
       keyof Omit<
-        SingleListProps<Key>,
+        SingleListProps<SelectKey>,
         'children' | 'items' | 'grid' | 'compositeIndex' | 'label'
       >
     >,

--- a/static/app/components/compactSelect/gridList/index.tsx
+++ b/static/app/components/compactSelect/gridList/index.tsx
@@ -11,7 +11,7 @@ import type {FormSize} from 'sentry/utils/theme';
 import {SelectContext} from '../control';
 import {SelectFilterContext} from '../list';
 import {ListLabel, ListSeparator, ListWrap, SizeLimitMessage} from '../styles';
-import type {SelectSection} from '../types';
+import type {SelectKey, SelectSection} from '../types';
 
 import {GridListOption} from './option';
 import {GridListSection} from './section';
@@ -44,7 +44,7 @@ interface GridListProps
    * and before `onChange`.
    */
   onSectionToggle?: (
-    section: SelectSection<React.Key>,
+    section: SelectSection<SelectKey>,
     type: 'select' | 'unselect'
   ) => void;
   size?: FormSize;

--- a/static/app/components/compactSelect/gridList/section.tsx
+++ b/static/app/components/compactSelect/gridList/section.tsx
@@ -14,7 +14,7 @@ import {
   SectionTitle,
   SectionWrap,
 } from '../styles';
-import type {SelectSection} from '../types';
+import type {SelectKey, SelectSection} from '../types';
 import {SectionToggle} from '../utils';
 
 import {GridListOption} from './option';
@@ -23,7 +23,7 @@ interface GridListSectionProps {
   listState: ListState<any>;
   node: Node<any>;
   size: FormSize;
-  onToggle?: (section: SelectSection<React.Key>, type: 'select' | 'unselect') => void;
+  onToggle?: (section: SelectSection<SelectKey>, type: 'select' | 'unselect') => void;
 }
 
 /**

--- a/static/app/components/compactSelect/index.tsx
+++ b/static/app/components/compactSelect/index.tsx
@@ -10,6 +10,7 @@ import type {MultipleListProps, SingleListProps} from './list';
 import {List} from './list';
 import {EmptyMessage} from './styles';
 import type {
+  SelectKey,
   SelectOption,
   SelectOptionOrSection,
   SelectOptionOrSectionWithKey,
@@ -17,27 +18,27 @@ import type {
 } from './types';
 import {getItemsWithKeys} from './utils';
 
-export type {SelectOption, SelectOptionOrSection, SelectSection};
+export type {SelectOption, SelectOptionOrSection, SelectSection, SelectKey};
 
-interface BaseSelectProps<Value extends React.Key> extends ControlProps {
+interface BaseSelectProps<Value extends SelectKey> extends ControlProps {
   options: SelectOptionOrSection<Value>[];
 }
 
-export interface SingleSelectProps<Value extends React.Key>
+export interface SingleSelectProps<Value extends SelectKey>
   extends BaseSelectProps<Value>,
     Omit<
       SingleListProps<Value>,
       'children' | 'items' | 'grid' | 'compositeIndex' | 'label'
     > {}
 
-export interface MultipleSelectProps<Value extends React.Key>
+export interface MultipleSelectProps<Value extends SelectKey>
   extends BaseSelectProps<Value>,
     Omit<
       MultipleListProps<Value>,
       'children' | 'items' | 'grid' | 'compositeIndex' | 'label'
     > {}
 
-export type SelectProps<Value extends React.Key> =
+export type SelectProps<Value extends SelectKey> =
   | SingleSelectProps<Value>
   | MultipleSelectProps<Value>;
 
@@ -45,12 +46,12 @@ export type SelectProps<Value extends React.Key> =
 // option value types (number vs string), and selection mode (singular vs multiple)
 function CompactSelect<Value extends number>(props: SelectProps<Value>): JSX.Element;
 function CompactSelect<Value extends string>(props: SelectProps<Value>): JSX.Element;
-function CompactSelect<Value extends React.Key>(props: SelectProps<Value>): JSX.Element;
+function CompactSelect<Value extends SelectKey>(props: SelectProps<Value>): JSX.Element;
 
 /**
  * Flexible select component with a customizable trigger button
  */
-function CompactSelect<Value extends React.Key>({
+function CompactSelect<Value extends SelectKey>({
   // List props
   options,
   value,

--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -277,7 +277,7 @@ function List<Value extends SelectKey>({
    * event was intercepted. If yes, then no further callback function should be run.
    */
   const keyDownHandler = useCallback(
-    (e: KeyboardEvent<HTMLUListElement>) => {
+    (e: React.KeyboardEvent<HTMLUListElement>) => {
       // Don't handle ArrowDown/Up key presses if focus already wraps
       if (shouldFocusWrap && !grid) {
         return true;

--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -12,7 +12,12 @@ import type {FormSize} from 'sentry/utils/theme';
 import {SelectContext} from './control';
 import {GridList} from './gridList';
 import {ListBox} from './listBox';
-import type {SelectOption, SelectOptionOrSectionWithKey, SelectSection} from './types';
+import type {
+  SelectKey,
+  SelectOption,
+  SelectOptionOrSectionWithKey,
+  SelectSection,
+} from './types';
 import {
   getDisabledOptions,
   getEscapedKey,
@@ -21,9 +26,9 @@ import {
   HiddenSectionToggle,
 } from './utils';
 
-export const SelectFilterContext = createContext(new Set<React.Key>());
+export const SelectFilterContext = createContext(new Set<SelectKey>());
 
-interface BaseListProps<Value extends React.Key>
+interface BaseListProps<Value extends SelectKey>
   extends ListProps<any>,
     Omit<
       AriaListBoxOptions<any>,
@@ -70,7 +75,7 @@ interface BaseListProps<Value extends React.Key>
    * have `showToggleAllButton` set to true.) Note: this will be called in addition to
    * and before `onChange`.
    */
-  onSectionToggle?: (section: SelectSection<React.Key>) => void;
+  onSectionToggle?: (section: SelectSection<SelectKey>) => void;
   size?: FormSize;
   /**
    * Upper limit for the number of options to display in the menu at a time. Users can
@@ -85,7 +90,7 @@ interface BaseListProps<Value extends React.Key>
   sizeLimitMessage?: string;
 }
 
-export interface SingleListProps<Value extends React.Key> extends BaseListProps<Value> {
+export interface SingleListProps<Value extends SelectKey> extends BaseListProps<Value> {
   /**
    * Whether to close the menu. Accepts either a boolean value or a callback function
    * that receives the newly selected option and returns whether to close the menu.
@@ -97,7 +102,7 @@ export interface SingleListProps<Value extends React.Key> extends BaseListProps<
   value?: Value;
 }
 
-export interface MultipleListProps<Value extends React.Key> extends BaseListProps<Value> {
+export interface MultipleListProps<Value extends SelectKey> extends BaseListProps<Value> {
   multiple: true;
   /**
    * Whether to close the menu. Accepts either a boolean value or a callback function
@@ -116,7 +121,7 @@ export interface MultipleListProps<Value extends React.Key> extends BaseListProp
  * In composite selectors, there may be multiple self-contained lists, each
  * representing a select "region".
  */
-function List<Value extends React.Key>({
+function List<Value extends SelectKey>({
   items,
   value,
   defaultValue,
@@ -272,7 +277,7 @@ function List<Value extends React.Key>({
    * event was intercepted. If yes, then no further callback function should be run.
    */
   const keyDownHandler = useCallback(
-    (e: React.KeyboardEvent<HTMLUListElement>) => {
+    (e: KeyboardEvent<HTMLUListElement>) => {
       // Don't handle ArrowDown/Up key presses if focus already wraps
       if (shouldFocusWrap && !grid) {
         return true;

--- a/static/app/components/compactSelect/listBox/index.tsx
+++ b/static/app/components/compactSelect/listBox/index.tsx
@@ -10,7 +10,7 @@ import type {FormSize} from 'sentry/utils/theme';
 import {SelectContext} from '../control';
 import {SelectFilterContext} from '../list';
 import {ListLabel, ListSeparator, ListWrap, SizeLimitMessage} from '../styles';
-import type {SelectSection} from '../types';
+import type {SelectKey, SelectSection} from '../types';
 
 import {ListBoxOption} from './option';
 import {ListBoxSection} from './section';
@@ -52,7 +52,7 @@ interface ListBoxProps
    * and before `onChange`.
    */
   onSectionToggle?: (
-    section: SelectSection<React.Key>,
+    section: SelectSection<SelectKey>,
     type: 'select' | 'unselect'
   ) => void;
   size?: FormSize;

--- a/static/app/components/compactSelect/listBox/section.tsx
+++ b/static/app/components/compactSelect/listBox/section.tsx
@@ -15,7 +15,7 @@ import {
   SectionTitle,
   SectionWrap,
 } from '../styles';
-import type {SelectSection} from '../types';
+import type {SelectKey, SelectSection} from '../types';
 import {SectionToggle} from '../utils';
 
 import {ListBoxOption} from './option';
@@ -24,7 +24,7 @@ interface ListBoxSectionProps extends AriaListBoxSectionProps {
   item: Node<any>;
   listState: ListState<any>;
   size: FormSize;
-  onToggle?: (section: SelectSection<React.Key>, type: 'select' | 'unselect') => void;
+  onToggle?: (section: SelectSection<SelectKey>, type: 'select' | 'unselect') => void;
 }
 
 /**

--- a/static/app/components/compactSelect/types.tsx
+++ b/static/app/components/compactSelect/types.tsx
@@ -1,6 +1,8 @@
 import type {SelectValue} from 'sentry/types';
 
-export interface SelectOption<Value extends React.Key> extends SelectValue<Value> {
+export type SelectKey = string | number;
+
+export interface SelectOption<Value extends SelectKey> extends SelectValue<Value> {
   /**
    * Whether to hide the checkbox/checkmark. Available for backward compatibility only.
    * If true, an alternative selection state indicator must be present.
@@ -10,7 +12,7 @@ export interface SelectOption<Value extends React.Key> extends SelectValue<Value
   hideCheck?: boolean;
 }
 
-export interface SelectSection<Value extends React.Key> {
+export interface SelectSection<Value extends SelectKey> {
   options: SelectOption<Value>[];
   /**
    * When true, all options inside this section will be disabled.
@@ -20,7 +22,7 @@ export interface SelectSection<Value extends React.Key> {
    * Optional key to identify this section. If not specified, the section's index will
    * be used.
    */
-  key?: React.Key;
+  key?: SelectKey;
   /**
    * Title to display in the section header.
    */
@@ -32,26 +34,26 @@ export interface SelectSection<Value extends React.Key> {
   showToggleAllButton?: boolean;
 }
 
-export type SelectOptionOrSection<Value extends React.Key> =
+export type SelectOptionOrSection<Value extends SelectKey> =
   | SelectOption<Value>
   | SelectSection<Value>;
 
-export interface SelectOptionWithKey<Value extends React.Key>
+export interface SelectOptionWithKey<Value extends SelectKey>
   extends SelectOption<Value> {
   /**
    * Key to identify this section. If not specified, the section's index will
    * be used.
    */
-  key: React.Key;
+  key: SelectKey;
 }
 
-export interface SelectSectionWithKey<Value extends React.Key>
+export interface SelectSectionWithKey<Value extends SelectKey>
   extends SelectSection<Value> {
   /**
    * Key to identify this section. If not specified, the section's index will
    * be used.
    */
-  key: React.Key;
+  key: SelectKey;
   options: SelectOptionWithKey<Value>[];
 }
 
@@ -59,6 +61,6 @@ export interface SelectSectionWithKey<Value extends React.Key>
  * Select option/section type used for internal selection manager. DO NOT import in
  * other components. Import `SelectOptionOrSection` instead.
  */
-export type SelectOptionOrSectionWithKey<Value extends React.Key> =
+export type SelectOptionOrSectionWithKey<Value extends SelectKey> =
   | SelectOptionWithKey<Value>
   | SelectSectionWithKey<Value>;

--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -10,6 +10,7 @@ import {t} from 'sentry/locale';
 
 import {SectionToggleButton} from './styles';
 import type {
+  SelectKey,
   SelectOption,
   SelectOptionOrSection,
   SelectOptionOrSectionWithKey,
@@ -17,17 +18,17 @@ import type {
   SelectSection,
 } from './types';
 
-export function getEscapedKey<Value extends React.Key | undefined>(value: Value): string {
+export function getEscapedKey<Value extends SelectKey | undefined>(value: Value): string {
   return CSS.escape(String(value));
 }
 
-export function getItemsWithKeys<Value extends React.Key>(
+export function getItemsWithKeys<Value extends SelectKey>(
   options: SelectOption<Value>[]
 ): SelectOptionWithKey<Value>[];
-export function getItemsWithKeys<Value extends React.Key>(
+export function getItemsWithKeys<Value extends SelectKey>(
   options: SelectOptionOrSection<Value>[]
 ): SelectOptionOrSectionWithKey<Value>[];
-export function getItemsWithKeys<Value extends React.Key>(
+export function getItemsWithKeys<Value extends SelectKey>(
   options: SelectOptionOrSection<Value>[]
 ): SelectOptionOrSectionWithKey<Value>[] {
   return options.map((item, i) => {
@@ -47,7 +48,7 @@ export function getItemsWithKeys<Value extends React.Key>(
  * Recursively finds the selected option(s) from an options array. Useful for
  * non-flat arrays that contain sections (groups of options).
  */
-export function getSelectedOptions<Value extends React.Key>(
+export function getSelectedOptions<Value extends SelectKey>(
   items: SelectOptionOrSectionWithKey<Value>[],
   selection: Selection
 ): SelectOption<Value>[] {
@@ -71,7 +72,7 @@ export function getSelectedOptions<Value extends React.Key>(
  * arrays that contain sections (groups of options). Returns the values of options that
  * were removed.
  */
-export function getDisabledOptions<Value extends React.Key>(
+export function getDisabledOptions<Value extends SelectKey>(
   items: SelectOptionOrSection<Value>[],
   isOptionDisabled?: (opt: SelectOption<Value>) => boolean
 ): Value[] {
@@ -97,7 +98,7 @@ export function getDisabledOptions<Value extends React.Key>(
  * Recursively finds the option(s) that don't match the designated search string or are
  * outside the list box's count limit.
  */
-export function getHiddenOptions<Value extends React.Key>(
+export function getHiddenOptions<Value extends Key>(
   items: SelectOptionOrSection<Value>[],
   search: string,
   limit: number = Infinity
@@ -178,7 +179,7 @@ export function getHiddenOptions<Value extends React.Key>(
  * selected, then this function selects all of them. If all of the options are selected,
  * then this function unselects all of them.
  */
-export function toggleOptions<Value extends React.Key>(
+export function toggleOptions<Value extends SelectKey>(
   optionKeys: Value[],
   selectionManager: SelectionManager
 ) {
@@ -198,7 +199,7 @@ interface SectionToggleProps {
   item: Node<any>;
   listState: ListState<any>;
   listId?: string;
-  onToggle?: (section: SelectSection<React.Key>, type: 'select' | 'unselect') => void;
+  onToggle?: (section: SelectSection<SelectKey>, type: 'select' | 'unselect') => void;
 }
 
 /**

--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -98,7 +98,7 @@ export function getDisabledOptions<Value extends SelectKey>(
  * Recursively finds the option(s) that don't match the designated search string or are
  * outside the list box's count limit.
  */
-export function getHiddenOptions<Value extends Key>(
+export function getHiddenOptions<Value extends SelectKey>(
   items: SelectOptionOrSection<Value>[],
   search: string,
   limit: number = Infinity

--- a/static/app/components/organizations/hybridFilter.tsx
+++ b/static/app/components/organizations/hybridFilter.tsx
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/button';
 import Checkbox from 'sentry/components/checkbox';
 import type {
   MultipleSelectProps,
+  SelectKey,
   SelectOption,
   SelectOptionOrSection,
   SelectSection,
@@ -18,7 +19,7 @@ import {space} from 'sentry/styles/space';
 import {isModifierKeyPressed} from 'sentry/utils/isModifierKeyPressed';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 
-export interface HybridFilterProps<Value extends React.Key>
+export interface HybridFilterProps<Value extends SelectKey>
   extends Omit<
     MultipleSelectProps<Value>,
     | 'grid'
@@ -76,7 +77,7 @@ export interface HybridFilterProps<Value extends React.Key>
  * Note: this component is controlled only — changes must be handled via the `onChange`
  * callback.
  */
-export function HybridFilter<Value extends React.Key>({
+export function HybridFilter<Value extends SelectKey>({
   options,
   multiple,
   value,
@@ -290,7 +291,7 @@ export function HybridFilter<Value extends React.Key>({
 
   const sectionToggleWasPressed = useRef(false);
   const handleSectionToggle = useCallback(
-    (section: SelectSection<React.Key>) => {
+    (section: SelectSection<SelectKey>) => {
       onSectionToggle?.(section);
       sectionToggleWasPressed.current = true;
     },

--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -59,7 +59,7 @@ export const TabsContext = createContext<TabContext>({
  * child components (TabList and TabPanels) to work together. See example
  * usage in tabs.stories.js
  */
-export function Tabs<T extends React.Key>({
+export function Tabs<T extends string | number>({
   orientation = 'horizontal',
   className,
   children,

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -157,7 +157,7 @@ function BaseTabList({
       (a, b) => sortedKeys.indexOf(a) - sortedKeys.indexOf(b)
     );
 
-    return sortedOverflowTabs.flatMap<SelectOption<React.Key>>(key => {
+    return sortedOverflowTabs.flatMap<SelectOption<string | number>>(key => {
       const item = state.collection.getItem(key);
 
       if (!item) {


### PR DESCRIPTION
In react 18 `React.Key` becomes `string | number | bigint` and that breaks use with objects and sets since they don't want bigint.

Adds our own type for this instead.

part of https://github.com/getsentry/frontend-tsc/issues/22