### PR TITLE
fix(performance): Fix a typo in the mri of measurements.inp

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -282,7 +282,7 @@ METRICS_MAP = {
     "measurements.score.weight.cls": "d:transactions/measurements.score.weight.cls@ratio",
     "measurements.score.weight.fcp": "d:transactions/measurements.score.weight.fcp@ratio",
     "measurements.score.weight.ttfb": "d:transactions/measurements.score.weight.ttfb@ratio",
-    "measurements.inp": "d:spans/webvital.inp@ratio",
+    "measurements.inp": "d:spans/webvital.inp@millisecond",
     "measurements.score.inp": "d:spans/webvital.score.inp@ratio",
     "measurements.score.weight.inp": "d:spans/webvital.score.weight.inp@ratio",
     "spans.browser": "d:transactions/breakdowns.span_ops.ops.browser@millisecond",


### PR DESCRIPTION
`measurements.inp` should point to `d:spans/webvital.inp@millisecond`