### PR TITLE
chore(hc): Adds Debug File upload config endpoint

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -69,11 +69,26 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         # User-Agent: sentry-cli/1.70.1
         user_agent = request.headers.get("User-Agent", "")
         sentrycli_version = SENTRYCLI_SEMVER_RE.search(user_agent)
-        supports_relative_url = (sentrycli_version is not None) and (
-            int(sentrycli_version.group("major")),
-            int(sentrycli_version.group("minor")),
-            int(sentrycli_version.group("patch")),
-        ) >= (1, 70, 1)
+        sentrycli_version_split = None
+        if sentrycli_version is not None:
+            sentrycli_version_split = (
+                int(sentrycli_version.group("major")),
+                int(sentrycli_version.group("minor")),
+                int(sentrycli_version.group("patch")),
+            )
+
+        region_upload_urls_enabled = options.get("hybrid_cloud.use_region_specific_upload_url")
+        requires_region_url = (
+            region_upload_urls_enabled
+            and sentrycli_version_split
+            and sentrycli_version_split >= (2, 30, 0)
+        )
+
+        supports_relative_url = (
+            not requires_region_url
+            and sentrycli_version_split
+            and sentrycli_version_split >= (1, 70, 1)
+        )
 
         # If user do not overwritten upload url prefix
         if len(endpoint) == 0:
@@ -85,7 +100,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 # We need to generate region specific upload URLs when possible to avoid hitting the API proxy
                 # which tends to cause timeouts and performance issues for uploads.
                 base_url = None
-                if options.get("hybrid_cloud.use_region_specific_upload_url"):
+                if region_upload_urls_enabled:
                     base_url = generate_region_url()
                 url = absolute_uri(relative_url, base_url)
         else:

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -388,7 +388,7 @@ class DebugFilesConfigEndpoint(ProjectEndpoint):
 
         return Response(
             {
-                "region_url": absolute_uri(
+                "regionUrl": absolute_uri(
                     dsym_file_url,
                     generate_region_url(),
                 )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -200,6 +200,7 @@ from .endpoints.custom_rules import CustomRulesEndpoint
 from .endpoints.data_scrubbing_selector_suggestions import DataScrubbingSelectorSuggestionsEndpoint
 from .endpoints.debug_files import (
     AssociateDSymFilesEndpoint,
+    DebugFilesConfigEndpoint,
     DebugFilesEndpoint,
     DifAssembleEndpoint,
     ProguardArtifactReleasesEndpoint,
@@ -2221,6 +2222,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/files/dsyms/$",
         DebugFilesEndpoint.as_view(),
         name="sentry-api-0-dsym-files",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/files/dsyms/config$",
+        DebugFilesConfigEndpoint.as_view(),
+        name="sentry-api-0-dsym-file-config",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/files/source-maps/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2224,7 +2224,7 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-dsym-files",
     ),
     re_path(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/files/dsyms/config$",
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/files/dsyms/config/$",
         DebugFilesConfigEndpoint.as_view(),
         name="sentry-api-0-dsym-file-config",
     ),

--- a/tests/sentry/api/endpoints/test_debug_files.py
+++ b/tests/sentry/api/endpoints/test_debug_files.py
@@ -563,7 +563,7 @@ class DebugFilesConfigEndpointTest(APITestCase):
 
         response = self.client.get(url)
         assert response.status_code == 200
-        assert response.data == {"region_url": base_url + "/api/0/projects/baz/foo/files/dsyms/"}
+        assert response.data == {"regionUrl": base_url + "/api/0/projects/baz/foo/files/dsyms/"}
 
     def test_no_auth(self):
         project = self.create_project(name="foo")


### PR DESCRIPTION
Adds a new endpoint that surfaces config information for legacy DSYM file uploads. It currently only surfaces a region URL for a CLI client to upload to the correct region, bypassing the API gateway entirely and avoiding timeout issues. The root cause for the timeout issues is still being determined, but seems to be abnormally long spans originating from the chunk-upload requests being proxied. Regardless, there is no reason for upload traffic to be routed through the API gateway when using the CLI, as it will always incur unnecessary additional latency.

This endpoint requires passing in the organization and project slugs similar to the actual upload endpoint itself in order to pre-construct the full URL for the client.

More info on this change and its potential use case can be found here:
[Region Safe Uploads](https://www.notion.so/sentry/Region-Safe-Uploads-Spec-b431fa85b77e48808ff6eeaf6c61163e?pvs=4)
This is a sibling PR of [getsentry/sentry-cli#1983](https://github.com/getsentry/sentry-cli/pull/1983) which consumes this endpoint and issues DSym uploads to the url provided in the response body.