### PR TITLE
fix(crons): Fix backfill script to handle the case where a monitor with a slug already exists in the target org

### DIFF
--- a/tests/sentry/migrations/test_0660_fix_cron_monitor_invalid_orgs.py
+++ b/tests/sentry/migrations/test_0660_fix_cron_monitor_invalid_orgs.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.monitors.models import Monitor
 from sentry.testutils.cases import TestMigrations
 
@@ -20,9 +22,26 @@ class RenamePrioritySortToTrendsTest(TestMigrations):
             slug="invalid-monitor",
             name="invalid-monitor",
         )
+        self.slug_already_exists = Monitor.objects.create(
+            organization_id=self.other_org.id,
+            project_id=self.project.id,
+            slug="already-exists",
+            name="already-exists",
+        )
+        self.existing_monitor = Monitor.objects.create(
+            organization_id=self.project.organization_id,
+            project_id=self.project.id,
+            slug="already-exists",
+            name="already-exists",
+        )
 
     def test(self):
         self.valid_monitor.refresh_from_db()
         self.invalid_monitor.refresh_from_db()
+        self.existing_monitor.refresh_from_db()
         assert self.valid_monitor.organization_id == self.project.organization_id
         assert self.invalid_monitor.organization_id == self.project.organization_id
+        assert self.existing_monitor.organization_id == self.project.organization_id
+        assert self.existing_monitor.organization_id == self.project.organization_id
+        with pytest.raises(Monitor.DoesNotExist):
+            self.slug_already_exists.refresh_from_db()


### PR DESCRIPTION
There are 4 monitors that exist twice in the same project, but in different orgs. The ones that have a different org than the project's org are totally broken and can't receive checkins. We'll just delete them, they're inaccessible at the moment.
