### PR TITLE
feat(metrics): Render samples as scatter plot

### DIFF
--- a/static/app/utils/metrics/useMetricsSamples.tsx
+++ b/static/app/utils/metrics/useMetricsSamples.tsx
@@ -11,6 +11,7 @@ type FieldTypes = {
   id: string;
   profile_id: string | undefined;
   project: string;
+  'project.id': number;
   'span.description': string;
   'span.duration': number;
   'span.op': string;
@@ -91,4 +92,20 @@ export function useMetricsSamples<F extends Field>({
     retry: false,
     enabled,
   });
+}
+
+export function getSummaryValueForOp(summary: Summary, op?: string) {
+  switch (op) {
+    case 'count':
+      return summary.count;
+    case 'min':
+      return summary.min;
+    case 'max':
+      return summary.max;
+    case 'sum':
+      return summary.sum;
+    case 'avg':
+    default:
+      return summary.sum / summary.count;
+  }
 }

--- a/static/app/views/ddm/chart/useMetricChartSamples.tsx
+++ b/static/app/views/ddm/chart/useMetricChartSamples.tsx
@@ -1,18 +1,24 @@
 import type {RefObject} from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
-import type {XAXisOption} from 'echarts/types/dist/shared';
+import type {XAXisOption, YAXisOption} from 'echarts/types/dist/shared';
 import moment from 'moment';
 
 import {getFormatter} from 'sentry/components/charts/components/tooltip';
 import {isChartHovered} from 'sentry/components/charts/utils';
+import type {Field} from 'sentry/components/ddm/metricSamplesTable';
 import {t} from 'sentry/locale';
 import type {EChartClickHandler, ReactEchartsRef, Series} from 'sentry/types/echarts';
+import {defined} from 'sentry/utils';
 import mergeRefs from 'sentry/utils/mergeRefs';
 import {isCumulativeOp} from 'sentry/utils/metrics';
 import {formatMetricsUsingUnitAndOp} from 'sentry/utils/metrics/formatters';
 import {getMetricValueNormalizer} from 'sentry/utils/metrics/normalizeMetricValue';
 import type {MetricCorrelation, MetricSummary} from 'sentry/utils/metrics/types';
+import {
+  getSummaryValueForOp,
+  type MetricsSamplesResults,
+} from 'sentry/utils/metrics/useMetricsSamples';
 import {fitToValueRect, getValueRect} from 'sentry/views/ddm/chart/chartUtils';
 import type {CombinedMetricChartProps} from 'sentry/views/ddm/chart/types';
 import type {Sample} from 'sentry/views/ddm/widget';
@@ -94,7 +100,7 @@ export function useMetricChartSamples({
     };
   }, [valueRect.xMin, valueRect.xMax, timeseries]);
 
