### PR TITLE
fix(ui): Add children to RouteProps

### DIFF
--- a/static/app/types/react-router.d.ts
+++ b/static/app/types/react-router.d.ts
@@ -8,6 +8,11 @@ declare module 'react-router' {
     children?: ReactNode;
   }
 
+  // React 18 removed children from ComponentType, this adds them back
+  interface RouteProps {
+    children?: ReactNode;
+  }
+
   interface InjectedRouter<P = Record<string, string>, Q = any> {
     location: Location<Q>;
     params: P;


### PR DESCRIPTION
part of https://github.com/getsentry/frontend-tsc/issues/22

adds children back to Route props which is used in getsentry
