### PR TITLE
fix(metrics): Tweak how samples are chosen for each bucket

### DIFF
--- a/src/sentry/sentry_metrics/querying/samples_list.py
+++ b/src/sentry/sentry_metrics/querying/samples_list.py
@@ -856,7 +856,8 @@ def pick_samples(
     idx_m = bisect(keys, avg_m)
     # ensure there is at least 1 element on both sides
     # of the middle element we just picked
-    idx_m = min(max(1, idx_m), len(keys) - 2)
+    # i.e. should not pick index 0 and len(keys) - 1
+    idx_m = _clip(idx_m, 1, len(keys) - 2)
 
     # second element is near the average of first
     # split, but must not be the split element
@@ -864,7 +865,7 @@ def pick_samples(
     idx_l = bisect(keys, avg_l, hi=idx_m - 1)
     idx_l += 1  # push it closer to the middle
     # ensure this is not the same as middle element
-    idx_l = min(max(0, idx_l), idx_m - 1)
+    idx_l = _clip(idx_l, 0, idx_m - 1)
 
     # third element is near the average of second
     # split, but must not be the split element
@@ -872,6 +873,12 @@ def pick_samples(
     idx_r = bisect(keys, avg_r, lo=idx_m + 1)
     idx_r -= 1  # push it closer to the middle
     # ensure this is not the same as middle element
-    idx_r = min(max(idx_m + 1, idx_r), len(keys) - 1)
+    idx_r = _clip(idx_r, idx_m + 1, len(keys) - 1)
 
     return [samples[idx_m], samples[idx_l], samples[idx_r]]
+
+
+def _clip(val: int, left: int, right: int) -> int:
+    val = max(left, val)
+    val = min(val, right)
+    return val

--- a/src/sentry/sentry_metrics/querying/samples_list.py
+++ b/src/sentry/sentry_metrics/querying/samples_list.py
@@ -850,14 +850,28 @@ def pick_samples(
 
     keys = [metric_key(sample) for sample in samples]
 
+    # first element is the one near the average
+    # but must not be the first or last element
     avg_m = sum(keys) / len(keys)
     idx_m = bisect(keys, avg_m)
+    # ensure there is at least 1 element on both sides
+    # of the middle element we just picked
     idx_m = min(max(1, idx_m), len(keys) - 2)
 
+    # second element is near the average of first
+    # split, but must not be the split element
     avg_l = sum(keys[:idx_m]) / idx_m
-    idx_l = max(0, bisect(keys, avg_l))
+    idx_l = bisect(keys, avg_l, hi=idx_m - 1)
+    idx_l += 1  # push it closer to the middle
+    # ensure this is not the same as middle element
+    idx_l = min(max(0, idx_l), idx_m - 1)
 
+    # third element is near the average of second
+    # split, but must not be the split element
     avg_r = sum(keys[idx_m + 1 :]) / (len(keys) - idx_m - 1)
-    idx_r = min(bisect(keys, avg_r), len(keys) - 1)
+    idx_r = bisect(keys, avg_r, lo=idx_m + 1)
+    idx_r -= 1  # push it closer to the middle
+    # ensure this is not the same as middle element
+    idx_r = min(max(idx_m + 1, idx_r), len(keys) - 1)
 
-    return [samples[idx_l], samples[idx_m], samples[idx_r]]
+    return [samples[idx_m], samples[idx_l], samples[idx_r]]

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -654,7 +654,7 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
             }
             response = self.do_request(query)
             assert response.status_code == 200, response.data
-            expected = {int(span_ids[i], 16) for i in [0, 2, 4]}
+            expected = {int(span_ids[i], 16) for i in [2, 3, 4]}
             actual = {int(row["id"], 16) for row in response.data["data"]}
             assert actual == expected
 
@@ -698,6 +698,6 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
             }
             response = self.do_request(query)
             assert response.status_code == 200, response.data
-            expected = {int(span_ids[i], 16) for i in [0, 2, 4]}
+            expected = {int(span_ids[i], 16) for i in [2, 3, 4]}
             actual = {int(row["id"], 16) for row in response.data["data"]}
             assert actual == expected


### PR DESCRIPTION
Always choosing the smallest + biggest often results in the samples lying at the extremes of the chart. This changes the strategy a little to always pick near the middle of the distribution.