### PR TITLE
ref(crons): Clarify why incident creation skip happens

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -138,22 +138,25 @@ def mark_failed_threshold(failed_checkin: MonitorCheckIn, failure_issue_threshol
         monitor_env.status = MonitorStatus.ERROR
         monitor_env.save(update_fields=("status",))
 
-        # Do not create incident if monitor is muted
-        if not monitor_muted:
-            starting_checkin = previous_checkins[0]
+        # Do not create incident if monitor is muted. This check happens late
+        # as we still want the status to have been updated
+        if monitor_muted:
+            return True
 
-            # for new incidents, generate a uuid as the fingerprint. This is
-            # not deterministic of any property of the incident and is simply
-            # used to associate the incident to it's event occurrences
-            fingerprint = uuid.uuid4().hex
+        starting_checkin = previous_checkins[0]
 
-            MonitorIncident.objects.create(
-                monitor=monitor_env.monitor,
-                monitor_environment=monitor_env,
-                starting_checkin_id=starting_checkin["id"],
-                starting_timestamp=starting_checkin["date_added"],
-                grouphash=fingerprint,
-            )
+        # for new incidents, generate a uuid as the fingerprint. This is
+        # not deterministic of any property of the incident and is simply
+        # used to associate the incident to it's event occurrences
+        fingerprint = uuid.uuid4().hex
+
+        MonitorIncident.objects.create(
+            monitor=monitor_env.monitor,
+            monitor_environment=monitor_env,
+            starting_checkin_id=starting_checkin["id"],
+            starting_timestamp=starting_checkin["date_added"],
+            grouphash=fingerprint,
+        )
     elif monitor_env.status in [
         MonitorStatus.ERROR,
         MonitorStatus.MISSED_CHECKIN,


### PR DESCRIPTION
Guard statments tend to be clearer