-  const yAxis = useMemo(() => {
+  const yAxis: YAXisOption = useMemo(() => {
     return {
       id: 'yAxisScatter',
       scale: false,
@@ -256,6 +262,207 @@ export function useMetricChartSamples({
     }),
     [applyChartProps]
   );
+}
+
+interface UseMetricChartSamplesV2Options {
+  timeseries: Series[];
+  onSampleClick?: (sample: MetricsSamplesResults<Field>['data'][number]) => void;
+  operation?: string;
+  samples?: MetricsSamplesResults<Field>['data'];
+  unit?: string;
+}
+
+export function useMetricChartSamplesV2({
+  timeseries,
+  onSampleClick,
+  operation,
+  samples,
+  unit = '',
+}: UseMetricChartSamplesV2Options) {
+  const theme = useTheme();
+  const chartRef = useRef<ReactEchartsRef>(null);
+
+  const [valueRect, setValueRect] = useState(getValueRect(chartRef));
+
+  const samplesById = useMemo(() => {
+    return (samples ?? []).reduce((acc, sample) => {
+      acc[sample.id] = sample;
+      return acc;
+    }, {});
+  }, [samples]);
+
+  useEffect(() => {
+    // Changes in timeseries change the valueRect since the timeseries yAxis auto scales
+    // and scatter yAxis needs to match the scale
+    setValueRect(getValueRect(chartRef));
+  }, [chartRef, timeseries]);
+
+  const xAxis: XAXisOption = useMemo(() => {
+    const {min, max} = getDateRange(timeseries);
+
+    return {
+      id: 'xAxisScatter',
+      scale: false,
+      show: false,
+      axisLabel: {
+        formatter: () => {
+          return '';
+        },
+      },
+      axisPointer: {
+        type: 'none',
+      },
+      min: Math.max(valueRect.xMin, min),
+      max: Math.min(valueRect.xMax, max),
+    };
+  }, [valueRect.xMin, valueRect.xMax, timeseries]);
+
+  const yAxis: YAXisOption = useMemo(() => {
+    return {
+      id: 'yAxisScatter',
+      scale: false,
+      show: false,
+      axisLabel: {
+        formatter: () => {
+          return '';
+        },
+      },
+
+      min: valueRect.yMin,
+      max: valueRect.yMax,
+    };
+  }, [valueRect.yMin, valueRect.yMax]);
+
+  const series = useMemo(() => {
+    if (operation === 'sum' || operation === 'count_unique') {
+      // TODO: for now we do not show samples for cumulative operations
+      // figure out how should this be shown
+      return [];
+    }
+
+    const normalizeMetric = getMetricValueNormalizer(unit);
+
+    return (samples ?? []).map(sample => {
+      const isHighlighted = false;
+
+      const xValue = moment(sample.timestamp).valueOf();
+      const value = getSummaryValueForOp(sample.summary, operation);
+      const yValue = normalizeMetric(value) ?? 0;
+
+      const [xPosition, yPosition] = fitToValueRect(xValue, yValue, valueRect);
+
+      return {
+        seriesName: sample.id,
+        id: sample.id,
+        operation: '',
+        unit: '',
+        symbolSize: isHighlighted ? 20 : 10,
+        animation: false,
+        symbol: yPosition === yValue ? 'circle' : 'arrow',
+        symbolRotate: yPosition > yValue ? 180 : 0,
+        color: theme.purple400,
+        itemStyle: {
+          color: theme.purple400,
+          opacity: 1,
+        },
+        yAxisIndex: 1,
+        xAxisIndex: 1,
+        xValue,
+        yValue,
+        tooltip: {
+          axisPointer: {
+            type: 'none',
+          },
+        },
+        data: [
+          {
+            name: xPosition,
+            value: yPosition,
+          },
+        ],
+        z: 10,
+      };
+    });
+  }, [operation, samples, theme, unit, valueRect]);
+
+  const formatterOptions = useMemo(() => {
+    return {
+      isGroupedByDate: true,
+      limit: 1,
+      showTimeInTooltip: true,
+      addSecondsToTimeFormat: true,
+      nameFormatter: (name: string) => {
+        return t('Span %s', name.substring(0, 8));
+      },
+      valueFormatter: (_, label?: string) => {
+        // We need to access the sample as the charts datapoints are fit to the charts viewport
+        const sample = samplesById[label ?? ''];
+        const yValue = getSummaryValueForOp(sample.summary, operation);
+        return formatMetricsUsingUnitAndOp(yValue, unit, operation);
+      },
+    };
+  }, [operation, samplesById, unit]);
+
+  const handleClick = useCallback<EChartClickHandler>(
+    (event: EChartMouseEventParam) => {
+      const sample = samplesById[event.seriesId];
+      if (defined(onSampleClick) && defined(sample)) {
+        onSampleClick(sample);
+      }
+    },
+    [onSampleClick, samplesById]
+  );
+
+  const applyChartProps = useCallback(
+    (baseProps: CombinedMetricChartProps): CombinedMetricChartProps => {
+      return {
+        ...baseProps,
+        forwardedRef: mergeRefs([baseProps.forwardedRef, chartRef]),
+        scatterSeries: series,
+        xAxes: [...(Array.isArray(baseProps.xAxes) ? baseProps.xAxes : []), xAxis],
+        yAxes: [...(Array.isArray(baseProps.yAxes) ? baseProps.yAxes : []), yAxis],
+        onClick: (...args) => {
+          handleClick(...args);
+          baseProps.onClick?.(...args);
+        },
+        tooltip: {
+          formatter: (params: any, asyncTicket) => {
+            // Only show the tooltip if the current chart is hovered
+            // as chart groups trigger the tooltip for all charts in the group when one is hoverered
+            if (!isChartHovered(chartRef?.current)) {
+              return '';
+            }
+
+            // Hovering a single correlated sample datapoint
+            if (params.seriesType === 'scatter') {
+              return getFormatter(formatterOptions)(params, asyncTicket);
+            }
+
+            const baseFormatter = baseProps.tooltip?.formatter;
+            if (typeof baseFormatter === 'string') {
+              return baseFormatter;
+            }
+
+            if (!baseFormatter) {
+              throw new Error(
+                'You need to define a tooltip formatter for the chart when using metric samples'
+              );
+            }
+
+            return baseFormatter(params, asyncTicket);
+          },
+        },
+      };
+    },
+    [formatterOptions, handleClick, series, xAxis, yAxis]
+  );
+
+  return useMemo(() => {
+    if (!defined(samples)) {
+      return undefined;
+    }
+    return {applyChartProps};
+  }, [applyChartProps, samples]);
 }
 
 export type UseMetricSamplesResult = ReturnType<typeof useMetricChartSamples>;

--- a/static/app/views/ddm/chart/useMetricChartSamples.tsx
+++ b/static/app/views/ddm/chart/useMetricChartSamples.tsx
@@ -266,6 +266,7 @@ export function useMetricChartSamples({
 
 interface UseMetricChartSamplesV2Options {
   timeseries: Series[];
+  highlightedSampleId?: string;
   onSampleClick?: (sample: MetricsSamplesResults<Field>['data'][number]) => void;
   operation?: string;
   samples?: MetricsSamplesResults<Field>['data'];
@@ -274,6 +275,7 @@ interface UseMetricChartSamplesV2Options {
 
 export function useMetricChartSamplesV2({
   timeseries,
+  highlightedSampleId,
   onSampleClick,
   operation,
   samples,
@@ -343,7 +345,7 @@ export function useMetricChartSamplesV2({
     const normalizeMetric = getMetricValueNormalizer(unit);
 
     return (samples ?? []).map(sample => {
-      const isHighlighted = false;
+      const isHighlighted = highlightedSampleId === sample.id;
 
       const xValue = moment(sample.timestamp).valueOf();
       const value = getSummaryValueForOp(sample.summary, operation);
@@ -383,7 +385,7 @@ export function useMetricChartSamplesV2({
         z: 10,
       };
     });
-  }, [operation, samples, theme, unit, valueRect]);
+  }, [highlightedSampleId, operation, samples, theme, unit, valueRect]);
 
   const formatterOptions = useMemo(() => {
     return {

--- a/static/app/views/ddm/context.tsx
+++ b/static/app/views/ddm/context.tsx
@@ -9,6 +9,7 @@ import {
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 
+import type {Field} from 'sentry/components/ddm/metricSamplesTable';
 import {useInstantRef, useUpdateQuery} from 'sentry/utils/metrics';
 import {
   emptyMetricsFormulaWidget,
@@ -16,6 +17,7 @@ import {
   NO_QUERY_ID,
 } from 'sentry/utils/metrics/constants';
 import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
+import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import {decodeInteger, decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
@@ -45,6 +47,9 @@ interface DDMContextValue {
   setDefaultQuery: (query: Record<string, any> | null) => void;
   setHighlightedSampleId: (sample?: string) => void;
   setIsMultiChartMode: (value: boolean) => void;
+  setMetricsSamples: React.Dispatch<
+    React.SetStateAction<MetricsSamplesResults<Field>['data'] | undefined>
+  >;
   setSelectedWidgetIndex: (index: number) => void;
   showQuerySymbols: boolean;
   updateWidget: (
@@ -53,6 +58,7 @@ interface DDMContextValue {
   ) => void;
   widgets: MetricWidgetQueryParams[];
   highlightedSampleId?: string;
+  metricsSamples?: MetricsSamplesResults<Field>['data'];
 }
 
 export const DDMContext = createContext<DDMContextValue>({
@@ -63,11 +69,13 @@ export const DDMContext = createContext<DDMContextValue>({
   highlightedSampleId: undefined,
   isDefaultQuery: false,
   isMultiChartMode: false,
+  metricsSamples: [],
   removeWidget: () => {},
   selectedWidgetIndex: 0,
   setDefaultQuery: () => {},
   setHighlightedSampleId: () => {},
   setIsMultiChartMode: () => {},
+  setMetricsSamples: () => {},
   setSelectedWidgetIndex: () => {},
   showQuerySymbols: false,
   updateWidget: () => {},
@@ -233,6 +241,10 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
   const {widgets, updateWidget, addWidget, removeWidget, duplicateWidget} =
     useMetricWidgets();
 
+  const [metricsSamples, setMetricsSamples] = useState<
+    MetricsSamplesResults<Field>['data'] | undefined
+  >();
+
   const [highlightedSampleId, setHighlightedSampleId] = useState<string | undefined>();
 
   const selectedProjects = useSelectedProjects();
@@ -346,6 +358,8 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
       setHighlightedSampleId,
       isMultiChartMode: isMultiChartMode,
       setIsMultiChartMode: handleSetIsMultiChartMode,
+      metricsSamples,
+      setMetricsSamples,
     }),
     [
       handleAddWidget,
@@ -362,6 +376,7 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
       highlightedSampleId,
       isMultiChartMode,
       handleSetIsMultiChartMode,
+      metricsSamples,
     ]
   );
 

--- a/static/app/views/ddm/scratchpad.tsx
+++ b/static/app/views/ddm/scratchpad.tsx
@@ -2,10 +2,12 @@ import {useCallback, useLayoutEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import * as echarts from 'echarts/core';
 
+import type {Field} from 'sentry/components/ddm/metricSamplesTable';
 import {space} from 'sentry/styles/space';
 import {getMetricsCorrelationSpanUrl, unescapeMetricsFormula} from 'sentry/utils/metrics';
 import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
 import type {MetricsQueryApiQueryParams} from 'sentry/utils/metrics/useMetricsQuery';
+import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -54,6 +56,7 @@ export function MetricScratchpad() {
     highlightedSampleId,
     focusArea,
     isMultiChartMode,
+    metricsSamples,
   } = useDDMContext();
   const {selection} = usePageFilters();
 
@@ -88,6 +91,21 @@ export function MetricScratchpad() {
       );
     },
     [projects, router, organization]
+  );
+
+  const handleSampleClickV2 = useCallback(
+    (sample: MetricsSamplesResults<Field>['data'][number]) => {
+      router.push(
+        getMetricsCorrelationSpanUrl(
+          organization,
+          sample.project,
+          sample.id,
+          sample['transaction.id'],
+          sample['segment.id']
+        )
+      );
+    },
+    [router, organization]
   );
 
   const firstWidget = widgets[0];
@@ -177,10 +195,12 @@ export function MetricScratchpad() {
                 focusAreaProps={focusArea}
                 showQuerySymbols={showQuerySymbols}
                 onSampleClick={handleSampleClick}
+                onSampleClickV2={handleSampleClickV2}
                 chartHeight={200}
                 highlightedSampleId={
                   selectedWidgetIndex === index ? highlightedSampleId : undefined
                 }
+                metricsSamples={metricsSamples}
                 context="ddm"
               />
             )}
@@ -202,8 +222,10 @@ export function MetricScratchpad() {
           focusAreaProps={focusArea}
           showQuerySymbols={false}
           onSampleClick={handleSampleClick}
+          onSampleClickV2={handleSampleClickV2}
           chartHeight={200}
           highlightedSampleId={highlightedSampleId}
+          metricsSamples={metricsSamples}
           context="ddm"
         />
       )}

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -366,6 +366,7 @@ const MetricWidgetBody = memo(
 
     const samplesV2Prop = useMetricChartSamplesV2({
       samples: samplesV2?.data,
+      highlightedSampleId: samples?.higlightedId,
       operation: samplesV2?.operation,
       onSampleClick: samplesV2?.onSampleClick,
       timeseries: chartSeries,

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -10,6 +10,7 @@ import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingM
 import type {DateTimeObject} from 'sentry/components/charts/utils';
 import type {SelectOption} from 'sentry/components/compactSelect';
 import {CompactSelect} from 'sentry/components/compactSelect';
+import type {Field} from 'sentry/components/ddm/metricSamplesTable';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
@@ -19,6 +20,7 @@ import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {MetricsQueryApiResponse, PageFilters} from 'sentry/types';
+import {defined} from 'sentry/utils';
 import {
   getDefaultMetricDisplayType,
   getFormattedMQL,
@@ -47,11 +49,15 @@ import {
   type MetricsQueryApiRequestQuery,
   useMetricsQuery,
 } from 'sentry/utils/metrics/useMetricsQuery';
+import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import useRouter from 'sentry/utils/useRouter';
 import {getIngestionSeriesId, MetricChart} from 'sentry/views/ddm/chart/chart';
 import type {Series} from 'sentry/views/ddm/chart/types';
 import {useFocusArea} from 'sentry/views/ddm/chart/useFocusArea';
-import {useMetricChartSamples} from 'sentry/views/ddm/chart/useMetricChartSamples';
+import {
+  useMetricChartSamples,
+  useMetricChartSamplesV2,
+} from 'sentry/views/ddm/chart/useMetricChartSamples';
 import type {FocusAreaProps} from 'sentry/views/ddm/context';
 import {FormularFormatter} from 'sentry/views/ddm/formulaParser/formatter';
 import {QuerySymbol} from 'sentry/views/ddm/querySymbol';
@@ -76,7 +82,9 @@ type MetricWidgetProps = {
   highlightedSampleId?: string;
   index?: number;
   isSelected?: boolean;
+  metricsSamples?: MetricsSamplesResults<Field>['data'];
   onSampleClick?: (sample: Sample) => void;
+  onSampleClickV2?: (sample: MetricsSamplesResults<Field>['data'][number]) => void;
   onSelect?: (index: number) => void;
   queryId?: number;
   showQuerySymbols?: boolean;
@@ -134,9 +142,11 @@ export const MetricWidget = memo(
     showQuerySymbols,
     focusAreaProps,
     onSampleClick,
+    onSampleClickV2,
     highlightedSampleId,
     chartHeight = 300,
     focusedSeries,
+    metricsSamples,
     context = 'ddm',
   }: MetricWidgetProps) => {
     const firstQuery = queries
@@ -180,6 +190,18 @@ export const MetricWidget = memo(
       firstQuery?.op,
       highlightedSampleId,
     ]);
+
+    const samplesV2 = useMemo(() => {
+      if (!defined(metricsSamples)) {
+        return undefined;
+      }
+      return {
+        data: metricsSamples,
+        onSampleClick: onSampleClickV2,
+        unit: parseMRI(firstQuery?.mri)?.unit ?? '',
+        operation: firstQuery?.op ?? '',
+      };
+    }, [metricsSamples, firstQuery?.mri, firstQuery?.op, onSampleClickV2]);
 
     const widgetTitle = getWidgetTitle(queries);
 
@@ -228,6 +250,7 @@ export const MetricWidget = memo(
                 onChange={handleChange}
                 focusAreaProps={focusAreaProps}
                 samples={samples}
+                samplesV2={samplesV2}
                 chartHeight={chartHeight}
                 chartGroup={DDM_CHART_GROUP}
                 queries={queries}
@@ -266,6 +289,7 @@ interface MetricWidgetBodyProps {
   getChartPalette?: (seriesNames: string[]) => Record<string, string>;
   onChange?: (data: Partial<MetricWidgetQueryParams>) => void;
   samples?: SamplesProps;
+  samplesV2?: SamplesV2Props;
   tableSort?: SortState;
 }
 
@@ -275,6 +299,14 @@ export interface SamplesProps {
   data?: MetricCorrelation[];
   higlightedId?: string;
   onClick?: (sample: Sample) => void;
+}
+
+export interface SamplesV2Props {
+  operation: string;
+  unit: string;
+  data?: MetricsSamplesResults<Field>['data'];
+  higlightedId?: string;
+  onSampleClick?: (sample: MetricsSamplesResults<Field>['data'][number]) => void;
 }
 
 const MetricWidgetBody = memo(
@@ -289,6 +321,7 @@ const MetricWidgetBody = memo(
     chartHeight,
     chartGroup,
     samples,
+    samplesV2,
     filters,
     queries,
     context,
@@ -329,6 +362,14 @@ const MetricWidgetBody = memo(
       highlightedSampleId: samples?.higlightedId,
       operation: samples?.operation,
       timeseries: chartSeries,
+    });
+
+    const samplesV2Prop = useMetricChartSamplesV2({
+      samples: samplesV2?.data,
+      operation: samplesV2?.operation,
+      onSampleClick: samplesV2?.onSampleClick,
+      timeseries: chartSeries,
+      unit: samplesV2?.unit,
     });
 
     const handleZoom = useCallback(
@@ -444,7 +485,7 @@ const MetricWidgetBody = memo(
           series={chartSeries}
           displayType={displayType}
           height={chartHeight}
-          samples={samplesProp}
+          samples={samplesV2Prop ?? samplesProp}
           focusArea={focusArea}
           group={chartGroup}
         />

--- a/static/app/views/ddm/widgetDetails.tsx
+++ b/static/app/views/ddm/widgetDetails.tsx
@@ -145,6 +145,7 @@ export function MetricDetails({
                 <MetricSamplesTable
                   focusArea={focusArea?.selection?.range}
                   mri={mri}
+                  onRowHover={onRowHover}
                   op={op}
                   query={queryWithFocusedSeries}
                   setMetricsSamples={setMetricsSamples}

--- a/static/app/views/ddm/widgetDetails.tsx
+++ b/static/app/views/ddm/widgetDetails.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {MetricSamplesTable} from 'sentry/components/ddm/metricSamplesTable';
+import {type Field, MetricSamplesTable} from 'sentry/components/ddm/metricSamplesTable';
 import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
@@ -15,6 +15,7 @@ import type {
   MetricWidgetQueryParams,
 } from 'sentry/utils/metrics/types';
 import {MetricQueryType} from 'sentry/utils/metrics/types';
+import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import useOrganization from 'sentry/utils/useOrganization';
 import {CodeLocations} from 'sentry/views/ddm/codeLocations';
 import type {FocusAreaProps} from 'sentry/views/ddm/context';
@@ -29,8 +30,13 @@ enum Tab {
 }
 
 export function WidgetDetails() {
-  const {selectedWidgetIndex, widgets, focusArea, setHighlightedSampleId} =
-    useDDMContext();
+  const {
+    selectedWidgetIndex,
+    widgets,
+    focusArea,
+    setHighlightedSampleId,
+    setMetricsSamples,
+  } = useDDMContext();
 
   const selectedWidget = widgets[selectedWidgetIndex] as
     | MetricWidgetQueryParams
@@ -57,6 +63,7 @@ export function WidgetDetails() {
       query={query}
       focusedSeries={focusedSeries}
       onRowHover={handleSampleRowHover}
+      setMetricsSamples={setMetricsSamples}
       focusArea={focusArea}
     />
   );
@@ -69,6 +76,9 @@ interface MetricDetailsProps {
   onRowHover?: SamplesTableProps['onRowHover'];
   op?: string;
   query?: string;
+  setMetricsSamples?: React.Dispatch<
+    React.SetStateAction<MetricsSamplesResults<Field>['data'] | undefined>
+  >;
 }
 
 // TODO: add types
@@ -79,6 +89,7 @@ export function MetricDetails({
   focusedSeries,
   onRowHover,
   focusArea,
+  setMetricsSamples,
 }: MetricDetailsProps) {
   const organization = useOrganization();
 
@@ -136,6 +147,7 @@ export function MetricDetails({
                   mri={mri}
                   op={op}
                   query={queryWithFocusedSeries}
+                  setMetricsSamples={setMetricsSamples}
                 />
               ) : (
                 <SampleTable


### PR DESCRIPTION
This renders the new samples list in the chart as a scatter plot with the sample click to open functionality as before.