### PR TITLE
fix(notification-actions): increase pagination max per page

### DIFF
--- a/src/sentry/api/endpoints/notifications/notification_actions_index.py
+++ b/src/sentry/api/endpoints/notifications/notification_actions_index.py
@@ -114,6 +114,8 @@ class NotificationActionsIndexEndpoint(OrganizationEndpoint):
             queryset=queryset,
             on_results=lambda action: serialize(action, request.user),
             paginator_cls=OffsetPaginator,
+            max_per_page=1000,
+            max_limit=1000,
         )
 
     @extend_schema(

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
@@ -67,6 +67,23 @@ class NotificationActionsIndexEndpointTest(APITestCase):
         for action in notif_actions:
             assert serialize(action) in response.data
 
+    def test_get_pagination(self):
+        for _ in range(200):
+            self.create_notification_action(organization=self.organization)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=status.HTTP_200_OK,
+        )
+
+        assert len(response.data) == 100
+
+        response = self.get_success_response(
+            self.organization.slug, status_code=status.HTTP_200_OK, per_page=150
+        )
+
+        assert len(response.data) == 150
+
     @patch.object(
         NotificationAction,
         "get_trigger_types",


### PR DESCRIPTION
For the spike protection settings page, we hit the `/api/0/projects` endpoint, which is paginated and loads 100 projects per page. we take those 100 projects and pass them into the notification actions endpoint `/api/0/{organization_slug}/notifications/actions/`, which is also paginated (100 actions per page).

Pagination for the notification actions endpoint is currently not handled on the frontend. So if there are 100 projects and some of them have 2+ notification actions, any notification actions created after those first 100 will not show up on the spike protection settings page and it looks like the notification action disappears after creating it.

A quick fix here is the increase the possible number of results per page for the notification actions endpoint, and add an extra query param on the spike protection FE.