### PR TITLE
ref(event-tags): More UI Changes for Event Tags Tree

### DIFF
--- a/static/app/components/events/contextSummary/index.tsx
+++ b/static/app/components/events/contextSummary/index.tsx
@@ -51,6 +51,10 @@ type Props = {
 };
 
 function ContextSummary({event}: Props) {
+  if (objectIsEmpty(event.contexts)) {
+    return null;
+  }
+
   const filteredContexts = KNOWN_CONTEXTS.filter(makeContextFilter(event));
 
   // XXX: We want to have *at least* MIN_CONTEXTS, so we first find all the

--- a/static/app/components/events/contextSummary/utils.tsx
+++ b/static/app/components/events/contextSummary/utils.tsx
@@ -11,6 +11,8 @@ const serverSideSdks = [
   'sentry.javascript.sveltekit',
 ];
 
+export const CONTEXT_DOCS_LINK = `https://docs.sentry.io/platform-redirect/?next=/enriching-events/context/`;
+
 function isServerSideRenderedEvent(event: Event) {
   return event.sdk && serverSideSdks.includes(event.sdk.name);
 }

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
 import {CommitRow} from 'sentry/components/commitRow';
 import {EventEvidence} from 'sentry/components/events/eventEvidence';
@@ -39,7 +38,6 @@ import {SuspectCommits} from './suspectCommits';
 import {EventUserFeedback} from './userFeedback';
 
 type Props = {
-  location: Location;
   /**
    * The organization can be the shared view on a public issue view.
    */
@@ -55,7 +53,6 @@ type Props = {
 function EventEntries({
   organization,
   project,
-  location,
   event,
   group,
   className,
@@ -106,9 +103,7 @@ function EventEntries({
       {showTagSummary && (
         <EventTagsAndScreenshot
           event={event}
-          organization={organization as Organization}
           projectSlug={projectSlug}
-          location={location}
           isShare={isShare}
         />
       )}

--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -142,7 +142,6 @@ function EventDisplay({
   transaction,
   durationBaseline,
 }: EventDisplayProps) {
-  const location = useLocation();
   const organization = useOrganization();
   const [selectedEventId, setSelectedEventId] = useState<string>('');
 
@@ -282,12 +281,7 @@ function EventDisplay({
         </ComparisonContentWrapper>
       </div>
 
-      <EventTags
-        event={eventData}
-        organization={organization}
-        projectSlug={project.slug}
-        location={location}
-      />
+      <EventTags event={eventData} projectSlug={project.slug} />
     </EventDisplayContainer>
   );
 }

--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -7,7 +7,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {EventTags} from 'sentry/components/events/eventTags';
 
 describe('EventTagsTree', function () {
-  const {organization, project} = initializeOrg();
+  const {organization, project, router} = initializeOrg();
   const tags = [
     {key: 'tree', value: 'maple'},
     {key: 'tree.branch', value: 'jagged'},
@@ -54,9 +54,8 @@ describe('EventTagsTree', function () {
     });
   });
 
-  it('renders tag tree with query param', function () {
-    render(<EventTags projectSlug={project.slug} event={event} />, {organization});
-
+  /** Asserts that new tags view is rendering the appropriate data. Requires render() call prior. */
+  function assertNewTagsView() {
     tags.forEach(({value}) => {
       expect(screen.getByText(value)).toBeInTheDocument();
     });
@@ -68,6 +67,16 @@ describe('EventTagsTree', function () {
     treeBranchTags.forEach(tag => {
       expect(screen.getByText(tag)).toBeInTheDocument();
     });
+  }
+
+  it('renders tag tree with query param', function () {
+    router.location.query.tagsTree = '1';
+    render(<EventTags projectSlug={project.slug} event={event} />, {
+      organization,
+      router,
+    });
+
+    assertNewTagsView();
   });
 
   it("renders tag tree with the 'event-tags-tree-ui' feature", function () {
@@ -76,16 +85,6 @@ describe('EventTagsTree', function () {
       organization: featuredOrganization,
     });
 
-    tags.forEach(({value}) => {
-      expect(screen.getByText(value)).toBeInTheDocument();
-    });
-
-    pillOnlyTags.forEach(tag => {
-      expect(screen.queryByText(tag)).not.toBeInTheDocument();
-    });
-
-    treeBranchTags.forEach(tag => {
-      expect(screen.getByText(tag)).toBeInTheDocument();
-    });
+    assertNewTagsView();
   });
 });

--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -7,7 +7,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {EventTags} from 'sentry/components/events/eventTags';
 
 describe('EventTagsTree', function () {
-  const {organization, project, router} = initializeOrg();
+  const {organization, project} = initializeOrg();
   const tags = [
     {key: 'tree', value: 'maple'},
     {key: 'tree.branch', value: 'jagged'},
@@ -47,15 +47,7 @@ describe('EventTagsTree', function () {
   const event = EventFixture({tags});
 
   it('avoids tag tree without query param', function () {
-    render(
-      <EventTags
-        organization={organization}
-        projectSlug={project.slug}
-        location={router.location}
-        event={event}
-      />,
-      {organization}
-    );
+    render(<EventTags projectSlug={project.slug} event={event} />, {organization});
     tags.forEach(({key: fullTagKey, value}) => {
       expect(screen.getByText(fullTagKey)).toBeInTheDocument();
       expect(screen.getByText(value)).toBeInTheDocument();
@@ -63,15 +55,7 @@ describe('EventTagsTree', function () {
   });
 
   it('renders tag tree with query param', function () {
-    render(
-      <EventTags
-        organization={organization}
-        projectSlug={project.slug}
-        location={{...router.location, query: {tagsTree: '1'}}}
-        event={event}
-      />,
-      {organization}
-    );
+    render(<EventTags projectSlug={project.slug} event={event} />, {organization});
 
     tags.forEach(({value}) => {
       expect(screen.getByText(value)).toBeInTheDocument();
@@ -88,15 +72,9 @@ describe('EventTagsTree', function () {
 
   it("renders tag tree with the 'event-tags-tree-ui' feature", function () {
     const featuredOrganization = OrganizationFixture({features: ['event-tags-tree-ui']});
-    render(
-      <EventTags
-        organization={featuredOrganization}
-        projectSlug={project.slug}
-        location={router.location}
-        event={event}
-      />,
-      {organization: featuredOrganization}
-    );
+    render(<EventTags projectSlug={project.slug} event={event} />, {
+      organization: featuredOrganization,
+    });
 
     tags.forEach(({value}) => {
       expect(screen.getByText(value)).toBeInTheDocument();

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -187,8 +187,8 @@ function TagTreeColumns({meta, tags, ...props}: EventTagsTreeProps) {
     const data = tagTreeRowGroups.reduce<TagTreeColumnData>(
       ({startIndex, runningTotal, columns}, rowList, index) => {
         runningTotal += rowList.length;
-        // When we reach the goal size (or the last row group), wrap rows in a TreeColumn.
-        if (runningTotal > columnRowGoal || index === tagTreeRowGroups.length - 1) {
+        // When we reach the goal size wrap rows in a TreeColumn.
+        if (runningTotal > columnRowGoal) {
           columns.push(
             <TreeColumn key={columns.length}>
               {tagTreeRowGroups.slice(startIndex, index)}
@@ -196,6 +196,14 @@ function TagTreeColumns({meta, tags, ...props}: EventTagsTreeProps) {
           );
           runningTotal = 0;
           startIndex = index;
+        }
+        // If it's the last entry, wrap the column
+        if (index === tagTreeRowGroups.length - 1) {
+          columns.push(
+            <TreeColumn key={columns.length}>
+              {tagTreeRowGroups.slice(startIndex)}
+            </TreeColumn>
+          );
         }
         return {startIndex, runningTotal, columns};
       },

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -2,7 +2,7 @@ import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import EventTagsContent from 'sentry/components/events/eventTags/eventTagContent';
-import type {TagFilter} from 'sentry/components/events/eventTagsAndScreenshot/tags';
+import type {TagFilter} from 'sentry/components/events/eventTags/util';
 import {space} from 'sentry/styles/space';
 import type {EventTag} from 'sentry/types';
 import {generateQueryWithTag} from 'sentry/utils';

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -2,6 +2,7 @@ import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import EventTagsContent from 'sentry/components/events/eventTags/eventTagContent';
+import type {TagFilter} from 'sentry/components/events/eventTagsAndScreenshot/tags';
 import {space} from 'sentry/styles/space';
 import type {EventTag} from 'sentry/types';
 import {generateQueryWithTag} from 'sentry/utils';
@@ -15,6 +16,7 @@ const COLUMN_COUNT = 2;
 interface TagTree {
   [key: string]: TagTreeContent;
 }
+
 interface TagTreeContent {
   subtree: TagTree;
   value: string;
@@ -39,10 +41,12 @@ interface TagTreeRowProps {
   isLast?: boolean;
   spacerCount?: number;
 }
+
 interface EventTagsTreeProps {
   projectId: string;
   projectSlug: string;
   streamPath: string;
+  tagFilter: TagFilter;
   tags: EventTag[];
   meta?: Record<any, any>;
 }
@@ -200,26 +204,34 @@ function assembleTagTreeColumns({
 }
 
 function EventTagsTree(props: EventTagsTreeProps) {
-  const tagTreeColumns = useMemo(() => assembleTagTreeColumns(props), [props]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const tagTreeColumns = useMemo(() => assembleTagTreeColumns(props), []);
   return (
     <TreeContainer>
-      <TreeGarden>{tagTreeColumns}</TreeGarden>
+      <TreeGarden columnCount={COLUMN_COUNT}>{tagTreeColumns}</TreeGarden>
     </TreeContainer>
   );
 }
 
-const TreeContainer = styled('div')``;
+const TreeContainer = styled('div')`
+  margin-top: ${space(1.5)};
+`;
 
-const TreeGarden = styled('div')`
+const TreeGarden = styled('div')<{columnCount: number}>`
   display: grid;
   gap: 0 ${space(2)};
-  grid-template-columns: repeat(${COLUMN_COUNT}, 1fr);
+  grid-template-columns: repeat(${p => p.columnCount}, 1fr);
   align-items: start;
 `;
 
 const TreeColumn = styled('div')`
   display: grid;
-  grid-template-columns: 150px 1fr;
+  grid-template-columns: minmax(auto, 150px) 1fr;
+  grid-column-gap: ${space(3)};
+  &:not(:first-child) {
+    border-left: 1px solid ${p => p.theme.gray200};
+    padding-left: ${space(2)};
+  }
 `;
 
 const TreeRow = styled('div')`

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -63,6 +63,7 @@ interface TagTreeRowProps {
   projectSlug: string;
   streamPath: string;
   tagKey: string;
+  isEven?: boolean;
   isLast?: boolean;
   spacerCount?: number;
 }
@@ -72,6 +73,7 @@ function TagTreeRow({
   tagKey,
   spacerCount = 0,
   isLast = false,
+  isEven = false,
   ...props
 }: TagTreeRowProps) {
   const subtreeTags = Object.keys(content.subtree);
@@ -81,7 +83,7 @@ function TagTreeRow({
 
   return (
     <Fragment>
-      <TreeRow>
+      <TreeRow isEven={isEven}>
         <TreeKeyTrunk spacerCount={spacerCount}>
           {spacerCount > 0 && (
             <Fragment>
@@ -117,6 +119,7 @@ function TagTreeRow({
           content={content.subtree[t]}
           spacerCount={spacerCount + 1}
           isLast={i === subtreeTags.length - 1}
+          isEven={isEven}
           {...props}
         />
       ))}
@@ -148,12 +151,13 @@ function EventTagsTree({tags, meta, ...props}: EventTagsTreeProps) {
   return (
     <TreeContainer>
       <TreeGarden>
-        {tagTreeItemData.map(([tagKey, tagTreeContent]) => (
+        {tagTreeItemData.map(([tagKey, tagTreeContent], i) => (
           <TreeItem key={tagKey}>
             <TagTreeRow
               tagKey={tagKey}
               content={tagTreeContent}
               spacerCount={0}
+              isEven={i % 2 === 0}
               {...props}
             />
           </TreeItem>
@@ -176,17 +180,17 @@ const TreeItem = styled('div')`
   grid-column: span 2;
   grid-template-columns: subgrid;
   background-color: ${p => p.theme.background};
-  padding: ${space(0.5)} ${space(0.75)};
-  :nth-child(odd) {
-    background-color: ${p => p.theme.backgroundSecondary};
-  }
+  padding: 0 ${space(0.75)};
 `;
 
-const TreeRow = styled('div')`
+const TreeRow = styled('div')<{isEven: boolean}>`
   border-radius: ${p => p.theme.borderRadius};
   display: grid;
   grid-column: span 2;
   grid-template-columns: subgrid;
+  :nth-child(${p => (p.isEven ? 'even' : 'odd')}) {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
 `;
 
 const TreeSpacer = styled('div')<{isLast: boolean; spacerCount: number}>`

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -73,7 +73,6 @@ function TagTreeRow({
   tagKey,
   spacerCount = 0,
   isLast = false,
-  isEven = false,
   ...props
 }: TagTreeRowProps) {
   const subtreeTags = Object.keys(content.subtree);
@@ -83,7 +82,7 @@ function TagTreeRow({
 
   return (
     <Fragment>
-      <TreeRow isEven={isEven}>
+      <TreeRow>
         <TreeKeyTrunk spacerCount={spacerCount}>
           {spacerCount > 0 && (
             <Fragment>
@@ -119,7 +118,6 @@ function TagTreeRow({
           content={content.subtree[t]}
           spacerCount={spacerCount + 1}
           isLast={i === subtreeTags.length - 1}
-          isEven={isEven}
           {...props}
         />
       ))}
@@ -151,16 +149,15 @@ function EventTagsTree({tags, meta, ...props}: EventTagsTreeProps) {
   return (
     <TreeContainer>
       <TreeGarden>
-        {tagTreeItemData.map(([tagKey, tagTreeContent], i) => (
-          <TreeItem key={tagKey}>
+        {tagTreeItemData.map(([tagKey, tagTreeContent]) => (
+          <Fragment key={tagKey}>
             <TagTreeRow
               tagKey={tagKey}
               content={tagTreeContent}
               spacerCount={0}
-              isEven={i % 2 === 0}
               {...props}
             />
-          </TreeItem>
+          </Fragment>
         ))}
       </TreeGarden>
     </TreeContainer>
@@ -175,20 +172,13 @@ const TreeGarden = styled('div')`
   grid-template-columns: 200px 1fr;
 `;
 
-const TreeItem = styled('div')`
-  display: grid;
-  grid-column: span 2;
-  grid-template-columns: subgrid;
-  background-color: ${p => p.theme.background};
-  padding: 0 ${space(0.75)};
-`;
-
-const TreeRow = styled('div')<{isEven: boolean}>`
+const TreeRow = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
+  padding: 0 ${space(1)};
   display: grid;
   grid-column: span 2;
   grid-template-columns: subgrid;
-  :nth-child(${p => (p.isEven ? 'even' : 'odd')}) {
+  :nth-child(odd) {
     background-color: ${p => p.theme.backgroundSecondary};
   }
 `;

--- a/static/app/components/events/eventTags/index.spec.tsx
+++ b/static/app/components/events/eventTags/index.spec.tsx
@@ -74,7 +74,8 @@ describe('event tags', function () {
       ) // Fall back case
     ).toBeInTheDocument(); // tooltip description
   });
-  it('transacation tag links to transaction overview', function () {
+
+  it('transaction tag links to transaction overview', function () {
     const tags = [{key: 'transaction', value: 'mytransaction'}];
 
     const event = EventFixture({

--- a/static/app/components/events/eventTags/index.spec.tsx
+++ b/static/app/components/events/eventTags/index.spec.tsx
@@ -15,21 +15,13 @@ describe('event tags', function () {
       },
     });
 
-    const {organization, project, router} = initializeOrg({
+    const {organization, project} = initializeOrg({
       organization: {
         relayPiiConfig: null,
       },
     });
 
-    render(
-      <EventTags
-        organization={organization}
-        projectSlug={project.slug}
-        location={router.location}
-        event={event}
-      />,
-      {organization}
-    );
+    render(<EventTags projectSlug={project.slug} event={event} />, {organization});
 
     await userEvent.hover(screen.getByText(/redacted/));
     expect(
@@ -60,21 +52,13 @@ describe('event tags', function () {
       },
     });
 
-    const {organization, project, router} = initializeOrg({
+    const {organization, project} = initializeOrg({
       organization: {
         relayPiiConfig: null,
       },
     });
 
-    render(
-      <EventTags
-        organization={organization}
-        projectSlug={project.slug}
-        location={router.location}
-        event={event}
-      />,
-      {organization}
-    );
+    render(<EventTags projectSlug={project.slug} event={event} />, {organization});
 
     expect(screen.getByText('device.family')).toBeInTheDocument();
     expect(screen.getByText('iOS')).toBeInTheDocument();
@@ -97,21 +81,13 @@ describe('event tags', function () {
       tags,
     });
 
-    const {organization, project, router} = initializeOrg({
+    const {organization, project} = initializeOrg({
       organization: {
         relayPiiConfig: null,
       },
     });
 
-    render(
-      <EventTags
-        organization={organization}
-        projectSlug={project.slug}
-        location={router.location}
-        event={event}
-      />,
-      {organization}
-    );
+    render(<EventTags projectSlug={project.slug} event={event} />, {organization});
 
     expect(screen.getByText('mytransaction')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute(

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -4,8 +4,7 @@ import * as Sentry from '@sentry/react';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import EventTagsTree from 'sentry/components/events/eventTags/eventTagsTree';
-import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
-import {TagFilter} from 'sentry/components/events/eventTagsAndScreenshot/tags';
+import {TagFilter, useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
 import Pills from 'sentry/components/pills';
 import type {Event} from 'sentry/types/event';
 import {defined, generateQueryWithTag} from 'sentry/utils';

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -6,6 +6,7 @@ import type {Location} from 'history';
 import ClippedBox from 'sentry/components/clippedBox';
 import EventTagsTree from 'sentry/components/events/eventTags/eventTagsTree';
 import {shouldUseNewTagsUI} from 'sentry/components/events/eventTags/util';
+import {TagFilter} from 'sentry/components/events/eventTagsAndScreenshot/tags';
 import Pills from 'sentry/components/pills';
 import type {Organization} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
@@ -22,11 +23,18 @@ type Props = {
   location: Location;
   organization: Organization;
   projectSlug: string;
+  tagFilter?: TagFilter;
 };
 
 const IOS_DEVICE_FAMILIES = ['iPhone', 'iOS', 'iOS-Device'];
 
-export function EventTags({event, organization, projectSlug, location}: Props) {
+export function EventTags({
+  event,
+  organization,
+  projectSlug,
+  location,
+  tagFilter = TagFilter.ALL,
+}: Props) {
   const meta = event._meta?.tags;
   const projectId = event.projectID;
 
@@ -106,6 +114,7 @@ export function EventTags({event, organization, projectSlug, location}: Props) {
           projectSlug={projectSlug}
           projectId={projectId}
           streamPath={streamPath}
+          tagFilter={tagFilter}
         />
       ) : (
         <Pills>

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -1,18 +1,18 @@
 import {useEffect} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
-import type {Location} from 'history';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import EventTagsTree from 'sentry/components/events/eventTags/eventTagsTree';
 import {shouldUseNewTagsUI} from 'sentry/components/events/eventTags/util';
 import {TagFilter} from 'sentry/components/events/eventTagsAndScreenshot/tags';
 import Pills from 'sentry/components/pills';
-import type {Organization} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import {defined, generateQueryWithTag} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isMobilePlatform} from 'sentry/utils/platform';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import {AnnotatedText} from '../meta/annotatedText';
 
@@ -20,21 +20,15 @@ import EventTagsPill from './eventTagsPill';
 
 type Props = {
   event: Event;
-  location: Location;
-  organization: Organization;
   projectSlug: string;
   tagFilter?: TagFilter;
 };
 
 const IOS_DEVICE_FAMILIES = ['iPhone', 'iOS', 'iOS-Device'];
 
-export function EventTags({
-  event,
-  organization,
-  projectSlug,
-  location,
-  tagFilter = TagFilter.ALL,
-}: Props) {
+export function EventTags({event, projectSlug, tagFilter = TagFilter.ALL}: Props) {
+  const location = useLocation();
+  const organization = useOrganization();
   const meta = event._meta?.tags;
   const projectId = event.projectID;
 

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/react';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import EventTagsTree from 'sentry/components/events/eventTags/eventTagsTree';
-import {shouldUseNewTagsUI} from 'sentry/components/events/eventTags/util';
+import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
 import {TagFilter} from 'sentry/components/events/eventTagsAndScreenshot/tags';
 import Pills from 'sentry/components/pills';
 import type {Event} from 'sentry/types/event';
@@ -29,6 +29,7 @@ const IOS_DEVICE_FAMILIES = ['iPhone', 'iOS', 'iOS-Device'];
 export function EventTags({event, projectSlug, tagFilter = TagFilter.ALL}: Props) {
   const location = useLocation();
   const organization = useOrganization();
+  const hasNewTagsUI = useHasNewTagsUI();
   const meta = event._meta?.tags;
   const projectId = event.projectID;
 
@@ -101,7 +102,7 @@ export function EventTags({event, projectSlug, tagFilter = TagFilter.ALL}: Props
   const streamPath = `/organizations/${orgSlug}/issues/`;
   return (
     <StyledClippedBox clipHeight={150}>
-      {shouldUseNewTagsUI() ? (
+      {hasNewTagsUI ? (
         <EventTagsTree
           tags={tags}
           meta={meta}

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -5,6 +5,7 @@ import type {Location} from 'history';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import EventTagsTree from 'sentry/components/events/eventTags/eventTagsTree';
+import {shouldDisplayTagsTree} from 'sentry/components/events/eventTags/util';
 import Pills from 'sentry/components/pills';
 import type {Organization} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
@@ -32,9 +33,6 @@ export function EventTags({event, organization, projectSlug, location}: Props) {
   const tags = !organization.features.includes('device-classification')
     ? event.tags?.filter(tag => tag.key !== 'device.class')
     : event.tags;
-
-  const shouldDisplayTagTree =
-    location.query.tagsTree || organization.features.includes('event-tags-tree-ui');
 
   useEffect(() => {
     if (
@@ -101,7 +99,7 @@ export function EventTags({event, organization, projectSlug, location}: Props) {
   const streamPath = `/organizations/${orgSlug}/issues/`;
   return (
     <StyledClippedBox clipHeight={150}>
-      {shouldDisplayTagTree ? (
+      {shouldDisplayTagsTree() ? (
         <EventTagsTree
           tags={tags}
           meta={meta}

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -5,7 +5,7 @@ import type {Location} from 'history';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import EventTagsTree from 'sentry/components/events/eventTags/eventTagsTree';
-import {shouldDisplayTagsTree} from 'sentry/components/events/eventTags/util';
+import {shouldUseNewTagsUI} from 'sentry/components/events/eventTags/util';
 import Pills from 'sentry/components/pills';
 import type {Organization} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
@@ -99,7 +99,7 @@ export function EventTags({event, organization, projectSlug, location}: Props) {
   const streamPath = `/organizations/${orgSlug}/issues/`;
   return (
     <StyledClippedBox clipHeight={150}>
-      {shouldDisplayTagsTree() ? (
+      {shouldUseNewTagsUI() ? (
         <EventTagsTree
           tags={tags}
           meta={meta}

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -3,6 +3,14 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 export const TAGS_DOCS_LINK = `https://docs.sentry.io/platform-redirect/?next=/enriching-events/tags`;
 
+export enum TagFilter {
+  ALL = 'All',
+  CUSTOM = 'Custom',
+  USER = 'User',
+  SYSTEM = 'System',
+  EVENT = 'Event',
+}
+
 export function useHasNewTagsUI() {
   const location = useLocation();
   const organization = useOrganization();

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -1,8 +1,7 @@
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-// TODO(Leander): Update once the docs have been added
-export const TAGS_DOCS_LINK = `https://docs.sentry.io`;
+export const TAGS_DOCS_LINK = `https://docs.sentry.io/platform-redirect/?next=/enriching-events/tags`;
 
 export function shouldUseNewTagsUI() {
   const location = useLocation();

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -3,7 +3,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 export const TAGS_DOCS_LINK = `https://docs.sentry.io/platform-redirect/?next=/enriching-events/tags`;
 
-export function shouldUseNewTagsUI() {
+export function useHasNewTagsUI() {
   const location = useLocation();
   const organization = useOrganization();
   return (

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -1,12 +1,14 @@
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-// TODO(Leander): Update once the docs have been put up
-export const TAGS_TREE_DOCS_LINK = `https://docs.sentry.io`;
-export const CONTEXT_DOCS_LINK = `https://docs.sentry.io/platform-redirect/?next=/enriching-events/context/`;
+// TODO(Leander): Update once the docs have been added
+export const TAGS_DOCS_LINK = `https://docs.sentry.io`;
 
 export function shouldUseNewTagsUI() {
   const location = useLocation();
   const organization = useOrganization();
-  return location.query.tagsTree || organization.features.includes('event-tags-tree-ui');
+  return (
+    location.query.tagsTree === '1' ||
+    organization.features.includes('event-tags-tree-ui')
+  );
 }

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -1,0 +1,8 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function shouldDisplayTagsTree() {
+  const location = useLocation();
+  const organization = useOrganization();
+  return location.query.tagsTree || organization.features.includes('event-tags-tree-ui');
+}

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -1,7 +1,11 @@
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export function shouldDisplayTagsTree() {
+// TODO(Leander): Update once the docs have been put up
+export const TAGS_TREE_DOCS_LINK = `https://docs.sentry.io`;
+export const CONTEXT_DOCS_LINK = `https://docs.sentry.io/platform-redirect/?next=/enriching-events/context/`;
+
+export function shouldUseNewTagsUI() {
   const location = useLocation();
   const organization = useOrganization();
   return location.query.tagsTree || organization.features.includes('event-tags-tree-ui');

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -12,8 +12,8 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import {TagFilter} from 'sentry/components/events/eventTags/util';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
-import {TagFilter} from 'sentry/components/events/eventTagsAndScreenshot/tags';
 import GlobalModal from 'sentry/components/globalModal';
 import type {EventAttachment} from 'sentry/types';
 

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -118,7 +118,7 @@ describe('EventTagsAndScreenshot', function () {
 
   const event = EventFixture({user});
 
-  const {organization, project, router} = initializeOrg({
+  const {organization, project} = initializeOrg({
     organization: {
       orgRole: 'member',
       attachmentsRole: 'member',
@@ -189,9 +189,7 @@ describe('EventTagsAndScreenshot', function () {
       render(
         <EventTagsAndScreenshot
           event={EventFixture({...event, tags, contexts})}
-          organization={organization}
           projectSlug={project.slug}
-          location={router.location}
         />,
         {organization}
       );
@@ -236,9 +234,7 @@ describe('EventTagsAndScreenshot', function () {
       render(
         <EventTagsAndScreenshot
           event={EventFixture({...event, tags, contexts})}
-          organization={organization}
           projectSlug={project.slug}
-          location={router.location}
           isShare
         />,
         {organization}
@@ -255,9 +251,7 @@ describe('EventTagsAndScreenshot', function () {
       render(
         <EventTagsAndScreenshot
           event={EventFixture({...event, tags, contexts})}
-          organization={organization}
           projectSlug={project.slug}
-          location={router.location}
           isShare
         />
       );
@@ -284,9 +278,7 @@ describe('EventTagsAndScreenshot', function () {
           <GlobalModal />
           <EventTagsAndScreenshot
             event={EventFixture({user: {}, contexts: {}})}
-            organization={organization}
             projectSlug={project.slug}
-            location={router.location}
           />
         </Fragment>,
         {organization}
@@ -339,9 +331,7 @@ describe('EventTagsAndScreenshot', function () {
       render(
         <EventTagsAndScreenshot
           event={EventFixture({...event, tags, contexts})}
-          organization={organization}
           projectSlug={project.slug}
-          location={router.location}
         />,
         {organization}
       );
@@ -396,9 +386,7 @@ describe('EventTagsAndScreenshot', function () {
       render(
         <EventTagsAndScreenshot
           event={EventFixture({...event, tags, contexts})}
-          organization={organization}
           projectSlug={project.slug}
-          location={router.location}
         />,
         {organization}
       );
@@ -439,9 +427,7 @@ describe('EventTagsAndScreenshot', function () {
       render(
         <EventTagsAndScreenshot
           event={EventFixture({...event, tags, contexts})}
-          organization={organization}
           projectSlug={project.slug}
-          location={router.location}
         />,
         {organization}
       );
@@ -473,9 +459,7 @@ describe('EventTagsAndScreenshot', function () {
       render(
         <EventTagsAndScreenshot
           event={EventFixture({...event, contexts})}
-          organization={organization}
           projectSlug={project.slug}
-          location={router.location}
         />,
         {organization}
       );
@@ -502,12 +486,7 @@ describe('EventTagsAndScreenshot', function () {
 
     it('has tags and attachments only', async function () {
       render(
-        <EventTagsAndScreenshot
-          event={{...event, tags}}
-          organization={organization}
-          projectSlug={project.slug}
-          location={router.location}
-        />,
+        <EventTagsAndScreenshot event={{...event, tags}} projectSlug={project.slug} />,
         {organization}
       );
 

--- a/static/app/components/events/eventTagsAndScreenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.tsx
@@ -31,11 +31,7 @@ const SCREENSHOT_NAMES = [
   'screenshot-2.png',
 ];
 
-type Props = Omit<
-  React.ComponentProps<typeof Tags>,
-  'projectSlug' | 'hasEventContext'
-> & {
-  projectSlug: string;
+type Props = React.ComponentProps<typeof Tags> & {
   isShare?: boolean;
 };
 
@@ -126,14 +122,7 @@ export function EventTagsAndScreenshot({projectSlug, event, isShare = false}: Pr
   return (
     <Wrapper showScreenshot={showScreenshot} showTags={showTags}>
       <TagWrapper>
-        {showTags && (
-          <Tags
-            organization={organization}
-            event={event}
-            projectSlug={projectSlug}
-            location={location}
-          />
-        )}
+        {showTags && <Tags event={event} projectSlug={projectSlug} />}
       </TagWrapper>
       {showScreenshot && (
         <div>

--- a/static/app/components/events/eventTagsAndScreenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.tsx
@@ -13,6 +13,8 @@ import {t, tn} from 'sentry/locale';
 import type {EventAttachment} from 'sentry/types/group';
 import {objectIsEmpty} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import {SCREENSHOT_TYPE} from 'sentry/views/issueDetails/groupEventAttachments/groupEventAttachmentsFilter';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 
@@ -37,13 +39,9 @@ type Props = Omit<
   isShare?: boolean;
 };
 
-export function EventTagsAndScreenshot({
-  projectSlug,
-  location,
-  event,
-  organization,
-  isShare = false,
-}: Props) {
+export function EventTagsAndScreenshot({projectSlug, event, isShare = false}: Props) {
+  const location = useLocation();
+  const organization = useOrganization();
   const {tags = []} = event;
   const hasContext = !objectIsEmpty(event.user ?? {}) || !objectIsEmpty(event.contexts);
   const {data: attachments} = useFetchEventAttachments(
@@ -66,8 +64,6 @@ export function EventTagsAndScreenshot({
 
   const showScreenshot = !isShare && !!screenshots.length;
   const screenshot = screenshots[screenshotInFocus];
-  // Check for context bailout condition. No context is rendered if only user is provided
-  const hasEventContext = hasContext && !objectIsEmpty(event.contexts);
   const showTags = !!tags.length || hasContext;
 
   const handleDeleteScreenshot = (attachmentId: string) => {
@@ -136,7 +132,6 @@ export function EventTagsAndScreenshot({
             event={event}
             projectSlug={projectSlug}
             location={location}
-            hasEventContext={hasEventContext}
           />
         )}
       </TagWrapper>

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -4,7 +4,11 @@ import styled from '@emotion/styled';
 import ButtonBar from 'sentry/components/buttonBar';
 import EventContextSummary from 'sentry/components/events/contextSummary';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
-import {TAGS_DOCS_LINK, useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
+import {
+  TagFilter,
+  TAGS_DOCS_LINK,
+  useHasNewTagsUI,
+} from 'sentry/components/events/eventTags/util';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t, tct} from 'sentry/locale';
@@ -18,14 +22,6 @@ type Props = {
   event: Event;
   projectSlug: Project['slug'];
 };
-
-export enum TagFilter {
-  ALL = 'All',
-  CUSTOM = 'Custom',
-  USER = 'User',
-  SYSTEM = 'System',
-  EVENT = 'Event',
-}
 
 function Tags({event, projectSlug}: Props) {
   const [tagFilter, setTagFilter] = useState<TagFilter>(TagFilter.ALL);

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -1,21 +1,22 @@
 import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
 import ButtonBar from 'sentry/components/buttonBar';
+import EventContextSummary from 'sentry/components/events/contextSummary';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {shouldUseNewTagsUI} from 'sentry/components/events/eventTags/util';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization, Project} from 'sentry/types';
+import type {Project} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import {EventTags} from '../eventTags';
 
 type Props = {
   event: Event;
-  location: Location;
-  organization: Organization;
   projectSlug: Project['slug'];
 };
 
@@ -27,34 +28,40 @@ export enum TagFilter {
   EVENT = 'Event',
 }
 
-function Tags({event, organization, projectSlug, location}: Props) {
+function Tags({event, projectSlug}: Props) {
+  const location = useLocation();
+  const organization = useOrganization();
   const [tagFilter, setTagFilter] = useState<TagFilter>(TagFilter.ALL);
   const handleTagFilterChange = useCallback((value: TagFilter) => {
     setTagFilter(value);
   }, []);
 
+  const hasNewUI = shouldUseNewTagsUI();
+  const actions = !hasNewUI ? null : (
+    <ButtonBar gap={1}>
+      <SegmentedControl
+        size="xs"
+        aria-label={t('Filter tags')}
+        value={tagFilter}
+        onChange={handleTagFilterChange}
+      >
+        {Object.values(TagFilter).map(v => (
+          <SegmentedControl.Item key={v}>{`${v}`}</SegmentedControl.Item>
+        ))}
+      </SegmentedControl>
+    </ButtonBar>
+  );
+
   return (
     <StyledEventDataSection
       title={t('Tags')}
       help={t('The default and custom tags associated with this event.')}
-      actions={
-        <ButtonBar gap={1}>
-          <SegmentedControl
-            size="xs"
-            aria-label={t('Filter tags')}
-            value={tagFilter}
-            onChange={handleTagFilterChange}
-          >
-            {Object.values(TagFilter).map(v => (
-              <SegmentedControl.Item key={v}>{`${v}`}</SegmentedControl.Item>
-            ))}
-          </SegmentedControl>
-        </ButtonBar>
-      }
+      actions={actions}
       data-test-id="event-tags"
       guideTarget="tags"
       type="tags"
     >
+      {!hasNewUI && <EventContextSummary event={event} />}
       <EventTags
         event={event}
         tagFilter={tagFilter}

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -14,8 +14,6 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 
 import {EventTags} from '../eventTags';
 
@@ -33,8 +31,6 @@ export enum TagFilter {
 }
 
 function Tags({event, projectSlug}: Props) {
-  const location = useLocation();
-  const organization = useOrganization();
   const [tagFilter, setTagFilter] = useState<TagFilter>(TagFilter.ALL);
   const handleTagFilterChange = useCallback((value: TagFilter) => {
     setTagFilter(value);
@@ -69,13 +65,7 @@ function Tags({event, projectSlug}: Props) {
       type="tags"
     >
       {!hasNewUI && <EventContextSummary event={event} />}
-      <EventTags
-        event={event}
-        tagFilter={tagFilter}
-        organization={organization}
-        projectSlug={projectSlug}
-        location={location}
-      />
+      <EventTags event={event} projectSlug={projectSlug} tagFilter={tagFilter} />
     </StyledEventDataSection>
   );
 }

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -4,10 +4,7 @@ import styled from '@emotion/styled';
 import ButtonBar from 'sentry/components/buttonBar';
 import EventContextSummary from 'sentry/components/events/contextSummary';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
-import {
-  shouldUseNewTagsUI,
-  TAGS_DOCS_LINK,
-} from 'sentry/components/events/eventTags/util';
+import {TAGS_DOCS_LINK, useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t, tct} from 'sentry/locale';
@@ -36,8 +33,8 @@ function Tags({event, projectSlug}: Props) {
     setTagFilter(value);
   }, []);
 
-  const hasNewUI = shouldUseNewTagsUI();
-  const actions = !hasNewUI ? null : (
+  const hasNewTagsUI = useHasNewTagsUI();
+  const actions = !hasNewTagsUI ? null : (
     <ButtonBar gap={1}>
       <SegmentedControl
         size="xs"
@@ -64,7 +61,7 @@ function Tags({event, projectSlug}: Props) {
       guideTarget="tags"
       type="tags"
     >
-      {!hasNewUI && <EventContextSummary event={event} />}
+      {!hasNewTagsUI && <EventContextSummary event={event} />}
       <EventTags event={event} projectSlug={projectSlug} tagFilter={tagFilter} />
     </StyledEventDataSection>
   );

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -1,7 +1,10 @@
+import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
+import ButtonBar from 'sentry/components/buttonBar';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization, Project} from 'sentry/types';
@@ -16,17 +19,45 @@ type Props = {
   projectSlug: Project['slug'];
 };
 
+export enum TagFilter {
+  ALL = 'All',
+  CUSTOM = 'Custom',
+  USER = 'User',
+  SYSTEM = 'System',
+  EVENT = 'Event',
+}
+
 function Tags({event, organization, projectSlug, location}: Props) {
+  const [tagFilter, setTagFilter] = useState<TagFilter>(TagFilter.ALL);
+  const handleTagFilterChange = useCallback((value: TagFilter) => {
+    setTagFilter(value);
+  }, []);
+
   return (
     <StyledEventDataSection
       title={t('Tags')}
       help={t('The default and custom tags associated with this event.')}
+      actions={
+        <ButtonBar gap={1}>
+          <SegmentedControl
+            size="xs"
+            aria-label={t('Filter tags')}
+            value={tagFilter}
+            onChange={handleTagFilterChange}
+          >
+            {Object.values(TagFilter).map(v => (
+              <SegmentedControl.Item key={v}>{`${v}`}</SegmentedControl.Item>
+            ))}
+          </SegmentedControl>
+        </ButtonBar>
+      }
       data-test-id="event-tags"
       guideTarget="tags"
       type="tags"
     >
       <EventTags
         event={event}
+        tagFilter={tagFilter}
         organization={organization}
         projectSlug={projectSlug}
         location={location}

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -4,9 +4,13 @@ import styled from '@emotion/styled';
 import ButtonBar from 'sentry/components/buttonBar';
 import EventContextSummary from 'sentry/components/events/contextSummary';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
-import {shouldUseNewTagsUI} from 'sentry/components/events/eventTags/util';
+import {
+  shouldUseNewTagsUI,
+  TAGS_DOCS_LINK,
+} from 'sentry/components/events/eventTags/util';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
@@ -55,7 +59,10 @@ function Tags({event, projectSlug}: Props) {
   return (
     <StyledEventDataSection
       title={t('Tags')}
-      help={t('The default and custom tags associated with this event.')}
+      help={tct('The searchable tags associated with this event. [link:Learn more]', {
+        link: <ExternalLink openInNewTab href={TAGS_DOCS_LINK} />,
+      })}
+      isHelpHoverable
       actions={actions}
       data-test-id="event-tags"
       guideTarget="tags"

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
-import EventContextSummary from 'sentry/components/events/contextSummary';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -12,22 +11,20 @@ import {EventTags} from '../eventTags';
 
 type Props = {
   event: Event;
-  hasEventContext: boolean;
   location: Location;
   organization: Organization;
   projectSlug: Project['slug'];
 };
 
-function Tags({event, organization, projectSlug, location, hasEventContext}: Props) {
+function Tags({event, organization, projectSlug, location}: Props) {
   return (
     <StyledEventDataSection
       title={t('Tags')}
-      help={t('The default and custom tags associated with this event')}
+      help={t('The default and custom tags associated with this event.')}
       data-test-id="event-tags"
       guideTarget="tags"
       type="tags"
     >
-      {hasEventContext && <EventContextSummary event={event} />}
       <EventTags
         event={event}
         organization={organization}

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -248,7 +248,6 @@ function EventDetailsContent(props: Props) {
                                       organization={organization}
                                       event={event}
                                       project={projects[0] as Project}
-                                      location={location}
                                       showTagSummary={false}
                                     />
                                   </ProfileGroupProvider>
@@ -260,7 +259,6 @@ function EventDetailsContent(props: Props) {
                               organization={organization}
                               event={event}
                               project={projects[0] as Project}
-                              location={location}
                               showTagSummary={false}
                             />
                           )}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -6,6 +6,7 @@ import {CommitAuthorFixture} from 'sentry-fixture/commitAuthor';
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
@@ -14,7 +15,7 @@ import {SentryAppComponentFixture} from 'sentry-fixture/sentryAppComponent';
 import {SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
 
 import type {Event, Group} from 'sentry/types';
 import {EntryType, IssueCategory, IssueType} from 'sentry/types';
@@ -60,6 +61,38 @@ const makeDefaultMockData = (
         {key: 'mechanism', value: 'ANR'},
       ],
       contexts: {
+        app: {
+          app_start_time: '2021-08-31T15:14:21Z',
+          device_app_hash: '0b77c3f2567d65fe816e1fa7013779fbe3b51633',
+          build_type: 'test',
+          app_identifier: 'io.sentry.sample.iOS-Swift',
+          app_name: 'iOS-Swift',
+          app_version: '7.2.3',
+          app_build: '390',
+          app_id: 'B2690307-FDD1-3D34-AA1E-E280A9C2406C',
+          type: 'app',
+        },
+        device: {
+          family: 'iOS',
+          model: 'iPhone13,4',
+          model_id: 'D54pAP',
+          memory_size: 5987008512,
+          free_memory: 154435584,
+          usable_memory: 4706893824,
+          storage_size: 127881465856,
+          boot_time: '2021-08-29T06:05:51Z',
+          timezone: 'CEST',
+          type: 'device',
+        },
+        os: {
+          name: 'iOS',
+          version: '14.7.1',
+          build: '18G82',
+          kernel_version:
+            'Darwin Kernel Version 20.6.0: Mon Jun 21 21:23:35 PDT 2021; root:xnu-7195.140.42~10/RELEASE_ARM64_T8101',
+          rooted: false,
+          type: 'os',
+        },
         trace: {
           trace_id: TRACE_ID,
           span_id: 'b0e6f15b45c36b12',
@@ -461,6 +494,30 @@ describe('groupEventDetails', () => {
         name: /resources/i,
       })
     ).toBeInTheDocument();
+  });
+
+  it("renders the changes for 'event-tags-tree-ui' flag", async function () {
+    const props = makeDefaultMockData();
+    mockGroupApis(props.organization, props.project, props.group, props.event);
+    const organization = OrganizationFixture({
+      features: ['event-tags-tree-ui'],
+    });
+    const {routerContext} = initializeOrg({organization});
+
+    render(<TestComponent group={props.group} event={props.event} />, {
+      organization,
+      context: routerContext,
+    });
+    expect(await screen.findByText('Event ID:')).toBeInTheDocument();
+    const contextSummary = screen.getByTestId('context-summary');
+
+    const contextSummaryContainer = within(contextSummary);
+    expect(contextSummaryContainer.queryAllByTestId('context-item')).toHaveLength(
+      // trace doesn't get a context item
+      Object.keys(props.event.contexts).length - 1
+    );
+
+    expect(screen.getByTestId('event-tags')).toBeInTheDocument();
   });
 });
 

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -71,7 +71,6 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
     params,
   } = props;
   const eventWithMeta = withMeta(event);
-
   // Reprocessing
   const hasReprocessingV2Feature = organization.features?.includes('reprocessing-v2');
   const {activity: activities} = group;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -124,6 +124,7 @@ function DefaultGroupEventDetailsContent({
       {group.issueCategory === IssueCategory.CRON && (
         <CronTimelineSection event={event} organization={organization} />
       )}
+      {/* TODO(Leander): Hide this behind new UI flag */}
       <EventDataSection
         title="Context Summary"
         type="context-summary"

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -5,6 +5,7 @@ import {CommitRow} from 'sentry/components/commitRow';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EventContexts} from 'sentry/components/events/contexts';
 import ContextSummary from 'sentry/components/events/contextSummary';
+import {CONTEXT_DOCS_LINK} from 'sentry/components/events/contextSummary/utils';
 import {EventDevice} from 'sentry/components/events/device';
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
@@ -36,7 +37,8 @@ import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import {DataSection} from 'sentry/components/events/styles';
 import {SuspectCommits} from 'sentry/components/events/suspectCommits';
 import {EventUserFeedback} from 'sentry/components/events/userFeedback';
-import {t} from 'sentry/locale';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Group, Project} from 'sentry/types';
 import {IssueCategory, IssueType} from 'sentry/types';
@@ -123,12 +125,16 @@ function DefaultGroupEventDetailsContent({
       {group.issueCategory === IssueCategory.CRON && (
         <CronTimelineSection event={event} organization={organization} />
       )}
-      {/* TODO(Leander): Hide this behind new UI flag */}
       {shouldUseNewTagsUI() && (
         <EventDataSection
           title={t('Context Summary')}
+          help={tct('A summary contexts derived from this event. [link:Learn more]', {
+            link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
+          })}
+          isHelpHoverable
+          data-test-id="context-summary"
+          guideTarget="context-summary"
           type="context-summary"
-          help={t('A summary some useful context')}
         >
           <ContextSummary event={event} />
         </EventDataSection>

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -22,6 +22,7 @@ import {EventFunctionComparisonList} from 'sentry/components/events/eventStatist
 import {EventRegressionSummary} from 'sentry/components/events/eventStatisticalDetector/eventRegressionSummary';
 import {EventFunctionBreakpointChart} from 'sentry/components/events/eventStatisticalDetector/functionBreakpointChart';
 import {TransactionsDeltaProvider} from 'sentry/components/events/eventStatisticalDetector/transactionsDeltaProvider';
+import {shouldUseNewTagsUI} from 'sentry/components/events/eventTags/util';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
@@ -42,7 +43,6 @@ import {IssueCategory, IssueType} from 'sentry/types';
 import type {EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {shouldShowCustomErrorResourceConfig} from 'sentry/utils/issueTypeConfig';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ResourcesAndMaybeSolutions} from 'sentry/views/issueDetails/resourcesAndMaybeSolutions';
 
@@ -83,7 +83,6 @@ function DefaultGroupEventDetailsContent({
   project,
 }: Required<GroupEventDetailsContentProps>) {
   const organization = useOrganization();
-  const location = useLocation();
   const projectSlug = project.slug;
   const hasReplay = Boolean(event.tags?.find(({key}) => key === 'replayId')?.value);
   const mechanism = event.tags?.find(({key}) => key === 'mechanism')?.value;
@@ -113,7 +112,7 @@ function DefaultGroupEventDetailsContent({
         />
       </StyledDataSection>
       {event.userReport && (
-        <EventDataSection title="User Feedback" type="user-feedback">
+        <EventDataSection title={t('User Feedback')} type="user-feedback">
           <EventUserFeedback
             report={event.userReport}
             orgSlug={organization.slug}
@@ -125,19 +124,16 @@ function DefaultGroupEventDetailsContent({
         <CronTimelineSection event={event} organization={organization} />
       )}
       {/* TODO(Leander): Hide this behind new UI flag */}
-      <EventDataSection
-        title="Context Summary"
-        type="context-summary"
-        help="A summary of useful contexts"
-      >
-        <ContextSummary event={event} />
-      </EventDataSection>
-      <EventTagsAndScreenshot
-        event={event}
-        organization={organization}
-        projectSlug={project.slug}
-        location={location}
-      />
+      {shouldUseNewTagsUI() && (
+        <EventDataSection
+          title={t('Context Summary')}
+          type="context-summary"
+          help={t('A summary some useful context')}
+        >
+          <ContextSummary event={event} />
+        </EventDataSection>
+      )}
+      <EventTagsAndScreenshot event={event} projectSlug={project.slug} />
       {showMaybeSolutionsHigher && (
         <ResourcesAndMaybeSolutions event={event} project={project} group={group} />
       )}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -23,7 +23,7 @@ import {EventFunctionComparisonList} from 'sentry/components/events/eventStatist
 import {EventRegressionSummary} from 'sentry/components/events/eventStatisticalDetector/eventRegressionSummary';
 import {EventFunctionBreakpointChart} from 'sentry/components/events/eventStatisticalDetector/functionBreakpointChart';
 import {TransactionsDeltaProvider} from 'sentry/components/events/eventStatisticalDetector/transactionsDeltaProvider';
-import {shouldUseNewTagsUI} from 'sentry/components/events/eventTags/util';
+import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
@@ -85,6 +85,8 @@ function DefaultGroupEventDetailsContent({
   project,
 }: Required<GroupEventDetailsContentProps>) {
   const organization = useOrganization();
+  const hasNewTagsUI = useHasNewTagsUI();
+
   const projectSlug = project.slug;
   const hasReplay = Boolean(event.tags?.find(({key}) => key === 'replayId')?.value);
   const mechanism = event.tags?.find(({key}) => key === 'mechanism')?.value;
@@ -125,7 +127,7 @@ function DefaultGroupEventDetailsContent({
       {group.issueCategory === IssueCategory.CRON && (
         <CronTimelineSection event={event} organization={organization} />
       )}
-      {shouldUseNewTagsUI() && (
+      {hasNewTagsUI && (
         <EventDataSection
           title={t('Context Summary')}
           help={tct('A summary contexts derived from this event. [link:Learn more]', {

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {CommitRow} from 'sentry/components/commitRow';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EventContexts} from 'sentry/components/events/contexts';
+import ContextSummary from 'sentry/components/events/contextSummary';
 import {EventDevice} from 'sentry/components/events/device';
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
@@ -123,6 +124,13 @@ function DefaultGroupEventDetailsContent({
       {group.issueCategory === IssueCategory.CRON && (
         <CronTimelineSection event={event} organization={organization} />
       )}
+      <EventDataSection
+        title="Context Summary"
+        type="context-summary"
+        help="A summary of useful contexts"
+      >
+        <ContextSummary event={event} />
+      </EventDataSection>
       <EventTagsAndScreenshot
         event={event}
         organization={organization}

--- a/static/app/views/issueDetails/groupTags.tsx
+++ b/static/app/views/issueDetails/groupTags.tsx
@@ -4,6 +4,7 @@ import {useFetchIssueTags} from 'sentry/actionCreators/group';
 import {Alert} from 'sentry/components/alert';
 import Count from 'sentry/components/count';
 import {DeviceName} from 'sentry/components/deviceName';
+import {TAGS_DOCS_LINK} from 'sentry/components/events/eventTags/util';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -82,9 +83,7 @@ function GroupTags({group, baseUrl, environments}: GroupTagsProps) {
           {tct(
             'Tags are automatically indexed for searching and breakdown charts. Learn how to [link: add custom tags to issues]',
             {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platform-redirect/?next=/enriching-events/tags" />
-              ),
+              link: <ExternalLink href={TAGS_DOCS_LINK} />,
             }
           )}
         </Alert>

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -253,7 +253,6 @@ function EventDetailsContent(props: Props) {
                                           event={event}
                                           project={_projects[0] as Project}
                                           showTagSummary={false}
-                                          location={location}
                                         />
                                       </ProfileGroupProvider>
                                     )}
@@ -265,7 +264,6 @@ function EventDetailsContent(props: Props) {
                                   event={event}
                                   project={_projects[0] as Project}
                                   showTagSummary={false}
-                                  location={location}
                                 />
                               )}
                             </QuickTraceContext.Provider>

--- a/static/app/views/settings/projectTags/index.tsx
+++ b/static/app/views/settings/projectTags/index.tsx
@@ -7,6 +7,7 @@ import Access from 'sentry/components/acl/access';
 import {Button} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 import EmptyMessage from 'sentry/components/emptyMessage';
+import {TAGS_DOCS_LINK} from 'sentry/components/events/eventTags/util';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -93,9 +94,7 @@ function ProjectTags(props: Props) {
           `Each event in Sentry may be annotated with various tags (key and value pairs).
                  Learn how to [link:add custom tags].`,
           {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platform-redirect/?next=/enriching-events/tags/" />
-            ),
+            link: <ExternalLink href={TAGS_DOCS_LINK} />,
           }
         )}
       </TextBlock>

--- a/static/app/views/sharedGroupDetails/index.tsx
+++ b/static/app/views/sharedGroupDetails/index.tsx
@@ -120,7 +120,6 @@ class SharedGroupDetails extends Component<Props, State> {
       return <LoadingError onRetry={this.handleRetry} />;
     }
 
-    const {location} = this.props;
     const {permalink, latestEvent, project} = group;
     const title = this.getTitle();
     // project.organization is not a real organization, it's just the slug and name
@@ -148,7 +147,6 @@ class SharedGroupDetails extends Component<Props, State> {
                   <SharedGroupHeader group={group} />
                   <Container className="group-overview event-details-container">
                     <BorderlessEventEntries
-                      location={location}
                       organization={org}
                       group={group}
                       event={latestEvent}


### PR DESCRIPTION
Still working on this branch but refactoring to allow a few new UI features:
- Filtering event tags in the tree
- Column layout (currently set to 2 columns)
- Context Summary moved away from Tags (into its own Data Section)

A few changes were made to tangential files to prevent things like prop drilling location or organization.

For future PRS:
- Ensure filtering works (add grouping for common tags)
- Add dropdown for links on tags

Still todo:
- [x] Add tests for the new UI
- [x] Add screenshots/video


New UI

<img width="978" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/80381dd3-7124-4da7-87e4-75752fee4b4c">

Without Flag/QParam
<img width="978" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/67fc584f-795c-42f8-a389-35a74ed1aba6">

