### PR TITLE
ref: Let createAlertButton call useProjects()

### DIFF
--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -10,14 +10,28 @@ import CreateAlertButton, {
 } from 'sentry/components/createAlertButton';
 import GuideStore from 'sentry/stores/guideStore';
 import EventView from 'sentry/utils/discover/eventView';
+import useProjects from 'sentry/utils/useProjects';
 import {DEFAULT_EVENT_VIEW} from 'sentry/views/discover/data';
 
 const onClickMock = jest.fn();
 
+jest.mock('sentry/utils/useProjects');
 jest.mock('sentry/actionCreators/navigation');
 
 describe('CreateAlertFromViewButton', () => {
   const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    jest.mocked(useProjects).mockReturnValue({
+      projects: [],
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
+  });
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -52,16 +66,27 @@ describe('CreateAlertFromViewButton', () => {
       ...organization,
       access: [],
     };
-    const noAccessProj = {
-      ...ProjectFixture(),
-      access: [],
-    };
+    const projects = [
+      {
+        ...ProjectFixture(),
+        access: [],
+      },
+    ];
+    jest.mocked(useProjects).mockReturnValue({
+      projects,
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
 
     render(
       <CreateAlertFromViewButton
         organization={noAccessOrg}
         eventView={eventView}
-        projects={[noAccessProj]}
+        projects={projects}
         onClick={onClickMock}
       />,
       {
@@ -77,16 +102,27 @@ describe('CreateAlertFromViewButton', () => {
     const eventView = EventView.fromSavedQuery({
       ...DEFAULT_EVENT_VIEW,
     });
-    const noAccessProj = {
-      ...ProjectFixture(),
-      access: [],
-    };
+    const projects = [
+      {
+        ...ProjectFixture(),
+        access: [],
+      },
+    ];
+    jest.mocked(useProjects).mockReturnValue({
+      projects,
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
 
     render(
       <CreateAlertFromViewButton
         organization={organization}
         eventView={eventView}
-        projects={[noAccessProj]}
+        projects={projects}
         onClick={onClickMock}
       />,
       {
@@ -121,6 +157,16 @@ describe('CreateAlertFromViewButton', () => {
       },
     ];
 
+    jest.mocked(useProjects).mockReturnValue({
+      projects,
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
+
     render(
       <CreateAlertFromViewButton
         organization={noAccessOrg}
@@ -143,9 +189,16 @@ describe('CreateAlertFromViewButton', () => {
       access: [],
     };
 
-    render(<CreateAlertButton organization={noAccessOrg} showPermissionGuide />, {
-      organization: noAccessOrg,
-    });
+    render(
+      <CreateAlertButton
+        aria-label="Create Alert"
+        organization={noAccessOrg}
+        showPermissionGuide
+      />,
+      {
+        organization: noAccessOrg,
+      }
+    );
 
     expect(GuideStore.state.anchors).toEqual(new Set(['alerts_write_member']));
   });
@@ -156,15 +209,22 @@ describe('CreateAlertFromViewButton', () => {
       access: ['org:write'],
     });
 
-    render(<CreateAlertButton organization={adminAccessOrg} showPermissionGuide />, {
-      organization: adminAccessOrg,
-    });
+    render(
+      <CreateAlertButton
+        aria-label="Create Alert"
+        organization={adminAccessOrg}
+        showPermissionGuide
+      />,
+      {
+        organization: adminAccessOrg,
+      }
+    );
 
     expect(GuideStore.state.anchors).toEqual(new Set(['alerts_write_owner']));
   });
 
   it('redirects to alert wizard with no project', async () => {
-    render(<CreateAlertButton organization={organization} />, {
+    render(<CreateAlertButton aria-label="Create Alert" organization={organization} />, {
       organization,
     });
     await userEvent.click(screen.getByRole('button'));
@@ -179,9 +239,16 @@ describe('CreateAlertFromViewButton', () => {
   });
 
   it('redirects to alert wizard with a project', () => {
-    render(<CreateAlertButton organization={organization} projectSlug="proj-slug" />, {
-      organization,
-    });
+    render(
+      <CreateAlertButton
+        aria-label="Create Alert"
+        organization={organization}
+        projectSlug="proj-slug"
+      />,
+      {
+        organization,
+      }
+    );
 
     expect(screen.getByRole('button')).toHaveAttribute(
       'href',
@@ -192,6 +259,17 @@ describe('CreateAlertFromViewButton', () => {
   it('removes a duplicate project filter', async () => {
     const context = RouterContextFixture();
 
+    const projects = [ProjectFixture()];
+    jest.mocked(useProjects).mockReturnValue({
+      projects,
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
+
     const eventView = EventView.fromSavedQuery({
       ...DEFAULT_EVENT_VIEW,
       query: 'event.type:error project:project-slug',
@@ -201,7 +279,7 @@ describe('CreateAlertFromViewButton', () => {
       <CreateAlertFromViewButton
         organization={organization}
         eventView={eventView}
-        projects={[ProjectFixture()]}
+        projects={projects}
         onClick={onClickMock}
       />,
       {context}

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -15,8 +15,8 @@ import {t, tct} from 'sentry/locale';
 import type {Organization, Project} from 'sentry/types';
 import type EventView from 'sentry/utils/discover/eventView';
 import useApi from 'sentry/utils/useApi';
+import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
-import withProjects from 'sentry/utils/withProjects';
 import type {AlertType, AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {
   AlertWizardRuleTemplates,
@@ -92,7 +92,6 @@ function CreateAlertFromViewButton({
   return (
     <CreateAlertButton
       organization={organization}
-      projects={projects}
       onClick={handleClick}
       to={to}
       aria-label={t('Create Alert')}
@@ -103,7 +102,6 @@ function CreateAlertFromViewButton({
 
 type CreateAlertButtonProps = {
   organization: Organization;
-  projects: Project[];
   alertOption?: keyof typeof AlertWizardAlertNames;
   hideIcon?: boolean;
   iconProps?: SVGIconProps;
@@ -118,9 +116,8 @@ type CreateAlertButtonProps = {
   showPermissionGuide?: boolean;
 } & ButtonProps;
 
-function CreateAlertButton({
+export default function CreateAlertButton({
   organization,
-  projects,
   projectSlug,
   iconProps,
   referrer,
@@ -132,6 +129,7 @@ function CreateAlertButton({
 }: CreateAlertButtonProps) {
   const router = useRouter();
   const api = useApi();
+  const {projects} = useProjects();
   const createAlertUrl = (providedProj: string): string => {
     const params = new URLSearchParams();
     if (referrer) {
@@ -213,4 +211,3 @@ function CreateAlertButton({
 }
 
 export {CreateAlertFromViewButton};
-export default withProjects(CreateAlertButton);


### PR DESCRIPTION
Don't call `withProjects` on a functional component

Note that i didn't remove any existing ProjectsStore test setup code because that stuff could be used by downstream class-based components. Its tedious sort out whether that is the case right now or not, so for now there are 2 ways to do mocks.