### PR TITLE
feat(feedback): [1/4] add dotnet platforms to issues feedback onboarding

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/useSourcePackageRegistries.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/useSourcePackageRegistries.tsx
@@ -8,6 +8,7 @@ export type ReleaseRegistrySdk = Record<
   string,
   {
     canonical: string;
+    files: Record<string, {checksums: Record<string, string>}>;
     main_docs_url: string;
     name: string;
     package_url: string;

--- a/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
@@ -167,7 +167,7 @@ export function getCrashReportSDKInstallFirstStep(params) {
   };
 }
 
-export const getCrashReportDotnetInstallStep = params => [
+export const getCrashReportGenericInstallStep = params => [
   {
     type: StepType.INSTALL,
     configurations: [

--- a/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
@@ -141,3 +141,61 @@ export const getCrashReportJavaScriptInstallStep = params => [
     configurations: getCrashReportModalSnippetJavaScript(params),
   },
 ];
+
+export function getCrashReportSDKInstallFirstStep(params) {
+  const version =
+    params.sourcePackageRegistries.data['sentry.javascript.browser'].version;
+  const hash =
+    params.sourcePackageRegistries.data['sentry.javascript.browser'].files[
+      'bundle.min.js'
+    ].checksums['sha384-base64'];
+
+  return {
+    description: t('Make sure you have the JavaScript SDK available:'),
+    code: [
+      {
+        label: 'HTML',
+        value: 'html',
+        language: 'html',
+        code: `<script
+  src="https://browser.sentry-cdn.com/${version}/bundle.min.js"
+  integrity="sha384-${hash}"
+  crossorigin="anonymous"
+></script>`,
+      },
+    ],
+  };
+}
+
+export const getCrashReportDotnetInstallStep = params => [
+  {
+    type: StepType.INSTALL,
+    configurations: [
+      getCrashReportSDKInstallFirstStep(params),
+      {
+        description: tct(
+          'You will then need to call [codeShow:showReportDialog] and pass in the generated event ID. This event ID is returned from all calls to [codeEvent:CaptureEvent] and [codeException:CaptureException]. There is also a function called [codeLast:LastEventId] that returns the ID of the most recently sent event.',
+          {
+            codeShow: <code />,
+            codeEvent: <code />,
+            codeException: <code />,
+            codeLast: <code />,
+          }
+        ),
+        code: [
+          {
+            label: 'HTML',
+            value: 'html',
+            language: 'html',
+            code: `<script>
+  Sentry.init({ dsn: "${params.dsn}" });
+  Sentry.showReportDialog({
+    eventId: "{{ event_id }}",
+  });
+</script>`,
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/static/app/gettingStartedDocs/dotnet/aspnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnet.tsx
@@ -197,7 +197,7 @@ const crashReportOnboarding: OnboardingConfig = {
           ),
           code: [
             {
-              label: 'Cshtml',
+              label: 'cshtml',
               value: 'html',
               language: 'html',
               code: `@if (SentrySdk.LastEventId != SentryId.Empty) {

--- a/static/app/gettingStartedDocs/dotnet/aspnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnet.tsx
@@ -11,6 +11,11 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+  getCrashReportSDKInstallFirstStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -178,9 +183,51 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => [
+    {
+      type: StepType.INSTALL,
+      configurations: [
+        getCrashReportSDKInstallFirstStep(params),
+        {
+          description: tct(
+            'If you are rendering the page from the server, for example on ASP.NET MVC, the [code:Error.cshtml] razor page can be:',
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'Cshtml',
+              value: 'html',
+              language: 'html',
+              code: `@if (SentrySdk.LastEventId != SentryId.Empty) {
+  <script>
+    Sentry.init({ dsn: "${params.dsn}" });
+    Sentry.showReportDialog({ eventId: "@SentrySdk.LastEventId" });
+  </script>
+}`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/guides/aspnet/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/aspnetcore.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnetcore.tsx
@@ -9,6 +9,11 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+  getCrashReportSDKInstallFirstStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getDotnetMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
@@ -199,10 +204,56 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => [
+    {
+      type: StepType.INSTALL,
+      configurations: [
+        getCrashReportSDKInstallFirstStep(params),
+        {
+          description: tct(
+            'If you are rendering the page from the server, for example on ASP.NET MVC, the [code:Error.cshtml] razor page can be:',
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'Cshtml',
+              value: 'html',
+              language: 'html',
+              code: `@using Sentry
+@using Sentry.AspNetCore
+@inject Microsoft.Extensions.Options.IOptions<SentryAspNetCoreOptions> SentryOptions
+
+@if (SentrySdk.LastEventId != SentryId.Empty) {
+  <script>
+    Sentry.init({ dsn: "@(SentryOptions.Value.Dsn)" });
+    Sentry.showReportDialog({ eventId: "@SentrySdk.LastEventId" });
+  </script>
+}`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/guides/aspnetcore/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
   customMetricsOnboarding: getDotnetMetricsOnboarding({packageName: 'Sentry.AspNetCore'}),
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/aspnetcore.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnetcore.tsx
@@ -218,7 +218,7 @@ const crashReportOnboarding: OnboardingConfig = {
           ),
           code: [
             {
-              label: 'Cshtml',
+              label: 'cshtml',
               value: 'html',
               language: 'html',
               code: `@using Sentry

--- a/static/app/gettingStartedDocs/dotnet/awslambda.tsx
+++ b/static/app/gettingStartedDocs/dotnet/awslambda.tsx
@@ -8,7 +8,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getCrashReportDotnetInstallStep,
+  getCrashReportGenericInstallStep,
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
@@ -162,7 +162,7 @@ const onboarding: OnboardingConfig = {
 
 const crashReportOnboarding: OnboardingConfig = {
   introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  install: (params: Params) => getCrashReportGenericInstallStep(params),
   configure: () => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/dotnet/awslambda.tsx
+++ b/static/app/gettingStartedDocs/dotnet/awslambda.tsx
@@ -7,6 +7,11 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportDotnetInstallStep,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getDotnetMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
 import {t, tct} from 'sentry/locale';
@@ -155,10 +160,26 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/guides/aws-lambda/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
   customMetricsOnboarding: getDotnetMetricsOnboarding({packageName: 'Sentry.AspNetCore'}),
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/dotnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet.tsx
@@ -12,7 +12,7 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   getCrashReportApiIntroduction,
-  getCrashReportDotnetInstallStep,
+  getCrashReportGenericInstallStep,
   getCrashReportInstallDescription,
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
@@ -249,7 +249,7 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
 
 const crashReportOnboarding: OnboardingConfig = {
   introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  install: (params: Params) => getCrashReportGenericInstallStep(params),
   configure: () => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/dotnet/dotnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/dotnet.tsx
@@ -12,7 +12,10 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   getCrashReportApiIntroduction,
+  getCrashReportDotnetInstallStep,
   getCrashReportInstallDescription,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getDotnetMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
@@ -244,10 +247,26 @@ SentrySdk.CaptureUserFeedback(eventId, "user@example.com", "It broke.", "The Use
   nextSteps: () => [],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
   customMetricsOnboarding: getDotnetMetricsOnboarding({packageName: 'Sentry'}),
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
@@ -9,6 +9,11 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportDotnetInstallStep,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getDotnetMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
 import {t, tct} from 'sentry/locale';
@@ -195,12 +200,28 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/guides/google-cloud-functions/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
   customMetricsOnboarding: getDotnetMetricsOnboarding({
     packageName: 'Sentry.Google.Cloud.Functions',
   }),
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/dotnet/gcpfunctions.tsx
@@ -10,7 +10,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getCrashReportDotnetInstallStep,
+  getCrashReportGenericInstallStep,
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
@@ -202,7 +202,7 @@ const onboarding: OnboardingConfig = {
 
 const crashReportOnboarding: OnboardingConfig = {
   introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  install: (params: Params) => getCrashReportGenericInstallStep(params),
   configure: () => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/dotnet/maui.tsx
+++ b/static/app/gettingStartedDocs/dotnet/maui.tsx
@@ -8,7 +8,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getCrashReportDotnetInstallStep,
+  getCrashReportGenericInstallStep,
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
@@ -211,7 +211,7 @@ const onboarding: OnboardingConfig = {
 
 const crashReportOnboarding: OnboardingConfig = {
   introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  install: (params: Params) => getCrashReportGenericInstallStep(params),
   configure: () => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/dotnet/maui.tsx
+++ b/static/app/gettingStartedDocs/dotnet/maui.tsx
@@ -7,6 +7,11 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportDotnetInstallStep,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getDotnetMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
 import {t, tct} from 'sentry/locale';
@@ -204,10 +209,26 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/guides/maui/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
   customMetricsOnboarding: getDotnetMetricsOnboarding({packageName: 'Sentry.Maui'}),
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/uwp.tsx
+++ b/static/app/gettingStartedDocs/dotnet/uwp.tsx
@@ -11,6 +11,11 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportDotnetInstallStep,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getDotnetMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
 import {t, tct} from 'sentry/locale';
@@ -227,10 +232,26 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/guides/uwp/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
   customMetricsOnboarding: getDotnetMetricsOnboarding({packageName: 'Sentry'}),
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/uwp.tsx
+++ b/static/app/gettingStartedDocs/dotnet/uwp.tsx
@@ -12,7 +12,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getCrashReportDotnetInstallStep,
+  getCrashReportGenericInstallStep,
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
@@ -234,7 +234,7 @@ const onboarding: OnboardingConfig = {
 
 const crashReportOnboarding: OnboardingConfig = {
   introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  install: (params: Params) => getCrashReportGenericInstallStep(params),
   configure: () => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/dotnet/winforms.tsx
+++ b/static/app/gettingStartedDocs/dotnet/winforms.tsx
@@ -11,6 +11,11 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportDotnetInstallStep,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getDotnetMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
 import {t, tct} from 'sentry/locale';
@@ -199,10 +204,26 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/guides/winforms/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
   customMetricsOnboarding: getDotnetMetricsOnboarding({packageName: 'Sentry'}),
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/winforms.tsx
+++ b/static/app/gettingStartedDocs/dotnet/winforms.tsx
@@ -12,7 +12,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getCrashReportDotnetInstallStep,
+  getCrashReportGenericInstallStep,
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
@@ -206,7 +206,7 @@ const onboarding: OnboardingConfig = {
 
 const crashReportOnboarding: OnboardingConfig = {
   introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  install: (params: Params) => getCrashReportGenericInstallStep(params),
   configure: () => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/dotnet/wpf.tsx
+++ b/static/app/gettingStartedDocs/dotnet/wpf.tsx
@@ -11,6 +11,11 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportDotnetInstallStep,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {getDotnetMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
 import {t, tct} from 'sentry/locale';
@@ -199,10 +204,26 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/guides/wpf/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
   customMetricsOnboarding: getDotnetMetricsOnboarding({packageName: 'Sentry'}),
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/wpf.tsx
+++ b/static/app/gettingStartedDocs/dotnet/wpf.tsx
@@ -12,7 +12,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getCrashReportDotnetInstallStep,
+  getCrashReportGenericInstallStep,
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
@@ -206,7 +206,7 @@ const onboarding: OnboardingConfig = {
 
 const crashReportOnboarding: OnboardingConfig = {
   introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  install: (params: Params) => getCrashReportGenericInstallStep(params),
   configure: () => [
     {
       type: StepType.CONFIGURE,

--- a/static/app/gettingStartedDocs/dotnet/xamarin.tsx
+++ b/static/app/gettingStartedDocs/dotnet/xamarin.tsx
@@ -7,6 +7,11 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  getCrashReportDotnetInstallStep,
+  getCrashReportModalConfigDescription,
+  getCrashReportModalIntroduction,
+} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {csharpFeedbackOnboarding} from 'sentry/gettingStartedDocs/dotnet/dotnet';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -245,9 +250,25 @@ const onboarding: OnboardingConfig = {
   ],
 };
 
+const crashReportOnboarding: OnboardingConfig = {
+  introduction: () => getCrashReportModalIntroduction(),
+  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: getCrashReportModalConfigDescription({
+        link: 'https://docs.sentry.io/platforms/dotnet/guides/xamarin/user-feedback/configuration/#crash-report-modal',
+      }),
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
+
 const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: csharpFeedbackOnboarding,
+  crashReportOnboarding,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet/xamarin.tsx
+++ b/static/app/gettingStartedDocs/dotnet/xamarin.tsx
@@ -8,7 +8,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getCrashReportDotnetInstallStep,
+  getCrashReportGenericInstallStep,
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
@@ -252,7 +252,7 @@ const onboarding: OnboardingConfig = {
 
 const crashReportOnboarding: OnboardingConfig = {
   introduction: () => getCrashReportModalIntroduction(),
-  install: (params: Params) => getCrashReportDotnetInstallStep(params),
+  install: (params: Params) => getCrashReportGenericInstallStep(params),
   configure: () => [
     {
       type: StepType.CONFIGURE,


### PR DESCRIPTION
This PR adds the following platforms to issues feedback onboarding:
-  'dotnet',
-  'dotnet-aspnet',
-  'dotnet-aspnetcore',
-  'dotnet-awslambda',
-  'dotnet-gcpfunctions',
-  'dotnet-maui',
-  'dotnet-uwp',
-  'dotnet-winforms',
-  'dotnet-wpf',
-  'dotnet-xamarin',
<img width="462" alt="SCR-20240307-oaqz" src="https://github.com/getsentry/sentry/assets/56095982/d5c02a0d-07d5-48e8-9ef5-751bf0f098a0">

It also modifies the `useSourcePackageRegistries` hook to include `files` in the datatype. It was always there being returned from the endpoint; the datatype just didn't have the property. We need to use this information to display some of the strings in the first JS snippet.


Relates to https://github.com/getsentry/sentry/issues/66162