### PR TITLE
feat(spans): Tag perf problems created from standalone spans

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2696,10 +2696,12 @@ def _calculate_span_grouping(jobs: Sequence[Job], projects: ProjectsMapping) -> 
 
 
 @metrics.wraps("save_event.detect_performance_problems")
-def _detect_performance_problems(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
+def _detect_performance_problems(
+    jobs: Sequence[Job], projects: ProjectsMapping, is_standalone_spans: bool = False
+) -> None:
     for job in jobs:
         job["performance_problems"] = detect_performance_problems(
-            job["data"], projects[job["project_id"]]
+            job["data"], projects[job["project_id"]], is_standalone_spans=is_standalone_spans
         )
 
 

--- a/src/sentry/tasks/spans.py
+++ b/src/sentry/tasks/spans.py
@@ -180,6 +180,9 @@ def _process_segment(project_id, segment_id):
     _pull_out_data(jobs, projects)
     _calculate_span_grouping(jobs, projects)
     _detect_performance_problems(jobs, projects, is_standalone_spans=True)
+
+    # Updates group type and fingerprint of all performance problems
+    # so they don't double write occurrences as we test.
     _update_occurrence_group_type(jobs, projects)
 
     return jobs

--- a/src/sentry/tasks/spans.py
+++ b/src/sentry/tasks/spans.py
@@ -97,6 +97,7 @@ def _update_occurrence_group_type(jobs: Sequence[Job], projects: ProjectsMapping
         performance_problems = job.pop("performance_problems")
         for performance_problem in performance_problems:
             performance_problem.type = PerformanceStreamedSpansGroupTypeExperimental
+            performance_problem.fingerprint = f"{performance_problem.fingerprint}-{PerformanceStreamedSpansGroupTypeExperimental.type_id}"
             updated_problems.append(performance_problem)
 
         job["performance_problems"] = updated_problems
@@ -178,7 +179,7 @@ def _process_segment(project_id, segment_id):
 
     _pull_out_data(jobs, projects)
     _calculate_span_grouping(jobs, projects)
-    _detect_performance_problems(jobs, projects)
+    _detect_performance_problems(jobs, projects, is_standalone_spans=True)
     _update_occurrence_group_type(jobs, projects)
 
     return jobs

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -637,8 +637,12 @@ class PerformanceIssueTestCase(BaseTestCase):
         perf_event_manager = EventManager(event_data)
         perf_event_manager.normalize()
 
-        def detect_performance_problems_interceptor(data: Event, project: Project):
-            perf_problems = detect_performance_problems(data, project)
+        def detect_performance_problems_interceptor(
+            data: Event, project: Project, is_standalone_spans: bool = False
+        ):
+            perf_problems = detect_performance_problems(
+                data, project, is_standalone_spans=is_standalone_spans
+            )
             if fingerprint:
                 for perf_problem in perf_problems:
                     perf_problem.fingerprint = fingerprint

--- a/src/sentry/utils/mockdata/__init__.py
+++ b/src/sentry/utils/mockdata/__init__.py
@@ -1,1 +1,2 @@
 from .core import *  # noqa
+from .run_test_detector import *  # noqa

--- a/src/sentry/utils/mockdata/__init__.py
+++ b/src/sentry/utils/mockdata/__init__.py
@@ -1,2 +1,1 @@
 from .core import *  # noqa
-from .run_test_detector import *  # noqa

--- a/tests/sentry/tasks/test_spans.py
+++ b/tests/sentry/tasks/test_spans.py
@@ -85,7 +85,7 @@ class TestSpansTask(TestCase):
 
         assert (
             job["performance_problems"][0].fingerprint
-            == "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-f906d576ffde8f005fd741f7b9c8a35062361e67"
+            == "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-f906d576ffde8f005fd741f7b9c8a35062361e67-1019"
         )
 
         assert job["performance_problems"][0].type == PerformanceStreamedSpansGroupTypeExperimental

--- a/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
@@ -127,6 +127,7 @@ class MNPlusOneDBDetectorTest(TestCase):
             [
                 call("_pi_all_issue_count", 1),
                 call("_pi_sdk_name", "sentry.javascript.node"),
+                call("is_standalone_spans", False),
                 call("_pi_transaction", "3818ae4f54ba4fa6ac6f68c9e32793c4"),
                 call(
                     "_pi_m_n_plus_one_db_fp",

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -421,7 +421,7 @@ class PerformanceDetectionTest(TestCase):
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock, self.project)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 7
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 8
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
@@ -432,6 +432,7 @@ class PerformanceDetectionTest(TestCase):
                     "_pi_sdk_name",
                     "",
                 ),
+                call("is_standalone_spans", False),
                 call(
                     "_pi_transaction",
                     "da78af6000a6400aaa87cf6e14ddeb40",


### PR DESCRIPTION
As we set up the application logic to run performance issue detection
on standalone spans, we want to collect metrics to check if transaction
based and span based perf issue detection are equivalent. Tagging
metrics with `is_standalone_spans` to track this.
This also updates fingerprint so the standalone span occurrences 
don't get grouped with existing perf issues during testing.
