### PR TITLE
feat(rules): Send a notification on create and edit

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -41,6 +41,7 @@ from sentry.models.rule import NeglectedRule, RuleActivity, RuleActivityType
 from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.models.team import Team
 from sentry.models.user import User
+from sentry.rules import rules as rule_registry
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.signals import alert_rule_edited
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
@@ -367,7 +368,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             if features.has(
                 "organizations:rule-create-edit-confirm-notification", project.organization
             ):
-                send_confirmation_notification(rule=rule, new=False)
+                send_confirmation_notification(rule=rule, new=False, rules=rule_registry)
             return Response(serialize(updated_rule, request.user))
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -7,7 +7,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, audit_log
+from sentry import analytics, audit_log, features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.rule import RuleEndpoint
@@ -364,7 +364,10 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 sender=self,
                 is_api_token=request.auth is not None,
             )
-            send_confirmation_notification(rule=rule, new=False)
+            if features.has(
+                "organizations:rule-save-edit-confirm-notification", project.organization
+            ):
+                send_confirmation_notification(rule=rule, new=False)
             return Response(serialize(updated_rule, request.user))
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -41,7 +41,6 @@ from sentry.models.rule import NeglectedRule, RuleActivity, RuleActivityType
 from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.models.team import Team
 from sentry.models.user import User
-from sentry.rules import rules as rule_registry
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.signals import alert_rule_edited
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
@@ -368,7 +367,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             if features.has(
                 "organizations:rule-create-edit-confirm-notification", project.organization
             ):
-                send_confirmation_notification(rule=rule, new=False, rules=rule_registry)
+                send_confirmation_notification(rule=rule, new=False)
             return Response(serialize(updated_rule, request.user))
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -365,7 +365,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 is_api_token=request.auth is not None,
             )
             if features.has(
-                "organizations:rule-save-edit-confirm-notification", project.organization
+                "organizations:rule-create-edit-confirm-notification", project.organization
             ):
                 send_confirmation_notification(rule=rule, new=False)
             return Response(serialize(updated_rule, request.user))

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -11,7 +11,7 @@ from sentry import analytics, audit_log
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.rule import RuleEndpoint
-from sentry.api.endpoints.project_rules import find_duplicate_rule
+from sentry.api.endpoints.project_rules import find_duplicate_rule, send_confirmation_notification
 from sentry.api.fields.actor import ActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer
@@ -364,7 +364,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 sender=self,
                 is_api_token=request.auth is not None,
             )
-
+            send_confirmation_notification(rule=rule, new=False)
             return Response(serialize(updated_rule, request.user))
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -841,7 +841,9 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             duplicate_rule=duplicate_rule,
             wizard_v3=wizard_v3,
         )
-        if features.has("organizations:rule-save-edit-confirm-notification", project.organization):
+        if features.has(
+            "organizations:rule-create-edit-confirm-notification", project.organization
+        ):
             send_confirmation_notification(rule=rule, new=True)
 
         return Response(serialize(rule, request.user))

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -31,12 +31,21 @@ from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
-from sentry.rules.actions.base import EventAction
+from sentry.rules.actions.base import instantiate_action
 from sentry.rules.processor import is_condition_slow
 from sentry.signals import alert_rule_created
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
-from sentry.utils.imports import import_string
 from sentry.utils.safe import safe_execute
+
+
+def send_confirmation_notification(rule: Rule, new: bool):
+    for action in rule.data.get("actions", ()):
+        action_inst = instantiate_action(rule, action)
+        safe_execute(
+            action_inst.send_confirmation_notification,
+            rule=rule,
+            new=True,
+        )
 
 
 def clean_rule_data(data):
@@ -832,29 +841,6 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             duplicate_rule=duplicate_rule,
             wizard_v3=wizard_v3,
         )
-
-        # TODO add msteams and discord
-        SUPPORTED_ACTIONS_MAP = {
-            "sentry.integrations.slack.notify_action.SlackNotifyServiceAction": "sentry.integrations.slack.actions.notification.SlackNotifyServiceAction"
-        }
-
-        # TODO put this in a function that takes 'rule' and 'new' to be shared with project_rule_index
-        for action in rule.data.get("actions", ()):
-            action_cls_id = action.get("id")
-            action_cls = import_string(SUPPORTED_ACTIONS_MAP[action_cls_id])
-            if action_cls is None:
-                self.logger.warning("Unregistered action %r", action["id"])
-                continue
-
-            action_inst = action_cls(project, data=action, rule=rule)
-            if not isinstance(action_inst, EventAction):
-                self.logger.warning("Unregistered action %r", action["id"])
-                continue
-
-            safe_execute(
-                action_inst.send_confirmation_notification,
-                rule=rule,
-                new=True,
-            )
+        send_confirmation_notification(rule=rule, new=True)
 
         return Response(serialize(rule, request.user))

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -841,6 +841,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             duplicate_rule=duplicate_rule,
             wizard_v3=wizard_v3,
         )
