### PR TITLE
perf(projects): optionally emit metrics for killswitch

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -716,7 +716,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             if not self._collapse(LATEST_DEPLOYS_KEY):
                 attrs[item]["deploys"] = deploys_by_project.get(item.id)
             attrs[item]["symbolication_degraded"] = should_demote_symbolication(
-                project_id=item.id, lpq_projects=lpq_projects
+                project_id=item.id, lpq_projects=lpq_projects, emit_metrics=False
             )
 
         return attrs

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -251,7 +251,7 @@ def normalize_value(
     return rv
 
 
-def killswitch_matches_context(killswitch_name: str, context: Context, emit_metrics=False) -> bool:
+def killswitch_matches_context(killswitch_name: str, context: Context, emit_metrics=True) -> bool:
     assert killswitch_name in ALL_KILLSWITCH_OPTIONS
     assert set(ALL_KILLSWITCH_OPTIONS[killswitch_name].fields) == set(context)
     option_value = options.get(killswitch_name)

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -251,15 +251,19 @@ def normalize_value(
     return rv
 
 
-def killswitch_matches_context(killswitch_name: str, context: Context) -> bool:
+def killswitch_matches_context(killswitch_name: str, context: Context, emit_metrics=False) -> bool:
     assert killswitch_name in ALL_KILLSWITCH_OPTIONS
     assert set(ALL_KILLSWITCH_OPTIONS[killswitch_name].fields) == set(context)
     option_value = options.get(killswitch_name)
     rv = _value_matches(killswitch_name, option_value, context)
-    metrics.incr(
-        "killswitches.run",
-        tags={"killswitch_name": killswitch_name, "decision": "matched" if rv else "passed"},
-    )
+
+    if emit_metrics:
+        # metrics can have a meaningful performance impact, so allow caller to opt out
+        # TODO: re-evaluate after we make metric collection aysnc.
+        metrics.incr(
+            "killswitches.run",
+            tags={"killswitch_name": killswitch_name, "decision": "matched" if rv else "passed"},
+        )
 
     return rv
 


### PR DESCRIPTION
as an alternative to https://github.com/getsentry/sentry/pull/66032, while we wait for https://github.com/getsentry/sentry/pull/66039

keep the metrics for the killswitch call here, but turn them off from the project serializer caller.

big impact on performance, see https://sentry.sentry.io/profiling/profile/sentry/e409e184a7a7449c883c90abcdcc28f3/flamegraph/?colorCoding=by+system+vs+application+frame&fov=0%2C94%2C8144141824%2C10&query=&sorting=call+order&tid=136213193283328&view=top+down


Related: #65939 