### PR TITLE
fix(staff): Set access by calling parent method before checking staff

### DIFF
--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -90,7 +90,7 @@ class StaffPermissionMixin:
             active_staff = is_active_staff(request)
             if not active_staff:
                 raise
-            return active_staff
+            return True
         return is_active_staff(request)
 
     def has_object_permission(self, request, *args, **kwargs) -> bool:
@@ -106,7 +106,7 @@ class StaffPermissionMixin:
             active_staff = is_active_staff(request)
             if not active_staff:
                 raise
-            return active_staff
+            return True
         return is_active_staff(request)
 
     def is_not_2fa_compliant(self, request, *args, **kwargs) -> bool:

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -87,8 +87,7 @@ class StaffPermissionMixin:
             if super().has_permission(request, *args, **kwargs):
                 return True
         except Exception:
-            active_staff = is_active_staff(request)
-            if not active_staff:
+            if not is_active_staff(request):
                 raise
             return True
         return is_active_staff(request)
@@ -103,8 +102,7 @@ class StaffPermissionMixin:
             if super().has_object_permission(request, *args, **kwargs):
                 return True
         except Exception:
-            active_staff = is_active_staff(request)
-            if not active_staff:
+            if not is_active_staff(request):
                 raise
             return True
         return is_active_staff(request)

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -79,8 +79,9 @@ class StaffPermissionMixin:
 
     def has_permission(self, request, *args, **kwargs) -> bool:
         """
-        Calls the parent class's has_permission method. If it fails or raises an
-        error, we then checks if the request is from an active staff.
+        Calls the parent class's has_permission method. If it returns False or raises
+        an exception, we then check if the request is from an active staff. Raised
+        exceptions are not caught if the request is not from an active staff.
         """
         try:
             if super().has_permission(request, *args, **kwargs):
@@ -94,8 +95,9 @@ class StaffPermissionMixin:
 
     def has_object_permission(self, request, *args, **kwargs) -> bool:
         """
-        Calls the parent class's has_object_permission method. If it fails or
-        raises an error, we then checks if the request is from an active staff.
+        Calls the parent class's has_object_permission method. If it returns False or
+        raises an exception, we then check if the request is from an active staff.
+        Raised exceptions are not caught if the request is not from an active staff.
         """
         try:
             if super().has_object_permission(request, *args, **kwargs):

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -78,16 +78,34 @@ class StaffPermissionMixin:
     staff_allowed_methods = {"GET", "POST", "PUT", "DELETE"}
 
     def has_permission(self, request, *args, **kwargs) -> bool:
-        # Check for staff before calling super to avoid catching exceptions from super
-        if request.method in self.staff_allowed_methods and is_active_staff(request):
-            return True
-        return super().has_permission(request, *args, **kwargs)
+        """
+        Calls the parent class's has_permission method. If it fails or raises an
+        error, we then checks if the request is from an active staff.
+        """
+        try:
+            if super().has_permission(request, *args, **kwargs):
+                return True
+        except Exception:
+            active_staff = is_active_staff(request)
+            if not active_staff:
+                raise
+            return active_staff
+        return is_active_staff(request)
 
     def has_object_permission(self, request, *args, **kwargs) -> bool:
-        # Check for staff before calling super to avoid catching exceptions from super
-        if request.method in self.staff_allowed_methods and is_active_staff(request):
-            return True
-        return super().has_object_permission(request, *args, **kwargs)
+        """
+        Calls the parent class's has_object_permission method. If it fails or
+        raises an error, we then checks if the request is from an active staff.
+        """
+        try:
+            if super().has_object_permission(request, *args, **kwargs):
+                return True
+        except Exception:
+            active_staff = is_active_staff(request)
+            if not active_staff:
+                raise
+            return active_staff
+        return is_active_staff(request)
 
     def is_not_2fa_compliant(self, request, *args, **kwargs) -> bool:
         return super().is_not_2fa_compliant(request, *args, **kwargs) and not is_active_staff(

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -87,10 +87,10 @@ class StaffPermissionMixin:
             if super().has_permission(request, *args, **kwargs):
                 return True
         except Exception:
-            if not is_active_staff(request):
+            if not (request.method in self.staff_allowed_methods and is_active_staff(request)):
                 raise
             return True
-        return is_active_staff(request)
+        return request.method in self.staff_allowed_methods and is_active_staff(request)
 
     def has_object_permission(self, request, *args, **kwargs) -> bool:
         """
@@ -102,10 +102,10 @@ class StaffPermissionMixin:
             if super().has_object_permission(request, *args, **kwargs):
                 return True
         except Exception:
-            if not is_active_staff(request):
+            if not (request.method in self.staff_allowed_methods and is_active_staff(request)):
                 raise
             return True
-        return is_active_staff(request)
+        return request.method in self.staff_allowed_methods and is_active_staff(request)
 
     def is_not_2fa_compliant(self, request, *args, **kwargs) -> bool:
         return super().is_not_2fa_compliant(request, *args, **kwargs) and not is_active_staff(

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -79,9 +79,10 @@ class StaffPermissionMixin:
 
     def has_permission(self, request, *args, **kwargs) -> bool:
         """
-        Calls the parent class's has_permission method. If it returns False or raises
-        an exception, we then check if the request is from an active staff. Raised
-        exceptions are not caught if the request is not from an active staff.
+        Calls the parent class's has_permission method. If it returns False or
+        raises an exception and the method is allowed by the mixin, we then check
+        if the request is from an active staff. Raised exceptions are not caught
+        if the request is not allowed by the mixin or from an active staff.
         """
         try:
             if super().has_permission(request, *args, **kwargs):
@@ -95,8 +96,9 @@ class StaffPermissionMixin:
     def has_object_permission(self, request, *args, **kwargs) -> bool:
         """
         Calls the parent class's has_object_permission method. If it returns False or
-        raises an exception, we then check if the request is from an active staff.
-        Raised exceptions are not caught if the request is not from an active staff.
+        raises an exception and the method is allowed by the mixin, we then check
+        if the request is from an active staff. Raised exceptions are not caught
+        if the request is not allowed by the mixin or from an active staff.
         """
         try:
             if super().has_object_permission(request, *args, **kwargs):


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/65835, I switched the order in which we call the parent method's `has_{object}_permission` and staff's `is_active_staff` because the parent method would error for sentry apps.
Instead of catching this error and then calling `is_active_staff`, it was more readable to simply switch the order to check staff first.

The problem with this is having active staff and then going to your own org messes up the access class attached to your request. You pass `has_object_permission` without calling the parent method, which would've populated the request's access method here:
https://github.com/getsentry/sentry/blob/79f3aaf4540e5a4926589eb9b3ec8a1248c6403e/src/sentry/api/bases/organization.py#L79-L85

Without access scopes, this ends up causing very strange things such as an org owner missing many buttons that would otherwise appear (example video below)

https://github.com/getsentry/sentry/assets/67301797/152cd1c6-4dfb-4ac4-9527-0c802947afc4

---

### NOTE
Testing is done in the PR below
Requires https://github.com/getsentry/getsentry/pull/13138
