### PR TITLE
ref(trace): render multiple autogrouped bars

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -167,7 +167,14 @@ function TraceViewContent(props: TraceViewContentProps) {
     }
 
     return TraceTree.Empty();
-  }, [props.traceSlug, props.trace, props.status, projects, rootEvent]);
+  }, [
+    props.traceSlug,
+    props.trace,
+    props.status,
+    projects,
+    rootEvent.data,
+    rootEvent.status,
+  ]);
 
   const traceType = useMemo(() => {
     if (props.status !== 'resolved' || !tree) {

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1164,17 +1164,17 @@ interface AutogroupedTraceBarProps {
 }
 
 function AutogroupedTraceBar(props: AutogroupedTraceBarProps) {
-  if (props.node_space && props.node_space.length <= 1) {
-    return (
-      <TraceBar
-        color={props.color}
-        node_space={props.node_space[0]}
-        viewManager={props.viewManager}
-        virtualizedIndex={props.virtualizedIndex}
-        duration={props.duration}
-      />
-    );
-  }
+  // if (props.node_space && props.node_space.length <= 1) {
+  //   return (
+  //     <TraceBar
+  //       color={props.color}
+  //       node_space={props.node_space[0]}
+  //       viewManager={props.viewManager}
+  //       virtualizedIndex={props.virtualizedIndex}
+  //       duration={props.duration}
+  //     />
+  //   );
+  // }
 
   if (!props.node_space) {
     return null;
@@ -1198,7 +1198,7 @@ function AutogroupedTraceBar(props: AutogroupedTraceBarProps) {
         ref={r =>
           props.viewManager.registerSpanBarRef(r, entire_space, props.virtualizedIndex)
         }
-        className="TraceBar"
+        className="TraceBar Invisible"
         style={{
           transform: `matrix(${spanTransform.join(',')})`,
           backgroundColor: props.color,
@@ -1424,6 +1424,14 @@ const TraceStylingWrapper = styled('div')`
     width: 100%;
     background-color: black;
     transform-origin: left center;
+
+    &.Invisible {
+      background-color: transparent !important;
+
+      > div {
+        height: 100%;
+      }
+    }
   }
 
   .TraceBarDuration {


### PR DESCRIPTION
The previous implementation wasnt compatible with zooming behavior. The new one now renders multiple bars by precomputing the collapsed segments and placing the inside an invisible bar. This way we get zooming on N bars at the cost of 1 single bar (as the durations and offsets of autogrouped nodes are static compared to the autogrouped node itself)

I also noticed the space initialization wasnt properly considering the start by doing a min(start_timestamp) and end by max(timestamp) for the autogrouped member nodes