### PR TITLE
fix(hc): Have client_config list regions in stable order

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -32,7 +32,12 @@ from sentry.services.hybrid_cloud.user import UserSerializeType
 from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.silo.base import SiloMode
-from sentry.types.region import Region, find_all_multitenant_region_names, get_region_by_name
+from sentry.types.region import (
+    Region,
+    RegionCategory,
+    find_all_multitenant_region_names,
+    get_region_by_name,
+)
 from sentry.utils import auth, json
 from sentry.utils.assets import get_frontend_dist_prefix
 from sentry.utils.email import is_smtp_enabled
@@ -348,9 +353,12 @@ class _ClientConfig:
         memberships = user_service.get_organizations(user_id=user.id)
         unique_regions = set(region_names) | {membership.region_name for membership in memberships}
 
-        def region_display_order(region: Region) -> tuple[bool, str]:
-            # Monolith (default) region comes first, then alphabetical
-            return (not region.is_historic_monolith_region()), region.name
+        def region_display_order(region: Region) -> tuple[bool, bool, str]:
+            return (
+                not region.is_historic_monolith_region(),  # default region comes first
+                region.category != RegionCategory.MULTI_TENANT,  # multi-tenants before single
+                region.name,  # then sort alphabetically
+            )
 
         regions = [get_region_by_name(name) for name in unique_regions]
         regions.sort(key=region_display_order)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -32,7 +32,7 @@ from sentry.services.hybrid_cloud.user import UserSerializeType
 from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.silo.base import SiloMode
-from sentry.types.region import find_all_multitenant_region_names, get_region_by_name
+from sentry.types.region import Region, find_all_multitenant_region_names, get_region_by_name
 from sentry.utils import auth, json
 from sentry.utils.assets import get_frontend_dist_prefix
 from sentry.utils.email import is_smtp_enabled
@@ -348,7 +348,13 @@ class _ClientConfig:
         memberships = user_service.get_organizations(user_id=user.id)
         unique_regions = set(region_names) | {membership.region_name for membership in memberships}
 
-        return [get_region_by_name(name).api_serialize() for name in unique_regions]
+        def region_display_order(region: Region) -> tuple[bool, str]:
+            # Monolith (default) region comes first, then alphabetical
+            return (not region.is_historic_monolith_region()), region.name
+
+        regions = [get_region_by_name(name) for name in unique_regions]
+        regions.sort(key=region_display_order)
+        return [region.api_serialize() for region in regions]
 
     def get_context(self) -> Mapping[str, Any]:
         return {

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -237,6 +237,24 @@ def test_client_config_links_regionurl():
         assert result["links"]["regionUrl"] == "http://eu.testserver"
 
 
+@control_silo_test(
+    regions=create_test_regions("us", "eu", "acme", "de", "apac", single_tenants=["acme"]),
+    include_monolith_run=True,
+)
+@django_db_all
+def test_client_config_region_display_order():
+    request, user = make_user_request_from_org()
+    request.user = user
+
+    Factories.create_organization(slug="acme-co", owner=user)
+    mapping = OrganizationMapping.objects.get(slug="acme-co")
+    mapping.update(region_name="acme")
+
+    result = get_client_config(request)
+    region_names = [region["name"] for region in result["regions"]]
+    assert region_names == ["us", "apac", "de", "eu", "acme"]
+
+
 @multiregion_client_config_test
 @django_db_all
 def test_client_config_links_with_priority_org():


### PR DESCRIPTION
Have the historic monolith region appear first (if the client can see it). List multi-tenant regions above single-tenant, with each group ordered alphabetically by name.

This allows the admin UI to use the first region as a default.