-        send_confirmation_notification(rule=rule, new=True)
+        if features.has("organizations:rule-save-edit-confirm-notification", project.organization):
+            send_confirmation_notification(rule=rule, new=True)
 
         return Response(serialize(rule, request.user))

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -30,19 +30,17 @@ from sentry.mediators.project_rules.creator import Creator
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.models.team import Team
 from sentry.models.user import User
-from sentry.rules import rules as rule_registry
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.actions.base import instantiate_action
 from sentry.rules.processor import is_condition_slow
-from sentry.rules.registry import RuleRegistry
 from sentry.signals import alert_rule_created
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
 from sentry.utils.safe import safe_execute
 
 
-def send_confirmation_notification(rule: Rule, new: bool, rules: RuleRegistry):
+def send_confirmation_notification(rule: Rule, new: bool):
     for action in rule.data.get("actions", ()):
-        action_inst = instantiate_action(rule, action, rules)
+        action_inst = instantiate_action(rule, action)
         safe_execute(
             action_inst.send_confirmation_notification,
             rule=rule,
@@ -846,6 +844,6 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         if features.has(
             "organizations:rule-create-edit-confirm-notification", project.organization
         ):
-            send_confirmation_notification(rule=rule, new=True, rules=rule_registry)
+            send_confirmation_notification(rule=rule, new=True)
 
         return Response(serialize(rule, request.user))

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -44,7 +44,7 @@ def send_confirmation_notification(rule: Rule, new: bool):
         safe_execute(
             action_inst.send_confirmation_notification,
             rule=rule,
-            new=True,
+            new=new,
         )
 
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1827,8 +1827,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:releases-v2-st": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
-    # Enable post save/edit rule confirmation notifications
-    "organizations:rule-save-edit-confirm-notification": False,
+    # Enable post create/edit rule confirmation notifications
+    "organizations:rule-create-edit-confirm-notification": False,
     # Enable team member role provisioning through scim
     "organizations:scim-team-roles": False,
     # Enable detecting SDK crashes during event processing

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1827,6 +1827,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:releases-v2-st": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
+    # Enable post save/edit rule confirmation notifications
+    "organizations:rule-save-edit-confirm-notification": False,
     # Enable team member role provisioning through scim
     "organizations:scim-team-roles": False,
     # Enable detecting SDK crashes during event processing

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -229,7 +229,7 @@ default_manager.add("organizations:releases-v2-st", OrganizationFeature, Feature
 default_manager.add("organizations:releases-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:releases-v2-internal", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:rule-save-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:rule-create-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:required-email-verification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:scim-team-roles", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -229,6 +229,7 @@ default_manager.add("organizations:releases-v2-st", OrganizationFeature, Feature
 default_manager.add("organizations:releases-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:releases-v2-internal", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:rule-save-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:required-email-verification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:scim-team-roles", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -229,7 +229,7 @@ default_manager.add("organizations:releases-v2-st", OrganizationFeature, Feature
 default_manager.add("organizations:releases-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:releases-v2-internal", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:rule-create-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:rule-create-edit-confirm-notification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:required-email-verification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:scim-team-roles", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -164,7 +164,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 "channel_name": self.get_option("channel"),
             }
             self.logger.info(
-                "rule.fail.slack_post",
+                "rule_confirmation.fail.slack_post",
                 extra=log_params,
             )
 

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -10,14 +10,12 @@ from sentry.utils.http import absolute_uri
 class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
     def __init__(
         self,
-        rules: list[Rule],
+        rule: Rule,
         new: bool,
-        edited: bool,
     ) -> None:
         super().__init__()
-        self.rule = rules[0]
+        self.rule = rule
         self.new = new
-        self.edited = edited
 
     def linkify_rule(self):
         org_slug = self.rule.project.organization.slug

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -4,6 +4,7 @@ from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.models.rule import Rule
+from sentry.notifications.types import NotificationSettingEnum
 from sentry.utils.http import absolute_uri
 
 
@@ -27,13 +28,26 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
         rule_name = self.rule.label
         return f"<{rule_url}|*{escape_slack_text(rule_name)}*>"
 
+    def get_settings_url(self):
+        url_str = "/settings/account/notifications/"
+        fine_tuning_key = NotificationSettingEnum.ISSUE_ALERTS.value
+        url_str += f"{fine_tuning_key}/"
+        url = str(self.rule.project.organization.absolute_url(url_str))
+        return f"<{url}|*Notification Settings*>"
+
     def build(self) -> SlackBlock:
+        blocks = []
         rule_url = self.linkify_rule()
         project = self.rule.project.slug
         if self.new:
-            rule_text = f"{rule_url} was created in the {project} project and will send notifications to this channel."
+            rule_text = f"{rule_url} was created in the *{project}* project and will send notifications here."
         else:
-            rule_text = f"{rule_url} was updated."
-        # TODO add short summary of the trigger & filter conditions, plus a link to the notif setting
-        blocks = [self.get_markdown_block(rule_text)]
+            rule_text = f"{rule_url} in the *{project}* project was updated."
+
+        # TODO add short summary of the trigger & filter conditions
+        blocks.append(self.get_markdown_block(rule_text))
+
+        settings_link = self.get_settings_url()
+        blocks.append(self.get_context_block(settings_link))
+
         return self._build_blocks(*blocks, fallback_text=rule_text)

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from sentry.integrations.slack.message_builder import SlackBlock
+from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
+from sentry.integrations.slack.utils.escape import escape_slack_text
+from sentry.models.rule import Rule
+from sentry.utils.http import absolute_uri
+
+
+class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
+    def __init__(
+        self,
+        rules: list[Rule],
+        new: bool,
+        edited: bool,
+    ) -> None:
+        super().__init__()
+        self.rule = rules[0]
+        self.new = new
+        self.edited = edited
+
+    def linkify_rule(self):
+        org_slug = self.rule.project.organization.slug
+        project_slug = self.rule.project.slug
+        rule_url_path = (
+            f"/organizations/{org_slug}/alerts/rules/{project_slug}/{self.rule.id}/details/"
+        )
+        rule_url = absolute_uri(rule_url_path)
+        rule_name = self.rule.label
+        return f"<{rule_url}|*{escape_slack_text(rule_name)}*>"
+
+    def build(self) -> SlackBlock:
+        rule_url = self.linkify_rule()
+        project = self.rule.project.slug
+        if self.new:
+            rule_text = f"{rule_url} was created in the {project} project and will send notifications to this channel."
+        else:
+            rule_text = f"{rule_url} was updated."
+        # TODO add short summary of the trigger & filter conditions, plus a link to the notif setting
+        blocks = [self.get_markdown_block(rule_text)]
+        return self._build_blocks(*blocks, fallback_text=rule_text)

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -7,12 +7,13 @@ from collections.abc import Generator
 from sentry.eventstore.models import GroupEvent
 from sentry.models.rule import Rule
 from sentry.rules.base import CallbackFuture, EventState, RuleBase
-from sentry.rules.registry import RuleRegistry
 
 logger = logging.getLogger("sentry.rules")
 
 
-def instantiate_action(rule: Rule, action, rules: RuleRegistry):
+def instantiate_action(rule: Rule, action):
+    from sentry.rules import rules
+
     action_cls = rules.get(action["id"])
     if action_cls is None:
         logger.warning("Unregistered action %r", action["id"])

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -11,6 +11,22 @@ from sentry.rules.base import CallbackFuture, EventState, RuleBase
 logger = logging.getLogger("sentry.rules")
 
 
+def instantiate_action(rule: Rule, action):
+    from sentry.rules import rules
+
+    action_cls = rules.get(action["id"])
+    if action_cls is None:
+        logger.warning("Unregistered action %r", action["id"])
+        return None
+
+    action_inst = action_cls(rule.project, data=action, rule=rule)
+    if not isinstance(action_inst, EventAction):
+        logger.warning("Unregistered action %r", action["id"])
+        return None
+
+    return action_inst
+
+
 class EventAction(RuleBase, abc.ABC):
     rule_type = "action/event"
 

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Generator
 
 from sentry.eventstore.models import GroupEvent
+from sentry.models.rule import Rule
 from sentry.rules.base import CallbackFuture, EventState, RuleBase
 
 logger = logging.getLogger("sentry.rules")
@@ -36,3 +37,9 @@ class EventAction(RuleBase, abc.ABC):
         >>>     for future in futures:
         >>>         print(future)
         """
+
+    def send_confirmation_notification(self, rule: Rule, new: bool):
+        """
+        Send a notification confirming that a rule was created or edited
+        """
+        pass

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -7,13 +7,12 @@ from collections.abc import Generator
 from sentry.eventstore.models import GroupEvent
 from sentry.models.rule import Rule
 from sentry.rules.base import CallbackFuture, EventState, RuleBase
+from sentry.rules.registry import RuleRegistry
 
 logger = logging.getLogger("sentry.rules")
 
 
-def instantiate_action(rule: Rule, action):
-    from sentry.rules import rules
-
+def instantiate_action(rule: Rule, action, rules: RuleRegistry):
     action_cls = rules.get(action["id"])
     if action_cls is None:
         logger.warning("Unregistered action %r", action["id"])

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -269,6 +269,8 @@ class RuleProcessor:
         state = self.get_state()
         for action in rule.data.get("actions", ()):
             action_inst = instantiate_action(rule, action)
+            if not action_inst:
+                continue
 
             results = safe_execute(
                 action_inst.after,

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -265,13 +265,7 @@ class RuleProcessor:
         history.record(rule, self.group, self.event.event_id, notification_uuid)
         self.activate_downstream_actions(rule, notification_uuid)
 
-    def activate_downstream_actions(
-        self,
-        rule: Rule,
-        notification_uuid: str | None = None,
-        new: bool = False,
-        edited: bool = False,
-    ) -> None:
+    def activate_downstream_actions(self, rule: Rule, notification_uuid: str | None = None) -> None:
         state = self.get_state()
         for action in rule.data.get("actions", ()):
             action_cls = rules.get(action["id"])
@@ -283,14 +277,13 @@ class RuleProcessor:
             if not isinstance(action_inst, EventAction):
                 self.logger.warning("Unregistered action %r", action["id"])
                 continue
+
             results = safe_execute(
                 action_inst.after,
                 event=self.event,
                 state=state,
                 _with_transaction=False,
                 notification_uuid=notification_uuid,
-                new=new,
-                edited=edited,
             )
             if results is None:
                 self.logger.warning("Action %s did not return any futures", action["id"])

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -268,7 +268,7 @@ class RuleProcessor:
     def activate_downstream_actions(self, rule: Rule, notification_uuid: str | None = None) -> None:
         state = self.get_state()
         for action in rule.data.get("actions", ()):
-            action_inst = instantiate_action(rule, action, rules)
+            action_inst = instantiate_action(rule, action)
             if not action_inst:
                 continue
 

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -265,7 +265,13 @@ class RuleProcessor:
         history.record(rule, self.group, self.event.event_id, notification_uuid)
         self.activate_downstream_actions(rule, notification_uuid)
 
-    def activate_downstream_actions(self, rule: Rule, notification_uuid: str | None = None) -> None:
+    def activate_downstream_actions(
+        self,
+        rule: Rule,
+        notification_uuid: str | None = None,
+        new: bool = False,
+        edited: bool = False,
+    ) -> None:
         state = self.get_state()
         for action in rule.data.get("actions", ()):
             action_cls = rules.get(action["id"])
@@ -277,13 +283,14 @@ class RuleProcessor:
             if not isinstance(action_inst, EventAction):
                 self.logger.warning("Unregistered action %r", action["id"])
                 continue
-
             results = safe_execute(
                 action_inst.after,
                 event=self.event,
                 state=state,
                 _with_transaction=False,
                 notification_uuid=notification_uuid,
+                new=new,
+                edited=edited,
             )
             if results is None:
                 self.logger.warning("Action %s did not return any futures", action["id"])

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -268,7 +268,7 @@ class RuleProcessor:
     def activate_downstream_actions(self, rule: Rule, notification_uuid: str | None = None) -> None:
         state = self.get_state()
         for action in rule.data.get("actions", ()):
-            action_inst = instantiate_action(rule, action)
+            action_inst = instantiate_action(rule, action, rules)
             if not action_inst:
                 continue
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -946,7 +946,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert_rule_from_payload(self.rule, payload)
 
     @responses.activate
-    @with_feature("organizations:rule-save-edit-confirm-notification")
+    @with_feature("organizations:rule-create-edit-confirm-notification")
     @patch(
         "sentry.integrations.slack.actions.notification.SlackNotifyServiceAction.send_confirmation_notification"
     )
@@ -1002,7 +1002,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert_rule_from_payload(self.rule, payload)
 
     @responses.activate
-    @with_feature("organizations:rule-save-edit-confirm-notification")
+    @with_feature("organizations:rule-create-edit-confirm-notification")
     def test_slack_confirmation_notification_contents(self):
         conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
         actions = [

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -22,6 +22,7 @@ from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 
@@ -945,6 +946,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert_rule_from_payload(self.rule, payload)
 
     @responses.activate
+    @with_feature("organizations:rule-save-edit-confirm-notification")
     @patch(
         "sentry.integrations.slack.actions.notification.SlackNotifyServiceAction.send_confirmation_notification"
     )
@@ -1000,6 +1002,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert_rule_from_payload(self.rule, payload)
 
     @responses.activate
+    @with_feature("organizations:rule-save-edit-confirm-notification")
     def test_slack_confirmation_notification_contents(self):
         conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
         actions = [

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1071,10 +1071,10 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         data = parse_qs(responses.calls[1].request.body)
         message = f"<http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> in the *{self.project.slug}* project was updated."
         assert data["text"][0] == message
-        blocks = json.loads(data["blocks"][0])
-        assert blocks[0]["text"]["text"] == message
+        rendered_blocks = json.loads(data["blocks"][0])
+        assert rendered_blocks[0]["text"]["text"] == message
         assert (
-            blocks[1]["elements"][0]["text"]
+            rendered_blocks[1]["elements"][0]["text"]
             == "<http://testserver/settings/account/notifications/alerts/|*Notification Settings*>"
         )
 

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -350,6 +350,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         )
 
     @responses.activate
+    @with_feature("organizations:rule-save-edit-confirm-notification")
     @patch(
         "sentry.integrations.slack.actions.notification.SlackNotifyServiceAction.send_confirmation_notification"
     )
@@ -379,6 +380,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         assert mock_send_confirmation_notification.call_count == 1
 
     @responses.activate
+    @with_feature("organizations:rule-save-edit-confirm-notification")
     def test_slack_confirmation_notification_contents(self):
         responses.add(
             method=responses.GET,

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -425,10 +425,10 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         data = parse_qs(responses.calls[1].request.body)
         message = f"<http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> was created in the *{self.project.slug}* project and will send notifications here."
         assert data["text"][0] == message
-        blocks = json.loads(data["blocks"][0])
-        assert blocks[0]["text"]["text"] == message
+        rendered_blocks = json.loads(data["blocks"][0])
+        assert rendered_blocks[0]["text"]["text"] == message
         assert (
-            blocks[1]["elements"][0]["text"]
+            rendered_blocks[1]["elements"][0]["text"]
             == "<http://testserver/settings/account/notifications/alerts/|*Notification Settings*>"
         )
 

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -350,7 +350,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         )
 
     @responses.activate
-    @with_feature("organizations:rule-save-edit-confirm-notification")
+    @with_feature("organizations:rule-create-edit-confirm-notification")
     @patch(
         "sentry.integrations.slack.actions.notification.SlackNotifyServiceAction.send_confirmation_notification"
     )
@@ -380,7 +380,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         assert mock_send_confirmation_notification.call_count == 1
 
     @responses.activate
-    @with_feature("organizations:rule-save-edit-confirm-notification")
+    @with_feature("organizations:rule-create-edit-confirm-notification")
     def test_slack_confirmation_notification_contents(self):
         responses.add(
             method=responses.GET,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -403,12 +403,11 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
         MOCK_RULES = ("sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",)
 
         redis_buffer = RedisBuffer()
-        with (
-            mock.patch("sentry.buffer.backend.get", redis_buffer.get),
-            mock.patch("sentry.buffer.backend.incr", redis_buffer.incr),
-            patch("sentry.constants._SENTRY_RULES", MOCK_RULES),
-            patch("sentry.rules.processor.rules", init_registry()) as rules,
-        ):
+        with mock.patch("sentry.buffer.backend.get", redis_buffer.get), mock.patch(
+            "sentry.buffer.backend.incr", redis_buffer.incr
+        ), patch("sentry.constants._SENTRY_RULES", MOCK_RULES), patch(
+            "sentry.rules.rules", init_registry()
+        ) as rules:
             MockAction = mock.Mock()
             MockAction.id = "tests.sentry.tasks.post_process.tests.MockAction"
             MockAction.return_value = mock.Mock(spec=EventAction)


### PR DESCRIPTION
Send a Slack notification when a rule with a Slack action is created or edited that confirms the rule was created or edited. In the future we'll add this for MSTeams and Discord.

I'm keeping the notification simple for now, but in the future we also may expand what's shown (e.g. adding the alert rule details to show the filters, conditions, and actions).

<img width="742" alt="Screenshot 2024-03-06 at 12 00 31 PM" src="https://github.com/getsentry/sentry/assets/29959063/efd14db4-8027-4061-a927-f3f6e5c96e96">

Closes https://github.com/getsentry/sentry/issues/66237