### PR TITLE
fix(profiling): remove early return

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingSidebar.tsx
@@ -49,11 +49,6 @@ export function ProfilingOnboardingSidebar(props: CommonSidebarProps) {
   );
 
   useEffect(() => {
-    // If we already picked a project, don't do anything
-    if (currentProject) {
-      return;
-    }
-
     // we'll only ever select an unsupportedProject if they do not have a supported project in their organization
     if (supportedProjects.length === 0 && unsupportedProjects.length > 0) {
       if (pageFilters.selection.projects[0] === ALL_ACCESS_PROJECTS) {


### PR DESCRIPTION
At some random point in time, this spun into an infinite loop and the selection check was added to quickly mitigate the issue. It seems as if it now no longer does that and the external root cause was fixed and we can revert this.