### PR TITLE
fix(ui): Remove custom prism text selection styles

### DIFF
--- a/static/app/styles/prism.tsx
+++ b/static/app/styles/prism.tsx
@@ -123,13 +123,6 @@ export const prismStyles = (theme: Theme) => css`
     }
   }
 
-  pre[class*='language-']::selection,
-  code[class*='language-']::selection,
-  code[class*='language-'] *::selection {
-    text-shadow: none;
-    background: var(--prism-selected);
-  }
-
   pre[data-line] {
     position: relative;
   }

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -141,7 +141,6 @@ export const darkColors = {
 
 const prismLight = {
   '--prism-base': '#332B3B',
-  '--prism-selected': '#F5F3F7',
   '--prism-inline-code': '#332B3B',
   '--prism-inline-code-background': '#F5F3F7',
   '--prism-highlight-background': '#5C78A31C',
@@ -158,7 +157,6 @@ const prismLight = {
 
 const prismDark = {
   '--prism-base': '#D6D0DC',
-  '--prism-selected': '#393041',
   '--prism-inline-code': '#D6D0DC',
   '--prism-inline-code-background': '#18121C',
   '--prism-highlight-background': '#A8A2C31C',


### PR DESCRIPTION
The existing styles were too similar to the highlighted line color. Using browser default coloring works well enough:

![image](https://github.com/getsentry/sentry/assets/10888943/03d4293d-b09b-48f9-8512-a2b42aa5551e)
