### PR TITLE
fix(staff): Separate staff and superuser U2F state in session

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -73,17 +73,12 @@ class BaseAuthIndexEndpoint(Endpoint):
     def _verify_user_via_inputs(validator: AuthVerifyValidator, request: Request) -> bool:
         # See if we have a u2f challenge/response
         if "challenge" in validator.validated_data and "response" in validator.validated_data:
-            getsentry_logger.info(
-                "verify.user.inputs.failed",
-                extra={"user": request.user.id, "validator": validator.validated_data},
-            )
             try:
                 interface = Authenticator.objects.get_interface(request.user, "u2f")
                 if not interface.is_enrolled():
                     raise LookupError()
                 challenge = json.loads(validator.validated_data["challenge"])
                 response = json.loads(validator.validated_data["response"])
-                print(interface.validate_response)
                 authenticated = interface.validate_response(request, challenge, response)
                 getsentry_logger.info(
                     "verify.user.inputs",
@@ -164,13 +159,12 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
                 "verify_authenticator": verify_authenticator,
             },
         )
-        print("DISABLE_SSO_CHECK_FOR_LOCAL_DEV", DISABLE_SSO_CHECK_FOR_LOCAL_DEV)
         # Disable exception for missing password or u2f code if we're running locally
         validator.is_valid(raise_exception=not DISABLE_SSO_CHECK_FOR_LOCAL_DEV)
 
         authenticated = (
             self._verify_user_via_inputs(validator, request)
-            if (verify_authenticator) or is_self_hosted()
+            if (not DISABLE_SSO_CHECK_FOR_LOCAL_DEV and verify_authenticator) or is_self_hosted()
             else True
         )
 
