### PR TITLE
ref(perf): Remove boolean filter value condition from data hooks

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -48,7 +48,7 @@ function ResourceSummaryCharts(props: {groupId: string}) {
         `avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`,
         `avg(${HTTP_RESPONSE_TRANSFER_SIZE})`,
       ],
-      enabled: Object.values(filters).every(value => Boolean(value)),
+      enabled: Boolean(props.groupId),
     });
 
   if (spanMetricsSeriesData) {

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -48,6 +48,7 @@ function ResourceSummaryCharts(props: {groupId: string}) {
         `avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`,
         `avg(${HTTP_RESPONSE_TRANSFER_SIZE})`,
       ],
+      enabled: Object.values(filters).every(value => Boolean(value)),
     });
 
   if (spanMetricsSeriesData) {

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -104,6 +104,7 @@ export function DatabaseLandingPage() {
   } = useSpanMetricsSeries({
     filters: chartFilters,
     yAxis: ['spm()'],
+    enabled: Object.values(chartFilters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-landing-page-metrics-chart',
   });
 
@@ -114,6 +115,7 @@ export function DatabaseLandingPage() {
   } = useSpanMetricsSeries({
     filters: chartFilters,
     yAxis: [`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
+    enabled: Object.values(chartFilters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-landing-page-metrics-chart',
   });
 

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -1,7 +1,6 @@
 import React, {Fragment} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
-import pickBy from 'lodash/pickBy';
 
 import Alert from 'sentry/components/alert';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -81,7 +80,7 @@ export function DatabaseLandingPage() {
   const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
 
   const queryListResponse = useSpanMetrics({
-    filters: pickBy(tableFilters, value => value !== undefined),
+    filters: tableFilters,
     fields: [
       'project.id',
       'span.group',
@@ -104,7 +103,6 @@ export function DatabaseLandingPage() {
   } = useSpanMetricsSeries({
     filters: chartFilters,
     yAxis: ['spm()'],
-    enabled: Object.values(chartFilters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-landing-page-metrics-chart',
   });
 
@@ -115,7 +113,6 @@ export function DatabaseLandingPage() {
   } = useSpanMetricsSeries({
     filters: chartFilters,
     yAxis: [`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
-    enabled: Object.values(chartFilters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-landing-page-metrics-chart',
   });
 

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -102,6 +102,7 @@ function SpanSummaryPage({params}: Props) {
   } = useSpanMetricsSeries({
     filters,
     yAxis: ['spm()'],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-summary-page-metrics-chart',
   });
 
@@ -112,6 +113,7 @@ function SpanSummaryPage({params}: Props) {
   } = useSpanMetricsSeries({
     filters,
     yAxis: [`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-summary-page-metrics-chart',
   });
 

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -59,6 +59,9 @@ function SpanSummaryPage({params}: Props) {
 
   if (endpoint) {
     filters.transaction = endpoint;
+  }
+
+  if (endpointMethod) {
     filters['transaction.method'] = endpointMethod;
   }
 
@@ -78,7 +81,7 @@ function SpanSummaryPage({params}: Props) {
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
       `${SpanFunction.HTTP_ERROR_COUNT}()`,
     ],
-    enabled: Object.values(filters).every(value => Boolean(value)),
+    enabled: Boolean(groupId),
     referrer: 'api.starfish.span-summary-page-metrics',
   });
 
@@ -102,7 +105,7 @@ function SpanSummaryPage({params}: Props) {
   } = useSpanMetricsSeries({
     filters,
     yAxis: ['spm()'],
-    enabled: Object.values(filters).every(value => Boolean(value)),
+    enabled: Boolean(groupId),
     referrer: 'api.starfish.span-summary-page-metrics-chart',
   });
 
@@ -113,7 +116,7 @@ function SpanSummaryPage({params}: Props) {
   } = useSpanMetricsSeries({
     filters,
     yAxis: [`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
-    enabled: Object.values(filters).every(value => Boolean(value)),
+    enabled: Boolean(groupId),
     referrer: 'api.starfish.span-summary-page-metrics-chart',
   });
 

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -78,6 +78,7 @@ function SpanSummaryPage({params}: Props) {
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
       `${SpanFunction.HTTP_ERROR_COUNT}()`,
     ],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-summary-page-metrics',
   });
 

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -53,6 +53,7 @@ export function HTTPDomainSummaryPage() {
       `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
     ],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.http-module-domain-summary-metrics-ribbon',
   });
 

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -53,7 +53,7 @@ export function HTTPDomainSummaryPage() {
       `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
     ],
-    enabled: Object.values(filters).every(value => Boolean(value)),
+    enabled: Boolean(domain),
     referrer: 'api.starfish.http-module-domain-summary-metrics-ribbon',
   });
 
@@ -64,7 +64,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     filters,
     yAxis: ['spm()'],
-    enabled: Object.values(filters).every(value => Boolean(value)),
+    enabled: Boolean(domain),
     referrer: 'api.starfish.http-module-domain-summary-throughput-chart',
   });
 
