### PR TITLE
feat(metrics): Do not plot scatter plot for count

### DIFF
--- a/static/app/views/ddm/chart/useMetricChartSamples.tsx
+++ b/static/app/views/ddm/chart/useMetricChartSamples.tsx
@@ -336,7 +336,7 @@ export function useMetricChartSamplesV2({
   }, [valueRect.yMin, valueRect.yMax]);
 
   const series = useMemo(() => {
-    if (operation === 'sum' || operation === 'count_unique') {
+    if (isCumulativeOp(operation)) {
       // TODO: for now we do not show samples for cumulative operations
       // figure out how should this be shown
       return [];


### PR DESCRIPTION
Similar to sum and count_unique, the scatter plot for count just results in all the dots being at the bottom of the chart. Let's disable it for now.