### PR TITLE
feat(feedback): Show unread count next to each mailbox

### DIFF
--- a/static/app/components/badge.stories.tsx
+++ b/static/app/components/badge.stories.tsx
@@ -21,7 +21,7 @@ export default storyBook(Badge, story => {
       <Badge type="new">New</Badge>
       <Badge type="experimental">Experimental</Badge>
       <Badge type="warning">Warning</Badge>
-      <Badge type="purple">Warning</Badge>
+      <Badge type="purple">Purple</Badge>
     </SideBySide>
   ));
 });

--- a/static/app/components/badge.stories.tsx
+++ b/static/app/components/badge.stories.tsx
@@ -21,7 +21,7 @@ export default storyBook(Badge, story => {
       <Badge type="new">New</Badge>
       <Badge type="experimental">Experimental</Badge>
       <Badge type="warning">Warning</Badge>
-      <Badge type="purple">Purple</Badge>
+      <Badge type="gray">Gray</Badge>
     </SideBySide>
   ));
 });

--- a/static/app/components/badge.stories.tsx
+++ b/static/app/components/badge.stories.tsx
@@ -21,6 +21,7 @@ export default storyBook(Badge, story => {
       <Badge type="new">New</Badge>
       <Badge type="experimental">Experimental</Badge>
       <Badge type="warning">Warning</Badge>
+      <Badge type="purple">Warning</Badge>
     </SideBySide>
   ));
 });

--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -40,11 +40,16 @@ export default function MailboxPicker({onChange, value}: Props) {
           <SegmentedControl.Item key={c.key}>
             <Flex align="center">
               {c.label}
-              {data?.[c.key] ? <Badge type="purple" text={data?.[c.key] ?? ''} /> : null}
+              {data?.[c.key] ? <CountBadge count={data?.[c.key]} /> : null}
             </Flex>
           </SegmentedControl.Item>
         ))}
       </SegmentedControl>
     </Flex>
   );
+}
+
+function CountBadge({count}: {count: number}) {
+  const display = count >= 100 ? '99+' : count;
+  return <Badge type="gray" text={display} />;
 }

--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -3,6 +3,7 @@ import type decodeMailbox from 'sentry/components/feedback/decodeMailbox';
 import useMailboxCounts from 'sentry/components/feedback/list/useMailboxCounts';
 import {Flex} from 'sentry/components/profiling/flex';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -36,20 +37,23 @@ export default function MailboxPicker({onChange, value}: Props) {
         value={value}
         onChange={onChange}
       >
-        {filteredMailboxes.map(c => (
-          <SegmentedControl.Item key={c.key}>
-            <Flex align="center">
-              {c.label}
-              {data?.[c.key] ? <CountBadge count={data?.[c.key]} /> : null}
-            </Flex>
-          </SegmentedControl.Item>
-        ))}
+        {filteredMailboxes.map(c => {
+          const count = data?.[c.key];
+          const display = count && count >= 100 ? '99+' : count;
+          const title =
+            count === 1 ? t('1 unassigned item') : t('%s unassigned items', display);
+          return (
+            <SegmentedControl.Item key={c.key}>
+              <Tooltip disabled={!count} title={title}>
+                <Flex align="center">
+                  {c.label}
+                  {display ? <Badge type="gray" text={display} /> : null}
+                </Flex>
+              </Tooltip>
+            </SegmentedControl.Item>
+          );
+        })}
       </SegmentedControl>
     </Flex>
   );
-}
-
-function CountBadge({count}: {count: number}) {
-  const display = count >= 100 ? '99+' : count;
-  return <Badge type="gray" text={display} />;
 }

--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -1,4 +1,6 @@
+import Badge from 'sentry/components/badge';
 import type decodeMailbox from 'sentry/components/feedback/decodeMailbox';
+import useMailboxCounts from 'sentry/components/feedback/list/useMailboxCounts';
 import {Flex} from 'sentry/components/profiling/flex';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
@@ -11,7 +13,7 @@ interface Props {
   value: Mailbox;
 }
 
