### PR TITLE
nit: Refactor relocation tests

### DIFF
--- a/src/sentry/api/endpoints/relocations/index.py
+++ b/src/sentry/api/endpoints/relocations/index.py
@@ -18,9 +18,9 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
 from sentry.api.paginator import OffsetPaginator
+from sentry.api.permissions import SuperuserPermission
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.relocation import RelocationSerializer
-from sentry.auth.elevated_mode import has_elevated_mode
 from sentry.models.files.file import File
 from sentry.models.relocation import Relocation, RelocationFile
 from sentry.models.user import MAX_USERNAME_LENGTH
@@ -64,11 +64,9 @@ def should_throttle_relocation(relocation_bucket_size: str) -> bool:
         date_added__gte=(timezone.now() - timedelta(days=1))
     )
     num_recent_same_size_relocation_files = reduce(
-        lambda acc, relocation_file: (
-            acc + 1
-            if get_relocation_size_category(relocation_file.file.size) == relocation_bucket_size
-            else acc
-        ),
+        lambda acc, relocation_file: acc + 1
+        if get_relocation_size_category(relocation_file.file.size) == relocation_bucket_size
+        else acc,
         recent_relocation_files,
         0,
     )
@@ -91,18 +89,16 @@ class RelocationsPostSerializer(serializers.Serializer):
 def validate_new_relocation_request(
     request: Request, owner_username: str, org_slugs: list[str], file_size: int
 ) -> Response | None:
-    # TODO(schew2381): Remove all superuser references in function after feature flag is removed.
-
-    # We only honor the `relocation.enabled` flag for non-superusers/staff.
-    elevated_user = has_elevated_mode(request)
-    if not options.get("relocation.enabled") and not elevated_user:
+    # We only honor the `relocation.enabled` flag for non-superusers.
+    is_superuser = SuperuserPermission().has_permission(request, None)
+    if not options.get("relocation.enabled") and not is_superuser:
         return Response({"detail": ERR_FEATURE_DISABLED}, status=status.HTTP_403_FORBIDDEN)
 
-    # Only superuser/staff can start relocations for other users.
+    # Only superusers can start relocations for other users.
     creator = user_service.get_user(user_id=request.user.id)
     if creator is None:
         raise RuntimeError("Could not ascertain request user's username")
