### PR TITLE
feat(autofix): Use new 'progress' schema to display logs and sub-steps

### DIFF
--- a/fixtures/js-stubs/autofixData.tsx
+++ b/fixtures/js-stubs/autofixData.tsx
@@ -1,0 +1,11 @@
+import {AutofixData} from 'sentry/components/events/aiAutofix/types';
+
+export function AutofixDataFixture(params: Partial<AutofixData>): AutofixData {
+  return {
+    status: 'PROCESSING',
+    completed_at: '',
+    created_at: '',
+    steps: [],
+    ...params,
+  };
+}

--- a/fixtures/js-stubs/autofixProgressItem.tsx
+++ b/fixtures/js-stubs/autofixProgressItem.tsx
@@ -1,0 +1,13 @@
+import {AutofixProgressItem} from 'sentry/components/events/aiAutofix/types';
+
+export function AutofixProgressItemFixture(
+  params: Partial<AutofixProgressItem>
+): AutofixProgressItem {
+  return {
+    message: 'Example log message',
+    timestamp: '2024-01-01T00:00:00',
+    type: 'INFO',
+    data: null,
+    ...params,
+  };
+}

--- a/fixtures/js-stubs/autofixResult.tsx
+++ b/fixtures/js-stubs/autofixResult.tsx
@@ -1,0 +1,12 @@
+import {AutofixResult} from 'sentry/components/events/aiAutofix/types';
+
+export function AutofixResultFixture(params: Partial<AutofixResult>): AutofixResult {
+  return {
+    title: 'Fixed the bug!',
+    pr_number: 123,
+    description: 'This is a description',
+    pr_url: 'https://github.com/pulls/1234',
+    repo_name: 'getsentry/sentry',
+    ...params,
+  };
+}

--- a/fixtures/js-stubs/autofixStep.tsx
+++ b/fixtures/js-stubs/autofixStep.tsx
@@ -1,0 +1,12 @@
+import {AutofixStep} from 'sentry/components/events/aiAutofix/types';
+
+export function AutofixStepFixture(params: Partial<AutofixStep>): AutofixStep {
+  return {
+    id: '1',
+    index: 1,
+    title: 'I am processing',
+    status: 'PROCESSING',
+    progress: [],
+    ...params,
+  };
+}

--- a/static/app/components/events/aiAutofix/types.ts
+++ b/static/app/components/events/aiAutofix/types.ts
@@ -1,5 +1,13 @@
 import type {EventMetadata, Group} from 'sentry/types';
 
+export type AutofixResult = {
+  description: string;
+  pr_number: number;
+  pr_url: string;
+  repo_name: string;
+  title: string;
+};
+
 export type AutofixData = {
   created_at: string;
   status: 'PROCESSING' | 'COMPLETED' | 'NOFIX' | 'ERROR';
@@ -9,23 +17,24 @@ export type AutofixData = {
   };
   completed_at?: string | null;
   error_message?: string;
-  fix?: {
-    description: string;
-    pr_number: number;
-    pr_url: string;
-    repo_name: string;
-    title: string;
-  };
+  fix?: AutofixResult;
   steps?: AutofixStep[];
+};
+
+export type AutofixProgressItem = {
+  data: any;
+  message: string;
+  timestamp: string;
+  type: 'INFO' | 'WARNING' | 'ERROR' | 'NEED_MORE_INFORMATION' | 'USER_RESPONSE';
 };
 
 export type AutofixStep = {
   id: string;
   index: number;
+  progress: Array<AutofixProgressItem | AutofixStep>;
   status: 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'ERROR' | 'CANCELLED';
   title: string;
-  children?: AutofixStep[];
-  description?: string;
+  completedMessage?: string;
 };
 
 export type EventMetadataWithAutofix = EventMetadata & {

--- a/static/app/components/events/aiAutofix/useAiAutofix.tsx
+++ b/static/app/components/events/aiAutofix/useAiAutofix.tsx
@@ -51,6 +51,7 @@ export const useAiAutofix = (group: GroupWithAutofix, event: Event) => {
             index: 0,
             status: 'PROCESSING',
             title: 'Starting Autofix...',
+            progress: [],
           },
         ],
         created_at: new Date().toISOString(),


### PR DESCRIPTION
Uses the new schema defined here: https://github.com/getsentry/timeseries-analysis-service/issues/244