### PR TITLE
ref: split incident and alert_rule models into separate files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,7 +287,6 @@ module = [
     "sentry.incidents.endpoints.organization_incident_comment_details",
     "sentry.incidents.endpoints.organization_incident_index",
     "sentry.incidents.logic",
-    "sentry.incidents.models",
     "sentry.incidents.subscription_processor",
     "sentry.incidents.tasks",
     "sentry.integrations.aws_lambda.integration",

--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -4,7 +4,7 @@ from rest_framework.request import Request
 from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.incidents.models import Incident
+from sentry.incidents.models.incident import Incident
 
 
 class IncidentPermission(OrganizationPermission):

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -12,7 +12,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.rule import Rule

--- a/src/sentry/api/endpoints/team_alerts_triggered.py
+++ b/src/sentry/api/endpoints/team_alerts_triggered.py
@@ -14,8 +14,8 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
 from sentry.api.utils import get_date_range_from_params
-from sentry.incidents.models import (
-    AlertRule,
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import (
     IncidentActivity,
     IncidentActivityType,
     IncidentProject,

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -11,7 +11,7 @@ from drf_spectacular.utils import extend_schema_serializer
 from sentry import features
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.rule import RuleSerializer
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleActivity,
     AlertRuleActivityType,
@@ -19,8 +19,8 @@ from sentry.incidents.models import (
     AlertRuleMonitorType,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
-    Incident,
 )
+from sentry.incidents.models.incident import Incident
 from sentry.models.actor import ACTOR_TYPES, Actor, actor_type_to_string
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -5,7 +5,7 @@ from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.endpoints.utils import translate_threshold
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRuleTrigger,
     AlertRuleTriggerAction,
     AlertRuleTriggerExclusion,

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -1,7 +1,7 @@
 import logging
 
 from sentry.api.serializers import Serializer, register
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -4,7 +4,7 @@ from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
-from sentry.incidents.models import (
+from sentry.incidents.models.incident import (
     Incident,
     IncidentActivity,
     IncidentProject,

--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -1,7 +1,7 @@
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register
-from sentry.incidents.models import IncidentActivity
+from sentry.incidents.models.incident import IncidentActivity
 from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
 from sentry.services.hybrid_cloud.user.service import user_service
 

--- a/src/sentry/api/serializers/models/incidentseen.py
+++ b/src/sentry/api/serializers/models/incidentseen.py
@@ -1,5 +1,5 @@
 from sentry.api.serializers import Serializer, register
-from sentry.incidents.models import IncidentSeen
+from sentry.incidents.models.incident import IncidentSeen
 from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
 from sentry.services.hybrid_cloud.user.service import user_service
 

--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -78,7 +78,6 @@ registered Group task. It will instead take a more efficient approach of batch d
 descendants, such as Event, so it can more efficiently bulk delete rows.
 """
 
-
 from .base import BulkModelDeletionTask, ModelDeletionTask, ModelRelation  # NOQA
 from .defaults.artifactbundle import ArtifactBundleDeletionTask
 from .manager import DeletionTaskManager
@@ -89,7 +88,11 @@ default_manager = DeletionTaskManager(default_task=ModelDeletionTask)
 def load_defaults():
     from sentry import models
     from sentry.discover.models import DiscoverSavedQuery
-    from sentry.incidents.models import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
+    from sentry.incidents.models.alert_rule import (
+        AlertRule,
+        AlertRuleTrigger,
+        AlertRuleTriggerAction,
+    )
     from sentry.models.commitfilechange import CommitFileChange
     from sentry.monitors import models as monitor_models
 

--- a/src/sentry/deletions/defaults/alert_rule_trigger.py
+++ b/src/sentry/deletions/defaults/alert_rule_trigger.py
@@ -3,7 +3,7 @@ from ..base import ModelDeletionTask, ModelRelation
 
 class AlertRuleTriggerDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
-        from sentry.incidents.models import AlertRuleTriggerAction
+        from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 
         return [
             ModelRelation(AlertRuleTriggerAction, {"alert_rule_trigger_id": instance.id}),

--- a/src/sentry/deletions/defaults/alertrule.py
+++ b/src/sentry/deletions/defaults/alertrule.py
@@ -7,7 +7,7 @@ class AlertRuleDeletionTask(ModelDeletionTask):
     manager_name = "objects_with_snapshots"
 
     def get_child_relations(self, instance):
-        from sentry.incidents.models import AlertRuleTrigger
+        from sentry.incidents.models.alert_rule import AlertRuleTrigger
 
         return [
             ModelRelation(AlertRuleTrigger, {"alert_rule_id": instance.id}),

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -19,7 +19,8 @@ class OrganizationDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry.deletions.defaults.discoversavedquery import DiscoverSavedQueryDeletionTask
         from sentry.discover.models import DiscoverSavedQuery, TeamKeyTransaction
-        from sentry.incidents.models import AlertRule, Incident
+        from sentry.incidents.models.alert_rule import AlertRule
+        from sentry.incidents.models.incident import Incident
         from sentry.models.artifactbundle import ArtifactBundle
         from sentry.models.commitauthor import CommitAuthor
         from sentry.models.dashboard import Dashboard

--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -7,7 +7,8 @@ class ProjectDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry import models
         from sentry.discover.models import DiscoverSavedQueryProject
-        from sentry.incidents.models import AlertRule, IncidentProject
+        from sentry.incidents.models.alert_rule import AlertRule
+        from sentry.incidents.models.incident import IncidentProject
         from sentry.models.projectteam import ProjectTeam
         from sentry.monitors.models import Monitor
         from sentry.replays.models import ReplayRecordingSegment

--- a/src/sentry/deletions/defaults/team.py
+++ b/src/sentry/deletions/defaults/team.py
@@ -17,7 +17,7 @@ class TeamDeletionTask(ModelDeletionTask):
                 instance.update(status=TeamStatus.DELETION_IN_PROGRESS)
 
     def delete_instance(self, instance):
-        from sentry.incidents.models import AlertRule
+        from sentry.incidents.models.alert_rule import AlertRule
         from sentry.models.rule import Rule
 
         AlertRule.objects.filter(owner_id=instance.actor_id).update(owner=None)

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -13,13 +13,8 @@ from sentry import analytics, features
 from sentry.charts.types import ChartSize
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.models import (
-    INCIDENT_STATUS,
-    AlertRuleThresholdType,
-    AlertRuleTriggerAction,
-    IncidentStatus,
-    TriggerStatus,
-)
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType, AlertRuleTriggerAction
+from sentry.incidents.models.incident import INCIDENT_STATUS, IncidentStatus, TriggerStatus
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.models.user import User
 from sentry.notifications.types import NotificationSettingEnum

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -15,7 +15,8 @@ from sentry.api.utils import get_datetime_from_stats_period
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartSize, ChartType
 from sentry.incidents.logic import translate_aggregate_field
-from sentry.incidents.models import AlertRule, Incident
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import Incident
 from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
 from sentry.models.user import User

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -6,7 +6,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.incidents.models import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
 
 
 class ProjectAlertRuleEndpoint(ProjectEndpoint):

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -19,7 +19,7 @@ from sentry.incidents.logic import (
     get_opsgenie_teams,
     get_pagerduty_services,
 )
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation, app_service

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -34,7 +34,8 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidParams
 from sentry.incidents.logic import get_slack_actions_with_async_lookups
-from sentry.incidents.models import AlertRule, Incident
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import Incident
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
 from sentry.integrations.slack.utils import RedisRuleStatus

--- a/src/sentry/incidents/endpoints/organization_incident_comment_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_comment_details.py
@@ -10,7 +10,7 @@ from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import delete_comment, update_comment
-from sentry.incidents.models import IncidentActivity, IncidentActivityType
+from sentry.incidents.models.incident import IncidentActivity, IncidentActivityType
 
 
 class CommentSerializer(serializers.Serializer):

--- a/src/sentry/incidents/endpoints/organization_incident_comment_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_comment_index.py
@@ -13,7 +13,7 @@ from sentry.api.serializers.rest_framework.mentions import (
     extract_user_ids_from_mentions,
 )
 from sentry.incidents.logic import create_incident_activity
-from sentry.incidents.models import IncidentActivityType
+from sentry.incidents.models.incident import IncidentActivityType
 
 
 class CommentSerializer(serializers.Serializer, MentionsMixin):

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -9,7 +9,7 @@ from sentry.api.bases.incident import IncidentEndpoint, IncidentPermission
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import DetailedIncidentSerializer
 from sentry.incidents.logic import update_incident_status
-from sentry.incidents.models import IncidentStatus, IncidentStatusMethod
+from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 
 
 class IncidentSerializer(serializers.Serializer):

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -15,12 +15,8 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import IncidentSerializer
 from sentry.exceptions import InvalidParams
-from sentry.incidents.models import (
-    AlertRuleActivity,
-    AlertRuleActivityType,
-    Incident,
-    IncidentStatus,
-)
+from sentry.incidents.models.alert_rule import AlertRuleActivity, AlertRuleActivityType
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.snuba.dataset import Dataset
 from sentry.utils.dates import ensure_aware
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -7,7 +7,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models.alert_rule import AlertRule
 from sentry.integrations.slack.utils import RedisRuleStatus
 
 

--- a/src/sentry/incidents/endpoints/utils.py
+++ b/src/sentry/incidents/endpoints/utils.py
@@ -1,5 +1,5 @@
 from sentry.api.helpers.teams import get_teams
-from sentry.incidents.models import AlertRule, AlertRuleThresholdType
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
 
 
 def parse_team_params(request, organization, teams):

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -18,7 +18,7 @@ from sentry import analytics, audit_log, features, quotas
 from sentry.auth.access import SystemAccess
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, ObjectStatus
 from sentry.incidents import tasks
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleActivationCondition,
     AlertRuleActivity,
@@ -30,6 +30,8 @@ from sentry.incidents.models import (
     AlertRuleTrigger,
     AlertRuleTriggerAction,
     AlertRuleTriggerExclusion,
+)
+from sentry.incidents.models.incident import (
     Incident,
     IncidentActivity,
     IncidentActivityType,

--- a/src/sentry/incidents/models/__init__.py
+++ b/src/sentry/incidents/models/__init__.py
@@ -1,0 +1,10 @@
+from .alert_rule import AlertRule, AlertRuleStatus, AlertRuleThresholdType, AlertRuleTriggerAction
+from .incident import Incident
+
+__all__ = (
+    "AlertRule",
+    "AlertRuleStatus",
+    "AlertRuleThresholdType",
+    "AlertRuleTriggerAction",
+    "Incident",
+)

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -6,44 +6,39 @@ from collections.abc import Callable
 from datetime import timedelta
 from enum import Enum
 from typing import Any, ClassVar, Self
-from uuid import uuid4
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db import IntegrityError, models, router, transaction
+from django.db import models
 from django.db.models import QuerySet
 from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
-from sentry.backup.dependencies import PrimaryKeyMap, get_model_name
+from sentry.backup.dependencies import PrimaryKeyMap
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import (
-    ArrayField,
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
     JSONField,
     Model,
-    OneToOneCascadeDeletes,
-    UUIDField,
     region_silo_only_model,
     sane_repr,
 )
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager import BaseManager
+from sentry.incidents.models.incident import IncidentTrigger
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.actor import Actor
 from sentry.models.notificationaction import AbstractNotificationAction, ActionService, ActionTarget
-from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.snuba.models import QuerySubscription
 from sentry.snuba.subscriptions import bulk_create_snuba_subscriptions, delete_snuba_subscription
 from sentry.utils import metrics
-from sentry.utils.retries import TimedRetryPolicy
 
 alert_subscription_callback_registry: dict[
     AlertRuleMonitorType, Callable[[QuerySubscription], bool]
@@ -72,306 +67,6 @@ def invoke_alert_subscription_callback(
 
 
 logger = logging.getLogger(__name__)
-
-
-@region_silo_only_model
-class IncidentProject(Model):
-    __relocation_scope__ = RelocationScope.Excluded
-
-    project = FlexibleForeignKey("sentry.Project", db_index=False, db_constraint=False)
-    incident = FlexibleForeignKey("sentry.Incident")
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_incidentproject"
-        unique_together = (("project", "incident"),)
-
-
-@region_silo_only_model
-class IncidentSeen(Model):
-    __relocation_scope__ = RelocationScope.Excluded
-
-    incident = FlexibleForeignKey("sentry.Incident")
-    user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", db_index=False)
-    last_seen = models.DateTimeField(default=timezone.now)
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_incidentseen"
-        unique_together = (("user_id", "incident"),)
-
-
-class IncidentManager(BaseManager["Incident"]):
-    CACHE_KEY = "incidents:active:%s:%s"
-
-    def fetch_for_organization(self, organization, projects):
-        return self.filter(organization=organization, projects__in=projects).distinct()
-
-    @classmethod
-    def _build_active_incident_cache_key(cls, alert_rule_id, project_id):
-        return cls.CACHE_KEY % (alert_rule_id, project_id)
-
-    def get_active_incident(self, alert_rule, project):
-        cache_key = self._build_active_incident_cache_key(alert_rule.id, project.id)
-        incident = cache.get(cache_key)
-        if incident is None:
-            try:
-                incident = (
-                    Incident.objects.filter(
-                        type=IncidentType.ALERT_TRIGGERED.value,
-                        alert_rule=alert_rule,
-                        projects=project,
-                    )
-                    .exclude(status=IncidentStatus.CLOSED.value)
-                    .order_by("-date_added")[0]
-                )
-            except IndexError:
-                # Set this to False so that we can have a negative cache as well.
-                incident = False
-            cache.set(cache_key, incident)
-            if incident is False:
-                incident = None
-        elif not incident:
-            # If we had a falsey not None value in the cache, then we stored that there
-            # are no current active incidents. Just set to None
-            incident = None
-
-        return incident
-
-    @classmethod
-    def clear_active_incident_cache(cls, instance, **kwargs):
-        for project in instance.projects.all():
-            cache.delete(cls._build_active_incident_cache_key(instance.alert_rule_id, project.id))
-            assert (
-                cache.get(cls._build_active_incident_cache_key(instance.alert_rule_id, project.id))
-                is None
-            )
-
-    @classmethod
-    def clear_active_incident_project_cache(cls, instance, **kwargs):
-        cache.delete(
-            cls._build_active_incident_cache_key(
-                instance.incident.alert_rule_id, instance.project_id
-            )
-        )
-        assert (
-            cache.get(
-                cls._build_active_incident_cache_key(
-                    instance.incident.alert_rule_id, instance.project_id
-                )
-            )
-            is None
-        )
-
-    @TimedRetryPolicy.wrap(timeout=5, exceptions=(IntegrityError,))
-    def create(self, organization, **kwargs):
-        """
-        Creates an Incident. Fetches the maximum identifier value for the org
-        and increments it by one. If two incidents are created for the
-        Organization at the same time then an integrity error will be thrown,
-        and we'll retry again several times. I prefer to lock optimistically
-        here since if we're creating multiple Incidents a second for an
-        Organization then we're likely failing at making Incidents useful.
-        """
-        with transaction.atomic(router.db_for_write(Organization)):
-            result = self.filter(organization=organization).aggregate(models.Max("identifier"))
-            identifier = result["identifier__max"]
-            if identifier is None:
-                identifier = 1
-            else:
-                identifier += 1
-
-            return super().create(organization=organization, identifier=identifier, **kwargs)
-
-
-class IncidentType(Enum):
-    DETECTED = 0
-    ALERT_TRIGGERED = 2
-
-
-class IncidentStatus(Enum):
-    OPEN = 1
-    CLOSED = 2
-    WARNING = 10
-    CRITICAL = 20
-
-
-class IncidentStatusMethod(Enum):
-    MANUAL = 1
-    RULE_UPDATED = 2
-    RULE_TRIGGERED = 3
-
-
-INCIDENT_STATUS = {
-    IncidentStatus.OPEN: "Open",
-    IncidentStatus.CLOSED: "Resolved",
-    IncidentStatus.CRITICAL: "Critical",
-    IncidentStatus.WARNING: "Warning",
-}
-
-
-@region_silo_only_model
-class Incident(Model):
-    __relocation_scope__ = RelocationScope.Organization
-
-    objects: ClassVar[IncidentManager] = IncidentManager()
-
-    organization = FlexibleForeignKey("sentry.Organization")
-    projects = models.ManyToManyField(
-        "sentry.Project", related_name="incidents", through=IncidentProject
-    )
-    alert_rule = FlexibleForeignKey("sentry.AlertRule", on_delete=models.PROTECT)
-    # Incrementing id that is specific to the org.
-    identifier = models.IntegerField()
-    # Identifier used to match incoming events from the detection algorithm
-    detection_uuid = UUIDField(null=True, db_index=True)
-    status = models.PositiveSmallIntegerField(default=IncidentStatus.OPEN.value)
-    status_method = models.PositiveSmallIntegerField(
-        default=IncidentStatusMethod.RULE_TRIGGERED.value
-    )
-    type = models.PositiveSmallIntegerField()
-    title = models.TextField()
-    # When we suspect the incident actually started
-    date_started = models.DateTimeField(default=timezone.now)
-    # When we actually detected the incident
-    date_detected = models.DateTimeField(default=timezone.now)
-    date_added = models.DateTimeField(default=timezone.now)
-    date_closed = models.DateTimeField(null=True)
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_incident"
-        unique_together = (("organization", "identifier"),)
-        indexes = (models.Index(fields=("alert_rule", "type", "status")),)
-
-    @property
-    def current_end_date(self):
-        """
-        Returns the current end of the incident. Either the date it was closed,
-        or the current time if it's still open.
-        """
-        return self.date_closed if self.date_closed else timezone.now()
-
-    @property
-    def duration(self):
-        return self.current_end_date - self.date_started
-
-    def normalize_before_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
-    ) -> int | None:
-        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
-        if old_pk is None:
-            return None
-
-        # Generate a new UUID, if one exists.
-        if self.detection_uuid:
-            self.detection_uuid = uuid4()
-        return old_pk
-
-
-@region_silo_only_model
-class PendingIncidentSnapshot(Model):
-    __relocation_scope__ = RelocationScope.Organization
-
-    incident = OneToOneCascadeDeletes("sentry.Incident", db_constraint=False)
-    target_run_date = models.DateTimeField(db_index=True, default=timezone.now)
-    date_added = models.DateTimeField(default=timezone.now)
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_pendingincidentsnapshot"
-
-
-@region_silo_only_model
-class IncidentSnapshot(Model):
-    __relocation_scope__ = RelocationScope.Organization
-
-    incident = OneToOneCascadeDeletes("sentry.Incident", db_constraint=False)
-    event_stats_snapshot = FlexibleForeignKey("sentry.TimeSeriesSnapshot", db_constraint=False)
-    unique_users = models.IntegerField()
-    total_events = models.IntegerField()
-    date_added = models.DateTimeField(default=timezone.now)
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_incidentsnapshot"
-
-
-@region_silo_only_model
-class TimeSeriesSnapshot(Model):
-    __relocation_scope__ = RelocationScope.Organization
-    __relocation_dependencies__ = {"sentry.Incident"}
-
-    start = models.DateTimeField()
-    end = models.DateTimeField()
-    values = ArrayField(of=ArrayField(models.FloatField()))
-    period = models.IntegerField()
-    date_added = models.DateTimeField(default=timezone.now)
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_timeseriessnapshot"
-
-    @classmethod
-    def query_for_relocation_export(cls, q: models.Q, pk_map: PrimaryKeyMap) -> models.Q:
-        pks = IncidentSnapshot.objects.filter(
-            incident__in=pk_map.get_pks(get_model_name(Incident))
-        ).values_list("event_stats_snapshot_id", flat=True)
-
-        return q & models.Q(pk__in=pks)
-
-
-class IncidentActivityType(Enum):
-    CREATED = 1
-    STATUS_CHANGE = 2
-    COMMENT = 3
-    DETECTED = 4
-
-
-@region_silo_only_model
-class IncidentActivity(Model):
-    __relocation_scope__ = RelocationScope.Organization
-
-    incident = FlexibleForeignKey("sentry.Incident")
-    user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", null=True)
-    type: models.Field[int | IncidentActivityType, int] = models.IntegerField()
-    value = models.TextField(null=True)
-    previous_value = models.TextField(null=True)
-    comment = models.TextField(null=True)
-    date_added = models.DateTimeField(default=timezone.now)
-    notification_uuid = models.UUIDField("notification_uuid", null=True)
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_incidentactivity"
-
-    def normalize_before_relocation_import(
-        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
-    ) -> int | None:
-        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
-        if old_pk is None:
-            return None
-
-        # Generate a new UUID, if one exists.
-        if self.notification_uuid:
-            self.notification_uuid = uuid4()
-        return old_pk
-
-
-@region_silo_only_model
-class IncidentSubscription(Model):
-    __relocation_scope__ = RelocationScope.Organization
-
-    incident = FlexibleForeignKey("sentry.Incident", db_index=False)
-    user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE")
-    date_added = models.DateTimeField(default=timezone.now)
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_incidentsubscription"
-        unique_together = (("incident", "user_id"),)
-
-    __repr__ = sane_repr("incident_id", "user_id")
 
 
 class AlertRuleStatus(Enum):
@@ -650,61 +345,6 @@ class AlertRule(Model):
                 query_extra,
             )
         return []
-
-
-class TriggerStatus(Enum):
-    ACTIVE = 0
-    RESOLVED = 1
-
-
-class IncidentTriggerManager(BaseManager["IncidentTrigger"]):
-    CACHE_KEY = "incident:triggers:%s"
-
-    @classmethod
-    def _build_cache_key(cls, incident_id):
-        return cls.CACHE_KEY % incident_id
-
-    def get_for_incident(self, incident):
-        """
-        Fetches the IncidentTriggers associated with an Incident. Attempts to fetch from
-        cache then hits the database.
-        """
-        cache_key = self._build_cache_key(incident.id)
-        triggers = cache.get(cache_key)
-        if triggers is None:
-            triggers = list(IncidentTrigger.objects.filter(incident=incident))
-            cache.set(cache_key, triggers, 3600)
-
-        return triggers
-
-    @classmethod
-    def clear_incident_cache(cls, instance, **kwargs):
-        cache.delete(cls._build_cache_key(instance.id))
-        assert cache.get(cls._build_cache_key(instance.id)) is None
-
-    @classmethod
-    def clear_incident_trigger_cache(cls, instance, **kwargs):
-        cache.delete(cls._build_cache_key(instance.incident_id))
-        assert cache.get(cls._build_cache_key(instance.incident_id)) is None
-
-
-@region_silo_only_model
-class IncidentTrigger(Model):
-    __relocation_scope__ = RelocationScope.Organization
-
-    objects: ClassVar[IncidentTriggerManager] = IncidentTriggerManager()
-
-    incident = FlexibleForeignKey("sentry.Incident", db_index=False)
-    alert_rule_trigger = FlexibleForeignKey("sentry.AlertRuleTrigger")
-    status = models.SmallIntegerField()
-    date_modified = models.DateTimeField(default=timezone.now, null=False)
-    date_added = models.DateTimeField(default=timezone.now)
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_incidenttrigger"
-        unique_together = (("incident", "alert_rule_trigger"),)
-        indexes = (models.Index(fields=("alert_rule_trigger", "incident_id")),)
 
 
 class AlertRuleTriggerManager(BaseManager["AlertRuleTrigger"]):
@@ -989,11 +629,3 @@ post_delete.connect(AlertRuleTriggerManager.clear_alert_rule_trigger_cache, send
 post_save.connect(AlertRuleTriggerManager.clear_alert_rule_trigger_cache, sender=AlertRule)
 post_save.connect(AlertRuleTriggerManager.clear_trigger_cache, sender=AlertRuleTrigger)
 post_delete.connect(AlertRuleTriggerManager.clear_trigger_cache, sender=AlertRuleTrigger)
-
-post_save.connect(IncidentManager.clear_active_incident_cache, sender=Incident)
-post_save.connect(IncidentManager.clear_active_incident_project_cache, sender=IncidentProject)
-post_delete.connect(IncidentManager.clear_active_incident_project_cache, sender=IncidentProject)
-
-post_delete.connect(IncidentTriggerManager.clear_incident_cache, sender=Incident)
-post_save.connect(IncidentTriggerManager.clear_incident_trigger_cache, sender=IncidentTrigger)
-post_delete.connect(IncidentTriggerManager.clear_incident_trigger_cache, sender=IncidentTrigger)

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -273,9 +273,9 @@ class AlertRule(Model):
         if self.owner_id is not None and self.team_id is None and self.user_id is None:
             raise ValueError("AlertRule with owner requires either team_id or user_id")
 
-    def save(self, **kwargs: Any) -> None:
+    def save(self, *args, **kwargs: Any) -> None:
         self._validate_actor()
-        return super().save(**kwargs)
+        return super().save(*args, **kwargs)
 
     @property
     def created_by_id(self):
@@ -474,7 +474,7 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
     Type = ActionService
     TargetType = ActionTarget
 
-    _type_registrations = {}
+    _type_registrations: dict[ActionService, TypeRegistration] = {}
 
     INTEGRATION_TYPES = frozenset(
         (

--- a/src/sentry/incidents/models/incident.py
+++ b/src/sentry/incidents/models/incident.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import ClassVar
+from uuid import uuid4
+
+from django.conf import settings
+from django.core.cache import cache
+from django.db import IntegrityError, models, router, transaction
+from django.db.models.signals import post_delete, post_save
+from django.utils import timezone
+
+from sentry.backup.dependencies import PrimaryKeyMap, get_model_name
+from sentry.backup.helpers import ImportFlags
+from sentry.backup.scopes import ImportScope, RelocationScope
+from sentry.db.models import (
+    ArrayField,
+    FlexibleForeignKey,
+    Model,
+    OneToOneCascadeDeletes,
+    UUIDField,
+    region_silo_only_model,
+    sane_repr,
+)
+from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
+from sentry.db.models.manager import BaseManager
+from sentry.models.organization import Organization
+from sentry.utils.retries import TimedRetryPolicy
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_only_model
+class IncidentProject(Model):
+    __relocation_scope__ = RelocationScope.Excluded
+
+    project = FlexibleForeignKey("sentry.Project", db_index=False, db_constraint=False)
+    incident = FlexibleForeignKey("sentry.Incident")
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_incidentproject"
+        unique_together = (("project", "incident"),)
+
+
+@region_silo_only_model
+class IncidentSeen(Model):
+    __relocation_scope__ = RelocationScope.Excluded
+
+    incident = FlexibleForeignKey("sentry.Incident")
+    user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", db_index=False)
+    last_seen = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_incidentseen"
+        unique_together = (("user_id", "incident"),)
+
+
+class IncidentManager(BaseManager["Incident"]):
+    CACHE_KEY = "incidents:active:%s:%s"
+
+    def fetch_for_organization(self, organization, projects):
+        return self.filter(organization=organization, projects__in=projects).distinct()
+
+    @classmethod
+    def _build_active_incident_cache_key(cls, alert_rule_id, project_id):
+        return cls.CACHE_KEY % (alert_rule_id, project_id)
+
+    def get_active_incident(self, alert_rule, project):
+        cache_key = self._build_active_incident_cache_key(alert_rule.id, project.id)
+        incident = cache.get(cache_key)
+        if incident is None:
+            try:
+                incident = (
+                    Incident.objects.filter(
+                        type=IncidentType.ALERT_TRIGGERED.value,
+                        alert_rule=alert_rule,
+                        projects=project,
+                    )
+                    .exclude(status=IncidentStatus.CLOSED.value)
+                    .order_by("-date_added")[0]
+                )
+            except IndexError:
+                # Set this to False so that we can have a negative cache as well.
+                incident = False
+            cache.set(cache_key, incident)
+            if incident is False:
+                incident = None
+        elif not incident:
+            # If we had a falsey not None value in the cache, then we stored that there
+            # are no current active incidents. Just set to None
+            incident = None
+
+        return incident
+
+    @classmethod
+    def clear_active_incident_cache(cls, instance, **kwargs):
+        for project in instance.projects.all():
+            cache.delete(cls._build_active_incident_cache_key(instance.alert_rule_id, project.id))
+            assert (
+                cache.get(cls._build_active_incident_cache_key(instance.alert_rule_id, project.id))
+                is None
+            )
+
+    @classmethod
+    def clear_active_incident_project_cache(cls, instance, **kwargs):
+        cache.delete(
+            cls._build_active_incident_cache_key(
+                instance.incident.alert_rule_id, instance.project_id
+            )
+        )
+        assert (
+            cache.get(
+                cls._build_active_incident_cache_key(
+                    instance.incident.alert_rule_id, instance.project_id
+                )
+            )
+            is None
+        )
+
+    @TimedRetryPolicy.wrap(timeout=5, exceptions=(IntegrityError,))
+    def create(self, organization, **kwargs):
+        """
+        Creates an Incident. Fetches the maximum identifier value for the org
+        and increments it by one. If two incidents are created for the
+        Organization at the same time then an integrity error will be thrown,
+        and we'll retry again several times. I prefer to lock optimistically
+        here since if we're creating multiple Incidents a second for an
+        Organization then we're likely failing at making Incidents useful.
+        """
+        with transaction.atomic(router.db_for_write(Organization)):
+            result = self.filter(organization=organization).aggregate(models.Max("identifier"))
+            identifier = result["identifier__max"]
+            if identifier is None:
+                identifier = 1
+            else:
+                identifier += 1
+
+            return super().create(organization=organization, identifier=identifier, **kwargs)
+
+
+class IncidentType(Enum):
+    DETECTED = 0
+    ALERT_TRIGGERED = 2
+
+
+class IncidentStatus(Enum):
+    OPEN = 1
+    CLOSED = 2
+    WARNING = 10
+    CRITICAL = 20
+
+
+class IncidentStatusMethod(Enum):
+    MANUAL = 1
+    RULE_UPDATED = 2
+    RULE_TRIGGERED = 3
+
+
+INCIDENT_STATUS = {
+    IncidentStatus.OPEN: "Open",
+    IncidentStatus.CLOSED: "Resolved",
+    IncidentStatus.CRITICAL: "Critical",
+    IncidentStatus.WARNING: "Warning",
+}
+
+
+@region_silo_only_model
+class Incident(Model):
+    __relocation_scope__ = RelocationScope.Organization
+
+    objects: ClassVar[IncidentManager] = IncidentManager()
+
+    organization = FlexibleForeignKey("sentry.Organization")
+    projects = models.ManyToManyField(
+        "sentry.Project", related_name="incidents", through=IncidentProject
+    )
+    alert_rule = FlexibleForeignKey("sentry.AlertRule", on_delete=models.PROTECT)
+    # Incrementing id that is specific to the org.
+    identifier = models.IntegerField()
+    # Identifier used to match incoming events from the detection algorithm
+    detection_uuid = UUIDField(null=True, db_index=True)
+    status = models.PositiveSmallIntegerField(default=IncidentStatus.OPEN.value)
+    status_method = models.PositiveSmallIntegerField(
+        default=IncidentStatusMethod.RULE_TRIGGERED.value
+    )
+    type = models.PositiveSmallIntegerField()
+    title = models.TextField()
+    # When we suspect the incident actually started
+    date_started = models.DateTimeField(default=timezone.now)
+    # When we actually detected the incident
+    date_detected = models.DateTimeField(default=timezone.now)
+    date_added = models.DateTimeField(default=timezone.now)
+    date_closed = models.DateTimeField(null=True)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_incident"
+        unique_together = (("organization", "identifier"),)
+        indexes = (models.Index(fields=("alert_rule", "type", "status")),)
+
+    @property
+    def current_end_date(self):
+        """
+        Returns the current end of the incident. Either the date it was closed,
+        or the current time if it's still open.
+        """
+        return self.date_closed if self.date_closed else timezone.now()
+
+    @property
+    def duration(self):
+        return self.current_end_date - self.date_started
+
+    def normalize_before_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
+    ) -> int | None:
+        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
+        if old_pk is None:
+            return None
+
+        # Generate a new UUID, if one exists.
+        if self.detection_uuid:
+            self.detection_uuid = uuid4()
+        return old_pk
+
+
+@region_silo_only_model
+class PendingIncidentSnapshot(Model):
+    __relocation_scope__ = RelocationScope.Organization
+
+    incident = OneToOneCascadeDeletes("sentry.Incident", db_constraint=False)
+    target_run_date = models.DateTimeField(db_index=True, default=timezone.now)
+    date_added = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_pendingincidentsnapshot"
+
+
+@region_silo_only_model
+class IncidentSnapshot(Model):
+    __relocation_scope__ = RelocationScope.Organization
+
+    incident = OneToOneCascadeDeletes("sentry.Incident", db_constraint=False)
+    event_stats_snapshot = FlexibleForeignKey("sentry.TimeSeriesSnapshot", db_constraint=False)
+    unique_users = models.IntegerField()
+    total_events = models.IntegerField()
+    date_added = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_incidentsnapshot"
+
+
+@region_silo_only_model
+class TimeSeriesSnapshot(Model):
+    __relocation_scope__ = RelocationScope.Organization
+    __relocation_dependencies__ = {"sentry.Incident"}
+
+    start = models.DateTimeField()
+    end = models.DateTimeField()
+    values = ArrayField(of=ArrayField(models.FloatField()))
+    period = models.IntegerField()
+    date_added = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_timeseriessnapshot"
+
+    @classmethod
+    def query_for_relocation_export(cls, q: models.Q, pk_map: PrimaryKeyMap) -> models.Q:
+        pks = IncidentSnapshot.objects.filter(
+            incident__in=pk_map.get_pks(get_model_name(Incident))
+        ).values_list("event_stats_snapshot_id", flat=True)
+
+        return q & models.Q(pk__in=pks)
+
+
+class IncidentActivityType(Enum):
+    CREATED = 1
+    STATUS_CHANGE = 2
+    COMMENT = 3
+    DETECTED = 4
+
+
+@region_silo_only_model
+class IncidentActivity(Model):
+    __relocation_scope__ = RelocationScope.Organization
+
+    incident = FlexibleForeignKey("sentry.Incident")
+    user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", null=True)
+    type: models.Field[int | IncidentActivityType, int] = models.IntegerField()
+    value = models.TextField(null=True)
+    previous_value = models.TextField(null=True)
+    comment = models.TextField(null=True)
+    date_added = models.DateTimeField(default=timezone.now)
+    notification_uuid = models.UUIDField("notification_uuid", null=True)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_incidentactivity"
+
+    def normalize_before_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
+    ) -> int | None:
+        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
+        if old_pk is None:
+            return None
+
+        # Generate a new UUID, if one exists.
+        if self.notification_uuid:
+            self.notification_uuid = uuid4()
+        return old_pk
+
+
+@region_silo_only_model
+class IncidentSubscription(Model):
+    __relocation_scope__ = RelocationScope.Organization
+
+    incident = FlexibleForeignKey("sentry.Incident", db_index=False)
+    user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE")
+    date_added = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_incidentsubscription"
+        unique_together = (("incident", "user_id"),)
+
+    __repr__ = sane_repr("incident_id", "user_id")
+
+
+class TriggerStatus(Enum):
+    ACTIVE = 0
+    RESOLVED = 1
+
+
+class IncidentTriggerManager(BaseManager["IncidentTrigger"]):
+    CACHE_KEY = "incident:triggers:%s"
+
+    @classmethod
+    def _build_cache_key(cls, incident_id):
+        return cls.CACHE_KEY % incident_id
+
+    def get_for_incident(self, incident):
+        """
+        Fetches the IncidentTriggers associated with an Incident. Attempts to fetch from
+        cache then hits the database.
+        """
+        cache_key = self._build_cache_key(incident.id)
+        triggers = cache.get(cache_key)
+        if triggers is None:
+            triggers = list(IncidentTrigger.objects.filter(incident=incident))
+            cache.set(cache_key, triggers, 3600)
+
+        return triggers
+
+    @classmethod
+    def clear_incident_cache(cls, instance, **kwargs):
+        cache.delete(cls._build_cache_key(instance.id))
+        assert cache.get(cls._build_cache_key(instance.id)) is None
+
+    @classmethod
+    def clear_incident_trigger_cache(cls, instance, **kwargs):
+        cache.delete(cls._build_cache_key(instance.incident_id))
+        assert cache.get(cls._build_cache_key(instance.incident_id)) is None
+
+
+@region_silo_only_model
+class IncidentTrigger(Model):
+    __relocation_scope__ = RelocationScope.Organization
+
+    objects: ClassVar[IncidentTriggerManager] = IncidentTriggerManager()
+
+    incident = FlexibleForeignKey("sentry.Incident", db_index=False)
+    alert_rule_trigger = FlexibleForeignKey("sentry.AlertRuleTrigger")
+    status = models.SmallIntegerField()
+    date_modified = models.DateTimeField(default=timezone.now, null=False)
+    date_added = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_incidenttrigger"
+        unique_together = (("incident", "alert_rule_trigger"),)
+        indexes = (models.Index(fields=("alert_rule_trigger", "incident_id")),)
+
+
+post_save.connect(IncidentManager.clear_active_incident_cache, sender=Incident)
+post_save.connect(IncidentManager.clear_active_incident_project_cache, sender=IncidentProject)
+post_delete.connect(IncidentManager.clear_active_incident_project_cache, sender=IncidentProject)
+
+post_delete.connect(IncidentTriggerManager.clear_incident_cache, sender=Incident)
+post_save.connect(IncidentTriggerManager.clear_incident_trigger_cache, sender=IncidentTrigger)
+post_delete.connect(IncidentTriggerManager.clear_incident_trigger_cache, sender=IncidentTrigger)

--- a/src/sentry/incidents/models/incident.py
+++ b/src/sentry/incidents/models/incident.py
@@ -291,7 +291,7 @@ class IncidentActivity(Model):
 
     incident = FlexibleForeignKey("sentry.Incident")
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", null=True)
-    type: models.Field[int | IncidentActivityType, int] = models.IntegerField()
+    type: models.Field = models.IntegerField()
     value = models.TextField(null=True)
     previous_value = models.TextField(null=True)
     comment = models.TextField(null=True)

--- a/src/sentry/incidents/models/incident.py
+++ b/src/sentry/incidents/models/incident.py
@@ -291,7 +291,7 @@ class IncidentActivity(Model):
 
     incident = FlexibleForeignKey("sentry.Incident")
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", null=True)
-    type: models.Field[int | IncidentActivityType, int] = models.IntegerField()
+    type: models.Field[int | IncidentActivityType, int] = models.IntegerField()  # type: ignore
     value = models.TextField(null=True)
     previous_value = models.TextField(null=True)
     comment = models.TextField(null=True)

--- a/src/sentry/incidents/models/incident.py
+++ b/src/sentry/incidents/models/incident.py
@@ -291,7 +291,7 @@ class IncidentActivity(Model):
 
     incident = FlexibleForeignKey("sentry.Incident")
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", null=True)
-    type: models.Field[int | IncidentActivityType, int] = models.IntegerField()  # type: ignore
+    type: models.Field[int | IncidentActivityType, int] = models.IntegerField()
     value = models.TextField(null=True)
     previous_value = models.TextField(null=True)
     comment = models.TextField(null=True)

--- a/src/sentry/incidents/receivers.py
+++ b/src/sentry/incidents/receivers.py
@@ -3,7 +3,8 @@ from datetime import datetime, timezone
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
-from sentry.incidents.models.alert_rule import AlertRule, IncidentTrigger
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import IncidentTrigger
 from sentry.models.project import Project
 
 

--- a/src/sentry/incidents/receivers.py
+++ b/src/sentry/incidents/receivers.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
-from sentry.incidents.models import AlertRule, IncidentTrigger
+from sentry.incidents.models.alert_rule import AlertRule, IncidentTrigger
 from sentry.models.project import Project
 
 

--- a/src/sentry/incidents/serializers/__init__.py
+++ b/src/sentry/incidents/serializers/__init__.py
@@ -1,4 +1,4 @@
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -26,7 +26,7 @@ from sentry.incidents.logic import (
     translate_aggregate_field,
     update_alert_rule,
 )
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleMonitorType,
     AlertRuleThresholdType,

--- a/src/sentry/incidents/serializers/alert_rule_trigger.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger.py
@@ -10,7 +10,7 @@ from sentry.incidents.logic import (
     rewrite_trigger_action_fields,
     update_alert_rule_trigger,
 )
-from sentry.incidents.models import AlertRuleTrigger, AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTrigger, AlertRuleTriggerAction
 
 from .alert_rule_trigger_action import AlertRuleTriggerActionSerializer
 

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -8,7 +8,7 @@ from sentry.incidents.logic import (
     create_alert_rule_trigger_action,
     update_alert_rule_trigger_action,
 )
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.serializers import (
     ACTION_TARGET_TYPE_TO_STRING,
     STRING_TO_ACTION_TARGET_TYPE,

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -22,11 +22,14 @@ from sentry.incidents.logic import (
     deduplicate_trigger_actions,
     update_incident_status,
 )
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleMonitorType,
     AlertRuleThresholdType,
     AlertRuleTrigger,
+    invoke_alert_subscription_callback,
+)
+from sentry.incidents.models.incident import (
     Incident,
     IncidentActivity,
     IncidentStatus,
@@ -34,7 +37,6 @@ from sentry.incidents.models import (
     IncidentTrigger,
     IncidentType,
     TriggerStatus,
-    invoke_alert_subscription_callback,
 )
 from sentry.incidents.tasks import handle_trigger_action
 from sentry.incidents.utils.types import QuerySubscriptionUpdate

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -7,10 +7,9 @@ from urllib.parse import urlencode
 from django.urls import reverse
 
 from sentry.auth.access import from_user
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import AlertRuleStatus, AlertRuleTriggerAction
+from sentry.incidents.models.incident import (
     INCIDENT_STATUS,
-    AlertRuleStatus,
-    AlertRuleTriggerAction,
     Incident,
     IncidentActivity,
     IncidentActivityType,
@@ -240,7 +239,7 @@ def handle_trigger_action(
 )
 def auto_resolve_snapshot_incidents(alert_rule_id: int, **kwargs: Any) -> None:
     from sentry.incidents.logic import update_incident_status
-    from sentry.incidents.models import AlertRule
+    from sentry.incidents.models.alert_rule import AlertRule
 
     try:
         alert_rule = AlertRule.objects_with_snapshots.get(id=alert_rule_id)

--- a/src/sentry/incidents/utils/sentry_apps.py
+++ b/src/sentry/incidents/utils/sentry_apps.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 
 from sentry.auth.access import NoAccess
 from sentry.incidents.logic import get_filtered_actions
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.serializers import AlertRuleTriggerActionSerializer
 from sentry.services.hybrid_cloud.app import app_service
 

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -4,7 +4,8 @@ import sentry_sdk
 
 from sentry import features
 from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.discord.client import DiscordClient
 from sentry.integrations.discord.message_builder.metric_alerts import (
     DiscordMetricAlertMessageBuilder,

--- a/src/sentry/integrations/discord/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/discord/message_builder/metric_alerts.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import time
 from datetime import datetime
 
-from sentry.incidents.models import AlertRule, Incident, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.discord.message_builder import INCIDENT_COLOR_MAPPING, LEVEL_TO_COLOR
 from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
 from sentry.integrations.discord.message_builder.base.embed.base import DiscordMessageEmbed

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -7,10 +7,9 @@ from django.utils.translation import gettext as _
 
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.logic import get_incident_aggregates
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
+from sentry.incidents.models.incident import (
     INCIDENT_STATUS,
-    AlertRule,
-    AlertRuleThresholdType,
     Incident,
     IncidentStatus,
     IncidentTrigger,

--- a/src/sentry/integrations/msteams/card_builder/incident_attachment.py
+++ b/src/sentry/integrations/msteams/card_builder/incident_attachment.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from sentry.incidents.models import Incident, IncidentStatus
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.integrations.msteams.card_builder.block import (
     AdaptiveCard,

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import enum
 import logging
 
-from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.models.integrations.integration import Integration
 from sentry.services.hybrid_cloud.integration import integration_service
 

--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -4,7 +4,8 @@ import logging
 from typing import Any, cast
 
 from sentry.constants import ObjectStatus
-from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcOrganizationIntegration

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -6,7 +6,8 @@ from typing import Any, TypedDict
 from django.db import router, transaction
 from django.http import Http404
 
-from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.integration import integration_service

--- a/src/sentry/integrations/repository/metric_alert.py
+++ b/src/sentry/integrations/repository/metric_alert.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from logging import Logger, getLogger
 
-from sentry.incidents.models import AlertRuleTriggerAction, Incident
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import Incident
 from sentry.integrations.repository.base import BaseNewNotificationMessage, BaseNotificationMessage
 from sentry.models.notificationmessage import NotificationMessage
 
@@ -22,9 +23,11 @@ class MetricAlertNotificationMessage(BaseNotificationMessage):
             error_code=instance.error_code,
             error_details=instance.error_details,
             message_identifier=instance.message_identifier,
-            parent_notification_message_id=instance.parent_notification_message.id
-            if instance.parent_notification_message
-            else None,
+            parent_notification_message_id=(
+                instance.parent_notification_message.id
+                if instance.parent_notification_message
+                else None
+            ),
             incident=instance.incident,
             trigger_action=instance.trigger_action,
             date_added=instance.date_added,

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sentry.incidents.models import Incident, IncidentStatus
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.integrations.slack.message_builder import (
     INCIDENT_COLOR_MAPPING,

--- a/src/sentry/integrations/slack/message_builder/metric_alerts.py
+++ b/src/sentry/integrations/slack/message_builder/metric_alerts.py
@@ -1,4 +1,5 @@
-from sentry.incidents.models import AlertRule, Incident, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.metric_alerts import metric_alert_attachment_info
 from sentry.integrations.slack.message_builder import (
     INCIDENT_COLOR_MAPPING,

--- a/src/sentry/integrations/slack/unfurl/metric_alerts.py
+++ b/src/sentry/integrations/slack/unfurl/metric_alerts.py
@@ -12,7 +12,8 @@ from django.http.request import HttpRequest, QueryDict
 
 from sentry import features
 from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.models import AlertRule, Incident
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import Incident
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.models.integrations.integration import Integration
 from sentry.models.organization import Organization

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -8,7 +8,8 @@ import sentry_sdk
 from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.incidents.charts import build_metric_alert_chart
-from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.repository import get_default_metric_alert_repository
 from sentry.integrations.repository.metric_alert import (
     MetricAlertNotificationMessageRepository,

--- a/src/sentry/migrations/0651_enable_activated_alert_rules.py
+++ b/src/sentry/migrations/0651_enable_activated_alert_rules.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 
 import sentry.db.models.fields.bounded
 import sentry.db.models.fields.foreignkey
-import sentry.incidents.models
+import sentry.incidents.models.alert_rule
 from sentry.new_migrations.migrations import CheckedMigration
 
 
@@ -45,7 +45,7 @@ class Migration(CheckedMigration):
                     model_name="alertrule",
                     name="monitor_type",
                     field=models.IntegerField(
-                        default=sentry.incidents.models.AlertRuleMonitorType.CONTINUOUS.value
+                        default=sentry.incidents.models.alert_rule.AlertRuleMonitorType.CONTINUOUS.value
                     ),
                 ),
             ],

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -312,8 +312,9 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
     def next_short_id(self, delta: int = 1) -> int:
         from sentry.models.counter import Counter
 
-        with sentry_sdk.start_span(op="project.next_short_id") as span, metrics.timer(
-            "project.next_short_id"
+        with (
+            sentry_sdk.start_span(op="project.next_short_id") as span,
+            metrics.timer("project.next_short_id"),
         ):
             span.set_data("project_id", self.id)
             span.set_data("project_slug", self.slug)
@@ -412,7 +413,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
         return self.slug
 
     def transfer_to(self, organization):
-        from sentry.incidents.models import AlertRule
+        from sentry.incidents.models.alert_rule import AlertRule
         from sentry.models.actor import ACTOR_TYPES
         from sentry.models.environment import Environment, EnvironmentProject
         from sentry.models.integrations.external_issue import ExternalIssue
@@ -547,7 +548,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
             return True
 
     def remove_team(self, team):
-        from sentry.incidents.models import AlertRule
+        from sentry.incidents.models.alert_rule import AlertRule
         from sentry.models.projectteam import ProjectTeam
         from sentry.models.rule import Rule
 

--- a/src/sentry/models/releases/release_project.py
+++ b/src/sentry/models/releases/release_project.py
@@ -49,7 +49,7 @@ class ReleaseProjectModelManager(BaseManager["ReleaseProject"]):
         NOTE: import AlertRule model here to avoid circular dependency
         TODO: move once AlertRule has been split into separate subdirectory files
         """
-        from sentry.incidents.models import AlertRule
+        from sentry.incidents.models.alert_rule import AlertRule
 
         query_extra = f"release:{release.version} AND event.timestamp:>{timezone.now().isoformat()}"
         return AlertRule.objects.conditionally_subscribe_project_to_alert_rules(

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -16,7 +16,7 @@ from django.utils.translation import gettext_lazy as _
 
 from sentry import integrations
 from sentry.eventstore.models import Event, GroupEvent
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.integrations import IntegrationFeatures, IntegrationProvider
 from sentry.issues.grouptype import (
     PerformanceConsecutiveDBQueriesGroupType,
@@ -458,9 +458,9 @@ class PerformanceProblemContext:
             "transaction_name": self.transaction,
             "parent_span": get_span_evidence_value(self.parent_span),
             "repeating_spans": get_span_evidence_value(self.repeating_spans),
-            "num_repeating_spans": str(len(self.problem.offender_span_ids))
-            if self.problem.offender_span_ids
-            else "",
+            "num_repeating_spans": (
+                str(len(self.problem.offender_span_ids)) if self.problem.offender_span_ids else ""
+            ),
         }
 
     @property
@@ -531,9 +531,9 @@ class NPlusOneAPICallProblemContext(PerformanceProblemContext):
             "transaction_name": self.transaction,
             "repeating_spans": self.path_prefix,
             "parameters": self.parameters,
-            "num_repeating_spans": str(len(self.problem.offender_span_ids))
-            if self.problem.offender_span_ids
-            else "",
+            "num_repeating_spans": (
+                str(len(self.problem.offender_span_ids)) if self.problem.offender_span_ids else ""
+            ),
         }
 
     @property

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -14,7 +14,7 @@ from sentry_relay.processing import validate_sampling_condition
 from sentry import features, options
 from sentry.api.endpoints.project_transaction_threshold import DEFAULT_THRESHOLD
 from sentry.api.utils import get_date_range_from_params
-from sentry.incidents.models import AlertRule, AlertRuleStatus
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
 from sentry.models.dashboard_widget import (
     ON_DEMAND_ENABLED_KEY,
     DashboardWidgetQuery,

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -10,7 +10,8 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.app_platform_event import AppPlatformEvent
 from sentry.api.serializers.models.incident import IncidentSerializer
 from sentry.eventstore.models import GroupEvent
-from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.plugins.base import plugins
 from sentry.rules import EventState

--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -10,7 +10,7 @@ from sentry import analytics
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import AppPlatformEvent
 from sentry.constants import SentryAppInstallationStatus
-from sentry.incidents.models import INCIDENT_STATUS, IncidentStatus
+from sentry.incidents.models.incident import INCIDENT_STATUS, IncidentStatus
 from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.msteams import MsTeamsClient
 from sentry.models.integrations import Integration, OrganizationIntegration

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -52,7 +52,7 @@ class SnubaQuery(Model):
 
     @classmethod
     def query_for_relocation_export(cls, q: models.Q, pk_map: PrimaryKeyMap) -> models.Q:
-        from sentry.incidents.models import AlertRule
+        from sentry.incidents.models.alert_rule import AlertRule
         from sentry.models.actor import Actor
         from sentry.models.organization import Organization
         from sentry.models.project import Project

--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 
 from sentry.dynamic_sampling import get_redis_client_for_ds
 from sentry.exceptions import IncompatibleMetricsQuery
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.dashboard_widget import (
     ON_DEMAND_ENABLED_KEY,
     DashboardWidgetQuery,

--- a/src/sentry/tasks/integrations/slack/find_channel_id_for_alert_rule.py
+++ b/src/sentry/tasks/integrations/slack/find_channel_id_for_alert_rule.py
@@ -11,7 +11,7 @@ from sentry.incidents.logic import (
     InvalidTriggerActionError,
     get_slack_channel_ids,
 )
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.serializers import AlertRuleSerializer
 from sentry.integrations.slack.utils import SLACK_RATE_LIMITED_MESSAGE, RedisRuleStatus
 from sentry.models.organization import Organization

--- a/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
+++ b/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any
 
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.integrations.slack.utils import (
     SLACK_RATE_LIMITED_MESSAGE,
     RedisRuleStatus,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -35,10 +35,12 @@ from sentry.incidents.logic import (
     create_alert_rule_trigger_action,
     query_datasets_to_type,
 )
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRuleMonitorType,
     AlertRuleThresholdType,
     AlertRuleTriggerAction,
+)
+from sentry.incidents.models.incident import (
     Incident,
     IncidentActivity,
     IncidentProject,

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -8,7 +8,8 @@ import pytest
 from django.utils.functional import cached_property
 
 from sentry.eventstore.models import Event
-from sentry.incidents.models import AlertRuleMonitorType, IncidentActivityType
+from sentry.incidents.models.alert_rule import AlertRuleMonitorType
+from sentry.incidents.models.incident import IncidentActivityType
 from sentry.models.activity import Activity
 from sentry.models.actor import Actor, get_actor_id_for_user
 from sentry.models.grouprelease import GroupRelease

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -42,8 +42,8 @@ from sentry.backup.scopes import ExportScope
 from sentry.backup.validate import validate
 from sentry.db.models.fields.bounded import BoundedBigAutoField
 from sentry.db.models.paranoia import ParanoidModel
-from sentry.incidents.models import (
-    AlertRuleMonitorType,
+from sentry.incidents.models.alert_rule import AlertRuleMonitorType
+from sentry.incidents.models.incident import (
     IncidentActivity,
     IncidentSnapshot,
     IncidentSubscription,

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -20,7 +20,8 @@ from sentry import buffer, roles, tsdb
 from sentry.constants import ObjectStatus
 from sentry.exceptions import HashDiscarded
 from sentry.incidents.logic import create_alert_rule, create_alert_rule_trigger, create_incident
-from sentry.incidents.models import AlertRuleThresholdType, IncidentType
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
+from sentry.incidents.models.incident import IncidentType
 from sentry.models.activity import Activity
 from sentry.models.broadcast import Broadcast
 from sentry.models.commit import Commit

--- a/src/sentry/web/frontend/debug/debug_incident_activity_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_activity_email.py
@@ -1,7 +1,7 @@
 from django.http import HttpRequest, HttpResponse
 from django.views.generic import View
 
-from sentry.incidents.models import Incident, IncidentActivity, IncidentActivityType
+from sentry.incidents.models.incident import Incident, IncidentActivity, IncidentActivityType
 from sentry.incidents.tasks import generate_incident_activity_email
 from sentry.models.organization import Organization
 from sentry.models.user import User

--- a/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_trigger_email.py
@@ -4,13 +4,8 @@ from uuid import uuid4
 from django.utils import timezone
 
 from sentry.incidents.action_handlers import generate_incident_trigger_email_context
-from sentry.incidents.models import (
-    AlertRule,
-    AlertRuleTrigger,
-    Incident,
-    IncidentStatus,
-    TriggerStatus,
-)
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTrigger
+from sentry.incidents.models.incident import Incident, IncidentStatus, TriggerStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.user import User

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -1,7 +1,7 @@
 from django.utils import timezone as django_timezone
 
 from sentry.incidents.logic import update_incident_status
-from sentry.incidents.models import IncidentStatus, IncidentStatusMethod
+from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import no_silo_test

--- a/tests/acceptance/test_organization_alert_rules.py
+++ b/tests/acceptance/test_organization_alert_rules.py
@@ -1,6 +1,7 @@
 from django.utils import timezone
 
-from sentry.incidents.models import AlertRuleThresholdType, IncidentTrigger, TriggerStatus
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
+from sentry.incidents.models.incident import IncidentTrigger, TriggerStatus
 from sentry.models.rule import Rule
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.silo import no_silo_test

--- a/tests/acceptance/test_project_detail.py
+++ b/tests/acceptance/test_project_detail.py
@@ -1,6 +1,6 @@
 from django.utils import timezone
 
-from sentry.incidents.models import IncidentStatus
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
 

--- a/tests/sentry/api/endpoints/test_team_alerts_triggered.py
+++ b/tests/sentry/api/endpoints/test_team_alerts_triggered.py
@@ -1,8 +1,8 @@
 from datetime import timezone
 
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
+from sentry.incidents.models.incident import (
     INCIDENT_STATUS,
-    AlertRuleThresholdType,
     IncidentActivity,
     IncidentActivityType,
     IncidentStatus,

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -4,7 +4,7 @@ from sentry.api.serializers.models.alert_rule import (
     DetailedAlertRuleSerializer,
 )
 from sentry.incidents.logic import create_alert_rule_trigger
-from sentry.incidents.models import AlertRule, AlertRuleThresholdType
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
 from sentry.models.rule import Rule
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.snuba.models import SnubaQueryEventType

--- a/tests/sentry/api/serializers/test_alert_rule_trigger.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger.py
@@ -1,7 +1,7 @@
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule_trigger import DetailedAlertRuleTriggerSerializer
 from sentry.incidents.logic import create_alert_rule_trigger
-from sentry.incidents.models import AlertRuleThresholdType
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.testutils.cases import TestCase
 
 NOT_SET = object()

--- a/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
@@ -2,7 +2,7 @@ import responses
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING
 from sentry.integrations.discord.utils.channel import ChannelType
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/api/serializers/test_incident_activity.py
+++ b/tests/sentry/api/serializers/test_incident_activity.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_incident_activity
-from sentry.incidents.models import IncidentActivityType
+from sentry.incidents.models.incident import IncidentActivityType
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -31,7 +31,8 @@ from sentry.api.paginator import (
     SequencePaginator,
     reverse_bisect_left,
 )
-from sentry.incidents.models import AlertRule, Incident
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import Incident
 from sentry.models.rule import Rule
 from sentry.models.user import User
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -29,7 +29,7 @@ from sentry.backup.imports import (
     import_in_user_scope,
 )
 from sentry.backup.scopes import ExportScope, ImportScope, RelocationScope
-from sentry.incidents.models import AlertRule, AlertRuleThresholdType
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
 from sentry.models.actor import ACTOR_TYPES, Actor
 from sentry.models.apitoken import DEFAULT_EXPIRATION, ApiToken, generate_token
 from sentry.models.authenticator import Authenticator
@@ -1031,9 +1031,10 @@ class DecryptionTests(ImportTestCase):
             with assume_test_silo_mode(SiloMode.CONTROL):
                 assert User.objects.count() == 0
 
-            with open(tmp_tarball_path, "rb") as tmp_tarball_file, open(
-                tmp_priv_key_path, "rb"
-            ) as tmp_priv_key_file:
+            with (
+                open(tmp_tarball_path, "rb") as tmp_tarball_file,
+                open(tmp_priv_key_path, "rb") as tmp_priv_key_file,
+            ):
                 import_in_user_scope(
                     tmp_tarball_file,
                     decryptor=LocalFileDecryptor(tmp_priv_key_file),
@@ -1048,9 +1049,10 @@ class DecryptionTests(ImportTestCase):
             (tmp_tarball_path, tmp_priv_key_path) = self.encrypt_json_fixture(tmp_dir)
             assert Organization.objects.count() == 0
 
-            with open(tmp_tarball_path, "rb") as tmp_tarball_file, open(
-                tmp_priv_key_path, "rb"
-            ) as tmp_priv_key_file:
+            with (
+                open(tmp_tarball_path, "rb") as tmp_tarball_file,
+                open(tmp_priv_key_path, "rb") as tmp_priv_key_file,
+            ):
                 import_in_organization_scope(
                     tmp_tarball_file,
                     decryptor=LocalFileDecryptor(tmp_priv_key_file),
@@ -1065,9 +1067,10 @@ class DecryptionTests(ImportTestCase):
             with assume_test_silo_mode(SiloMode.CONTROL):
                 assert UserRole.objects.count() == 0
 
-            with open(tmp_tarball_path, "rb") as tmp_tarball_file, open(
-                tmp_priv_key_path, "rb"
-            ) as tmp_priv_key_file:
+            with (
+                open(tmp_tarball_path, "rb") as tmp_tarball_file,
+                open(tmp_priv_key_path, "rb") as tmp_priv_key_file,
+            ):
                 import_in_config_scope(
                     tmp_tarball_file,
                     decryptor=LocalFileDecryptor(tmp_priv_key_file),
@@ -1086,9 +1089,10 @@ class DecryptionTests(ImportTestCase):
                 assert User.objects.count() == 0
                 assert UserRole.objects.count() == 0
 
-            with open(tmp_tarball_path, "rb") as tmp_tarball_file, open(
-                tmp_priv_key_path, "rb"
-            ) as tmp_priv_key_file:
+            with (
+                open(tmp_tarball_path, "rb") as tmp_tarball_file,
+                open(tmp_priv_key_path, "rb") as tmp_priv_key_file,
+            ):
                 import_in_global_scope(
                     tmp_tarball_file,
                     decryptor=LocalFileDecryptor(tmp_priv_key_file),

--- a/tests/sentry/deletions/test_alert_rule.py
+++ b/tests/sentry/deletions/test_alert_rule.py
@@ -1,4 +1,4 @@
-from sentry.incidents.models import AlertRule, AlertRuleTrigger
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTrigger
 from sentry.models.organization import Organization
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/deletions/test_alert_rule_trigger.py
+++ b/tests/sentry/deletions/test_alert_rule_trigger.py
@@ -1,4 +1,4 @@
-from sentry.incidents.models import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin

--- a/tests/sentry/deletions/test_alert_rule_trigger_action.py
+++ b/tests/sentry/deletions/test_alert_rule_trigger_action.py
@@ -1,4 +1,4 @@
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.models.notificationmessage import NotificationMessage
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
-from sentry.incidents.models import AlertRule, AlertRuleStatus
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
 from sentry.models.actor import ActorTuple
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor

--- a/tests/sentry/deletions/test_project.py
+++ b/tests/sentry/deletions/test_project.py
@@ -1,5 +1,6 @@
 from sentry import eventstore
-from sentry.incidents.models import AlertRule, Incident
+from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.incident import Incident
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.debugfile import ProjectDebugFile

--- a/tests/sentry/incidents/action_handlers/__init__.py
+++ b/tests/sentry/incidents/action_handlers/__init__.py
@@ -1,7 +1,7 @@
 import abc
 
 from sentry.incidents.logic import update_incident_status
-from sentry.incidents.models import Incident, IncidentStatus, IncidentStatusMethod
+from sentry.incidents.models.incident import Incident, IncidentStatus, IncidentStatusMethod
 from sentry.testutils.cases import TestCase
 
 

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -14,13 +14,8 @@ from sentry.incidents.action_handlers import (
 )
 from sentry.incidents.charts import fetch_metric_alert_events_timeseries
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL
-from sentry.incidents.models import (
-    INCIDENT_STATUS,
-    AlertRuleThresholdType,
-    AlertRuleTriggerAction,
-    IncidentStatus,
-    TriggerStatus,
-)
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType, AlertRuleTriggerAction
+from sentry.incidents.models.incident import INCIDENT_STATUS, IncidentStatus, TriggerStatus
 from sentry.models.notificationsettingoption import NotificationSettingOption
 from sentry.models.options.user_option import UserOption
 from sentry.models.useremail import UserEmail

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 import responses
 
 from sentry.incidents.action_handlers import MsTeamsActionHandler
-from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.silo import SiloMode
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -4,7 +4,8 @@ import responses
 
 from sentry.incidents.action_handlers import OpsgenieActionHandler
 from sentry.incidents.logic import update_incident_status
-from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus, IncidentStatusMethod
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.models.integrations import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.testutils.helpers.datetime import freeze_time

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -7,7 +7,8 @@ from django.http import Http404
 
 from sentry.incidents.action_handlers import PagerDutyActionHandler
 from sentry.incidents.logic import update_incident_status
-from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus, IncidentStatusMethod
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.silo import SiloMode
 from sentry.testutils.helpers.datetime import freeze_time

--- a/tests/sentry/incidents/action_handlers/test_sentry_app.py
+++ b/tests/sentry/incidents/action_handlers/test_sentry_app.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 import responses
 
 from sentry.incidents.action_handlers import SentryAppActionHandler
-from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -5,7 +5,8 @@ import responses
 
 from sentry.constants import ObjectStatus
 from sentry.incidents.action_handlers import SlackActionHandler
-from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -5,7 +5,7 @@ from sentry.constants import ObjectStatus, SentryAppStatus
 from sentry.incidents.endpoints.organization_alert_rule_available_action_index import (
     build_action_response,
 )
-from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.integrations import SentryAppComponent, SentryAppInstallation
 from sentry.models.integrations.organization_integration import OrganizationIntegration

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -15,14 +15,13 @@ from sentry import audit_log
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.auth.access import OrganizationGlobalAccess
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleStatus,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
-    Incident,
-    IncidentStatus,
 )
+from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.serializers import AlertRuleSerializer
 from sentry.integrations.slack.client import SlackClient
 from sentry.models.auditlogentry import AuditLogEntry

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -10,7 +10,7 @@ from rest_framework import status
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleThresholdType,
     AlertRuleTrigger,
@@ -122,8 +122,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
         self.login_as(self.user)
 
     def test_simple(self):
-        with outbox_runner(), self.feature(
-            ["organizations:incidents", "organizations:performance-view"]
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
         ):
             resp = self.get_success_response(
                 self.organization.slug,
@@ -157,12 +158,15 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
             assert "projects" in response_data
 
     def test_status_filter(self):
-        with outbox_runner(), self.feature(
-            [
-                "organizations:incidents",
-                "organizations:performance-view",
-                "organizations:metric-alert-ignore-archived",
-            ]
+        with (
+            outbox_runner(),
+            self.feature(
+                [
+                    "organizations:incidents",
+                    "organizations:performance-view",
+                    "organizations:metric-alert-ignore-archived",
+                ]
+            ),
         ):
             data = deepcopy(self.alert_rule_dict)
             data["query"] = "is:unresolved"
@@ -536,8 +540,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
         assert resp.status_code == 404
 
     def test_no_perms(self):
-        with assume_test_silo_mode(SiloMode.REGION), outbox_context(
-            transaction.atomic(using=router.db_for_write(OrganizationMember))
+        with (
+            assume_test_silo_mode(SiloMode.REGION),
+            outbox_context(transaction.atomic(using=router.db_for_write(OrganizationMember))),
         ):
             OrganizationMember.objects.filter(user_id=self.user.id).update(role="member")
         with self.feature("organizations:incidents"):
@@ -879,8 +884,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
         char_256_name = "wOOFmsWY80o0RPrlsrrqDp2Ylpr5K2unBWbsrqvuNb4Fy3vzawkNAyFJdqeFLlXNWF2kMfgMT9EQmFF3u3MqW3CTI7L2SLsmS9uSDQtcinjlZrr8BT4v8Q6ySrVY5HmiFO97w3awe4lA8uyVikeaSwPjt8MD5WSjdTI0RRXYeK3qnHTpVswBe9AIcQVMLKQXHgjulpsrxHc0DI0Vb8hKA4BhmzQXhYmAvKK26ZwCSjJurAODJB6mgIdlV7tigsFO"
         alert_rule_dict = self.alert_rule_dict
         alert_rule_dict["name"] = char_256_name
-        with outbox_runner(), self.feature(
-            ["organizations:incidents", "organizations:performance-view"]
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
         ):
             resp = self.get_success_response(
                 self.organization.slug,
@@ -894,8 +900,9 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
         char_257_name = "wOOFmsWY80o0RPrlsrrqDp2Ylpr5K2unBWbsrqvuNb4Fy3vzawkNAyFJdqeFLlXNWF2kMfgMT9EQmFF3u3MqW3CTI7L2SLsmS9uSDQtcinjlZrr8BT4v8Q6ySrVY5HmiFO97w3awe4lA8uyVikeaSwPjt8MD5WSjdTI0RRXYeK3qnHTpVswBe9AIcQVMLKQXHgjulpsrxHc0DI0Vb8hKA4BhmzQXhYmAvKK26ZwCSjJurAODJB6mgIdlV7tigsFOK"
         alert_rule_dict = self.alert_rule_dict
         alert_rule_dict["name"] = char_257_name
-        with outbox_runner(), self.feature(
-            ["organizations:incidents", "organizations:performance-view"]
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
         ):
             resp = self.get_error_response(
                 self.organization.slug, status_code=400, **alert_rule_dict

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -3,7 +3,8 @@ from datetime import UTC, datetime, timezone
 import requests
 
 from sentry.constants import ObjectStatus
-from sentry.incidents.models import AlertRuleThresholdType, IncidentTrigger, TriggerStatus
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
+from sentry.incidents.models.incident import IncidentTrigger, TriggerStatus
 from sentry.models.rule import Rule, RuleSource
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.snuba.dataset import Dataset

--- a/tests/sentry/incidents/endpoints/test_organization_incident_activity_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_activity_index.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_incident_activity
-from sentry.incidents.models import IncidentActivityType
+from sentry.incidents.models.incident import IncidentActivityType
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
@@ -1,6 +1,6 @@
 from functools import cached_property
 
-from sentry.incidents.models import IncidentActivity, IncidentActivityType
+from sentry.incidents.models.incident import IncidentActivity, IncidentActivityType
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_index.py
@@ -1,7 +1,11 @@
 from functools import cached_property
 
 from sentry.api.serializers import serialize
-from sentry.incidents.models import IncidentActivity, IncidentActivityType, IncidentSubscription
+from sentry.incidents.models.incident import (
+    IncidentActivity,
+    IncidentActivityType,
+    IncidentSubscription,
+)
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 from sentry.api.serializers import serialize
-from sentry.incidents.models import Incident, IncidentActivity, IncidentStatus
+from sentry.incidents.models.incident import Incident, IncidentActivity, IncidentStatus
 from sentry.silo import SiloMode
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import APITestCase

--- a/tests/sentry/incidents/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_index.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import update_incident_status
-from sentry.incidents.models import IncidentStatus
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import APITestCase
 

--- a/tests/sentry/incidents/endpoints/test_organization_incident_seen.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_seen.py
@@ -2,7 +2,7 @@ from functools import cached_property
 
 from django.urls import reverse
 
-from sentry.incidents.models import IncidentSeen
+from sentry.incidents.models.incident import IncidentSeen
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 

--- a/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 from sentry.incidents.logic import subscribe_to_incident
-from sentry.incidents.models import IncidentSubscription
+from sentry.incidents.models.incident import IncidentSubscription
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sentry import audit_log
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo import SiloMode
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -96,8 +96,9 @@ class AlertRuleCreateEndpointTest(APITestCase):
         self.login_as(self.user)
 
     def test_simple(self):
-        with outbox_runner(), self.feature(
-            ["organizations:incidents", "organizations:performance-view"]
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
         ):
             resp = self.get_success_response(
                 self.organization.slug,
@@ -120,12 +121,15 @@ class AlertRuleCreateEndpointTest(APITestCase):
         )
 
     def test_status_filter(self):
-        with outbox_runner(), self.feature(
-            [
-                "organizations:incidents",
-                "organizations:performance-view",
-                "organizations:metric-alert-ignore-archived",
-            ]
+        with (
+            outbox_runner(),
+            self.feature(
+                [
+                    "organizations:incidents",
+                    "organizations:performance-view",
+                    "organizations:metric-alert-ignore-archived",
+                ]
+            ),
         ):
             data = deepcopy(self.valid_alert_rule)
             data["query"] = "is:unresolved"
@@ -144,8 +148,9 @@ class AlertRuleCreateEndpointTest(APITestCase):
         """Test that if you don't provide the project data in the request, we grab it from the URL"""
         data = deepcopy(self.valid_alert_rule)
         del data["projects"]
-        with outbox_runner(), self.feature(
-            ["organizations:incidents", "organizations:performance-view"]
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
         ):
             resp = self.get_success_response(
                 self.organization.slug,

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -17,7 +17,11 @@ from sentry.incidents.logic import (
     ChannelLookupTimeoutError,
     create_alert_rule_trigger,
 )
-from sentry.incidents.models import AlertRule, AlertRuleThresholdType, AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import (
+    AlertRule,
+    AlertRuleThresholdType,
+    AlertRuleTriggerAction,
+)
 from sentry.incidents.serializers import (
     ACTION_TARGET_TYPE_TO_STRING,
     QUERY_TYPE_VALID_DATASETS,

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -146,7 +146,7 @@ class IncidentAlertRuleRelationTest(TestCase):
 
 
 class AlertRuleTest(TestCase):
-    @patch("sentry.incidents.models.alert_rules.bulk_create_snuba_subscriptions")
+    @patch("sentry.incidents.models.alert_rule.bulk_create_snuba_subscriptions")
     def test_subscribes_projects_to_alert_rule(self, mock_bulk_create_snuba_subscriptions):
         # eg. creates QuerySubscription's/SnubaQuery's for AlertRule + Project
         alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.ACTIVATED)
@@ -291,7 +291,7 @@ class AlertRuleTriggerActionResolveTest(AlertRuleTriggerActionActivateBaseTest, 
 class AlertRuleTriggerActionActivateTest(TestCase):
     @pytest.fixture(autouse=True)
     def _setup_metric_patch(self):
-        with mock.patch("sentry.incidents.models.alert_rules.metrics") as self.metrics:
+        with mock.patch("sentry.incidents.models.alert_rule.metrics") as self.metrics:
             yield
 
     def setUp(self):

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -5,10 +5,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.core.cache import cache
-from django.db import router, transaction
 from django.utils import timezone
 
-from sentry.db.models.manager import BaseManager
 from sentry.incidents.logic import delete_alert_rule, update_alert_rule
 from sentry.incidents.models.alert_rule import (
     AlertRule,
@@ -22,59 +20,12 @@ from sentry.incidents.models.alert_rule import (
     clean_expired_alerts,
     register_alert_subscription_callback,
 )
-from sentry.incidents.models.incident import (
-    Incident,
-    IncidentStatus,
-    IncidentTrigger,
-    IncidentType,
-    TriggerStatus,
-)
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.snuba.models import QuerySubscription
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
-
-
-@region_silo_test
-class FetchForOrganizationTest(TestCase):
-    def test_empty(self):
-        incidents = Incident.objects.fetch_for_organization(self.organization, [self.project])
-        assert [] == list(incidents)
-        self.create_project()
-
-    def test_simple(self):
-        incident = self.create_incident()
-
-        assert [incident] == list(
-            Incident.objects.fetch_for_organization(self.organization, [self.project])
-        )
-
-    def test_invalid_project(self):
-        project = self.create_project()
-        incident = self.create_incident(projects=[project])
-
-        assert [] == list(
-            Incident.objects.fetch_for_organization(self.organization, [self.project])
-        )
-        assert [incident] == list(
-            Incident.objects.fetch_for_organization(self.organization, [project])
-        )
-
-    def test_multi_project(self):
-        project = self.create_project()
-        incident = self.create_incident(projects=[project, self.project])
-
-        assert [incident] == list(
-            Incident.objects.fetch_for_organization(self.organization, [self.project])
-        )
-        assert [incident] == list(
-            Incident.objects.fetch_for_organization(self.organization, [project])
-        )
-        assert [incident] == list(
-            Incident.objects.fetch_for_organization(self.organization, [self.project, project])
-        )
 
 
 class IncidentGetForSubscriptionTest(TestCase):
@@ -176,200 +127,6 @@ class AlertRuleTriggerClearCacheTest(TestCase):
         ) is None
 
 
-class ActiveIncidentClearCacheTest(TestCase):
-    def setUp(self):
-        self.alert_rule = self.create_alert_rule()
-        self.trigger = self.create_alert_rule_trigger(self.alert_rule)
-
-    def test_negative_cache(self):
-        assert (
-            cache.get(
-                Incident.objects._build_active_incident_cache_key(
-                    self.alert_rule.id, self.project.id
-                )
-            )
-            is None
-        )
-        Incident.objects.get_active_incident(self.alert_rule, self.project)
-        assert (
-            cache.get(
-                Incident.objects._build_active_incident_cache_key(
-                    self.alert_rule.id, self.project.id
-                )
-            )
-            is False
-        )
-        self.create_incident(status=IncidentStatus.CLOSED.value)
-        self.alert_rule.save()
-        assert (
-            cache.get(
-                Incident.objects._build_active_incident_cache_key(
-                    self.alert_rule.id, self.project.id
-                )
-            )
-        ) is False
-
-    def test_cache(self):
-        assert (
-            cache.get(
-                Incident.objects._build_active_incident_cache_key(
-                    self.alert_rule.id, self.project.id
-                )
-            )
-            is None
-        )
-        active_incident = self.create_incident(alert_rule=self.alert_rule, projects=[self.project])
-        Incident.objects.get_active_incident(self.alert_rule, self.project)
-        assert (
-            cache.get(
-                Incident.objects._build_active_incident_cache_key(
-                    self.alert_rule.id, self.project.id
-                )
-            )
-            == active_incident
-        )
-        active_incident = self.create_incident(alert_rule=self.alert_rule, projects=[self.project])
-        assert (
-            cache.get(
-                Incident.objects._build_active_incident_cache_key(
-                    self.alert_rule.id, self.project.id
-                )
-            )
-            is None
-        )
-        Incident.objects.get_active_incident(self.alert_rule, self.project)
-        assert (
-            cache.get(
-                Incident.objects._build_active_incident_cache_key(
-                    self.alert_rule.id, self.project.id
-                )
-            )
-            == active_incident
-        )
-
-
-class IncidentTriggerClearCacheTest(TestCase):
-    def setUp(self):
-        self.alert_rule = self.create_alert_rule()
-        self.trigger = self.create_alert_rule_trigger(self.alert_rule)
-        self.incident = self.create_incident(alert_rule=self.alert_rule, projects=[self.project])
-
-    def test_deleted_incident(self):
-        incident_trigger = IncidentTrigger.objects.create(
-            incident=self.incident,
-            alert_rule_trigger=self.trigger,
-            status=TriggerStatus.ACTIVE.value,
-        )
-        IncidentTrigger.objects.get_for_incident(self.incident)
-        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) == [
-            incident_trigger
-        ]
-        self.incident.delete()
-        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) is None
-
-    def test_updated_incident_trigger(self):
-        IncidentTrigger.objects.get_for_incident(self.incident)
-        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) == []
-        incident_trigger = IncidentTrigger.objects.create(
-            incident=self.incident,
-            alert_rule_trigger=self.trigger,
-            status=TriggerStatus.ACTIVE.value,
-        )
-        IncidentTrigger.objects.get_for_incident(self.incident)
-        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) == [
-            incident_trigger
-        ]
-
-    def test_deleted_incident_trigger(self):
-        incident_trigger = IncidentTrigger.objects.create(
-            incident=self.incident,
-            alert_rule_trigger=self.trigger,
-            status=TriggerStatus.ACTIVE.value,
-        )
-        IncidentTrigger.objects.get_for_incident(self.incident)
-        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) == [
-            incident_trigger
-        ]
-        self.trigger.delete()
-        assert (cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id))) is None
-
-
-class IncidentCreationTest(TestCase):
-    def test_simple(self):
-        title = "hello"
-        alert_rule = self.create_alert_rule()
-        incident = Incident.objects.create(
-            self.organization,
-            title=title,
-            type=IncidentType.ALERT_TRIGGERED.value,
-            alert_rule=alert_rule,
-        )
-        assert incident.identifier == 1
-        assert incident.title == title
-
-        # Check identifier correctly increments
-        incident = Incident.objects.create(
-            self.organization,
-            title=title,
-            type=IncidentType.ALERT_TRIGGERED.value,
-            alert_rule=alert_rule,
-        )
-        assert incident.identifier == 2
-
-    def test_identifier_conflict(self):
-        create_method = BaseManager.create
-        call_count = [0]
-        alert_rule = self.create_alert_rule()
-
-        def mock_base_create(*args, **kwargs):
-            if not call_count[0]:
-                call_count[0] += 1
-                # This incident will take the identifier we already fetched and
-                # use it, which will cause the database to throw an integrity
-                # error.
-                with transaction.atomic(router.db_for_write(Incident)):
-                    incident = Incident.objects.create(
-                        self.organization,
-                        status=IncidentStatus.OPEN.value,
-                        title="Conflicting Incident",
-                        type=IncidentType.ALERT_TRIGGERED.value,
-                        alert_rule=alert_rule,
-                    )
-                assert incident.identifier == kwargs["identifier"]
-                create_method(*args, **kwargs)
-                self.fail("Expected an integrity error")
-            else:
-                call_count[0] += 1
-
-            return create_method(*args, **kwargs)
-
-        self.organization
-        with patch.object(BaseManager, "create", new=mock_base_create):
-            incident = Incident.objects.create(
-                self.organization,
-                alert_rule=alert_rule,
-                status=IncidentStatus.OPEN.value,
-                title="hi",
-                type=IncidentType.ALERT_TRIGGERED.value,
-            )
-            # We should have 3 calls - one for initial create, one for conflict,
-            # then the final one for the retry we get due to the conflict
-            assert call_count[0] == 3
-            # Ideally this would be 2, but because we create the conflicting
-            # row inside of a transaction it ends up rolled back. We just want
-            # to verify that it was created successfully.
-            assert incident.identifier == 1
-
-
-@freeze_time()
-class IncidentDurationTest(unittest.TestCase):
-    def test(self):
-        incident = Incident(date_started=timezone.now() - timedelta(minutes=5))
-        assert incident.duration == timedelta(minutes=5)
-        incident.date_closed = incident.date_started + timedelta(minutes=2)
-        assert incident.duration == timedelta(minutes=2)
-
-
 class IncidentAlertRuleRelationTest(TestCase):
     def test(self):
         self.alert_rule = self.create_alert_rule()
@@ -386,15 +143,6 @@ class IncidentAlertRuleRelationTest(TestCase):
         all_alert_rules = list(AlertRule.objects.all())
         assert self.alert_rule not in all_alert_rules
         assert self.incident.alert_rule.id == self.alert_rule.id
-
-
-@freeze_time()
-class IncidentCurrentEndDateTest(unittest.TestCase):
-    def test(self):
-        incident = Incident()
-        assert incident.current_end_date == timezone.now()
-        incident.date_closed = timezone.now() - timedelta(minutes=10)
-        assert incident.current_end_date == timezone.now() - timedelta(minutes=10)
 
 
 class AlertRuleTest(TestCase):

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -146,7 +146,7 @@ class IncidentAlertRuleRelationTest(TestCase):
 
 
 class AlertRuleTest(TestCase):
-    @patch("sentry.incidents.models.bulk_create_snuba_subscriptions")
+    @patch("sentry.incidents.models.alert_rules.bulk_create_snuba_subscriptions")
     def test_subscribes_projects_to_alert_rule(self, mock_bulk_create_snuba_subscriptions):
         # eg. creates QuerySubscription's/SnubaQuery's for AlertRule + Project
         alert_rule = self.create_alert_rule(monitor_type=AlertRuleMonitorType.ACTIVATED)
@@ -291,7 +291,7 @@ class AlertRuleTriggerActionResolveTest(AlertRuleTriggerActionActivateBaseTest, 
 class AlertRuleTriggerActionActivateTest(TestCase):
     @pytest.fixture(autouse=True)
     def _setup_metric_patch(self):
-        with mock.patch("sentry.incidents.models.metrics") as self.metrics:
+        with mock.patch("sentry.incidents.models.alert_rules.metrics") as self.metrics:
             yield
 
     def setUp(self):

--- a/tests/sentry/incidents/models/test_incidents.py
+++ b/tests/sentry/incidents/models/test_incidents.py
@@ -1,0 +1,262 @@
+import unittest
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.db import router, transaction
+from django.utils import timezone
+
+from sentry.db.models.manager import BaseManager
+from sentry.incidents.models.incident import (
+    Incident,
+    IncidentStatus,
+    IncidentTrigger,
+    IncidentType,
+    TriggerStatus,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class FetchForOrganizationTest(TestCase):
+    def test_empty(self):
+        incidents = Incident.objects.fetch_for_organization(self.organization, [self.project])
+        assert [] == list(incidents)
+        self.create_project()
+
+    def test_simple(self):
+        incident = self.create_incident()
+
+        assert [incident] == list(
+            Incident.objects.fetch_for_organization(self.organization, [self.project])
+        )
+
+    def test_invalid_project(self):
+        project = self.create_project()
+        incident = self.create_incident(projects=[project])
+
+        assert [] == list(
+            Incident.objects.fetch_for_organization(self.organization, [self.project])
+        )
+        assert [incident] == list(
+            Incident.objects.fetch_for_organization(self.organization, [project])
+        )
+
+    def test_multi_project(self):
+        project = self.create_project()
+        incident = self.create_incident(projects=[project, self.project])
+
+        assert [incident] == list(
+            Incident.objects.fetch_for_organization(self.organization, [self.project])
+        )
+        assert [incident] == list(
+            Incident.objects.fetch_for_organization(self.organization, [project])
+        )
+        assert [incident] == list(
+            Incident.objects.fetch_for_organization(self.organization, [self.project, project])
+        )
+
+
+class ActiveIncidentClearCacheTest(TestCase):
+    def setUp(self):
+        self.alert_rule = self.create_alert_rule()
+        self.trigger = self.create_alert_rule_trigger(self.alert_rule)
+
+    def test_negative_cache(self):
+        assert (
+            cache.get(
+                Incident.objects._build_active_incident_cache_key(
+                    self.alert_rule.id, self.project.id
+                )
+            )
+            is None
+        )
+        Incident.objects.get_active_incident(self.alert_rule, self.project)
+        assert (
+            cache.get(
+                Incident.objects._build_active_incident_cache_key(
+                    self.alert_rule.id, self.project.id
+                )
+            )
+            is False
+        )
+        self.create_incident(status=IncidentStatus.CLOSED.value)
+        self.alert_rule.save()
+        assert (
+            cache.get(
+                Incident.objects._build_active_incident_cache_key(
+                    self.alert_rule.id, self.project.id
+                )
+            )
+        ) is False
+
+    def test_cache(self):
+        assert (
+            cache.get(
+                Incident.objects._build_active_incident_cache_key(
+                    self.alert_rule.id, self.project.id
+                )
+            )
+            is None
+        )
+        active_incident = self.create_incident(alert_rule=self.alert_rule, projects=[self.project])
+        Incident.objects.get_active_incident(self.alert_rule, self.project)
+        assert (
+            cache.get(
+                Incident.objects._build_active_incident_cache_key(
+                    self.alert_rule.id, self.project.id
+                )
+            )
+            == active_incident
+        )
+        active_incident = self.create_incident(alert_rule=self.alert_rule, projects=[self.project])
+        assert (
+            cache.get(
+                Incident.objects._build_active_incident_cache_key(
+                    self.alert_rule.id, self.project.id
+                )
+            )
+            is None
+        )
+        Incident.objects.get_active_incident(self.alert_rule, self.project)
+        assert (
+            cache.get(
+                Incident.objects._build_active_incident_cache_key(
+                    self.alert_rule.id, self.project.id
+                )
+            )
+            == active_incident
+        )
+
+
+class IncidentTriggerClearCacheTest(TestCase):
+    def setUp(self):
+        self.alert_rule = self.create_alert_rule()
+        self.trigger = self.create_alert_rule_trigger(self.alert_rule)
+        self.incident = self.create_incident(alert_rule=self.alert_rule, projects=[self.project])
+
+    def test_deleted_incident(self):
+        incident_trigger = IncidentTrigger.objects.create(
+            incident=self.incident,
+            alert_rule_trigger=self.trigger,
+            status=TriggerStatus.ACTIVE.value,
+        )
+        IncidentTrigger.objects.get_for_incident(self.incident)
+        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) == [
+            incident_trigger
+        ]
+        self.incident.delete()
+        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) is None
+
+    def test_updated_incident_trigger(self):
+        IncidentTrigger.objects.get_for_incident(self.incident)
+        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) == []
+        incident_trigger = IncidentTrigger.objects.create(
+            incident=self.incident,
+            alert_rule_trigger=self.trigger,
+            status=TriggerStatus.ACTIVE.value,
+        )
+        IncidentTrigger.objects.get_for_incident(self.incident)
+        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) == [
+            incident_trigger
+        ]
+
+    def test_deleted_incident_trigger(self):
+        incident_trigger = IncidentTrigger.objects.create(
+            incident=self.incident,
+            alert_rule_trigger=self.trigger,
+            status=TriggerStatus.ACTIVE.value,
+        )
+        IncidentTrigger.objects.get_for_incident(self.incident)
+        assert cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id)) == [
+            incident_trigger
+        ]
+        self.trigger.delete()
+        assert (cache.get(IncidentTrigger.objects._build_cache_key(self.incident.id))) is None
+
+
+class IncidentCreationTest(TestCase):
+    def test_simple(self):
+        title = "hello"
+        alert_rule = self.create_alert_rule()
+        incident = Incident.objects.create(
+            self.organization,
+            title=title,
+            type=IncidentType.ALERT_TRIGGERED.value,
+            alert_rule=alert_rule,
+        )
+        assert incident.identifier == 1
+        assert incident.title == title
+
+        # Check identifier correctly increments
+        incident = Incident.objects.create(
+            self.organization,
+            title=title,
+            type=IncidentType.ALERT_TRIGGERED.value,
+            alert_rule=alert_rule,
+        )
+        assert incident.identifier == 2
+
+    def test_identifier_conflict(self):
+        create_method = BaseManager.create
+        call_count = [0]
+        alert_rule = self.create_alert_rule()
+
+        def mock_base_create(*args, **kwargs):
+            if not call_count[0]:
+                call_count[0] += 1
+                # This incident will take the identifier we already fetched and
+                # use it, which will cause the database to throw an integrity
+                # error.
+                with transaction.atomic(router.db_for_write(Incident)):
+                    incident = Incident.objects.create(
+                        self.organization,
+                        status=IncidentStatus.OPEN.value,
+                        title="Conflicting Incident",
+                        type=IncidentType.ALERT_TRIGGERED.value,
+                        alert_rule=alert_rule,
+                    )
+                assert incident.identifier == kwargs["identifier"]
+                create_method(*args, **kwargs)
+                self.fail("Expected an integrity error")
+            else:
+                call_count[0] += 1
+
+            return create_method(*args, **kwargs)
+
+        self.organization
+        with patch.object(BaseManager, "create", new=mock_base_create):
+            incident = Incident.objects.create(
+                self.organization,
+                alert_rule=alert_rule,
+                status=IncidentStatus.OPEN.value,
+                title="hi",
+                type=IncidentType.ALERT_TRIGGERED.value,
+            )
+            # We should have 3 calls - one for initial create, one for conflict,
+            # then the final one for the retry we get due to the conflict
+            assert call_count[0] == 3
+            # Ideally this would be 2, but because we create the conflicting
+            # row inside of a transaction it ends up rolled back. We just want
+            # to verify that it was created successfully.
+            assert incident.identifier == 1
+
+
+@freeze_time()
+class IncidentDurationTest(unittest.TestCase):
+    def test(self):
+        incident = Incident(date_started=timezone.now() - timedelta(minutes=5))
+        assert incident.duration == timedelta(minutes=5)
+        incident.date_closed = incident.date_started + timedelta(minutes=2)
+        assert incident.duration == timedelta(minutes=2)
+
+
+@freeze_time()
+class IncidentCurrentEndDateTest(unittest.TestCase):
+    def test(self):
+        incident = Incident()
+        assert incident.current_end_date == timezone.now()
+        incident.date_closed = timezone.now() - timedelta(minutes=10)
+        assert incident.current_end_date == timezone.now() - timedelta(minutes=10)

--- a/tests/sentry/incidents/test_charts.py
+++ b/tests/sentry/incidents/test_charts.py
@@ -3,7 +3,7 @@ import datetime
 from django.utils.dateparse import parse_datetime
 
 from sentry.incidents.charts import incident_date_range
-from sentry.incidents.models import Incident
+from sentry.incidents.models.incident import Incident
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -50,7 +50,7 @@ from sentry.incidents.logic import (
     update_alert_rule_trigger_action,
     update_incident_status,
 )
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleMonitorType,
     AlertRuleStatus,
@@ -58,6 +58,8 @@ from sentry.incidents.models import (
     AlertRuleTrigger,
     AlertRuleTriggerAction,
     AlertRuleTriggerExclusion,
+)
+from sentry.incidents.models.incident import (
     Incident,
     IncidentActivity,
     IncidentActivityType,

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 
 from sentry.db.models.manager import BaseManager
 from sentry.incidents.logic import delete_alert_rule, update_alert_rule
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleActivity,
     AlertRuleActivityType,
@@ -18,14 +18,16 @@ from sentry.incidents.models import (
     AlertRuleStatus,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
+    alert_subscription_callback_registry,
+    clean_expired_alerts,
+    register_alert_subscription_callback,
+)
+from sentry.incidents.models.incident import (
     Incident,
     IncidentStatus,
     IncidentTrigger,
     IncidentType,
     TriggerStatus,
-    alert_subscription_callback_registry,
-    clean_expired_alerts,
-    register_alert_subscription_callback,
 )
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.services.hybrid_cloud.user.service import user_service

--- a/tests/sentry/incidents/test_receivers.py
+++ b/tests/sentry/incidents/test_receivers.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
-from sentry.incidents.models import (
-    AlertRuleTrigger,
+from sentry.incidents.models.alert_rule import AlertRuleTrigger
+from sentry.incidents.models.incident import (
     Incident,
     IncidentStatus,
     IncidentTrigger,

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -16,19 +16,21 @@ from sentry.incidents.logic import (
     create_alert_rule_trigger_action,
     update_alert_rule,
 )
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleMonitorType,
     AlertRuleThresholdType,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
+    alert_subscription_callback_registry,
+)
+from sentry.incidents.models.incident import (
     Incident,
     IncidentActivity,
     IncidentStatus,
     IncidentTrigger,
     IncidentType,
     TriggerStatus,
-    alert_subscription_callback_registry,
 )
 from sentry.incidents.subscription_processor import (
     SubscriptionProcessor,
@@ -280,9 +282,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             subscription = self.sub
         processor = SubscriptionProcessor(subscription)
         message = self.build_subscription_update(subscription, value=value, time_delta=time_delta)
-        with self.feature(
-            ["organizations:incidents", "organizations:performance-view"]
-        ), self.capture_on_commit_callbacks(execute=True):
+        with (
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.capture_on_commit_callbacks(execute=True),
+        ):
             processor.process_update(message)
         return processor
 
@@ -2272,9 +2275,10 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
             timestamp = django_timezone.now()
         timestamp = timestamp.replace(tzinfo=timezone.utc, microsecond=0)
 
-        with self.feature(
-            ["organizations:incidents", "organizations:performance-view"]
-        ), self.capture_on_commit_callbacks(execute=True):
+        with (
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.capture_on_commit_callbacks(execute=True),
+        ):
             if value is None:
                 numerator, denominator = 0, 0
             else:
@@ -2286,9 +2290,9 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
             processor.process_update(
                 {
                     "entity": "entity",
-                    "subscription_id": subscription.subscription_id
-                    if subscription
-                    else uuid4().hex,
+                    "subscription_id": (
+                        subscription.subscription_id if subscription else uuid4().hex
+                    ),
                     "values": {
                         "data": [
                             {
@@ -2781,9 +2785,10 @@ class MetricsCrashRateAlertProcessUpdateV1Test(MetricsCrashRateAlertProcessUpdat
             timestamp = django_timezone.now()
         timestamp = timestamp.replace(tzinfo=timezone.utc, microsecond=0)
 
-        with self.feature(
-            ["organizations:incidents", "organizations:performance-view"]
-        ), self.capture_on_commit_callbacks(execute=True):
+        with (
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+            self.capture_on_commit_callbacks(execute=True),
+        ):
             if value is None:
                 numerator, denominator = 0, 0
             else:
@@ -2798,9 +2803,9 @@ class MetricsCrashRateAlertProcessUpdateV1Test(MetricsCrashRateAlertProcessUpdat
             processor.process_update(
                 {
                     "entity": "entity",
-                    "subscription_id": subscription.subscription_id
-                    if subscription
-                    else uuid4().hex,
+                    "subscription_id": (
+                        subscription.subscription_id if subscription else uuid4().hex
+                    ),
                     "values": {
                         "data": [
                             {"project_id": 8, session_status: tag_value_init, "value": denominator},

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -14,9 +14,9 @@ from sentry.incidents.logic import (
     create_incident_activity,
     subscribe_to_incident,
 )
-from sentry.incidents.models import (
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import (
     INCIDENT_STATUS,
-    AlertRuleTriggerAction,
     IncidentActivityType,
     IncidentStatus,
     IncidentSubscription,

--- a/tests/sentry/integrations/discord/test_message_builder.py
+++ b/tests/sentry/integrations/discord/test_message_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from django.urls import reverse
 
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
-from sentry.incidents.models import IncidentStatus
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.integrations.discord.message_builder import LEVEL_TO_COLOR
 from sentry.integrations.discord.message_builder.metric_alerts import (
     DiscordMetricAlertMessageBuilder,

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 
 from sentry.eventstore.models import Event
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
-from sentry.incidents.models import IncidentStatus
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.integrations.message_builder import build_attachment_text, build_attachment_title
 from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import pytest
 import responses
 
-from sentry.incidents.models import AlertRule, AlertRuleTriggerAction
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleTriggerAction
 from sentry.integrations.slack.utils import RedisRuleStatus
 from sentry.models.rule import Rule
 from sentry.receivers.rules import DEFAULT_RULE_LABEL, DEFAULT_RULE_LABEL_NEW

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -5,7 +5,7 @@ import pytest
 from django.utils import timezone
 
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
-from sentry.incidents.models import IncidentStatus, IncidentTrigger
+from sentry.incidents.models.incident import IncidentStatus, IncidentTrigger
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import BaseIncidentsTest, BaseMetricsTestCase, SnubaTestCase, TestCase

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from django.utils import timezone
 
 from sentry.dynamic_sampling import ProjectBoostedReleases
-from sentry.incidents.models import AlertRule, AlertRuleMonitorType
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleMonitorType
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject, ReleaseProjectModelManager

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -94,7 +94,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
         # models.signals.post_save.send(instance=inst, sender=type(inst), created=False)
 
     @patch(
-        "sentry.incidents.models.AlertRule.objects.conditionally_subscribe_project_to_alert_rules"
+        "sentry.incidents.models.alert_rules.AlertRule.objects.conditionally_subscribe_project_to_alert_rules"
     )
     def test_subscribe_project_to_alert_rule_constructs_query(self, mock_conditionally_subscribe):
         project = self.create_project(name="foo")
@@ -126,7 +126,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
 
         subscribe_project = AlertRule.objects.conditionally_subscribe_project_to_alert_rules
         with patch(
-            "sentry.incidents.models.AlertRule.objects.conditionally_subscribe_project_to_alert_rules",
+            "sentry.incidents.models.alert_rules.AlertRule.objects.conditionally_subscribe_project_to_alert_rules",
             wraps=subscribe_project,
         ) as wrapped_subscribe_project:
             with self.tasks():

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -94,7 +94,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
         # models.signals.post_save.send(instance=inst, sender=type(inst), created=False)
 
     @patch(
-        "sentry.incidents.models.alert_rules.AlertRule.objects.conditionally_subscribe_project_to_alert_rules"
+        "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules"
     )
     def test_subscribe_project_to_alert_rule_constructs_query(self, mock_conditionally_subscribe):
         project = self.create_project(name="foo")
@@ -126,7 +126,7 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
 
         subscribe_project = AlertRule.objects.conditionally_subscribe_project_to_alert_rules
         with patch(
-            "sentry.incidents.models.alert_rules.AlertRule.objects.conditionally_subscribe_project_to_alert_rules",
+            "sentry.incidents.models.alert_rule.AlertRule.objects.conditionally_subscribe_project_to_alert_rules",
             wraps=subscribe_project,
         ) as wrapped_subscribe_project:
             with self.tasks():

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 from django.utils import timezone
 
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.dashboard_widget import DashboardWidgetQuery, DashboardWidgetQueryOnDemand
 from sentry.models.environment import Environment
 from sentry.models.project import Project
@@ -680,8 +680,11 @@ def test_get_metric_extraction_config_multiple_widgets_not_using_extended_specs(
 def test_get_metric_extraction_config_multiple_widgets_above_extended_max_limit(
     default_project: Project,
 ) -> None:
-    with Feature({ON_DEMAND_METRICS_WIDGETS: True}), override_options(
-        {"on_demand.extended_widget_spec_orgs": [default_project.organization.id]}
+    with (
+        Feature({ON_DEMAND_METRICS_WIDGETS: True}),
+        override_options(
+            {"on_demand.extended_widget_spec_orgs": [default_project.organization.id]}
+        ),
     ):
         create_widget(["count()"], "transaction.duration:>=1100", default_project)
         create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 2")
@@ -707,8 +710,11 @@ def test_get_metric_extraction_config_multiple_widgets_above_extended_max_limit(
 def test_get_metric_extraction_config_multiple_widgets_under_extended_max_limit(
     default_project: Project,
 ) -> None:
-    with Feature({ON_DEMAND_METRICS_WIDGETS: True}), override_options(
-        {"on_demand.extended_widget_spec_orgs": [default_project.organization.id]}
+    with (
+        Feature({ON_DEMAND_METRICS_WIDGETS: True}),
+        override_options(
+            {"on_demand.extended_widget_spec_orgs": [default_project.organization.id]}
+        ),
     ):
         create_widget(["count()"], "transaction.duration:>=1100", default_project)
         create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 2")
@@ -1337,9 +1343,12 @@ def test_get_metric_extraction_config_multiple_widgets_with_high_cardinality(
     default_project: Project,
 ) -> None:
     duration = 1000
-    with Feature({ON_DEMAND_METRICS_WIDGETS: True}), mock.patch(
-        "sentry.relay.config.metric_extraction._is_widget_query_low_cardinality"
-    ) as mock_cardinality:
+    with (
+        Feature({ON_DEMAND_METRICS_WIDGETS: True}),
+        mock.patch(
+            "sentry.relay.config.metric_extraction._is_widget_query_low_cardinality"
+        ) as mock_cardinality,
+    ):
         mock_cardinality.side_effect = [True, False, True]
         create_widget(
             ["epm()"],
@@ -1374,11 +1383,15 @@ def test_get_metric_extraction_config_multiple_widgets_with_high_cardinality(
 @override_options({"on_demand.max_widget_cardinality.count": 1})
 def test_get_metric_extraction_config_with_extraction_enabled(default_project: Project) -> None:
     duration = 1000
-    with Feature({ON_DEMAND_METRICS_WIDGETS: True}), mock.patch(
-        "sentry.relay.config.metric_extraction._can_widget_query_use_stateful_extraction"
-    ) as mock_can_use_stateful, mock.patch(
-        "sentry.relay.config.metric_extraction._widget_query_stateful_extraction_enabled"
-    ) as mock_extraction_enabled:
+    with (
+        Feature({ON_DEMAND_METRICS_WIDGETS: True}),
+        mock.patch(
+            "sentry.relay.config.metric_extraction._can_widget_query_use_stateful_extraction"
+        ) as mock_can_use_stateful,
+        mock.patch(
+            "sentry.relay.config.metric_extraction._widget_query_stateful_extraction_enabled"
+        ) as mock_extraction_enabled,
+    ):
         mock_can_use_stateful.return_value = True
         mock_extraction_enabled.return_value = True
         create_widget(
@@ -1404,11 +1417,15 @@ def test_stateful_get_metric_extraction_config_with_extraction_disabled(
     default_project: Project,
 ) -> None:
     duration = 1000
-    with Feature({ON_DEMAND_METRICS_WIDGETS: True}), mock.patch(
-        "sentry.relay.config.metric_extraction._can_widget_query_use_stateful_extraction"
-    ) as mock_can_use_stateful, mock.patch(
-        "sentry.relay.config.metric_extraction._widget_query_stateful_extraction_enabled"
-    ) as mock_extraction_enabled:
+    with (
+        Feature({ON_DEMAND_METRICS_WIDGETS: True}),
+        mock.patch(
+            "sentry.relay.config.metric_extraction._can_widget_query_use_stateful_extraction"
+        ) as mock_can_use_stateful,
+        mock.patch(
+            "sentry.relay.config.metric_extraction._widget_query_stateful_extraction_enabled"
+        ) as mock_extraction_enabled,
+    ):
         mock_can_use_stateful.return_value = True
         mock_extraction_enabled.return_value = False
         create_widget(
@@ -1429,11 +1446,15 @@ def test_stateful_get_metric_extraction_config_multiple_widgets_with_extraction_
     default_project: Project,
 ) -> None:
     duration = 1000
-    with Feature({ON_DEMAND_METRICS_WIDGETS: True}), mock.patch(
-        "sentry.relay.config.metric_extraction._can_widget_query_use_stateful_extraction"
-    ) as mock_can_use_stateful, mock.patch(
-        "sentry.relay.config.metric_extraction._widget_query_stateful_extraction_enabled"
-    ) as mock_extraction_enabled:
+    with (
+        Feature({ON_DEMAND_METRICS_WIDGETS: True}),
+        mock.patch(
+            "sentry.relay.config.metric_extraction._can_widget_query_use_stateful_extraction"
+        ) as mock_can_use_stateful,
+        mock.patch(
+            "sentry.relay.config.metric_extraction._widget_query_stateful_extraction_enabled"
+        ) as mock_extraction_enabled,
+    ):
         mock_can_use_stateful.return_value = True
         mock_extraction_enabled.side_effect = [True, False, True]
         create_widget(

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -18,8 +18,8 @@ from sentry.incidents.logic import (
     create_alert_rule_trigger,
     create_alert_rule_trigger_action,
 )
-from sentry.incidents.models import (
-    AlertRuleTriggerAction,
+from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+from sentry.incidents.models.incident import (
     Incident,
     IncidentActivity,
     IncidentStatus,


### PR DESCRIPTION
currently the incidents/models.py file is nearly 1k lines long and the file name `model` does not do much to tell us what it's contents are

PR to split up the file names and directory

edit:

oh lawd. i swear most of these are modifying imports now that the directory structure has been modified

Resolves https://github.com/getsentry/getsentry/pull/13170
Requires https://github.com/getsentry/getsentry/pull/13170