### PR TITLE
fix(metrics-extraction): Allow overriding split decision

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -324,8 +324,13 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 try:
                     widget = DashboardWidget.objects.get(id=dashboard_widget_id)
                     does_widget_have_split = widget.discover_widget_split is not None
+                    has_override_feature = features.has(
+                        "organizations:performance-discover-widget-split-override-save",
+                        organization,
+                        actor=request.user,
+                    )
 
-                    if does_widget_have_split:
+                    if does_widget_have_split and not has_override_feature:
                         # This is essentially cached behaviour and we skip the check
                         split_query = scoped_query
                         if widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS:

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -323,8 +323,13 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                 try:
                     widget = DashboardWidget.objects.get(id=dashboard_widget_id)
                     does_widget_have_split = widget.discover_widget_split is not None
+                    has_override_feature = features.has(
+                        "organizations:performance-discover-widget-split-override-save",
+                        organization,
+                        actor=request.user,
+                    )
 
-                    if does_widget_have_split:
+                    if does_widget_have_split and not has_override_feature:
                         # This is essentially cached behaviour and we skip the check
                         split_query = query
                         if widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1719,6 +1719,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:performance-database-view-percentiles": False,
     # Enable UI sending a discover split for widget
     "organizations:performance-discover-widget-split-ui": False,
+    # Enable backend overriding and always making a fresh split decision
+    "organizations:performance-discover-widget-split-override-save": False,
     # Enables updated all events tab in a performance issue
     "organizations:performance-issues-all-events-tab": False,
     # Enable compressed assets performance issue type

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -175,6 +175,7 @@ default_manager.add("organizations:performance-database-view-percentiles", Organ
 default_manager.add("organizations:performance-database-view", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-db-main-thread-detector", OrganizationFeature)
 default_manager.add("organizations:performance-discover-widget-split-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:performance-discover-widget-split-override-save", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-file-io-main-thread-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-issues-all-events-tab", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-issues-compressed-assets-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
### Summary
If there are any problems with the split decision this will cause it to always re-run the code and save the new decision,
