### PR TITLE
Giving the correct type to `apply_modifications_to_frame`

### DIFF
--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -310,13 +310,13 @@ def normalize_stacktraces_for_grouping(
             if frames:
                 stacktrace_frames.append(frames)
                 stacktrace_containers.append(
-                    stacktrace_info.container if stacktrace_info.is_exception else None
+                    stacktrace_info.container if stacktrace_info.is_exception else {}
                 )
 
     if not stacktrace_frames:
         return
 
-    platform = data.get("platform")
+    platform = data.get("platform", "")
     sentry_sdk.set_tag("platform", platform)
 
     # Put the trimmed function names into the frames.  We only do this if

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -500,5 +500,5 @@ def test_sentinel_and_prefix(action, type):
 )
 def test_app_no_matches(frame):
     enhancements = Enhancements.from_config_string("app:no +app")
-    enhancements.apply_modifications_to_frame([frame], "native", None)
+    enhancements.apply_modifications_to_frame([frame], "native", {})
     assert frame.get("in_app")


### PR DESCRIPTION
The given `platform` can be `None` (see line 319) and the given `stacktrace_container` can also be `None` (line 313).
I would like to make `platform` an empty string `""` in case it is not set and `stacktrace_containers` an empty dict `{}` on the mentioned lines to give the correct types to `apply_modifications_to_frame` (line 337).