### PR TITLE
chore(crons): Add feature to disable legacy ingestion endpoints

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1487,6 +1487,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable creating organizations within sentry
     # (if SENTRY_SINGLE_ORGANIZATION is not enabled).
     "organizations:create": True,
+    # Disables legacy cron ingest endpoints
+    "organizations:crons-disable-ingest-endpoints": False,
     # Disables projects with zero monitors to create new ones
     "organizations:crons-disable-new-projects": False,
     # Metrics: Enable ingestion and storage of custom metrics. See ddm-ui for UI.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -81,6 +81,7 @@ default_manager.add("organizations:api-keys", OrganizationFeature, FeatureHandle
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:codecov-commit-sha-from-git-blame", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:daily-summary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:crons-disable-ingest-endpoints", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:crons-disable-new-projects", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:dashboard-widget-indicators", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboards-import", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_details.py
@@ -25,6 +25,8 @@ from sentry.monitors.serializers import MonitorCheckInSerializer
 from sentry.monitors.utils import get_new_timeout_at, valid_duration
 from sentry.monitors.validators import MonitorCheckInValidator
 
+from ... import features
+from ...api.exceptions import ResourceDoesNotExist
 from .base import MonitorIngestEndpoint
 
 
@@ -69,6 +71,9 @@ class MonitorIngestCheckInDetailsEndpoint(MonitorIngestEndpoint):
         You may use `latest` for the `checkin_id` parameter in order to retrieve
         the most recent (by creation date) check-in which is still mutable (not marked as finished).
         """
+        if features.has("organizations:crons-disable-ingest-endpoints", project.organization):
+            raise ResourceDoesNotExist
+
         if checkin.status in CheckInStatus.FINISHED_VALUES:
             return self.respond(status=400)
 


### PR DESCRIPTION
Before we fully remove these we want to roll out the deletion slowly, so we're able to revert it quickly if we hear a lot of complaints.
