### PR TITLE
ref(deps): Bump sentry-relay to v0.8.48

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ sentry-arroyo>=2.16.2
 sentry-kafka-schemas>=0.1.58
 sentry-ophio==0.1.5
 sentry-redis-tools>=0.1.7
-sentry-relay>=0.8.45
+sentry-relay>=0.8.48
 sentry-sdk>=1.39.2
 snuba-sdk>=2.0.29
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -180,7 +180,7 @@ sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.58
 sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
-sentry-relay==0.8.45
+sentry-relay==0.8.48
 sentry-sdk==1.39.2
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -122,7 +122,7 @@ sentry-arroyo==2.16.2
 sentry-kafka-schemas==0.1.58
 sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
-sentry-relay==0.8.45
+sentry-relay==0.8.48
 sentry-sdk==1.39.2
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -210,11 +210,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
                 {"id": user_id, "email": email, "username": username, "ip_address": ip_address}
             )
 
-        user = self.get_interface("user")
-        if user is not None:
-            user._data.pop("sentry_user", None)
-            return user
-        return None
+        return self.get_interface("user")
 
     def get_event_type(self) -> str:
         """

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -210,7 +210,10 @@ class BaseEvent(metaclass=abc.ABCMeta):
                 {"id": user_id, "email": email, "username": username, "ip_address": ip_address}
             )
 
-        return self.get_interface("user")
+        user = self.get_interface("user")
+        if user is not None:
+            user._data.pop("sentry_user", None)
+            return user
 
     def get_event_type(self) -> str:
         """

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -214,6 +214,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
         if user is not None:
             user._data.pop("sentry_user", None)
             return user
+        return None
 
     def get_event_type(self) -> str:
         """

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -122,7 +122,7 @@ def record_event_processed(project, event, **kwargs):
     # Check to make sure more the ip address is being sent.
     # testing for this in test_no_user_tracking_for_ip_address_only
     # list(d.keys()) pattern is to make this python3 safe
-    if user_context and list(user_context.keys()) != ["ip_address", "sentry_user"]:
+    if user_context and len(user_context.keys() - {"ip_address", "sentry_user"}) > 0:
         feature_slugs.append("user_tracking")
 
     # Custom Tags

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -122,7 +122,7 @@ def record_event_processed(project, event, **kwargs):
     # Check to make sure more the ip address is being sent.
     # testing for this in test_no_user_tracking_for_ip_address_only
     # list(d.keys()) pattern is to make this python3 safe
-    if user_context and list(user_context.keys()) != ["ip_address"]:
+    if user_context and list(user_context.keys()) != ["ip_address", "sentry_user"]:
         feature_slugs.append("user_tracking")
 
     # Custom Tags

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -33,6 +33,21 @@ def call_endpoint(client, relay, private_key):
 @pytest.mark.django_db
 def test_global_config():
     config = get_global_config()
+    # Set options to Relay's non-default values to avoid Relay skipping deserialization
+    config["options"]["relay.cardinality-limiter.error-sample-rate"] = 1.0
+    config["options"]["profiling.profile_metrics.unsampled_profiles.enabled"] = True
+    config["options"]["profiling.profile_metrics.unsampled_profiles.platforms"] = ["fake-platform"]
+    config["options"]["profiling.profile_metrics.unsampled_profiles.sample_rate"] = 1.0
+    config["options"]["relay.metric-bucket-encodings"] = {
+        "sessions": "array",
+        "transactions": "array",
+        "spans": "array",
+        "custom": "array",
+        "unsupported": "array",
+    }
+    config["options"]["relay.span-usage-metric"] = True
+    config["options"]["relay.cardinality-limiter.mode"] = "passive"
+
     normalized = normalize_global_config(config)
     assert normalized == config
 

--- a/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_multiple_full.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_multiple_full.pysnap
@@ -1,13 +1,11 @@
 ---
-created: '2019-07-11T19:30:21.322813Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_spans.py
 ---
 errors: null
 to_json:
 - data:
+    http.response.status_code: 200
     reason: OK
-    status_code: 200
   description: GET http://example.com
   op: http
   span_id: 8c931f4740435fb8

--- a/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_single_full.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_single_full.pysnap
@@ -1,13 +1,11 @@
 ---
-created: '2019-07-11T19:26:32.626601Z'
-creator: sentry
 source: tests/sentry/event_manager/interfaces/test_spans.py
 ---
 errors: null
 to_json:
 - data:
+    http.response.status_code: 200
     reason: OK
-    status_code: 200
   description: GET http://example.com
   op: http
   span_id: 8c931f4740435fb8

--- a/tests/sentry/event_manager/test_normalization.py
+++ b/tests/sentry/event_manager/test_normalization.py
@@ -42,7 +42,7 @@ def test_interface_is_relabeled():
     manager.normalize()
     data = manager.get_data()
 
-    assert data["user"] == {"id": "1"}
+    assert data["user"] == {"id": "1", "sentry_user": "id:1"}
 
 
 @pytest.mark.parametrize("user", ["missing", None, {}, {"ip_address": None}])

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -8,6 +8,7 @@ from sentry.db.models.fields.node import NodeData, NodeIntegrityFailure
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.grouping.api import GroupingConfig
 from sentry.grouping.enhancer import Enhancements
+from sentry.interfaces.user import User
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.environment import Environment
 from sentry.snuba.dataset import Dataset
@@ -254,7 +255,17 @@ class EventTest(TestCase, PerformanceIssueTestCase):
         assert event_from_nodestore.location == event_from_snuba.location
         assert event_from_nodestore.culprit == event_from_snuba.culprit
 
-        assert event_from_nodestore.get_minimal_user() == event_from_snuba.get_minimal_user()
+        user_from_nodestore = event_from_nodestore.get_minimal_user()
+        user_from_nodestore = User.to_python(
+            {
+                "id": user_from_nodestore._data.get("id"),
+                "email": user_from_nodestore._data.get("email"),
+                "username": user_from_nodestore._data.get("username"),
+                "ip_address": user_from_nodestore._data.get("ip_address"),
+            }
+        )
+        assert user_from_nodestore == event_from_snuba.get_minimal_user()
+
         assert event_from_nodestore.ip_address == event_from_snuba.ip_address
         assert event_from_nodestore.tags == event_from_snuba.tags
 


### PR DESCRIPTION
Along the way of bumping dependencies, some tests are fixed to cover for the changes in Relay.