### PR TITLE
ref(issues): Add a new task to validate group statuses

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -939,6 +939,10 @@ CELERY_QUEUES_REGION = [
     Queue("auto_resolve_issues", routing_key="auto_resolve_issues"),
     Queue("on_demand_metrics", routing_key="on_demand_metrics"),
     Queue("spans.process_segment", routing_key="spans.process_segment"),
+    Queue(
+        "invalid_group_status_detection",
+        routing_key="invalid_group_status_detection",
+    ),
 ]
 
 from celery.schedules import crontab
@@ -1225,6 +1229,10 @@ CELERYBEAT_SCHEDULE_REGION = {
     "on-demand-metrics-schedule-on-demand-check": {
         "task": "sentry.tasks.on_demand_metrics.schedule_on_demand_check",
         "schedule": crontab(minute="*/5"),
+    },
+    "invalid_group_status_detection": {
+        "task": "sentry.tasks.invalid_group_status_detection",
+        "schedule": crontab(hour="10", day_of_week="sunday"),  # 03:00 PDT, 07:00 EDT, 10:00 UTC
     },
 }
 

--- a/src/sentry/tasks/invalid_group_status_detection.py
+++ b/src/sentry/tasks/invalid_group_status_detection.py
@@ -1,0 +1,87 @@
+import random
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from logging import getLogger
+
+from django.db import connection
+
+from sentry.models.group import Group, GroupStatus
+from sentry.models.grouphistory import GroupHistoryStatus
+from sentry.silo import SiloMode
+from sentry.tasks.auto_ongoing_issues import TRANSITION_AFTER_DAYS
+from sentry.tasks.base import instrumented_task
+from sentry.types.group import SUBSTATUS_TO_STR, UNRESOLVED_SUBSTATUS_CHOICES, GroupSubStatus
+from sentry.utils.query import RangeQuerySetWrapper
+
+logger = getLogger(__name__)
+
+SAMPLE_SIZE = 500
+SEVEN_DAYS_AGO = datetime.now(tz=timezone.utc) - timedelta(days=TRANSITION_AFTER_DAYS)
+QUERY = """SELECT group_id, MAX(date_added)
+    FROM sentry_grouphistory
+    WHERE group_id IN ({group_ids}) and status = {status}
+    GROUP BY group_id
+"""
+
+
+@instrumented_task(
+    name="sentry.tasks.issues.invalid_group_status_detection",
+    queue="invalid_group_status_detection",
+    time_limit=5 * 60,  # 5 minutes
+    max_retries=3,
+    default_retry_delay=60,
+    silo_mode=SiloMode.REGION,
+)
+def detect_invalid_group_status() -> None:
+    group_ids = list(Group.objects.values_list("id", flat=True))
+    random_group_ids = random.sample(group_ids, SAMPLE_SIZE)
+    invalid_groups = defaultdict(list)
+    regressed_groups = []
+    escalating_groups = []
+    for group in RangeQuerySetWrapper(
+        Group.objects.filter(id__in=random_group_ids, status=GroupStatus.UNRESOLVED)
+    ):
+        if group.substatus not in UNRESOLVED_SUBSTATUS_CHOICES:
+            invalid_groups[group.substatus].append(group.id)
+
+        if group.substatus == GroupSubStatus.NEW:
+            if group.first_seen < SEVEN_DAYS_AGO:
+                invalid_groups[group.substatus].append(group.id)
+
+        if group.substatus == GroupSubStatus.REGRESSED:
+            regressed_groups.append(str(group.id))
+        elif group.substatus == GroupSubStatus.ESCALATING:
+            escalating_groups.append(str(group.id))
+
+    cursor = connection.cursor()
+    if len(escalating_groups) > 0:
+        cursor.execute(
+            QUERY.format(
+                group_ids=(",".join(escalating_groups)), status=GroupHistoryStatus.ESCALATING
+            ),
+        )
+
+        for group_id, status_date in cursor.fetchall():
+            if status_date < SEVEN_DAYS_AGO:
+                invalid_groups[GroupSubStatus.ESCALATING].append(group_id)
+
+    if len(regressed_groups) > 0:
+        cursor.execute(
+            QUERY.format(
+                group_ids=(",".join(regressed_groups)), status=GroupHistoryStatus.REGRESSED
+            ),
+        )
+
+        for group_id, status_date in cursor.fetchall():
+            if status_date < SEVEN_DAYS_AGO:
+                invalid_groups[GroupSubStatus.REGRESSED].append(group_id)
+
+    error_extra = {SUBSTATUS_TO_STR[k]: v for k, v in invalid_groups.items()}
+    if len(invalid_groups) > 0:
+        logger.error(
+            "Found groups with incorrect substatus",
+            extra={
+                "count": sum(len(v) for v in invalid_groups.values()),
+                **error_extra,
+            },
+        )

