### PR TITLE
feat(onboarding): Default to using team

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.tsx
@@ -1,10 +1,10 @@
 import type {ComponentProps} from 'react';
-import selectEvent from 'react-select-event';
 import styled from '@emotion/styled';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {makeCloseButton} from 'sentry/components/globalModal/components';
@@ -206,8 +206,8 @@ describe('InviteMembersModal', function () {
     });
 
     expect(await screen.findByRole('button', {name: 'Add another'})).toBeInTheDocument();
-
     await setupMemberInviteState();
+
     const teamInputs = screen.getAllByRole('textbox', {name: 'Add to Team'});
     await selectEvent.select(teamInputs[0], '#team-slug');
     await selectEvent.select(teamInputs[1], '#team-slug');
@@ -393,9 +393,9 @@ describe('InviteMembersModal', function () {
 
   describe('member invite request mode', function () {
     it('has adjusted wording', async function () {
-      setupView({orgAccess: undefined});
+      setupView({orgAccess: []});
       expect(
-        await screen.findByRole('button', {name: 'Send invite'})
+        await screen.findByRole('button', {name: 'Send invite request'})
       ).toBeInTheDocument();
     });
 
@@ -412,7 +412,7 @@ describe('InviteMembersModal', function () {
       const initialData = [{emails: new Set([initialEmail])}];
 
       const {mocks} = setupView({
-        orgAccess: undefined,
+        orgAccess: [],
         mockApiResponses: [defaultMockOrganizationRoles, createInviteRequestMock],
         modalProps: {
           ...defaultMockModalProps,
@@ -421,7 +421,7 @@ describe('InviteMembersModal', function () {
       });
 
       expect(await screen.findByText(initialEmail)).toBeInTheDocument();
-      await userEvent.click(screen.getByRole('button', {name: 'Send invite'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Send invite request'}));
       const apiMock = mocks[1];
       expect(apiMock).toHaveBeenCalledTimes(1);
     });

--- a/static/app/components/modals/inviteMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.tsx
@@ -172,7 +172,7 @@ describe('InviteMembersModal', function () {
     expect(close).toHaveBeenCalled();
   });
 
-  it('sends all successful invites', async function () {
+  it('sends all successful invites, and removes team defaults', async function () {
     jest.mocked(useOrganization).mockReturnValue(org);
     const createMemberMock = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/members/`,
@@ -196,6 +196,67 @@ describe('InviteMembersModal', function () {
     await userEvent.tab();
     await selectEvent.select(roleInputs[0], 'Admin');
     await selectEvent.select(teamInputs[0], '#team-slug');
+
+    await userEvent.type(emailInputs[1], 'test2@test.com');
+    await selectEvent.select(teamInputs[1], '#team-slug');
+    await userEvent.tab();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Send invites (2)'}));
+
+    // Verify data sent to the backend
+    expect(createMemberMock).toHaveBeenCalledTimes(2);
+
+    expect(createMemberMock).toHaveBeenNthCalledWith(
+      1,
+      `/organizations/${org.slug}/members/`,
+      expect.objectContaining({
+        data: {email: 'test1@test.com', role: 'admin', teams: []},
+      })
+    );
+    expect(createMemberMock).toHaveBeenNthCalledWith(
+      2,
+      `/organizations/${org.slug}/members/`,
+      expect.objectContaining({
+        data: {email: 'test2@test.com', role: 'member', teams: []},
+      })
+    );
+
+    // Wait for them to finish
+    expect(
+      await screen.findByText(textWithMarkupMatcher('Sent 2 invites'))
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Close'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Send more invites'})).toBeInTheDocument();
+
+    // Send more reset the modal
+    await userEvent.click(screen.getByRole('button', {name: 'Send more invites'}));
+
+    expect(screen.getByRole('button', {name: 'Send invite'})).toBeDisabled();
+  });
+
+  it('sends all successful invites with team default', async function () {
+    jest.mocked(useOrganization).mockReturnValue(org);
+    const createMemberMock = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/`,
+      method: 'POST',
+    });
+
+    render(<InviteMembersModal {...modalProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: 'Add another'})).toBeInTheDocument();
+    });
+
+    // Setup two rows, one email each, the first with a admin role.
+    await userEvent.click(screen.getByRole('button', {name: 'Add another'}));
+
+    const emailInputs = screen.getAllByRole('textbox', {name: 'Email Addresses'});
+    const roleInputs = screen.getAllByRole('textbox', {name: 'Role'});
+
+    await userEvent.type(emailInputs[0], 'test1@test.com');
+    await userEvent.tab();
+    await selectEvent.select(roleInputs[0], 'Admin');
 
     await userEvent.type(emailInputs[1], 'test2@test.com');
     await userEvent.tab();

--- a/static/app/components/modals/inviteMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.tsx
@@ -216,7 +216,7 @@ describe('InviteMembersModal', function () {
       2,
       `/organizations/${org.slug}/members/`,
       expect.objectContaining({
-        data: {email: 'test2@test.com', role: 'member', teams: []},
+        data: {email: 'test2@test.com', role: 'member', teams: ['team-slug']},
       })
     );
 
@@ -284,7 +284,7 @@ describe('InviteMembersModal', function () {
     expect(createMemberMock).toHaveBeenCalledWith(
       `/organizations/${org.slug}/members/`,
       expect.objectContaining({
-        data: {email: initialEmail, role: 'member', teams: []},
+        data: {email: initialEmail, role: 'member', teams: ['team-slug']},
       })
     );
 

--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -123,6 +123,7 @@ function InviteRowControl({
         placeholder={t('None')}
         value={teams}
         onChange={onChangeTeams}
+        useTeamDefaultIfOnlyOne
         multiple
         clearable
       />


### PR DESCRIPTION
In the invite member modal, if there is only one team available based on the filters, we want to default using that team. Broken out from: https://github.com/getsentry/sentry/pull/66289

Requires: https://github.com/getsentry/sentry/pull/66387

Resolves: https://github.com/getsentry/sentry/issues/65673
