### PR TITLE
feat(onboarding): Allow showing errors in modal

### DIFF
--- a/static/app/components/modals/inviteMembersModal/inviteMembersModalview.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteMembersModalview.spec.tsx
@@ -1,0 +1,48 @@
+import type {ComponentProps} from 'react';
+import styled from '@emotion/styled';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import InviteMembersModalView from 'sentry/components/modals/inviteMembersModal/inviteMembersModalview';
+
+describe('InviteMembersModalView', function () {
+  const styledWrapper = styled(c => c.children);
+  const modalProps: ComponentProps<typeof InviteMembersModalView> = {
+    Footer: styledWrapper(),
+    addInviteRow: () => {},
+    canSend: true,
+    closeModal: () => {},
+    complete: false,
+    headerInfo: null,
+    inviteStatus: {},
+    invites: [],
+    member: undefined,
+    pendingInvites: [],
+    removeInviteRow: () => {},
+    reset: () => {},
+    sendInvites: () => {},
+    sendingInvites: false,
+    setEmails: () => {},
+    setRole: () => {},
+    setTeams: () => {},
+    willInvite: false,
+  };
+
+  it('renders', function () {
+    render(<InviteMembersModalView {...modalProps} />);
+
+    expect(screen.getByText('Invite New Members')).toBeInTheDocument();
+    expect(screen.getByText('Add another')).toBeInTheDocument();
+  });
+
+  it('renders with error', function () {
+    const modalPropsWithError = {
+      ...modalProps,
+      error: 'This is an error message',
+    };
+    render(<InviteMembersModalView {...modalPropsWithError} />);
+
+    // Check that the Alert component renders with the provided error message
+    expect(screen.getByText('This is an error message')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/modals/inviteMembersModal/inviteMembersModalview.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteMembersModalview.tsx
@@ -40,6 +40,7 @@ interface Props {
   setRole: (role: string, index: number) => void;
   setTeams: (teams: string[], index: number) => void;
   willInvite: boolean;
+  error?: string;
 }
 
 export default function InviteMembersModalView({
@@ -61,6 +62,7 @@ export default function InviteMembersModalView({
   setRole,
   setTeams,
   willInvite,
+  error,
 }: Props) {
   const disableInputs = sendingInvites || complete;
 
@@ -68,8 +70,15 @@ export default function InviteMembersModalView({
   const hasDuplicateEmails = inviteEmails.length !== new Set(inviteEmails).size;
   const isValidInvites = invites.length > 0 && !hasDuplicateEmails;
 
+  const errorAlert = error ? (
+    <Alert type="error" showIcon>
+      {error}
+    </Alert>
+  ) : null;
+
   return (
     <Fragment>
+      {errorAlert}
       <Heading>{t('Invite New Members')}</Heading>
       {willInvite ? (
         <Subtext>{t('Invite new members by email to join your organization.')}</Subtext>


### PR DESCRIPTION
We should be able to show errors in an alert banner for the modal. This lets the calling parent choose to render the alert or not.

Broken off from: https://github.com/getsentry/sentry/pull/66289

Resolves: https://github.com/getsentry/sentry/issues/65673
