### PR TITLE
ref(ui): Swap React.Key for our own type in Tab components

### DIFF
--- a/static/app/components/tabs/item.tsx
+++ b/static/app/components/tabs/item.tsx
@@ -3,7 +3,7 @@ import type {ItemProps} from '@react-types/shared';
 import type {LocationDescriptor} from 'history';
 
 export interface TabListItemProps extends ItemProps<any> {
-  key: React.Key;
+  key: string | number;
   disabled?: boolean;
   hidden?: boolean;
   to?: LocationDescriptor;

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -32,10 +32,10 @@ function useOverflowTabs({
   tabItems,
 }: {
   tabItems: TabListItemProps[];
-  tabItemsRef: React.RefObject<Record<React.Key, HTMLLIElement | null>>;
+  tabItemsRef: React.RefObject<Record<string | number, HTMLLIElement | null>>;
   tabListRef: React.RefObject<HTMLUListElement>;
 }) {
-  const [overflowTabs, setOverflowTabs] = useState<React.Key[]>([]);
+  const [overflowTabs, setOverflowTabs] = useState<Array<string | number>>([]);
 
   useEffect(() => {
     const options = {
@@ -143,7 +143,7 @@ function BaseTabList({
   }, [state.disabledKeys, state.selectedItem, state.selectedKey, props.children]);
 
   // Detect tabs that overflow from the wrapper and put them in an overflow menu
-  const tabItemsRef = useRef<Record<React.Key, HTMLLIElement | null>>({});
+  const tabItemsRef = useRef<Record<string | number, HTMLLIElement | null>>({});
   const overflowTabs = useOverflowTabs({
     tabListRef,
     tabItemsRef,


### PR DESCRIPTION
follow up to https://github.com/getsentry/sentry/pull/66149 with a few places that were missed
