### PR TITLE
nit(typo): Fix typo in method name

### DIFF
--- a/static/app/components/teamSelector.tsx
+++ b/static/app/components/teamSelector.tsx
@@ -343,7 +343,7 @@ function TeamSelector(props: Props) {
     createTeamOutsideProjectOption,
   ]);
 
-  const handleInputCHange = useMemo(
+  const handleInputChange = useMemo(
     () => debounce(val => void onSearch(val), DEFAULT_DEBOUNCE_DURATION),
     [onSearch]
   );
@@ -361,7 +361,7 @@ function TeamSelector(props: Props) {
     <SelectControl
       ref={selectRef}
       options={options}
-      onInputChange={handleInputCHange}
+      onInputChange={handleInputChange}
       getOptionValue={getOptionValue}
       filterOption={filterOption}
       styles={styles}


### PR DESCRIPTION
Fix typo in method. I'm working in this code area, and saw this needed updating. Fixed it in a separate PR so as to not block it from going through with other changes that might need more iteration or discussion.
