### PR TITLE
fix(ddm): Fix units normalization when * and / are used

### DIFF
--- a/src/sentry/sentry_metrics/querying/visitors/query_expression.py
+++ b/src/sentry/sentry_metrics/querying/visitors/query_expression.py
@@ -295,7 +295,6 @@ class UnitsNormalizationVisitor(QueryExpressionVisitor[QueryExpression]):
 
         self._is_formula = False
 
-    # 2 * (a * b)
     def _visit_formula(self, formula: Formula) -> QueryExpression:
         self._is_formula = True
 

--- a/src/sentry/sentry_metrics/querying/visitors/query_expression.py
+++ b/src/sentry/sentry_metrics/querying/visitors/query_expression.py
@@ -1,6 +1,14 @@
 from collections.abc import Sequence
 
-from snuba_sdk import AliasedExpression, Column, Condition, Formula, Op, Timeseries
+from snuba_sdk import (
+    AliasedExpression,
+    ArithmeticOperator,
+    Column,
+    Condition,
+    Formula,
+    Op,
+    Timeseries,
+)
 from snuba_sdk.conditions import ConditionGroup
 
 from sentry.models.environment import Environment
@@ -274,6 +282,10 @@ class UnitsNormalizationVisitor(QueryExpressionVisitor[QueryExpression]):
     case units are incompatible.
     """
 
+    UNITLESS_FORMULA_FUNCTIONS = {
+        ArithmeticOperator.DIVIDE.value,
+        ArithmeticOperator.MULTIPLY.value,
+    }
     UNITLESS_AGGREGATES = {"count", "count_unique"}
 
     def __init__(self):
@@ -285,7 +297,24 @@ class UnitsNormalizationVisitor(QueryExpressionVisitor[QueryExpression]):
 
     def _visit_formula(self, formula: Formula) -> QueryExpression:
         self._is_formula = True
-        return super()._visit_formula(formula)
+
+        contains_timeseries = False
+        parameters = []
+        for parameter in formula.parameters:
+            if isinstance(parameter, Timeseries):
+                contains_timeseries = True
+
+            parameters.append(self.visit(parameter))
+
+        # If we have a division or multiplication being performed on at least one timeseries, we want to unwind and not
+        # apply any units normalization.
+        if formula.function_name in self.UNITLESS_FORMULA_FUNCTIONS and contains_timeseries:
+            raise NonNormalizableUnitsError(
+                "A unitless formula function is being used and has at least one "
+                "timeseries in one of its operands"
+            )
+
+        return formula.set_parameters(parameters)
 
     def _visit_timeseries(self, timeseries: Timeseries) -> QueryExpression:
         extracted_unit = self._extract_unit(timeseries=timeseries)

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -1444,12 +1444,14 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
                 UseCaseID.CUSTOM,
             )
 
-        for formula, expected_result in (
-            ("$query_1 * $query_2", 300.0),
-            ("$query_1 / 2", 10.0),
-            ("$query_1 * $query_2 + 25", 325.0)
+        for formula, expected_result, expected_unit_family in (
+            ("$query_1 * $query_2", 300.0, None),
+            ("$query_1 * $query_2 + 25", 325.0, None),
+            ("$query_1 * $query_2 / 1", 300.0, None),
+            ("$query_1 * 2", 40.0, UnitFamily.DURATION.value),
+            ("$query_1 / 2", 10.0, UnitFamily.DURATION.value)
             # disabled since the layer fails validation of the use cases used when nested formulas have only scalars
-            # ("$query_1 + (100 / 1)", 21.0)
+            # ("$query_1 * (100 / 1)", 21.0)
         ):
             query_1 = self.mql("avg", mri_1)
             query_2 = self.mql("sum", mri_2)
@@ -1477,6 +1479,4 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             assert data[0][0]["totals"] == expected_result
             meta = results["meta"]
             assert len(meta) == 1
-            assert meta[0][1]["unit_family"] is None
-            assert meta[0][1]["unit"] is None
-            assert meta[0][1]["scaling_factor"] is None
+            assert meta[0][1]["unit_family"] == expected_unit_family

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -1374,8 +1374,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [None, 35.0, None]
-        assert data[0][0]["totals"] == 35.0
+        assert data[0][0]["series"] == [None, 21.0, None]
+        assert data[0][0]["totals"] == 21.0
         meta = results["meta"]
         assert len(meta) == 1
         assert meta[0][1]["unit_family"] is None
@@ -1420,8 +1420,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [None, 300.0, None]
-        assert data[0][0]["totals"] == 300.0
+        assert data[0][0]["series"] == [None, 35.0, None]
+        assert data[0][0]["totals"] == 35.0
         meta = results["meta"]
         assert len(meta) == 1
         assert meta[0][1]["unit_family"] == UnitFamily.UNKNOWN.value

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -1266,7 +1266,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             MetricsQueriesPlan()
             .declare_query("query_1", query_1)
             .declare_query("query_2", query_2)
-            .apply_formula("$query_1 * $query_2")
+            .apply_formula("$query_1 + $query_2")
         )
 
         results = self.run_query(
@@ -1282,8 +1282,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [None, 300000.0, None]
-        assert data[0][0]["totals"] == 300000.0
+        assert data[0][0]["series"] == [None, 20015.0, None]
+        assert data[0][0]["totals"] == 20015.0
         meta = results["meta"]
         assert len(meta) == 1
         assert meta[0][1]["unit_family"] == UnitFamily.DURATION.value
@@ -1312,7 +1312,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             MetricsQueriesPlan()
             .declare_query("query_1", query_1)
             .declare_query("query_2", query_2)
-            .apply_formula("$query_1 * $query_2")
+            .apply_formula("$query_1 + $query_2")
         )
 
         results = self.run_query(
@@ -1328,8 +1328,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [None, 300.0, None]
-        assert data[0][0]["totals"] == 300.0
+        assert data[0][0]["series"] == [None, 35.0, None]
+        assert data[0][0]["totals"] == 35.0
         meta = results["meta"]
         assert len(meta) == 1
         assert meta[0][1]["unit_family"] is None
@@ -1358,7 +1358,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             MetricsQueriesPlan()
             .declare_query("query_1", query_1)
             .declare_query("query_2", query_2)
-            .apply_formula("$query_1 * $query_2")
+            .apply_formula("$query_1 + $query_2")
         )
 
         results = self.run_query(
@@ -1374,8 +1374,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         data = results["data"]
         assert len(data) == 1
         assert data[0][0]["by"] == {}
-        assert data[0][0]["series"] == [None, 20.0, None]
-        assert data[0][0]["totals"] == 20.0
+        assert data[0][0]["series"] == [None, 35.0, None]
+        assert data[0][0]["totals"] == 35.0
         meta = results["meta"]
         assert len(meta) == 1
         assert meta[0][1]["unit_family"] is None
@@ -1404,7 +1404,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             MetricsQueriesPlan()
             .declare_query("query_1", query_1)
             .declare_query("query_2", query_2)
-            .apply_formula("$query_1 * $query_2")
+            .apply_formula("$query_1 + $query_2")
         )
 
         results = self.run_query(
@@ -1427,3 +1427,56 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert meta[0][1]["unit_family"] == UnitFamily.UNKNOWN.value
         assert meta[0][1]["unit"] is None
         assert meta[0][1]["scaling_factor"] is None
+
+    @with_feature("organizations:ddm-metrics-api-unit-normalization")
+    def test_query_with_basic_formula_and_unitless_formula_functions(self):
+        mri_1 = "d:custom/page_load@nanosecond"
+        mri_2 = "d:custom/load_time@microsecond"
+        for mri, value in ((mri_1, 20), (mri_2, 15)):
+            self.store_metric(
+                self.project.organization.id,
+                self.project.id,
+                "distribution",
+                mri,
+                {},
+                self.ts(self.now()),
+                value,
+                UseCaseID.CUSTOM,
+            )
+
+        for formula, expected_result in (
+            ("$query_1 * $query_2", 300.0),
+            ("$query_1 / 2", 10.0),
+            ("$query_1 * $query_2 + 25", 325.0)
+            # disabled since the layer fails validation of the use cases used when nested formulas have only scalars
+            # ("$query_1 + (100 / 1)", 21.0)
+        ):
+            query_1 = self.mql("avg", mri_1)
+            query_2 = self.mql("sum", mri_2)
+            plan = (
+                MetricsQueriesPlan()
+                .declare_query("query_1", query_1)
+                .declare_query("query_2", query_2)
+                .apply_formula(formula)
+            )
+
+            results = self.run_query(
+                metrics_queries_plan=plan,
+                start=self.now() - timedelta(minutes=30),
+                end=self.now() + timedelta(hours=1, minutes=30),
+                interval=3600,
+                organization=self.project.organization,
+                projects=[self.project],
+                environments=[],
+                referrer="metrics.data.api",
+            )
+            data = results["data"]
+            assert len(data) == 1
+            assert data[0][0]["by"] == {}
+            assert data[0][0]["series"] == [None, expected_result, None]
+            assert data[0][0]["totals"] == expected_result
+            meta = results["meta"]
+            assert len(meta) == 1
+            assert meta[0][1]["unit_family"] is None
+            assert meta[0][1]["unit"] is None
+            assert meta[0][1]["scaling_factor"] is None


### PR DESCRIPTION
This PR fixes units normalization semantics by not performing normalization whenever inside `*` or `/` there are all timeseries as operands.