### PR TITLE
feat(profiling): Support vertical scrolling on flamegraph preview

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
@@ -1,9 +1,11 @@
 import type {CSSProperties} from 'react';
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import {vec2} from 'gl-matrix';
+import {type mat3, vec2} from 'gl-matrix';
 
 import {FlamegraphTooltip} from 'sentry/components/profiling/flamegraph/flamegraphTooltip';
+import {useCanvasScroll} from 'sentry/components/profiling/flamegraph/interactions/useCanvasScroll';
+import {useCanvasZoomOrScroll} from 'sentry/components/profiling/flamegraph/interactions/useCanvasZoomOrScroll';
 import {defined} from 'sentry/utils';
 import {
   CanvasPoolManager,
@@ -106,6 +108,35 @@ export function FlamegraphPreview({
     return new FlamegraphTextRenderer(flamegraphCanvasRef, flamegraphTheme, flamegraph);
   }, [flamegraph, flamegraphCanvasRef, flamegraphTheme]);
 
+  // Uses a useLayoutEffect to ensure that these top level/global listeners are added before
+  // any of the children components effects actually run. This way we do not lose events
+  // when we register/unregister these top level listeners.
+  useLayoutEffect(() => {
+    if (!flamegraphCanvas || !flamegraphView) {
+      return undefined;
+    }
+
+    const onTransformConfigView = (
+      mat: mat3,
+      sourceTransformConfigView: CanvasView<any>
+    ) => {
+      if (sourceTransformConfigView === flamegraphView) {
+        flamegraphView.transformConfigView(mat);
+      }
+      canvasPoolManager.draw();
+    };
+
+    /**
+     * There are other events that the scheduler can subscribe to but
+     * this is all that's supported on the preview.
+     */
+    scheduler.on('transform config view', onTransformConfigView);
+
+    return () => {
+      scheduler.off('transform config view', onTransformConfigView);
+    };
+  }, [canvasPoolManager, flamegraphCanvas, flamegraphView, scheduler]);
+
   useEffect(() => {
     if (!flamegraphCanvas || !flamegraphView || !flamegraphRenderer || !textRenderer) {
       return undefined;
@@ -192,6 +223,19 @@ export function FlamegraphPreview({
     flamegraphCanvas,
     flamegraphView
   );
+
+  const onCanvasScroll = useCanvasScroll(
+    flamegraphCanvas,
+    flamegraphView,
+    canvasPoolManager,
+    true // disables x panning
+  );
+
+  useCanvasZoomOrScroll({
+    setConfigSpaceCursor,
+    handleScroll: onCanvasScroll,
+    canvas: flamegraphCanvasRef,
+  });
 
   return (
     <CanvasContainer>

--- a/static/app/components/profiling/flamegraph/interactions/useCanvasZoomOrScroll.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useCanvasZoomOrScroll.tsx
@@ -11,10 +11,10 @@ export function useCanvasZoomOrScroll({
   setLastInteraction,
 }: {
   canvas: HTMLCanvasElement | null;
-  handleScroll: (evt: WheelEvent) => void;
-  handleWheel: (evt: WheelEvent) => void;
   setConfigSpaceCursor: React.Dispatch<React.SetStateAction<vec2 | null>>;
-  setLastInteraction: React.Dispatch<
+  handleScroll?: (evt: WheelEvent) => void;
+  handleWheel?: (evt: WheelEvent) => void;
+  setLastInteraction?: React.Dispatch<
     React.SetStateAction<'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null>
   >;
 }) {
@@ -29,7 +29,7 @@ export function useCanvasZoomOrScroll({
         window.cancelAnimationFrame(wheelStopTimeoutId.current);
       }
       wheelStopTimeoutId = requestAnimationFrameTimeout(() => {
-        setLastInteraction(null);
+        setLastInteraction?.(null);
       }, 300);
 
       // When we zoom, we want to clear cursor so that any tooltips
@@ -38,11 +38,11 @@ export function useCanvasZoomOrScroll({
 
       // pinch to zoom is recognized as `ctrlKey + wheelEvent`
       if (evt.metaKey || evt.ctrlKey) {
-        handleWheel(evt);
-        setLastInteraction('zoom');
+        handleWheel?.(evt);
+        setLastInteraction?.('zoom');
       } else {
-        handleScroll(evt);
-        setLastInteraction('scroll');
+        handleScroll?.(evt);
+        setLastInteraction?.('scroll');
       }
     }
 


### PR DESCRIPTION
The preview tries to scroll to the relevant parts of the flamegraph but because it's limited in height, sometimes the relevant frames are cut off still. This allows for vertical scrolling so the user can still scroll to see more of what's going on in the profiling data.