### PR TITLE
feat(grouping): get pseudo-random sample of events from issue

### DIFF
--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -67,8 +67,8 @@ def get_query_builder_for_group(
     if orderby is None:
         orderby = "-timestamp"
     elif orderby == "sample":
-        # using group id as salt for consistent sampling across paginated queries
-        selected_columns.append(f"salted_column_hash('{group.id}', id) as sample")
+        # IDs are UUIDs, so should be random, but we'll hasd them just in case
+        selected_columns.append("column_hash(id) as sample")
 
     return QueryBuilder(
         dataset=dataset,
@@ -79,6 +79,6 @@ def get_query_builder_for_group(
         limit=limit,
         offset=offset,
         config=QueryBuilderConfig(
-            functions_acl=["salted_column_hash"],
+            functions_acl=["column_hash"],
         ),
     )

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -10,7 +10,7 @@ from sentry.api.serializers import serialize
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import GroupCategory
 from sentry.search.events.builder import QueryBuilder
-from sentry.search.events.types import ParamsType
+from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.utils.validators import normalize_event_id
 
@@ -52,17 +52,33 @@ def get_direct_hit_response(
 
 
 def get_query_builder_for_group(
-    query: str, snuba_params: ParamsType, group: Group, limit: int, offset: int
+    query: str,
+    snuba_params: ParamsType,
+    group: Group,
+    limit: int,
+    offset: int,
+    orderby: str | None = None,
 ) -> QueryBuilder:
     dataset = Dataset.IssuePlatform
     if group.issue_category == GroupCategory.ERROR:
         dataset = Dataset.Events
+    selected_columns = ["id", "project.id", "issue.id", "timestamp"]
+
+    if orderby is None:
+        orderby = "-timestamp"
+    elif orderby == "sample":
+        # using group id as salt for consistent sampling across paginated queries
+        selected_columns.append(f"salted_column_hash('{group.id}', id) as sample")
+
     return QueryBuilder(
         dataset=dataset,
         query=f"issue:{group.qualified_short_id} {query}",
         params=snuba_params,
-        selected_columns=["id", "project.id", "issue.id", "timestamp"],
-        orderby=["-timestamp"],
+        selected_columns=selected_columns,
+        orderby=[orderby],
         limit=limit,
         offset=offset,
+        config=QueryBuilderConfig(
+            functions_acl=["salted_column_hash"],
+        ),
     )

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -54,6 +54,9 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
                            include the full event body, including the stacktrace.
                            Set to 1 to enable.
 
+        :qparam bool sample: return events in pseudo-random order. This is deterministic,
+                             same query will return the same events in the same order.
+
         :pparam string issue_id: the ID of the issue to retrieve.
 
         :auth: required

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -106,11 +106,22 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
             params["environment"] = [env.name for env in environments]
 
         full = request.GET.get("full") in ("1", "true")
+        sample = request.GET.get("sample") in ("1", "true")
+
+        if sample:
+            orderby = "sample"
+        else:
+            orderby = None
 
         def data_fn(offset: int, limit: int) -> Any:
             try:
                 snuba_query = get_query_builder_for_group(
-                    request.GET.get("query", ""), params, group, limit=limit, offset=offset
+                    request.GET.get("query", ""),
+                    params,
+                    group,
+                    limit=limit,
+                    offset=offset,
+                    orderby=orderby,
                 )
             except InvalidSearchQuery as e:
                 raise ParseError(detail=str(e))

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1025,12 +1025,12 @@ class DiscoverDatasetConfig(DatasetConfig):
                     private=True,
                 ),
                 SnQLFunction(
-                    "salted_column_hash",
+                    "column_hash",
                     # TODO: figure out how to make this take arbitrary number of arbirary type arguemnts
-                    required_args=[SnQLStringArg("salt"), ColumnArg("column")],
+                    required_args=[ColumnArg("column")],
                     snql_aggregate=lambda args, alias: Function(
                         "farmFingerprint64",  # farmFingerprint64 aka farmHash64 is a newer, faster replacement for cityHash64
-                        [args["salt"], args["column"]],
+                        [args["column"]],
                         alias,
                     ),
                     default_result_type="integer",

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1026,7 +1026,7 @@ class DiscoverDatasetConfig(DatasetConfig):
                 ),
                 SnQLFunction(
                     "column_hash",
-                    # TODO: figure out how to make this take arbitrary number of arbirary type arguemnts
+                    # TODO: this supports only one column, but hash functions can support arbitrary parameters
                     required_args=[ColumnArg("column")],
                     snql_aggregate=lambda args, alias: Function(
                         "farmFingerprint64",  # farmFingerprint64 aka farmHash64 is a newer, faster replacement for cityHash64

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -200,9 +200,11 @@ class DiscoverDatasetConfig(DatasetConfig):
                     calculated_args=[
                         {
                             "name": "tolerated",
-                            "fn": lambda args: args["satisfaction"] * 4.0
-                            if args["satisfaction"] is not None
-                            else None,
+                            "fn": lambda args: (
+                                args["satisfaction"] * 4.0
+                                if args["satisfaction"] is not None
+                                else None
+                            ),
                         }
                     ],
                     snql_aggregate=self._resolve_count_miserable_function,
@@ -224,9 +226,11 @@ class DiscoverDatasetConfig(DatasetConfig):
                     calculated_args=[
                         {
                             "name": "tolerated",
-                            "fn": lambda args: args["satisfaction"] * 4.0
-                            if args["satisfaction"] is not None
-                            else None,
+                            "fn": lambda args: (
+                                args["satisfaction"] * 4.0
+                                if args["satisfaction"] is not None
+                                else None
+                            ),
                         },
                         {"name": "parameter_sum", "fn": lambda args: args["alpha"] + args["beta"]},
                     ],
@@ -1018,6 +1022,18 @@ class DiscoverDatasetConfig(DatasetConfig):
                     snql_column=lambda args, alias: function_aliases.resolve_rounded_timestamp(
                         args["interval"], alias
                     ),
+                    private=True,
+                ),
+                SnQLFunction(
+                    "salted_column_hash",
+                    # TODO: figure out how to make this take arbitrary number of arbirary type arguemnts
+                    required_args=[SnQLStringArg("salt"), ColumnArg("column")],
+                    snql_aggregate=lambda args, alias: Function(
+                        "farmFingerprint64",  # farmFingerprint64 aka farmHash64 is a newer, faster replacement for cityHash64
+                        [args["salt"], args["column"]],
+                        alias,
+                    ),
+                    default_result_type="integer",
                     private=True,
                 ),
             ]

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -522,3 +522,30 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
+
+    def test_sample(self):
+        """Test that random=true doesn't blow up. We can't really test if they're in random order."""
+        self.login_as(user=self.user)
+
+        event = self.store_event(
+            data={
+                "fingerprint": ["group_1"],
+                "event_id": "a" * 32,
+                "message": "foo",
+                "timestamp": iso_format(self.min_ago),
+            },
+            project_id=self.project.id,
+        )
+        event = self.store_event(
+            data={
+                "fingerprint": ["group_1"],
+                "event_id": "b" * 32,
+                "message": "foo",
+                "timestamp": iso_format(self.two_min_ago),
+            },
+            project_id=self.project.id,
+        )
+
+        url = f"/api/0/issues/{event.group.id}/events/?sample=true"
+        response = self.do_request(url)
+        assert len(response.data) == 2

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -843,10 +843,10 @@ class QueryBuilderTest(TestCase):
             Dataset.Discover,
             self.params,
             query="",
-            selected_columns=["salted_column_hash('salt', transaction) as sample"],
+            selected_columns=["column_hash(transaction) as sample"],
             orderby=["sample"],
             config=QueryBuilderConfig(
-                functions_acl=["salted_column_hash"],
+                functions_acl=["column_hash"],
             ),
         )
         snql_query = query.get_snql_query().query
@@ -854,7 +854,7 @@ class QueryBuilderTest(TestCase):
             snql_query.orderby,
             [
                 OrderBy(
-                    Function("farmFingerprint64", ["'salt'", Column("transaction")], "sample"),
+                    Function("farmFingerprint64", [Column("transaction")], "sample"),
                     Direction.ASC,
                 )
             ],

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -837,3 +837,25 @@ class QueryBuilderTest(TestCase):
                 selected_columns=["count()"],
                 orderby="equation|",
             )
+
+    def test_orderby_salted_column_hash(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            query="",
+            selected_columns=["salted_column_hash('salt', transaction) as sample"],
+            orderby=["sample"],
+            config=QueryBuilderConfig(
+                functions_acl=["salted_column_hash"],
+            ),
+        )
+        snql_query = query.get_snql_query().query
+        self.assertCountEqual(
+            snql_query.orderby,
+            [
+                OrderBy(
+                    Function("farmFingerprint64", ["'salt'", Column("transaction")], "sample"),
+                    Direction.ASC,
+                )
+            ],
+        )


### PR DESCRIPTION
- Adding a private SnQLFunction `column_hash(column)` that generates [farmFingerprint64](https://opensource.googleblog.com/2014/03/introducing-farmhash.html) hash of a single column.
- using that function to return events in pseudo-random order in Group Events endpoint. 
