### PR TITLE
feat(feedback): add crash api platforms to issues feedback sidebar

### DIFF
--- a/static/app/gettingStartedDocs/android/android.tsx
+++ b/static/app/gettingStartedDocs/android/android.tsx
@@ -285,6 +285,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
 const docs: Docs<PlatformOptions> = {
   onboarding,
   feedbackOnboardingCrashApi: feedbackOnboardingCrashApiJava,
+  crashReportOnboarding: feedbackOnboardingCrashApiJava,
   platformOptions,
 };
 

--- a/static/app/gettingStartedDocs/apple/apple-ios.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-ios.tsx
@@ -178,6 +178,7 @@ const onboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: appleFeedbackOnboarding,
+  crashReportOnboarding: appleFeedbackOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/apple/apple-macos.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-macos.tsx
@@ -284,6 +284,7 @@ SentrySDK.start { options in
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: appleFeedbackOnboarding,
+  crashReportOnboarding: appleFeedbackOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dart/dart.tsx
+++ b/static/app/gettingStartedDocs/dart/dart.tsx
@@ -197,6 +197,7 @@ Sentry.captureUserFeedback(userFeedback);`,
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedbackOnboardingCrashApiDart,
+  crashReportOnboarding: feedbackOnboardingCrashApiDart,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -178,6 +178,7 @@ const onboarding: OnboardingConfig = {
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedbackOnboardingCrashApiDart,
+  crashReportOnboarding: feedbackOnboardingCrashApiDart,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/java/java.tsx
+++ b/static/app/gettingStartedDocs/java/java.tsx
@@ -349,6 +349,7 @@ Sentry.captureUserFeedback(userFeedback)`,
 const docs: Docs<PlatformOptions> = {
   platformOptions,
   feedbackOnboardingCrashApi: feedbackOnboardingCrashApiJava,
+  crashReportOnboarding: feedbackOnboardingCrashApiJava,
   onboarding,
 };
 

--- a/static/app/gettingStartedDocs/java/log4j2.tsx
+++ b/static/app/gettingStartedDocs/java/log4j2.tsx
@@ -333,6 +333,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
 const docs: Docs<PlatformOptions> = {
   platformOptions,
   feedbackOnboardingCrashApi: feedbackOnboardingCrashApiJava,
+  crashReportOnboarding: feedbackOnboardingCrashApiJava,
   onboarding,
 };
 

--- a/static/app/gettingStartedDocs/java/logback.tsx
+++ b/static/app/gettingStartedDocs/java/logback.tsx
@@ -340,6 +340,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
 const docs: Docs<PlatformOptions> = {
   onboarding,
   feedbackOnboardingCrashApi: feedbackOnboardingCrashApiJava,
+  crashReportOnboarding: feedbackOnboardingCrashApiJava,
   platformOptions,
 };
 

--- a/static/app/gettingStartedDocs/java/spring-boot.tsx
+++ b/static/app/gettingStartedDocs/java/spring-boot.tsx
@@ -9,6 +9,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {feedbackOnboardingCrashApiJava} from 'sentry/gettingStartedDocs/java/java';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -302,6 +303,7 @@ const docs: Docs<PlatformOptions> = {
   onboarding,
   platformOptions,
   replayOnboardingJsLoader,
+  crashReportOnboarding: feedbackOnboardingCrashApiJava,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/java/spring.tsx
+++ b/static/app/gettingStartedDocs/java/spring.tsx
@@ -9,6 +9,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {feedbackOnboardingCrashApiJava} from 'sentry/gettingStartedDocs/java/java';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -373,6 +374,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
 const docs: Docs<PlatformOptions> = {
   onboarding,
   platformOptions,
+  crashReportOnboarding: feedbackOnboardingCrashApiJava,
   replayOnboardingJsLoader,
 };
 

--- a/static/app/gettingStartedDocs/kotlin/kotlin.tsx
+++ b/static/app/gettingStartedDocs/kotlin/kotlin.tsx
@@ -313,6 +313,7 @@ Sentry.captureUserFeedback(userFeedback)`,
 const docs: Docs<PlatformOptions> = {
   platformOptions,
   feedbackOnboardingCrashApi,
+  crashReportOnboarding: feedbackOnboardingCrashApi,
   onboarding,
 };
 

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -330,6 +330,7 @@ Sentry.captureUserFeedback(userFeedback);`,
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi,
+  crashReportOnboarding: feedbackOnboardingCrashApi,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/unity/unity.tsx
+++ b/static/app/gettingStartedDocs/unity/unity.tsx
@@ -160,6 +160,7 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedbackOnboarding,
+  crashReportOnboarding: feedbackOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/unreal/unreal.tsx
+++ b/static/app/gettingStartedDocs/unreal/unreal.tsx
@@ -268,6 +268,7 @@ SentrySubsystem->CaptureUserFeedbackWithParams(EventId, "test@sentry.io", "Some 
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi,
+  crashReportOnboarding: feedbackOnboardingCrashApi,
 };
 
 export default docs;


### PR DESCRIPTION
- these platforms all use the crash report API for onboarding

this PR adds the instructions for
- android
-  apple-ios
-  apple-macos
-  dart
-  flutter
-  java
-  java-log4j2
-  java-logback
-  java-spring
-  java-spring-boot
-  kotlin
-  unity
-  unreal
-  react-native
<img width="466" alt="SCR-20240306-nwgg" src="https://github.com/getsentry/sentry/assets/56095982/f7f8f71d-34b4-47d0-ba97-b1611f157fd6">

relates to https://github.com/getsentry/sentry/issues/66162