### PR TITLE
perf: do not include projects and teams

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -364,7 +364,10 @@ class SentryAppInstallationPermission(SentryPermission):
 
         # TODO(hybrid-cloud): Replace this RPC with an org member lookup when that exists?
         org_context = organization_service.get_organization_by_id(
-            id=installation.organization_id, user_id=request.user.id
+            id=installation.organization_id,
+            user_id=request.user.id,
+            include_teams=False,
+            include_projects=False,
         )
         if (
             org_context.member is None

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -66,7 +66,9 @@ class BaseAuthIndexEndpoint(Endpoint):
         if not url_has_allowed_host_and_scheme(redirect, allowed_hosts=(request.get_host(),)):
             redirect = None
         initiate_login(request, redirect)
-        organization_context = organization_service.get_organization_by_id(id=org_id)
+        organization_context = organization_service.get_organization_by_id(
+            id=org_id, include_teams=False, include_projects=False
+        )
         assert organization_context, "Failed to fetch organization in _reauthenticate_with_sso"
         raise SsoRequired(
             organization=organization_context.organization,
@@ -242,7 +244,9 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
 
             if not DISABLE_SSO_CHECK_FOR_LOCAL_DEV and not is_self_hosted():
                 if Superuser.org_id:
-                    superuser_org = organization_service.get_organization_by_id(id=Superuser.org_id)
+                    superuser_org = organization_service.get_organization_by_id(
+                        id=Superuser.org_id, include_teams=False, include_projects=False
+                    )
 
                     verify_authenticator = (
                         False

--- a/src/sentry/api/endpoints/integrations/sentry_apps/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/details.py
@@ -58,7 +58,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                 status=403,
             )
         owner_context = organization_service.get_organization_by_id(
-            id=sentry_app.owner_id, user_id=None
+            id=sentry_app.owner_id, user_id=None, include_projects=False, include_teams=False
         )
         if (
             owner_context

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -776,7 +776,7 @@ class SlackActionEndpoint(Endpoint):
         use_block_kit = False
         if len(org_integrations):
             org_context = organization_service.get_organization_by_id(
-                id=org_integrations[0].organization_id
+                id=org_integrations[0].organization_id, include_projects=False, include_teams=False
             )
             if org_context:
                 use_block_kit = any(

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -133,7 +133,9 @@ class SlackEventEndpoint(SlackDMEndpoint):
             )
             organization_id = ois[0].organization_id if len(ois) > 0 else None
             organization_context = (
-                organization_service.get_organization_by_id(id=organization_id, user_id=None)
+                organization_service.get_organization_by_id(
+                    id=organization_id, user_id=None, include_projects=False, include_teams=False
+                )
                 if organization_id
                 else None
             )

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -89,7 +89,9 @@ def bind_org_context_from_integration(
         check_tag_for_scope_bleed("integration_id", integration_id, add_to_scope=False)
     elif len(org_integrations) == 1:
         org_integration = org_integrations[0]
-        org = organization_service.get_organization_by_id(id=org_integration.organization_id)
+        org = organization_service.get_organization_by_id(
+            id=org_integration.organization_id, include_teams=False, include_projects=False
+        )
         if org is not None:
             bind_organization_context(org.organization)
         else:

--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -85,7 +85,9 @@ class Pipeline(abc.ABC):
 
         organization: RpcOrganization | None = None
         if state.org_id:
-            org_context = organization_service.get_organization_by_id(id=state.org_id)
+            org_context = organization_service.get_organization_by_id(
+                id=state.org_id, include_teams=False
+            )
             if org_context:
                 organization = org_context.organization
 

--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -151,7 +151,9 @@ def createuser(emails, org_id, password, superuser, staff, no_password, no_input
 
                 # Get the org if specified, otherwise use the default.
                 if org_id:
-                    org_context = organization_service.get_organization_by_id(id=org_id)
+                    org_context = organization_service.get_organization_by_id(
+                        id=org_id, include_teams=False, include_projects=False
+                    )
                     if org_context is None:
                         raise Exception("Organization ID not found")
                     org = org_context.organization


### PR DESCRIPTION
By default we query `projects` and `teams` on every request. This is an attempt to reduce the unnecessary database queries.