@@ -238,7 +232,6 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
 
         :auth: required
         """
-        DISABLE_SSO_CHECK_FOR_LOCAL_DEV = False  # noqa: F811
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         validator = AuthVerifyValidator(data=request.data)
@@ -254,12 +247,10 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
             verify_authenticator = False
 
             if not DISABLE_SSO_CHECK_FOR_LOCAL_DEV and not is_self_hosted():
-                print("SUPERUSER_ORG_ID", SUPERUSER_ORG_ID)
                 if SUPERUSER_ORG_ID:
                     verify_authenticator = organization_service.check_organization_by_id(
                         id=SUPERUSER_ORG_ID, only_visible=False
                     )
-                print("verify_authenticator", verify_authenticator)
 
                 if verify_authenticator:
                     if not Authenticator.objects.filter(

--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -14,7 +14,6 @@ from fido2.ctap2 import AuthenticatorData, base
 from fido2.server import Fido2Server, U2FFido2Server
 from fido2.utils import websafe_decode
 from fido2.webauthn import PublicKeyCredentialRpEntity
-from rest_framework.request import Request
 from u2flib_server.model import DeviceRegistration
 
 from sentry import options
@@ -216,7 +215,7 @@ class U2fInterface(AuthenticatorInterface):
 
         return ActivationChallengeResult(challenge=cbor.encode(challenge["publicKey"]))
 
-    def validate_response(self, request: Request, challenge, response):
+    def validate_response(self, request: HttpRequest, challenge, response):
         try:
             credentials = self.credentials()
             # Only 1 U2F state should be set at a time

--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -205,11 +205,11 @@ class U2fInterface(AuthenticatorInterface):
         challenge, state = self.webauthn_authentication_server.authenticate_begin(
             credentials=credentials
         )
-        if request.session.get("staff_u2f", False):
+        if request.session.get("staff_auth_flow", False):
             request.session["staff_webauthn_authentication_state"] = state
             # Remove the staff U2F flag in case we don't validate the generated
             # challenge/response and want to next use a non-staff U2F flow
-            del request.session["staff_u2f"]
+            del request.session["staff_auth_flow"]
         else:
             request.session["webauthn_authentication_state"] = state
 

--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -203,20 +203,17 @@ class U2fInterface(AuthenticatorInterface):
         challenge, state = self.webauthn_authentication_server.authenticate_begin(
             credentials=credentials
         )
-        print(request.session.get("staff_u2f", False))
         if request.session.get("staff_u2f", False):
             request.session["staff_webauthn_authentication_state"] = state
             # Remove the staff U2F flag in case we don't validate the generated
             # challenge/response and want to next use a non-staff U2F flow
             del request.session["staff_u2f"]
-            print("set session for staff", request.session.__dict__)
         else:
             request.session["webauthn_authentication_state"] = state
 
         return ActivationChallengeResult(challenge=cbor.encode(challenge["publicKey"]))
 
     def validate_response(self, request: Request, challenge, response):
-        print("request session", request.session.__dict__)
         try:
             credentials = self.credentials()
             # Only 1 U2F state should be set at a time
@@ -235,7 +232,6 @@ class U2fInterface(AuthenticatorInterface):
             return False
         finally:
             # Cleanup the U2F state from the session
-            print("first pop", request.session.pop("webauthn_authentication_state", None))
-            print("second pop", request.session.pop("staff_webauthn_authentication_state", None))
-        print("request session", request.session.__dict__)
+            request.session.pop("webauthn_authentication_state", None)
+            request.session.pop("staff_webauthn_authentication_state", None)
         return True

--- a/tests/sentry/auth/authenticators/test_u2f.py
+++ b/tests/sentry/auth/authenticators/test_u2f.py
@@ -1,16 +1,15 @@
+from unittest.mock import Mock
+
 from fido2 import cbor
 from fido2.ctap2 import AuthenticatorData
 from fido2.server import Fido2Server
 from fido2.webauthn import PublicKeyCredentialRpEntity
+from pytest import raises
 
 from sentry.auth.authenticators.base import ActivationChallengeResult
 from sentry.auth.authenticators.u2f import U2fInterface
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
-
-
-def verifiy_origin(origin):
-    return True
 
 
 @control_silo_test
@@ -19,7 +18,7 @@ class U2FInterfaceTest(TestCase):
         self.u2f = U2fInterface()
         self.login_as(user=self.user)
         rp = PublicKeyCredentialRpEntity("richardmasentry.ngrok.io", "Sentry")
-        self.test_registration_server = Fido2Server(rp, verify_origin=verifiy_origin)
+        self.test_registration_server = Fido2Server(rp, verify_origin=lambda origin: True)
 
     def test_start_enrollment_webauthn(self):
         self.u2f.webauthn_registration_server = self.test_registration_server
@@ -62,6 +61,74 @@ class U2FInterfaceTest(TestCase):
         self.test_try_enroll_webauthn()
         request = self.make_request(user=self.user)
         result = self.u2f.activate(request)
+
         assert isinstance(result, ActivationChallengeResult)
         assert len(request.session["webauthn_authentication_state"]["challenge"]) == 43
         assert request.session["webauthn_authentication_state"]["user_verification"] is None
+
+    def test_activate_staff_webauthn(self):
+        self.test_try_enroll_webauthn()
+        request = self.make_request(user=self.user)
+        request.session["staff_u2f"] = True
+
+        result = self.u2f.activate(request)
+
+        assert isinstance(result, ActivationChallengeResult)
+        assert "webauthn_authentication_state" not in request.session
+        assert len(request.session["staff_webauthn_authentication_state"]["challenge"]) == 43
+        assert request.session["staff_webauthn_authentication_state"]["user_verification"] is None
+
+    def test_validate_response_normal_state(self):
+        self.test_try_enroll_webauthn()
+        mock_state = Mock()
+        self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
+        request = self.make_request(user=self.user)
+        request.session["webauthn_authentication_state"] = "normal state"
+        response = {
+            "keyHandle": "F5MKBNqJMnHX-g0jee03d0slMyvz0FMWAf1YzF9mjZhA6ePDEwt8QT2zNR-ungcffGGxpGtp4yXRC5gz8t1Lww",
+            "clientData": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRjJYS0tyZ19FY1h6OEljUjBUX3BzcUJqenc5X1VIYTFIU2premtFbTUzQSIsIm9yaWdpbiI6Imh0dHBzOi8vc2VudHJ5LmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlLCJvdGhlcl9rZXlzX2Nhbl9iZV9hZGRlZF9oZXJlIjoiZG8gbm90IGNvbXBhcmUgY2xpZW50RGF0YUpTT04gYWdhaW5zdCBhIHRlbXBsYXRlLiBTZWUgaHR0cHM6Ly9nb28uZ2wveWFiUGV4In0",
+            "signatureData": "MEUCIDe2DPI7E3tWa31JN_FG5m9rhc2v2lDRsWY-Yy7jgdT0AiEA5hkw8UGEfu-d_H5CEHuGC1Cj1wvFPqiRu-c_q50R6NM",
+            "authenticatorData": "ss7JfEqyMJeXvxXeO3AXn9tPTh1R4bNVGkMcr6WH-08BAAAD_A",
+        }
+
+        assert self.u2f.validate_response(request, None, response)
+        _, kwargs = mock_state.call_args
+        assert kwargs.get("state") == "normal state"
+        assert "webauthn_authentication_state" not in request.session
+
+    def test_validate_response_staff_state(self):
+        self.test_try_enroll_webauthn()
+        mock_state = Mock()
+        self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
+        request = self.make_request(user=self.user)
+        request.session["staff_webauthn_authentication_state"] = "staff state"
+        response = {
+            "keyHandle": "F5MKBNqJMnHX-g0jee03d0slMyvz0FMWAf1YzF9mjZhA6ePDEwt8QT2zNR-ungcffGGxpGtp4yXRC5gz8t1Lww",
+            "clientData": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRjJYS0tyZ19FY1h6OEljUjBUX3BzcUJqenc5X1VIYTFIU2premtFbTUzQSIsIm9yaWdpbiI6Imh0dHBzOi8vc2VudHJ5LmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlLCJvdGhlcl9rZXlzX2Nhbl9iZV9hZGRlZF9oZXJlIjoiZG8gbm90IGNvbXBhcmUgY2xpZW50RGF0YUpTT04gYWdhaW5zdCBhIHRlbXBsYXRlLiBTZWUgaHR0cHM6Ly9nb28uZ2wveWFiUGV4In0",
+            "signatureData": "MEUCIDe2DPI7E3tWa31JN_FG5m9rhc2v2lDRsWY-Yy7jgdT0AiEA5hkw8UGEfu-d_H5CEHuGC1Cj1wvFPqiRu-c_q50R6NM",
+            "authenticatorData": "ss7JfEqyMJeXvxXeO3AXn9tPTh1R4bNVGkMcr6WH-08BAAAD_A",
+        }
+
+        assert self.u2f.validate_response(request, None, response)
+        _, kwargs = mock_state.call_args
+        assert kwargs.get("state") == "staff state"
+        assert "staff_webauthn_authentication_state" not in request.session
+
+    def test_validate_response_failing_still_clears_all_states(self):
+        self.test_try_enroll_webauthn()
+        mock_state = Mock(side_effect=ValueError("test"))
+        self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
+        request = self.make_request(user=self.user)
+        request.session["webauthn_authentication_state"] = "normal state"
+        request.session["staff_webauthn_authentication_state"] = "staff state"
+        response = {
+            "keyHandle": "F5MKBNqJMnHX-g0jee03d0slMyvz0FMWAf1YzF9mjZhA6ePDEwt8QT2zNR-ungcffGGxpGtp4yXRC5gz8t1Lww",
+            "clientData": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRjJYS0tyZ19FY1h6OEljUjBUX3BzcUJqenc5X1VIYTFIU2premtFbTUzQSIsIm9yaWdpbiI6Imh0dHBzOi8vc2VudHJ5LmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlLCJvdGhlcl9rZXlzX2Nhbl9iZV9hZGRlZF9oZXJlIjoiZG8gbm90IGNvbXBhcmUgY2xpZW50RGF0YUpTT04gYWdhaW5zdCBhIHRlbXBsYXRlLiBTZWUgaHR0cHM6Ly9nb28uZ2wveWFiUGV4In0",
+            "signatureData": "MEUCIDe2DPI7E3tWa31JN_FG5m9rhc2v2lDRsWY-Yy7jgdT0AiEA5hkw8UGEfu-d_H5CEHuGC1Cj1wvFPqiRu-c_q50R6NM",
+            "authenticatorData": "ss7JfEqyMJeXvxXeO3AXn9tPTh1R4bNVGkMcr6WH-08BAAAD_A",
+        }
+
+        with raises(ValueError):
+            self.u2f.validate_response(request, None, response)
+        assert "webauthn_authentication_state" not in request.session
+        assert "staff_webauthn_authentication_state" not in request.session

--- a/tests/sentry/auth/authenticators/test_u2f.py
+++ b/tests/sentry/auth/authenticators/test_u2f.py
@@ -69,7 +69,7 @@ class U2FInterfaceTest(TestCase):
     def test_activate_staff_webauthn(self):
         self.test_try_enroll_webauthn()
         request = self.make_request(user=self.user)
-        request.session["staff_u2f"] = True
+        request.session["staff_auth_flow"] = True
 
         result = self.u2f.activate(request)
 


### PR DESCRIPTION
Use the staff flag attached to the request session in https://github.com/getsentry/getsentry/pull/13196 to store separate U2F state variables for staff and superuser.

Also cleanup the state after validating with U2F.