### PR TITLE
ref(dashboard): Add concept of metric expression ids

### DIFF
--- a/static/app/components/modals/metricWidgetViewerModal.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal.tsx
@@ -164,9 +164,7 @@ function MetricWidgetViewerModal({
         </Header>
         <Body>
           <Queries
-            metricWidgetQueries={metricExpressions.filter(
-              (q): q is DashboardMetricsQuery => !isMetricsFormula(q)
-            )}
+            metricWidgetQueries={metricQueries}
             handleChange={handleQueryChange}
             addQuery={addQuery}
             removeQuery={removeQuery}

--- a/static/app/components/modals/metricWidgetViewerModal.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal.tsx
@@ -10,20 +10,36 @@ import {MetricVisualization} from 'sentry/components/modals/metricWidgetViewerMo
 import type {WidgetViewerModalOptions} from 'sentry/components/modals/widgetViewerModal';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types';
-import {getDdmUrl, getWidgetTitle} from 'sentry/utils/metrics';
-import {emptyMetricsQueryWidget} from 'sentry/utils/metrics/constants';
+import {getDdmUrl, unescapeMetricsFormula} from 'sentry/utils/metrics';
 import {convertToDashboardWidget, toDisplayType} from 'sentry/utils/metrics/dashboard';
-import type {MetricQueryWidgetParams} from 'sentry/utils/metrics/types';
-import type {MetricsQueryApiRequestQuery} from 'sentry/utils/metrics/useMetricsQuery';
+import {formatMRIField, MRIToField} from 'sentry/utils/metrics/mri';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import type {Order} from 'sentry/views/dashboards/metrics/types';
-import {getMetricQueries} from 'sentry/views/dashboards/metrics/utils';
-import {getQuerySymbol} from 'sentry/views/ddm/querySymbol';
+import type {
+  DashboardMetricsExpression,
+  DashboardMetricsQuery,
+  Order,
+} from 'sentry/views/dashboards/metrics/types';
+import {
+  expressionsToApiQueries,
+  getMetricExpressions,
+  isMetricsFormula,
+  useGenerateExpressionId,
+} from 'sentry/views/dashboards/metrics/utils';
 import {MetricDetails} from 'sentry/views/ddm/widgetDetails';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 interface Props extends ModalRenderProps, WidgetViewerModalOptions {
   organization: Organization;
+}
+
+function getWidgetTitle(queries: DashboardMetricsExpression[]) {
+  return queries
+    .map(q =>
+      isMetricsFormula(q)
+        ? unescapeMetricsFormula(q.formula)
+        : formatMRIField(MRIToField(q.mri, q.op))
+    )
+    .join(', ');
 }
 
 function MetricWidgetViewerModal({
@@ -37,33 +53,43 @@ function MetricWidgetViewerModal({
   dashboardFilters,
 }: Props) {
   const {selection} = usePageFilters();
-  const [metricWidgetQueries, setMetricWidgetQueries] = useState<
-    MetricsQueryApiRequestQuery[]
-  >(getMetricQueries(widget, dashboardFilters));
+  const [metricExpressions, setMetricExpressions] = useState<
+    DashboardMetricsExpression[]
+  >(getMetricExpressions(widget, dashboardFilters));
 
-  const widgetMQL = useMemo(
-    () => getWidgetTitle(metricWidgetQueries),
-    [metricWidgetQueries]
+  const generateExpressionId = useGenerateExpressionId(metricExpressions);
+
+  const metricQueries = useMemo(() => {
+    return metricExpressions.filter(
+      (e): e is DashboardMetricsQuery => !isMetricsFormula(e)
+    );
+  }, [metricExpressions]);
+
+  const apiQueries = useMemo(
+    () => expressionsToApiQueries(metricQueries),
+    [metricQueries]
   );
+
+  const widgetMQL = useMemo(() => getWidgetTitle(metricExpressions), [metricExpressions]);
 
   const [displayType, setDisplayType] = useState(widget.displayType);
   const [editedTitle, setEditedTitle] = useState<string>(widget.title);
   // If user renamed the widget, dislay that title, otherwise display the MQL
   const titleToDisplay = editedTitle === '' ? widgetMQL : editedTitle;
 
-  const handleChange = useCallback(
-    (data: Partial<MetricQueryWidgetParams>, index: number) => {
-      setMetricWidgetQueries(curr => {
+  const handleQueryChange = useCallback(
+    (data: Partial<DashboardMetricsQuery>, index: number) => {
+      setMetricExpressions(curr => {
         const updated = [...curr];
-        updated[index] = {...updated[index], ...data};
+        updated[index] = {...updated[index], ...data} as DashboardMetricsQuery;
         return updated;
       });
     },
-    [setMetricWidgetQueries]
+    [setMetricExpressions]
   );
 
   const handleOrderChange = useCallback((order: Order, index: number) => {
-    setMetricWidgetQueries(curr => {
+    setMetricExpressions(curr => {
       return curr.map((query, i) => {
         const orderBy = i === index ? order : undefined;
         return {...query, orderBy};
@@ -79,36 +105,31 @@ function MetricWidgetViewerModal({
   );
 
   const addQuery = useCallback(() => {
-    setMetricWidgetQueries(curr => {
+    setMetricExpressions(curr => {
       return [
         ...curr,
         {
-          ...emptyMetricsQueryWidget,
-          // TODO: generate a unique name
-          name: 'temporary',
+          ...metricExpressions[metricExpressions.length - 1],
+          id: generateExpressionId(),
         },
       ];
     });
-  }, [setMetricWidgetQueries]);
+  }, [generateExpressionId, metricExpressions]);
 
   const removeQuery = useCallback(
     (index: number) => {
-      setMetricWidgetQueries(curr => {
+      setMetricExpressions(curr => {
         const updated = [...curr];
         updated.splice(index, 1);
         return updated;
       });
     },
-    [setMetricWidgetQueries]
+    [setMetricExpressions]
   );
 
   const handleSubmit = useCallback(() => {
-    const convertedWidget = convertToDashboardWidget(
-      metricWidgetQueries.map(query => ({
-        ...query,
-        ...selection,
-      }))
-    );
+    // TODO: check saving id
+    const convertedWidget = convertToDashboardWidget(metricQueries);
 
     const updatedWidget = {
       ...widget,
@@ -121,21 +142,13 @@ function MetricWidgetViewerModal({
 
     closeModal();
   }, [
+    metricQueries,
+    widget,
     titleToDisplay,
-    metricWidgetQueries,
+    displayType,
     onMetricWidgetEdit,
     closeModal,
-    widget,
-    selection,
-    displayType,
   ]);
-
-  // Quick fix to avoid the page crashing with multiple queries
-  // We will need a persistent unique identifier here so we can support formulas in the future
-  const queriesWithName = metricWidgetQueries.map((query, index) => ({
-    ...query,
-    name: getQuerySymbol(index),
-  }));
 
   return (
     <Fragment>
@@ -151,27 +164,26 @@ function MetricWidgetViewerModal({
         </Header>
         <Body>
           <Queries
-            metricWidgetQueries={queriesWithName}
-            handleChange={handleChange}
+            metricWidgetQueries={metricExpressions.filter(
+              (q): q is DashboardMetricsQuery => !isMetricsFormula(q)
+            )}
+            handleChange={handleQueryChange}
             addQuery={addQuery}
             removeQuery={removeQuery}
           />
           <MetricVisualization
-            queries={queriesWithName}
+            queries={apiQueries}
             displayType={displayType}
             onDisplayTypeChange={setDisplayType}
             onOrderChange={handleOrderChange}
           />
-          <MetricDetails
-            mri={metricWidgetQueries[0].mri}
-            query={metricWidgetQueries[0].query}
-          />
+          <MetricDetails mri={metricQueries[0].mri} query={metricQueries[0].query} />
         </Body>
         <Footer>
           <ButtonBar gap={1}>
             <LinkButton
               to={getDdmUrl(organization.slug, {
-                widgets: metricWidgetQueries,
+                widgets: metricQueries,
                 ...selection.datetime,
                 project: selection.projects,
                 environment: selection.environments,

--- a/static/app/components/modals/metricWidgetViewerModal/queries.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal/queries.tsx
@@ -9,17 +9,17 @@ import {IconAdd, IconClose, IconEllipsis, IconSettings, IconSiren} from 'sentry/
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {isCustomMetric} from 'sentry/utils/metrics';
-import type {MetricsQuery} from 'sentry/utils/metrics/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
+import type {DashboardMetricsQuery} from 'sentry/views/dashboards/metrics/types';
 import {getCreateAlert} from 'sentry/views/ddm/metricQueryContextMenu';
 import {QueryBuilder} from 'sentry/views/ddm/queryBuilder';
 
 interface Props {
   addQuery: () => void;
-  handleChange: (data: Partial<MetricsQuery>, index: number) => void;
-  metricWidgetQueries: MetricsQuery[];
+  handleChange: (data: Partial<DashboardMetricsQuery>, index: number) => void;
+  metricWidgetQueries: DashboardMetricsQuery[];
   removeQuery: (index: number) => void;
 }
 
@@ -36,11 +36,8 @@ export function Queries({
       {metricWidgetQueries.map((query, index) => (
         <QueryWrapper key={index}>
           <QueryBuilder
-            // @ts-expect-error TODO: adjust query builder type
             onChange={data => handleChange(data, index)}
             metricsQuery={query}
-            // @ts-expect-error TODO: remove display type from query builder
-            displayType={'line'}
             projects={selection.projects}
           />
           <ContextMenu
@@ -60,7 +57,7 @@ export function Queries({
 
 interface ContextMenuProps {
   canRemoveQuery: boolean;
-  metricsQuery: MetricsQuery;
+  metricsQuery: DashboardMetricsQuery;
   queryIndex: number;
   removeQuery: (index: number) => void;
 }

--- a/static/app/components/modals/metricWidgetViewerModal/visualization.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal/visualization.tsx
@@ -166,7 +166,7 @@ export function MetricVisualization({
         displayType={displayType}
       />
     );
-  }, [displayType, isLoading, queries, timeseriesData, onOrderChange]);
+  }, [timeseriesData, displayType, isLoading, queries, onOrderChange]);
 
   if (!timeseriesData || isError) {
     return (

--- a/static/app/utils/metrics/useIncrementQueryMetric.tsx
+++ b/static/app/utils/metrics/useIncrementQueryMetric.tsx
@@ -2,13 +2,10 @@ import {useCallback} from 'react';
 import * as Sentry from '@sentry/react';
 
 import type {MRI} from 'sentry/types';
-import {getDefaultMetricDisplayType} from 'sentry/utils/metrics';
 import {getReadableMetricType} from 'sentry/utils/metrics/formatters';
 import {parseMRI} from 'sentry/utils/metrics/mri';
-import type {MetricDisplayType} from 'sentry/utils/metrics/types';
 
 interface Options {
-  displayType: MetricDisplayType;
   mri: MRI;
   groupBy?: string[];
   op?: string;
@@ -19,7 +16,6 @@ export const useIncrementQueryMetric = (options: Options) => {
   return useCallback(
     (metricName: string, values: Partial<Options>) => {
       const mergedValues = {
-        displayType: options.displayType,
         mri: options.mri,
         groupBy: options.groupBy,
         op: options.op,
@@ -28,9 +24,6 @@ export const useIncrementQueryMetric = (options: Options) => {
       };
       Sentry.metrics.increment(metricName, 1, {
         tags: {
-          display:
-            mergedValues.displayType ??
-            getDefaultMetricDisplayType(mergedValues.mri, mergedValues.op),
           type: getReadableMetricType(parseMRI(mergedValues.mri)?.type),
           operation: mergedValues.op,
           isGrouped: !!mergedValues.groupBy?.length,
@@ -38,6 +31,6 @@ export const useIncrementQueryMetric = (options: Options) => {
         },
       });
     },
-    [options.displayType, options.mri, options.groupBy, options.op, options.query]
+    [options.mri, options.groupBy, options.op, options.query]
   );
 };

--- a/static/app/utils/metrics/useMetricsQuery.tsx
+++ b/static/app/utils/metrics/useMetricsQuery.tsx
@@ -43,7 +43,7 @@ export interface MetricsQueryApiRequestQuery {
   query?: string;
 }
 
-interface MetricsQueryApiRequestFormula {
+export interface MetricsQueryApiRequestFormula {
   formula: string;
   name: string;
   limit?: number;

--- a/static/app/views/dashboards/metrics/types.tsx
+++ b/static/app/views/dashboards/metrics/types.tsx
@@ -1,1 +1,26 @@
+import type {MRI} from 'sentry/types/metrics';
+import type {MetricQueryType} from 'sentry/utils/metrics/types';
+
 export type Order = 'asc' | 'desc' | undefined;
+
+export interface DashboardMetricsQuery {
+  id: number;
+  mri: MRI;
+  op: string;
+  type: MetricQueryType.QUERY;
+  groupBy?: string[];
+  isQueryOnly?: boolean;
+  limit?: number;
+  orderBy?: 'asc' | 'desc';
+  query?: string;
+}
+
+export interface DashboardMetricsFormula {
+  formula: string;
+  id: number;
+  type: MetricQueryType.FORMULA;
+  limit?: number;
+  orderBy?: 'asc' | 'desc';
+}
+
+export type DashboardMetricsExpression = DashboardMetricsQuery | DashboardMetricsFormula;

--- a/static/app/views/dashboards/metrics/utils.spec.tsx
+++ b/static/app/views/dashboards/metrics/utils.spec.tsx
@@ -31,7 +31,7 @@ describe('getMetricExpressions function', () => {
     ]);
   });
 
-  it('should return a equation', () => {
+  it('should return an equation', () => {
     const widget = {
       queries: [
         {

--- a/static/app/views/dashboards/metrics/utils.tsx
+++ b/static/app/views/dashboards/metrics/utils.tsx
@@ -1,11 +1,19 @@
+import {useMemo} from 'react';
+
 import type {MRI} from 'sentry/types';
 import {NO_QUERY_ID} from 'sentry/utils/metrics/constants';
 import {parseField} from 'sentry/utils/metrics/mri';
 import {MetricDisplayType, MetricQueryType} from 'sentry/utils/metrics/types';
 import type {MetricsQueryApiRequestQuery} from 'sentry/utils/metrics/useMetricsQuery';
-import type {Order} from 'sentry/views/dashboards/metrics/types';
+import type {
+  DashboardMetricsExpression,
+  DashboardMetricsFormula,
+  DashboardMetricsQuery,
+  Order,
+} from 'sentry/views/dashboards/metrics/types';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {getQuerySymbol} from 'sentry/views/ddm/querySymbol';
+import {getUniqueQueryIdGenerator} from 'sentry/views/ddm/utils/uniqueQueryId';
 
 function extendQuery(query = '', dashboardFilters?: DashboardFilters) {
   if (!dashboardFilters?.release?.length) {
@@ -31,24 +39,75 @@ function getReleaseQuery(dashboardFilters: DashboardFilters) {
   return `release:[${release.join(',')}]`;
 }
 
-export function getMetricQueries(
+export function isMetricsFormula(
+  query: DashboardMetricsExpression
+): query is DashboardMetricsFormula {
+  return query.type === MetricQueryType.FORMULA;
+}
+
+export function getMetricExpressions(
   widget: Widget,
   dashboardFilters?: DashboardFilters
-): MetricsQueryApiRequestQuery[] {
-  return widget.queries.map((query, index) => {
+): DashboardMetricsExpression[] {
+  const usedIds = new Set<number>();
+  const indizesWithoutId: number[] = [];
+
+  const queries = widget.queries.map((query, index) => {
+    let id = query.name && Number(query.name);
+    if (typeof id !== 'number' || Number.isNaN(id) || id < 0 || !Number.isInteger(id)) {
+      id = NO_QUERY_ID;
+      indizesWithoutId.push(index);
+    } else {
+      usedIds.add(id);
+    }
+
+    if (query.aggregates[0].startsWith('equation|')) {
+      return {
+        id: id,
+        type: MetricQueryType.FORMULA,
+        formula: query.aggregates[0].slice(9),
+      } satisfies DashboardMetricsFormula;
+    }
+
     const parsed = parseField(query.aggregates[0]) || {mri: '' as MRI, op: ''};
     const orderBy = query.orderby ? query.orderby : undefined;
     return {
+      id: id,
       type: MetricQueryType.QUERY,
-      id: NO_QUERY_ID,
       mri: parsed.mri,
       op: parsed.op,
       query: extendQuery(query.conditions, dashboardFilters),
       groupBy: query.columns,
-      name: query.name || getQuerySymbol(index),
       orderBy: orderBy as Order,
-    };
+    } satisfies DashboardMetricsQuery;
   });
+
+  if (indizesWithoutId.length > 0) {
+    const generateId = getUniqueQueryIdGenerator(usedIds);
+    for (const index of indizesWithoutId) {
+      const query = queries[index];
+      if (!query) {
+        continue;
+      }
+      query.id = generateId.next().value;
+    }
+  }
+  return queries;
+}
+
+export function useGenerateExpressionId(expressions: DashboardMetricsExpression[]) {
+  return useMemo(() => {
+    const usedIds = new Set<number>(expressions.map(e => e.id));
+    return () => getUniqueQueryIdGenerator(usedIds).next().value;
+  }, [expressions]);
+}
+
+export function expressionsToApiQueries(
+  expressions: DashboardMetricsExpression[]
+): MetricsQueryApiRequestQuery[] {
+  return expressions
+    .filter((e): e is DashboardMetricsQuery => !isMetricsFormula(e))
+    .map(e => ({...e, name: getQuerySymbol(e.id)}));
 }
 
 export function toMetricDisplayType(displayType: unknown): MetricDisplayType {

--- a/static/app/views/dashboards/metrics/widgetCard.tsx
+++ b/static/app/views/dashboards/metrics/widgetCard.tsx
@@ -17,7 +17,8 @@ import {MetricBigNumberContainer} from 'sentry/views/dashboards/metrics/bigNumbe
 import {MetricChartContainer} from 'sentry/views/dashboards/metrics/chart';
 import {MetricTableContainer} from 'sentry/views/dashboards/metrics/table';
 import {
-  getMetricQueries,
+  expressionsToApiQueries,
+  getMetricExpressions,
   toMetricDisplayType,
 } from 'sentry/views/dashboards/metrics/utils';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -58,7 +59,7 @@ export function MetricWidgetCard({
   showContextMenu = true,
 }: Props) {
   const metricQueries = useMemo(
-    () => getMetricQueries(widget, dashboardFilters),
+    () => expressionsToApiQueries(getMetricExpressions(widget, dashboardFilters)),
     [widget, dashboardFilters]
   );
 

--- a/static/app/views/ddm/queries.tsx
+++ b/static/app/views/ddm/queries.tsx
@@ -12,6 +12,7 @@ import {
   type MetricFormulaWidgetParams,
   MetricQueryType,
   type MetricQueryWidgetParams,
+  type MetricsQuery,
   type MetricWidgetQueryParams,
 } from 'sentry/utils/metrics/types';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -161,8 +162,12 @@ function Query({
   }, [index, onToggleVisibility]);
 
   const handleChange = useCallback(
-    (data: Partial<MetricWidgetQueryParams>) => {
-      onChange(index, data);
+    (data: Partial<MetricsQuery>) => {
+      const changes: Partial<MetricQueryWidgetParams> = {...data};
+      if (changes.mri || changes.groupBy) {
+        changes.focusedSeries = undefined;
+      }
+      onChange(index, changes);
     },
     [index, onChange]
   );
@@ -183,8 +188,6 @@ function Query({
       <QueryBuilder
         onChange={handleChange}
         metricsQuery={metricsQuery}
-        displayType={widget.displayType}
-        isEdit
         projects={projects}
       />
       <MetricQueryContextMenu

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -1,4 +1,4 @@
-import {Fragment, memo, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, memo, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import uniqBy from 'lodash/uniqBy';
 
@@ -11,7 +11,6 @@ import {space} from 'sentry/styles/space';
 import type {MetricMeta, MetricsOperation, MRI} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
-  getDefaultMetricDisplayType,
   isAllowedOp,
   isCustomMetric,
   isMeasurement,
@@ -20,29 +19,20 @@ import {
 } from 'sentry/utils/metrics';
 import {getReadableMetricType} from 'sentry/utils/metrics/formatters';
 import {formatMRI} from 'sentry/utils/metrics/mri';
-import type {
-  MetricDisplayType,
-  MetricsQuery,
-  MetricWidgetQueryParams,
-} from 'sentry/utils/metrics/types';
+import type {MetricsQuery} from 'sentry/utils/metrics/types';
 import {useBreakpoints} from 'sentry/utils/metrics/useBreakpoints';
 import {useIncrementQueryMetric} from 'sentry/utils/metrics/useIncrementQueryMetric';
 import {useMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
 import {useMetricsTags} from 'sentry/utils/metrics/useMetricsTags';
 import {middleEllipsis} from 'sentry/utils/middleEllipsis';
-import useKeyPress from 'sentry/utils/useKeyPress';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {MetricSearchBar} from 'sentry/views/ddm/metricSearchBar';
 
 type QueryBuilderProps = {
-  displayType: MetricDisplayType;
-  isEdit: boolean;
   metricsQuery: MetricsQuery;
-  onChange: (data: Partial<MetricWidgetQueryParams>) => void;
+  onChange: (data: Partial<MetricsQuery>) => void;
   projects: number[];
-  fixedWidth?: boolean;
-  powerUserMode?: boolean;
 };
 
 const isShownByDefault = (metric: MetricMeta) =>
@@ -58,23 +48,12 @@ function getOpsForMRI(mri: MRI, meta: MetricMeta[]) {
 export const QueryBuilder = memo(function QueryBuilder({
   metricsQuery,
   projects,
-  displayType,
-  powerUserMode,
   onChange,
 }: QueryBuilderProps) {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
   const {data: meta} = useMetricsMeta(pageFilters.selection);
-  const mriModeKeyPressed = useKeyPress('`', undefined, true);
-  const [mriMode, setMriMode] = useState(powerUserMode); // power user mode that shows raw MRI instead of metrics names
   const breakpoints = useBreakpoints();
-
-  useEffect(() => {
-    if (mriModeKeyPressed && !powerUserMode) {
-      setMriMode(!mriMode);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mriModeKeyPressed, powerUserMode]);
 
   const {data: tagsData = [], isLoading: tagsIsLoading} = useMetricsTags(
     metricsQuery.mri,
@@ -88,15 +67,11 @@ export const QueryBuilder = memo(function QueryBuilder({
   }, [tagsData]);
 
   const displayedMetrics = useMemo(() => {
-    if (mriMode) {
-      return meta;
-    }
-
     const isSelected = (metric: MetricMeta) => metric.mri === metricsQuery.mri;
     return meta
       .filter(metric => isShownByDefault(metric) || isSelected(metric))
       .sort(metric => (isSelected(metric) ? -1 : 1));
-  }, [meta, metricsQuery.mri, mriMode]);
+  }, [meta, metricsQuery.mri]);
 
   const selectedMeta = useMemo(() => {
     return meta.find(metric => metric.mri === metricsQuery.mri);
@@ -104,7 +79,6 @@ export const QueryBuilder = memo(function QueryBuilder({
 
   const incrementQueryMetric = useIncrementQueryMetric({
     ...metricsQuery,
-    displayType,
   });
 
   const handleMRIChange = useCallback(
@@ -120,15 +94,11 @@ export const QueryBuilder = memo(function QueryBuilder({
         mri: value,
         op: selectedOp,
         groupBy: undefined,
-        displayType: getDefaultMetricDisplayType(value, selectedOp),
       };
 
       trackAnalytics('ddm.widget.metric', {organization});
       incrementQueryMetric('ddm.widget.metric', queryChanges);
-      onChange({
-        ...queryChanges,
-        focusedSeries: undefined,
-      });
+      onChange(queryChanges);
     },
     [incrementQueryMetric, meta, metricsQuery.op, onChange, organization]
   );
@@ -152,7 +122,6 @@ export const QueryBuilder = memo(function QueryBuilder({
       });
       onChange({
         groupBy: options.map(o => o.value),
-        focusedSeries: undefined,
       });
     },
     [incrementQueryMetric, onChange, organization]
@@ -170,18 +139,18 @@ export const QueryBuilder = memo(function QueryBuilder({
   const mriOptions = useMemo(
     () =>
       displayedMetrics.map<SelectOption<MRI>>(metric => ({
-        label: mriMode ? metric.mri : formatMRI(metric.mri),
+        label: formatMRI(metric.mri),
         // enable search by mri, name, unit (millisecond), type (c:), and readable type (counter)
         textValue: `${metric.mri}${getReadableMetricType(metric.type)}`,
         value: metric.mri,
-        trailingItems: mriMode ? undefined : (
+        trailingItems: (
           <Fragment>
             <Tag tooltipText={t('Type')}>{getReadableMetricType(metric.type)}</Tag>
             <Tag tooltipText={t('Unit')}>{metric.unit}</Tag>
           </Fragment>
         ),
       })),
-    [displayedMetrics, mriMode]
+    [displayedMetrics]
   );
 
   return (


### PR DESCRIPTION
Refactor mapping of dashboard data to metrics expressions.
Add support for formulas (not in use yet) and ids that can be used to identify queries inside formulas.
Clean-up query builder props.
Duplicate last query on adding.

- closes https://github.com/getsentry/sentry/issues/66499