### PR TITLE
ref(superuser): Standardize superuser org id constant and imports

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -19,7 +19,7 @@ from sentry.api.serializers import DetailedSelfUserSerializer, serialize
 from sentry.api.validators import AuthVerifyValidator
 from sentry.api.validators.auth import MISSING_PASSWORD_OR_U2F_CODE
 from sentry.auth.authenticators.u2f import U2fInterface
-from sentry.auth.superuser import Superuser
+from sentry.auth.superuser import SUPERUSER_ORG_ID
 from sentry.models.authenticator import Authenticator
 from sentry.services.hybrid_cloud.auth.impl import promote_request_rpc_user
 from sentry.services.hybrid_cloud.organization import organization_service
@@ -168,10 +168,10 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
             else True
         )
 
-        if Superuser.org_id:
-            if not has_completed_sso(request, Superuser.org_id):
+        if SUPERUSER_ORG_ID:
+            if not has_completed_sso(request, SUPERUSER_ORG_ID):
                 request.session[PREFILLED_SU_MODAL_KEY] = request.data
-                self._reauthenticate_with_sso(request, Superuser.org_id)
+                self._reauthenticate_with_sso(request, SUPERUSER_ORG_ID)
 
         return authenticated
 
@@ -247,9 +247,9 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
             verify_authenticator = False
 
             if not DISABLE_SSO_CHECK_FOR_LOCAL_DEV and not is_self_hosted():
-                if Superuser.org_id:
+                if SUPERUSER_ORG_ID:
                     superuser_org = organization_service.get_organization_by_id(
-                        id=Superuser.org_id, include_teams=False, include_projects=False
+                        id=SUPERUSER_ORG_ID, include_teams=False, include_projects=False
                     )
 
                     if superuser_org is not None:

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -16,7 +16,7 @@ from sentry.api.exceptions import (
 )
 from sentry.auth import access
 from sentry.auth.staff import is_active_staff
-from sentry.auth.superuser import Superuser, is_active_superuser
+from sentry.auth.superuser import SUPERUSER_ORG_ID, is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.services.hybrid_cloud import extract_id_from
 from sentry.services.hybrid_cloud.organization import (
@@ -262,7 +262,7 @@ class SentryPermission(ScopedPermission):
                     "access.not-2fa-compliant",
                     extra=extra,
                 )
