### PR TITLE
fix(app-start): Default the start type to cold

### DIFF
--- a/static/app/views/starfish/modules/mobile/appStartup.tsx
+++ b/static/app/views/starfish/modules/mobile/appStartup.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect} from 'react';
+import {useCallback} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
@@ -16,40 +16,20 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
-import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
 import Onboarding from 'sentry/views/performance/onboarding';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import AppStartup from 'sentry/views/starfish/views/appStartup';
-import {
-  COLD_START_TYPE,
-  StartTypeSelector,
-} from 'sentry/views/starfish/views/appStartup/screenSummary/startTypeSelector';
+import {StartTypeSelector} from 'sentry/views/starfish/views/appStartup/screenSummary/startTypeSelector';
 
 export default function InitializationModule() {
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
   const location = useLocation();
-
-  const appStartType =
-    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
-  useEffect(() => {
-    // Default the start type to cold start if not present
-    if (!appStartType) {
-      browserHistory.replace({
-        ...location,
-        query: {
-          ...location.query,
-          [SpanMetricsField.APP_START_TYPE]: COLD_START_TYPE,
-        },
-      });
-    }
-  }, [location, appStartType]);
 
   const handleProjectChange = useCallback(() => {
     browserHistory.replace({

--- a/static/app/views/starfish/views/appStartup/averageComparisonChart.tsx
+++ b/static/app/views/starfish/views/appStartup/averageComparisonChart.tsx
@@ -61,7 +61,7 @@ export function AverageComparisonChart({chartHeight}: Props) {
   const {selection} = usePageFilters();
 
   const appStartType =
-    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
 
   const query = new MutableSearch([
     'event.type:transaction',

--- a/static/app/views/starfish/views/appStartup/countChart.tsx
+++ b/static/app/views/starfish/views/appStartup/countChart.tsx
@@ -25,6 +25,7 @@ import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/cons
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {useEventsStatsQuery} from 'sentry/views/starfish/utils/useEventsStatsQuery';
 import {MAX_CHART_RELEASE_CHARS} from 'sentry/views/starfish/views/appStartup';
+import {COLD_START_TYPE} from 'sentry/views/starfish/views/appStartup/screenSummary/startTypeSelector';
 import {OUTPUT_TYPE, YAxis} from 'sentry/views/starfish/views/screens';
 
 function transformData(data?: MultiSeriesEventsStats, primaryRelease?: string) {
@@ -69,7 +70,7 @@ export function CountChart({chartHeight}: Props) {
   } = useReleaseSelection();
 
   const appStartType =
-    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
 
   const query = new MutableSearch([`span.op:app.start.${appStartType}`]);
   const queryString = `${appendReleaseFilters(

--- a/static/app/views/starfish/views/appStartup/index.tsx
+++ b/static/app/views/starfish/views/appStartup/index.tsx
@@ -61,7 +61,7 @@ function AppStartup({additionalFilters, chartHeight}: Props) {
   const router = useRouter();
 
   const appStartType =
-    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
 
   const query = new MutableSearch([
     'event.type:transaction',

--- a/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
@@ -56,7 +56,8 @@ function DeviceClassBreakdownBarChart({
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
 
-  const startType = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+  const startType =
+    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
   const yAxis =
     YAXIS_COLUMNS[startType === COLD_START_TYPE ? YAxis.COLD_START : YAxis.WARM_START];
   const query = new MutableSearch([...(additionalFilters ?? [])]);

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -46,7 +46,8 @@ export function EventSamples({
   const cursor = decodeScalar(location.query?.[cursorName]);
 
   const deviceClass = decodeScalar(location.query[SpanMetricsField.DEVICE_CLASS]) ?? '';
-  const startType = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+  const startType =
+    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
 
   const searchQuery = new MutableSearch([
     `transaction:${transaction}`,

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -61,7 +61,8 @@ export function SpanOperationTable({
   const cursor = decodeScalar(location.query?.[MobileCursors.SPANS_TABLE]);
 
   const spanOp = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
-  const startType = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+  const startType =
+    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
   const deviceClass = decodeScalar(location.query[SpanMetricsField.DEVICE_CLASS]) ?? '';
 
   const searchQuery = new MutableSearch([

--- a/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
@@ -69,7 +69,8 @@ function StartDurationWidget({additionalFilters, chartHeight}: Props) {
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
 
-  const startType = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+  const startType =
+    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
 
   const query = new MutableSearch([
     ...(startType === COLD_START_TYPE ? COLD_START_CONDITIONS : WARM_START_CONDITIONS),

--- a/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startTypeSelector.tsx
@@ -13,7 +13,8 @@ export const WARM_START_TYPE = 'warm';
 export function StartTypeSelector() {
   const location = useLocation();
 
-  const value = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+  const value =
+    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
 
   const options = [
     {value: COLD_START_TYPE, label: t('Cold Start')},

--- a/static/app/views/starfish/views/appStartup/screensTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screensTable.tsx
@@ -26,6 +26,7 @@ import {
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import Breakdown from 'sentry/views/starfish/views/appStartup/breakdown';
+import {COLD_START_TYPE} from 'sentry/views/starfish/views/appStartup/screenSummary/startTypeSelector';
 import {TOP_SCREENS} from 'sentry/views/starfish/views/screens';
 
 type Props = {
@@ -40,7 +41,8 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
   const organization = useOrganization();
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
 
-  const startType = decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? '';
+  const startType =
+    decodeScalar(location.query[SpanMetricsField.APP_START_TYPE]) ?? COLD_START_TYPE;
 
   const columnNameMap = {
     transaction: t('Screen'),


### PR DESCRIPTION
Removes a `useEffect` that was wiping the `statsPeriod` query param and resetting the time range.

I realize this was a lot of in-place changes. I think this can be replaced with a hook that but I wanted to fix the redirect issue first.