### PR TITLE
fix(link): leading slash breaks anchor

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/replay/tracePropagationMessage.tsx
@@ -9,7 +9,7 @@ export default function TracePropagationMessage() {
         `To see replays for backend errors, ensure that you have set up trace propagation. To learn more, [link:read the docs].`,
         {
           link: (
-            <ExternalLink href="https://docs.sentry.io/product/session-replay/getting-started/#replays-for-backend-errors/" />
+            <ExternalLink href="https://docs.sentry.io/product/session-replay/getting-started/#replays-for-backend-errors" />
           ),
         }
       )}


### PR DESCRIPTION
Clicking on this link took me to the page but not to the anchor. 

Removing the leading slash fixes that