### PR TITLE
fix(superuser): Remove u2f flag, only check superuser org exists

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -9,7 +9,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import QuietBasicAuthentication
@@ -248,17 +247,9 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
 
             if not DISABLE_SSO_CHECK_FOR_LOCAL_DEV and not is_self_hosted():
                 if SUPERUSER_ORG_ID:
-                    superuser_org = organization_service.get_organization_by_id(
-                        id=SUPERUSER_ORG_ID, include_teams=False, include_projects=False
+                    verify_authenticator = organization_service.check_organization_by_id(
+                        id=SUPERUSER_ORG_ID, only_visible=False
                     )
-
-                    if superuser_org is not None:
-                        has_u2f_flag = features.has(
-                            "organizations:u2f-superuser-form",
-                            superuser_org.organization,
-                            actor=request.user,
-                        )
-                        verify_authenticator = has_u2f_flag
 
                 if verify_authenticator:
                     if not Authenticator.objects.filter(
@@ -270,8 +261,7 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
                 logger.info(
                     "auth-index.put",
                     extra={
-                        "organization": superuser_org,
-                        "u2f_flag": has_u2f_flag,
+                        "organization": SUPERUSER_ORG_ID,
                         "user": request.user.id,
                         "verify_authenticator": verify_authenticator,
                     },

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1943,8 +1943,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:transaction-name-normalize": True,
     # Sanitize transaction names in the ingestion pipeline.
     "organizations:transaction-name-sanitization": False,  # DEPRECATED
-    # Enable u2f verification on superuser form
-    "organizations:u2f-superuser-form": False,
     # Enable the metrics layer for alerts queries.
     "organizations:use-metrics-layer-in-alerts": False,
     # Enable User Feedback v2 ingest

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -282,7 +282,6 @@ default_manager.add("organizations:transaction-metrics-extraction", Organization
 default_manager.add("organizations:transaction-name-mark-scrubbed-as-sanitized", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-normalize", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-sanitization", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:u2f-superuser-form", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:use-metrics-layer-in-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:user-feedback-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -3,7 +3,6 @@ from unittest import mock
 from urllib.parse import urlencode
 
 from django.test import override_settings
-from pytest import fixture
 
 from sentry.api.validators.auth import MISSING_PASSWORD_OR_U2F_CODE
 from sentry.auth.superuser import COOKIE_NAME
@@ -168,11 +167,6 @@ class AuthVerifyEndpointTest(APITestCase):
 @control_silo_test
 class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
     path = "/api/0/auth/"
-
-    @fixture(autouse=True)
-    def setup_u2f_and_feature_flag(self):
-        with self.feature("organizations:u2f-superuser-form"):
-            yield
 
     @mock.patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
     @mock.patch("sentry.auth.authenticators.U2fInterface.validate_response", return_value=True)


### PR DESCRIPTION
Remove u2f feature flag, and only check superuser org exists instead of fetching entire org

Closes https://github.com/getsentry/team-core-product-foundations/issues/147