-    if not elevated_user and creator.username != owner_username:
+    if not is_superuser and creator.username != owner_username:
         return Response(
             {"detail": ERR_INVALID_OWNER.substitute(creator_username=creator.username)},
             status=status.HTTP_400_BAD_REQUEST,
@@ -116,9 +112,9 @@ def validate_new_relocation_request(
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-    # Regular users may be throttled, but superuser/staff never are.
+    # Regular users may be throttled, but superusers never are.
     relocation_size_category = get_relocation_size_category(file_size)
-    if not elevated_user and should_throttle_relocation(relocation_size_category):
+    if not is_superuser and should_throttle_relocation(relocation_size_category):
         return Response(
             {"detail": ERR_THROTTLED_RELOCATION},
             status=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -168,11 +164,14 @@ class RelocationIndexEndpoint(Endpoint):
 
         logger.info("relocations.index.get.start", extra={"caller": request.user.id})
 
+        # Non-superusers can only see their own relocations.
         queryset = Relocation.objects.all()
-
-        # TODO(schew2381): Remove the superuser reference below after feature flag is removed.
-        # Non-superuser/staff can only see their own relocations.
-        if not has_elevated_mode(request):
+        is_superuser = False
+        try:
+            is_superuser = SuperuserPermission().has_permission(request, None)
+        except Exception:
+            pass
+        if not is_superuser:
             queryset = queryset.filter(owner_id=request.user.id)
 
         query = request.GET.get("query")

--- a/src/sentry/api/endpoints/relocations/index.py
+++ b/src/sentry/api/endpoints/relocations/index.py
@@ -18,9 +18,9 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
 from sentry.api.paginator import OffsetPaginator
-from sentry.api.permissions import SuperuserPermission
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.relocation import RelocationSerializer
+from sentry.auth.superuser import is_active_superuser
 from sentry.models.files.file import File
 from sentry.models.relocation import Relocation, RelocationFile
 from sentry.models.user import MAX_USERNAME_LENGTH
@@ -64,9 +64,11 @@ def should_throttle_relocation(relocation_bucket_size: str) -> bool:
         date_added__gte=(timezone.now() - timedelta(days=1))
     )
     num_recent_same_size_relocation_files = reduce(
-        lambda acc, relocation_file: acc + 1
-        if get_relocation_size_category(relocation_file.file.size) == relocation_bucket_size
-        else acc,
+        lambda acc, relocation_file: (
+            acc + 1
+            if get_relocation_size_category(relocation_file.file.size) == relocation_bucket_size
+            else acc
+        ),
         recent_relocation_files,
         0,
     )
@@ -90,15 +92,15 @@ def validate_new_relocation_request(
     request: Request, owner_username: str, org_slugs: list[str], file_size: int
 ) -> Response | None:
     # We only honor the `relocation.enabled` flag for non-superusers.
-    is_superuser = SuperuserPermission().has_permission(request, None)
-    if not options.get("relocation.enabled") and not is_superuser:
+    active_superuser = is_active_superuser(request)
+    if not options.get("relocation.enabled") and not active_superuser:
         return Response({"detail": ERR_FEATURE_DISABLED}, status=status.HTTP_403_FORBIDDEN)
 
     # Only superusers can start relocations for other users.
     creator = user_service.get_user(user_id=request.user.id)
     if creator is None:
         raise RuntimeError("Could not ascertain request user's username")
-    if not is_superuser and creator.username != owner_username:
+    if not active_superuser and creator.username != owner_username:
         return Response(
             {"detail": ERR_INVALID_OWNER.substitute(creator_username=creator.username)},
             status=status.HTTP_400_BAD_REQUEST,
@@ -114,7 +116,7 @@ def validate_new_relocation_request(
 
     # Regular users may be throttled, but superusers never are.
     relocation_size_category = get_relocation_size_category(file_size)
-    if not is_superuser and should_throttle_relocation(relocation_size_category):
+    if not active_superuser and should_throttle_relocation(relocation_size_category):
         return Response(
             {"detail": ERR_THROTTLED_RELOCATION},
             status=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -164,14 +166,9 @@ class RelocationIndexEndpoint(Endpoint):
 
         logger.info("relocations.index.get.start", extra={"caller": request.user.id})
 
-        # Non-superusers can only see their own relocations.
         queryset = Relocation.objects.all()
-        is_superuser = False
-        try:
-            is_superuser = SuperuserPermission().has_permission(request, None)
-        except Exception:
-            pass
-        if not is_superuser:
+        # Non-superusers can only see their own relocations.
+        if not is_active_superuser(request):
             queryset = queryset.filter(owner_id=request.user.id)
 
         query = request.GET.get("query")

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -704,13 +704,13 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
         :returns Response object
         """
         url = reverse(self.endpoint, args=args)
-        # In some cases we want to pass querystring params to put/post, handle
-        # this here.
+        # In some cases we want to pass querystring params to put/post, handle this here.
         if "qs_params" in params:
             query_string = urlencode(params.pop("qs_params"), doseq=True)
             url = f"{url}?{query_string}"
 
         headers = params.pop("extra_headers", {})
+        format = params.pop("format", "json")
         raw_data = params.pop("raw_data", None)
         if raw_data and isinstance(raw_data, bytes):
             raw_data = raw_data.decode("utf-8")
@@ -719,7 +719,7 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
         data = raw_data or params
         method = params.pop("method", self.method).lower()
 
-        return getattr(self.client, method)(url, format="json", data=data, **headers)
+        return getattr(self.client, method)(url, format=format, data=data, **headers)
 
     def get_success_response(self, *args, **params):
         """

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -22,6 +22,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import generate_rsa_key_pair
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
@@ -105,7 +106,14 @@ class GetRelocationsTest(APITestCase):
 
         self.success_uuid = Relocation.objects.get(status=Relocation.Status.SUCCESS.value)
 
-    def test_good_simple(self):
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_good_staff_simple(self):
+        self.login_as(user=self.staff_user, staff=True)
+        response = self.get_success_response(status_code=200)
+
+        assert len(response.data) == 4
+
+    def test_good_superuser_simple(self):
         self.login_as(user=self.superuser, superuser=True)
         response = self.get_success_response(status_code=200)
 
@@ -284,6 +292,7 @@ class PostRelocationsTest(APITestCase):
             email="owner", is_superuser=False, is_staff=False, is_active=True
         )
         self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
 
     def tmp_keys(self, tmp_dir: str) -> tuple[Path, Path]:
         (priv_key_pem, pub_key_pem) = generate_rsa_key_pair()
@@ -529,9 +538,71 @@ class PostRelocationsTest(APITestCase):
             sender=RelocationIndexEndpoint,
         )
 
+    @with_feature("auth:enterprise-staff-cookie")
     @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 1})
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_good_with_superuser_when_feature_disabled(
+    def test_good_staff_when_feature_disabled(
+        self,
+        uploading_complete_mock: Mock,
+        relocation_link_promo_code_signal_mock: Mock,
+        analytics_record_mock: Mock,
+    ):
+        self.login_as(user=self.staff_user, staff=True)
+        relocation_count = Relocation.objects.count()
+        relocation_file_count = RelocationFile.objects.count()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    response = self.get_success_response(
+                        owner=self.owner.username,
+                        file=SimpleUploadedFile(
+                            "export.tar",
+                            create_encrypted_export_tarball(data, LocalFileEncryptor(p)).getvalue(),
+                            content_type="application/tar",
+                        ),
+                        orgs="testing",
+                        format="multipart",
+                        status_code=201,
+                    )
+
+        assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
+        assert response.data["step"] == Relocation.Step.UPLOADING.name
+        assert response.data["creatorId"] == str(self.staff_user.id)
+        assert response.data["creatorEmail"] == str(self.staff_user.email)
+        assert response.data["creatorUsername"] == str(self.staff_user.username)
+        assert response.data["ownerId"] == str(self.owner.id)
+        assert response.data["ownerEmail"] == str(self.owner.email)
+        assert response.data["ownerUsername"] == str(self.owner.username)
+
+        relocation: Relocation = Relocation.objects.get(owner_id=self.owner.id)
+        assert str(relocation.uuid) == response.data["uuid"]
+        assert relocation.want_org_slugs == ["testing"]
+        assert Relocation.objects.count() == relocation_count + 1
+        assert RelocationFile.objects.count() == relocation_file_count + 1
+
+        assert uploading_complete_mock.call_count == 1
+
+        assert analytics_record_mock.call_count == 1
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            creator_id=int(response.data["creatorId"]),
+            owner_id=int(response.data["ownerId"]),
+            uuid=response.data["uuid"],
+        )
+
+        assert relocation_link_promo_code_signal_mock.call_count == 1
+        relocation_link_promo_code_signal_mock.assert_called_with(
+            relocation_uuid=UUID(response.data["uuid"]),
+            promo_code=None,
+            sender=RelocationIndexEndpoint,
+        )
+
+    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 1})
+    @patch("sentry.tasks.relocation.uploading_complete.delay")
+    def test_good_superuser_when_feature_disabled(
         self,
         uploading_complete_mock: Mock,
         relocation_link_promo_code_signal_mock: Mock,
@@ -886,8 +957,40 @@ class PostRelocationsTest(APITestCase):
 
         assert relocation_link_promo_code_signal_mock.call_count == 0
 
+    @with_feature("auth:enterprise-staff-cookie")
     @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
-    def test_bad_nonexistent_owner(
+    def test_bad_staff_nonexistent_owner(
+        self, relocation_link_promo_code_signal_mock: Mock, analytics_record_mock: Mock
+    ):
+        self.login_as(user=self.staff_user, staff=True)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    response = self.get_error_response(
+                        owner="doesnotexist",
+                        file=SimpleUploadedFile(
+                            "export.tar",
+                            create_encrypted_export_tarball(data, LocalFileEncryptor(p)).getvalue(),
+                            content_type="application/tar",
+                        ),
+                        orgs="testing, foo",
+                        format="multipart",
+                        status_code=400,
+                    )
+
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_OWNER_NOT_FOUND.substitute(
+            owner_username="doesnotexist"
+        )
+
+        analytics_record_mock.assert_not_called()
+
+        assert relocation_link_promo_code_signal_mock.call_count == 0
+
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
+    def test_bad_superuser_nonexistent_owner(
         self, relocation_link_promo_code_signal_mock: Mock, analytics_record_mock: Mock
     ):
         self.login_as(user=self.superuser, superuser=True)
@@ -1054,6 +1157,90 @@ class PostRelocationsTest(APITestCase):
             relocation_uuid=UUID(initial_response.data["uuid"]),
             promo_code=None,
             sender=RelocationIndexEndpoint,
+        )
+
+    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
+    def test_good_no_throttle_for_staff(
+        self, relocation_link_promo_code_signal_mock: Mock, analytics_record_mock: Mock
+    ):
+        self.login_as(user=self.staff_user, staff=True)
+        relocation_count = Relocation.objects.count()
+        relocation_file_count = RelocationFile.objects.count()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    initial_response = self.get_success_response(
+                        owner=self.owner.username,
+                        file=SimpleUploadedFile(
+                            "export.tar",
+                            create_encrypted_export_tarball(data, LocalFileEncryptor(p)).getvalue(),
+                            content_type="application/tar",
+                        ),
+                        orgs="testing, foo",
+                        format="multipart",
+                        status_code=201,
+                    )
+
+                    # Simulate completion of relocation job
+                    relocation = Relocation.objects.all()[0]
+                    relocation.status = Relocation.Status.SUCCESS.value
+                    relocation.save()
+                    relocation.refresh_from_db()
+
+                with open(tmp_pub_key_path, "rb") as p:
+                    unthrottled_response = self.get_success_response(
+                        owner=self.owner.username,
+                        file=SimpleUploadedFile(
+                            "export.tar",
+                            create_encrypted_export_tarball(data, LocalFileEncryptor(p)).getvalue(),
+                            content_type="application/tar",
+                        ),
+                        orgs="testing, foo",
+                        format="multipart",
+                        status_code=201,
+                    )
+
+        assert initial_response.status_code == status.HTTP_201_CREATED
+        assert unthrottled_response.status_code == status.HTTP_201_CREATED
+        assert Relocation.objects.count() == relocation_count + 2
+        assert RelocationFile.objects.count() == relocation_file_count + 2
+
+        assert analytics_record_mock.call_count == 2
+        analytics_record_mock.assert_has_calls(
+            [
+                call(
+                    "relocation.created",
+                    creator_id=int(initial_response.data["creatorId"]),
+                    owner_id=int(initial_response.data["ownerId"]),
+                    uuid=initial_response.data["uuid"],
+                ),
+                call(
+                    "relocation.created",
+                    creator_id=int(unthrottled_response.data["creatorId"]),
+                    owner_id=int(unthrottled_response.data["ownerId"]),
+                    uuid=unthrottled_response.data["uuid"],
+                ),
+            ]
+        )
+
+        assert relocation_link_promo_code_signal_mock.call_count == 2
+        relocation_link_promo_code_signal_mock.assert_has_calls(
+            [
+                call(
+                    relocation_uuid=UUID(initial_response.data["uuid"]),
+                    promo_code=None,
+                    sender=RelocationIndexEndpoint,
+                ),
+                call(
+                    relocation_uuid=UUID(unthrottled_response.data["uuid"]),
+                    promo_code=None,
+                    sender=RelocationIndexEndpoint,
+                ),
+            ]
         )
 
     @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -43,7 +43,6 @@ class GetRelocationsTest(APITestCase):
             email="owner", is_superuser=False, is_staff=False, is_active=True
         )
         self.superuser = self.create_user(is_superuser=True)
