### PR TITLE
ref(ui): Remove render function from dropdown label 

### DIFF
--- a/static/app/components/dropdownAutoComplete/types.tsx
+++ b/static/app/components/dropdownAutoComplete/types.tsx
@@ -1,6 +1,6 @@
 export type Item = {
   index: number;
-  label: ((value: any) => React.ReactNode) | React.ReactNode;
+  label: React.ReactNode;
   value: any;
   'data-test-id'?: string;
   disabled?: boolean;

--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -189,7 +189,7 @@ export function TimeRangeSelector({
               value: item.value,
               // Wrap inside OptionLabel to offset custom margins from SelectorItemLabel
               // TODO: Remove SelectorItemLabel & OptionLabel
-              label: <OptionLabel>{item.label as string}</OptionLabel>,
+              label: <OptionLabel>{item.label}</OptionLabel>,
               details:
                 start && end ? (
                   <AbsoluteSummary>{getAbsoluteSummary(start, end, utc)}</AbsoluteSummary>
@@ -207,7 +207,7 @@ export function TimeRangeSelector({
 
           return {
             value: item.value,
-            label: <OptionLabel>{item.label as string}</OptionLabel>,
+            label: <OptionLabel>{item.label}</OptionLabel>,
             textValue: item.searchKey,
           };
         });
@@ -224,7 +224,7 @@ export function TimeRangeSelector({
 
       return filteredItems.map<SelectOption<string>>(item => ({
         value: item.value,
-        label: item.label as string,
+        label: item.label,
         textValue: item.searchKey,
       }));
     },


### PR DESCRIPTION
- label should be a ReactNode of some kind and not a render function
- Removes type casts that were added
