### PR TITLE
fix(hybridcloud) Add visiblity to region configuration

### DIFF
--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -62,6 +62,9 @@ class Region:
     category: RegionCategory
     """The region's category."""
 
+    visible: bool = True
+    """Whether the region is visible in API responses"""
+
     def validate(self) -> None:
         from sentry.utils.snowflake import REGION_ID
 
@@ -134,6 +137,9 @@ class RegionDirectory:
 
     def get_by_name(self, region_name: str) -> Region | None:
         return self._by_name.get(region_name)
+
+    def get_regions(self, category: RegionCategory | None = None) -> Iterable[Region]:
+        return (r for r in self.regions if (category is None or r.category == category))
 
     def get_region_names(self, category: RegionCategory | None = None) -> Iterable[str]:
         return (r.name for r in self.regions if (category is None or r.category == category))
@@ -335,7 +341,11 @@ def find_all_region_names() -> Iterable[str]:
 
 
 def find_all_multitenant_region_names() -> list[str]:
-    return list(get_global_directory().get_region_names(RegionCategory.MULTI_TENANT))
+    """
+    Return all visible multi_tenant regions.
+    """
+    regions = get_global_directory().get_regions(RegionCategory.MULTI_TENANT)
+    return list([r.name for r in regions if r.visible])
 
 
 def find_all_region_addresses() -> Iterable[str]:

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -328,16 +328,23 @@ class _ClientConfig:
         has membership on any single-tenant regions those will also be included.
         """
         user = self.user
+
+        # Only expose visible regions.
+        # When new regions are added they can take some work to get working correctly.
+        # Before they are working we need ways to bring parts of the region online without
+        # exposing the region to customers.
         region_names = find_all_multitenant_region_names()
+
         if not region_names:
             return [{"name": "default", "url": options.get("system.url-prefix")}]
 
-        # No logged in user.
+        # Show all visible multi-tenant regions to unauthenticated users as they could
+        # create a new account
         if not user or not user.id:
-            return [get_region_by_name(region).api_serialize() for region in region_names]
+            return [get_region_by_name(name).api_serialize() for name in region_names]
 
         # Ensure all regions the current user is in are included as there
-        # could be single tenants as well.
+        # could be single tenants or hidden regions
         memberships = user_service.get_organizations(user_id=user.id)
         unique_regions = set(region_names) | {membership.region_name for membership in memberships}
 

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -204,6 +204,24 @@ class RegionDirectoryTest(TestCase):
             assert set(result) == {"us", "eu"}
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_find_all_multitenant_region_names_non_visible(self):
+        inputs = [
+            *self._INPUTS,
+            {
+                "name": "ja",
+                "snowflake_id": 4,
+                "address": "https://ja.testserver",
+                "category": RegionCategory.MULTI_TENANT.name,
+                "visible": False,
+            },
+        ]
+        with override_settings(SENTRY_MONOLITH_REGION="us"):
+            directory = load_from_config(inputs)
+        with self._in_global_state(directory):
+            result = find_all_multitenant_region_names()
+            assert set(result) == {"us", "eu"}
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_subdomain_is_region(self):
         regions = [
             Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT),


### PR DESCRIPTION
When we add regions we need a way to keep the region out of UI interactions and the public API responses until it has been validated.

The `find_all_multitenant_region_names` method is used in sentry and getsentry to get the list of multi-tenant regions that are available for new account creation.

Once we have a new region functionally working it can be made visible. Even after a region is visible account creation would be gated by feature flags.