### PR TITLE
ref(perf): Respect `enabled` prop in metrics data hooks

### DIFF
--- a/static/app/views/starfish/queries/useSpanMetrics.spec.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.spec.tsx
@@ -50,6 +50,28 @@ describe('useSpanMetrics', () => {
 
   jest.mocked(useOrganization).mockReturnValue(organization);
 
+  it('respects the `enabled` prop', () => {
+    const eventsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+    });
+
+    const {result} = reactHooks.renderHook(
+      ({fields, enabled}) => useSpanMetrics({fields, enabled}),
+      {
+        wrapper: Wrapper,
+        initialProps: {
+          fields: ['spm()'] as MetricsProperty[],
+          enabled: false,
+        },
+      }
+    );
+
+    expect(result.current.isFetching).toEqual(false);
+    expect(eventsRequest).not.toHaveBeenCalled();
+  });
+
   it('queries for current selection', async () => {
     const eventsRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,

--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -13,6 +13,7 @@ import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery
 
 interface UseSpanMetricsOptions<Fields> {
   cursor?: string;
+  enabled?: boolean;
   fields?: Fields;
   filters?: SpanMetricsQueryFilters;
   limit?: number;
@@ -29,7 +30,9 @@ export const useSpanMetrics = <Fields extends MetricsProperty[]>(
 
   const eventView = getEventView(filters, fields, sorts, pageFilters.selection);
 
-  const enabled = Object.values(filters).every(value => Boolean(value));
+  // TODO: Checking that every filter has a value might not be a good choice, since this API is not convenient. Instead, it's probably fine to omit keys with blank values
+  const enabled =
+    options.enabled && Object.values(filters).every(value => Boolean(value));
 
   const result = useWrappedDiscoverQuery({
     eventView,

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.spec.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.spec.tsx
@@ -53,6 +53,34 @@ describe('useSpanMetricsSeries', () => {
 
   jest.mocked(useOrganization).mockReturnValue(organization);
 
+  it('respects the `enabled` prop', () => {
+    const eventsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      method: 'GET',
+      body: {},
+    });
+
+    const {result} = reactHooks.renderHook(
+      ({filters, enabled}) =>
+        useSpanMetricsSeries({
+          filters,
+          enabled,
+        }),
+      {
+        wrapper: Wrapper,
+        initialProps: {
+          filters: {
+            'span.group': '221aa7ebd216',
+          },
+          enabled: false,
+        },
+      }
+    );
+
+    expect(result.current.isFetching).toEqual(false);
+    expect(eventsRequest).not.toHaveBeenCalled();
+  });
+
   it('queries for current selection', async () => {
     const eventsRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -20,6 +20,7 @@ interface SpanMetricTimeseriesRow {
 }
 
 interface UseSpanMetricsSeriesOptions<Fields> {
+  enabled?: boolean;
   filters?: SpanMetricsQueryFilters;
   referrer?: string;
   yAxis?: Fields;
@@ -34,7 +35,9 @@ export const useSpanMetricsSeries = <Fields extends MetricsProperty[]>(
 
   const eventView = getEventView(filters, pageFilters.selection, yAxis);
 
-  const enabled = Object.values(filters).every(value => Boolean(value));
+  // TODO: Checking that every filter has a value might not be a good choice, since this API is not convenient. Instead, it's probably fine to omit keys with blank values
+  const enabled =
+    options.enabled && Object.values(filters).every(value => Boolean(value));
 
   const result = useWrappedDiscoverTimeseriesQuery<SpanMetricTimeseriesRow[]>({
     eventView,


### PR DESCRIPTION
So far, we haven't had a need for an `enabled` prop, because most pages either guarantee that all conditions are satisfied _or_ they provide an empty filter value like `{'span.group': undefined}` which prevents the hook from running.

This is okay, but an explicit `enabled` prop is much clearer, and is a simpler way to prevent a query from running. In upcoming modules like HTTP, I need to disabled some queries explicitly and I'd rather do that with a boolean.

For now, I left the empty value checking in place, so I don't break anything, but in the future I'd love to get rid of that and make all loading explicitly enabled or disabled.

Follows the behaviour of TanStack's built-in `useQuery`.

- `enabled` can be a boolean or undefined
- if set to `false`, the query doesn't run
- otherwise, runs