@@ -75,7 +75,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     filters,
     yAxis: [`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
-    enabled: Object.values(filters).every(value => Boolean(value)),
+    enabled: Boolean(domain),
     referrer: 'api.starfish.http-module-domain-summary-duration-chart',
   });
 

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -64,6 +64,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     filters,
     yAxis: ['spm()'],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.http-module-domain-summary-throughput-chart',
   });
 
@@ -74,6 +75,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     filters,
     yAxis: [`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.http-module-domain-summary-duration-chart',
   });
 

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -1,5 +1,4 @@
 import React, {Fragment} from 'react';
-import pickBy from 'lodash/pickBy';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
@@ -55,7 +54,6 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     filters: chartFilters,
     yAxis: ['spm()'],
-    enabled: Object.values(chartFilters).every(value => Boolean(value)),
     referrer: 'api.starfish.http-module-landing-throughput-chart',
   });
 
@@ -66,12 +64,11 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     filters: chartFilters,
     yAxis: [`avg(span.self_time)`],
-    enabled: Object.values(chartFilters).every(value => Boolean(value)),
     referrer: 'api.starfish.http-module-landing-duration-chart',
   });
 
   const domainsListResponse = useSpanMetrics({
-    filters: pickBy(tableFilters, value => value !== undefined),
+    filters: tableFilters,
     fields: [
       'project.id',
       'span.domain',

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -55,6 +55,7 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     filters: chartFilters,
     yAxis: ['spm()'],
+    enabled: Object.values(chartFilters).every(value => Boolean(value)),
     referrer: 'api.starfish.http-module-landing-throughput-chart',
   });
 
@@ -65,6 +66,7 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     filters: chartFilters,
     yAxis: [`avg(span.self_time)`],
+    enabled: Object.values(chartFilters).every(value => Boolean(value)),
     referrer: 'api.starfish.http-module-landing-duration-chart',
   });
 

