### PR TITLE
chore(superuser): Add loggers to _needs_validation

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.contrib.auth import logout
 from django.contrib.auth.models import AnonymousUser
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -32,10 +31,6 @@ logger: logging.Logger = logging.getLogger(__name__)
 getsentry_logger = logging.getLogger("getsentry.staff_auth_index")
 
 PREFILLED_SU_MODAL_KEY = "prefilled_su_modal"
-
-DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL = getattr(
-    settings, "DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL", False
-)
 
 
 @control_silo_endpoint

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -179,7 +179,15 @@ class Superuser(ElevatedMode):
 
     @staticmethod
     def _needs_validation():
-        if is_self_hosted() or DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL:
+        self_hosted = is_self_hosted()
+        logger.info(
+            "superuser.needs-validation",
+            extra={
+                "DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL": DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL,
+                "self_hosted": self_hosted,
+            },
+        )
+        if self_hosted or DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL:
             return False
         return settings.VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON
 

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -191,7 +191,7 @@ class SuperuserTestCase(TestCase):
         superuser = Superuser(request, org_id=None)
         superuser.set_logged_in(request.user)
         assert superuser.is_active is True
-        assert logger.info.call_count == 2
+        assert logger.info.call_count == 3
         logger.info.assert_any_call(
             "superuser.superuser_access",
             extra={
@@ -411,7 +411,7 @@ class SuperuserTestCase(TestCase):
         superuser = Superuser(request, org_id=None)
         superuser.set_logged_in(request.user)
         assert superuser.is_active is True
-        assert logger.info.call_count == 1
+        assert logger.info.call_count == 2
         logger.info.assert_any_call(
             "superuser.logged-in",
             extra={"ip_address": "127.0.0.1", "user_id": user.id},


### PR DESCRIPTION
There's a bug where we're no longer requiring superuser access category and reason validation, which is caused by https://github.com/getsentry/sentry/pull/66043/files.

I want to validate what those booleans are in order to find out if this is the cause of the bug.