### PR TITLE
fix(ui): Cast more objects to ReactNode

### DIFF
--- a/static/app/components/compactSelect/gridList/index.tsx
+++ b/static/app/components/compactSelect/gridList/index.tsx
@@ -3,6 +3,7 @@ import type {AriaGridListOptions} from '@react-aria/gridlist';
 import {useGridList} from '@react-aria/gridlist';
 import {mergeProps} from '@react-aria/utils';
 import type {ListState} from '@react-stately/list';
+import type {CollectionChildren} from '@react-types/shared';
 
 import {t} from 'sentry/locale';
 import domId from 'sentry/utils/domId';
@@ -17,7 +18,7 @@ import {GridListOption} from './option';
 import {GridListSection} from './section';
 
 interface GridListProps
-  extends React.HTMLAttributes<HTMLUListElement>,
+  extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'>,
     Omit<
       AriaGridListOptions<any>,
       'disabledKeys' | 'selectedKeys' | 'defaultSelectedKeys' | 'onSelectionChange'
@@ -34,6 +35,7 @@ interface GridListProps
    * `useGridList()`.
    */
   listState: ListState<any>;
+  children?: CollectionChildren<any>;
   /**
    * Text label to be rendered as heading on top of grid list.
    */

--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -353,7 +353,9 @@ function List<Value extends SelectKey>({
           listState={listState}
           sizeLimitMessage={sizeLimitMessage}
           keyDownHandler={keyDownHandler}
-        />
+        >
+          {props.children as React.ReactNode}
+        </GridList>
       ) : (
         <ListBox
           {...props}
@@ -363,7 +365,9 @@ function List<Value extends SelectKey>({
           shouldFocusOnHover={shouldFocusOnHover}
           sizeLimitMessage={sizeLimitMessage}
           keyDownHandler={keyDownHandler}
-        />
+        >
+          {props.children as React.ReactNode}
+        </ListBox>
       )}
 
       {multiple &&

--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -353,9 +353,7 @@ function List<Value extends SelectKey>({
           listState={listState}
           sizeLimitMessage={sizeLimitMessage}
           keyDownHandler={keyDownHandler}
-        >
-          {props.children as React.ReactNode}
-        </GridList>
+        />
       ) : (
         <ListBox
           {...props}
@@ -365,9 +363,7 @@ function List<Value extends SelectKey>({
           shouldFocusOnHover={shouldFocusOnHover}
           sizeLimitMessage={sizeLimitMessage}
           keyDownHandler={keyDownHandler}
-        >
-          {props.children as React.ReactNode}
-        </ListBox>
+        />
       )}
 
       {multiple &&

--- a/static/app/components/compactSelect/listBox/index.tsx
+++ b/static/app/components/compactSelect/listBox/index.tsx
@@ -3,6 +3,7 @@ import type {AriaListBoxOptions} from '@react-aria/listbox';
 import {useListBox} from '@react-aria/listbox';
 import {mergeProps} from '@react-aria/utils';
 import type {ListState} from '@react-stately/list';
+import type {CollectionChildren} from '@react-types/shared';
 
 import {t} from 'sentry/locale';
 import type {FormSize} from 'sentry/utils/theme';
@@ -18,7 +19,7 @@ import {ListBoxSection} from './section';
 interface ListBoxProps
   extends Omit<
       React.HTMLAttributes<HTMLUListElement>,
-      'onBlur' | 'onFocus' | 'autoFocus'
+      'onBlur' | 'onFocus' | 'autoFocus' | 'children'
     >,
     Omit<
       AriaListBoxOptions<any>,
@@ -42,6 +43,7 @@ interface ListBoxProps
    * `useListBox()`.
    */
   listState: ListState<any>;
+  children?: CollectionChildren<any>;
   /**
    * Text label to be rendered as heading on top of grid list.
    */

--- a/static/app/components/events/interfaces/request/richHttpContentClippedBoxKeyValueList.tsx
+++ b/static/app/components/events/interfaces/request/richHttpContentClippedBoxKeyValueList.tsx
@@ -52,7 +52,8 @@ export function RichHttpContentClippedBoxKeyValueList({
         />
       );
     } catch {
-      return <pre>{data}</pre>;
+      // TODO(TS): Types indicate that data might be an object
+      return <pre>{data as any}</pre>;
     }
   }
 

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanTree.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanTree.tsx
@@ -805,7 +805,8 @@ class NewTraceDetailsSpanTree extends Component<PropType> {
           {({height, isScrolling, onChildScroll, scrollTop, registerChild}) => (
             <AutoSizer disableHeight>
               {({width}) => (
-                <div ref={el => registerChild(el)}>
+                // TODO(TS): registerChild expects a ReactNode instead of a HTML ref
+                <div ref={el => registerChild(el as any)}>
                   <ReactVirtualizedList
                     autoHeight
                     isScrolling={isScrolling}

--- a/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
+++ b/static/app/components/events/interfaces/spans/profilingMeasurements.tsx
@@ -148,9 +148,9 @@ type ProfilingMeasurementsProps = {
     cursorGuideHeight: number;
     mouseLeft: number | undefined;
     showCursorGuide: boolean;
-  }) => void;
-  renderFog?: () => void;
-  renderWindowSelection?: () => void;
+  }) => React.ReactNode;
+  renderFog?: () => React.ReactNode;
+  renderWindowSelection?: () => React.ReactNode;
 };
 
 function ProfilingMeasurements({

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -187,7 +187,7 @@ export default class AbstractExternalIssueForm<
         <Fragment>
           <QuestionTooltip
             title={tct('This is your current [label].', {
-              label: field.label,
+              label: field.label as React.ReactNode,
             })}
             size="xs"
           />{' '}

--- a/static/app/components/hookOrDefault.tsx
+++ b/static/app/components/hookOrDefault.tsx
@@ -12,7 +12,7 @@ interface Params<H extends HookName> {
   /**
    * Component that will be shown if no hook is available
    */
-  defaultComponent?: ReturnType<Hooks[H]>;
+  defaultComponent?: ReturnType<Hooks[H]> | (() => ReturnType<Hooks[H]>);
   /**
    * This is a function that returns a promise (more specifically a function
    * that returns the result of a dynamic import using `import()`. This will

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -66,7 +66,7 @@ interface ErrorBoundaryState {
 }
 
 // Error boundaries currently have to be classes.
-class ErrorBoundary extends Component<{}, ErrorBoundaryState> {
+class ErrorBoundary extends Component<{children: React.ReactNode}, ErrorBoundaryState> {
   static getDerivedStateFromError(error: Error) {
     return {
       hasError: true,

--- a/static/app/components/organizations/hybridFilter.tsx
+++ b/static/app/components/organizations/hybridFilter.tsx
@@ -235,7 +235,7 @@ export function HybridFilter<Value extends SelectKey>({
           <Fragment>
             {footerMessage && <FooterMessage>{footerMessage}</FooterMessage>}
             <FooterWrap>
-              <FooterInnerWrap>{menuFooter}</FooterInnerWrap>
+              <FooterInnerWrap>{menuFooter as React.ReactNode}</FooterInnerWrap>
               {showModifierTip && (
                 <FooterTip>
                   <IconInfo size="xs" />

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -178,15 +178,7 @@ function Search({
                 searchOptions={searchOptions}
                 query={searchQuery}
                 params={params}
-                sources={
-                  sources ??
-                  ([
-                    ApiSource,
-                    FormSource,
-                    RouteSource,
-                    CommandSource,
-                  ] as React.ComponentType[])
-                }
+                sources={sources ?? [ApiSource, FormSource, RouteSource, CommandSource]}
               >
                 {({isLoading, results, hasAnyResults}) => (
                   <List

--- a/static/app/components/search/sources/index.tsx
+++ b/static/app/components/search/sources/index.tsx
@@ -14,7 +14,7 @@ type Props = {
   children: (props: ChildProps) => React.ReactElement;
   params: {orgId: string};
   query: string;
-  sources: React.ComponentType[];
+  sources: React.ComponentType<any>[];
   searchOptions?: Fuse.IFuseOptions<any>;
 };
 

--- a/static/app/components/stories/matrix.tsx
+++ b/static/app/components/stories/matrix.tsx
@@ -57,7 +57,8 @@ export default function Matrix<P extends RenderProps>({
   return (
     <div>
       <h4 style={{margin: 0}}>
-        <samp>{selectedProps[0]}</samp> vs <samp>{selectedProps[1]}</samp>
+        <samp>{selectedProps[0] as string | number}</samp> vs{' '}
+        <samp>{selectedProps[1] as string | number}</samp>
       </h4>
       <Grid
         style={{

--- a/static/app/components/structuredEventData/index.tsx
+++ b/static/app/components/structuredEventData/index.tsx
@@ -32,7 +32,8 @@ export type StructuredEventDataProps = {
    * Allows customization of how values are rendered
    */
   config?: StructedEventDataConfig;
-  data?: React.ReactNode;
+  // TODO(TS): What possible types can `data` be?
+  data?: any;
   'data-test-id'?: string;
   maxDefaultDepth?: number;
   meta?: Record<any, any>;
@@ -80,7 +81,8 @@ function StructuredData({
   maxDefaultDepth: number;
   meta: Record<any, any> | undefined;
   withAnnotatedText: boolean;
-  value?: React.ReactNode;
+  // TODO(TS): What possible types can `value` be?
+  value?: any;
 }) {
   let i = 0;
 

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -300,7 +300,8 @@ function mark<T extends React.ReactNode>(node: T): T {
   };
 
   proxy.toString = () => '✅' + node + '✅';
-  return proxy as T;
+  // TODO(TS): Should proxy be created using `React.createElement`?
+  return proxy as any as T;
 }
 
 /**

--- a/static/app/utils/isRenderFunc.tsx
+++ b/static/app/utils/isRenderFunc.tsx
@@ -1,6 +1,8 @@
 /**
  * Generic type guard for children as a function patterns.
  */
-export function isRenderFunc<T>(func: React.ReactNode | Function): func is T {
+export function isRenderFunc<T extends React.ReactNode | Function>(
+  func: React.ReactNode | Function
+): func is T {
   return typeof func === 'function';
 }

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -665,7 +665,8 @@ function getSectionFieldSet(section: Section, fields: Field[]) {
   return (
     <fieldset key={section.key}>
       {section.heading && <legend>{section.heading}</legend>}
-      {fields}
+      {/* TODO(TS): Types indicate fields can be an object */}
+      {fields as React.ReactNode}
     </fieldset>
   );
 }

--- a/static/app/views/performance/database/noDataMessage.tsx
+++ b/static/app/views/performance/database/noDataMessage.tsx
@@ -12,7 +12,7 @@ import {useDenylistedProjects} from 'sentry/views/performance/database/useDenyli
 import {useOutdatedSDKProjects} from 'sentry/views/performance/database/useOutdatedSDKProjects';
 
 interface Props {
-  Wrapper?: React.ComponentType;
+  Wrapper?: React.ComponentType<any>;
   isDataAvailable?: boolean;
 }
 

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -157,7 +157,10 @@ function ProjectStabilityScoreCard(props: Props) {
   if (error) {
     return (
       <LoadingError
-        message={error.responseJSON?.detail || t('There was an error loading data.')}
+        message={
+          (error.responseJSON?.detail as React.ReactNode) ||
+          t('There was an error loading data.')
+        }
         onRetry={refetch}
       />
     );

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -59,6 +59,7 @@ type RouteParams = {
 
 type Props = RouteComponentProps<RouteParams, {}> &
   WithRouteAnalyticsProps & {
+    children: React.ReactNode;
     organization: Organization;
     releaseMeta: ReleaseMeta;
     selection: PageFilters;

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -49,8 +49,8 @@ function NotificationSettings({organizations}: NotificationSettingsProps) {
     return (
       <FieldWrapper key={type}>
         <div>
-          <FieldLabel>{field.label}</FieldLabel>
-          <FieldHelp>{field.help}</FieldHelp>
+          <FieldLabel>{field.label as React.ReactNode}</FieldLabel>
+          <FieldHelp>{field.help as React.ReactNode}</FieldHelp>
         </div>
         <IconWrapper>
           <LinkButton

--- a/static/app/views/starfish/index.tsx
+++ b/static/app/views/starfish/index.tsx
@@ -7,7 +7,7 @@ import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
-  children: React.ReactChildren;
+  children: React.ReactNode;
 };
 
 const queryClient = new QueryClient();


### PR DESCRIPTION
React 18 throws type errors when we're trying to render objects, the types were defined in a way that isn't properly narrowed or maybe we are rendering objects. Added some comments but for the most part I think they are ReactNodes.

part of https://github.com/getsentry/frontend-tsc/issues/22
