### PR TITLE
chore(commit-context): Remove unused feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1479,8 +1479,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:codecov-commit-sha-from-git-blame": False,
     # The overall flag for codecov integration, gated by plans.
     "organizations:codecov-integration": False,
-    # Enable the Commit Context feature
-    "organizations:commit-context": True,
     # Enable alerting based on crash free sessions/users
     "organizations:crash-rate-alerts": True,
     # Enable creating organizations within sentry

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -16,7 +16,6 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:advanced-search",
         "organizations:app-store-connect-multiple",
         "organizations:change-alerts",
-        "organizations:commit-context",
         "organizations:codecov-integration",
         "organizations:crash-rate-alerts",
         "organizations:custom-symbol-sources",

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1174,10 +1174,7 @@ def process_commits(job: PostProcessJob) -> None:
                     # Cache the integrations check for 4 hours
                     cache.set(integration_cache_key, has_integrations, 14400)
 
-                if (
-                    features.has("organizations:commit-context", event.project.organization)
-                    and has_integrations
-                ):
+                if has_integrations:
                     if not job["group_state"]["is_new"]:
                         return
 

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -143,114 +143,112 @@ class EventCommittersTest(APITestCase):
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
 
-    def test_with_commit_context_feature_flag(self):
-        with self.feature({"organizations:commit-context": True}):
-            self.login_as(user=self.user)
-            self.repo = Repository.objects.create(
-                organization_id=self.organization.id,
-                name="example",
-                integration_id=self.integration.id,
-            )
-            self.commit = self.create_commit(
-                project=self.project,
-                repo=self.repo,
-                author=self.create_commit_author(project=self.project, user=self.user),
-                key="asdfwreqr",
-                message="placeholder commit message",
-            )
-            event = self.store_event(
-                data={
-                    "fingerprint": ["group1"],
-                    "timestamp": iso_format(before_now(minutes=1)),
-                    "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
-                },
-                project_id=self.project.id,
-            )
+    def test_with_commit_context(self):
+        self.login_as(user=self.user)
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="example",
+            integration_id=self.integration.id,
+        )
+        self.commit = self.create_commit(
+            project=self.project,
+            repo=self.repo,
+            author=self.create_commit_author(project=self.project, user=self.user),
+            key="asdfwreqr",
+            message="placeholder commit message",
+        )
+        event = self.store_event(
+            data={
+                "fingerprint": ["group1"],
+                "timestamp": iso_format(before_now(minutes=1)),
+                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+            },
+            project_id=self.project.id,
+        )
 
-            GroupOwner.objects.create(
-                group=event.group,
-                user_id=self.user.id,
-                project=self.project,
-                organization=self.organization,
-                type=GroupOwnerType.SUSPECT_COMMIT.value,
-                context={"commitId": self.commit.id},
-            )
+        GroupOwner.objects.create(
+            group=event.group,
+            user_id=self.user.id,
+            project=self.project,
+            organization=self.organization,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            context={"commitId": self.commit.id},
+        )
 
-            url = reverse(
-                "sentry-api-0-event-file-committers",
-                kwargs={
-                    "event_id": event.event_id,
-                    "project_slug": event.project.slug,
-                    "organization_slug": event.project.organization.slug,
-                },
-            )
+        url = reverse(
+            "sentry-api-0-event-file-committers",
+            kwargs={
+                "event_id": event.event_id,
+                "project_slug": event.project.slug,
+                "organization_slug": event.project.organization.slug,
+            },
+        )
 
-            response = self.client.get(url, format="json")
-            assert response.status_code == 200, response.content
-            assert len(response.data["committers"]) == 1
-            assert response.data["committers"][0]["author"]["username"] == "admin@localhost"
-            commits = response.data["committers"][0]["commits"]
-            assert len(commits) == 1
-            assert commits[0]["message"] == "placeholder commit message"
-            assert commits[0]["suspectCommitType"] == "via SCM integration"
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data["committers"]) == 1
+        assert response.data["committers"][0]["author"]["username"] == "admin@localhost"
+        commits = response.data["committers"][0]["commits"]
+        assert len(commits) == 1
+        assert commits[0]["message"] == "placeholder commit message"
+        assert commits[0]["suspectCommitType"] == "via SCM integration"
 
     def test_with_commit_context_pull_request(self):