-        self.staff_user = self.create_user(is_staff=True)
 
         # Add 1 relocation of each status.
         common = {
@@ -128,32 +127,26 @@ class GetRelocationsTest(APITestCase):
 
     def test_good_status_pause(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_success_response(
-            status=Relocation.Status.PAUSE.name, status_code=200
-        )
+        response = self.get_success_response(status=Relocation.Status.PAUSE.name, status_code=200)
 
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.PAUSE.name
 
     def test_good_status_success(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_success_response(
-            status=Relocation.Status.SUCCESS.name, status_code=200
-        )
+        response = self.get_success_response(status=Relocation.Status.SUCCESS.name, status_code=200)
 
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.SUCCESS.name
 
     def test_good_status_failure(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_success_response(
-            status=Relocation.Status.FAILURE.name, status_code=200
-        )
+        response = self.get_success_response(status=Relocation.Status.FAILURE.name, status_code=200)
         assert response.data[0]["status"] == Relocation.Status.FAILURE.name
 
     def test_good_single_query_partial_uuid(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_success_response(
+        response = self.get_success_response(
             qs_params={
                 "query": "ccef828a",
             },
@@ -164,7 +157,7 @@ class GetRelocationsTest(APITestCase):
 
     def test_good_single_query_full_uuid(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_success_response(
+        response = self.get_success_response(
             qs_params={
                 "query": "af3d45ee-ce76-4de0-90c1-fc739da29523",
             },
@@ -176,7 +169,7 @@ class GetRelocationsTest(APITestCase):
 
     def test_good_single_query_org_slug(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_success_response(
+        response = self.get_success_response(
             qs_params={
                 "query": "foo",
             },
@@ -189,7 +182,7 @@ class GetRelocationsTest(APITestCase):
 
     def test_good_single_query_username(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_success_response(
+        response = self.get_success_response(
             qs_params={
                 "query": "alice",
             },
@@ -202,7 +195,7 @@ class GetRelocationsTest(APITestCase):
 
     def test_good_single_query_letter(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_success_response(
+        response = self.get_success_response(
             qs_params={
                 "query": "b",
             },
@@ -215,7 +208,7 @@ class GetRelocationsTest(APITestCase):
 
     def test_good_multiple_queries(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_success_response(
+        response = self.get_success_response(
             qs_params={
                 "query": "foo alice",
             },
@@ -247,7 +240,7 @@ class GetRelocationsTest(APITestCase):
 
     def test_good_no_regular_user_with_query(self):
         self.login_as(user=self.owner, superuser=False)
-        response = response = self.get_success_response(
+        response = self.get_success_response(
             qs_params={
                 "query": "alice",
             },
@@ -260,7 +253,7 @@ class GetRelocationsTest(APITestCase):
 
     def test_bad_unknown_status(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = response = self.get_error_response(status="nonexistent", status_code=400)
+        response = self.get_error_response(status="nonexistent", status_code=400)
 
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_UNKNOWN_RELOCATION_STATUS.substitute(
@@ -284,7 +277,6 @@ class PostRelocationsTest(APITestCase):
             email="owner", is_superuser=False, is_staff=False, is_active=True
         )
         self.superuser = self.create_user(is_superuser=True)
-        self.staff_user = self.create_user(is_staff=True)
 
     def tmp_keys(self, tmp_dir: str) -> tuple[Path, Path]:
         (priv_key_pem, pub_key_pem) = generate_rsa_key_pair()

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -284,7 +284,7 @@ class GetRelocationsTest(APITestCase):
 @patch("sentry.signals.relocation_link_promo_code.send_robust")
 class PostRelocationsTest(APITestCase):
     endpoint = "sentry-api-0-relocations-index"
-    method = "post"
+    method = "POST"
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -22,7 +22,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import generate_rsa_key_pair
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
@@ -105,13 +104,6 @@ class GetRelocationsTest(APITestCase):
         )
 
         self.success_uuid = Relocation.objects.get(status=Relocation.Status.SUCCESS.value)
-
-    @with_feature("auth:enterprise-staff-cookie")
-    def test_good_staff_simple(self):
-        self.login_as(user=self.staff_user, staff=True)
-        response = self.get_success_response(status_code=200)
-
-        assert len(response.data) == 4
 
     def test_good_superuser_simple(self):
         self.login_as(user=self.superuser, superuser=True)
@@ -538,68 +530,6 @@ class PostRelocationsTest(APITestCase):
             sender=RelocationIndexEndpoint,
         )
 
-    @with_feature("auth:enterprise-staff-cookie")
-    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 1})
-    @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_good_staff_when_feature_disabled(
-        self,
-        uploading_complete_mock: Mock,
-        relocation_link_promo_code_signal_mock: Mock,
-        analytics_record_mock: Mock,
-    ):
-        self.login_as(user=self.staff_user, staff=True)
-        relocation_count = Relocation.objects.count()
-        relocation_file_count = RelocationFile.objects.count()
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
-                with open(tmp_pub_key_path, "rb") as p:
-                    response = self.get_success_response(
-                        owner=self.owner.username,
-                        file=SimpleUploadedFile(
-                            "export.tar",
-                            create_encrypted_export_tarball(data, LocalFileEncryptor(p)).getvalue(),
-                            content_type="application/tar",
-                        ),
-                        orgs="testing",
-                        format="multipart",
-                        status_code=201,
-                    )
-
-        assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
-        assert response.data["step"] == Relocation.Step.UPLOADING.name
-        assert response.data["creatorId"] == str(self.staff_user.id)
-        assert response.data["creatorEmail"] == str(self.staff_user.email)
-        assert response.data["creatorUsername"] == str(self.staff_user.username)
-        assert response.data["ownerId"] == str(self.owner.id)
-        assert response.data["ownerEmail"] == str(self.owner.email)
-        assert response.data["ownerUsername"] == str(self.owner.username)
-
-        relocation: Relocation = Relocation.objects.get(owner_id=self.owner.id)
-        assert str(relocation.uuid) == response.data["uuid"]
-        assert relocation.want_org_slugs == ["testing"]
-        assert Relocation.objects.count() == relocation_count + 1
-        assert RelocationFile.objects.count() == relocation_file_count + 1
-
-        assert uploading_complete_mock.call_count == 1
-
-        assert analytics_record_mock.call_count == 1
-        analytics_record_mock.assert_called_with(
-            "relocation.created",
-            creator_id=int(response.data["creatorId"]),
-            owner_id=int(response.data["ownerId"]),
-            uuid=response.data["uuid"],
-        )
-
-        assert relocation_link_promo_code_signal_mock.call_count == 1
-        relocation_link_promo_code_signal_mock.assert_called_with(
-            relocation_uuid=UUID(response.data["uuid"]),
-            promo_code=None,
-            sender=RelocationIndexEndpoint,
-        )
-
     @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 1})
     @patch("sentry.tasks.relocation.uploading_complete.delay")
     def test_good_superuser_when_feature_disabled(
@@ -957,38 +887,6 @@ class PostRelocationsTest(APITestCase):
 
         assert relocation_link_promo_code_signal_mock.call_count == 0
 
-    @with_feature("auth:enterprise-staff-cookie")
-    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
-    def test_bad_staff_nonexistent_owner(
-        self, relocation_link_promo_code_signal_mock: Mock, analytics_record_mock: Mock
-    ):
-        self.login_as(user=self.staff_user, staff=True)
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
-                with open(tmp_pub_key_path, "rb") as p:
-                    response = self.get_error_response(
-                        owner="doesnotexist",
-                        file=SimpleUploadedFile(
-                            "export.tar",
-                            create_encrypted_export_tarball(data, LocalFileEncryptor(p)).getvalue(),
-                            content_type="application/tar",
-                        ),
-                        orgs="testing, foo",
-                        format="multipart",
-                        status_code=400,
-                    )
-
-        assert response.data.get("detail") is not None
-        assert response.data.get("detail") == ERR_OWNER_NOT_FOUND.substitute(
-            owner_username="doesnotexist"
-        )
-
-        analytics_record_mock.assert_not_called()
-
-        assert relocation_link_promo_code_signal_mock.call_count == 0
-
     @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
     def test_bad_superuser_nonexistent_owner(
         self, relocation_link_promo_code_signal_mock: Mock, analytics_record_mock: Mock
@@ -1157,90 +1055,6 @@ class PostRelocationsTest(APITestCase):
             relocation_uuid=UUID(initial_response.data["uuid"]),
             promo_code=None,
             sender=RelocationIndexEndpoint,
-        )
-
-    @with_feature("auth:enterprise-staff-cookie")
-    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
-    def test_good_no_throttle_for_staff(
-        self, relocation_link_promo_code_signal_mock: Mock, analytics_record_mock: Mock
-    ):
-        self.login_as(user=self.staff_user, staff=True)
-        relocation_count = Relocation.objects.count()
-        relocation_file_count = RelocationFile.objects.count()
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
-                with open(tmp_pub_key_path, "rb") as p:
-                    initial_response = self.get_success_response(
-                        owner=self.owner.username,
-                        file=SimpleUploadedFile(
-                            "export.tar",
-                            create_encrypted_export_tarball(data, LocalFileEncryptor(p)).getvalue(),
-                            content_type="application/tar",
-                        ),
-                        orgs="testing, foo",
-                        format="multipart",
-                        status_code=201,
-                    )
-
-                    # Simulate completion of relocation job
-                    relocation = Relocation.objects.all()[0]
-                    relocation.status = Relocation.Status.SUCCESS.value
-                    relocation.save()
-                    relocation.refresh_from_db()
-
-                with open(tmp_pub_key_path, "rb") as p:
-                    unthrottled_response = self.get_success_response(
-                        owner=self.owner.username,
-                        file=SimpleUploadedFile(
-                            "export.tar",
-                            create_encrypted_export_tarball(data, LocalFileEncryptor(p)).getvalue(),
-                            content_type="application/tar",
-                        ),
-                        orgs="testing, foo",
-                        format="multipart",
-                        status_code=201,
-                    )
-
-        assert initial_response.status_code == status.HTTP_201_CREATED
-        assert unthrottled_response.status_code == status.HTTP_201_CREATED
-        assert Relocation.objects.count() == relocation_count + 2
-        assert RelocationFile.objects.count() == relocation_file_count + 2
-
-        assert analytics_record_mock.call_count == 2
-        analytics_record_mock.assert_has_calls(
-            [
-                call(
-                    "relocation.created",
-                    creator_id=int(initial_response.data["creatorId"]),
-                    owner_id=int(initial_response.data["ownerId"]),
-                    uuid=initial_response.data["uuid"],
-                ),
-                call(
-                    "relocation.created",
-                    creator_id=int(unthrottled_response.data["creatorId"]),
-                    owner_id=int(unthrottled_response.data["ownerId"]),
-                    uuid=unthrottled_response.data["uuid"],
-                ),
-            ]
-        )
-
-        assert relocation_link_promo_code_signal_mock.call_count == 2
-        relocation_link_promo_code_signal_mock.assert_has_calls(
-            [
-                call(
-                    relocation_uuid=UUID(initial_response.data["uuid"]),
-                    promo_code=None,
-                    sender=RelocationIndexEndpoint,
-                ),
-                call(
-                    relocation_uuid=UUID(unthrottled_response.data["uuid"]),
-                    promo_code=None,
-                    sender=RelocationIndexEndpoint,
-                ),
-            ]
         )
 
     @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})

--- a/tests/sentry/api/endpoints/relocations/test_retry.py
+++ b/tests/sentry/api/endpoints/relocations/test_retry.py
@@ -52,7 +52,6 @@ class RetryRelocationTest(APITestCase):
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
         self.superuser = self.create_user(is_superuser=True)
-        self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
             creator_id=self.superuser.id,
@@ -168,8 +167,8 @@ class RetryRelocationTest(APITestCase):
             uuid=response.data["uuid"],
         )
 
-    @patch("sentry.tasks.relocation.uploading_complete.delay")
     @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 2})
+    @patch("sentry.tasks.relocation.uploading_complete.delay")
     def test_bad_without_superuser_when_feature_disabled(
         self, uploading_complete_mock: Mock, analytics_record_mock: Mock
     ):
@@ -193,8 +192,8 @@ class RetryRelocationTest(APITestCase):
 
         assert uploading_complete_mock.call_count == 0
 
-    @patch("sentry.tasks.relocation.uploading_complete.delay")
     @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 2})
+    @patch("sentry.tasks.relocation.uploading_complete.delay")
     def test_bad_expired_superuser_when_feature_disabled(
         self, uploading_complete_mock: Mock, analytics_record_mock: Mock
     ):

--- a/tests/sentry/api/endpoints/relocations/test_retry.py
+++ b/tests/sentry/api/endpoints/relocations/test_retry.py
@@ -4,8 +4,6 @@ from io import BytesIO
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
-from rest_framework import status
-
 from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
 from sentry.api.endpoints.relocations.index import (
     ERR_DUPLICATE_RELOCATION,
@@ -24,6 +22,8 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import generate_rsa_key_pair
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 from sentry.utils.relocation import RELOCATION_FILE_TYPE, OrderedTask
@@ -45,15 +45,15 @@ def get_test_tarball() -> BytesIO:
 @patch("sentry.analytics.record")
 class RetryRelocationTest(APITestCase):
     endpoint = "sentry-api-0-relocations-retry"
+    method = "POST"
 
     def setUp(self):
         super().setUp()
         self.owner = self.create_user(
             email="owner", is_superuser=False, is_staff=True, is_active=True
         )
-        self.superuser = self.create_user(
-            "superuser", is_superuser=True, is_staff=True, is_active=True
-        )
+        self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
         self.relocation: Relocation = Relocation.objects.create(
             date_added=TEST_DATE_ADDED,
             creator_id=self.superuser.id,
@@ -85,6 +85,7 @@ class RetryRelocationTest(APITestCase):
             kind=RelocationFile.Kind.RAW_USER_DATA.value,
         )
 
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 2})
     @patch("sentry.tasks.relocation.uploading_complete.delay")
     def test_good_simple(self, uploading_complete_mock: Mock, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
@@ -92,10 +93,8 @@ class RetryRelocationTest(APITestCase):
         relocation_file_count = RelocationFile.objects.count()
         file_count = File.objects.count()
 
-        with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 2}):
-            response = self.client.post(f"/api/0/relocations/{str(self.relocation.uuid)}/retry/")
+        response = self.get_success_response(self.relocation.uuid, status_code=201)
 
-        assert response.status_code == status.HTTP_201_CREATED
         assert response.data["uuid"] != self.relocation.uuid
         assert self.relocation.date_added is not None
         assert response.data["dateAdded"] > self.relocation.date_added
@@ -132,8 +131,48 @@ class RetryRelocationTest(APITestCase):
             uuid=response.data["uuid"],
         )
 
+    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 2})
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_good_with_superuser_when_feature_disabled(
+    def test_good_staff_when_feature_disabled(
+        self, uploading_complete_mock: Mock, analytics_record_mock: Mock
+    ):
+        self.login_as(user=self.staff_user, staff=True)
+        relocation_count = Relocation.objects.count()
+        relocation_file_count = RelocationFile.objects.count()
+        file_count = File.objects.count()
+
+        response = self.get_success_response(self.relocation.uuid, status_code=201)
+
+        assert response.data["uuid"] != self.relocation.uuid
+        assert response.data["creatorId"] == str(self.staff_user.id)
+        assert response.data["creatorEmail"] == str(self.staff_user.email)
+        assert response.data["creatorUsername"] == str(self.staff_user.username)
+        assert response.data["ownerId"] == str(self.owner.id)
+        assert response.data["ownerEmail"] == str(self.owner.email)
+        assert response.data["ownerUsername"] == str(self.owner.username)
+
+        assert (
+            Relocation.objects.filter(owner_id=self.owner.id)
+            .exclude(uuid=self.relocation.uuid)
+            .exists()
+        )
+        assert Relocation.objects.count() == relocation_count + 1
+        assert RelocationFile.objects.count() == relocation_file_count + 1
+        assert File.objects.count() == file_count
+
+        assert uploading_complete_mock.call_count == 1
+
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            creator_id=int(response.data["creatorId"]),
+            owner_id=int(response.data["ownerId"]),
+            uuid=response.data["uuid"],
+        )
+
+    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 2})
+    @patch("sentry.tasks.relocation.uploading_complete.delay")
+    def test_good_superuser_when_feature_disabled(
         self, uploading_complete_mock: Mock, analytics_record_mock: Mock
     ):
         self.login_as(user=self.superuser, superuser=True)
@@ -141,10 +180,8 @@ class RetryRelocationTest(APITestCase):
         relocation_file_count = RelocationFile.objects.count()
         file_count = File.objects.count()
 
-        with self.options({"relocation.enabled": False, "relocation.daily-limit.small": 2}):
-            response = self.client.post(f"/api/0/relocations/{str(self.relocation.uuid)}/retry/")
+        response = self.get_success_response(self.relocation.uuid, status_code=201)
 
-        assert response.status_code == status.HTTP_201_CREATED
         assert response.data["uuid"] != self.relocation.uuid
         assert response.data["creatorId"] == str(self.superuser.id)
         assert response.data["creatorEmail"] == str(self.superuser.email)
@@ -172,6 +209,7 @@ class RetryRelocationTest(APITestCase):
         )
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
+    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 2})
     def test_bad_without_superuser_when_feature_disabled(
         self, uploading_complete_mock: Mock, analytics_record_mock: Mock
     ):
@@ -180,10 +218,8 @@ class RetryRelocationTest(APITestCase):
         relocation_file_count = RelocationFile.objects.count()
         file_count = File.objects.count()
 
-        with self.options({"relocation.enabled": False, "relocation.daily-limit.small": 2}):
-            response = self.client.post(f"/api/0/relocations/{str(self.relocation.uuid)}/retry/")
+        response = self.get_error_response(self.relocation.uuid, status_code=403)
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.data.get("detail") == ERR_FEATURE_DISABLED
 
         assert not (
@@ -198,6 +234,7 @@ class RetryRelocationTest(APITestCase):
         assert uploading_complete_mock.call_count == 0
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
+    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 2})
     def test_bad_expired_superuser_when_feature_disabled(
         self, uploading_complete_mock: Mock, analytics_record_mock: Mock
     ):
@@ -206,10 +243,8 @@ class RetryRelocationTest(APITestCase):
         relocation_file_count = RelocationFile.objects.count()
         file_count = File.objects.count()
 
-        with self.options({"relocation.enabled": False, "relocation.daily-limit.small": 2}):
-            response = self.client.post(f"/api/0/relocations/{str(self.relocation.uuid)}/retry/")
+        response = self.get_error_response(self.relocation.uuid, status_code=403)
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.data.get("detail") == ERR_FEATURE_DISABLED
 
         assert not (
@@ -224,20 +259,19 @@ class RetryRelocationTest(APITestCase):
         assert uploading_complete_mock.call_count == 0
         analytics_record_mock.assert_not_called()
 
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 2})
     @patch("sentry.tasks.relocation.uploading_complete.delay")
     def test_bad_relocation_not_found(
         self, uploading_complete_mock: Mock, analytics_record_mock: Mock
     ):
         self.login_as(user=self.owner, superuser=False)
 
-        with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 2}):
-            response = self.client.post(f"/api/0/relocations/{str(uuid4().hex)}/retry/")
-
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        self.get_error_response(str(uuid4().hex), status_code=404)
 
         assert uploading_complete_mock.call_count == 0
         analytics_record_mock.assert_not_called()
 
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 2})
     @patch("sentry.tasks.relocation.uploading_complete.delay")
     def test_bad_relocation_file_not_found(
         self, uploading_complete_mock: Mock, analytics_record_mock: Mock
@@ -245,53 +279,62 @@ class RetryRelocationTest(APITestCase):
         self.login_as(user=self.owner, superuser=False)
         RelocationFile.objects.all().delete()
 
-        with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 2}):
-            response = self.client.post(f"/api/0/relocations/{str(self.relocation.uuid)}/retry/")
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data.get("detail") == ERR_FILE_NO_LONGER_EXISTS
-
         assert uploading_complete_mock.call_count == 0
         analytics_record_mock.assert_not_called()
 
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 2})
     @patch("sentry.tasks.relocation.uploading_complete.delay")
     def test_bad_file_not_found(self, uploading_complete_mock: Mock, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         File.objects.all().delete()
 
-        with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 2}):
-            response = self.client.post(f"/api/0/relocations/{str(self.relocation.uuid)}/retry/")
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data.get("detail") == ERR_FILE_NO_LONGER_EXISTS
-
         assert uploading_complete_mock.call_count == 0
 
