### PR TITLE
feat(metrics): Add feature flag for metrics sample list search

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1660,6 +1660,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:metrics-blocking": False,
     # Enables the new samples list experience
     "organizations:metrics-samples-list": False,
+    # Enables the search bar for metrics samples list
+    "organizations:metrics-samples-list-search": False,
     # Enable Session Stats down to a minute resolution
     "organizations:minute-resolution-sessions": True,
     # Adds the ttid & ttfd vitals to the frontend

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -144,6 +144,7 @@ default_manager.add("organizations:metrics-api-new-metrics-layer", OrganizationF
 default_manager.add("organizations:metrics-blocking", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:metrics-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:metrics-samples-list", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:metrics-samples-list-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:mobile-cpu-memory-in-transactions", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:mobile-ttid-ttfd-contribution", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
Going to put the search behind a feature flag because it won't work for all metrics immediately but I want to be start rolling out the new samples list soon.