### PR TITLE
chore(processing) Remove non-service reprocessing redis usage

### DIFF
--- a/src/sentry/eventstore/reprocessing/base.py
+++ b/src/sentry/eventstore/reprocessing/base.py
@@ -9,6 +9,7 @@ class ReprocessingStore(Service):
     __all__ = (
         "event_count_for_hashes",
         "pop_batched_events",
+        "pop_batched_events_by_key",
         "get_old_primary_hashes",
         "expire_hash",
         "add_hash",
@@ -30,6 +31,11 @@ class ReprocessingStore(Service):
 
     def pop_batched_events(
         self, project_id: int, group_id: int, primary_hash: str
+    ) -> tuple[list[str], datetime | None, datetime | None]:
+        raise NotImplementedError()
+
+    def pop_batched_events_by_key(
+        self, key: str
     ) -> tuple[list[str], datetime | None, datetime | None]:
         raise NotImplementedError()
 

--- a/src/sentry/eventstore/reprocessing/redis.py
+++ b/src/sentry/eventstore/reprocessing/redis.py
@@ -55,10 +55,15 @@ class RedisReprocessingStore(ReprocessingStore):
         `event id;datetime of event`, returns a list of event IDs, the
         earliest datetime, and the latest datetime.
         """
+        key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
+        return self.pop_batched_events_by_key(key)
+
+    def pop_batched_events_by_key(
+        self, key: str
+    ) -> tuple[list[str], datetime | None, datetime | None]:
         event_ids_batch = []
         min_datetime: datetime | None = None
         max_datetime: datetime | None = None
-        key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
 
         for row in self.redis.lrange(key, 0, -1):
             datetime_raw, event_id = row.split(";")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -965,7 +965,7 @@ register(
 register("reprocessing2.drop-delete-old-primary-hash", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Switch to use service wrapper for reprocessing redis operations
-register("reprocessing.use_store", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("reprocessing.use_store", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # BEGIN ABUSE QUOTAS
 

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -80,17 +80,14 @@ instead of group deletion is:
 """
 
 import logging
-import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal, Union
 
-import redis
 import sentry_sdk
 from django.conf import settings
 from django.db import router
-from rediscluster import RedisCluster
 
 from sentry import eventstore, models, nodestore, options
 from sentry.attachments import CachedAttachment, attachment_cache
@@ -101,8 +98,6 @@ from sentry.eventstore.reprocessing import reprocessing_store
 from sentry.models.eventattachment import EventAttachment
 from sentry.snuba.dataset import Dataset
 from sentry.utils import json, metrics, snuba
-from sentry.utils.dates import to_datetime, to_timestamp
-from sentry.utils.redis import redis_clusters
 from sentry.utils.safe import get_path, set_path
 
 logger = logging.getLogger("sentry.reprocessing")
@@ -140,8 +135,6 @@ CannotReprocessReason = Union[
     # A required attachment, such as the original minidump, is missing.
     Literal["attachment.not_found"],
 ]
-
-use_store_option = "reprocessing.use_store"
 
 
 class CannotReprocess(Exception):
@@ -254,12 +247,7 @@ def get_original_primary_hash(event):
     return get_path(event.data, "contexts", "reprocessing", "original_primary_hash")
 
 
-def _get_old_primary_hash_subset_key(project_id: int, group_id: int, primary_hash: str):
-    return f"re2:tombstones:{{{project_id}:{group_id}:{primary_hash}}}"
-
-
 def _send_delete_old_primary_hash_messages(
-    client,
     project_id: int,
     group_id: int,
     old_primary_hashes: Sequence[str],
@@ -268,15 +256,9 @@ def _send_delete_old_primary_hash_messages(
     # Events for a group are split and bucketed by their primary hashes. If flushing is to be
     # performed on a per-group basis, the event count needs to be summed up across all buckets
     # belonging to a single group.
-    if options.get(use_store_option):
-        event_count = reprocessing_store.event_count_for_hashes(
-            project_id, group_id, old_primary_hashes
-        )
-    else:
-        event_count = 0
-        for primary_hash in old_primary_hashes:
-            key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
-            event_count += client.llen(key)
+    event_count = reprocessing_store.event_count_for_hashes(
+        project_id, group_id, old_primary_hashes
+    )
 
     if (
         not force_flush_batch
@@ -285,13 +267,9 @@ def _send_delete_old_primary_hash_messages(
         return
 
     for primary_hash in old_primary_hashes:
-        if options.get(use_store_option):
-            event_ids, from_date, to_date = reprocessing_store.pop_batched_events(
-                project_id, group_id, primary_hash
-            )
-        else:
-            event_key = _get_old_primary_hash_subset_key(project_id, group_id, primary_hash)
-            event_ids, from_date, to_date = pop_batched_events_from_redis(event_key)
+        event_ids, from_date, to_date = reprocessing_store.pop_batched_events(
+            project_id, group_id, primary_hash
+        )
 
         # Racing might be happening between two different tasks. Give up on the
         # task that's lagging behind by prematurely terminating flushing.
@@ -377,35 +355,14 @@ def buffered_delete_old_primary_hash(
     ):
         return
 
-    client = _get_sync_redis_client()
-
-    if options.get(use_store_option):
-        old_primary_hashes = reprocessing_store.get_old_primary_hashes(project_id, group_id)
-    else:
-        # This is a meta key that contains old primary hashes. These hashes are then
-        # combined with other values to construct a key that points to a list of
-        # tombstonable events.
-        primary_hash_set_key = f"re2:tombstone-primary-hashes:{project_id}:{group_id}"
-        old_primary_hashes = client.smembers(primary_hash_set_key)
+    old_primary_hashes = reprocessing_store.get_old_primary_hashes(project_id, group_id)
 
     if old_primary_hash is not None and old_primary_hash != current_primary_hash:
-        if options.get(use_store_option):
-            reprocessing_store.expire_hash(
-                project_id, group_id, event_id, datetime, old_primary_hash
-            )
-        else:
-            event_key = _get_old_primary_hash_subset_key(project_id, group_id, old_primary_hash)
-            client.lpush(event_key, f"{to_timestamp(datetime)};{event_id}")
-            client.expire(event_key, settings.SENTRY_REPROCESSING_TOMBSTONES_TTL)
+        reprocessing_store.expire_hash(project_id, group_id, event_id, datetime, old_primary_hash)
 
         if old_primary_hash not in old_primary_hashes:
             old_primary_hashes.add(old_primary_hash)
-            if options.get(use_store_option):
-                reprocessing_store.add_hash(project_id, group_id, old_primary_hash)
-            else:
-                primary_hash_set_key = f"re2:tombstone-primary-hashes:{project_id}:{group_id}"
-                client.sadd(primary_hash_set_key, old_primary_hash)
-                client.expire(primary_hash_set_key, settings.SENTRY_REPROCESSING_TOMBSTONES_TTL)
+            reprocessing_store.add_hash(project_id, group_id, old_primary_hash)
 
     with sentry_sdk.configure_scope() as scope:
         scope.set_tag("project_id", project_id)
@@ -416,7 +373,7 @@ def buffered_delete_old_primary_hash(
         op="sentry.reprocessing2.buffered_delete_old_primary_hash.flush_events"
     ):
         _send_delete_old_primary_hash_messages(
-            client, project_id, group_id, old_primary_hashes, force_flush_batch
+            project_id, group_id, old_primary_hashes, force_flush_batch
         )
 
 
@@ -465,19 +422,6 @@ def _get_original_issue_id(data):
     return get_path(data, "contexts", "reprocessing", "original_issue_id")
 
 
-def _get_sync_redis_client() -> RedisCluster:
-    id = settings.SENTRY_REPROCESSING_SYNC_REDIS_CLUSTER
-    return redis_clusters.get(id)  # type: ignore[return-value]
-
-
-def _get_sync_counter_key(group_id):
-    return f"re2:count:{group_id}"
-
-
-def _get_info_reprocessed_key(group_id):
-    return f"re2:info:{group_id}"
-
-
 def buffered_handle_remaining_events(
     project_id: int,
     old_group_id: int,
@@ -498,50 +442,12 @@ def buffered_handle_remaining_events(
     Ideally we'd have batching implemented via a service like buffers, but for
     more than counters.
     """
-
-    key = None
-    client = _get_sync_redis_client()
-
-    if options.get(use_store_option):
-        llen = reprocessing_store.get_remaining_event_count(
-            project_id, old_group_id, datetime_to_event
-        )
-    else:
-        # We explicitly cluster by only project_id and group_id here such that our
-        # RENAME command later succeeds.
-        key = f"re2:remaining:{{{project_id}:{old_group_id}}}"
-
-        if datetime_to_event:
-            llen = client.lpush(
-                key,
-                *(
-                    f"{to_timestamp(datetime)};{event_id}"
-                    for datetime, event_id in datetime_to_event
-                ),
-            )
-            client.expire(key, settings.SENTRY_REPROCESSING_SYNC_TTL)
-        else:
-            llen = client.llen(key)
+    llen = reprocessing_store.get_remaining_event_count(project_id, old_group_id, datetime_to_event)
 
     if force_flush_batch or llen > settings.SENTRY_REPROCESSING_REMAINING_EVENTS_BUF_SIZE:
-
-        if options.get(use_store_option):
-            new_key = reprocessing_store.rename_key(project_id, old_group_id)
-            if not new_key:
-                return
-        else:
-            assert key, "Key must exist in this branch"
-            new_key = f"{key}:{uuid.uuid4().hex}"
-
-            try:
-                # Rename `key` to a new temp key that is passed to celery task. We
-                # use `renamenx` instead of `rename` only to detect UUID collisions.
-                assert client.renamenx(key, new_key), "UUID collision for new_key?"
-            except redis.exceptions.ResponseError:
-                # `key` does not exist in Redis. `ResponseError` is a bit too broad
-                # but it seems we'd have to do string matching on error message
-                # otherwise.
-                return
+        new_key = reprocessing_store.rename_key(project_id, old_group_id)
+        if not new_key:
+            return
 
         from sentry.tasks.reprocessing2 import handle_remaining_events
 
@@ -560,27 +466,7 @@ def pop_batched_events_from_redis(key):
     `event id;datetime of event`, returns a list of event IDs, the
     earliest datetime, and the latest datetime.
     """
-    client = _get_sync_redis_client()
-    event_ids_batch = []
-    min_datetime = None
-    max_datetime = None
-
-    for row in client.lrange(key, 0, -1):
-        datetime_raw, event_id = row.split(";")
-        datetime = to_datetime(float(datetime_raw))
-
-        assert datetime is not None
-
-        if min_datetime is None or datetime < min_datetime:
-            min_datetime = datetime
-        if max_datetime is None or datetime > max_datetime:
-            max_datetime = datetime
-
-        event_ids_batch.append(event_id)
-
-    client.delete(key)
-
-    return event_ids_batch, min_datetime, max_datetime
+    return reprocessing_store.pop_batched_events_by_key(key)
 
 
 def mark_event_reprocessed(data=None, group_id=None, project_id=None, num_events=1):
@@ -597,22 +483,11 @@ def mark_event_reprocessed(data=None, group_id=None, project_id=None, num_events
 
         project_id = data["project"]
 
-    if options.get(use_store_option):
-        result = reprocessing_store.mark_event_reprocessed(group_id, num_events)
-        if result:
-            from sentry.tasks.reprocessing2 import finish_reprocessing
+    result = reprocessing_store.mark_event_reprocessed(group_id, num_events)
+    if result:
+        from sentry.tasks.reprocessing2 import finish_reprocessing
 
-            finish_reprocessing.delay(project_id=project_id, group_id=group_id)
-    else:
-        client = _get_sync_redis_client()
-        # refresh the TTL of the metadata:
-        client.expire(_get_info_reprocessed_key(group_id), settings.SENTRY_REPROCESSING_SYNC_TTL)
-        key = _get_sync_counter_key(group_id)
-        client.expire(key, settings.SENTRY_REPROCESSING_SYNC_TTL)
-        if client.decrby(key, num_events) == 0:
-            from sentry.tasks.reprocessing2 import finish_reprocessing
-
-            finish_reprocessing.delay(project_id=project_id, group_id=group_id)
+        finish_reprocessing.delay(project_id=project_id, group_id=group_id)
 
 
 def start_group_reprocessing(
@@ -696,20 +571,7 @@ def start_group_reprocessing(
     # New Activity Timestamp
     date_created = new_activity.datetime
 
-    if options.get(use_store_option):
-        reprocessing_store.start_reprocessing(group_id, date_created, sync_count, event_count)
-    else:
-        client = _get_sync_redis_client()
-        client.setex(
-            _get_sync_counter_key(group_id), settings.SENTRY_REPROCESSING_SYNC_TTL, sync_count
-        )
-        client.setex(
-            _get_info_reprocessed_key(group_id),
-            settings.SENTRY_REPROCESSING_SYNC_TTL,
-            json.dumps(
-                {"dateCreated": date_created, "syncCount": sync_count, "totalEvents": event_count}
-            ),
-        )
+    reprocessing_store.start_reprocessing(group_id, date_created, sync_count, event_count)
 
     return new_group.id
 
@@ -724,15 +586,8 @@ def is_group_finished(group_id):
 
 
 def get_progress(group_id, project_id=None):
-    if options.get(use_store_option):
-        pending, ttl = reprocessing_store.get_pending(group_id)
-        info = reprocessing_store.get_progress(group_id)
-    else:
-        client = _get_sync_redis_client()
-        pending_key = _get_sync_counter_key(group_id)
-        pending = client.get(pending_key)
-        ttl = client.ttl(pending_key)
-        info = client.get(_get_info_reprocessed_key(group_id))
+    pending, ttl = reprocessing_store.get_pending(group_id)
+    info = reprocessing_store.get_progress(group_id)
     if pending is None:
         logger.error("reprocessing2.missing_counter")
         return 0, None

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from sentry import eventstore, options
+from sentry import eventstore
 from sentry.attachments import attachment_cache
 from sentry.event_manager import EventManager
 from sentry.eventstore.processing import event_processing_store
@@ -105,22 +105,13 @@ def register_event_preprocessor(register_plugin):
     return inner
 
 
-@pytest.fixture
-def cleanup_option_state():
-    yield
-
-    options.set("reprocessing.use_store", False)
-
-
 @django_db_all
 @pytest.mark.snuba
 @pytest.mark.parametrize("change_groups", (True, False), ids=("new_group", "same_group"))
-@pytest.mark.parametrize("use_store", (True, False), ids=("use_store", "use_direct"))
 def test_basic(
     task_runner,
     default_project,
     change_groups,
-    use_store,
     reset_snuba,
     process_and_save,
     register_event_preprocessor,
@@ -129,8 +120,6 @@ def test_basic(
     django_cache,
 ):
     from sentry import eventstream
-
-    options.set("reprocessing.use_store", use_store)
 
     tombstone_calls = []
     old_tombstone_fn = eventstream.backend.tombstone_events_unsafe
@@ -228,7 +217,6 @@ def test_basic(
 
 @django_db_all
 @pytest.mark.snuba
-@pytest.mark.parametrize("use_store", (True, False), ids=("use_store", "use_direct"))
 def test_concurrent_events_go_into_new_group(
     default_project,
     reset_snuba,
@@ -237,14 +225,12 @@ def test_concurrent_events_go_into_new_group(
     burst_task_runner,
     default_user,
     django_cache,
-    use_store,
 ):
     """
     Assert that both unmodified and concurrently inserted events go into "the
     new group", i.e. the successor of the reprocessed (old) group that
     inherited the group hashes.
     """
-    options.set("reprocessing.use_store", use_store)
 
     @register_event_preprocessor
     def event_preprocessor(data):
@@ -297,7 +283,6 @@ def test_concurrent_events_go_into_new_group(
 @pytest.mark.snuba
 @pytest.mark.parametrize("remaining_events", ["delete", "keep"])
 @pytest.mark.parametrize("max_events", [2, None])
-@pytest.mark.parametrize("use_store", (True, False), ids=("use_store", "use_direct"))
 def test_max_events(
     default_project,
     reset_snuba,
@@ -307,7 +292,6 @@ def test_max_events(
     monkeypatch,
     remaining_events,
     max_events,
-    use_store,
 ):
     @register_event_preprocessor
     def event_preprocessor(data):
@@ -373,7 +357,6 @@ def test_max_events(
 
 @django_db_all
 @pytest.mark.snuba
-@pytest.mark.parametrize("use_store", (True, False), ids=("use_store", "use_direct"))
 def test_attachments_and_userfeedback(
     default_project,
     reset_snuba,
@@ -381,10 +364,7 @@ def test_attachments_and_userfeedback(
     process_and_save,
     burst_task_runner,
     monkeypatch,
-    use_store,
 ):
-    options.set("reprocessing.use_store", use_store)
-
     @register_event_preprocessor
     def event_preprocessor(data):
         extra = data.setdefault("extra", {})
@@ -445,7 +425,6 @@ def test_attachments_and_userfeedback(
 @django_db_all
 @pytest.mark.snuba
 @pytest.mark.parametrize("remaining_events", ["keep", "delete"])
-@pytest.mark.parametrize("use_store", (True, False), ids=("use_store", "use_direct"))
 @mock.patch("sentry.reprocessing2.logger")
 def test_nodestore_missing(
     mock_logger,
@@ -456,9 +435,7 @@ def test_nodestore_missing(
     monkeypatch,
     remaining_events,
     django_cache,
-    use_store,
 ):
-    options.set("reprocessing.use_store", use_store)
 
     event_id = process_and_save({"message": "hello world", "platform": "python"})
     event = eventstore.backend.get_event_by_id(default_project.id, event_id)
@@ -493,20 +470,17 @@ def test_nodestore_missing(
 
 @django_db_all
 @pytest.mark.snuba
-@pytest.mark.parametrize("use_store", (True, False), ids=("use_store", "use_direct"))
 def test_apply_new_fingerprinting_rules(
     default_project,
     reset_snuba,
     register_event_preprocessor,
     process_and_save,
     burst_task_runner,
-    use_store,
 ):
     """
     Assert that after changing fingerprinting rules, the new fingerprinting config
     is respected by reprocessing.
     """
-    options.set("reprocessing.use_store", use_store)
 
     @register_event_preprocessor
     def event_preprocessor(data):
@@ -560,20 +534,17 @@ def test_apply_new_fingerprinting_rules(
 
 @django_db_all
 @pytest.mark.snuba
-@pytest.mark.parametrize("use_store", (True, False), ids=("use_store", "use_direct"))
 def test_apply_new_stack_trace_rules(
     default_project,
     reset_snuba,
     register_event_preprocessor,
     process_and_save,
     burst_task_runner,
-    use_store,
 ):
     """
     Assert that after changing stack trace rules, the new grouping config
     is respected by reprocessing.
     """
-    options.set("reprocessing.use_store", use_store)
 
     @register_event_preprocessor
     def event_preprocessor(data):
@@ -654,10 +625,7 @@ def test_apply_new_stack_trace_rules(
 
 
 @django_db_all
-@pytest.mark.parametrize("use_store", (True, False), ids=("use_store", "use_direct"))
-def test_finish_reprocessing(default_project, use_store):
-    options.set("reprocessing.use_store", use_store)
-
+def test_finish_reprocessing(default_project):
     # Pretend that the old group has more than one activity still connected:
     old_group = Group.objects.create(project=default_project)
     new_group = Group.objects.create(project=default_project)


### PR DESCRIPTION
With reprocessing using the Service wrapper for all operations we can remove the previous implementation. With this merged we can start shifting traffic to the new cluster with a `ServiceDelegator`