### PR TITLE
ref(replays): remove rage click creation celery task

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -6,16 +6,12 @@ import time
 import uuid
 from collections.abc import Generator
 from hashlib import md5
-from typing import Any, Literal, TypedDict, cast
+from typing import Any, Literal, TypedDict
 
 from sentry import features
 from sentry.conf.types.kafka_definition import Topic
 from sentry.models.project import Project
-from sentry.replays.usecases.ingest.events import SentryEvent
-from sentry.replays.usecases.ingest.issue_creation import (
-    report_rage_click_issue,
-    report_rage_click_issue_with_replay_event,
-)
+from sentry.replays.usecases.ingest.issue_creation import report_rage_click_issue_with_replay_event
 from sentry.utils import json, kafka_config, metrics
 from sentry.utils.pubsub import KafkaPublisher
 
@@ -401,10 +397,6 @@ def _handle_breadcrumb(
                                 payload["data"]["url"],
                                 payload["data"]["node"],
                                 replay_event,
-                            )
-                        else:
-                            report_rage_click_issue.delay(
-                                project_id, replay_id, cast(SentryEvent, event)
                             )
         # Log the event for tracking.
         log = event["data"].get("payload", {}).copy()

--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -5,85 +5,13 @@ from typing import Any
 from sentry.constants import MAX_CULPRIT_LENGTH
 from sentry.issues.grouptype import ReplayRageClickType
 from sentry.issues.issue_occurrence import IssueEvidence
-from sentry.models.project import Project
-from sentry.replays.query import query_replay_instance
-from sentry.replays.usecases.ingest.events import SentryEvent
 from sentry.replays.usecases.issue import new_issue_occurrence
-from sentry.silo.base import SiloMode
-from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 
 logger = logging.getLogger()
 
 RAGE_CLICK_TITLE = "Rage Click"
 RAGE_CLICK_LEVEL = "error"
