### PR TITLE
fix(github): emit info logger for missing handler instead of sentry error

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -626,7 +626,7 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
             return HttpResponse(status=400)
 
         if not handler:
-            logger.error(
+            logger.info(
                 "github.webhook.missing-handler",
                 extra={"event_type": request.META["HTTP_X_GITHUB_EVENT"]},
             )


### PR DESCRIPTION
[This error](https://sentry.sentry.io/issues/4208729459/?) is happening because we use `logger.error` which emits a Sentry error when we are missing a handler for a Github event via webhook (e.g. a pull request event, a push event, etc).

This is not a concern we need to be notified about. `logger.info` should suffice.