### PR TITLE
feat(discover): allows filtering metric queries on span.op

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -316,6 +316,7 @@ DEFAULT_METRIC_TAGS = {
     "transaction.method",
     "transaction.op",
     "transaction.status",
+    "span.op",
 }
 SPAN_METRICS_MAP = {
     "user": "s:spans/user@none",


### PR DESCRIPTION
Adds `span.op` to `DEFAULT_METRIC_TAGS` so that it is available in discover metrics queries.