### PR TITLE
fix(ddm): Handle division by zero

### DIFF
--- a/src/sentry/sentry_metrics/querying/data_v2/transformation/metrics_api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation/metrics_api.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from sentry.search.utils import parse_datetime_string
 from sentry.sentry_metrics.querying.data_v2.execution import QueryResult
 from sentry.sentry_metrics.querying.data_v2.transformation import QueryTransformer
-from sentry.sentry_metrics.querying.data_v2.utils import nan_to_none
+from sentry.sentry_metrics.querying.data_v2.utils import undefined_value_to_none
 from sentry.sentry_metrics.querying.errors import MetricsQueryExecutionError
 from sentry.sentry_metrics.querying.types import GroupKey, ResultValue, Series, Totals
 
@@ -86,7 +86,7 @@ def _generate_full_series(
     for time, value in series:
         time_seconds = parse_datetime_string(time).timestamp()
         index = int((time_seconds - start_seconds) / interval)
-        full_series[index] = nan_to_none(value)
+        full_series[index] = undefined_value_to_none(value)
 
     return full_series
 
@@ -213,7 +213,7 @@ class MetricsAPIQueryTransformer(QueryTransformer[Mapping[str, Any]]):
                         "series": _generate_full_series(
                             int(start.timestamp()), len(intervals), interval, group_value.series
                         ),
-                        "totals": nan_to_none(group_value.totals),
+                        "totals": undefined_value_to_none(group_value.totals),
                     }
                 )
 

--- a/src/sentry/sentry_metrics/querying/data_v2/utils.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/utils.py
@@ -3,26 +3,30 @@ import math
 from sentry.sentry_metrics.querying.types import ResultValue
 
 
-def nan_to_none(value: ResultValue) -> ResultValue:
+def undefined_value_to_none(value: ResultValue) -> ResultValue:
     """
-    Converts a nan value to None or returns the original value.
+    Converts an undefined value to None or returns the original value.
     """
     if value is None:
         return None
 
-    if is_nan(value):
+    if is_undefined(value):
         return None
 
     return value
 
 
-def is_nan(value: ResultValue) -> bool:
+def is_undefined(value: ResultValue) -> bool:
     """
-    Returns whether the result of a query is nan.
+    Returns whether the result of a query is undefined.
     """
     if value is None:
         return False
-    elif isinstance(value, list):
-        return any(map(lambda e: e is not None and math.isnan(e), value))
 
-    return math.isnan(value)
+    def _is_undefined(inner_value: int | float) -> bool:
+        return math.isnan(inner_value) or math.isinf(inner_value)
+
+    if isinstance(value, list):
+        return any(map(lambda e: e is not None and _is_undefined(value), value))
+
+    return _is_undefined(value)

--- a/src/sentry/sentry_metrics/querying/data_v2/utils.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/utils.py
@@ -27,6 +27,6 @@ def is_undefined(value: ResultValue) -> bool:
         return math.isnan(inner_value) or math.isinf(inner_value)
 
     if isinstance(value, list):
-        return any(map(lambda e: e is not None and _is_undefined(value), value))
+        return any(map(lambda e: e is not None and _is_undefined(e), value))
 
     return _is_undefined(value)


### PR DESCRIPTION
This PR adds the support for `inf` in the JSON returned by Snuba.

Please note that `inf` and `nan` are not valid JSON values and it's currently working only because Python allows them in the JSON specification.