+    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 2})
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_bad_owner_not_found(self, uploading_complete_mock: Mock, analytics_record_mock: Mock):
+    def test_bad_staff_owner_not_found(
+        self, uploading_complete_mock: Mock, analytics_record_mock: Mock
+    ):
+        self.login_as(user=self.staff_user, staff=True)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            User.objects.filter(id=self.owner.id).delete()
+
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
+
+        assert response.data.get("detail") == ERR_OWNER_NO_LONGER_EXISTS
+        assert uploading_complete_mock.call_count == 0
+        analytics_record_mock.assert_not_called()
+
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 2})
+    @patch("sentry.tasks.relocation.uploading_complete.delay")
+    def test_bad_superuser_owner_not_found(
+        self, uploading_complete_mock: Mock, analytics_record_mock: Mock
+    ):
         self.login_as(user=self.superuser, superuser=True)
         with assume_test_silo_mode(SiloMode.CONTROL):
             User.objects.filter(id=self.owner.id).delete()
 
-        with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 2}):
-            response = self.client.post(f"/api/0/relocations/{str(self.relocation.uuid)}/retry/")
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data.get("detail") == ERR_OWNER_NO_LONGER_EXISTS
-
         assert uploading_complete_mock.call_count == 0
         analytics_record_mock.assert_not_called()
 
