### PR TITLE
ref(crons): Remove unused code branch in mark_failed

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -70,15 +70,6 @@ def mark_failed(
         "next_checkin_latest": next_checkin_latest,
     }
 
-    # Additionally update status when not using thresholds. The threshold based
-    # failure will only update status once it has passed the threshold.
-    if not failure_issue_threshold:
-        failed_status_map = {
-            CheckInStatus.MISSED: MonitorStatus.MISSED_CHECKIN,
-            CheckInStatus.TIMEOUT: MonitorStatus.TIMEOUT,
-        }
-        field_updates["status"] = failed_status_map.get(failed_checkin.status, MonitorStatus.ERROR)
-
     affected = monitors_to_update.update(**field_updates)
 
     # If we did not update the monitor environment it means there was a newer


### PR DESCRIPTION
failure_issue_threshold will never be falsey due because of this condition here [0]

[0]: https://github.com/getsentry/sentry/blob/11e039354141a8487776be19d7535d0da2ee53ce/src/sentry/monitors/logic/mark_failed.py#L44-L45