### PR TITLE
feat(webvitals): Updates metric query filters in web vitals to check for span.op

### DIFF
--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -36,9 +36,8 @@ export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props =
       ],
       name: 'Web Vitals',
       query: [
-        // TODO: inp spans don't have a transaction.op.
-        // Plan to update this filter to also check span.op:ui.interaction.click once we have the ability.
         'transaction.op:[pageload,""]',
+        'span.op:[ui.interaction.click,""]',
         ...(transaction ? [`transaction:"${transaction}"`] : []),
         ...(tag ? [`{tag.key}:"${tag.name}"`] : []),
       ].join(' '),

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -36,9 +36,7 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
       ],
       name: 'Web Vitals',
       query: [
-        // TODO: inp spans don't have a transaction.op.
-        // Plan to update this filter to also check span.op:ui.interaction.click once we have the ability.
-        'transaction.op:[pageload,""]',
+        'transaction.op:pageload OR span.op:ui.interaction.click',
         ...(transaction ? [`transaction:"${transaction}"`] : []),
       ].join(' '),
       version: 2,

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -36,7 +36,8 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
       ],
       name: 'Web Vitals',
       query: [
-        'transaction.op:pageload OR span.op:ui.interaction.click',
+        'transaction.op:[pageload,""]',
+        'span.op:[ui.interaction.click,""]',
         ...(transaction ? [`transaction:"${transaction}"`] : []),
       ].join(' '),
       version: 2,

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -56,9 +56,7 @@ export const useProjectWebVitalsScoresQuery = ({
       ],
       name: 'Web Vitals',
       query: [
-        // TODO: inp spans don't have a transaction.op.
-        // Plan to update this filter to also check span.op:ui.interaction.click once we have the ability.
-        'transaction.op:[pageload,""]',
+        'transaction.op:pageload OR span.op:ui.interaction.click',
         ...(transaction ? [`transaction:"${transaction}"`] : []),
         ...(tag ? [`${tag.key}:"${tag.name}"`] : []),
       ].join(' '),

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -56,7 +56,8 @@ export const useProjectWebVitalsScoresQuery = ({
       ],
       name: 'Web Vitals',
       query: [
-        'transaction.op:pageload OR span.op:ui.interaction.click',
+        'transaction.op:[pageload,""]',
+        'span.op:[ui.interaction.click,""]',
         ...(transaction ? [`transaction:"${transaction}"`] : []),
         ...(tag ? [`${tag.key}:"${tag.name}"`] : []),
       ].join(' '),

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -54,9 +54,7 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
       ],
       name: 'Web Vitals',
       query: [
-        // TODO: inp spans don't have a transaction.op.
-        // Plan to update this filter to also check span.op:ui.interaction.click once we have the ability.
-        'transaction.op:[pageload,""] has:measurements.score.total',
+        'transaction.op:pageload OR span.op:ui.interaction.click has:measurements.score.total',
         ...(transaction ? [`transaction:"${transaction}"`] : []),
         ...(tag ? [`${tag.key}:"${tag.name}"`] : []),
       ].join(' '),

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -54,7 +54,9 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
       ],
       name: 'Web Vitals',
       query: [
-        'transaction.op:pageload OR span.op:ui.interaction.click has:measurements.score.total',
+        'transaction.op:[pageload,""]',
+        'span.op:[ui.interaction.click,""]',
+        'has:measurements.score.total',
         ...(transaction ? [`transaction:"${transaction}"`] : []),
         ...(tag ? [`${tag.key}:"${tag.name}"`] : []),
       ].join(' '),

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -60,8 +60,9 @@ export const useTransactionWebVitalsScoresQuery = ({
       ],
       name: 'Web Vitals',
       query: [
-        'transaction.op:pageload OR span.op:ui.interaction.click',
-        'avg(measurements.score.total):>=0',
+        'transaction.op:[pageload,""]',
+        'span.op:[ui.interaction.click,""]',
+        'has:measurements.score.total',
         ...(transaction ? [`transaction:"${transaction}"`] : []),
         ...(query ? [query] : []),
       ].join(' '),

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -60,9 +60,7 @@ export const useTransactionWebVitalsScoresQuery = ({
       ],
       name: 'Web Vitals',
       query: [
-        // TODO: inp spans don't have a transaction.op.
-        // Plan to update this filter to also check span.op:ui.interaction.click once we have the ability.
-        'transaction.op:[pageload,""]',
+        'transaction.op:pageload OR span.op:ui.interaction.click',
         'avg(measurements.score.total):>=0',
         ...(transaction ? [`transaction:"${transaction}"`] : []),
         ...(query ? [query] : []),

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -962,7 +962,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'count_web_vitals(measurements.ttfb, any)',
             'count()',
           ],
-          query: 'transaction.op:pageload OR span.op:ui.interaction.click',
+          query: 'transaction.op:[pageload,""] span.op:[ui.interaction.click,""]',
         }),
       })
     );

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -962,7 +962,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'count_web_vitals(measurements.ttfb, any)',
             'count()',
           ],
-          query: 'transaction.op:[pageload,""]',
+          query: 'transaction.op:pageload OR span.op:ui.interaction.click',
         }),
       })
     );


### PR DESCRIPTION
span.op is queryable so we can update our query condition to also check for ui.interaction.click instead of only relying on transaction.op being empty