### PR TITLE
style(issues): fix typo in comment for escalation

### DIFF
--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -1,6 +1,7 @@
 """This module has the logic for querying Snuba for the hourly event count for a list of groups.
 This is later used for generating group forecasts for determining when a group may be escalating.
 """
+
 from __future__ import annotations
 
 import logging
@@ -442,7 +443,7 @@ def is_escalating(group: Group) -> tuple[bool, int | None]:
     """
     group_hourly_count = get_group_hourly_count(group)
     forecast_today = EscalatingGroupForecast.fetch_todays_forecast(group.project.id, group.id)
-    # Check if current event occurance is greater than forecast for today's date
+    # Check if current event occurence is greater than forecast for today's date
     if forecast_today and group_hourly_count > forecast_today:
         return True, forecast_today
     return False, None

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -443,7 +443,7 @@ def is_escalating(group: Group) -> tuple[bool, int | None]:
     """
     group_hourly_count = get_group_hourly_count(group)
     forecast_today = EscalatingGroupForecast.fetch_todays_forecast(group.project.id, group.id)
-    # Check if current event occurence is greater than forecast for today's date
+    # Check if current event occurrence is greater than forecast for today's date
     if forecast_today and group_hourly_count > forecast_today:
         return True, forecast_today
     return False, None


### PR DESCRIPTION
inspired by https://github.com/getsentry/sentry/pull/66467 , this pr fixes a typo in a comment for the escalation code