### PR TITLE
fix(replays): add default environment

### DIFF
--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -34,7 +34,7 @@ def report_rage_click_issue_with_replay_event(
 
     new_issue_occurrence(
         culprit=url[:MAX_CULPRIT_LENGTH],
-        environment=replay_event["environment"],
+        environment=replay_event.get("environment"),
         fingerprint=[selector],
         issue_type=ReplayRageClickType,
         level=RAGE_CLICK_LEVEL,

--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -34,7 +34,9 @@ def report_rage_click_issue_with_replay_event(
 
     new_issue_occurrence(
         culprit=url[:MAX_CULPRIT_LENGTH],
-        environment=replay_event.get("environment"),
+        environment=replay_event.get(
+            "environment", "production"
+        ),  # if no environment is set, default to production
         fingerprint=[selector],
         issue_type=ReplayRageClickType,
         level=RAGE_CLICK_LEVEL,

--- a/src/sentry/replays/usecases/issue.py
+++ b/src/sentry/replays/usecases/issue.py
@@ -10,7 +10,7 @@ from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 
 def new_issue_occurrence(
     culprit: str,
-    environment: str,
+    environment: str | None,
     fingerprint: Sequence[str],
     issue_type: type[GroupType],
     level: str,

--- a/src/sentry/replays/usecases/issue.py
+++ b/src/sentry/replays/usecases/issue.py
@@ -43,7 +43,7 @@ def new_issue_occurrence(
         level=level,
     )
 
-    event_data = {
+    event_data: dict[str, Any] = {
         "id": event_id,
         "environment": environment,
         "platform": platform,


### PR DESCRIPTION
- If no environment exists on `replay_event`, default to production. This is what is used as the default in other places. 

Fixes https://sentry.sentry.io/issues/5043584967/