### PR TITLE
ref(ddm): Remove multiple metrics meta queries

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -100,6 +100,7 @@ export type MetricMeta = {
   // name is returned by the API but should not be used, use parseMRI(mri).name instead
   // name: string;
   operations: MetricsOperation[];
+  projectIds: number[];
   type: MetricType;
   unit: string;
 };

--- a/static/app/utils/metrics/dashboardImport.spec.tsx
+++ b/static/app/utils/metrics/dashboardImport.spec.tsx
@@ -47,6 +47,7 @@ const mockAvailableMetrics = (mris: MRI[]): MetricMeta[] => {
     mri,
     operations: [],
     blockingStatus: [],
+    projectIds: [],
   })) as MetricMeta[];
 };
 

--- a/static/app/utils/metrics/useBlockMetric.tsx
+++ b/static/app/utils/metrics/useBlockMetric.tsx
@@ -1,7 +1,6 @@
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
 import type {MetricMeta, MRI, Project} from 'sentry/types';
-import {getUseCaseFromMRI} from 'sentry/utils/metrics/mri';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -46,21 +45,22 @@ export const useBlockMetric = (project: Project) => {
       });
     },
     onSuccess: data => {
-      const useCase = getUseCaseFromMRI(data.metricMri);
-      const metaQueryKey = getMetricsMetaQueryKey(
-        slug,
-        {projects: [parseInt(project.id, 10)]},
-        useCase ?? 'custom'
-      );
-      queryClient.setQueryData(
-        metaQueryKey,
+      const metaQueryKey = getMetricsMetaQueryKey(slug, {});
+
+      // Only match the endpoint, to search in all insances of the query
+      const queryKeyFilter = {queryKey: [metaQueryKey[0]]};
+
+      queryClient.setQueriesData(
+        queryKeyFilter,
         (oldData: BlockMetricResponse): BlockMetricResponse => {
           if (!oldData) {
             return undefined;
           }
           const oldMeta = oldData[0];
           const index = oldMeta.findIndex(
-            (metric: {mri: MRI}) => metric.mri === data.metricMri
+            metric =>
+              metric.mri === data.metricMri &&
+              metric.projectIds.includes(Number(project.id))
           );
 
           if (index !== undefined && index !== -1) {
@@ -78,7 +78,7 @@ export const useBlockMetric = (project: Project) => {
 
       addSuccessMessage(t('Metric updated'));
 
-      queryClient.invalidateQueries(metaQueryKey);
+      queryClient.invalidateQueries(queryKeyFilter);
     },
     onError: () => {
       addErrorMessage(t('An error occurred while updating the metric'));

--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -1,6 +1,6 @@
 import type {PageFilters} from 'sentry/types';
 import {formatMRI, getUseCaseFromMRI} from 'sentry/utils/metrics/mri';
-import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -9,22 +9,12 @@ import type {MetricMeta, MRI, UseCase} from '../../types/metrics';
 import {getMetaDateTimeParams} from './index';
 
 const EMPTY_ARRAY: MetricMeta[] = [];
-const DEFAULT_USE_CASES = ['sessions', 'transactions', 'custom', 'spans'];
-
-export function getMetricsMetaQueryKeys(
-  orgSlug: string,
-  projects: PageFilters['projects'],
-  useCases?: UseCase[]
-): ApiQueryKey[] {
-  return (
-    useCases?.map(useCase => getMetricsMetaQueryKey(orgSlug, {projects}, useCase)) ?? []
-  );
-}
+const DEFAULT_USE_CASES: UseCase[] = ['sessions', 'transactions', 'custom', 'spans'];
 
 export function getMetricsMetaQueryKey(
   orgSlug: string,
   {projects, datetime}: Partial<PageFilters>,
-  useCase: UseCase
+  useCase?: UseCase[]
 ): ApiQueryKey {
   const queryParams = projects?.length
     ? {useCase, project: projects, ...getMetaDateTimeParams(datetime)}
@@ -32,72 +22,36 @@ export function getMetricsMetaQueryKey(
   return [`/organizations/${orgSlug}/metrics/meta/`, {query: queryParams}];
 }
 
-function useMetaUseCase(
-  useCase: UseCase,
+export function useMetricsMeta(
   pageFilters: Partial<PageFilters>,
-  options: Omit<UseApiQueryOptions<MetricMeta[]>, 'staleTime'>
-) {
+  useCases: UseCase[] = DEFAULT_USE_CASES,
+  filterBlockedMetrics = true,
+  enabled: boolean = true
+): {data: MetricMeta[]; isLoading: boolean} {
   const {slug} = useOrganization();
 
-  const apiQueryResult = useApiQuery<MetricMeta[]>(
-    getMetricsMetaQueryKey(slug, pageFilters, useCase),
+  const {data, isLoading} = useApiQuery<MetricMeta[]>(
+    getMetricsMetaQueryKey(slug, pageFilters, useCases),
     {
-      ...options,
+      enabled,
       staleTime: 2000, // 2 seconds to cover page load
     }
   );
 
-  return apiQueryResult;
-}
+  if (!data) {
+    return {data: EMPTY_ARRAY, isLoading};
+  }
 
-export function useMetricsMeta(
-  pageFilters: Partial<PageFilters>,
-  useCases?: UseCase[],
-  filterBlockedMetrics = true,
-  enabled: boolean = true
-): {data: MetricMeta[]; isLoading: boolean} {
-  const enabledUseCases = useCases ?? DEFAULT_USE_CASES;
-
-  const {data: sessionMeta = [], ...sessionsReq} = useMetaUseCase(
-    'sessions',
-    pageFilters,
-    {
-      enabled: enabled && enabledUseCases.includes('sessions'),
-    }
-  );
-  const {data: txnsMeta = [], ...txnsReq} = useMetaUseCase('transactions', pageFilters, {
-    enabled: enabled && enabledUseCases.includes('transactions'),
-  });
-  const {data: customMeta = [], ...customReq} = useMetaUseCase('custom', pageFilters, {
-    enabled: enabled && enabledUseCases.includes('custom'),
-  });
-  const {data: spansMeta = [], ...spansReq} = useMetaUseCase('spans', pageFilters, {
-    enabled: enabled && enabledUseCases.includes('spans'),
-  });
-
-  const isLoading =
-    (sessionsReq.isLoading && sessionsReq.fetchStatus !== 'idle') ||
-    (txnsReq.isLoading && txnsReq.fetchStatus !== 'idle') ||
-    (customReq.isLoading && customReq.fetchStatus !== 'idle') ||
-    (spansReq.isLoading && spansReq.fetchStatus !== 'idle');
-
-  const data = [
-    ...(enabledUseCases.includes('sessions') ? sessionMeta : []),
-    ...(enabledUseCases.includes('transactions') ? txnsMeta : []),
-    ...(enabledUseCases.includes('custom') ? customMeta : []),
-    ...(enabledUseCases.includes('spans') ? spansMeta : []),
-  ].sort((a, b) => formatMRI(a.mri).localeCompare(formatMRI(b.mri)));
+  const meta = data.sort((a, b) => formatMRI(a.mri).localeCompare(formatMRI(b.mri)));
 
   if (!filterBlockedMetrics) {
-    return {data, isLoading};
+    return {data: meta, isLoading};
   }
 
   return {
-    data: isLoading
-      ? EMPTY_ARRAY
-      : data.filter(meta => {
-          return meta.blockingStatus?.every(({isBlocked}) => !isBlocked) ?? true;
-        }),
+    data: data.filter(entry => {
+      return entry.blockingStatus?.every(({isBlocked}) => !isBlocked) ?? true;
+    }),
     isLoading,
   };
 }


### PR DESCRIPTION
Remove request duplication logic for metrics meta queries to utilize parallelization on the BE and unblock other requests in the browser.  