### PR TITLE
ref(replay): see full replay in rage click issue goes to breadcrumbs tab

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -110,6 +110,7 @@ function EventReplayContent({
                 {...commonProps}
                 component={replayClipPreview}
                 clipOffsets={CLIP_OFFSETS}
+                issueCategory={group?.issueCategory}
               />
             ) : (
               <LazyLoad {...commonProps} component={replayPreview} />

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -28,6 +28,7 @@ import TimeAndScrubberGrid from 'sentry/components/replays/timeAndScrubberGrid';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {IssueCategory} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
@@ -57,6 +58,7 @@ type Props = {
   replaySlug: string;
   focusTab?: TabKey;
   fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
+  issueCategory?: IssueCategory;
 };
 
 function getReplayAnalyticsStatus({
@@ -85,10 +87,12 @@ function ReplayPreviewPlayer({
   replayId,
   fullReplayButtonProps,
   replayRecord,
+  issueCategory,
 }: {
   replayId: string;
   replayRecord: ReplayRecord;
   fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
+  issueCategory?: IssueCategory;
 }) {
   const routes = useRoutes();
   const location = useLocation();
@@ -104,12 +108,15 @@ function ReplayPreviewPlayer({
   const isFullscreen = useIsFullscreen();
 
   const startOffsetMs = replay?.getStartOffsetMs() ?? 0;
+  const isRageClickIssue = issueCategory === IssueCategory.REPLAY;
+
   const fullReplayUrl = {
     pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${replayId}/`),
     query: {
       referrer: getRouteStringFromRoutes(routes),
-      t_main: TabKey.ERRORS,
+      t_main: isRageClickIssue ? TabKey.BREADCRUMBS : TabKey.ERRORS,
       t: (currentTime + startOffsetMs) / 1000,
+      f_b_type: isRageClickIssue ? 'rageOrDead' : undefined,
     },
   };
 
@@ -169,6 +176,7 @@ function ReplayClipPreview({
   orgSlug,
   replaySlug,
   fullReplayButtonProps,
+  issueCategory,
 }: Props) {
   const clipWindow = useMemo(
     () => ({
@@ -239,6 +247,7 @@ function ReplayClipPreview({
             replayId={replayId}
             fullReplayButtonProps={fullReplayButtonProps}
             replayRecord={replayRecord}
+            issueCategory={issueCategory}
           />
         )}
       </PlayerContainer>


### PR DESCRIPTION
From a rage click issue, "see full replay" takes you to the breadcrumbs tab with the rage & dead click filter selected.

Relates to https://github.com/getsentry/team-replay/issues/394. Temp solution until we can load in rage click issues to the errors tab

https://github.com/getsentry/sentry/assets/56095982/cda9511d-8458-4fc4-a506-0b36ed217d51

