### PR TITLE
ref(perf): Introduce `MetricReadout` component

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -119,6 +119,36 @@ export type Column = QueryFieldValue;
 
 export type Alignments = 'left' | 'right';
 
+export enum DurationUnit {
+  NANOSECOND = 'nanosecond',
+  MICROSECOND = 'microsecond',
+  MILLISECOND = 'millisecond',
+  SECOND = 'second',
+  MINUTE = 'minute',
+  HOUR = 'hour',
+  DAY = 'day',
+  WEEK = 'week',
+  MONTH = 'month',
+  YEAR = 'year',
+}
+
+export enum SizeUnit {
+  BIT = 'bit',
+  BYTE = 'byte',
+  KIBIBYTE = 'kibibyte',
+  KILOBYTE = 'kilobyte',
+  MEBIBYTE = 'mebibyte',
+  MEGABYTE = 'megabyte',
+  GIBIBYTE = 'gibibyte',
+  GIGABYTE = 'gigabyte',
+  TEBIBYTE = 'tebibyte',
+  TERABYTE = 'terabyte',
+  PEBIBYTE = 'pebibyte',
+  PETABYTE = 'petabyte',
+  EXBIBYTE = 'exbibyte',
+  EXABYTE = 'exabyte',
+}
+
 export enum RateUnit {
   PER_SECOND = '1/second',
   PER_MINUTE = '1/minute',

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -119,6 +119,8 @@ export type Column = QueryFieldValue;
 
 export type Alignments = 'left' | 'right';
 
+export type CountUnit = 'count';
+
 export enum DurationUnit {
   NANOSECOND = 'nanosecond',
   MICROSECOND = 'microsecond',

--- a/static/app/views/performance/metricReadout.spec.tsx
+++ b/static/app/views/performance/metricReadout.spec.tsx
@@ -1,0 +1,66 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DurationUnit, RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
+import {MetricReadout} from 'sentry/views/performance/metricReadout';
+
+describe('MetricReadout', function () {
+  it('shows a loading spinner if data is loading', () => {
+    render(
+      <MetricReadout
+        title="Duration"
+        unit={DurationUnit.MILLISECOND}
+        value={undefined}
+        isLoading
+      />
+    );
+
+    expect(screen.getByText('Duration')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+  });
+
+  it('shows placeholder text if data is missing', () => {
+    render(
+      <MetricReadout title="Duration" unit={DurationUnit.MILLISECOND} value={undefined} />
+    );
+
+    expect(screen.getByRole('heading', {name: 'Duration'})).toBeInTheDocument();
+    expect(screen.getByText('--')).toBeInTheDocument();
+  });
+
+  it('parses strings', () => {
+    render(<MetricReadout title="Rate" unit={RateUnit.PER_MINUTE} value={'17.8'} />);
+
+    expect(screen.getByRole('heading', {name: 'Rate'})).toBeInTheDocument();
+    expect(screen.getByText('17.8/min')).toBeInTheDocument();
+  });
+
+  it('renders rates', () => {
+    render(<MetricReadout title="Rate" unit={RateUnit.PER_MINUTE} value={17.8} />);
+
+    expect(screen.getByRole('heading', {name: 'Rate'})).toBeInTheDocument();
+    expect(screen.getByText('17.8/min')).toBeInTheDocument();
+  });
+
+  it('renders milliseconds', () => {
+    render(
+      <MetricReadout title="Duration" unit={DurationUnit.MILLISECOND} value={223142123} />
+    );
+
+    expect(screen.getByRole('heading', {name: 'Duration'})).toBeInTheDocument();
+    expect(screen.getByText('2.58d')).toBeInTheDocument();
+  });
+
+  it('renders bytes', () => {
+    render(<MetricReadout title="Size" unit={SizeUnit.BYTE} value={1172316} />);
+
+    expect(screen.getByRole('heading', {name: 'Size'})).toBeInTheDocument();
+    expect(screen.getByText('1.1 MiB')).toBeInTheDocument();
+  });
+
+  it('renders counts', () => {
+    render(<MetricReadout title="Count" unit="count" value={7800123} />);
+
+    expect(screen.getByRole('heading', {name: 'Count'})).toBeInTheDocument();
+    expect(screen.getByText('7.8m')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/metricReadout.tsx
+++ b/static/app/views/performance/metricReadout.tsx
@@ -1,3 +1,4 @@
+import type {ReactText} from 'react';
 import styled from '@emotion/styled';
 
 import Duration from 'sentry/components/duration';
@@ -10,15 +11,12 @@ import {DurationUnit, RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
 import {formatAbbreviatedNumber, formatRate} from 'sentry/utils/formatters';
 import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
-// TODO: Implement percentage units
-// TODO: Implement percentage change units
-// TODO: Implement string units
-type Unit = DurationUnit | SizeUnit | RateUnit | CountUnit;
+type Unit = DurationUnit.MILLISECOND | SizeUnit.BYTE | RateUnit | CountUnit;
 
 interface Props {
   title: string;
   unit: Unit;
-  value: number | undefined;
+  value: ReactText | undefined;
   align?: 'left' | 'right';
   isLoading?: boolean;
   tooltip?: React.ReactNode;

--- a/static/app/views/performance/metricReadout.tsx
+++ b/static/app/views/performance/metricReadout.tsx
@@ -1,0 +1,111 @@
+import styled from '@emotion/styled';
+
+import Duration from 'sentry/components/duration';
+import FileSize from 'sentry/components/fileSize';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {Tooltip} from 'sentry/components/tooltip';
+import {defined} from 'sentry/utils';
+import type {CountUnit} from 'sentry/utils/discover/fields';
+import {DurationUnit, RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
+import {formatAbbreviatedNumber, formatRate} from 'sentry/utils/formatters';
+import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
+
+// TODO: Implement percentage units
+// TODO: Implement percentage change units
+// TODO: Implement string units
+type Unit = DurationUnit | SizeUnit | RateUnit | CountUnit;
+
+interface Props {
+  title: string;
+  unit: Unit;
+  value: number | undefined;
+  align?: 'left' | 'right';
+  isLoading?: boolean;
+  tooltip?: React.ReactNode;
+}
+
+export function MetricReadout({
+  unit,
+  value,
+  title,
+  tooltip,
+  align = 'right',
+  isLoading,
+}: Props) {
+  return (
+    <Block title={title} alignment={align}>
+      {(() => {
+        if (isLoading) {
+          return <LoadingIndicator mini />;
+        }
+
+        if (!defined(value)) {
+          return '--';
+        }
+
+        let renderedValue: React.ReactNode;
+
+        if (isARateUnit(unit)) {
+          renderedValue = (
+            <NumberContainer align={align}>
+              {formatRate(typeof value === 'string' ? parseFloat(value) : value, unit)}
+            </NumberContainer>
+          );
+        }
+
+        if (unit === DurationUnit.MILLISECOND) {
+          // TODO: Implement other durations
+          renderedValue = (
+            <NumberContainer align={align}>
+              <Duration
+                seconds={typeof value === 'string' ? parseFloat(value) : value / 1000}
+                fixedDigits={2}
+                abbreviation
+              />
+            </NumberContainer>
+          );
+        }
+
+        if (unit === SizeUnit.BYTE) {
+          // TODO: Implement other sizes
+          renderedValue = (
+            <NumberContainer align={align}>
+              <FileSize bytes={typeof value === 'string' ? parseInt(value, 10) : value} />
+            </NumberContainer>
+          );
+        }
+
+        if (unit === 'count') {
+          renderedValue = (
+            <NumberContainer align={align}>
+              {formatAbbreviatedNumber(
+                typeof value === 'string' ? parseInt(value, 10) : value
+              )}
+            </NumberContainer>
+          );
+        }
+
+        if (tooltip) {
+          return (
+            <NumberContainer align={align}>
+              <Tooltip title={tooltip} isHoverable showUnderline>
+                {renderedValue}
+              </Tooltip>
+            </NumberContainer>
+          );
+        }
+
+        return <NumberContainer align={align}>{renderedValue}</NumberContainer>;
+      })()}
+    </Block>
+  );
+}
+
+const NumberContainer = styled('div')<{align: 'left' | 'right'}>`
+  text-align: ${p => p.align};
+  font-variant-numeric: tabular-nums;
+`;
+
+function isARateUnit(unit: string): unit is RateUnit {
+  return (Object.values(RateUnit) as string[]).includes(unit);
+}

--- a/static/app/views/performance/metricReadout.tsx
+++ b/static/app/views/performance/metricReadout.tsx
@@ -1,4 +1,5 @@
 import type {ReactText} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Duration from 'sentry/components/duration';
@@ -22,81 +23,74 @@ interface Props {
   tooltip?: React.ReactNode;
 }
 
-export function MetricReadout({
-  unit,
-  value,
-  title,
-  tooltip,
-  align = 'right',
-  isLoading,
-}: Props) {
+export function MetricReadout(props: Props) {
   return (
-    <Block title={title} alignment={align}>
-      {(() => {
-        if (isLoading) {
-          return <LoadingIndicator mini />;
-        }
-
-        if (!defined(value)) {
-          return '--';
-        }
-
-        let renderedValue: React.ReactNode;
-
-        if (isARateUnit(unit)) {
-          renderedValue = (
-            <NumberContainer align={align}>
-              {formatRate(typeof value === 'string' ? parseFloat(value) : value, unit)}
-            </NumberContainer>
-          );
-        }
-
-        if (unit === DurationUnit.MILLISECOND) {
-          // TODO: Implement other durations
-          renderedValue = (
-            <NumberContainer align={align}>
-              <Duration
-                seconds={typeof value === 'string' ? parseFloat(value) : value / 1000}
-                fixedDigits={2}
-                abbreviation
-              />
-            </NumberContainer>
-          );
-        }
-
-        if (unit === SizeUnit.BYTE) {
-          // TODO: Implement other sizes
-          renderedValue = (
-            <NumberContainer align={align}>
-              <FileSize bytes={typeof value === 'string' ? parseInt(value, 10) : value} />
-            </NumberContainer>
-          );
-        }
-
-        if (unit === 'count') {
-          renderedValue = (
-            <NumberContainer align={align}>
-              {formatAbbreviatedNumber(
-                typeof value === 'string' ? parseInt(value, 10) : value
-              )}
-            </NumberContainer>
-          );
-        }
-
-        if (tooltip) {
-          return (
-            <NumberContainer align={align}>
-              <Tooltip title={tooltip} isHoverable showUnderline>
-                {renderedValue}
-              </Tooltip>
-            </NumberContainer>
-          );
-        }
-
-        return <NumberContainer align={align}>{renderedValue}</NumberContainer>;
-      })()}
+    <Block title={props.title} alignment={props.align}>
+      <ReadoutContent {...props} />
     </Block>
   );
+}
+
+function ReadoutContent({unit, value, tooltip, align = 'right', isLoading}: Props) {
+  if (isLoading) {
+    return <LoadingIndicator mini />;
+  }
+
+  if (!defined(value)) {
+    return <Fragment>--</Fragment>;
+  }
+
+  let renderedValue: React.ReactNode;
+
+  if (isARateUnit(unit)) {
+    renderedValue = (
+      <NumberContainer align={align}>
+        {formatRate(typeof value === 'string' ? parseFloat(value) : value, unit)}
+      </NumberContainer>
+    );
+  }
+
+  if (unit === DurationUnit.MILLISECOND) {
+    // TODO: Implement other durations
+    renderedValue = (
+      <NumberContainer align={align}>
+        <Duration
+          seconds={typeof value === 'string' ? parseFloat(value) : value / 1000}
+          fixedDigits={2}
+          abbreviation
+        />
+      </NumberContainer>
+    );
+  }
+
+  if (unit === SizeUnit.BYTE) {
+    // TODO: Implement other sizes
+    renderedValue = (
+      <NumberContainer align={align}>
+        <FileSize bytes={typeof value === 'string' ? parseInt(value, 10) : value} />
+      </NumberContainer>
+    );
+  }
+
+  if (unit === 'count') {
+    renderedValue = (
+      <NumberContainer align={align}>
+        {formatAbbreviatedNumber(typeof value === 'string' ? parseInt(value, 10) : value)}
+      </NumberContainer>
+    );
+  }
+
+  if (tooltip) {
+    return (
+      <NumberContainer align={align}>
+        <Tooltip title={tooltip} isHoverable showUnderline>
+          {renderedValue}
+        </Tooltip>
+      </NumberContainer>
+    );
+  }
+
+  return <NumberContainer align={align}>{renderedValue}</NumberContainer>;
 }
 
 const NumberContainer = styled('div')<{align: 'left' | 'right'}>`


### PR DESCRIPTION
Extracted from #66229 as a first step. The `MetricReadout` component represents a single metric block in our various Starfish metrics ribbons.

**e.g.,**

There are three readouts in this screenshot!
<img width="403" alt="Screenshot 2024-03-04 at 4 28 47 PM" src="https://github.com/getsentry/sentry/assets/989898/12255bfa-9f44-4a16-87f7-beda83f05be4">

This component has some advantages over using plain `Block`s:

- consistent loading state
- consistent missing data state
- built-in support for different kinds of units
- built-in simple support for tooltips

This makes it easy to use it in all kinds of contexts.
