### PR TITLE
fix(event-stats): Remove error from top events

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -16,7 +16,6 @@ from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.organization import Organization
 from sentry.snuba import (
     discover,
-    errors,
     functions,
     metrics_enhanced_performance,
     metrics_performance,
@@ -214,7 +213,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     if dataset
                     in [
                         discover,
-                        errors,
                         functions,
                         metrics_performance,
                         metrics_enhanced_performance,


### PR DESCRIPTION
- Fixes SENTRY-2VV0
- Fixes a bug where we were saying errors supports top events even though it doesn't