### PR TITLE
ref(daily summary): Fix timezone

### DIFF
--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -41,7 +41,7 @@ from sentry.tasks.summaries.utils import (
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime, to_timestamp
 from sentry.utils.outcomes import Outcome
 from sentry.utils.query import RangeQuerySetWrapper
 
@@ -62,7 +62,7 @@ HOUR_TO_SEND_REPORT = 16
 def schedule_organizations(timestamp: float | None = None, duration: int | None = None) -> None:
     if timestamp is None:
         # The time that the report was generated
-        timestamp = to_timestamp(floor_to_utc_day(timezone.now()))
+        timestamp = to_timestamp(timezone.now())
 
     if duration is None:
         # The total timespan that the task covers


### PR DESCRIPTION
Using `floor_to_utc_day` made the timestamp always UTC midnight which equates to PST 4pm - this wasn't caught in tests because the timestamp was being passed in so this code path wasn't being hit. This should prevent the resending each hour to only sending at 4pm at the user's local time as intended.