### PR TITLE
feat(hybridcloud) Add region tag to errors/transactions

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -217,8 +217,11 @@ def before_send_transaction(event, _):
 
 
 def before_send(event, _):
-    if event.get("tags") and settings.SILO_MODE:
-        event["tags"]["silo_mode"] = settings.SILO_MODE
+    if event.get("tags"):
+        if settings.SILO_MODE:
+            event["tags"]["silo_mode"] = settings.SILO_MODE
+        if settings.SENTRY_REGION:
+            event["tags"]["sentry_region"] = settings.SENTRY_REGION
     return event
 
 


### PR DESCRIPTION
Add sentry_region to the tags of errors/transactions we collect. This helps with diagnosing which region an error is occurring in. Previously we were planning on using `environment` for this but it would have required a non-trivial amount of monitoring changes. The `sentry_region` name mirrors the tag used in other monitoring tools we use.