### PR TITLE
fix(ddm): Duplicate chart sample ids

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -62,17 +62,18 @@ export interface MetricsQueryApiResponse {
   }[][];
   end: string;
   intervals: string[];
-  meta: [
-    {name: string; type: string},
-    {
-      group_bys: string[];
-      limit: number | null;
-      order: string | null;
-      scaling_factor?: number | null;
-      unit?: string | null;
-      unit_family?: 'duration' | 'information' | null;
-    },
-  ][];
+  meta: (
+    | {name: string; type: string}
+    // The last entry in meta has a different shape
+    | {
+        group_bys: string[];
+        limit: number | null;
+        order: string | null;
+        scaling_factor?: number | null;
+        unit?: string | null;
+        unit_family?: 'duration' | 'information' | null;
+      }
+  )[][];
   start: string;
 }
 

--- a/static/app/views/dashboards/metrics/table.tsx
+++ b/static/app/views/dashboards/metrics/table.tsx
@@ -138,7 +138,9 @@ export function getTableData(
 
   const normalizedResults = filteredQueries.map((query, index) => {
     const queryResults = data.data[index];
-    const metaUnit = data.meta[index]?.[1]?.unit;
+    const meta = data.meta[index];
+    const lastMetaEntry = data.meta[index]?.[meta.length - 1];
+    const metaUnit = ('unit' in lastMetaEntry && lastMetaEntry.unit) || 'none';
     const normalizedGroupResults = queryResults.map(group => {
       return {
         by: {...getEmptyGroup(tags), ...group.by},

--- a/static/app/views/dashboards/metrics/table.tsx
+++ b/static/app/views/dashboards/metrics/table.tsx
@@ -140,7 +140,8 @@ export function getTableData(
     const queryResults = data.data[index];
     const meta = data.meta[index];
     const lastMetaEntry = data.meta[index]?.[meta.length - 1];
-    const metaUnit = ('unit' in lastMetaEntry && lastMetaEntry.unit) || 'none';
+    const metaUnit =
+      (lastMetaEntry && 'unit' in lastMetaEntry && lastMetaEntry.unit) || 'none';
     const normalizedGroupResults = queryResults.map(group => {
       return {
         by: {...getEmptyGroup(tags), ...group.by},

--- a/static/app/views/ddm/chart/useMetricChartSamples.tsx
+++ b/static/app/views/ddm/chart/useMetricChartSamples.tsx
@@ -157,7 +157,7 @@ export function useMetricChartSamples({
 
       return {
         seriesName: sample.transactionId,
-        id: sample.transactionId,
+        id: sample.spanId,
         operation: '',
         unit: '',
         symbolSize: isHighlighted ? 20 : 10,

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -12,6 +12,7 @@ import type {SelectOption} from 'sentry/components/compactSelect';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import type {Field} from 'sentry/components/ddm/metricSamplesTable';
 import EmptyMessage from 'sentry/components/emptyMessage';
+import ErrorBoundary from 'sentry/components/errorBoundary';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -240,22 +241,24 @@ export const MetricWidget = memo(
           </MetricWidgetHeader>
           <MetricWidgetBodyWrapper>
             {queriesAreComplete ? (
-              <MetricWidgetBody
-                widgetIndex={index}
-                getChartPalette={getChartPalette}
-                onChange={handleChange}
-                focusAreaProps={focusAreaProps}
-                samples={samples}
-                samplesV2={samplesV2}
-                chartHeight={chartHeight}
-                chartGroup={DDM_CHART_GROUP}
-                queries={queries}
-                filters={filters}
-                displayType={displayType}
-                tableSort={tableSort}
-                focusedSeries={focusedSeries}
-                context={context}
-              />
+              <ErrorBoundary mini>
+                <MetricWidgetBody
+                  widgetIndex={index}
+                  getChartPalette={getChartPalette}
+                  onChange={handleChange}
+                  focusAreaProps={focusAreaProps}
+                  samples={samples}
+                  samplesV2={samplesV2}
+                  chartHeight={chartHeight}
+                  chartGroup={DDM_CHART_GROUP}
+                  queries={queries}
+                  filters={filters}
+                  displayType={displayType}
+                  tableSort={tableSort}
+                  focusedSeries={focusedSeries}
+                  context={context}
+                />
+              </ErrorBoundary>
             ) : (
               <StyledMetricWidgetBody>
                 <EmptyMessage
@@ -515,8 +518,11 @@ export function getChartTimeseries(
 
   const series = data.data.flatMap((group, index) => {
     const query = filteredQueries[index];
-    const unit = data.meta[index]?.[1]?.unit;
-    const scalingFactor = data.meta[index]?.[1]?.scaling_factor ?? 1;
+    const meta = data.meta[index];
+    const lastMetaEntry = meta[meta.length - 1];
+    const unit = ('unit' in lastMetaEntry && lastMetaEntry.unit) || 'none';
+    const scalingFactor =
+      ('scaling_factor' in lastMetaEntry && lastMetaEntry.scaling_factor) || 1;
     const operation = isMetricFormula(query) ? 'count' : query.op;
     const isMultiQuery = filteredQueries.length > 1;
 

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -520,9 +520,13 @@ export function getChartTimeseries(
     const query = filteredQueries[index];
     const meta = data.meta[index];
     const lastMetaEntry = meta[meta.length - 1];
-    const unit = ('unit' in lastMetaEntry && lastMetaEntry.unit) || 'none';
+    const unit =
+      (lastMetaEntry && 'unit' in lastMetaEntry && lastMetaEntry.unit) || 'none';
     const scalingFactor =
-      ('scaling_factor' in lastMetaEntry && lastMetaEntry.scaling_factor) || 1;
+      (lastMetaEntry &&
+        'scaling_factor' in lastMetaEntry &&
+        lastMetaEntry.scaling_factor) ||
+      1;
     const operation = isMetricFormula(query) ? 'count' : query.op;
     const isMultiQuery = filteredQueries.length > 1;
 


### PR DESCRIPTION
* Use spanId for identifying chart samples
* Wrap widget with error boundary
* Fix query response meta type