-                if request.user.is_superuser and extract_id_from(organization) != Superuser.org_id:
+                if request.user.is_superuser and extract_id_from(organization) != SUPERUSER_ORG_ID:
                     raise SuperuserRequired()
 
                 raise TwoFactorRequired()

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -62,7 +62,7 @@ IDLE_MAX_AGE = getattr(settings, "SUPERUSER_IDLE_MAX_AGE", timedelta(minutes=15)
 
 ALLOWED_IPS = frozenset(getattr(settings, "SUPERUSER_ALLOWED_IPS", settings.INTERNAL_IPS) or ())
 
-ORG_ID = getattr(settings, "SUPERUSER_ORG_ID", None)
+SUPERUSER_ORG_ID = getattr(settings, "SUPERUSER_ORG_ID", None)
 
 SUPERUSER_ACCESS_CATEGORIES = getattr(settings, "SUPERUSER_ACCESS_CATEGORIES", ["for_unit_test"])
 
@@ -151,7 +151,7 @@ class EmptySuperuserAccessForm(SentryAPIException):
 
 class Superuser(ElevatedMode):
     allowed_ips = frozenset(ipaddress.ip_network(str(v), strict=False) for v in ALLOWED_IPS)
-    org_id = ORG_ID
+    org_id = SUPERUSER_ORG_ID
 
     def _check_expired_on_org_change(self) -> bool:
         if self.expires is not None:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -62,8 +62,7 @@ from sentry.auth.superuser import COOKIE_NAME as SU_COOKIE_NAME
 from sentry.auth.superuser import COOKIE_PATH as SU_COOKIE_PATH
 from sentry.auth.superuser import COOKIE_SALT as SU_COOKIE_SALT
 from sentry.auth.superuser import COOKIE_SECURE as SU_COOKIE_SECURE
-from sentry.auth.superuser import ORG_ID as SU_ORG_ID
-from sentry.auth.superuser import Superuser
+from sentry.auth.superuser import SUPERUSER_ORG_ID, Superuser
 from sentry.event_manager import EventManager
 from sentry.eventstore.models import Event
 from sentry.eventstream.snuba import SnubaEventStream
@@ -331,11 +330,11 @@ class BaseTestCase(Fixtures):
         else:
             organization_ids = set(organization_ids)
         if superuser and superuser_sso is not False:
-            if SU_ORG_ID:
-                organization_ids.add(SU_ORG_ID)
+            if SUPERUSER_ORG_ID:
+                organization_ids.add(SUPERUSER_ORG_ID)
         if staff and staff_sso is not False:
             if STAFF_ORG_ID:
-                organization_ids.add(SU_ORG_ID)
+                organization_ids.add(SUPERUSER_ORG_ID)
         if organization_id:
             organization_ids.add(organization_id)
 

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -286,9 +286,9 @@ class _ClientConfig:
         yield "regionUrl", region_url
         yield "sentryUrl", options.get("system.url-prefix")
 
-        if self._is_superuser() and superuser.ORG_ID is not None:
+        if self._is_superuser() and superuser.SUPERUSER_ORG_ID is not None:
             org_context = organization_service.get_organization_by_id(
-                id=superuser.ORG_ID,
+                id=superuser.SUPERUSER_ORG_ID,
                 user_id=None,
                 include_projects=False,
                 include_teams=False,

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 from pytest import fixture
 
 from sentry.api.validators.auth import MISSING_PASSWORD_OR_U2F_CODE
-from sentry.auth.superuser import COOKIE_NAME, Superuser
+from sentry.auth.superuser import COOKIE_NAME
 from sentry.models.authenticator import Authenticator
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
@@ -189,7 +189,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         AuthIdentity.objects.create(user=user, auth_provider=org_provider)
 
-        with mock.patch.object(Superuser, "org_id", self.organization.id):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user, organization_id=self.organization.id)
             response = self.client.put(
                 self.path,
@@ -221,7 +221,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         AuthIdentity.objects.create(user=user, auth_provider=org_provider)
 
-        with mock.patch.object(Superuser, "org_id", self.organization.id):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user, organization_id=self.organization.id)
 
             sso_session_expired = SsoSession(
@@ -272,7 +272,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         AuthIdentity.objects.create(user=user, auth_provider=org_provider)
 
-        with mock.patch.object(Superuser, "org_id", self.organization.id):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user, organization_id=self.organization.id)
 
             sso_session_expired = SsoSession(
@@ -321,7 +321,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         AuthIdentity.objects.create(user=user, auth_provider=org_provider)
 
-        with mock.patch.object(Superuser, "org_id", self.organization.id):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user, organization_id=self.organization.id)
             response = self.client.put(
                 self.path,
@@ -346,7 +346,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         AuthIdentity.objects.create(user=user, auth_provider=org_provider)
 
-        with mock.patch.object(Superuser, "org_id", self.organization.id):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user, organization_id=self.organization.id)
             response = self.client.put(
                 self.path,
@@ -370,7 +370,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         create_authenticator(user)
 
-        with mock.patch.object(Superuser, "org_id", self.organization.id):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user)
             response = self.client.put(
                 self.path,
@@ -389,7 +389,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         user = self.create_user("foo@example.com", is_superuser=True)
 
-        with mock.patch.object(Superuser, "org_id", None):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", None):
             self.login_as(user)
             response = self.client.put(
                 self.path,
@@ -406,7 +406,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         user = self.create_user("foo@example.com", is_superuser=True)
 
-        with mock.patch.object(Superuser, "org_id", None):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", None):
             self.login_as(user)
             response = self.client.put(
                 self.path,
@@ -429,7 +429,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         user = self.create_user("foo@example.com", is_superuser=True)
 
-        with mock.patch.object(Superuser, "org_id", self.organization.id):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user)
             response = self.client.put(
                 self.path,
@@ -446,7 +446,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         user = self.create_user("foo@example.com", is_superuser=True)
 
-        with mock.patch.object(Superuser, "org_id", None):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", None):
             self.login_as(user)
             response = self.client.put(
                 self.path,
@@ -463,7 +463,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
 
         user = self.create_user("foo@example.com", is_superuser=True)
 
-        with mock.patch.object(Superuser, "org_id", None):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", None):
             self.login_as(user)
             response = self.client.put(
                 self.path,
@@ -482,7 +482,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
         create_authenticator(user)
         AuthIdentity.objects.create(user=user, auth_provider=org_provider)
 
-        with mock.patch.object(Superuser, "org_id", self.organization.id):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user)
             response = self.client.put(
                 self.path,
@@ -505,7 +505,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
         create_authenticator(user)
         AuthIdentity.objects.create(user=user, auth_provider=org_provider)
 
-        with mock.patch.object(Superuser, "org_id", self.organization.id):
+        with mock.patch("sentry.api.endpoints.auth_index.SUPERUSER_ORG_ID", self.organization.id):
             self.login_as(user)
             response = self.client.put(
                 self.path,

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -196,7 +196,7 @@ class ClientConfigViewTest(TestCase):
 
         other_org = self.create_organization()
 
-        with mock.patch("sentry.auth.superuser.ORG_ID", self.organization.id):
+        with mock.patch("sentry.auth.superuser.SUPERUSER_ORG_ID", self.organization.id):
             resp = self.client.get(self.path)
 
         assert resp.status_code == 200
@@ -224,9 +224,11 @@ class ClientConfigViewTest(TestCase):
         assert "activeorg" not in self.client.session
 
         # Induce last active organization
-        with override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True), self.feature(
-            {"organizations:customer-domains": [other_org.slug]}
-        ), assume_test_silo_mode(SiloMode.MONOLITH):
+        with (
+            override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True),
+            self.feature({"organizations:customer-domains": [other_org.slug]}),
+            assume_test_silo_mode(SiloMode.MONOLITH),
+        ):
             response = self.client.get(
                 "/",
                 HTTP_HOST=f"{other_org.slug}.testserver",
@@ -245,7 +247,7 @@ class ClientConfigViewTest(TestCase):
                 assert "activeorg" not in self.client.session
 
         # lastOrganization is set
-        with mock.patch("sentry.auth.superuser.ORG_ID", self.organization.id):
+        with mock.patch("sentry.auth.superuser.SUPERUSER_ORG_ID", self.organization.id):
             resp = self.client.get(self.path)
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"


### PR DESCRIPTION
Switch from doing superuser file constant from `ORG_ID` to `SUPERUSER_ORG_ID` and switch imports from `Superuser.org_id` to `SUPERUSER_ORG_ID`.

This brings it in line with the staff constant and is easier to read.

Requires https://github.com/getsentry/getsentry/pull/13180