+    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
     @patch("sentry.tasks.relocation.uploading_complete.delay")
     def test_bad_throttled(self, uploading_complete_mock: Mock, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
 
-        with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 1}):
-            response = self.client.post(f"/api/0/relocations/{str(self.relocation.uuid)}/retry/")
+        response = self.get_error_response(self.relocation.uuid, status_code=429)
 
-        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
         assert response.data.get("detail") == ERR_THROTTLED_RELOCATION
-
         assert uploading_complete_mock.call_count == 0
         analytics_record_mock.assert_not_called()
 
@@ -300,6 +343,7 @@ class RetryRelocationTest(APITestCase):
         Relocation.Status.PAUSE,
     ]:
 
+        @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 2})
         @patch("sentry.tasks.relocation.uploading_complete.delay")
         def test_bad_relocation_still_ongoing(
             self, uploading_complete_mock: Mock, analytics_record_mock: Mock, stat=stat
@@ -309,16 +353,11 @@ class RetryRelocationTest(APITestCase):
             self.relocation.latest_notified = Relocation.EmailKind.STARTED.value
             self.relocation.save()
 
-            with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 2}):
-                response = self.client.post(
-                    f"/api/0/relocations/{str(self.relocation.uuid)}/retry/"
-                )
+            response = self.get_error_response(self.relocation.uuid, status_code=400)
 
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
             assert response.data.get("detail") == ERR_NOT_RETRYABLE_STATUS.substitute(
                 status=stat.name
             )
