### PR TITLE
feat(processing) Move redis operations in reprocessing to servicewrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -627,6 +627,7 @@ disable_error_code = [
 module = [
     "sentry.buffer.base",
     "sentry.buffer.redis",
+    "sentry.eventstore.reprocessing.redis",
     "sentry.utils.redis",
     "sentry.utils.redis_metrics",
     "sentry.tasks.on_demand_metrics",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3604,6 +3604,10 @@ SENTRY_GROUPING_UPDATE_MIGRATION_PHASE = 7 * 24 * 3600  # 7 days
 
 SENTRY_USE_UWSGI = True
 
+# Configure service wrapper for reprocessing2 state
+SENTRY_REPROCESSING_STORE = "sentry.eventstore.reprocessing.redis.RedisReprocessingStore"
+SENTRY_REPROCESSING_STORE_OPTIONS = {"cluster": "default"}
+
 # When copying attachments for to-be-reprocessed events into processing store,
 # how large is an individual file chunk? Each chunk is stored as Redis key.
 SENTRY_REPROCESSING_ATTACHMENT_CHUNK_SIZE = 2**20

--- a/src/sentry/eventstore/reprocessing/__init__.py
+++ b/src/sentry/eventstore/reprocessing/__init__.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+
+from sentry.eventstore.reprocessing.base import ReprocessingStore
+from sentry.utils.services import LazyServiceWrapper
+
+reprocessing_store = LazyServiceWrapper(
+    ReprocessingStore,
+    settings.SENTRY_REPROCESSING_STORE,
+    settings.SENTRY_REPROCESSING_STORE_OPTIONS,
+)
+
+
+__all__ = ["reprocessing_store"]

--- a/src/sentry/eventstore/reprocessing/base.py
+++ b/src/sentry/eventstore/reprocessing/base.py
@@ -54,7 +54,7 @@ class ReprocessingStore(Service):
     ) -> int:
         raise NotImplementedError()
 
-    def rename_key(self, project_id: int, old_group_id: int) -> bool:
+    def rename_key(self, project_id: int, old_group_id: int) -> str | None:
         raise NotImplementedError()
 
     def mark_event_reprocessed(self, group_id: int, num_events: int) -> bool:
@@ -68,5 +68,5 @@ class ReprocessingStore(Service):
     def get_pending(self, group_id: int) -> Any:
         raise NotImplementedError()
 
-    def get_progress(self, group_id: int) -> tuple[dict[str, Any] | None, int]:
+    def get_progress(self, group_id: int) -> dict[str, Any] | None:
         raise NotImplementedError()

--- a/src/sentry/eventstore/reprocessing/base.py
+++ b/src/sentry/eventstore/reprocessing/base.py
@@ -1,0 +1,72 @@
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any
+
+from sentry.utils.services import Service
+
+
+class ReprocessingStore(Service):
+    __all__ = (
+        "event_count_for_hashes",
+        "pop_batched_events",
+        "get_old_primary_hashes",
+        "expire_hash",
+        "add_hash",
+        "get_remaining_event_count",
+        "rename_key",
+        "mark_event_reprocessed",
+        "start_reprocessing",
+        "get_pending",
+        "get_progress",
+    )
+
+    def __init__(self, **options: Any) -> None:
+        pass
+
+    def event_count_for_hashes(
+        self, project_id: int, group_id: int, old_primary_hashes: Sequence[str]
+    ) -> int:
+        raise NotImplementedError()
+
+    def pop_batched_events(
+        self, project_id: int, group_id: int, primary_hash: str
+    ) -> tuple[list[str], datetime | None, datetime | None]:
+        raise NotImplementedError()
+
+    def get_old_primary_hashes(self, project_id: int, group_id: int) -> set[Any]:
+        raise NotImplementedError()
+
+    def expire_hash(
+        self,
+        project_id: int,
+        group_id: int,
+        event_id: str,
+        date_val: datetime,
+        old_primary_hash: str,
+    ) -> None:
+        raise NotImplementedError()
+
+    def add_hash(self, project_id: int, group_id: int, hash: str) -> None:
+        raise NotImplementedError()
+
+    def get_remaining_event_count(
+        self, project_id: int, old_group_id: int, datetime_to_event: list[tuple[datetime, str]]
+    ) -> int:
+        raise NotImplementedError()
+
+    def rename_key(self, project_id: int, old_group_id: int) -> bool:
+        raise NotImplementedError()
+
+    def mark_event_reprocessed(self, group_id: int, num_events: int) -> bool:
+        raise NotImplementedError()
+
+    def start_reprocessing(
+        self, group_id: int, date_created: Any, sync_count: int, event_count: int
+    ) -> None:
+        raise NotImplementedError()
+
+    def get_pending(self, group_id: int) -> Any:
+        raise NotImplementedError()
+
+    def get_progress(self, group_id: int) -> tuple[dict[str, Any] | None, int]:
+        raise NotImplementedError()

--- a/src/sentry/eventstore/reprocessing/redis.py
+++ b/src/sentry/eventstore/reprocessing/redis.py
@@ -1,0 +1,166 @@
+import uuid
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any
+
+import redis
+from django.conf import settings
+
+from sentry.utils import json
+from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.redis import redis_clusters
+
+from .base import ReprocessingStore
+
+
+def _get_sync_counter_key(group_id):
+    return f"re2:count:{group_id}"
+
+
+def _get_info_reprocessed_key(group_id):
+    return f"re2:info:{group_id}"
+
+
+def _get_old_primary_hash_subset_key(project_id: int, group_id: int, primary_hash: str):
+    return f"re2:tombstones:{{{project_id}:{group_id}:{primary_hash}}}"
+
+
+class RedisReprocessingStore(ReprocessingStore):
+    def __init__(self, **options) -> None:
+        self.redis = redis_clusters.get(options.pop("cluster", "default"))
+
+    def event_count_for_hashes(
+        self, project_id: int, group_id: int, old_primary_hashes: Sequence[str]
+    ) -> int:
+        # Events for a group are split and bucketed by their primary hashes. If flushing is to be
+        # performed on a per-group basis, the event count needs to be summed up across all buckets
+        # belonging to a single group.
+        event_count = 0
+        for primary_hash in old_primary_hashes:
+            key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
+            event_count += self.redis.llen(key)
+        return event_count
+
+    def pop_batched_events(
+        self, project_id: int, group_id: int, primary_hash: str
+    ) -> tuple[list[str], datetime | None, datetime | None]:
+        """
+        For redis key pointing to a list of buffered events structured like
+        `event id;datetime of event`, returns a list of event IDs, the
+        earliest datetime, and the latest datetime.
+        """
+        event_ids_batch = []
+        min_datetime = None
+        max_datetime = None
+        key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
+
+        for row in self.redis.lrange(key, 0, -1):
+            datetime_raw, event_id = row.split(";")
+            datetime = to_datetime(float(datetime_raw))
+
+            assert datetime is not None
+
+            if min_datetime is None or datetime < min_datetime:
+                min_datetime = datetime
+            if max_datetime is None or datetime > max_datetime:
+                max_datetime = datetime
+
+            event_ids_batch.append(event_id)
+
+        self.redis.delete(key)
+
+        return event_ids_batch, min_datetime, max_datetime
+
+    def get_old_primary_hashes(self, project_id: int, group_id: int) -> set[Any]:
+        # This is a meta key that contains old primary hashes. These hashes are then
+        # combined with other values to construct a key that points to a list of
+        # tombstonable events.
+        primary_hash_set_key = f"re2:tombstone-primary-hashes:{project_id}:{group_id}"
+
+        return self.redis.smembers(primary_hash_set_key)
+
+    def expire_hash(
+        self,
+        project_id: int,
+        group_id: int,
+        event_id: str,
+        date_val: datetime,
+        old_primary_hash: str,
+    ) -> None:
+        event_key = _get_old_primary_hash_subset_key(project_id, group_id, old_primary_hash)
+        self.redis.lpush(event_key, f"{to_timestamp(date_val)};{event_id}")
+        self.redis.expire(event_key, settings.SENTRY_REPROCESSING_TOMBSTONES_TTL)
+
+    def add_hash(self, project_id: int, group_id: int, hash: str) -> None:
+        primary_hash_set_key = f"re2:tombstone-primary-hashes:{project_id}:{group_id}"
+
+        self.redis.sadd(primary_hash_set_key, hash)
+        self.redis.expire(primary_hash_set_key, settings.SENTRY_REPROCESSING_TOMBSTONES_TTL)
+
+    def get_remaining_event_count(
+        self, project_id: int, old_group_id: int, datetime_to_event: list[tuple[datetime, str]]
+    ) -> int:
+        # We explicitly cluster by only project_id and group_id here such that our
+        # RENAME command later succeeds.
+        key = f"re2:remaining:{{{project_id}:{old_group_id}}}"
+
+        if datetime_to_event:
+            llen = self.redis.lpush(
+                key,
+                *(
+                    f"{to_timestamp(datetime)};{event_id}"
+                    for datetime, event_id in datetime_to_event
+                ),
+            )
+            self.redis.expire(key, settings.SENTRY_REPROCESSING_SYNC_TTL)
+        else:
+            llen = self.redis.llen(key)
+        return llen
+
+    def rename_key(self, project_id: int, old_group_id: int) -> str | None:
+        key = f"re2:remaining:{{{project_id}:{old_group_id}}}"
+        new_key = f"{key}:{uuid.uuid4().hex}"
+        try:
+            # Rename `key` to a new temp key that is passed to celery task. We
+            # use `renamenx` instead of `rename` only to detect UUID collisions.
+            assert self.redis.renamenx(key, new_key), "UUID collision for new_key?"
+
+            return new_key
+        except redis.exceptions.ResponseError:
+            # `key` does not exist in Redis. `ResponseError` is a bit too broad
+            # but it seems we'd have to do string matching on error message
+            # otherwise.
+            return None
+
+    def mark_event_reprocessed(self, group_id: int, num_events: int) -> bool:
+        # refresh the TTL of the metadata:
+        self.redis.expire(
+            _get_info_reprocessed_key(group_id), settings.SENTRY_REPROCESSING_SYNC_TTL
+        )
+        key = _get_sync_counter_key(group_id)
+        self.redis.expire(key, settings.SENTRY_REPROCESSING_SYNC_TTL)
+        return self.redis.decrby(key, num_events) == 0
+
+    def start_reprocessing(
+        self, group_id: int, date_created: Any, sync_count: int, event_count: int
+    ) -> None:
+        self.redis.setex(
+            _get_sync_counter_key(group_id), settings.SENTRY_REPROCESSING_SYNC_TTL, sync_count
+        )
+        self.redis.setex(
+            _get_info_reprocessed_key(group_id),
+            settings.SENTRY_REPROCESSING_SYNC_TTL,
+            json.dumps(
+                {"dateCreated": date_created, "syncCount": sync_count, "totalEvents": event_count}
+            ),
+        )
+
+    def get_pending(self, group_id: int) -> tuple[int | None, int]:
+        pending_key = _get_sync_counter_key(group_id)
+        pending = self.redis.get(pending_key)
+        ttl = self.redis.ttl(pending_key)
+        return pending, ttl
+
+    def get_progress(self, group_id: int) -> dict[str, Any] | None:
+        info = self.redis.get(_get_info_reprocessed_key(group_id))
+        return info

--- a/src/sentry/eventstore/reprocessing/redis.py
+++ b/src/sentry/eventstore/reprocessing/redis.py
@@ -13,11 +13,11 @@ from sentry.utils.redis import redis_clusters
 from .base import ReprocessingStore
 
 
-def _get_sync_counter_key(group_id) -> str:
+def _get_sync_counter_key(group_id: int) -> str:
     return f"re2:count:{group_id}"
 
 
-def _get_info_reprocessed_key(group_id) -> str:
+def _get_info_reprocessed_key(group_id: int) -> str:
     return f"re2:info:{group_id}"
 
 
@@ -30,8 +30,10 @@ def _get_remaining_key(project_id: int, group_id: int) -> str:
 
 
 class RedisReprocessingStore(ReprocessingStore):
-    def __init__(self, **options) -> None:
-        self.redis = redis_clusters.get(options.pop("cluster", "default"))
+    def __init__(self, **options: dict[str, Any]) -> None:
+        cluster = options.pop("cluster", "default")
+        assert isinstance(cluster, str), "cluster option must be a string"
+        self.redis = redis_clusters.get(cluster)
 
     def event_count_for_hashes(
         self, project_id: int, group_id: int, old_primary_hashes: Sequence[str]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -964,6 +964,9 @@ register(
 # Drop delete_old_primary_hash messages for a particular project.
 register("reprocessing2.drop-delete-old-primary-hash", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Switch to use service wrapper for reprocessing redis operations
+register("reprocessing.use_store", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # BEGIN ABUSE QUOTAS
 
 # Example:

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -264,14 +264,14 @@ def _send_delete_old_primary_hash_messages(
     old_primary_hashes: Sequence[str],
     force_flush_batch: bool,
 ):
+    # Events for a group are split and bucketed by their primary hashes. If flushing is to be
+    # performed on a per-group basis, the event count needs to be summed up across all buckets
+    # belonging to a single group.
     if options.get(use_store_option):
         event_count = reprocessing_store.event_count_for_hashes(
             project_id, group_id, old_primary_hashes
         )
     else:
-        # Events for a group are split and bucketed by their primary hashes. If flushing is to be
-        # performed on a per-group basis, the event count needs to be summed up across all buckets
-        # belonging to a single group.
         event_count = 0
         for primary_hash in old_primary_hashes:
             key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -96,6 +96,7 @@ from sentry.attachments import CachedAttachment, attachment_cache
 from sentry.deletions.defaults.group import DIRECT_GROUP_RELATED_MODELS
 from sentry.eventstore.models import Event
 from sentry.eventstore.processing import event_processing_store
+from sentry.eventstore.reprocessing import reprocessing_store
 from sentry.models.eventattachment import EventAttachment
 from sentry.snuba.dataset import Dataset
 from sentry.utils import json, metrics, snuba
@@ -138,6 +139,8 @@ CannotReprocessReason = Union[
     # A required attachment, such as the original minidump, is missing.
     Literal["attachment.not_found"],
 ]
+
+use_store_option = "reprocessing.use_store"
 
 
 class CannotReprocess(Exception):
@@ -261,13 +264,18 @@ def _send_delete_old_primary_hash_messages(
     old_primary_hashes: Sequence[str],
     force_flush_batch: bool,
 ):
-    # Events for a group are split and bucketed by their primary hashes. If flushing is to be
-    # performed on a per-group basis, the event count needs to be summed up across all buckets
-    # belonging to a single group.
-    event_count = 0
-    for primary_hash in old_primary_hashes:
-        key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
-        event_count += client.llen(key)
+    if options.get(use_store_option):
+        event_count = reprocessing_store.event_count_for_hashes(
+            project_id, group_id, old_primary_hashes
+        )
+    else:
+        # Events for a group are split and bucketed by their primary hashes. If flushing is to be
+        # performed on a per-group basis, the event count needs to be summed up across all buckets
+        # belonging to a single group.
+        event_count = 0
+        for primary_hash in old_primary_hashes:
+            key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
+            event_count += client.llen(key)
 
     if (
         not force_flush_batch
@@ -276,8 +284,13 @@ def _send_delete_old_primary_hash_messages(
         return
 
     for primary_hash in old_primary_hashes:
-        event_key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
-        event_ids, from_date, to_date = pop_batched_events_from_redis(event_key)
+        if options.get(use_store_option):
+            event_ids, from_date, to_date = reprocessing_store.pop_batched_events(
+                project_id, group_id, primary_hash
+            )
+        else:
+            event_key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
+            event_ids, from_date, to_date = pop_batched_events_from_redis(event_key)
 
         # Racing might be happening between two different tasks. Give up on the
         # task that's lagging behind by prematurely terminating flushing.
@@ -365,21 +378,33 @@ def buffered_delete_old_primary_hash(
 
     client = _get_sync_redis_client()
 
-    # This is a meta key that contains old primary hashes. These hashes are then
-    # combined with other values to construct a key that points to a list of
-    # tombstonable events.
-    primary_hash_set_key = f"re2:tombstone-primary-hashes:{project_id}:{group_id}"
-    old_primary_hashes = client.smembers(primary_hash_set_key)
+    if options.get(use_store_option):
+        old_primary_hashes = reprocessing_store.get_old_primary_hashes(project_id, group_id)
+    else:
+        # This is a meta key that contains old primary hashes. These hashes are then
+        # combined with other values to construct a key that points to a list of
+        # tombstonable events.
+        primary_hash_set_key = f"re2:tombstone-primary-hashes:{project_id}:{group_id}"
+        old_primary_hashes = client.smembers(primary_hash_set_key)
 
     if old_primary_hash is not None and old_primary_hash != current_primary_hash:
-        event_key = _get_old_primary_hash_subset_key(project_id, group_id, old_primary_hash)
-        client.lpush(event_key, f"{to_timestamp(datetime)};{event_id}")
-        client.expire(event_key, settings.SENTRY_REPROCESSING_TOMBSTONES_TTL)
+        if options.get(use_store_option):
+            reprocessing_store.expire_hash(
+                project_id, group_id, event_id, datetime, old_primary_hash
+            )
+        else:
+            event_key = _get_old_primary_hash_subset_key(project_id, group_id, old_primary_hash)
+            client.lpush(event_key, f"{to_timestamp(datetime)};{event_id}")
+            client.expire(event_key, settings.SENTRY_REPROCESSING_TOMBSTONES_TTL)
 
         if old_primary_hash not in old_primary_hashes:
             old_primary_hashes.add(old_primary_hash)
-            client.sadd(primary_hash_set_key, old_primary_hash)
-            client.expire(primary_hash_set_key, settings.SENTRY_REPROCESSING_TOMBSTONES_TTL)
+            if options.get(use_store_option):
+                reprocessing_store.add_hash(project_id, group_id, old_primary_hash)
+            else:
+                primary_hash_set_key = f"re2:tombstone-primary-hashes:{project_id}:{group_id}"
+                client.sadd(primary_hash_set_key, old_primary_hash)
+                client.expire(primary_hash_set_key, settings.SENTRY_REPROCESSING_TOMBSTONES_TTL)
 
     with sentry_sdk.configure_scope() as scope:
         scope.set_tag("project_id", project_id)
@@ -472,32 +497,49 @@ def buffered_handle_remaining_events(
     more than counters.
     """
 
+    key = None
     client = _get_sync_redis_client()
-    # We explicitly cluster by only project_id and group_id here such that our
-    # RENAME command later succeeds.
-    key = f"re2:remaining:{{{project_id}:{old_group_id}}}"
 
-    if datetime_to_event:
-        llen = client.lpush(
-            key,
-            *(f"{to_timestamp(datetime)};{event_id}" for datetime, event_id in datetime_to_event),
+    if options.get(use_store_option):
+        llen = reprocessing_store.get_remaining_event_count(
+            project_id, old_group_id, datetime_to_event
         )
-        client.expire(key, settings.SENTRY_REPROCESSING_SYNC_TTL)
     else:
-        llen = client.llen(key)
+        # We explicitly cluster by only project_id and group_id here such that our
+        # RENAME command later succeeds.
+        key = f"re2:remaining:{{{project_id}:{old_group_id}}}"
+
+        if datetime_to_event:
+            llen = client.lpush(
+                key,
+                *(
+                    f"{to_timestamp(datetime)};{event_id}"
+                    for datetime, event_id in datetime_to_event
+                ),
+            )
+            client.expire(key, settings.SENTRY_REPROCESSING_SYNC_TTL)
+        else:
+            llen = client.llen(key)
 
     if force_flush_batch or llen > settings.SENTRY_REPROCESSING_REMAINING_EVENTS_BUF_SIZE:
-        new_key = f"{key}:{uuid.uuid4().hex}"
 
-        try:
-            # Rename `key` to a new temp key that is passed to celery task. We
-            # use `renamenx` instead of `rename` only to detect UUID collisions.
-            assert client.renamenx(key, new_key), "UUID collision for new_key?"
-        except redis.exceptions.ResponseError:
-            # `key` does not exist in Redis. `ResponseError` is a bit too broad
-            # but it seems we'd have to do string matching on error message
-            # otherwise.
-            return
+        if options.get(use_store_option):
+            new_key = reprocessing_store.rename_key(project_id, old_group_id)
+            if not new_key:
+                return
+        else:
+            assert key, "Key must exist in this branch"
+            new_key = f"{key}:{uuid.uuid4().hex}"
+
+            try:
+                # Rename `key` to a new temp key that is passed to celery task. We
+                # use `renamenx` instead of `rename` only to detect UUID collisions.
+                assert client.renamenx(key, new_key), "UUID collision for new_key?"
+            except redis.exceptions.ResponseError:
+                # `key` does not exist in Redis. `ResponseError` is a bit too broad
+                # but it seems we'd have to do string matching on error message
+                # otherwise.
+                return
 
         from sentry.tasks.reprocessing2 import handle_remaining_events
 
@@ -553,15 +595,22 @@ def mark_event_reprocessed(data=None, group_id=None, project_id=None, num_events
 
         project_id = data["project"]
 
-    client = _get_sync_redis_client()
-    # refresh the TTL of the metadata:
-    client.expire(_get_info_reprocessed_key(group_id), settings.SENTRY_REPROCESSING_SYNC_TTL)
-    key = _get_sync_counter_key(group_id)
-    client.expire(key, settings.SENTRY_REPROCESSING_SYNC_TTL)
-    if client.decrby(key, num_events) == 0:
-        from sentry.tasks.reprocessing2 import finish_reprocessing
+    if options.get(use_store_option):
+        result = reprocessing_store.mark_event_reprocessed(group_id, num_events)
+        if result:
+            from sentry.tasks.reprocessing2 import finish_reprocessing
 
-        finish_reprocessing.delay(project_id=project_id, group_id=group_id)
+            finish_reprocessing.delay(project_id=project_id, group_id=group_id)
+    else:
+        client = _get_sync_redis_client()
+        # refresh the TTL of the metadata:
+        client.expire(_get_info_reprocessed_key(group_id), settings.SENTRY_REPROCESSING_SYNC_TTL)
+        key = _get_sync_counter_key(group_id)
+        client.expire(key, settings.SENTRY_REPROCESSING_SYNC_TTL)
+        if client.decrby(key, num_events) == 0:
+            from sentry.tasks.reprocessing2 import finish_reprocessing
+
+            finish_reprocessing.delay(project_id=project_id, group_id=group_id)
 
 
 def start_group_reprocessing(
@@ -645,15 +694,20 @@ def start_group_reprocessing(
     # New Activity Timestamp
     date_created = new_activity.datetime
 
-    client = _get_sync_redis_client()
-    client.setex(_get_sync_counter_key(group_id), settings.SENTRY_REPROCESSING_SYNC_TTL, sync_count)
-    client.setex(
-        _get_info_reprocessed_key(group_id),
-        settings.SENTRY_REPROCESSING_SYNC_TTL,
-        json.dumps(
-            {"dateCreated": date_created, "syncCount": sync_count, "totalEvents": event_count}
-        ),
-    )
+    if options.get(use_store_option):
+        reprocessing_store.start_reprocessing(group_id, date_created, sync_count, event_count)
+    else:
+        client = _get_sync_redis_client()
+        client.setex(
+            _get_sync_counter_key(group_id), settings.SENTRY_REPROCESSING_SYNC_TTL, sync_count
+        )
+        client.setex(
+            _get_info_reprocessed_key(group_id),
+            settings.SENTRY_REPROCESSING_SYNC_TTL,
+            json.dumps(
+                {"dateCreated": date_created, "syncCount": sync_count, "totalEvents": event_count}
+            ),
+        )
 
     return new_group.id
 
@@ -668,11 +722,15 @@ def is_group_finished(group_id):
 
 
 def get_progress(group_id, project_id=None):
-    client = _get_sync_redis_client()
-    pending_key = _get_sync_counter_key(group_id)
-    pending = client.get(pending_key)
-    ttl = client.ttl(pending_key)
-    info = client.get(_get_info_reprocessed_key(group_id))
+    if options.get(use_store_option):
+        pending, ttl = reprocessing_store.get_pending(group_id)
+        info = reprocessing_store.get_progress(group_id)
+    else:
+        client = _get_sync_redis_client()
+        pending_key = _get_sync_counter_key(group_id)
+        pending = client.get(pending_key)
+        ttl = client.ttl(pending_key)
+        info = client.get(_get_info_reprocessed_key(group_id))
     if pending is None:
         logger.error("reprocessing2.missing_counter")
         return 0, None


### PR DESCRIPTION
We need to shift the reprocessing workload to a new redis cluster without downtime. In order to do that I would like to use our Service wrappers and ServiceDelegator to dual write and then shift reads via runtime options.

Before I can move load with ServiceDelegator the existing logic needs to be moved into a service wrapper.