### PR TITLE
feat(onboarding): Show error in invite modal

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -42,6 +42,7 @@ function InviteMembersModal({
     inviteStatus,
     pendingInvites,
     sendingInvites,
+    error,
   } = useInviteModal({
     initialData,
     organization,
@@ -95,6 +96,7 @@ function InviteMembersModal({
               setRole={setRole}
               setTeams={setTeams}
               willInvite={willInvite}
+              error={error}
             />
           );
         }}

--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -133,13 +133,13 @@ export default function useInviteModal({organization, initialData, source}: Prop
               ? errorResponse.email[0]
               : errorResponse.email;
 
-        const orgLevelError = errorResponse?.organization || null;
+        const orgLevelError = errorResponse?.organization;
         const error = orgLevelError || emailError || t('Could not invite user');
 
         setState(prev => ({
           ...prev,
           inviteStatus: {...prev.inviteStatus, [invite.email]: {sent: false, error}},
-          error: orgLevelError ? orgLevelError : undefined,
+          error: orgLevelError,
         }));
         return;
       }

--- a/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
+++ b/static/app/components/modals/inviteMembersModal/useInviteModal.tsx
@@ -71,6 +71,7 @@ export default function useInviteModal({organization, initialData, source}: Prop
       inviteStatus: {},
       complete: false,
       sendingInvites: false,
+      error: undefined,
     };
   });
 
@@ -90,6 +91,7 @@ export default function useInviteModal({organization, initialData, source}: Prop
       inviteStatus: {},
       complete: false,
       sendingInvites: false,
+      error: undefined,
     });
     trackAnalytics('invite_modal.add_more', {
       organization,
@@ -131,11 +133,13 @@ export default function useInviteModal({organization, initialData, source}: Prop
               ? errorResponse.email[0]
               : errorResponse.email;
 
-        const error = emailError || t('Could not invite user');
+        const orgLevelError = errorResponse?.organization || null;
+        const error = orgLevelError || emailError || t('Could not invite user');
 
         setState(prev => ({
           ...prev,
           inviteStatus: {...prev.inviteStatus, [invite.email]: {sent: false, error}},
+          error: orgLevelError ? orgLevelError : undefined,
         }));
         return;
       }
@@ -220,5 +224,6 @@ export default function useInviteModal({organization, initialData, source}: Prop
     inviteStatus: state.inviteStatus,
     pendingInvites: state.pendingInvites,
     sendingInvites: state.sendingInvites,
+    error: state.error,
   };
 }


### PR DESCRIPTION
We should show the error in the invite member modal when it effects the entire modal, and is not specific to individual emails.

Split out from: https://github.com/getsentry/sentry/pull/66289

Resolves: https://github.com/getsentry/sentry/issues/65673