--- a/static/app/views/starfish/queries/useSpanMetrics.spec.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.spec.tsx
@@ -97,6 +97,7 @@ describe('useSpanMetrics', () => {
             'span.group': '221aa7ebd216',
             transaction: '/api/details',
             release: '0.0.1',
+            environment: undefined,
           },
           fields: ['spm()'] as MetricsProperty[],
           sorts: [{field: 'spm()', kind: 'desc' as const}],

--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -30,15 +30,11 @@ export const useSpanMetrics = <Fields extends MetricsProperty[]>(
 
   const eventView = getEventView(filters, fields, sorts, pageFilters.selection);
 
-  // TODO: Checking that every filter has a value might not be a good choice, since this API is not convenient. Instead, it's probably fine to omit keys with blank values
-  const enabled =
-    options.enabled && Object.values(filters).every(value => Boolean(value));
-
   const result = useWrappedDiscoverQuery({
     eventView,
     initialData: [],
     limit,
-    enabled,
+    enabled: options.enabled,
     referrer,
     cursor,
   });
@@ -50,7 +46,7 @@ export const useSpanMetrics = <Fields extends MetricsProperty[]>(
   return {
     ...result,
     data,
-    isEnabled: enabled,
+    isEnabled: options.enabled,
   };
 };
 

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.spec.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.spec.tsx
@@ -105,6 +105,7 @@ describe('useSpanMetricsSeries', () => {
             transaction: '/api/details',
             release: '0.0.1',
             'resource.render_blocking_status': 'blocking' as const,
+            environment: undefined,
           },
           yAxis: ['spm()'] as MetricsProperty[],
         },

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -35,15 +35,11 @@ export const useSpanMetricsSeries = <Fields extends MetricsProperty[]>(
 
   const eventView = getEventView(filters, pageFilters.selection, yAxis);
 
-  // TODO: Checking that every filter has a value might not be a good choice, since this API is not convenient. Instead, it's probably fine to omit keys with blank values
-  const enabled =
-    options.enabled && Object.values(filters).every(value => Boolean(value));
-
   const result = useWrappedDiscoverTimeseriesQuery<SpanMetricTimeseriesRow[]>({
     eventView,
     initialData: [],
     referrer,
-    enabled,
+    enabled: options.enabled,
   });
 
   const parsedData = keyBy(

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -79,6 +79,9 @@ export const useSpanSamples = (options: Options) => {
   const {isLoading: isLoadingSeries, data: spanMetricsSeriesData} = useSpanMetricsSeries({
     filters: {'span.group': groupId, ...filters},
     yAxis: [`avg(${SPAN_SELF_TIME})`],
+    enabled: Object.values({'span.group': groupId, ...filters}).every(value =>
+      Boolean(value)
+    ),
     referrer: 'api.starfish.sidebar-span-metrics',
   });
 

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
@@ -101,9 +101,7 @@ export function ScreenLoadSampleContainer({
   const {data} = useSpanMetrics({
     filters: {...filters, ...additionalFilters},
     fields: [`avg(${SPAN_SELF_TIME})`, 'count()', SPAN_OP],
-    enabled: Object.values({...filters, ...additionalFilters}).every(value =>
-      Boolean(value)
-    ),
+    enabled: Boolean(groupId) && Boolean(transactionName),
     referrer: 'api.starfish.span-summary-panel-samples-table-avg',
   });
 

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
@@ -101,6 +101,9 @@ export function ScreenLoadSampleContainer({
   const {data} = useSpanMetrics({
     filters: {...filters, ...additionalFilters},
     fields: [`avg(${SPAN_SELF_TIME})`, 'count()', SPAN_OP],
+    enabled: Object.values({...filters, ...additionalFilters}).every(value =>
+      Boolean(value)
+    ),
     referrer: 'api.starfish.span-summary-panel-samples-table-avg',
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -65,6 +65,7 @@ function SpanSummaryPage({params, location}: Props) {
   const {data, isLoading: isSpanMetricsLoading} = useSpanMetrics({
     filters,
     fields: ['span.op', 'span.group', 'project.id', 'sps()'],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-summary-page-metrics',
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/index.tsx
@@ -65,7 +65,7 @@ function SpanSummaryPage({params, location}: Props) {
   const {data, isLoading: isSpanMetricsLoading} = useSpanMetrics({
     filters,
     fields: ['span.op', 'span.group', 'project.id', 'sps()'],
-    enabled: Object.values(filters).every(value => Boolean(value)),
+    enabled: Boolean(groupId),
     referrer: 'api.starfish.span-summary-page-metrics',
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -108,6 +108,9 @@ function DurationChart({
   } = useSpanMetricsSeries({
     filters: {...filters, ...additionalFilters},
     yAxis: [`avg(${SPAN_SELF_TIME})`],
+    enabled: Object.values({...filters, ...additionalFilters}).every(value =>
+      Boolean(value)
+    ),
     referrer: 'api.starfish.sidebar-span-metrics-chart',
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -114,6 +114,7 @@ function DurationChart({
   const {data, error: spanMetricsError} = useSpanMetrics({
     filters,
     fields: [`avg(${SPAN_SELF_TIME})`, SPAN_OP],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-summary-panel-samples-table-avg',
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -52,6 +52,7 @@ function SampleInfo(props: Props) {
       'time_spent_percentage()',
       'count()',
     ],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-summary-panel-metrics',
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -67,6 +67,9 @@ function SampleTable({
   const {data, isFetching: isFetchingSpanMetrics} = useSpanMetrics({
     filters: {...filters, ...additionalFilters},
     fields: [`avg(${SPAN_SELF_TIME})`, SPAN_OP],
+    enabled: Object.values({...filters, ...additionalFilters}).every(value =>
+      Boolean(value)
+    ),
     referrer: 'api.starfish.span-summary-panel-samples-table-avg',
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -61,6 +61,7 @@ export function SpanSummaryView({groupId}: Props) {
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
       `${SpanFunction.HTTP_ERROR_COUNT}()`,
     ],
+    enabled: Object.values(filters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-summary-page-metrics',
   });
 

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -61,7 +61,7 @@ export function SpanSummaryView({groupId}: Props) {
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
       `${SpanFunction.HTTP_ERROR_COUNT}()`,
     ],
-    enabled: Object.values(filters).every(value => Boolean(value)),
+    enabled: Boolean(groupId),
     referrer: 'api.starfish.span-summary-page-metrics',
   });
 
@@ -89,9 +89,7 @@ export function SpanSummaryView({groupId}: Props) {
     useSpanMetricsSeries({
       filters: {'span.group': groupId, ...seriesQueryFilter},
       yAxis: [`avg(${SpanMetricsField.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
-      enabled: Object.values({'span.group': groupId, ...seriesQueryFilter}).every(value =>
-        Boolean(value)
-      ),
+      enabled: Boolean(groupId),
       referrer: 'api.starfish.span-summary-page-metrics-chart',
     });
 

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -89,6 +89,9 @@ export function SpanSummaryView({groupId}: Props) {
     useSpanMetricsSeries({
       filters: {'span.group': groupId, ...seriesQueryFilter},
       yAxis: [`avg(${SpanMetricsField.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
+      enabled: Object.values({'span.group': groupId, ...seriesQueryFilter}).every(value =>
+        Boolean(value)
+      ),
       referrer: 'api.starfish.span-summary-page-metrics-chart',
     });
 


### PR DESCRIPTION
## The Problem

There is a strange little secret at the heart of `useSpanMetrics` and `useSpanMetricsSeries` that I need to remove to pave the way for an incoming improvement (allowing a `MutableQuery` to be passed in instead of `filters`).

If any of the values in `filters` are falsey (`undefined` or `0` or `""`) the hook doesn't run. It's a hidden condition that competes with the `enabled` prop! It's a surprising behaviour, in which you could be passing totally normal-seeming data, but the hook doesn't run!

e.g., imagine you're getting a bunch of filters from the URL!

```js
const filters = {
  module: 'db',
  action: location.query['action'],
  domain: locatin.query['domain'],
};
```

If `location.query['action']` is `""` the hook won't run at all, even though it's a perfectly valid query!

## Changes

I removed that condition from both the hooks, and then for every hook usage I set an explicit `enabled` condition instead. `enabled` is one of the following:

- if every key in `filters` is guaranteed to be set, no `enabled` at all
- if only one or two values in `filters` be be falsy, set `enabled` to `Boolean(<field>)`
- if a few of the keys might be empty, filter out the empty values

This guarantees that all current loading conditions are preserved. I also added some small changes here and there to make sure that keys are added to `filters` objects conditionally.

As a result, lines like `pickBy(tableFilters, value => value !== undefined)` are not needed, since any `undefined` value is correctly ignored when making the network request.
