### PR TITLE
feat(indexed-spans): Support profile.id on indexed spans

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -135,6 +135,7 @@ SPAN_COLUMN_MAP = {
     "transaction.op": "transaction_op",
     "user": "user",
     "profile_id": "profile_id",
+    "profile.id": "profile_id",
     "transaction.method": "sentry_tags[transaction.method]",
     "system": "sentry_tags[system]",
     "raw_domain": "sentry_tags[raw_domain]",

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -134,7 +134,7 @@ SPAN_COLUMN_MAP = {
     "segment.id": "segment_id",
     "transaction.op": "transaction_op",
     "user": "user",
-    "profile_id": "profile_id",
+    "profile_id": "profile_id",  # deprecated in favour of `profile.id`
     "profile.id": "profile_id",
     "transaction.method": "sentry_tags[transaction.method]",
     "system": "sentry_tags[system]",

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from snuba_sdk import Column, Condition, Function, Op
+from snuba_sdk import AliasedExpression, Column, Condition, Function, Op
 
 from sentry.search.events.builder import SpansIndexedQueryBuilder
 from sentry.snuba.dataset import Dataset
@@ -52,7 +52,15 @@ span_duration = Function(
 
 
 @pytest.mark.parametrize(
-    ["field", "expected"], [pytest.param("span.duration", span_duration, id="span.duration")]
+    ["field", "expected"],
+    [
+        pytest.param("span.duration", span_duration, id="span.duration"),
+        pytest.param(
+            "profile.id",
+            AliasedExpression(Column("profile_id"), alias="profile.id"),
+            id="profile.id",
+        ),
+    ],
 )
 @django_db_all
 def test_field_alias(params, field, expected):


### PR DESCRIPTION
This column is called `profile.id` on other datasets. Not sure why it's called `profile_id` here. Especially when all other id columns in this dataset uses the dot notation. Keeping `profile_id` around for compatibility.