### PR TITLE
feat(ddm): Add support for querying only totals

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -444,11 +444,11 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
         return metrics_queries_plan
 
     def _get_query_type_from_request(self, request: Request) -> QueryType:
-        query_type = request.GET.get("queryType")
-        if query_type is None:
+        include_series = (request.GET.get("includeSeries") or "true") == "true"
+        if include_series:
             return QueryType.TOTALS_AND_SERIES
 
-        return QueryType(query_type)
+        return QueryType.TOTALS
 
     def post(self, request: Request, organization) -> Response:
         try:

--- a/src/sentry/sentry_metrics/querying/data_v2/api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/api.py
@@ -16,6 +16,7 @@ from sentry.sentry_metrics.querying.data_v2.preparation import (
     UnitNormalizationStep,
     run_preparation_steps,
 )
+from sentry.sentry_metrics.querying.types import QueryType
 from sentry.utils import metrics
 
 
@@ -52,6 +53,7 @@ def run_metrics_queries_plan(
     projects: Sequence[Project],
     environments: Sequence[Environment],
     referrer: str,
+    query_type: QueryType = QueryType.TOTALS_AND_SERIES,
 ) -> MetricsQueriesPlanResult:
     metrics.incr(
         key="ddm.metrics_api.queried_time_range",
@@ -102,7 +104,7 @@ def run_metrics_queries_plan(
     # We prepare the executor, that will be responsible for scheduling the execution of multiple queries.
     executor = QueryExecutor(organization=organization, projects=projects, referrer=referrer)
     for intermediate_query in intermediate_queries:
-        executor.schedule(intermediate_query)
+        executor.schedule(intermediate_query=intermediate_query, query_type=query_type)
 
     results = executor.execute()
 

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -202,10 +202,7 @@ class ScheduledQuery:
                 replace(updated_metrics_query.rollup, orderby=self.order.to_snuba_order())
             )
 
-        if self.limit:
-            updated_metrics_query = updated_metrics_query.set_limit(self.limit)
-        else:
-            updated_metrics_query = updated_metrics_query.set_limit(SNUBA_QUERY_LIMIT)
+        updated_metrics_query = updated_metrics_query.set_limit(self.limit or SNUBA_QUERY_LIMIT)
 
         return updated_metrics_query
 

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -13,7 +13,7 @@ from sentry.models.project import Project
 from sentry.sentry_metrics.querying.common import SNUBA_QUERY_LIMIT
 from sentry.sentry_metrics.querying.data_v2.preparation import IntermediateQuery
 from sentry.sentry_metrics.querying.errors import MetricsQueryExecutionError
-from sentry.sentry_metrics.querying.types import GroupKey, GroupsCollection, QueryOrder
+from sentry.sentry_metrics.querying.types import GroupKey, GroupsCollection, QueryOrder, QueryType
 from sentry.sentry_metrics.querying.units import MeasurementUnit, UnitFamily
 from sentry.sentry_metrics.querying.visitors import (
     QueriedMetricsVisitor,
@@ -615,16 +615,15 @@ class QueryExecutor:
 
         return cast(Sequence[QueryResult], self._query_results)
 
-    def schedule(self, intermediate_query: IntermediateQuery):
+    def schedule(self, intermediate_query: IntermediateQuery, query_type: QueryType):
         """
         Lazily schedules a query for execution.
 
         Note that this method won't execute the query, since it's lazy in nature.
         """
-        # For now, we are always building a (totals -> series) query, but the execution engine is fully capable of
-        # supporting either a single totals or series query.
-        series_query = ScheduledQuery(
-            type=ScheduledQueryType.SERIES,
+        # By default, we always want to have a totals query.
+        totals_query = ScheduledQuery(
+            type=ScheduledQueryType.TOTALS,
             metrics_query=intermediate_query.metrics_query,
             order=intermediate_query.order,
             limit=intermediate_query.limit,
@@ -632,12 +631,19 @@ class QueryExecutor:
             unit=intermediate_query.unit,
             scaling_factor=intermediate_query.scaling_factor,
         )
-        totals_query = replace(series_query, type=ScheduledQueryType.TOTALS, next=series_query)
+
+        # In case the user chooses to run also a series query, we will duplicate the query and chain it after totals.
+        series_query = None
+        if query_type == QueryType.TOTALS_AND_SERIES:
+            series_query = replace(totals_query, type=ScheduledQueryType.SERIES)
+
+        final_query = replace(totals_query, next=series_query)
 
         # We initialize the query by performing type-aware mutations that prepare the query to be executed correctly
         # (e.g., adding `totals` to a totals query...).
-        executable_query = totals_query.initialize(
-            self._organization, self._projects, self._blocked_metrics_for_projects
+        self._scheduled_queries.append(
+            final_query.initialize(
+                self._organization, self._projects, self._blocked_metrics_for_projects
+            )
         )
-        self._scheduled_queries.append(executable_query)
         self._query_results.append(None)

--- a/src/sentry/sentry_metrics/querying/data_v2/transformation/metrics_api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation/metrics_api.py
@@ -210,12 +210,12 @@ class MetricsAPIQueryTransformer(QueryTransformer[Mapping[str, Any]]):
         for query_groups in queries_groups:
             translated_query_groups = []
             for group_key, group_value in query_groups.items():
-                base_group = {
+                base_group: dict[str, Any] = {
                     "by": {name: value for name, value in group_key},
                     "totals": undefined_value_to_none(group_value.totals),
                 }
 
-                if intervals is not None:
+                if intervals is not None and interval is not None:
                     base_group["series"] = _generate_full_series(
                         int(start.timestamp()), len(intervals), interval, group_value.series
                     )

--- a/src/sentry/sentry_metrics/querying/types.py
+++ b/src/sentry/sentry_metrics/querying/types.py
@@ -52,3 +52,8 @@ class QueryOrder(Enum):
             return Direction.DESC
 
         raise InvalidMetricsQueryError(f"Ordering {self} does not exist is snuba")
+
+
+class QueryType(Enum):
+    TOTALS_AND_SERIES = 0
+    TOTALS = 1

--- a/src/sentry/sentry_metrics/querying/types.py
+++ b/src/sentry/sentry_metrics/querying/types.py
@@ -55,5 +55,5 @@ class QueryOrder(Enum):
 
 
 class QueryType(Enum):
-    TOTALS_AND_SERIES = 0
-    TOTALS = 1
+    TOTALS_AND_SERIES = "totals_and_series"
+    TOTALS = "totals"

--- a/src/sentry/sentry_metrics/querying/types.py
+++ b/src/sentry/sentry_metrics/querying/types.py
@@ -55,5 +55,5 @@ class QueryOrder(Enum):
 
 
 class QueryType(Enum):
-    TOTALS_AND_SERIES = "totals_and_series"
-    TOTALS = "totals"
+    TOTALS_AND_SERIES = 0
+    TOTALS = 1

--- a/tests/sentry/api/endpoints/test_organization_metrics_query.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_query.py
@@ -72,7 +72,7 @@ class OrganizationMetricsQueryTest(MetricsAPIBaseTestCase):
                 "interval": "1h",
                 "project": [self.project.id],
                 "environment": [],
-                "queryType": "totals",
+                "includeSeries": "false",
             },
         )
         assert "intervals" not in response.data

--- a/tests/sentry/api/endpoints/test_organization_metrics_query.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_query.py
@@ -32,7 +32,7 @@ class OrganizationMetricsQueryTest(MetricsAPIBaseTestCase):
     def now(self):
         return MetricsAPIBaseTestCase.MOCK_DATETIME
 
-    def test_query_simple(self):
+    def test_query_with_totals_and_series(self):
         response = self.get_success_response(
             self.project.organization.slug,
             status_code=200,
@@ -45,7 +45,38 @@ class OrganizationMetricsQueryTest(MetricsAPIBaseTestCase):
                 "environment": [],
             },
         )
+        assert len(response.data["intervals"]) == 3
         assert response.data["data"] == [[{"by": {}, "series": [3.0, 5.0, 10.0], "totals": 18.0}]]
+        assert response.data["meta"] == [
+            [
+                {"name": "aggregate_value", "type": "Float64"},
+                {
+                    "group_bys": [],
+                    "limit": 20,
+                    "order": None,
+                    "scaling_factor": None,
+                    "unit": None,
+                    "unit_family": None,
+                },
+            ]
+        ]
+
+    def test_query_with_totals(self):
+        response = self.get_success_response(
+            self.project.organization.slug,
+            status_code=200,
+            queries=[{"name": "query_1", "mql": f"sum({TransactionMRI.DURATION.value})"}],
+            formulas=[{"mql": "$query_1"}],
+            qs_params={
+                "statsPeriod": "3h",
+                "interval": "1h",
+                "project": [self.project.id],
+                "environment": [],
+                "queryType": "totals",
+            },
+        )
+        assert "intervals" not in response.data
+        assert response.data["data"] == [[{"by": {}, "totals": 18.0}]]
         assert response.data["meta"] == [
             [
                 {"name": "aggregate_value", "type": "Float64"},

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -858,7 +858,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert second_query[2]["totals"] == self.to_reference_unit(5.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_multiple_aggregations_and_single_group_by_and_order_by_with_limit(
         self,
     ) -> None:
@@ -919,9 +918,11 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         meta = results["meta"]
         assert len(meta) == 2
         first_meta = sorted(meta[0], key=lambda value: value.get("name", ""))
-        assert first_meta[0] == {"group_bys": ["platform"], "limit": 2, "order": "ASC"}
+        assert first_meta[0]["limit"] == 2
+        assert first_meta[0]["order"] == "ASC"
         second_meta = sorted(meta[1], key=lambda value: value.get("name", ""))
-        assert second_meta[0] == {"group_bys": ["platform"], "limit": 2, "order": "DESC"}
+        assert second_meta[0]["limit"] == 2
+        assert second_meta[0]["order"] == "DESC"
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     def test_query_with_custom_set(self):

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -15,7 +15,7 @@ from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
     MetricsQueryExecutionError,
 )
-from sentry.sentry_metrics.querying.types import QueryOrder
+from sentry.sentry_metrics.querying.types import QueryOrder, QueryType
 from sentry.sentry_metrics.querying.units import (
     MeasurementUnit,
     UnitFamily,
@@ -115,6 +115,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         projects: Sequence[Project],
         environments: Sequence[Environment],
         referrer: str,
+        query_type: QueryType = QueryType.TOTALS_AND_SERIES,
     ) -> Mapping[str, Any]:
         return run_metrics_queries_plan(
             metrics_queries_plan,
@@ -125,6 +126,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             projects,
             environments,
             referrer,
+            query_type,
         ).apply_transformer(self.query_transformer)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
@@ -207,6 +209,34 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             self.to_reference_unit(12.0),
             self.to_reference_unit(9.0),
         ]
+        assert data[0][0]["totals"] == self.to_reference_unit(21.0)
+        meta = results["meta"]
+        assert len(meta) == 1
+        assert meta[0][1]["unit_family"] == UnitFamily.DURATION.value
+        assert meta[0][1]["unit"] is not None
+        assert meta[0][1]["scaling_factor"] is not None
+
+    @with_feature("organizations:ddm-metrics-api-unit-normalization")
+    def test_query_with_one_aggregation_and_only_totals(self) -> None:
+        query_1 = self.mql("sum", TransactionMRI.DURATION.value)
+        plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
+
+        results = self.run_query(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+            query_type=QueryType.TOTALS,
+        )
+        assert "intervals" not in results
+        data = results["data"]
+        assert len(data) == 1
+        assert data[0][0]["by"] == {}
+        assert "series" not in data[0][0]
         assert data[0][0]["totals"] == self.to_reference_unit(21.0)
         meta = results["meta"]
         assert len(meta) == 1
@@ -442,6 +472,35 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             self.to_reference_unit(4.0),
         ]
         assert data[0][1]["totals"] == self.to_reference_unit(9.0)
+
+    @with_feature("organizations:ddm-metrics-api-unit-normalization")
+    def test_query_with_group_by_and_order_by_and_only_totals(self) -> None:
+        query_1 = self.mql("sum", TransactionMRI.DURATION.value, group_by="transaction")
+        plan = (
+            MetricsQueriesPlan()
+            .declare_query("query_1", query_1)
+            .apply_formula("$query_1", order=QueryOrder.ASC)
+        )
+
+        results = self.run_query(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+            query_type=QueryType.TOTALS,
+        )
+        assert "intervals" not in results
+        data = results["data"]
+        assert len(data) == 1
+        assert len(data[0]) == 2
+        assert data[0][0]["by"] == {"transaction": "/world"}
+        assert data[0][0]["totals"] == self.to_reference_unit(9.0)
+        assert data[0][1]["by"] == {"transaction": "/hello"}
+        assert data[0][1]["totals"] == self.to_reference_unit(12.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")


### PR DESCRIPTION
This PR adds support for querying only totals in the `metrics/query` endpoint and internal API. Such capability allows the querying of big-number widgets more efficiently.

The updated endpoint now accepts a new query parameter `includeSeries` which when set to `true` or not set will return both totals and series. If set to `false` it will return only totals.