### PR TITLE
test(ui): Fix a chunk of act warnings by switching to findBy, waitFor

### DIFF
--- a/static/app/components/deprecatedAsyncComponent.spec.tsx
+++ b/static/app/components/deprecatedAsyncComponent.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 
@@ -125,14 +125,14 @@ describe('DeprecatedAsyncComponent', function () {
 
       expect(screen.getByTestId('remaining-requests')).toHaveTextContent('2');
 
-      jest.advanceTimersByTime(40);
+      act(() => jest.advanceTimersByTime(40));
       expect(screen.getByTestId('remaining-requests')).toHaveTextContent('2');
 
-      jest.advanceTimersByTime(40);
+      act(() => jest.advanceTimersByTime(40));
       expect(screen.getByTestId('remaining-requests')).toHaveTextContent('1');
       expect(mockOnAllEndpointsSuccess).not.toHaveBeenCalled();
 
-      jest.advanceTimersByTime(40);
+      act(() => jest.advanceTimersByTime(40));
       expect(screen.queryByTestId('remaining-requests')).not.toBeInTheDocument();
       expect(mockOnAllEndpointsSuccess).toHaveBeenCalled();
 

--- a/static/app/components/hook.spec.tsx
+++ b/static/app/components/hook.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import Hook from 'sentry/components/hook';
 import HookStore from 'sentry/stores/hookStore';
@@ -50,11 +50,13 @@ describe('Hook', function () {
 
     expect(screen.getByTestId('hook-wrapper')).toBeInTheDocument();
 
-    HookStore.add('sidebar:help-menu', () => (
-      <HookWrapper key="new" organization={null}>
-        New Hook
-      </HookWrapper>
-    ));
+    act(() =>
+      HookStore.add('sidebar:help-menu', () => (
+        <HookWrapper key="new" organization={null}>
+          New Hook
+        </HookWrapper>
+      ))
+    );
 
     rerender(<Hook name="sidebar:help-menu" organization={OrganizationFixture()} />);
 
@@ -77,17 +79,21 @@ describe('Hook', function () {
       </Hook>
     );
 
-    HookStore.add('sidebar:help-menu', () => (
-      <HookWrapper key="new" organization={null}>
-        First Hook
-      </HookWrapper>
-    ));
+    act(() =>
+      HookStore.add('sidebar:help-menu', () => (
+        <HookWrapper key="new" organization={null}>
+          First Hook
+        </HookWrapper>
+      ))
+    );
 
-    HookStore.add('sidebar:help-menu', () => (
-      <HookWrapper key="new" organization={null}>
-        Second Hook
-      </HookWrapper>
-    ));
+    act(() =>
+      HookStore.add('sidebar:help-menu', () => (
+        <HookWrapper key="new" organization={null}>
+          Second Hook
+        </HookWrapper>
+      ))
+    );
 
     for (let i = 0; i < idx; i++) {
       expect(screen.getByText(`hook: ${idx}`)).toBeInTheDocument();

--- a/static/app/components/issueDiff/index.spec.tsx
+++ b/static/app/components/issueDiff/index.spec.tsx
@@ -50,7 +50,7 @@ describe('IssueDiff', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('is loading when initially rendering', function () {
+  it('is loading when initially rendering', async function () {
     render(
       <IssueDiff
         api={api}
@@ -61,6 +61,7 @@ describe('IssueDiff', function () {
       />
     );
     expect(screen.queryByTestId('split-diff')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('split-diff')).toBeInTheDocument();
   });
 
   it('can dynamically import SplitDiff', async function () {

--- a/static/app/components/modals/redirectToProject.spec.tsx
+++ b/static/app/components/modals/redirectToProject.spec.tsx
@@ -31,10 +31,10 @@ describe('RedirectToProjectModal', function () {
       ))
     );
 
-    jest.advanceTimersByTime(4900);
+    act(() => jest.advanceTimersByTime(4900));
     expect(window.location.assign).not.toHaveBeenCalled();
 
-    jest.advanceTimersByTime(200);
+    act(() => jest.advanceTimersByTime(200));
     expect(window.location.assign).toHaveBeenCalledTimes(1);
     expect(window.location.assign).toHaveBeenCalledWith('/org-slug/new-slug/');
   });

--- a/static/app/components/replays/playerDOMAlert.spec.tsx
+++ b/static/app/components/replays/playerDOMAlert.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import localStorage from 'sentry/utils/localStorage';
@@ -38,7 +38,7 @@ describe('PlayerDOMAlert', () => {
 
     expect(screen.getByTestId('player-dom-alert')).toBeVisible();
 
-    screen.getByLabelText('Close Alert').click();
+    await userEvent.click(screen.getByLabelText('Close Alert'));
 
     expect(screen.queryByTestId('player-dom-alert')).not.toBeInTheDocument();
     await waitFor(() =>

--- a/static/app/components/search/sources/apiSource.spec.tsx
+++ b/static/app/components/search/sources/apiSource.spec.tsx
@@ -95,7 +95,7 @@ describe('ApiSource', function () {
     ConfigStore.loadInitialData(configState);
   });
 
-  it('queries all API endpoints', function () {
+  it('queries all API endpoints', async function () {
     const mock = jest.fn().mockReturnValue(null);
     render(
       <ApiSource {...defaultProps} query="foo">
@@ -103,7 +103,7 @@ describe('ApiSource', function () {
       </ApiSource>
     );
 
-    expect(orgsMock).toHaveBeenCalled();
+    await waitFor(() => expect(orgsMock).toHaveBeenCalled());
     expect(projectsMock).toHaveBeenCalled();
     expect(teamsMock).toHaveBeenCalled();
     expect(membersMock).toHaveBeenCalled();
@@ -111,7 +111,7 @@ describe('ApiSource', function () {
     expect(eventIdMock).not.toHaveBeenCalled();
   });
 
-  it('queries multiple regions for organization lists', function () {
+  it('queries multiple regions for organization lists', async function () {
     const mock = jest.fn().mockReturnValue(null);
     ConfigStore.loadInitialData({
       ...configState,
@@ -127,7 +127,7 @@ describe('ApiSource', function () {
       </ApiSource>
     );
 
-    expect(orgsMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(orgsMock).toHaveBeenCalledTimes(2));
     expect(orgsMock).toHaveBeenCalledWith(
       '/organizations/',
       expect.objectContaining({host: 'https://us.sentry.io'})
@@ -211,26 +211,28 @@ describe('ApiSource', function () {
     expect(teamsMock).toHaveBeenCalled();
     expect(membersMock).toHaveBeenCalled();
     expect(shortIdMock).not.toHaveBeenCalled();
-    expect(mock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        results: [
-          {
-            item: expect.objectContaining({
-              title: 'event type',
-              description: 'event description',
-              sourceType: 'event',
-              resultType: 'event',
-              to: '/org-slug/project-slug/issues/1/events/12345678901234567890123456789012/',
-            }),
-            score: 1,
-            refIndex: 0,
-          },
-        ],
-      })
+    await waitFor(() =>
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          results: [
+            {
+              item: expect.objectContaining({
+                title: 'event type',
+                description: 'event description',
+                sourceType: 'event',
+                resultType: 'event',
+                to: '/org-slug/project-slug/issues/1/events/12345678901234567890123456789012/',
+              }),
+              score: 1,
+              refIndex: 0,
+            },
+          ],
+        })
+      )
     );
   });
 
-  it('only queries org endpoint if there is no org in context', function () {
+  it('only queries org endpoint if there is no org in context', async function () {
     const mock = jest.fn().mockReturnValue(null);
     render(
       <ApiSource {...omit(defaultProps, 'organization')} params={{orgId: ''}} query="foo">
@@ -238,7 +240,7 @@ describe('ApiSource', function () {
       </ApiSource>
     );
 
-    expect(orgsMock).toHaveBeenCalled();
+    await waitFor(() => expect(orgsMock).toHaveBeenCalled());
     expect(projectsMock).not.toHaveBeenCalled();
     expect(teamsMock).not.toHaveBeenCalled();
     expect(membersMock).not.toHaveBeenCalled();
@@ -415,40 +417,54 @@ describe('ApiSource', function () {
   });
 
   describe('API queries', function () {
-    it('calls API based on query string', function () {
+    it('calls API based on query string', async function () {
       const {rerender} = render(<ApiSource {...defaultProps} query="" />);
 
-      expect(projectsMock).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(projectsMock).toHaveBeenCalledTimes(1);
+      });
 
       rerender(<ApiSource {...defaultProps} query="f" />);
 
       // calls API when query string length is 1 char
-      expect(projectsMock).toHaveBeenCalledTimes(2);
+      await waitFor(() => {
+        expect(projectsMock).toHaveBeenCalledTimes(2);
+      });
 
       rerender(<ApiSource {...defaultProps} query="fo" />);
 
       // calls API when query string length increases from 1 -> 2
-      expect(projectsMock).toHaveBeenCalledTimes(3);
+      await waitFor(() => {
+        expect(projectsMock).toHaveBeenCalledTimes(3);
+      });
 
       rerender(<ApiSource {...defaultProps} query="foo" />);
 
       // Should not query API when query is > 2 chars
-      expect(projectsMock).toHaveBeenCalledTimes(3);
+      await waitFor(() => {
+        expect(projectsMock).toHaveBeenCalledTimes(3);
+      });
 
       // re-queries API if first 2 characters are different
       rerender(<ApiSource {...defaultProps} query="ba" />);
 
-      expect(projectsMock).toHaveBeenCalledTimes(4);
+      await waitFor(() => {
+        expect(projectsMock).toHaveBeenCalledTimes(4);
+      });
 
       // Does not requery when query stays the same
       rerender(<ApiSource {...defaultProps} query="ba" />);
 
-      expect(projectsMock).toHaveBeenCalledTimes(4);
+      await waitFor(() => {
+        expect(projectsMock).toHaveBeenCalledTimes(4);
+      });
 
       // queries if we go from 2 chars -> 1 char
       rerender(<ApiSource {...defaultProps} query="b" />);
 
-      expect(projectsMock).toHaveBeenCalledTimes(5);
+      await waitFor(() => {
+        expect(projectsMock).toHaveBeenCalledTimes(5);
+      });
     });
   });
 });

--- a/static/app/components/search/sources/routeSource.spec.tsx
+++ b/static/app/components/search/sources/routeSource.spec.tsx
@@ -61,7 +61,7 @@ describe('RouteSource', function () {
     });
   });
 
-  it('does not find any form field', function () {
+  it('does not find any form field', async function () {
     const mock = jest.fn().mockReturnValue(null);
     const {organization, project, routerProps} = initializeOrg();
     render(
@@ -70,6 +70,8 @@ describe('RouteSource', function () {
       </RouteSource>
     );
 
-    expect(mock).toHaveBeenCalledWith(expect.objectContaining({results: []}));
+    await waitFor(() =>
+      expect(mock).toHaveBeenCalledWith(expect.objectContaining({results: []}))
+    );
   });
 });

--- a/static/app/components/slider/index.spec.tsx
+++ b/static/app/components/slider/index.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {Slider} from 'sentry/components/slider';
 
@@ -38,7 +38,9 @@ describe('Slider', function () {
     // To focus on the slider, we should call the focus() method. The slider input element
     // is visually hidden and only rendered for screen-reader & keyboard accessibility —
     // users can't actually click on it.
-    screen.getByRole('slider', {name: 'Test'}).focus();
+    act(() => {
+      screen.getByRole('slider', {name: 'Test'}).focus();
+    });
 
     await userEvent.keyboard('{ArrowRight}');
     expect(onChangeMock).toHaveBeenCalledWith(6);
@@ -63,7 +65,9 @@ describe('Slider', function () {
     // To focus on the slider, we should call the focus() method. The slider input element
     // is visually hidden and only rendered for screen-reader & keyboard accessibility —
     // users can't actually click on it.
-    screen.getByRole('slider', {name: 'Test'}).focus();
+    act(() => {
+      screen.getByRole('slider', {name: 'Test'}).focus();
+    });
 
     await userEvent.keyboard('{ArrowRight}');
     expect(onChangeEndMock).toHaveBeenCalledWith(10);
@@ -84,7 +88,9 @@ describe('Slider', function () {
     // To focus on the slider, we should call the focus() method. The slider input element
     // is visually hidden and only rendered for screen-reader & keyboard accessibility —
     // users can't actually click on it.
-    screen.getByRole('slider', {name: 'Test'}).focus();
+    act(() => {
+      screen.getByRole('slider', {name: 'Test'}).focus();
+    });
 
     // Pressing Arrow Right/Left increases/decreases value by 1
     await userEvent.keyboard('{ArrowRight}');

--- a/static/app/components/smartSearchBar/index.spec.tsx
+++ b/static/app/components/smartSearchBar/index.spec.tsx
@@ -287,7 +287,7 @@ describe('SmartSearchBar', function () {
   });
 
   describe('pasting', function () {
-    it('trims pasted content', function () {
+    it('trims pasted content', async function () {
       const mockOnChange = jest.fn();
       render(<SmartSearchBar {...defaultProps} onChange={mockOnChange} />);
 
@@ -296,7 +296,9 @@ describe('SmartSearchBar', function () {
       fireEvent.paste(textbox, {clipboardData: {getData: () => ' something'}});
 
       expect(textbox).toHaveValue('something');
-      expect(mockOnChange).toHaveBeenCalledWith('something', expect.anything());
+      await waitFor(() =>
+        expect(mockOnChange).toHaveBeenCalledWith('something', expect.anything())
+      );
     });
   });
 

--- a/static/app/components/version.spec.tsx
+++ b/static/app/components/version.spec.tsx
@@ -46,6 +46,6 @@ describe('Version', () => {
     await userEvent.hover(screen.getByText('1.0.0 (20200101)'), {delay: null});
     act(() => jest.advanceTimersByTime(50));
 
-    expect(screen.getByText(VERSION)).toBeInTheDocument();
+    expect(await screen.findByText(VERSION)).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/metric/create.spec.tsx
+++ b/static/app/views/alerts/rules/metric/create.spec.tsx
@@ -3,7 +3,7 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import EventView from 'sentry/utils/discover/eventView';
 import MetricRulesCreate from 'sentry/views/alerts/rules/metric/create';
@@ -42,7 +42,7 @@ describe('Incident Rules Create', function () {
     });
   });
 
-  it('renders', function () {
+  it('renders', async function () {
     const {organization, project} = initializeOrg();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-meta/`,
@@ -60,18 +60,20 @@ describe('Incident Rules Create', function () {
       />
     );
 
-    expect(eventStatsMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: {
-          interval: '60m',
-          project: [2],
-          query: 'event.type:error',
-          statsPeriod: '9998m',
-          yAxis: 'count()',
-          referrer: 'api.organization-event-stats',
-        },
-      })
+    await waitFor(() =>
+      expect(eventStatsMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          query: {
+            interval: '60m',
+            project: [2],
+            query: 'event.type:error',
+            statsPeriod: '9998m',
+            yAxis: 'count()',
+            referrer: 'api.organization-event-stats',
+          },
+        })
+      )
     );
   });
 });

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -3,7 +3,7 @@ import {IncidentTriggerFixture} from 'sentry-fixture/incidentTrigger';
 import {MetricRuleFixture} from 'sentry-fixture/metricRule';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -95,31 +95,31 @@ describe('Incident Rules Form', () => {
   describe('Viewing the rule', () => {
     const rule = MetricRuleFixture();
 
-    it('is enabled without org-level alerts:write', () => {
+    it('is enabled without org-level alerts:write', async () => {
       organization.access = [];
       project.access = [];
       createWrapper({rule});
 
-      expect(screen.queryByText(permissionAlertText)).toBeInTheDocument();
+      expect(await screen.findByText(permissionAlertText)).toBeInTheDocument();
       expect(screen.queryByLabelText('Save Rule')).toBeDisabled();
     });
 
-    it('is enabled with org-level alerts:write', () => {
+    it('is enabled with org-level alerts:write', async () => {
       organization.access = ['alerts:write'];
       project.access = [];
       createWrapper({rule});
 
+      expect(await screen.findByLabelText('Save Rule')).toBeEnabled();
       expect(screen.queryByText(permissionAlertText)).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Save Rule')).toBeEnabled();
     });
 
-    it('is enabled with project-level alerts:write', () => {
+    it('is enabled with project-level alerts:write', async () => {
       organization.access = [];
       project.access = ['alerts:write'];
       createWrapper({rule});
 
+      expect(await screen.findByLabelText('Save Rule')).toBeEnabled();
       expect(screen.queryByText(permissionAlertText)).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Save Rule')).toBeEnabled();
     });
   });
 
@@ -448,15 +448,6 @@ describe('Incident Rules Form', () => {
   describe('Slack async lookup', () => {
     const uuid = 'xxxx-xxxx-xxxx';
 
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-      jest.runOnlyPendingTimers();
-      jest.useRealTimers();
-    });
-
     it('success status updates the rule', async () => {
       const alertRule = MetricRuleFixture({name: 'Slack Alert Rule'});
       MockApiClient.addMockResponse({
@@ -489,7 +480,6 @@ describe('Incident Rules Form', () => {
 
       expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
 
-      act(jest.runAllTimers);
       await waitFor(
         () => {
           expect(onSubmitSuccess).toHaveBeenCalledWith(
@@ -504,7 +494,7 @@ describe('Incident Rules Form', () => {
       );
     });
 
-    it('pending status keeps loading true', () => {
+    it('pending status keeps loading true', async () => {
       const alertRule = MetricRuleFixture({name: 'Slack Alert Rule'});
       MockApiClient.addMockResponse({
         url: `/organizations/org-slug/alert-rules/${alertRule.id}/`,
@@ -526,7 +516,7 @@ describe('Incident Rules Form', () => {
         onSubmitSuccess,
       });
 
-      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+      expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
       expect(onSubmitSuccess).not.toHaveBeenCalled();
     });
 
@@ -559,7 +549,6 @@ describe('Incident Rules Form', () => {
       );
       await userEvent.click(screen.getByLabelText('Save Rule'), {delay: null});
 
-      act(jest.runAllTimers);
       await waitFor(
         () => {
           expect(addErrorMessage).toHaveBeenCalledWith('An error occurred');

--- a/static/app/views/auth/login.spec.tsx
+++ b/static/app/views/auth/login.spec.tsx
@@ -10,7 +10,7 @@ describe('Login', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('renders a loading indicator', function () {
+  it('renders a loading indicator', async function () {
     MockApiClient.addMockResponse({
       url: '/auth/config/',
       body: {},
@@ -19,6 +19,7 @@ describe('Login', function () {
     render(<Login {...routerProps} />);
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(await screen.findByText('Lost your password?')).toBeInTheDocument();
   });
 
   it('renders an error if auth config cannot be loaded', async function () {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsStep.spec.tsx
@@ -12,7 +12,7 @@ const exampleThresholdsConfig: ThresholdsConfig = {
 };
 
 describe('Widget Builder > ThresholdsStep', function () {
-  it('renders thresholds step', function () {
+  it('renders thresholds step', async function () {
     const onChange = jest.fn();
     render(
       <ThresholdsStep
@@ -23,7 +23,7 @@ describe('Widget Builder > ThresholdsStep', function () {
       />
     );
 
-    expect(screen.getByText('Set thresholds')).toBeInTheDocument();
+    expect(await screen.findByText('Set thresholds')).toBeInTheDocument();
 
     // Check minimum value boxes are disabled
     expect(screen.getByLabelText('First Minimum')).toBeDisabled();

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -257,7 +257,6 @@ describe('WidgetBuilder', function () {
   afterEach(function () {
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
-    jest.useRealTimers();
   });
 
   it('no feature access', function () {
@@ -266,7 +265,7 @@ describe('WidgetBuilder', function () {
     expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
   });
 
-  it('widget not found', function () {
+  it('widget not found', async function () {
     const widget: Widget = {
       displayType: DisplayType.AREA,
       interval: '1d',
@@ -303,11 +302,11 @@ describe('WidgetBuilder', function () {
     });
 
     expect(
-      screen.getByText('The widget you want to edit was not found.')
+      await screen.findByText('The widget you want to edit was not found.')
     ).toBeInTheDocument();
   });
 
-  it('renders a widget not found message if the widget index url is not an integer', function () {
+  it('renders a widget not found message if the widget index url is not an integer', async function () {
     const widget: Widget = {
       displayType: DisplayType.AREA,
       interval: '1d',
@@ -336,7 +335,7 @@ describe('WidgetBuilder', function () {
     });
 
     expect(
-      screen.getByText('The widget you want to edit was not found.')
+      await screen.findByText('The widget you want to edit was not found.')
     ).toBeInTheDocument();
   });
 
@@ -1117,7 +1116,6 @@ describe('WidgetBuilder', function () {
   });
 
   it('does not error when query conditions field is blurred', async function () {
-    jest.useFakeTimers();
     const widget: Widget = {
       id: '0',
       title: 'sdk usage',
@@ -1150,7 +1148,7 @@ describe('WidgetBuilder', function () {
     await userEvent.keyboard('{Escape}', {delay: null});
 
     // Run all timers because the handleBlur contains a setTimeout
-    jest.runAllTimers();
+    await act(tick);
   });
 
   it('does not wipe column changes when filters are modified', async function () {

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -492,9 +492,11 @@ describe('Dashboards > WidgetCard', function () {
 
     await waitFor(() => expect(eventsMock).toHaveBeenCalled());
 
-    expect(SimpleTableChart).toHaveBeenCalledWith(
-      expect.objectContaining({stickyHeaders: true}),
-      expect.anything()
+    await waitFor(() =>
+      expect(SimpleTableChart).toHaveBeenCalledWith(
+        expect.objectContaining({stickyHeaders: true}),
+        expect.anything()
+      )
     );
   });
 

--- a/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
@@ -97,7 +97,7 @@ describe('Dashboards > IssueWidgetCard', function () {
     );
 
     expect(await screen.findByText('Issues')).toBeInTheDocument();
-    expect(screen.getByText('assignee')).toBeInTheDocument();
+    expect(await screen.findByText('assignee')).toBeInTheDocument();
     expect(screen.getByText('title')).toBeInTheDocument();
     expect(screen.getByText('issue')).toBeInTheDocument();
     expect(screen.getByText('DU')).toBeInTheDocument();

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {Widget} from 'sentry/views/dashboards/types';
 import {
@@ -95,26 +95,27 @@ describe('IssueWidgetQueries', function () {
       </IssueWidgetQueries>
     );
 
-    await tick();
-    expect(mockFunction).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tableResults: [
-          expect.objectContaining({
-            data: [
-              expect.objectContaining({
-                id: '1',
-                title: 'Error: Failed',
-                status: 'unresolved',
-                lifetimeEvents: 10,
-                lifetimeUsers: 5,
-                events: 6,
-                users: 3,
-                firstSeen: '2022-01-01T13:04:02Z',
-              }),
-            ],
-          }),
-        ],
-      })
+    await waitFor(() =>
+      expect(mockFunction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tableResults: [
+            expect.objectContaining({
+              data: [
+                expect.objectContaining({
+                  id: '1',
+                  title: 'Error: Failed',
+                  status: 'unresolved',
+                  lifetimeEvents: 10,
+                  lifetimeUsers: 5,
+                  events: 6,
+                  users: 3,
+                  firstSeen: '2022-01-01T13:04:02Z',
+                }),
+              ],
+            }),
+          ],
+        })
+      )
     );
   });
 

--- a/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
@@ -325,7 +325,7 @@ describe('Dashboards > WidgetQueries', function () {
       })
     );
     expect(childProps?.timeseriesResults).toBeUndefined();
-    expect(childProps?.tableResults?.[0].data).toHaveLength(1);
+    await waitFor(() => expect(childProps?.tableResults?.[0].data).toHaveLength(1));
     expect(childProps?.tableResults?.[0].meta).toBeDefined();
   });
 
@@ -391,7 +391,7 @@ describe('Dashboards > WidgetQueries', function () {
     expect(firstQuery).toHaveBeenCalledTimes(1);
     expect(secondQuery).toHaveBeenCalledTimes(1);
 
-    expect(childProps?.tableResults).toHaveLength(2);
+    await waitFor(() => expect(childProps?.tableResults).toHaveLength(2));
     expect(childProps?.tableResults?.[0].data[0]['sdk.name']).toBeDefined();
     expect(childProps?.tableResults?.[1].data[0].title).toBeDefined();
   });
@@ -451,7 +451,7 @@ describe('Dashboards > WidgetQueries', function () {
       })
     );
     expect(childProps?.timeseriesResults).toBeUndefined();
-    expect(childProps?.tableResults?.[0]?.data).toHaveLength(1);
+    await waitFor(() => expect(childProps?.tableResults?.[0]?.data).toHaveLength(1));
     expect(childProps?.tableResults?.[0]?.meta).toBeDefined();
   });
 
@@ -515,7 +515,7 @@ describe('Dashboards > WidgetQueries', function () {
     expect(firstQuery).toHaveBeenCalledTimes(1);
     expect(secondQuery).toHaveBeenCalledTimes(1);
 
-    expect(childProps?.loading).toEqual(false);
+    await waitFor(() => expect(childProps?.loading).toEqual(false));
   });
 
   it('sets bar charts to 1d interval', async function () {
@@ -607,13 +607,15 @@ describe('Dashboards > WidgetQueries', function () {
     await screen.findByTestId('child');
     expect(defaultMock).toHaveBeenCalledTimes(1);
     expect(errorMock).toHaveBeenCalledTimes(1);
-    expect(child).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        timeseriesResults: [
-          {data: [{name: 1000000, value: 200}], seriesName: 'errors : count()'},
-          {data: [{name: 1000000, value: 100}], seriesName: 'default : count()'},
-        ],
-      })
+    await waitFor(() =>
+      expect(child).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          timeseriesResults: [
+            {data: [{name: 1000000, value: 200}], seriesName: 'errors : count()'},
+            {data: [{name: 1000000, value: 100}], seriesName: 'default : count()'},
+          ],
+        })
+      )
     );
   });
 

--- a/static/app/views/discover/chartFooter.spec.tsx
+++ b/static/app/views/discover/chartFooter.spec.tsx
@@ -26,7 +26,7 @@ describe('Discover > ChartFooter', function () {
 
   afterEach(function () {});
 
-  it('renders yAxis option using OptionCheckboxSelector using entire yAxisValue', function () {
+  it('renders yAxis option using OptionCheckboxSelector using entire yAxisValue', async function () {
     const organization = OrganizationFixture({
       features: [...features],
     });
@@ -59,7 +59,7 @@ describe('Discover > ChartFooter', function () {
     render(chartFooter, {context: initialData.routerContext});
 
     expect(
-      screen.getByRole('button', {
+      await screen.findByRole('button', {
         name: `Y-Axis ${yAxisValue[0]} +${
           yAxisValue.filter(v => v !== yAxisValue[0]).length
         }`,
@@ -67,7 +67,7 @@ describe('Discover > ChartFooter', function () {
     ).toBeInTheDocument();
   });
 
-  it('renders display limits with default limit when top 5 mode is selected', function () {
+  it('renders display limits with default limit when top 5 mode is selected', async function () {
     const organization = OrganizationFixture({
       features,
     });
@@ -100,7 +100,9 @@ describe('Discover > ChartFooter', function () {
 
     render(chartFooter, {context: initialData.routerContext});
 
-    expect(screen.getByRole('button', {name: `Limit ${limit}`})).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', {name: `Limit ${limit}`})
+    ).toBeInTheDocument();
   });
 
   it('renders multi value y-axis dropdown selector on a non-Top display', async function () {

--- a/static/app/views/discover/index.spec.tsx
+++ b/static/app/views/discover/index.spec.tsx
@@ -109,14 +109,14 @@ describe('Discover > Landing', function () {
     );
   });
 
-  it('links back to the homepage', () => {
+  it('links back to the homepage', async () => {
     const org = OrganizationFixture({features});
 
     render(<DiscoverLanding organization={org} {...RouteComponentPropsFixture()} />, {
       context: RouterContextFixture(),
     });
 
-    expect(screen.getByText('Discover')).toHaveAttribute(
+    expect(await screen.findByText('Discover')).toHaveAttribute(
       'href',
       '/organizations/org-slug/discover/homepage/'
     );

--- a/static/app/views/discover/resultsChart.spec.tsx
+++ b/static/app/views/discover/resultsChart.spec.tsx
@@ -78,7 +78,7 @@ describe('Discover > ResultsChart', function () {
     });
   });
 
-  it('does not display a chart if no y axis is selected', function () {
+  it('does not display a chart if no y axis is selected', async function () {
     render(
       <ResultsChart
         router={RouterFixture()}
@@ -96,6 +96,6 @@ describe('Discover > ResultsChart', function () {
       {context: initialData.routerContext}
     );
 
-    expect(screen.getByText(/No Y-Axis selected/)).toBeInTheDocument();
+    expect(await screen.findByText(/No Y-Axis selected/)).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -114,7 +114,7 @@ describe('GroupEventCarousel', () => {
 
       render(<GroupEventCarousel {...singleEventProps} />);
 
-      expect(await screen.getByRole('button', {name: 'Recommended'})).toBeDisabled();
+      expect(await screen.findByRole('button', {name: 'Recommended'})).toBeDisabled();
     });
 
     it('if user default is recommended, it will show it as default', async () => {
@@ -123,7 +123,9 @@ describe('GroupEventCarousel', () => {
 
       render(<GroupEventCarousel {...singleEventProps} />);
 
-      expect(await screen.getByText('Recommended')).toBeInTheDocument();
+      expect(
+        await screen.findByRole('button', {name: 'Recommended'})
+      ).toBeInTheDocument();
     });
 
     it('if user default is latest, it will show it as default', async () => {
@@ -132,7 +134,7 @@ describe('GroupEventCarousel', () => {
 
       render(<GroupEventCarousel {...singleEventProps} />);
 
-      expect(await screen.getByText('Latest')).toBeInTheDocument();
+      expect(await screen.findByRole('button', {name: 'Latest'})).toBeInTheDocument();
     });
 
     it('if user default is oldest, it will show it as default', async () => {
@@ -141,7 +143,7 @@ describe('GroupEventCarousel', () => {
 
       render(<GroupEventCarousel {...singleEventProps} />);
 
-      expect(await screen.getByText('Oldest')).toBeInTheDocument();
+      expect(await screen.findByRole('button', {name: 'Oldest'})).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/issueDetails/groupMerged/index.spec.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.spec.tsx
@@ -1,7 +1,12 @@
 import {DetailedEventsFixture} from 'sentry-fixture/events';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from 'sentry-test/reactTestingLibrary';
 
 import GroupingStore from 'sentry/stores/groupingStore';
 import {GroupMergedView} from 'sentry/views/issueDetails/groupMerged';
@@ -34,7 +39,7 @@ describe('Issues -> Merged View', function () {
     });
   });
 
-  it('renders initially with loading component', function () {
+  it('renders initially with loading component', async function () {
     const {organization, project, router, routerContext} = initializeOrg({
       project: {
         slug: 'projectId',
@@ -61,6 +66,7 @@ describe('Issues -> Merged View', function () {
     );
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    await act(tick);
   });
 
   it('renders with mocked data', async function () {

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -349,7 +349,7 @@ describe('GroupReplays', () => {
       });
 
       // Expect the table to have 2 rows
-      expect(screen.getAllByText('testDisplayName')).toHaveLength(2);
+      expect(await screen.findAllByText('testDisplayName')).toHaveLength(2);
 
       const expectedQuery =
         'query=&referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&statsPeriod=14d&yAxis=count%28%29';

--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -89,7 +89,7 @@ describe('Issues Similar View', function () {
 
     await waitFor(() => expect(mock).toHaveBeenCalled());
 
-    expect(screen.getByText('Show 3 issues below threshold')).toBeInTheDocument();
+    expect(await screen.findByText('Show 3 issues below threshold')).toBeInTheDocument();
   });
 
   it('can merge and redirect to new parent', async function () {
@@ -184,7 +184,7 @@ describe('Issues Similar View', function () {
     await waitFor(() => expect(mock).toHaveBeenCalled());
 
     expect(
-      screen.getByText("There don't seem to be any similar issues.")
+      await screen.findByText("There don't seem to be any similar issues.")
     ).toBeInTheDocument();
     expect(
       screen.queryByText(
@@ -266,8 +266,8 @@ describe('Issues Similar Embeddings View', function () {
 
     await waitFor(() => expect(mock).toHaveBeenCalled());
 
+    expect(await screen.findByText('Would Group')).toBeInTheDocument();
     expect(screen.queryByText('Show 3 issues below threshold')).not.toBeInTheDocument();
-    expect(screen.queryByText('Would Group')).toBeInTheDocument();
   });
 
   it('can merge and redirect to new parent', async function () {
@@ -391,7 +391,7 @@ describe('Issues Similar Embeddings View', function () {
     await waitFor(() => expect(mock).toHaveBeenCalled());
 
     expect(
-      screen.getByText(
+      await screen.findByText(
         "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames."
       )
     ).toBeInTheDocument();

--- a/static/app/views/issueList/actions/index.spec.tsx
+++ b/static/app/views/issueList/actions/index.spec.tsx
@@ -305,7 +305,7 @@ describe('IssueListActions', function () {
     );
   });
 
-  it('can resolve but not merge issues from different projects', function () {
+  it('can resolve but not merge issues from different projects', async function () {
     jest
       .spyOn(SelectedGroupStore, 'getSelectedIds')
       .mockImplementation(() => new Set(['1', '2', '3']));
@@ -321,7 +321,7 @@ describe('IssueListActions', function () {
     render(<WrappedComponent />);
 
     // Can resolve but not merge issues from multiple projects
-    expect(screen.getByRole('button', {name: 'Resolve'})).toBeEnabled();
+    expect(await screen.findByRole('button', {name: 'Resolve'})).toBeEnabled();
     expect(screen.getByRole('button', {name: 'Merge Selected Issues'})).toBeDisabled();
   });
 
@@ -356,14 +356,14 @@ describe('IssueListActions', function () {
       expect(mockOnActionTaken).toHaveBeenCalledWith(['1', '2', '3'], {inbox: false});
     });
 
-    it('mark reviewed disabled for group that is already reviewed', function () {
+    it('mark reviewed disabled for group that is already reviewed', async function () {
       SelectedGroupStore.add(['1']);
       SelectedGroupStore.toggleSelectAll();
       GroupStore.loadInitialData([GroupFixture({id: '1', inbox: null})]);
 
       render(<WrappedComponent {...defaultProps} />);
 
-      expect(screen.getByRole('button', {name: 'Mark Reviewed'})).toBeDisabled();
+      expect(await screen.findByRole('button', {name: 'Mark Reviewed'})).toBeDisabled();
     });
   });
 

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -6,7 +6,7 @@ import {SearchFixture} from 'sentry-fixture/search';
 import {TagsFixture} from 'sentry-fixture/tags';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import StreamGroup from 'sentry/components/stream/group';
@@ -158,13 +158,15 @@ describe('IssueList -> Polling', function () {
   it('toggles polling for new issues', async function () {
     await renderComponent();
 
-    expect(issuesRequest).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        // Should be called with default query
-        data: expect.stringContaining('is%3Aunresolved'),
-      })
-    );
+    await waitFor(() => {
+      expect(issuesRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          // Should be called with default query
+          data: expect.stringContaining('is%3Aunresolved'),
+        })
+      );
+    });
 
     // Enable realtime updates
     await userEvent.click(
@@ -198,7 +200,9 @@ describe('IssueList -> Polling', function () {
     });
 
     await renderComponent();
-    expect(screen.getByText(textWithMarkupMatcher('1-1 of 1'))).toBeInTheDocument();
+    expect(
+      await screen.findByText(textWithMarkupMatcher('1-1 of 1'))
+    ).toBeInTheDocument();
 
     // Enable realtime updates
     await userEvent.click(
@@ -226,7 +230,7 @@ describe('IssueList -> Polling', function () {
 
     // Enable real time control
     await userEvent.click(
-      screen.getByRole('button', {name: 'Enable real-time updates'}),
+      await screen.findByRole('button', {name: 'Enable real-time updates'}),
       {delay: null}
     );
 
@@ -248,7 +252,7 @@ describe('IssueList -> Polling', function () {
 
     // Enable real time control
     await userEvent.click(
-      screen.getByRole('button', {name: 'Enable real-time updates'}),
+      await screen.findByRole('button', {name: 'Enable real-time updates'}),
       {delay: null}
     );
 
@@ -270,7 +274,7 @@ describe('IssueList -> Polling', function () {
 
     // Enable real time control
     await userEvent.click(
-      screen.getByRole('button', {name: 'Enable real-time updates'}),
+      await screen.findByRole('button', {name: 'Enable real-time updates'}),
       {delay: null}
     );
 

--- a/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.spec.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.spec.tsx
@@ -27,7 +27,7 @@ const tickConfig: TimeWindowOptions = {
 };
 
 describe('JobTickTooltip', function () {
-  it('renders tooltip representing single job run', function () {
+  it('renders tooltip representing single job run', async function () {
     const startTs = new Date('2023-06-15T11:00:00Z').valueOf();
     const endTs = startTs;
     const envMapping = generateEnvMapping('prod', [0, 0, 1, 0, 0]);
@@ -45,14 +45,14 @@ describe('JobTickTooltip', function () {
     );
 
     // Skip the header row
-    const statusRow = screen.getAllByRole('row')[1];
+    const statusRow = (await screen.findAllByRole('row'))[1];
 
     expect(within(statusRow).getByText('Missed')).toBeInTheDocument();
     expect(within(statusRow).getByText('prod')).toBeInTheDocument();
     expect(within(statusRow).getByText('1')).toBeInTheDocument();
   });
 
-  it('renders tooltip representing multiple job runs 1 env', function () {
+  it('renders tooltip representing multiple job runs 1 env', async function () {
     const startTs = new Date('2023-06-15T11:00:00Z').valueOf();
     const endTs = startTs;
     const envMapping = generateEnvMapping('prod', [0, 1, 1, 1, 1]);
@@ -69,7 +69,7 @@ describe('JobTickTooltip', function () {
       <JobTickTooltip jobTick={jobTick} timeWindowConfig={tickConfig} forceVisible />
     );
 
-    const okayRow = screen.getAllByRole('row')[1];
+    const okayRow = (await screen.findAllByRole('row'))[1];
     expect(within(okayRow).getByText('Okay')).toBeInTheDocument();
     expect(within(okayRow).getByText('prod')).toBeInTheDocument();
     expect(within(okayRow).getByText('1')).toBeInTheDocument();
@@ -90,7 +90,7 @@ describe('JobTickTooltip', function () {
     expect(within(errorRow).getByText('1')).toBeInTheDocument();
   });
 
-  it('renders tooltip representing multiple job runs multiple envs', function () {
+  it('renders tooltip representing multiple job runs multiple envs', async function () {
     const startTs = new Date('2023-06-15T11:00:00Z').valueOf();
     const endTs = startTs;
     const prodEnvMapping = generateEnvMapping('prod', [0, 0, 1, 0, 0]);
@@ -109,7 +109,7 @@ describe('JobTickTooltip', function () {
       <JobTickTooltip jobTick={jobTick} timeWindowConfig={tickConfig} forceVisible />
     );
 
-    const missedProdRow = screen.getAllByRole('row')[1];
+    const missedProdRow = (await screen.findAllByRole('row'))[1];
     expect(within(missedProdRow).getByText('Missed')).toBeInTheDocument();
     expect(within(missedProdRow).getByText('prod')).toBeInTheDocument();
     expect(within(missedProdRow).getByText('1')).toBeInTheDocument();

--- a/static/app/views/organizationContext.spec.tsx
+++ b/static/app/views/organizationContext.spec.tsx
@@ -199,7 +199,7 @@ describe('OrganizationContext', function () {
     await waitFor(() => !OrganizationStore.getState().loading);
 
     // eslint-disable-next-line no-console
-    expect(console.error).toHaveBeenCalled();
+    await waitFor(() => expect(console.error).toHaveBeenCalled());
     expect(openSudo).toHaveBeenCalled();
   });
 

--- a/static/app/views/organizationStats/teamInsights/issues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.spec.tsx
@@ -158,10 +158,10 @@ describe('TeamStatsIssues', () => {
     });
   }
 
-  it('defaults to first team', () => {
+  it('defaults to first team', async () => {
     createWrapper();
 
-    expect(screen.getByText('#backend')).toBeInTheDocument();
+    expect(await screen.findByText('#backend')).toBeInTheDocument();
     expect(screen.getByText('All Unresolved Issues')).toBeInTheDocument();
   });
 

--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {PlatformKey} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
@@ -53,9 +53,13 @@ function initializeData(opts?: InitialOpts) {
 describe('Performance > Transaction Summary Header', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/replay-count/',
+      body: {},
+    });
   });
 
-  it('should render web vitals tab when yes', function () {
+  it('should render web vitals tab when yes', async function () {
     const {project, organization, router, eventView} = initializeData();
 
     MockApiClient.addMockResponse({
@@ -76,10 +80,10 @@ describe('Performance > Transaction Summary Header', function () {
       />
     );
 
-    expect(screen.getByRole('tab', {name: 'Web Vitals'})).toBeInTheDocument();
+    expect(await screen.findByRole('tab', {name: 'Web Vitals'})).toBeInTheDocument();
   });
 
-  it('should not render web vitals tab when hasWebVitals=no', function () {
+  it('should not render web vitals tab when hasWebVitals=no', async function () {
     const {project, organization, router, eventView} = initializeData();
 
     MockApiClient.addMockResponse({
@@ -100,10 +104,12 @@ describe('Performance > Transaction Summary Header', function () {
       />
     );
 
+    await act(tick);
+
     expect(screen.queryByRole('tab', {name: 'Web Vitals'})).not.toBeInTheDocument();
   });
 
-  it('should render web vitals tab when maybe and is frontend platform', function () {
+  it('should render web vitals tab when maybe and is frontend platform', async function () {
     const {project, organization, router, eventView} = initializeData({
       platform: 'javascript',
     });
@@ -126,7 +132,7 @@ describe('Performance > Transaction Summary Header', function () {
       />
     );
 
-    expect(screen.getByRole('tab', {name: 'Web Vitals'})).toBeInTheDocument();
+    expect(await screen.findByRole('tab', {name: 'Web Vitals'})).toBeInTheDocument();
   });
 
   it('should render web vitals tab when maybe and has measurements', async function () {
@@ -185,7 +191,7 @@ describe('Performance > Transaction Summary Header', function () {
     expect(screen.queryByRole('tab', {name: 'Web Vitals'})).not.toBeInTheDocument();
   });
 
-  it('should render spans tab with feature', function () {
+  it('should render spans tab with feature', async function () {
     const {project, organization, router, eventView} = initializeData({});
 
     MockApiClient.addMockResponse({
@@ -206,6 +212,6 @@ describe('Performance > Transaction Summary Header', function () {
       />
     );
 
-    expect(screen.getByRole('tab', {name: 'Spans'})).toBeInTheDocument();
+    expect(await screen.findByRole('tab', {name: 'Spans'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -211,7 +211,7 @@ describe('Performance GridEditable Table', function () {
     expect(screen.queryByTestId('grid-head-cell-static')).not.toBeInTheDocument();
   });
 
-  it('renders basic columns without ops breakdown when not querying for span_ops_breakdown.relative', function () {
+  it('renders basic columns without ops breakdown when not querying for span_ops_breakdown.relative', async function () {
     const initialData = initializeData();
 
     fields = [
@@ -257,7 +257,7 @@ describe('Performance GridEditable Table', function () {
       {context: initialData.routerContext}
     );
 
-    expect(screen.getAllByRole('columnheader')).toHaveLength(6);
+    expect(await screen.findAllByRole('columnheader')).toHaveLength(6);
     expect(screen.queryByText(SPAN_OP_RELATIVE_BREAKDOWN_FIELD)).not.toBeInTheDocument();
     expect(screen.queryByTestId('relative-ops-breakdown')).not.toBeInTheDocument();
     expect(screen.queryByTestId('grid-head-cell-static')).not.toBeInTheDocument();

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
@@ -140,7 +140,7 @@ describe('Transaction Summary Content', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('performs basic rendering', function () {
+  it('performs basic rendering', async function () {
     const project = ProjectFixture();
     const {
       organization,
@@ -169,7 +169,9 @@ describe('Transaction Summary Content', function () {
       {context: routerContext}
     );
 
-    expect(screen.getByTestId('page-filter-environment-selector')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('page-filter-environment-selector')
+    ).toBeInTheDocument();
     expect(screen.getByTestId('page-filter-timerange-selector')).toBeInTheDocument();
     expect(screen.getByTestId('smart-search-bar')).toBeInTheDocument();
     expect(screen.getByTestId('transaction-summary-charts')).toBeInTheDocument();

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.spec.tsx
@@ -99,7 +99,7 @@ describe('WrapperComponent', function () {
     ProjectsStore.reset();
   });
 
-  it('renders basic UI elements', function () {
+  it('renders basic UI elements', async function () {
     const projects = [ProjectFixture()];
     const {
       organization,
@@ -122,11 +122,13 @@ describe('WrapperComponent', function () {
       />
     );
 
-    expect(screen.getByRole('heading', {name: 'Suspect Tags'})).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', {name: 'Suspect Tags'})
+    ).toBeInTheDocument();
     expect(screen.getByTestId('grid-editable')).toBeInTheDocument();
   });
 
-  it('Tag explorer uses LCP if projects are frontend', function () {
+  it('Tag explorer uses LCP if projects are frontend', async function () {
     const projects = [ProjectFixture({id: '123', platform: 'javascript-react'})];
     const {
       organization,
@@ -151,7 +153,9 @@ describe('WrapperComponent', function () {
       />
     );
 
-    expect(screen.getAllByTestId('grid-head-cell')[2]).toHaveTextContent('Avg LCP');
+    expect((await screen.findAllByTestId('grid-head-cell'))[2]).toHaveTextContent(
+      'Avg LCP'
+    );
 
     expect(facetApiMock).toHaveBeenCalledWith(
       facetUrl,
@@ -163,7 +167,7 @@ describe('WrapperComponent', function () {
     );
   });
 
-  it('Tag explorer view all tags button links to tags page', function () {
+  it('Tag explorer view all tags button links to tags page', async function () {
     const projects = [ProjectFixture({id: '123', platform: 'javascript-react'})];
     const {
       organization,
@@ -194,7 +198,7 @@ describe('WrapperComponent', function () {
       {context: routerContext}
     );
 
-    const button = screen.getByTestId('tags-explorer-open-tags');
+    const button = await screen.findByTestId('tags-explorer-open-tags');
     expect(button).toBeInTheDocument();
     expect(button).toHaveAttribute(
       'href',
@@ -202,7 +206,7 @@ describe('WrapperComponent', function () {
     );
   });
 
-  it('Tag explorer uses the operation breakdown as a column', function () {
+  it('Tag explorer uses the operation breakdown as a column', async function () {
     const projects = [ProjectFixture({platform: 'javascript-react'})];
     const {organization, location, eventView, api, transactionName} = initialize(
       projects,
@@ -221,7 +225,7 @@ describe('WrapperComponent', function () {
       />
     );
 
-    expect(screen.getAllByTestId('grid-head-cell')[2]).toHaveTextContent(
+    expect((await screen.findAllByTestId('grid-head-cell'))[2]).toHaveTextContent(
       'Avg Span Duration'
     );
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.spec.tsx
@@ -66,7 +66,7 @@ describe('Performance > Transaction Spans', function () {
 
     expect(eventsSpanOpsMock).toHaveBeenCalledTimes(1);
 
-    (await screen.findByRole('button', {name: 'Filter'})).click();
+    await userEvent.click(await screen.findByRole('button', {name: 'Filter'}));
     expect(await screen.findByText('op1')).toBeInTheDocument();
     expect(await screen.findByText('op2')).toBeInTheDocument();
   });
@@ -93,7 +93,7 @@ describe('Performance > Transaction Spans', function () {
     );
 
     expect(handleOpChange).not.toHaveBeenCalled();
-    (await screen.findByRole('button', {name: 'Filter'})).click();
+    await userEvent.click(await screen.findByRole('button', {name: 'Filter'}));
     const item = await screen.findByText('op1');
     expect(item).toBeInTheDocument();
     await userEvent.click(item!);

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -426,15 +426,17 @@ describe('Performance > Trends', function () {
     const input = await screen.findByTestId('smart-search-input');
     enterSearch(input, 'transaction.duration:>9000');
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
-      pathname: undefined,
-      query: expect.objectContaining({
-        project: ['1'],
-        query: 'transaction.duration:>9000',
-        improvedCursor: undefined,
-        regressionCursor: undefined,
-      }),
-    });
+    await waitFor(() =>
+      expect(browserHistory.push).toHaveBeenCalledWith({
+        pathname: undefined,
+        query: expect.objectContaining({
+          project: ['1'],
+          query: 'transaction.duration:>9000',
+          improvedCursor: undefined,
+          regressionCursor: undefined,
+        }),
+      })
+    );
   });
 
   it('exclude greater than list menu action modifies query', async function () {
@@ -733,7 +735,7 @@ describe('Performance > Trends', function () {
     }
   });
 
-  it('Visiting trends with trends feature will update filters if none are set', function () {
+  it('Visiting trends with trends feature will update filters if none are set', async function () {
     const data = initializeTrendsData(undefined, {}, false);
 
     render(
@@ -744,13 +746,15 @@ describe('Performance > Trends', function () {
       }
     );
 
-    expect(browserHistory.push).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        query: {
-          query: `tpm():>0.01 transaction.duration:>0 transaction.duration:<${DEFAULT_MAX_DURATION}`,
-        },
-      })
+    await waitFor(() =>
+      expect(browserHistory.push).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          query: {
+            query: `tpm():>0.01 transaction.duration:>0 transaction.duration:<${DEFAULT_MAX_DURATION}`,
+          },
+        })
+      )
     );
   });
 

--- a/static/app/views/projects/projectContext.spec.tsx
+++ b/static/app/views/projects/projectContext.spec.tsx
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectContext} from 'sentry/views/projects/projectContext';
 
@@ -110,7 +110,7 @@ describe('projectContext component', function () {
     expect(fetchMock).toHaveBeenCalled();
   });
 
-  it('fetches data again if projects list changes', function () {
+  it('fetches data again if projects list changes', async function () {
     const fetchMock = MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/`,
       method: 'GET',
@@ -154,6 +154,6 @@ describe('projectContext component', function () {
       </ProjectContext>
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
@@ -163,7 +163,7 @@ describe('ReleaseIssues', function () {
         location={LocationFixture({query: {issuesType: 'all'}})}
       />
     );
-    expect(screen.getByRole('button', {name: 'Open in Issues'})).toHaveAttribute(
+    expect(await screen.findByRole('button', {name: 'Open in Issues'})).toHaveAttribute(
       'href',
       '/organizations/org-slug/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&query=release%3A1.0.0&sort=freq&start=2020-03-23T01%3A02%3A00Z'
     );

--- a/static/app/views/settings/components/dataScrubbing/modals/form/eventIdField.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/eventIdField.spec.tsx
@@ -86,7 +86,7 @@ describe('EventIdField', function () {
     ).toBeInTheDocument();
   });
 
-  it('INVALID status', function () {
+  it('INVALID status', async function () {
     render(
       <EventIdField
         onUpdateEventId={jest.fn()}
@@ -94,12 +94,12 @@ describe('EventIdField', function () {
       />
     );
 
-    expect(screen.getByRole('textbox')).toHaveValue(eventIdValue);
+    expect(await screen.findByRole('textbox')).toHaveValue(eventIdValue);
 
     expect(screen.getByText('This event ID is invalid')).toBeInTheDocument();
   });
 
-  it('NOTFOUND status', function () {
+  it('NOTFOUND status', async function () {
     render(
       <EventIdField
         onUpdateEventId={jest.fn()}
@@ -107,7 +107,7 @@ describe('EventIdField', function () {
       />
     );
 
-    expect(screen.getByRole('textbox')).toHaveValue(eventIdValue);
+    expect(await screen.findByRole('textbox')).toHaveValue(eventIdValue);
 
     expect(
       screen.getByText('The chosen event ID was not found in projects you have access to')

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.spec.tsx
@@ -78,7 +78,9 @@ describe('IntegrationExternalMappingForm', function () {
     expect(
       await screen.findByDisplayValue(MOCK_USER_MAPPING.externalName)
     ).toBeInTheDocument();
-    expect(screen.getByText(`option${MOCK_USER_MAPPING.userId}`)).toBeInTheDocument();
+    expect(
+      await screen.findByText(`option${MOCK_USER_MAPPING.userId}`)
+    ).toBeInTheDocument();
     expect(screen.getByTestId('form-submit')).toBeInTheDocument();
   });
   it('renders with a full mapping provided as an inline field', async function () {

--- a/static/app/views/settings/project/projectOwnership/ownershipRulesTable.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownershipRulesTable.spec.tsx
@@ -20,12 +20,12 @@ describe('OwnershipRulesTable', () => {
     MemberListStore.loadInitialData([user1, user2]);
   });
 
-  it('should render empty state', () => {
+  it('should render empty state', async () => {
     render(<OwnershipRulesTable projectRules={[]} codeowners={[]} />);
-    expect(screen.getByText('No ownership rules found')).toBeInTheDocument();
+    expect(await screen.findByText('No ownership rules found')).toBeInTheDocument();
   });
 
-  it('should render project owners members', () => {
+  it('should render project owners members', async () => {
     const rules: ParsedOwnershipRule[] = [
       {
         matcher: {pattern: 'pattern', type: 'path'},
@@ -35,12 +35,12 @@ describe('OwnershipRulesTable', () => {
 
     render(<OwnershipRulesTable projectRules={rules} codeowners={[]} />);
 
-    expect(screen.getByText('path')).toBeInTheDocument();
+    expect(await screen.findByText('path')).toBeInTheDocument();
     expect(screen.getByText('pattern')).toBeInTheDocument();
     expect(screen.getByText(user1.name)).toBeInTheDocument();
   });
 
-  it('should filter codeowners rules without actor names', () => {
+  it('should filter codeowners rules without actor names', async () => {
     const rules: ParsedOwnershipRule[] = [
       {
         matcher: {pattern: 'pattern', type: 'path'},
@@ -60,12 +60,12 @@ describe('OwnershipRulesTable', () => {
       />
     );
 
-    expect(screen.getByText('pattern')).toBeInTheDocument();
+    expect(await screen.findByText('pattern')).toBeInTheDocument();
     expect(screen.getByText('my/path')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Everyone'})).toBeEnabled();
   });
 
-  it('should render multiple project owners', () => {
+  it('should render multiple project owners', async () => {
     const rules: ParsedOwnershipRule[] = [
       {
         matcher: {pattern: 'pattern', type: 'path'},
@@ -78,7 +78,7 @@ describe('OwnershipRulesTable', () => {
 
     render(<OwnershipRulesTable projectRules={rules} codeowners={[]} />);
 
-    expect(screen.getByText('path')).toBeInTheDocument();
+    expect(await screen.findByText('path')).toBeInTheDocument();
     expect(screen.getByText('pattern')).toBeInTheDocument();
     expect(screen.getByText(`${user1.name} and 1 other`)).toBeInTheDocument();
     expect(screen.queryByText(user2.name)).not.toBeInTheDocument();

--- a/static/app/views/starfish/components/spanDescription.spec.tsx
+++ b/static/app/views/starfish/components/spanDescription.spec.tsx
@@ -100,7 +100,9 @@ describe('DatabaseSpanDescription', function () {
 
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
 
-    expect(screen.getByText('SELECT users FROM my_table LIMIT 1;')).toBeInTheDocument();
+    expect(
+      await screen.findByText('SELECT users FROM my_table LIMIT 1;')
+    ).toBeInTheDocument();
   });
 
   it('shows query source if available', async function () {
@@ -149,7 +151,9 @@ describe('DatabaseSpanDescription', function () {
 
     await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
 
-    expect(screen.getByText('SELECT users FROM my_table LIMIT 1;')).toBeInTheDocument();
+    expect(
+      await screen.findByText('SELECT users FROM my_table LIMIT 1;')
+    ).toBeInTheDocument();
     expect(
       screen.getByText(textWithMarkupMatcher('/app/views/users.py at line 78'))
     ).toBeInTheDocument();


### PR DESCRIPTION
- switches lots of components that have requests from getBy to findBy
- wraps more stores and fake timers in act
- some expect to have been called with need waitFors

part of https://github.com/getsentry/frontend-tsc/issues/22