### PR TITLE
fix(crons): Avoid monitor incident creation races

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -145,18 +145,17 @@ def mark_failed_threshold(failed_checkin: MonitorCheckIn, failure_issue_threshol
 
         starting_checkin = previous_checkins[0]
 
-        # for new incidents, generate a uuid as the fingerprint. This is
-        # not deterministic of any property of the incident and is simply
-        # used to associate the incident to it's event occurrences
-        fingerprint = uuid.uuid4().hex
-
-        MonitorIncident.objects.create(
-            monitor=monitor_env.monitor,
+        incident, _ = MonitorIncident.objects.get_or_create(
             monitor_environment=monitor_env,
-            starting_checkin_id=starting_checkin["id"],
-            starting_timestamp=starting_checkin["date_added"],
-            grouphash=fingerprint,
+            resolving_checkin=None,
+            defaults={
+                "monitor": monitor_env.monitor,
+                "starting_checkin_id": starting_checkin["id"],
+                "starting_timestamp": starting_checkin["date_added"],
+            },
         )
+        fingerprint = incident.grouphash
+
     elif monitor_env.status in [
         MonitorStatus.ERROR,
         MonitorStatus.MISSED_CHECKIN,


### PR DESCRIPTION
As described in GH-66461 we want to avoid creating multiple monitor
incidents in the case where we have a race calling mark_failed