### PR TITLE
ref(crons): Remove legacy fingerprint generation

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -32,7 +32,6 @@ from sentry.db.models import (
 )
 from sentry.db.models.fields.slug import SentrySlugField
 from sentry.db.models.utils import slugify_instance
-from sentry.grouping.utils import hash_from_values
 from sentry.locks import locks
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleSource
@@ -642,8 +641,10 @@ class MonitorEnvironment(Model):
 
     @property
     def incident_grouphash(self):
-        # TODO(rjo100): Check to see if there's an active incident
-        # if not, use last_state_change as fallback
+        """
+        Retrieve the grouphash for the current active incident. If there is no
+        active incident None will be returned.
+        """
         active_incident = (
             MonitorIncident.objects.filter(
                 monitor_environment_id=self.id, resolving_checkin__isnull=True
@@ -654,18 +655,7 @@ class MonitorEnvironment(Model):
         if active_incident:
             return active_incident.grouphash
 
-        # XXX(rjo100): While we migrate monitor issues to using the
-        # Incident stored grouphash we still may have some active issues
-        # that are using the old hashes. We can remove this in the
-        # future once all existing issues are resolved.
-        return hash_from_values(
-            [
-                "monitor",
-                str(self.monitor.guid),
-                self.get_environment().name,
-                str(self.last_state_change),
-            ]
-        )
+        return None
 
 
 @receiver(pre_save, sender=MonitorEnvironment)

--- a/tests/sentry/monitors/logic/test_mark_ok.py
+++ b/tests/sentry/monitors/logic/test_mark_ok.py
@@ -1,8 +1,10 @@
+import uuid
 from datetime import timedelta
 from unittest.mock import patch
 
 from django.utils import timezone
 
+from sentry.grouping.utils import hash_from_values
 from sentry.issues.producer import PayloadType
 from sentry.models.group import GroupStatus
 from sentry.monitors.logic.mark_ok import mark_ok
@@ -103,7 +105,7 @@ class MarkOkTestCase(TestCase):
             monitor_environment=monitor_environment,
             starting_checkin=first_checkin,
             starting_timestamp=first_checkin.date_added,
-            grouphash=monitor_environment.incident_grouphash,
+            grouphash=hash_from_values([uuid.uuid4()]),
         )
 
         # Create OK check-ins


### PR DESCRIPTION
While implementing monitor incidents there was a period of time where we were "cutting over" to monitors creating incident entities instead of just producing issue occurrences where the grouphash was computed from an interim 'last_state_change'. All monitors are now producing incidents when they fail, so we no longer need the fallback grouphash computation

The `last_state_change` was only required for this interim period and will also be removed in a future commit.