### PR TITLE
fix(api): Tests for OrganizationSearchesEndpoint `get` method

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_searches.py
+++ b/tests/sentry/issues/endpoints/test_organization_searches.py
@@ -124,7 +124,7 @@ class OrgLevelOrganizationSearchesListTest(APITestCase):
 
 
 @region_silo_test
-class CreateOrganizationSearchesPostTest(APITestCase):
+class CreateOrganizationSearchesTest(APITestCase):
     endpoint = "sentry-api-0-organization-searches"
     method = "post"
 
@@ -348,7 +348,7 @@ class CreateOrganizationSearchesPostTest(APITestCase):
 
 
 @region_silo_test
-class OrgLevelOrganizationSearchesGetTest(APITestCase):
+class OrganizationSearchesGetTest(APITestCase):
     endpoint = "sentry-api-0-organization-searches"
     method = "get"
 

--- a/tests/sentry/issues/endpoints/test_organization_searches.py
+++ b/tests/sentry/issues/endpoints/test_organization_searches.py
@@ -371,7 +371,7 @@ class OrganizationSearchesGetTest(APITestCase):
             name="Manager's Issue Search",
             query="is:unresolved",
             type=SearchType.ISSUE.value,
-            visibility=Visibility.ORGANIZATION,
+            visibility=Visibility.OWNER,
             owner_id=self.manager.id,
         )
         self.issue_search_manager_2 = SavedSearch.objects.create(
@@ -379,7 +379,7 @@ class OrganizationSearchesGetTest(APITestCase):
             name="Manager's Issue Search 2",
             query="is:unresolved",
             type=SearchType.ISSUE.value,
-            visibility=Visibility.ORGANIZATION,
+            visibility=Visibility.OWNER_PINNED,
             owner_id=self.manager.id,
         )
         self.issue_search_member = SavedSearch.objects.create(


### PR DESCRIPTION
Noticed the `get` method didn't have any tests, so wrote some

Addresses: https://github.com/getsentry/team-core-product-foundations/issues/142
