### PR TITLE
feat(performance): Add organizations:deprecate-fid-from-performance-score feature flag option control

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1707,6 +1707,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:performance-anomaly-detection-ui": False,
     # Enable performance score calculation for transactions in relay
     "organizations:performance-calculate-score-relay": False,
+    # Deprecate fid from performance score calculation
+    "organizations:deprecate-fid-from-performance-score": False,
     # Enable performance change explorer panel on trends page
     "organizations:performance-change-explorer": False,
     # Enable interpolation of null data points in charts instead of zerofilling in performance

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -168,6 +168,7 @@ default_manager.add("organizations:onboarding", OrganizationFeature, FeatureHand
 default_manager.add("organizations:org-subdomains", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-anomaly-detection-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-calculate-score-relay", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:deprecate-fid-from-performance-score", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-change-explorer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-consecutive-db-issue", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -444,6 +444,9 @@ def _get_project_config(
         }
 
     if features.has("organizations:performance-calculate-score-relay", project.organization):
+        shouldIncludeFid = not features.has(
+            "organizations:deprecate-fid-from-performance-score", project.organization
+        )
         config["performanceScore"] = {
             "profiles": [
                 {
@@ -465,7 +468,7 @@ def _get_project_config(
                         },
                         {
                             "measurement": "fid",
-                            "weight": 0.30,
+                            "weight": 0.30 if shouldIncludeFid else 0.0,
                             "p10": 100.0,
                             "p50": 300.0,
                             "optional": True,
@@ -510,7 +513,7 @@ def _get_project_config(
                         },
                         {
                             "measurement": "fid",
-                            "weight": 0.30,
+                            "weight": 0.30 if shouldIncludeFid else 0.0,
                             "p10": 100.0,
                             "p50": 300.0,
                             "optional": True,
@@ -600,7 +603,7 @@ def _get_project_config(
                         },
                         {
                             "measurement": "fid",
-                            "weight": 0.30,
+                            "weight": 0.30 if shouldIncludeFid else 0.0,
                             "p10": 100.0,
                             "p50": 300.0,
                             "optional": True,
@@ -645,7 +648,7 @@ def _get_project_config(
                         },
                         {
                             "measurement": "fid",
-                            "weight": 0.30,
+                            "weight": 0.30 if shouldIncludeFid else 0.0,
                             "p10": 100.0,
                             "p50": 300.0,
                             "optional": True,


### PR DESCRIPTION
Add organizations:deprecate-fid-from-performance-score feature flag to control including fid in performance score calculation. If set to `true`, fid is always given a weight of 0 in performance score calculations, therefore excluded.