### PR TITLE
fix(feedback): correct usage of option name

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -817,10 +817,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                     "sentry:replay_rage_click_issues",
                     bool(options["sentry:replay_rage_click_issues"]),
                 )
-            if "sentry:feedback_user_report_notification" in options:
+            if "sentry:feedback_user_report_notifications" in options:
                 project.update_option(
-                    "sentry:feedback_user_report_notification",
-                    bool(options["sentry:feedback_user_report_notification"]),
+                    "sentry:feedback_user_report_notifications",
+                    bool(options["sentry:feedback_user_report_notifications"]),
                 )
             if "sentry:feedback_ai_spam_detection" in options:
                 project.update_option(

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -233,8 +233,8 @@ def format_options(attrs: dict[str, Any]) -> dict[str, Any]:
             options.get(f"sentry:{FilterTypes.ERROR_MESSAGES}", [])
         ),
         "feedback:branding": options.get("feedback:branding", "1") == "1",
-        "sentry:feedback_user_report_notification": bool(
-            options.get("sentry:feedback_user_report_notification")
+        "sentry:feedback_user_report_notifications": bool(
+            options.get("sentry:feedback_user_report_notifications")
         ),
         "sentry:feedback_ai_spam_detection": bool(options.get("sentry:feedback_ai_spam_detection")),
         "sentry:replay_rage_click_issues": options.get("sentry:replay_rage_click_issues"),

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1409,7 +1409,7 @@ def should_postprocess_feedback(job: PostProcessJob) -> bool:
         return True
 
     should_notify_on_old_feedbacks = job["event"].project.get_option(
-        "sentry:replay_rage_click_issues"
+        "sentry:feedback_user_report_notifications"
     )
 
     if (

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -610,7 +610,7 @@ class ProjectUpdateTest(APITestCase):
             "sentry:token_header": "*",
             "sentry:verify_ssl": False,
             "sentry:replay_rage_click_issues": True,
-            "sentry:feedback_user_report_notification": True,
+            "sentry:feedback_user_report_notifications": True,
             "sentry:feedback_ai_spam_detection": True,
             "feedback:branding": False,
             "filters:react-hydration-errors": True,
@@ -726,7 +726,7 @@ class ProjectUpdateTest(APITestCase):
             ).exists()
         assert project.get_option("feedback:branding") == "0"
         assert project.get_option("sentry:replay_rage_click_issues") is True
-        assert project.get_option("sentry:feedback_user_report_notification") is True
+        assert project.get_option("sentry:feedback_user_report_notifications") is True
         assert project.get_option("sentry:feedback_ai_spam_detection") is True
 
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -403,11 +403,12 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
         MOCK_RULES = ("sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",)
 
         redis_buffer = RedisBuffer()
-        with mock.patch("sentry.buffer.backend.get", redis_buffer.get), mock.patch(
-            "sentry.buffer.backend.incr", redis_buffer.incr
-        ), patch("sentry.constants._SENTRY_RULES", MOCK_RULES), patch(
-            "sentry.rules.processor.rules", init_registry()
-        ) as rules:
+        with (
+            mock.patch("sentry.buffer.backend.get", redis_buffer.get),
+            mock.patch("sentry.buffer.backend.incr", redis_buffer.incr),
+            patch("sentry.constants._SENTRY_RULES", MOCK_RULES),
+            patch("sentry.rules.processor.rules", init_registry()) as rules,
+        ):
             MockAction = mock.Mock()
             MockAction.id = "tests.sentry.tasks.post_process.tests.MockAction"
             MockAction.return_value = mock.Mock(spec=EventAction)
@@ -1683,8 +1684,9 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
     @patch("sentry.rules.processor.RuleProcessor")
     def test_invalidates_snooze_with_buffers(self, mock_processor, send_robust):
         redis_buffer = RedisBuffer()
-        with mock.patch("sentry.buffer.backend.get", redis_buffer.get), mock.patch(
-            "sentry.buffer.backend.incr", redis_buffer.incr
+        with (
+            mock.patch("sentry.buffer.backend.get", redis_buffer.get),
+            mock.patch("sentry.buffer.backend.incr", redis_buffer.incr),
         ):
             event = self.create_event(
                 data={"message": "testing", "fingerprint": ["group-1"]}, project_id=self.project.id
@@ -2750,7 +2752,7 @@ class PostProcessGroupFeedbackTest(
         return cache_key
 
     def test_not_ran_if_crash_report_option_disabled(self):
-        self.project.update_option("sentry:replay_rage_click_issues", False)
+        self.project.update_option("sentry:feedback_user_report_notifications", False)
         event = self.create_event(
             data={},
             project_id=self.project.id,
@@ -2776,7 +2778,7 @@ class PostProcessGroupFeedbackTest(
         assert mock_process_func.call_count == 0
 
     def test_not_ran_if_crash_report_project_option_enabled(self):
-        self.project.update_option("sentry:replay_rage_click_issues", True)
+        self.project.update_option("sentry:feedback_user_report_notifications", True)
 
         event = self.create_event(
             data={},


### PR DESCRIPTION
- I messed up the name of the project option in the endpoint, it should be plural, not singular
- I was using the wrong project option flag in the check 🤦‍♂️

Thank you to @jas-kas for catching this bug. 🙏🏼 this is what EA is for!


I do want to refactor project options to make it easier to test // less prone to bugs when adding additional ones. will add a TODO item. 

