### PR TITLE
fix(metrics-extraction): Fix attribute vs dict lookup

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -356,9 +356,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
                     original_results = _data_fn(scopedDataset, offset, limit, scoped_query)
                     if original_results.get("data"):
-                        dataset_meta = original_results.data.get("meta", {})
+                        dataset_meta = original_results.get("data").get("meta", {})
                     else:
-                        dataset_meta = list(original_results.values())[0].data.get("meta", {})
+                        dataset_meta = list(original_results.values())[0].get("data").get("meta", {})
                     using_metrics = dataset_meta.get("isMetricsData", False) or dataset_meta.get(
                         "isMetricsExtractedData", False
                     )

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -358,7 +358,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                     if original_results.get("data"):
                         dataset_meta = original_results.get("data").get("meta", {})
                     else:
-                        dataset_meta = list(original_results.values())[0].get("data").get("meta", {})
+                        dataset_meta = (
+                            list(original_results.values())[0].get("data").get("meta", {})
+                        )
                     using_metrics = dataset_meta.get("isMetricsData", False) or dataset_meta.get(
                         "isMetricsExtractedData", False
                     )


### PR DESCRIPTION
### Summary
Missed that the inner block was also getting `data` as if it was an attribute.

Fixes SENTRY-2VPR
