### PR TITLE
fix(apis): modifying ownership for EventAttachment endpoint

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -47,7 +47,7 @@ class EventAttachmentDetailsPermission(ProjectPermission):
 
 @region_silo_endpoint
 class EventAttachmentDetailsEndpoint(ProjectEndpoint):
-    owner = ApiOwner.PROCESSING
+    owner = ApiOwner.OWNERS_NATIVE
     publish_status = {
         "DELETE": ApiPublishStatus.UNKNOWN,
         "GET": ApiPublishStatus.UNKNOWN,

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -14,7 +14,7 @@ from sentry.search.utils import tokenize_query
 
 @region_silo_endpoint
 class EventAttachmentsEndpoint(ProjectEndpoint):
-    owner = ApiOwner.PROCESSING
+    owner = ApiOwner.OWNERS_NATIVE
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }


### PR DESCRIPTION
I originally assigned these to processing team but looks like they don't own it. Is this a better assignment?