### PR TITLE
fix(slack): correctly find endpoint regression approx. start time

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -89,7 +89,7 @@ def get_approx_start_time(group: Group):
 
     regression_time = occurrence.evidence_data.get("breakpoint", None)
 
-    if not regression_time:
+    if regression_time is None:
         return None
 
     # format moment into YYYY-mm-dd h:m:s

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -74,6 +74,29 @@ SUPPORTED_COMMIT_PROVIDERS = (
     "bitbucket",
     "integrations:bitbucket",
 )
+
+
+def get_approx_start_time(group: Group):
+    event = group.get_recommended_event_for_environments()
+
+    if event is None:
+        return None
+
+    occurrence = event.occurrence
+
+    if occurrence is None:
+        return None
+
+    regression_time = occurrence.evidence_data.get("breakpoint", None)
+
+    if not regression_time:
+        return None
+
+    # format moment into YYYY-mm-dd h:m:s
+    time = datetime.fromtimestamp(regression_time)
+    return time.strftime("%Y-%m-%d %H:%M:%S")
+
+
 # NOTE: if this starts getting large and functions get complicated,
 # pull things out into their own functions
 SUPPORTED_CONTEXT_DATA = {
@@ -81,8 +104,9 @@ SUPPORTED_CONTEXT_DATA = {
     "Users Affected": lambda group: group.count_users_seen(),
     "State": lambda group: SUBSTATUS_TO_STR.get(group.substatus, "").replace("_", " ").title(),
     "First Seen": lambda group: time_since(group.first_seen),
-    "Approx. Start Time": lambda group: group.active_at.strftime("%Y-%m-%d %H:%M:%S"),
+    "Approx. Start Time": get_approx_start_time,
 }
+
 
 REGRESSION_PERFORMANCE_ISSUE_TYPES = [
     PerformanceP95EndpointRegressionGroupType,


### PR DESCRIPTION
After some digging, I found that the actual `Approx. Start Time` seen in an Endpoint Regression issue is buried deep down in a call to `/api/0/organizations/sentry/issues/{issue_id}/events/recommended/?collapse=fullRelease`.
<img width="1150" alt="Screenshot 2024-03-07 at 13 22 43" src="https://github.com/getsentry/sentry/assets/70817427/81fbf9e6-14cb-4bc8-a94d-42333db6ab4d">


This calls `get_recommended_event_for_environments` on the `Group` object for the issue. The event has an occurrence attached to it, and the occurrence has `evidenceData` and a `breakpoint` within that `evidenceData` indicating the approximate start time of the regression.

https://github.com/getsentry/sentry/blob/3458315278ce335018b996ead3a3b8f4aac24c04/static/app/components/events/eventStatisticalDetector/eventRegressionSummary.tsx#L85-L87