### PR TITLE
ref(replay): Replace "No canvas found for id" exception with metric

### DIFF
--- a/static/app/components/replays/canvasReplayerPlugin.tsx
+++ b/static/app/components/replays/canvasReplayerPlugin.tsx
@@ -114,8 +114,10 @@ export function CanvasReplayerPlugin(events: eventWithTime[]) {
           canvases.get(e.data.id) ||
           (source && cloneCanvas(e.data.id, source as HTMLCanvasElement));
 
+        // No canvas found for id... this isn't reliably reproducible and not
+        // exactly sure why it flakes. Saving as metric to keep an eye on it.
         if (!target) {
-          Sentry.captureException(new Error('No canvas found for id'));
+          Sentry.metrics.increment('replay.canvas_player.no_canvas_id');
           return;
         }
 
@@ -125,8 +127,12 @@ export function CanvasReplayerPlugin(events: eventWithTime[]) {
           target: target as HTMLCanvasElement,
           imageMap,
           canvasEventMap,
-          errorHandler: () => {
-            Sentry.captureException(new Error('Error with canvasMutation'));
+          errorHandler: (err: unknown) => {
+            if (err instanceof Error) {
+              Sentry.captureException(err);
+            } else {
+              Sentry.metrics.increment('replay.canvas_player.error_canvas_mutation');
+            }
           },
         });
 


### PR DESCRIPTION
The "no canvas found for id" error seemed to be flakey to me (i.e. could not repro), changing this to be a metric so we can keep an eye on it so it does not explode, and at the same time reduce noise from issue alerts as grouping is a bit flaky too. The exception stacktrack itself is also not very helpful in debugging.

The canvas mutation similarly does not provide a helpful stacktrace, but since it is an error handler, it should provide us with a helpful exception + stacktrace, so use that instead of generating a new one inside of the handler.