### PR TITLE
feat(metrics): Add hook to disable samples list

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -92,6 +92,8 @@ type DisabledMemberTooltipProps = {children: React.ReactNode};
 
 type DashboardHeadersProps = {organization: Organization};
 
+type DDMMetricsSamplesListProps = {children: React.ReactNode; organization: Organization};
+
 type ReplayFeedbackButton = {children: React.ReactNode};
 type ReplayListPageHeaderProps = {children?: React.ReactNode};
 type ReplayOnboardingAlertProps = {children: React.ReactNode};
@@ -182,6 +184,7 @@ export type ComponentHooks = {
   'component:confirm-account-close': () => React.ComponentType<AttemptCloseAttemptProps>;
   'component:crons-list-page-header': () => React.ComponentType<CronsBillingBannerProps>;
   'component:dashboards-header': () => React.ComponentType<DashboardHeadersProps>;
+  'component:ddm-metrics-samples-list': () => React.ComponentType<DDMMetricsSamplesListProps>;
   'component:disabled-app-store-connect-multiple': () => React.ComponentType<DisabledAppStoreConnectMultiple>;
   'component:disabled-custom-symbol-sources': () => React.ComponentType<DisabledCustomSymbolSources>;
   'component:disabled-member': () => React.ComponentType<DisabledMemberViewProps>;

--- a/static/app/views/ddm/widgetDetails.tsx
+++ b/static/app/views/ddm/widgetDetails.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {
@@ -6,6 +6,7 @@ import {
   MetricSamplesTable,
   SearchableMetricSamplesTable,
 } from 'sentry/components/ddm/metricSamplesTable';
+import HookOrDefault from 'sentry/components/hookOrDefault';
 import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
@@ -145,34 +146,36 @@ export function MetricDetails({
         <ContentWrapper>
           <TabPanels>
             <TabPanels.Item key={Tab.SAMPLES}>
-              {organization.features.includes('metrics-samples-list') ? (
-                organization.features.includes('metrics-samples-list-search') ? (
-                  <SearchableMetricSamplesTable
-                    focusArea={focusArea?.selection?.range}
-                    mri={mri}
-                    onRowHover={onRowHover}
-                    op={op}
-                    query={queryWithFocusedSeries}
-                    setMetricsSamples={setMetricsSamples}
-                  />
+              <MetricSampleTableWrapper organization={organization}>
+                {organization.features.includes('metrics-samples-list') ? (
+                  organization.features.includes('metrics-samples-list-search') ? (
+                    <SearchableMetricSamplesTable
+                      focusArea={focusArea?.selection?.range}
+                      mri={mri}
+                      onRowHover={onRowHover}
+                      op={op}
+                      query={queryWithFocusedSeries}
+                      setMetricsSamples={setMetricsSamples}
+                    />
+                  ) : (
+                    <MetricSamplesTable
+                      focusArea={focusArea?.selection?.range}
+                      mri={mri}
+                      onRowHover={onRowHover}
+                      op={op}
+                      query={queryWithFocusedSeries}
+                      setMetricsSamples={setMetricsSamples}
+                    />
+                  )
                 ) : (
-                  <MetricSamplesTable
-                    focusArea={focusArea?.selection?.range}
+                  <SampleTable
                     mri={mri}
-                    onRowHover={onRowHover}
-                    op={op}
+                    {...focusArea?.selection?.range}
                     query={queryWithFocusedSeries}
-                    setMetricsSamples={setMetricsSamples}
+                    onRowHover={onRowHover}
                   />
-                )
-              ) : (
-                <SampleTable
-                  mri={mri}
-                  {...focusArea?.selection?.range}
-                  query={queryWithFocusedSeries}
-                  onRowHover={onRowHover}
-                />
-              )}
+                )}
+              </MetricSampleTableWrapper>
             </TabPanels.Item>
             <TabPanels.Item key={Tab.CODE_LOCATIONS}>
               <CodeLocations mri={mri} {...focusArea?.selection?.range} />
@@ -183,6 +186,11 @@ export function MetricDetails({
     </TrayWrapper>
   );
 }
+
+const MetricSampleTableWrapper = HookOrDefault({
+  hookName: 'component:ddm-metrics-samples-list',
+  defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
+});
 
 const TrayWrapper = styled('div')`
   padding-top: ${space(4)};


### PR DESCRIPTION
Not all orgs should have access to the samples list depending on the plan. This adds a hook so we can disable it accordingly from getsentry.