### PR TITLE
feat(ddm): Allow multiple use case ids to be queried at once and parallelize

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -67,6 +67,13 @@ METRIC_META_TYPE_SERIALIZER = {
     MetricMetaType.CODE_LOCATIONS.value: MetricCodeLocationsSerializer(),
 }
 
+DEFAULT_USE_CASE_IDS = [
+    UseCaseID.TRANSACTIONS,
+    UseCaseID.SESSIONS,
+    UseCaseID.SPANS,
+    UseCaseID.CUSTOM,
+]
+
 
 def get_use_case_id(request: Request) -> UseCaseID:
     """
@@ -77,6 +84,22 @@ def get_use_case_id(request: Request) -> UseCaseID:
     try:
         use_case_param = request.GET.get("useCase", "sessions")
         return string_to_use_case_id(use_case_param)
+    except ValueError:
+        raise ParseError(
+            detail=f"Invalid useCase parameter. Please use one of: {[uc.value for uc in UseCaseID]}"
+        )
+
+
+def get_use_case_ids(request: Request) -> Sequence[UseCaseID]:
+    """
+    Gets use case ids from the query params and validates them again the `UseCaseID` enum type.
+
+    If an empty list is supplied, the use case ids in `DEFAULT_USE_CASE_IDS` will be used.
+    """
+
+    try:
+        use_case_params = request.GET.getlist("useCase", DEFAULT_USE_CASE_IDS)
+        return [string_to_use_case_id(use_case_param) for use_case_param in use_case_params]
     except ValueError:
         raise ParseError(
             detail=f"Invalid useCase parameter. Please use one of: {[uc.value for uc in UseCaseID]}"
@@ -101,7 +124,7 @@ class OrganizationMetricsDetailsEndpoint(OrganizationEndpoint):
         start, end = get_date_range_from_params(request.GET)
 
         metrics = get_metrics_meta(
-            projects=projects, use_case_id=get_use_case_id(request), start=start, end=end
+            projects=projects, use_case_ids=get_use_case_ids(request), start=start, end=end
         )
 
         return Response(metrics, status=200)

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -46,6 +46,7 @@ from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.fields import run_metrics_query
 from sentry.snuba.metrics.fields.base import (
     SnubaDataType,
+    build_metrics_query,
     get_derived_metrics,
     org_id_from_projects,
 )
@@ -85,7 +86,7 @@ from sentry.snuba.metrics.utils import (
     get_intervals,
     to_intervals,
 )
-from sentry.utils.snuba import raw_snql_query
+from sentry.utils.snuba import bulk_snql_query, raw_snql_query
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +105,27 @@ def _get_metrics_for_entity(
         groupby=[Column("metric_id")],
         where=[Condition(Column("use_case_id"), Op.EQ, use_case_id.value)],
         referrer="snuba.metrics.get_metrics_names_for_entity",
+        project_ids=project_ids,
+        org_id=org_id,
+        use_case_id=use_case_id,
+        start=start,
+        end=end,
+    )
+
+
+def _get_metrics_by_project_for_entity_query(
+    entity_key: EntityKey,
+    project_ids: Sequence[int],
+    org_id: int,
+    use_case_id: UseCaseID,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> Request:
+    return build_metrics_query(
+        entity_key=entity_key,
+        select=[Column("project_id"), Column("metric_id")],
+        groupby=[Column("project_id"), Column("metric_id")],
+        where=[Condition(Column("use_case_id"), Op.EQ, use_case_id.value)],
         project_ids=project_ids,
         org_id=org_id,
         use_case_id=use_case_id,
@@ -186,12 +208,8 @@ def get_available_derived_metrics(
 
 
 def get_metrics_blocking_state_of_projects(
-    projects: Sequence[Project], use_case_id: UseCaseID
+    projects: Sequence[Project],
 ) -> dict[str, Sequence[tuple[bool, Sequence[str], int]]]:
-    # Blocked metrics are only supported for custom metrics.
-    if use_case_id != UseCaseID.CUSTOM:
-        return {}
-
     metrics_blocking_state_by_project = get_metrics_blocking_state(projects)
     metrics_blocking_state_by_mri = {}
 
@@ -220,15 +238,23 @@ def _build_metric_meta(
 
 def get_metrics_meta(
     projects: Sequence[Project],
-    use_case_id: UseCaseID,
+    use_case_ids: Sequence[UseCaseID],
     start: datetime | None = None,
     end: datetime | None = None,
 ) -> Sequence[MetricMeta]:
     if not projects:
         return []
 
-    stored_metrics = get_stored_metrics_of_projects(projects, use_case_id, start, end)
-    metrics_blocking_state = get_metrics_blocking_state_of_projects(projects, use_case_id)
+    has_custom_use_case_id = False
+    for use_case_id in use_case_ids:
+        if use_case_id == UseCaseID.CUSTOM:
+            has_custom_use_case_id = True
+            break
+
+    stored_metrics = get_stored_metrics_of_projects(projects, use_case_ids, start, end)
+    metrics_blocking_state = (
+        get_metrics_blocking_state_of_projects(projects) if has_custom_use_case_id else {}
+    )
 
     metrics_metas = []
     for metric_mri, project_ids in stored_metrics.items():
@@ -276,38 +302,66 @@ def get_metrics_meta(
 
 def get_stored_metrics_of_projects(
     projects: Sequence[Project],
-    use_case_id: UseCaseID,
+    use_case_ids: Sequence[UseCaseID],
     start: datetime | None = None,
     end: datetime | None = None,
 ) -> Mapping[str, Sequence[int]]:
     org_id = projects[0].organization_id
     project_ids = [project.id for project in projects]
 
-    stored_metrics = []
-    entity_keys = get_entity_keys_of_use_case_id(use_case_id=use_case_id)
-    for entity_key in entity_keys or ():
-        stored_metrics += _get_metrics_by_project_for_entity(
-            entity_key=entity_key,
-            project_ids=project_ids,
-            org_id=org_id,
-            use_case_id=use_case_id,
-            start=start,
-            end=end,
+    # We compute for each use case, the entities that we want to query.
+    entity_keys = defaultdict(set)
+    for use_case_id in use_case_ids:
+        entity_keys[use_case_id] = entity_keys[use_case_id].union(
+            get_entity_keys_of_use_case_id(use_case_id=use_case_id)
         )
 
-    grouped_stored_metrics = {}
-    for stored_metric in stored_metrics:
-        grouped_stored_metrics.setdefault(stored_metric["metric_id"], []).append(
-            stored_metric["project_id"]
-        )
+    # We compute a list of all the queries that we want to run in parallel across entities and use cases.
+    requests = []
+    use_case_id_to_index = defaultdict(list)
+    for use_case_id, entity_keys in entity_keys.items():
+        for entity_key in entity_keys:
+            requests.append(
+                _get_metrics_by_project_for_entity_query(
+                    entity_key=entity_key,
+                    project_ids=project_ids,
+                    org_id=org_id,
+                    use_case_id=use_case_id,
+                    start=start,
+                    end=end,
+                )
+            )
+            use_case_id_to_index[use_case_id].append(len(requests) - 1)
 
-    resolved_mris = bulk_reverse_resolve(
-        use_case_id, org_id, [metric_id for metric_id in grouped_stored_metrics.keys()]
+    # We run the queries all in parallel.
+    results = bulk_snql_query(
+        requests=requests,
+        referrer="snuba.metrics.datasource.get_stored_metrics_of_projects",
+        use_cache=True,
     )
 
-    return {
-        resolved_mris[metric_id]: projects for metric_id, projects in grouped_stored_metrics.items()
-    }
+    # We reverse resolve all the metric ids by bulking together all the resolutions of the same use case id to maximize
+    # the parallelism.
+    resolved_metric_ids = {}
+    for use_case_id, results_indexes in use_case_id_to_index.items():
+        metrics_ids = []
+        for result_index in results_indexes:
+            data = results[result_index]["data"]
+            for row in data or ():
+                metrics_ids.append(row["metric_id"])
+
+        resolved_metric_ids.update(
+            bulk_reverse_resolve(use_case_id, org_id, [metric_id for metric_id in metrics_ids])
+        )
+
+    # We iterate over each result and compute a map of `metric_id -> project_id`.
+    grouped_stored_metrics = defaultdict(list)
+    for result in results:
+        data = result["data"]
+        for row in data or ():
+            grouped_stored_metrics[resolved_metric_ids[row["metric_id"]]].append(row["project_id"])
+
+    return grouped_stored_metrics
 
 
 def get_custom_measurements(

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -245,15 +245,9 @@ def get_metrics_meta(
     if not projects:
         return []
 
-    has_custom_use_case_id = False
-    for use_case_id in use_case_ids:
-        if use_case_id == UseCaseID.CUSTOM:
-            has_custom_use_case_id = True
-            break
-
     stored_metrics = get_stored_metrics_of_projects(projects, use_case_ids, start, end)
     metrics_blocking_state = (
-        get_metrics_blocking_state_of_projects(projects) if has_custom_use_case_id else {}
+        get_metrics_blocking_state_of_projects(projects) if UseCaseID.CUSTOM in use_case_ids else {}
     )
 
     metrics_metas = []

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -303,17 +303,11 @@ def get_stored_metrics_of_projects(
     org_id = projects[0].organization_id
     project_ids = [project.id for project in projects]
 
-    # We compute for each use case, the entities that we want to query.
-    entity_keys = defaultdict(set)
-    for use_case_id in use_case_ids:
-        entity_keys[use_case_id] = entity_keys[use_case_id].union(
-            get_entity_keys_of_use_case_id(use_case_id=use_case_id)
-        )
-
     # We compute a list of all the queries that we want to run in parallel across entities and use cases.
     requests = []
     use_case_id_to_index = defaultdict(list)
-    for use_case_id, entity_keys in entity_keys.items():
+    for use_case_id in use_case_ids:
+        entity_keys = get_entity_keys_of_use_case_id(use_case_id=use_case_id)
         for entity_key in entity_keys:
             requests.append(
                 _get_metrics_by_project_for_entity_query(

--- a/tests/sentry/snuba/metrics/test_datasource.py
+++ b/tests/sentry/snuba/metrics/test_datasource.py
@@ -51,20 +51,31 @@ class DatasourceTestCase(BaseMetricsLayerTestCase, TestCase):
             UseCaseID.CUSTOM,
         )
 
-        mris = get_stored_metrics_of_projects([self.project], UseCaseID.TRANSACTIONS)
+        mris = get_stored_metrics_of_projects([self.project], [UseCaseID.TRANSACTIONS])
         assert mris == {
             "d:transactions/duration@millisecond": [self.project.id],
         }
 
-        mris = get_stored_metrics_of_projects([self.project], UseCaseID.SESSIONS)
+        mris = get_stored_metrics_of_projects([self.project], [UseCaseID.SESSIONS])
         assert mris == {
             "d:sessions/duration@second": [self.project.id],
             "c:sessions/session@none": [self.project.id],
             "s:sessions/user@none": [self.project.id],
         }
 
-        mris = get_stored_metrics_of_projects([self.project], UseCaseID.CUSTOM)
+        mris = get_stored_metrics_of_projects([self.project], [UseCaseID.CUSTOM])
         assert mris == {
+            custom_mri: [self.project.id],
+        }
+
+        mris = get_stored_metrics_of_projects(
+            [self.project], [UseCaseID.TRANSACTIONS, UseCaseID.SESSIONS, UseCaseID.CUSTOM]
+        )
+        assert mris == {
+            "d:transactions/duration@millisecond": [self.project.id],
+            "d:sessions/duration@second": [self.project.id],
+            "c:sessions/session@none": [self.project.id],
+            "s:sessions/user@none": [self.project.id],
             custom_mri: [self.project.id],
         }
 

--- a/tests/sentry/snuba/metrics/test_datasource.py
+++ b/tests/sentry/snuba/metrics/test_datasource.py
@@ -51,22 +51,22 @@ class DatasourceTestCase(BaseMetricsLayerTestCase, TestCase):
             UseCaseID.CUSTOM,
         )
 
-        # mris = get_stored_metrics_of_projects([self.project], [UseCaseID.TRANSACTIONS])
-        # assert mris == {
-        #     "d:transactions/duration@millisecond": [self.project.id],
-        # }
-        #
-        # mris = get_stored_metrics_of_projects([self.project], [UseCaseID.SESSIONS])
-        # assert mris == {
-        #     "d:sessions/duration@second": [self.project.id],
-        #     "c:sessions/session@none": [self.project.id],
-        #     "s:sessions/user@none": [self.project.id],
-        # }
-        #
-        # mris = get_stored_metrics_of_projects([self.project], [UseCaseID.CUSTOM])
-        # assert mris == {
-        #     custom_mri: [self.project.id],
-        # }
+        mris = get_stored_metrics_of_projects([self.project], [UseCaseID.TRANSACTIONS])
+        assert mris == {
+            "d:transactions/duration@millisecond": [self.project.id],
+        }
+
+        mris = get_stored_metrics_of_projects([self.project], [UseCaseID.SESSIONS])
+        assert mris == {
+            "d:sessions/duration@second": [self.project.id],
+            "c:sessions/session@none": [self.project.id],
+            "s:sessions/user@none": [self.project.id],
+        }
+
+        mris = get_stored_metrics_of_projects([self.project], [UseCaseID.CUSTOM])
+        assert mris == {
+            custom_mri: [self.project.id],
+        }
 
         mris = get_stored_metrics_of_projects(
             [self.project], [UseCaseID.TRANSACTIONS, UseCaseID.SESSIONS, UseCaseID.CUSTOM]

--- a/tests/sentry/snuba/metrics/test_datasource.py
+++ b/tests/sentry/snuba/metrics/test_datasource.py
@@ -51,22 +51,22 @@ class DatasourceTestCase(BaseMetricsLayerTestCase, TestCase):
             UseCaseID.CUSTOM,
         )
 
-        mris = get_stored_metrics_of_projects([self.project], [UseCaseID.TRANSACTIONS])
-        assert mris == {
-            "d:transactions/duration@millisecond": [self.project.id],
-        }
-
-        mris = get_stored_metrics_of_projects([self.project], [UseCaseID.SESSIONS])
-        assert mris == {
-            "d:sessions/duration@second": [self.project.id],
-            "c:sessions/session@none": [self.project.id],
-            "s:sessions/user@none": [self.project.id],
-        }
-
-        mris = get_stored_metrics_of_projects([self.project], [UseCaseID.CUSTOM])
-        assert mris == {
-            custom_mri: [self.project.id],
-        }
+        # mris = get_stored_metrics_of_projects([self.project], [UseCaseID.TRANSACTIONS])
+        # assert mris == {
+        #     "d:transactions/duration@millisecond": [self.project.id],
+        # }
+        #
+        # mris = get_stored_metrics_of_projects([self.project], [UseCaseID.SESSIONS])
+        # assert mris == {
+        #     "d:sessions/duration@second": [self.project.id],
+        #     "c:sessions/session@none": [self.project.id],
+        #     "s:sessions/user@none": [self.project.id],
+        # }
+        #
+        # mris = get_stored_metrics_of_projects([self.project], [UseCaseID.CUSTOM])
+        # assert mris == {
+        #     custom_mri: [self.project.id],
+        # }
 
         mris = get_stored_metrics_of_projects(
             [self.project], [UseCaseID.TRANSACTIONS, UseCaseID.SESSIONS, UseCaseID.CUSTOM]


### PR DESCRIPTION
This PR implements a new fully parallelized implementation of fetching metrics meta. The need for such implementation arose for two reasons:
1. The previous implementation was slow
2. The previous implementation didn't support multiple use case ids to be fetched in a single request

The new implementation parallelizes all queries for fetching data across entities and use case ids. It also maximizes parallelization when reverse resolving metric ids.

Closes: https://github.com/getsentry/sentry/issues/66126