--- a/tests/sentry/tasks/test_invalid_group_status_detection.py
+++ b/tests/sentry/tasks/test_invalid_group_status_detection.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from sentry.models.group import GroupStatus
+from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
+from sentry.tasks.invalid_group_status_detection import detect_invalid_group_status
+from sentry.testutils.cases import TestCase
+from sentry.types.group import GroupSubStatus
+
+
+@patch("sentry.tasks.invalid_group_status_detection.SAMPLE_SIZE", 4)
+class DetectInvalidGroupStatusTest(TestCase):
+    def setUp(self):
+        self.ongoing_group = self.create_group(substatus=GroupSubStatus.ONGOING)
+        self.new_group = self.create_group(substatus=GroupSubStatus.NEW)
+
+        self.regressed_group = self.create_group(substatus=GroupSubStatus.REGRESSED)
+        self.regressed_grouphistory = GroupHistory.objects.create(
+            group=self.regressed_group,
+            status=GroupHistoryStatus.REGRESSED,
+            date_added=datetime.now() - timedelta(days=3),
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+        )
+
+        self.escalating_group = self.create_group(substatus=GroupSubStatus.ESCALATING)
+        self.escalating_grouphistory = GroupHistory.objects.create(
+            group=self.escalating_group,
+            status=GroupHistoryStatus.ESCALATING,
+            date_added=datetime.now() - timedelta(days=3),
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+        )
+
+    @patch("sentry.tasks.invalid_group_status_detection.logger.error")
+    def test_no_bad_groups(self, mock_logger):
+        detect_invalid_group_status()
+        assert not mock_logger.called
+
+    @patch("sentry.tasks.invalid_group_status_detection.logger.error")
+    def test_bad_new_group(self, mock_logger):
+        self.new_group.update(
+            first_seen=datetime.now() - timedelta(days=8), substatus=GroupSubStatus.NEW
+        )
+        detect_invalid_group_status()
+        assert mock_logger.called
+        assert mock_logger.call_args[0][0] == "Found groups with incorrect substatus"
+        assert mock_logger.call_args.kwargs["extra"]["count"] == 1
+        assert mock_logger.call_args.kwargs["extra"]["new"] == [self.new_group.id]
+
+    @patch("sentry.tasks.invalid_group_status_detection.logger.error")
+    def test_bad_regressed_group(self, mock_logger):
+        self.regressed_grouphistory.update(
+            date_added=datetime.now() - timedelta(days=8),
+        )
+        detect_invalid_group_status()
+        assert mock_logger.called
+        assert mock_logger.call_args.kwargs["extra"]["count"] == 1
+        assert mock_logger.call_args.kwargs["extra"]["regressed"] == [self.regressed_group.id]
+
+    @patch("sentry.tasks.invalid_group_status_detection.logger.error")
+    def test_bad_escalating_group(self, mock_logger):
+        self.escalating_grouphistory.update(
+            date_added=datetime.now() - timedelta(days=8),
+        )
+        detect_invalid_group_status()
+        assert mock_logger.called
+        assert mock_logger.call_args.kwargs["extra"]["count"] == 1
+        assert mock_logger.call_args.kwargs["extra"]["escalating"] == [self.escalating_group.id]
+
+    @patch("sentry.tasks.invalid_group_status_detection.logger.error")
+    def test_unsupported_status(self, mock_logger):
+        bad_group = self.create_group()
+        bad_group.update(
+            status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.UNTIL_CONDITION_MET
+        )
+        detect_invalid_group_status()
+        assert mock_logger.called
+        assert mock_logger.call_args.kwargs["extra"]["count"] == 1
+        assert mock_logger.call_args.kwargs["extra"]["archived_until_condition_met"] == [
+            bad_group.id
+        ]


### PR DESCRIPTION
This is a followup from iNC-624, where issues had the wrong substatus when the auto-transition task stopped running.

This cron will check 500 random groups for group statuses inconsistencies once a week - tbd if that's the right cadence or sample size. 

Currently, this only checks for inconsistencies that could be a result of the auto-transition task not working. We could extend this to check for ignored issues that should have been marked unresolved, but that's pretty redundant with sentry/tasks/clear_expired_snoozes.py.

Fixes https://github.com/getsentry/team-issues/issues/16