-        with self.feature({"organizations:commit-context": True}):
-            self.login_as(user=self.user)
-            self.repo = Repository.objects.create(
-                organization_id=self.organization.id,
-                name="example",
-                integration_id=self.integration.id,
-            )
-            commit_author = self.create_commit_author(project=self.project, user=self.user)
-            self.commit = self.create_commit(
-                project=self.project,
-                repo=self.repo,
-                author=commit_author,
-                key="asdfwreqr",
-                message="placeholder commit message",
-            )
-            pull_request = PullRequest.objects.create(
-                organization_id=self.organization.id,
-                repository_id=self.repo.id,
-                key="9",
-                author=commit_author,
-                message="waddap",
-                title="cool pr",
-                merge_commit_sha=self.commit.key,
-            )
-            event = self.store_event(
-                data={
-                    "fingerprint": ["group1"],
-                    "timestamp": iso_format(before_now(minutes=1)),
-                    "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
-                },
-                project_id=self.project.id,
-            )
+        self.login_as(user=self.user)
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="example",
+            integration_id=self.integration.id,
+        )
+        commit_author = self.create_commit_author(project=self.project, user=self.user)
+        self.commit = self.create_commit(
+            project=self.project,
+            repo=self.repo,
+            author=commit_author,
+            key="asdfwreqr",
+            message="placeholder commit message",
+        )
+        pull_request = PullRequest.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key="9",
+            author=commit_author,
+            message="waddap",
+            title="cool pr",
+            merge_commit_sha=self.commit.key,
+        )
+        event = self.store_event(
+            data={
+                "fingerprint": ["group1"],
+                "timestamp": iso_format(before_now(minutes=1)),
+                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+            },
+            project_id=self.project.id,
+        )
 
-            GroupOwner.objects.create(
-                group=event.group,
-                user_id=self.user.id,
-                project=self.project,
-                organization=self.organization,
-                type=GroupOwnerType.SUSPECT_COMMIT.value,
-                context={"commitId": self.commit.id},
-            )
+        GroupOwner.objects.create(
+            group=event.group,
+            user_id=self.user.id,
+            project=self.project,
+            organization=self.organization,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            context={"commitId": self.commit.id},
+        )
 
-            url = reverse(
-                "sentry-api-0-event-file-committers",
-                kwargs={
-                    "event_id": event.event_id,
-                    "project_slug": event.project.slug,
-                    "organization_slug": event.project.organization.slug,
-                },
-            )
+        url = reverse(
+            "sentry-api-0-event-file-committers",
+            kwargs={
+                "event_id": event.event_id,
+                "project_slug": event.project.slug,
+                "organization_slug": event.project.organization.slug,
+            },
+        )
 
-            response = self.client.get(url, format="json")
-            assert response.status_code == 200, response.content
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200, response.content
 
-            commits = response.data["committers"][0]["commits"]
-            assert len(commits) == 1
-            assert "pullRequest" in commits[0]
-            assert commits[0]["pullRequest"]["id"] == pull_request.key
-            assert commits[0]["suspectCommitType"] == "via SCM integration"
+        commits = response.data["committers"][0]["commits"]
+        assert len(commits) == 1
+        assert "pullRequest" in commits[0]
+        assert commits[0]["pullRequest"]["id"] == pull_request.key
+        assert commits[0]["suspectCommitType"] == "via SCM integration"

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -66,7 +66,6 @@ class OrganizationSerializerTest(TestCase):
         assert result["features"] == {
             "advanced-search",
             "change-alerts",
-            "commit-context",
             "crash-rate-alerts",
             "custom-symbol-sources",
             "data-forwarding",

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1459,7 +1459,6 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
             )
         ]
 
-    @with_feature("organizations:commit-context")
     @patch(
         "sentry.integrations.github.GitHubIntegration.get_commit_context_all_frames",
         return_value=github_blame_return_value,
@@ -1481,7 +1480,6 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
 
         assert not mock_get_commit_context.called
 
-    @with_feature("organizations:commit-context")
     @patch(
         "sentry.integrations.github_enterprise.GitHubEnterpriseIntegration.get_commit_context_all_frames",
     )
@@ -1517,7 +1515,6 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         )
 
-    @with_feature("organizations:commit-context")
     @patch("sentry.integrations.github.GitHubIntegration.get_commit_context_all_frames")
     def test_skip_when_not_is_new(self, mock_get_commit_context):
         """
@@ -1538,7 +1535,6 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         ).exists()
 
-    @with_feature("organizations:commit-context")
     @patch(
         "sentry.integrations.github.GitHubIntegration.get_commit_context_all_frames",
     )

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -19,7 +19,6 @@ from sentry.models.repository import Repository
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils.committers import (
     _get_commit_file_changes,
@@ -739,7 +738,6 @@ class GetEventFileCommitters(CommitTestCase):
         assert result[0]["commits"][0]["id"] == "a" * 40
         assert result[0]["commits"][0]["suspectCommitType"] == "via commit in release"
 
-    @with_feature("organizations:commit-context")
     def test_no_author(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             model = self.create_provider_integration(
@@ -926,7 +924,6 @@ class GetEventFileCommitters(CommitTestCase):
         with pytest.raises(Commit.DoesNotExist):
             get_serialized_event_file_committers(self.project, event)
 
-    @with_feature("organizations:commit-context")
     def test_commit_context_fallback(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             Integration.objects.all().delete()


### PR DESCRIPTION
With https://github.com/getsentry/sentry/pull/65346 and https://github.com/getsentry/getsentry/pull/12983 merged, self-hosted and all organizations on SaaS now have access to the commit-context feature for suspect commits. The feature flag can be safely removed.