### PR TITLE
ref(ui): Add object type to KeyValue data item

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -475,7 +475,7 @@ const makeTransactionNameRow = (event: Event, orgSlug: string, projectSlug?: str
 
 const makeRow = (
   subject: KeyValueListDataItem['subject'],
-  value: KeyValueListDataItem['value'] | KeyValueListDataItem['value'][],
+  value: KeyValueListDataItem['value'],
   actionButton?: ReactNode
 ): KeyValueListDataItem => {
   const itemKey = kebabCase(subject);

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -912,7 +912,7 @@ export type KeyValueListDataItem = {
   meta?: Meta;
   subjectDataTestId?: string;
   subjectIcon?: React.ReactNode;
-  value?: React.ReactNode;
+  value?: React.ReactNode | Record<string, string | number>;
 };
 
 export type KeyValueListData = KeyValueListDataItem[];


### PR DESCRIPTION
in react 18 objects are removed from react node. Removes a recursive value[] being passed as value

part of https://github.com/getsentry/frontend-tsc/issues/22
