### PR TITLE
feat(webvitals): Greys out FID in the performance score breakdown chart and updates tooltip to label as deprecated

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
@@ -56,7 +56,7 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
   const shouldUseStoredScores = useStoredScoresSetting();
   const shouldReplaceFidWithInp = useReplaceFidWithInpSetting();
   const theme = useTheme();
-  const segmentColors = theme.charts.getColorPalette(3);
+  const segmentColors = [...theme.charts.getColorPalette(3).slice(0, 5), theme.gray200];
 
   const pageFilters = usePageFilters();
 
@@ -234,6 +234,9 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
         preserveIncompletePoints
         tooltipFormatterOptions={{
           nameFormatter: (name, seriesParams: any) => {
+            if (shouldReplaceFidWithInp && name === 'FID') {
+              return `${name} Score </strong>(${t('Deprecated')})</strong>`;
+            }
             const timestamp = seriesParams?.data[0];
             const weights = weightsSeries.find(
               series => series.name === timestamp

--- a/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
+++ b/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
@@ -25,7 +25,7 @@ type Props = {
 };
 
 export const ORDER = ['lcp', 'fcp', 'fid', 'cls', 'ttfb'];
-export const ORDER_WITH_INP = ['lcp', 'fcp', 'inp', 'cls', 'ttfb'];
+export const ORDER_WITH_INP = ['lcp', 'fcp', 'inp', 'cls', 'ttfb', 'fid'];
 
 export function PerformanceScoreChart({
   projectScore,


### PR DESCRIPTION
Greys out FID in the performance score breakdown chart and updates tooltip to label as deprecated

![image](https://github.com/getsentry/sentry/assets/83961295/6963cd61-75a2-4aed-b25d-6aa73f980b9b)