-
             assert uploading_complete_mock.call_count == 0
             analytics_record_mock.assert_not_called()
 
@@ -327,6 +366,7 @@ class RetryRelocationTest(APITestCase):
         Relocation.Status.PAUSE,
     ]:
 
+        @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 3})
         @patch("sentry.tasks.relocation.uploading_complete.delay")
         def test_bad_owner_has_another_active_relocation(
             self, uploading_complete_mock: Mock, analytics_record_mock: Mock, stat=stat
@@ -347,13 +387,8 @@ class RetryRelocationTest(APITestCase):
                 latest_task_attempts=1,
             )
 
-            with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 3}):
-                response = self.client.post(
-                    f"/api/0/relocations/{str(self.relocation.uuid)}/retry/"
-                )
+            response = self.get_error_response(self.relocation.uuid, status_code=409)
 
-            assert response.status_code == status.HTTP_409_CONFLICT
             assert response.data.get("detail") == ERR_DUPLICATE_RELOCATION
-
             assert uploading_complete_mock.call_count == 0
             analytics_record_mock.assert_not_called()


### PR DESCRIPTION
Split from https://github.com/getsentry/sentry/pull/66174

Refactor `test_retry` and `test_index` to use `get_success/error_response` instead of client.
This requires a change where we now recognize the passed in `format` to `get_success/error_response`.