### PR TITLE
fix(hc): Provide region specific urls for chunk-upload config

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -82,8 +82,12 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 url = relative_url.lstrip(API_PREFIX)
             # Otherwise, if we do not support them, return an absolute, versioned endpoint with a default, system-wide prefix
             else:
-                region_base_url = generate_region_url()
-                url = absolute_uri(relative_url, region_base_url)
+                # We need to generate region specific upload URLs when possible to avoid hitting the API proxy
+                # which tends to cause timeouts and performance issues for uploads.
+                base_url = None
+                if options.get("hybrid_cloud.use_region_specific_upload_url"):
+                    base_url = generate_region_url()
+                url = absolute_uri(relative_url, base_url)
         else:
             # If user overridden upload url prefix, we want an absolute, versioned endpoint, with user-configured prefix
             url = absolute_uri(relative_url, endpoint)

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -14,6 +14,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
+from sentry.api.utils import generate_region_url
 from sentry.models.files.fileblob import FileBlob
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.utils.files import get_max_file_size
@@ -81,7 +82,8 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 url = relative_url.lstrip(API_PREFIX)
             # Otherwise, if we do not support them, return an absolute, versioned endpoint with a default, system-wide prefix
             else:
-                url = absolute_uri(relative_url)
+                region_base_url = generate_region_url()
+                url = absolute_uri(relative_url, region_base_url)
         else:
             # If user overridden upload url prefix, we want an absolute, versioned endpoint, with user-configured prefix
             url = absolute_uri(relative_url, endpoint)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1650,6 +1650,10 @@ register("hybrid_cloud.multi-region-selector", default=False, flags=FLAG_AUTOMAT
 register("hybrid_cloud.region-domain-allow-list", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybrid_cloud.region-user-allow-list", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+register(
+    "hybrid_cloud.use_region_specific_upload_url", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+
 # Retry controls
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -15,6 +15,7 @@ from sentry.api.endpoints.chunk import (
     MAX_CONCURRENCY,
     MAX_REQUEST_SIZE,
 )
+from sentry.api.utils import generate_region_url
 from sentry.models.apitoken import ApiToken
 from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.utils import MAX_FILE_SIZE
@@ -48,7 +49,7 @@ class ChunkUploadTest(APITestCase):
         assert response.data["maxFileSize"] == options.get("system.maximum-file-size")
         assert response.data["concurrency"] == MAX_CONCURRENCY
         assert response.data["hashAlgorithm"] == HASH_ALGORITHM
-        assert response.data["url"] == options.get("system.url-prefix") + self.url
+        assert response.data["url"] == generate_region_url() + self.url
         assert response.data["accept"] == CHUNK_UPLOAD_ACCEPT
 
         options.set("system.upload-url-prefix", "test")
@@ -113,7 +114,7 @@ class ChunkUploadTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/1.70.0",
             format="json",
         )
-        assert response.data["url"] == options.get("system.url-prefix") + self.url
+        assert response.data["url"] == generate_region_url() + self.url
 
         response = self.client.get(
             self.url,
@@ -121,7 +122,7 @@ class ChunkUploadTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/0.69.3",
             format="json",
         )
-        assert response.data["url"] == options.get("system.url-prefix") + self.url
+        assert response.data["url"] == generate_region_url() + self.url
 
         # user overridden upload url prefix has priority, even when calling from sentry-cli that supports relative urls
         options.set("system.upload-url-prefix", "test")


### PR DESCRIPTION
Our current chunk-upload configuration will return a control-silo URL for the upload path, which in return will cause uploads in SaaS to issue uploads via the API proxy, which are slow and can often time out due to the number of RPCs the proxy performs. In order to avoid this, I've updated config to return a region-specific URL which should avoid the vast majority of these RPCs entirely.

This change has been placed behind an option check (`hybrid_cloud.use_region_specific_upload_url`) to ensure we can  rollback the changes if anything else breaks.