### PR TITLE
fix(hybrid-cloud): Prevent API gateway from resolving redirects

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -1,6 +1,7 @@
 """
 Utilities related to proxying a request to a region silo
 """
+
 from __future__ import annotations
 
 import logging
@@ -166,6 +167,10 @@ def proxy_region_request(
                 data=_body_with_length(request),
                 stream=True,
                 timeout=timeout,
+                # By default, external_request will resolve any redirects for any verb except for HEAD.
+                # We explicitly disable this behavior to avoid misrepresenting the original sentry.io request with the
+                # body response of the redirect.
+                allow_redirects=False,
             )
     except Timeout:
         # remote silo timeout. Use DRF timeout instead

--- a/src/sentry/testutils/helpers/apigateway.py
+++ b/src/sentry/testutils/helpers/apigateway.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs
 
 import responses
 from django.conf import settings
+from django.http import HttpResponseRedirect
 from django.test import override_settings
 from django.urls import re_path
 from rest_framework.permissions import AllowAny
@@ -31,6 +32,9 @@ class RegionEndpoint(OrganizationEndpoint):
 
     def get(self, request, organization):
         return Response({"proxy": False})
+
+    def post(self, request, organization):
+        return HttpResponseRedirect("https://zombo.com")
 
 
 @region_silo_endpoint


### PR DESCRIPTION
The API gateway middleware will resolve any redirects returned by the region silo, and will return the contents of the resolved redirect.

This occurs for all verbs except for `HEAD`. See: https://requests.readthedocs.io/en/latest/user/quickstart/#redirection-and-history

For example, in monolith mode, `POST https://orgslug.sentry.io/organizations/orgslug/auth/configure/` may return a `302 https://accounts.google.com/o/oauth2/auth` response. 

But in a control/region silo set up, the API gateway middleware in the control silo will resolve the `302 https://accounts.google.com/o/oauth2/auth` redirect, and return its body response for the URL `https://orgslug.sentry.io/organizations/orgslug/auth/configure/`. 

This pull request retains redirects, and properly propagates redirect responses back to the client (e.g. the browser) where they can perform the redirect themselves. 
