### PR TITLE
ref(crons): Remove usage of last_state_change

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -138,8 +138,7 @@ def mark_failed_threshold(failed_checkin: MonitorCheckIn, failure_issue_threshol
 
         # change monitor status + update fingerprint timestamp
         monitor_env.status = MonitorStatus.ERROR
-        monitor_env.last_state_change = monitor_env.last_checkin
-        monitor_env.save(update_fields=("status", "last_state_change"))
+        monitor_env.save(update_fields=("status",))
 
         # Do not create incident if monitor is muted
         if not monitor_muted:

--- a/src/sentry/monitors/logic/mark_ok.py
+++ b/src/sentry/monitors/logic/mark_ok.py
@@ -62,11 +62,11 @@ def mark_ok(checkin: MonitorCheckIn, ts: datetime):
             # Only send an occurrence if we have an active incident
             for grouphash in active_incidents.values_list("grouphash", flat=True):
                 resolve_incident_group(grouphash, checkin.monitor.project_id)
-            if active_incidents.update(
+
+            active_incidents.update(
                 resolving_checkin=checkin,
                 resolving_timestamp=checkin.date_added,
-            ):
-                params["last_state_change"] = ts
+            )
         else:
             # Don't update status if incident isn't recovered
             params.pop("status", None)

--- a/tests/sentry/monitors/logic/test_mark_ok.py
+++ b/tests/sentry/monitors/logic/test_mark_ok.py
@@ -91,7 +91,6 @@ class MarkOkTestCase(TestCase):
             monitor=monitor,
             environment_id=self.environment.id,
             status=MonitorStatus.ERROR,
-            last_state_change=None,
         )
         first_checkin = MonitorCheckIn.objects.create(
             monitor=monitor,
@@ -138,8 +137,6 @@ class MarkOkTestCase(TestCase):
         assert monitor_environment.status != MonitorStatus.OK
         assert monitor_environment.next_checkin == now + timedelta(minutes=1)
 
-        # check that timestamp has not updated
-        assert monitor_environment.last_state_change is None
         # Incident has not resolved
         assert incident.resolving_checkin is None
         assert incident.resolving_timestamp is None
@@ -182,8 +179,6 @@ class MarkOkTestCase(TestCase):
         assert monitor_environment.status == MonitorStatus.OK
         assert monitor_environment.next_checkin == last_checkin.date_added + timedelta(minutes=1)
 
-        # check that monitor environment has updated timestamp used for fingerprinting
-        assert monitor_environment.last_state_change == monitor_environment.last_checkin
         # Incident resolved
         assert incident.resolving_checkin == last_checkin
         assert incident.resolving_timestamp == last_checkin.date_added


### PR DESCRIPTION
This code is no longer needed now that we have stopped generating legacy
event hashes in GH-66250