-const items = [
+const MAILBOXES = [
   {key: 'unresolved', label: t('Inbox')},
   {key: 'resolved', label: t('Resolved')},
   {key: 'ignored', label: t('Spam')},
@@ -19,8 +21,13 @@ const items = [
 
 export default function MailboxPicker({onChange, value}: Props) {
   const organization = useOrganization();
+  const {data} = useMailboxCounts({organization});
+
   const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
-  const children = hasSpamFeature ? items : items.filter(i => i.key !== 'ignored');
+  const filteredMailboxes = hasSpamFeature
+    ? MAILBOXES
+    : MAILBOXES.filter(i => i.key !== 'ignored');
+
   return (
     <Flex justify="flex-end" flex="1 0 auto">
       <SegmentedControl
@@ -29,8 +36,13 @@ export default function MailboxPicker({onChange, value}: Props) {
         value={value}
         onChange={onChange}
       >
-        {children.map(c => (
-          <SegmentedControl.Item key={c.key}>{c.label}</SegmentedControl.Item>
+        {filteredMailboxes.map(c => (
+          <SegmentedControl.Item key={c.key}>
+            <Flex align="center">
+              {c.label}
+              {data?.[c.key] ? <Badge type="purple" text={data?.[c.key] ?? ''} /> : null}
+            </Flex>
+          </SegmentedControl.Item>
         ))}
       </SegmentedControl>
     </Flex>

--- a/static/app/components/feedback/list/useMailboxCounts.tsx
+++ b/static/app/components/feedback/list/useMailboxCounts.tsx
@@ -1,0 +1,59 @@
+import {useMemo} from 'react';
+
+import type {Organization} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {decodeList, decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+
+interface Props {
+  organization: Organization;
+}
+
+const MAILBOX = {
+  unresolved: 'is:unassigned is:unresolved',
+  resolved: 'is:unassigned is:resolved',
+  ignored: 'is:unassigned is:ignored',
+};
+
+export default function useMailboxCounts({organization}: Props) {
+  const queryView = useLocationQuery({
+    fields: {
+      end: decodeScalar,
+      environment: decodeList,
+      field: decodeList,
+      project: decodeList,
+      query: Object.values(MAILBOX),
+      queryReferrer: 'feedback_list_page',
+      start: decodeScalar,
+      statsPeriod: decodeScalar,
+      utc: decodeScalar,
+    },
+  });
+
+  const {data = {}, ...result} = useApiQuery(
+    [
+      `/organizations/${organization.slug}/issues-count/`,
+      {
+        query: queryView,
+      },
+    ],
+    {
+      staleTime: 1_000,
+      refetchInterval: 30_000,
+    }
+  );
+
+  return useMemo(
+    () => ({
+      ...result,
+      data: data
+        ? {
+            unresolved: data[MAILBOX.unresolved],
+            resolved: data[MAILBOX.resolved],
+            ignored: data[MAILBOX.ignored],
+          }
+        : undefined,
+    }),
+    [result, data]
+  );
+}

--- a/static/app/components/feedback/list/useMailboxCounts.tsx
+++ b/static/app/components/feedback/list/useMailboxCounts.tsx
@@ -10,9 +10,9 @@ interface Props {
 }
 
 const MAILBOX = {
-  unresolved: 'is:unassigned is:unresolved',
-  resolved: 'is:unassigned is:resolved',
-  ignored: 'is:unassigned is:ignored',
+  unresolved: 'issue.category:feedback is:unassigned is:unresolved',
+  resolved: 'issue.category:feedback is:unassigned is:resolved',
+  ignored: 'issue.category:feedback is:unassigned is:ignored',
 };
 
 export default function useMailboxCounts({organization}: Props) {

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -508,6 +508,11 @@ const generateBadgeTheme = (colors: BaseColors) => ({
     indicatorColor: colors.yellow300,
     color: colors.gray500,
   },
+  purple: {
+    background: colors.purple300,
+    indicatorColor: colors.purple200,
+    color: colors.white,
+  },
 });
 
 const generateTagTheme = (colors: BaseColors) => ({

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -508,10 +508,10 @@ const generateBadgeTheme = (colors: BaseColors) => ({
     indicatorColor: colors.yellow300,
     color: colors.gray500,
   },
-  purple: {
-    background: colors.purple300,
-    indicatorColor: colors.purple200,
-    color: colors.white,
+  gray: {
+    background: `rgba(43, 34, 51, 0.08)`,
+    indicatorColor: `rgba(43, 34, 51, 0.08)`,
+    color: colors.gray500,
   },
 });
 


### PR DESCRIPTION
<img width="432" alt="SCR-20240307-ssof" src="https://github.com/getsentry/sentry/assets/187460/7aa0da22-12fe-4ac4-9505-ee0d75b78b3b">


it's a query for `is:unassigned` instead of `is:unread` because we don't have read-status in issue search yet. But it's looking good in the UI

Fixes https://github.com/getsentry/sentry/issues/66332
Closes https://github.com/getsentry/sentry/issues/66695