### PR TITLE
ref(feedback): update links and system default for onboarding

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
@@ -2,13 +2,20 @@ import Alert from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 
-export const getFeedbackConfigureDescription = ({link}: {link: string}) =>
+export const getFeedbackConfigureDescription = ({
+  linkConfig,
+  linkButton,
+}: {
+  linkButton: string;
+  linkConfig: string;
+}) =>
   tct(
-    'To set up the integration, add the following to your Sentry initialization. There are many options you can pass to the [code:integrations] constructor to customize your form. [break] [break] You can even link the widget to a custom button if you don’t want to use our autoinjected floating button. Learn more about configuring User Feedback by reading the [link:configuration docs].',
+    'To set up the integration, add the following to your Sentry initialization. There are many options you can pass to the [code:integrations] constructor to customize your form. [break] [break] You can even [linkButton:link the widget to a custom button] if you don’t want to use our auto-injected floating button. Learn more about configuring User Feedback by reading the [linkConfig:configuration docs].',
     {
       code: <code />,
       break: <br />,
-      link: <ExternalLink href={link} />,
+      linkConfig: <ExternalLink href={linkConfig} />,
+      linkButton: <ExternalLink href={linkButton} />,
     }
   );
 
@@ -28,7 +35,7 @@ export const getFeedbackSDKSetupSnippet = ({
     integrations: [
       Sentry.feedbackIntegration({
 // Additional SDK configuration goes in here, for example:
-colorScheme: "light",
+colorScheme: "system",
 ${getFeedbackConfigOptions(feedbackOptions)}}),
     ],
   });`;

--- a/static/app/gettingStartedDocs/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/capacitor/capacitor.tsx
@@ -83,7 +83,7 @@ const getSentryInitLayout = (params: Params, siblingOption: string): string => {
       ? `
         Sentry.feedbackIntegration({
 // Additional SDK configuration goes in here, for example:
-colorScheme: "light",
+colorScheme: "system",
 ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
       : ''
   }${
@@ -446,7 +446,10 @@ const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/capacitor/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: getSetupConfiguration({
         params,

--- a/static/app/gettingStartedDocs/electron/electron.tsx
+++ b/static/app/gettingStartedDocs/electron/electron.tsx
@@ -268,7 +268,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/electron/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/electron/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/electron/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.tsx
@@ -218,7 +218,7 @@ function getSdkSetupSnippet(params: Params) {
         ? `
         Sentry.feedbackIntegration({
 // Additional SDK configuration goes in here, for example:
-colorScheme: "light",
+colorScheme: "system",
 ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
         : ''
     }${
@@ -324,7 +324,10 @@ const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/angular/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/angular/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/angular/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/javascript/astro.tsx
@@ -250,7 +250,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/astro/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/astro/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/astro/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/javascript/ember.tsx
@@ -40,7 +40,7 @@ Sentry.init({
       ? `
         Sentry.feedbackIntegration({
 // Additional SDK configuration goes in here, for example:
-colorScheme: "light",
+colorScheme: "system",
 ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
       : ''
   }
@@ -214,7 +214,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/ember/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/ember/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/ember/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/javascript/gatsby.tsx
@@ -37,7 +37,7 @@ Sentry.init({
       ? `
         Sentry.feedbackIntegration({
 // Additional SDK configuration goes in here, for example:
-colorScheme: "light",
+colorScheme: "system",
 ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
       : ''
   }${
@@ -248,7 +248,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/gatsby/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/gatsby/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/gatsby/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -36,7 +36,7 @@ Sentry.init({
       ? `
         Sentry.feedbackIntegration({
 // Additional SDK configuration goes in here, for example:
-colorScheme: "light",
+colorScheme: "system",
 ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
       : ''
   }${
@@ -215,7 +215,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/user-feedback/configuration/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -206,7 +206,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/nextjs/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/nextjs/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/react.tsx
+++ b/static/app/gettingStartedDocs/javascript/react.tsx
@@ -36,7 +36,7 @@ Sentry.init({
       ? `
         Sentry.feedbackIntegration({
 // Additional SDK configuration goes in here, for example:
-colorScheme: "light",
+colorScheme: "system",
 ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
       : ''
   }${
@@ -240,7 +240,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/react/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/react/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/react/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -194,7 +194,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/remix/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/remix/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/remix/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/javascript/svelte.tsx
@@ -38,7 +38,7 @@ Sentry.init({
       ? `
         Sentry.feedbackIntegration({
 // Additional SDK configuration goes in here, for example:
-colorScheme: "light",
+colorScheme: "system",
 ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
       : ''
   }${
@@ -237,7 +237,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/svelte/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/svelte/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/svelte/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/javascript/sveltekit.tsx
@@ -153,7 +153,10 @@ const feedbackOnboarding: OnboardingConfig = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/sveltekit/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/sveltekit/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/sveltekit/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -308,7 +308,10 @@ const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
     {
       type: StepType.CONFIGURE,
       description: getFeedbackConfigureDescription({
-        link: 'https://docs.sentry.io/platforms/javascript/guides/vue/user-feedback/',
+        linkConfig:
+          'https://docs.sentry.io/platforms/javascript/guides/vue/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/javascript/guides/vue/user-feedback/configuration/#bring-your-own-button',
       }),
       configurations: [
         {


### PR DESCRIPTION
Changed snippet example to `colorScheme: "system"`:
<img width="457" alt="SCR-20240305-jdjj" src="https://github.com/getsentry/sentry/assets/56095982/fe99f6aa-8b3e-4ed6-b117-15cacf9273dd">

Updated links and hyperlink to the specific "bring your own button" section in the docs:
<img width="465" alt="SCR-20240305-jcve" src="https://github.com/getsentry/sentry/assets/56095982/2a9984a4-4947-437c-bcc5-b93d991a70b9">
