### PR TITLE
feat(ddm): Filter empty series from summary table

### DIFF
--- a/static/app/views/ddm/summaryTable.tsx
+++ b/static/app/views/ddm/summaryTable.tsx
@@ -118,6 +118,8 @@ export const SummaryTable = memo(function SummaryTable({
         ...getValues(s.data),
       };
     })
+    // Filter series with no data
+    .filter(s => s.min !== Infinity)
     .sort((a, b) => {
       const {name, order} = sort;
       if (!name) {


### PR DESCRIPTION
Workaround as the endpoint returns empty series for groups that are excluded by a filter.