-
-
-@instrumented_task(
-    name="sentry.replays.usecases.ingest.issue_creation.report_rage_click_issue",
-    queue="replays.ingest_replay",
-    default_retry_delay=5,
-    max_retries=5,
-    silo_mode=SiloMode.REGION,
-)
-def report_rage_click_issue(project_id: int, replay_id: str, event: SentryEvent):
-    metrics.incr("replay.rage_click_issue_creation")
-    payload = event["data"]["payload"]
-
-    project = Project.objects.get(id=project_id)
-
-    # Seconds since epoch is UTC.
-    timestamp = datetime.datetime.fromtimestamp(payload["timestamp"])
-    timestamp = timestamp.replace(tzinfo=datetime.UTC)
-
-    replay_info_list = query_replay_instance(
-        project_id=project_id,
-        replay_id=replay_id,
-        start=timestamp - datetime.timedelta(hours=1),
-        end=timestamp,
-        organization=project.organization,
-    )
-    if not replay_info_list or len(replay_info_list) == 0:
-        metrics.incr("replay.rage_click_issue_creation.no_replay_info")
-        return
-
-    replay_info = replay_info_list[0]
-
-    selector = payload["message"]
-    clicked_element = selector.split(" > ")[-1]
-    new_issue_occurrence(
-        culprit=payload["data"]["url"][:MAX_CULPRIT_LENGTH],
-        environment=replay_info["agg_environment"],
-        fingerprint=[selector],
-        issue_type=ReplayRageClickType,
-        level=RAGE_CLICK_LEVEL,
-        platform="javascript",
-        project_id=project_id,
-        subtitle=selector,
-        timestamp=timestamp,
-        title=RAGE_CLICK_TITLE,
-        evidence_data={
-            # RRWeb node data of clicked element.
-            "node": payload["data"]["node"],
-            # CSS selector path to clicked element.
-            "selector": selector,
-        },
-        evidence_display=[
-            IssueEvidence(name="Clicked Element", value=clicked_element, important=True),
-            IssueEvidence(name="Selector Path", value=selector, important=True),
-        ],
-        extra_event_data={
-            "contexts": {"replay": {"replay_id": replay_id}},
-            "level": RAGE_CLICK_LEVEL,
-            "tags": {"replayId": replay_id, "url": payload["data"]["url"]},
-            "user": {
-                "id": replay_info["user_id"],
-                "username": replay_info["user_username"],
-                "email": replay_info["user_email"],
-                "ip_address": replay_info["user_ip"],
-            },
-        },
-    )
 
 
 def report_rage_click_issue_with_replay_event(

--- a/tests/sentry/replays/unit/test_ingest_dom_index.py
+++ b/tests/sentry/replays/unit/test_ingest_dom_index.py
@@ -27,12 +27,6 @@ def mock_replay_event():
 
 
 @pytest.fixture(autouse=True)
-def patch_rage_click_issue():
-    with mock.patch("sentry.replays.usecases.ingest.dom_index.report_rage_click_issue") as m:
-        yield m
-
-
-@pytest.fixture(autouse=True)
 def patch_rage_click_issue_with_replay_event():
     with mock.patch(
         "sentry.replays.usecases.ingest.dom_index.report_rage_click_issue_with_replay_event"
@@ -278,7 +272,7 @@ def test_parse_replay_actions():
 
 
 @django_db_all
-def test_parse_replay_dead_click_actions(patch_rage_click_issue, default_project):
+def test_parse_replay_dead_click_actions(patch_rage_click_issue_with_replay_event, default_project):
     events = [
         {
             "type": 5,
@@ -393,8 +387,10 @@ def test_parse_replay_dead_click_actions(patch_rage_click_issue, default_project
         }
     ):
         default_project.update_option("sentry:replay_rage_click_issues", True)
-        replay_actions = parse_replay_actions(default_project.id, "1", 30, events, None)
-    assert patch_rage_click_issue.delay.call_count == 2
+        replay_actions = parse_replay_actions(
+            default_project.id, "1", 30, events, mock_replay_event()
+        )
+    assert patch_rage_click_issue_with_replay_event.call_count == 2
     assert replay_actions is not None
     assert replay_actions["type"] == "replay_event"
     assert isinstance(replay_actions["start_time"], float)
@@ -437,7 +433,9 @@ def test_parse_replay_dead_click_actions(patch_rage_click_issue, default_project
 
 
 @django_db_all
-def test_parse_replay_click_actions_not_dead(patch_rage_click_issue, default_project):
+def test_parse_replay_click_actions_not_dead(
+    patch_rage_click_issue_with_replay_event, default_project
+):
     events = [
         {
             "type": 5,
@@ -476,7 +474,7 @@ def test_parse_replay_click_actions_not_dead(patch_rage_click_issue, default_pro
     ]
 
     replay_actions = parse_replay_actions(default_project.id, "1", 30, events, None)
-    assert patch_rage_click_issue.delay.call_count == 0
+    assert patch_rage_click_issue_with_replay_event.delay.call_count == 0
     assert replay_actions is None
 
 
@@ -719,7 +717,7 @@ def test_parse_request_response_old_format_request_and_response():
 
 @django_db_all
 def test_parse_replay_rage_clicks_with_replay_event(
-    patch_rage_click_issue_with_replay_event, default_project, patch_rage_click_issue
+    patch_rage_click_issue_with_replay_event, default_project
 ):
     events = [
         {
@@ -839,7 +837,6 @@ def test_parse_replay_rage_clicks_with_replay_event(
             default_project.id, "1", 30, events, mock_replay_event()
         )
     assert patch_rage_click_issue_with_replay_event.call_count == 2
-    assert patch_rage_click_issue.delay.call_count == 0
     assert replay_actions is not None
     assert replay_actions["type"] == "replay_event"
     assert isinstance(replay_actions["start_time"], float)
@@ -876,9 +873,10 @@ def test_log_sdk_options():
     log["project_id"] = 1
     log["replay_id"] = "1"
 
-    with mock.patch("sentry.replays.usecases.ingest.dom_index.logger") as logger, mock.patch(
-        "random.randint"
-    ) as randint:
+    with (
+        mock.patch("sentry.replays.usecases.ingest.dom_index.logger") as logger,
+        mock.patch("random.randint") as randint,
+    ):
         randint.return_value = 0
         parse_replay_actions(1, "1", 30, events, None)
         assert logger.info.call_args_list == [mock.call("SDK Options:", extra=log)]
@@ -905,9 +903,10 @@ def test_log_large_dom_mutations():
     log["project_id"] = 1
     log["replay_id"] = "1"
 
-    with mock.patch("sentry.replays.usecases.ingest.dom_index.logger") as logger, mock.patch(
-        "random.randint"
-    ) as randint:
+    with (
+        mock.patch("sentry.replays.usecases.ingest.dom_index.logger") as logger,
+        mock.patch("random.randint") as randint,
+    ):
         randint.return_value = 0
         parse_replay_actions(1, "1", 30, events, None)
         assert logger.info.call_args_list == [mock.call("Large DOM Mutations List:", extra=log)]

--- a/tests/sentry/replays/unit/test_issue_creation.py
+++ b/tests/sentry/replays/unit/test_issue_creation.py
@@ -1,106 +1,17 @@
-import time
 from datetime import datetime, timedelta
-from typing import cast
 from unittest.mock import patch
 
 import pytest
-import requests
-from django.conf import settings
 
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.group import Group
-from sentry.replays.testutils import mock_replay
-from sentry.replays.usecases.ingest.events import SentryEvent
-from sentry.replays.usecases.ingest.issue_creation import (
-    report_rage_click_issue,
-    report_rage_click_issue_with_replay_event,
-)
+from sentry.replays.usecases.ingest.issue_creation import report_rage_click_issue_with_replay_event
 from sentry.testutils.helpers.features import Feature
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.replays.unit.test_ingest_dom_index import mock_replay_event
 
 pytestmark = [requires_snuba]
-
-
-@pytest.mark.snuba
-@django_db_all
-@patch("sentry.replays.usecases.ingest.issue_creation.new_issue_occurrence")
-def test_report_rage_click_issue_a_tag(mock_new_issue_occurrence, default_project):
-    replay_id = "b58a67446c914f44a4e329763420047b"
-    seq1_timestamp = datetime.now() - timedelta(minutes=10, seconds=52)
-    seq2_timestamp = datetime.now() - timedelta(minutes=10, seconds=35)
-    response = requests.post(
-        settings.SENTRY_SNUBA + "/tests/entities/replays/insert",
-        json=[
-            mock_replay(
-                seq1_timestamp,
-                default_project.id,
-                replay_id,
-                segment_id=0,
-                urls=[
-                    "http://localhost/",
-                    "http://localhost/home/",
-                    "http://localhost/profile/",
-                ],
-            ),
-            mock_replay(seq2_timestamp, default_project.id, replay_id, segment_id=1),
-        ],
-    )
-    assert response.status_code == 200
-
-    event = {
-        "data": {
-            "payload": {
-                "data": {
-                    "node": {"tagName": "a"},
-                    "endReason": "timeout",
-                    "url": "https://www.sentry.io",
-                },
-                "message": "div.xyz > a",
-                "timestamp": time.time(),
-            }
-        }
-    }
-
-    report_rage_click_issue(
-        project_id=default_project.id, replay_id=replay_id, event=cast(SentryEvent, event)
-    )
-    issue_occurence_call = mock_new_issue_occurrence.call_args[1]
-    assert issue_occurence_call["culprit"] == "https://www.sentry.io"
-    assert issue_occurence_call["environment"] == "production"
-    assert issue_occurence_call["fingerprint"] == ["div.xyz > a"]
-    assert issue_occurence_call["issue_type"].type_id == 5002
-    assert issue_occurence_call["level"] == "error"
-    assert issue_occurence_call["platform"] == "javascript"
-    assert issue_occurence_call["project_id"] == default_project.id
-    assert issue_occurence_call["subtitle"] == "div.xyz > a"
-    assert issue_occurence_call["title"] == "Rage Click"
-    assert issue_occurence_call["evidence_data"] == {
-        "node": {"tagName": "a"},
-        "selector": "div.xyz > a",
-    }
-
-    assert (
-        issue_occurence_call["evidence_display"][0].to_dict()
-        == IssueEvidence(name="Clicked Element", value="a", important=True).to_dict()
-    )
-    assert (
-        issue_occurence_call["evidence_display"][1].to_dict()
-        == IssueEvidence(name="Selector Path", value="div.xyz > a", important=True).to_dict()
-    )
-
-    assert issue_occurence_call["extra_event_data"] == {
-        "contexts": {"replay": {"replay_id": "b58a67446c914f44a4e329763420047b"}},
-        "level": "error",
-        "tags": {"replayId": "b58a67446c914f44a4e329763420047b", "url": "https://www.sentry.io"},
-        "user": {
-            "id": "123",
-            "username": "username",
-            "email": "username@example.com",
-            "ip_address": "127.0.0.1",
-        },
-    }
 
 
 @django_db_all
@@ -158,47 +69,19 @@ def test_report_rage_click_issue_with_replay_event(mock_new_issue_occurrence, de
 def test_report_rage_click_long_url(default_project):
     replay_id = "b58a67446c914f44a4e329763420047b"
     seq1_timestamp = datetime.now() - timedelta(minutes=10, seconds=52)
-    seq2_timestamp = datetime.now() - timedelta(minutes=10, seconds=35)
-    response = requests.post(
-        settings.SENTRY_SNUBA + "/tests/entities/replays/insert",
-        json=[
-            mock_replay(
-                seq1_timestamp,
-                default_project.id,
-                replay_id,
-                segment_id=0,
-                urls=[
-                    "http://localhost/",
-                    "http://localhost/home/",
-                    "http://localhost/profile/",
-                ],
-            ),
-            mock_replay(seq2_timestamp, default_project.id, replay_id, segment_id=1),
-        ],
-    )
-    assert response.status_code == 200
-
-    event = {
-        "data": {
-            "payload": {
-                "data": {
-                    "node": {"tagName": "a"},
-                    "endReason": "timeout",
-                    "url": f"https://www.sentry.io{'a' * 300}",
-                },
-                "message": "div.xyz > a",
-                "timestamp": time.time(),
-            }
-        }
-    }
-
     with Feature(
         {
             "organizations:replay-click-rage-ingest": True,
         }
     ):
-        report_rage_click_issue(
-            project_id=default_project.id, replay_id=replay_id, event=cast(SentryEvent, event)
+        report_rage_click_issue_with_replay_event(
+            project_id=default_project.id,
+            replay_id=replay_id,
+            selector="div.xyz > a",
+            timestamp=seq1_timestamp.timestamp(),
+            url=f"https://www.sentry.io{'a' * 300}",
+            node={"tagName": "a"},
+            replay_event=mock_replay_event(),
         )
 
     # test that the Issue gets created with the truncated url


### PR DESCRIPTION
We've rolled out rage click_creation_with_replay_event, so we can remove this celery task and the usages of it. huzzah!

https://sentry.sentry.io/dashboard/77863/?project=1&statsPeriod=24h
(can see bottom metric has dropped to zero, while one to left has gone up).

this represents that now the new function is being called 100% of the time so we can remove this code.

