### PR TITLE
test(ui): Switch children to react nodes

### DIFF
--- a/static/app/components/noProjectMessage.spec.tsx
+++ b/static/app/components/noProjectMessage.spec.tsx
@@ -18,15 +18,16 @@ describe('NoProjectMessage', function () {
 
   it('renders', function () {
     const organization = OrganizationFixture({slug: 'org-slug'});
-    const childrenMock = jest.fn().mockReturnValue(null);
     ProjectsStore.loadInitialData([]);
 
     render(
-      <NoProjectMessage organization={organization}>{childrenMock}</NoProjectMessage>
+      <NoProjectMessage organization={organization}>
+        <div data-test-id="child">Test</div>
+      </NoProjectMessage>
     );
 
-    expect(childrenMock).not.toHaveBeenCalled();
     expect(screen.getByText('Remain Calm')).toBeInTheDocument();
+    expect(screen.queryByTestId('child')).not.toBeInTheDocument();
   });
 
   it('shows "Create Project" button when there are no projects', function () {

--- a/static/app/stores/guideStore.spec.tsx
+++ b/static/app/stores/guideStore.spec.tsx
@@ -120,7 +120,7 @@ describe('GuideStore', function () {
   it('hides when a modal is open', function () {
     expect(GuideStore.getState().forceHide).toBe(false);
 
-    ModalStore.openModal(() => {}, {});
+    ModalStore.openModal(() => <div />, {});
 
     expect(GuideStore.getState().forceHide).toBe(true);
 

--- a/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import {useMemo} from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -9,7 +8,7 @@ import {useProfileFunctionTrends} from 'sentry/utils/profiling/hooks/useProfileF
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
-function TestContext({children}: {children: ReactElement}) {
+function TestContext({children}: {children: React.ReactNode}) {
   const {organization} = useMemo(() => initializeOrg(), []);
 
   return (

--- a/static/app/utils/profiling/hooks/useProfileFunctions.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctions.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import {useMemo} from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -9,7 +8,7 @@ import {useProfileFunctions} from 'sentry/utils/profiling/hooks/useProfileFuncti
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
-function TestContext({children}: {children: ReactElement}) {
+function TestContext({children}: {children: React.ReactNode}) {
   const {organization} = useMemo(() => initializeOrg(), []);
 
   return (

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -38,7 +38,7 @@ type ProviderOptions = {
 type Options = ProviderOptions & rtl.RenderOptions;
 
 function createProvider(contextDefs: Record<string, any>) {
-  return class ContextProvider extends Component {
+  return class ContextProvider extends Component<{children?: React.ReactNode}> {
     static childContextTypes = contextDefs.childContextTypes;
 
     getChildContext() {


### PR DESCRIPTION
- adds a missing children prop, swaps ReactElement to ReactNode
- removes a render function used as a child

all part of type errors for react 18 https://github.com/getsentry/frontend-tsc/issues/22
