### PR TITLE
feat(autofix): Use active event + invoking user and issue shortid in payload

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -107,7 +107,7 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
 
     def _call_autofix(
         self,
-        user: User,
+        user: User | AnonymousUser,
         group: Group,
         repos: list[dict],
         event_entries: list[dict],
@@ -127,10 +127,14 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
                         "events": [{"entries": event_entries}],
                     },
                     "additional_context": additional_context,
-                    "invoking_user": {
-                        "id": user.id,
-                        "display_name": user.get_display_name(),
-                    },
+                    "invoking_user": (
+                        {
+                            "id": user.id,
+                            "display_name": user.get_display_name(),
+                        }
+                        if isinstance(user, User)
+                        else None
+                    ),
                 }
             ),
             headers={"content-type": "application/json;charset=utf-8"},

--- a/static/app/components/events/aiAutofix/index.spec.tsx
+++ b/static/app/components/events/aiAutofix/index.spec.tsx
@@ -1,3 +1,4 @@
+import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -6,6 +7,7 @@ import {AiAutofix} from 'sentry/components/events/aiAutofix';
 import type {EventMetadataWithAutofix} from 'sentry/components/events/aiAutofix/types';
 
 const group = GroupFixture();
+const event = EventFixture();
 
 describe('AiAutofix', () => {
   beforeAll(() => {
@@ -16,7 +18,7 @@ describe('AiAutofix', () => {
   });
 
   it('renders the Banner component when autofixData is null', () => {
-    render(<AiAutofix group={group} />);
+    render(<AiAutofix event={event} group={group} />);
 
     expect(screen.getByText('Try AI Autofix')).toBeInTheDocument();
   });
@@ -24,6 +26,7 @@ describe('AiAutofix', () => {
   it('renders the FixResult component when autofixData is present', () => {
     render(
       <AiAutofix
+        event={event}
         group={{
           ...group,
           metadata: {
@@ -55,6 +58,7 @@ describe('AiAutofix', () => {
   it('can toggle logs for completed fix', async () => {
     render(
       <AiAutofix
+        event={event}
         group={{
           ...group,
           metadata: {

--- a/static/app/components/events/aiAutofix/index.tsx
+++ b/static/app/components/events/aiAutofix/index.tsx
@@ -2,13 +2,15 @@ import {AutofixBanner} from 'sentry/components/events/aiAutofix/autofixBanner';
 import {AutofixCard} from 'sentry/components/events/aiAutofix/autofixCard';
 import type {GroupWithAutofix} from 'sentry/components/events/aiAutofix/types';
 import {useAiAutofix} from 'sentry/components/events/aiAutofix/useAiAutofix';
+import type {Event} from 'sentry/types';
 
 interface Props {
+  event: Event;
   group: GroupWithAutofix;
 }
 
-export function AiAutofix({group}: Props) {
-  const {autofixData, triggerAutofix, reset} = useAiAutofix(group);
+export function AiAutofix({event, group}: Props) {
+  const {autofixData, triggerAutofix, reset} = useAiAutofix(group, event);
 
   return (
     <div>

--- a/static/app/components/events/aiAutofix/useAiAutofix.tsx
+++ b/static/app/components/events/aiAutofix/useAiAutofix.tsx
@@ -4,12 +4,13 @@ import type {
   AutofixData,
   GroupWithAutofix,
 } from 'sentry/components/events/aiAutofix/types';
+import type {Event} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 
 const POLL_INTERVAL = 2500;
 
-export const useAiAutofix = (group: GroupWithAutofix) => {
+export const useAiAutofix = (group: GroupWithAutofix, event: Event) => {
   const api = useApi();
 
   const [overwriteData, setOverwriteData] = useState<AutofixData | 'reset' | null>(null);
@@ -59,6 +60,7 @@ export const useAiAutofix = (group: GroupWithAutofix) => {
         await api.requestPromise(`/issues/${group.id}/ai-autofix/`, {
           method: 'POST',
           data: {
+            event_id: event.id,
             additional_context: additionalContext,
           },
         });
@@ -68,7 +70,7 @@ export const useAiAutofix = (group: GroupWithAutofix) => {
 
       dataRefetch();
     },
-    [api, group.id, dataRefetch]
+    [api, group.id, event.id, dataRefetch]
   );
 
   const reset = useCallback(() => {

--- a/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
+++ b/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
@@ -56,7 +56,7 @@ export function ResourcesAndMaybeSolutions({event, project, group}: Props) {
         {displayAiSuggestedSolution && (
           <AiSuggestedSolution event={event} projectSlug={project.slug} />
         )}
-        {displayAiAutofix && <AiAutofix group={group} />}
+        {displayAiAutofix && <AiAutofix event={event} group={group} />}
       </Content>
     </Wrapper>
   );

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -78,7 +78,9 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         with patch(
             "sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix"
         ) as mock_call:
-            response = self.client.post(url, data={"additional_context": "Yes"}, format="json")
+            response = self.client.post(
+                url, data={"additional_context": "Yes", "event_id": event.event_id}, format="json"
+            )
             mock_call.assert_called_with(
                 ANY,
                 group,
@@ -133,7 +135,9 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         with patch(
             "sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix"
         ) as mock_call:
-            response = self.client.post(url, data={"additional_context": "Yes"}, format="json")
+            response = self.client.post(
+                url, data={"additional_context": "Yes", "event_id": event.event_id}, format="json"
+            )
             mock_call.assert_not_called()
 
         group = Group.objects.get(id=group.id)
@@ -182,7 +186,9 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         with patch(
             "sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix"
         ) as mock_call:
-            response = self.client.post(url, data={"additional_context": "Yes"}, format="json")
+            response = self.client.post(
+                url, data={"additional_context": "Yes", "event_id": event.event_id}, format="json"
+            )
             mock_call.assert_not_called()
 
         group = Group.objects.get(id=group.id)

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -83,7 +83,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             )
             mock_call.assert_called_with(
                 ANY,
-                group,
+                ANY,
                 [
                     {
                         "provider": "integrations:github",

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -83,7 +83,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             )
             mock_call.assert_called_with(
                 ANY,
-                ANY,
+                group,
                 [
                     {
                         "provider": "integrations:github",
@@ -95,7 +95,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
                 "Yes",
             )
 
-            actual_group_arg = mock_call.call_args[0][0]
+            actual_group_arg = mock_call.call_args[0][1]
             assert actual_group_arg.id == group.id
 
             entries_arg = mock_call.call_args[0][3]

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -81,6 +81,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             response = self.client.post(url, data={"additional_context": "Yes"}, format="json")
             mock_call.assert_called_with(
                 ANY,
+                group,
                 [
                     {
                         "provider": "integrations:github",
@@ -95,7 +96,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             actual_group_arg = mock_call.call_args[0][0]
             assert actual_group_arg.id == group.id
 
-            entries_arg = mock_call.call_args[0][2]
+            entries_arg = mock_call.call_args[0][3]
             assert any([entry.get("type") == "exception" for entry in entries_arg])
 
         group = Group.objects.get(id=group.id)


### PR DESCRIPTION
Update Autofix payload by including the invoking user and issue short id. Also uses the event the user triggered it with instead of the latest. We will revisit this in the future.

Double frontend+backend is due to passing the event id up from frontend