### PR TITLE
ref(feedback): remove duplicate native platform

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -424,7 +424,6 @@ export const feedbackWebApiPlatforms: readonly PlatformKey[] = [
   'rust',
   'native',
   'native-qt',
-  'native',
   'node-awslambda',
   'node-azurefunctions',
   'node-connect',


### PR DESCRIPTION
accidentally had two `native` platforms in this list