### PR TITLE
feat(js-loader): Only use es5/es6 bundles in v7 JS loader

### DIFF
--- a/src/sentry/api/endpoints/project_key_details.py
+++ b/src/sentry/api/endpoints/project_key_details.py
@@ -88,6 +88,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
                     help_text="The Sentry Javascript SDK version to use. The currently supported options are:",
                     # Ideally we would call get_browser_sdk_version_choices() here but that requires
                     # passing in project to this decorator
+                    # todo: v8 add version
                     choices=[("latest", "Most recent version"), ("7.x", "Version 7 releases")],
                     required=False,
                 ),

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -37,6 +37,7 @@ def get_highest_browser_sdk_version(versions):
 
 
 def get_all_browser_sdk_version_versions():
+    # todo: v8 add version
     return ["latest", "7.x", "6.x", "5.x", "4.x"]
 
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -169,6 +169,7 @@ register(
 )
 
 # The available loader SDK versions
+# todo: v8 add version
 register(
     key="sentry:loader_available_sdk_versions",
     epoch_defaults={1: ["7.x", "6.x", "5.x", "4.x"], 11: ["7.x"]},

--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -67,7 +67,8 @@ class JavaScriptSdkLoader(BaseView):
                 "hasDebug": False,
             }
 
-        is_greater_or_equal_v7_sdk = sdk_version >= Version("7.0.0")
+        is_v7_sdk = sdk_version >= Version("7.0.0") and sdk_version < Version("8.0.0")
+        is_v7_or_higher_sdk = sdk_version >= Version("7.0.0")
 
         is_lazy = True
         bundle_kind_modifier = ""
@@ -80,21 +81,21 @@ class JavaScriptSdkLoader(BaseView):
         # https://docs.sentry.io/platforms/javascript/install/cdn/
 
         # We depend on fixes in the tracing bundle that are only available in v7
-        if is_greater_or_equal_v7_sdk and has_performance:
+        if is_v7_or_higher_sdk and has_performance:
             bundle_kind_modifier += ".tracing"
             is_lazy = False
 
         # If the project does not have a v7 sdk set, we cannot load the replay bundle.
-        if is_greater_or_equal_v7_sdk and has_replay:
+        if is_v7_or_higher_sdk and has_replay:
             bundle_kind_modifier += ".replay"
             is_lazy = False
 
-        # From JavaScript SDK version 7 onwards, the default bundle code is ES6, however, in the loader we
+        # In JavaScript SDK version 7, the default bundle code is ES6, however, in the loader we
         # want to provide the ES5 version. This is why we need to modify the requested bundle name here.
         #
         # If we are loading replay, do not add the es5 modifier, as those bundles are
         # ES6 only.
-        if is_greater_or_equal_v7_sdk and not has_replay:
+        if is_v7_sdk and not has_replay:
             bundle_kind_modifier += ".es5"
 
         if has_debug:

--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -68,7 +68,7 @@ class JavaScriptSdkLoader(BaseView):
             }
 
         is_v7_sdk = sdk_version >= Version("7.0.0") and sdk_version < Version("8.0.0")
-        is_v7_or_higher_sdk = sdk_version >= Version("7.0.0")
+        is_greater_or_equal_v7_sdk = sdk_version >= Version("7.0.0")
 
         is_lazy = True
         bundle_kind_modifier = ""
@@ -81,12 +81,12 @@ class JavaScriptSdkLoader(BaseView):
         # https://docs.sentry.io/platforms/javascript/install/cdn/
 
         # We depend on fixes in the tracing bundle that are only available in v7
-        if is_v7_or_higher_sdk and has_performance:
+        if is_greater_or_equal_v7_sdk and has_performance:
             bundle_kind_modifier += ".tracing"
             is_lazy = False
 
         # If the project does not have a v7 sdk set, we cannot load the replay bundle.
-        if is_v7_or_higher_sdk and has_replay:
+        if is_greater_or_equal_v7_sdk and has_replay:
             bundle_kind_modifier += ".replay"
             is_lazy = False
 

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -177,7 +177,7 @@ class JavaScriptSdkLoaderTest(TestCase):
 
     @mock.patch(
         "sentry.loader.browsersdkversion.load_version_from_file",
-        return_value=["8.1.0", "8.0.0", "8", "8.0.0-alpha.0"],
+        return_value=["8.0.0"],
     )
     @mock.patch(
         "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="8.x"
@@ -192,6 +192,24 @@ class JavaScriptSdkLoaderTest(TestCase):
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
         assert b"/8.0.0/bundle.min.js" in resp.content
+
+    @mock.patch(
+        "sentry.loader.browsersdkversion.load_version_from_file",
+        return_value=["8.1.0", "8.0.0", "8", "8.0.0-alpha.0"],
+    )
+    @mock.patch(
+        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="8.x"
+    )
+    def test_returns_latest_v8_version_when_various_v8_versions_available(
+        self, load_version_from_file, get_selected_browser_sdk_version
+    ):
+        settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+        self.projectkey.data = {}
+        self.projectkey.save()
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
+        assert b"/8.1.0/bundle.min.js" in resp.content
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["7.37.0"])
     @mock.patch(

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -175,6 +175,24 @@ class JavaScriptSdkLoaderTest(TestCase):
         self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
         assert b"/7.100.0/bundle.tracing.replay.min.js" in resp.content
 
+    @mock.patch(
+        "sentry.loader.browsersdkversion.load_version_from_file",
+        return_value=["8.1.0", "8.0.0", "8", "8.0.0-alpha.0"],
+    )
+    @mock.patch(
+        "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="8.x"
+    )
+    def test_equal_to_v8_returns_default_bundle(
+        self, load_version_from_file, get_selected_browser_sdk_version
+    ):
+        settings.JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
+        self.projectkey.data = {}
+        self.projectkey.save()
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/js-sdk-loader.js.tmpl")
+        assert b"/8.0.0/bundle.min.js" in resp.content
+
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["7.37.0"])
     @mock.patch(
         "sentry.loader.browsersdkversion.get_selected_browser_sdk_version", return_value="7.x"


### PR DESCRIPTION
As the coming version of the JS SDK only uses ES2017 bundles, it is no longer necessary to differentiate between es5 and es6 bundles.

ref https://github.com/getsentry/sentry-javascript/pull/10911
