### PR TITLE
ref(daily summary): Dedupe escalated/regressed issues

### DIFF
--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -208,7 +208,10 @@ def build_summary_data(
                 type__in=(ActivityType.SET_REGRESSION.value, ActivityType.SET_ESCALATING.value),
             )
 
-            deduped_groups_by_activity_type = {"regressed": set(), "escalated": set()}
+            deduped_groups_by_activity_type: dict[str, set] = {
+                "regressed": set(),
+                "escalated": set(),
+            }
             for activity in regressed_or_escalated_groups_today:
                 if activity.type == ActivityType.SET_ESCALATING.value:
                     # if a group is already in the regressed set but we now see it in escalating, remove from regressed and add to escalating

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -210,11 +210,18 @@ def build_summary_data(
 
             deduped_groups_by_activity_type = {"regressed": set(), "escalated": set()}
             for activity in regressed_or_escalated_groups_today:
-                if activity.type == ActivityType.SET_REGRESSION.value:
-                    deduped_groups_by_activity_type["regressed"].add(activity.group)
+                if activity.type == ActivityType.SET_ESCALATING.value:
+                    # if a group is already in the regressed set but we now see it in escalating, remove from regressed and add to escalating
+                    # this means the group regressed and then later escalated, and we only want to list it once
+                    if activity.group in deduped_groups_by_activity_type["regressed"]:
+                        deduped_groups_by_activity_type["regressed"].remove(activity.group)
+                    deduped_groups_by_activity_type["escalated"].add(activity.group)
                 else:
-                    if activity.type == ActivityType.SET_ESCALATING.value:
-                        deduped_groups_by_activity_type["escalated"].add(activity.group)
+                    if (
+                        activity.type == ActivityType.SET_REGRESSION.value
+                        and activity.group not in deduped_groups_by_activity_type["escalated"]
+                    ):
+                        deduped_groups_by_activity_type["regressed"].add(activity.group)
 
             if deduped_groups_by_activity_type:
                 for activity_type, groups in deduped_groups_by_activity_type.items():

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -216,7 +216,7 @@ def build_summary_data(
             for activity in regressed_or_escalated_groups_today:
                 deduped_groups_by_activity_type.setdefault(ActivityType(activity.type), set()).add(
                     activity.group
-                )  # still need to remove from regressed
+                )
 
                 if activity.type == ActivityType.SET_ESCALATING.value:
                     # if a group is already in the regressed set but we now see it in escalating, remove from regressed and add to escalating

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -208,13 +208,13 @@ def build_summary_data(
                 type__in=(ActivityType.SET_REGRESSION.value, ActivityType.SET_ESCALATING.value),
             )
 
-            deduped_groups_by_activity_type: dict[int, set] = {
-                ActivityType.SET_REGRESSION.value: set(),
-                ActivityType.SET_ESCALATING.value: set(),
+            deduped_groups_by_activity_type: dict[ActivityType, set] = {
+                ActivityType.SET_REGRESSION: set(),
+                ActivityType.SET_ESCALATING: set(),
             }
 
             for activity in regressed_or_escalated_groups_today:
-                deduped_groups_by_activity_type.setdefault(activity.type, set()).add(
+                deduped_groups_by_activity_type.setdefault(ActivityType(activity.type), set()).add(
                     activity.group
                 )  # still need to remove from regressed
 
@@ -223,9 +223,9 @@ def build_summary_data(
                     # this means the group regressed and then later escalated, and we only want to list it once
                     if (
                         activity.group
-                        in deduped_groups_by_activity_type[ActivityType.SET_REGRESSION.value]
+                        in deduped_groups_by_activity_type[ActivityType.SET_REGRESSION]
                     ):
-                        deduped_groups_by_activity_type[ActivityType.SET_REGRESSION.value].remove(
+                        deduped_groups_by_activity_type[ActivityType.SET_REGRESSION].remove(
                             activity.group
                         )
 

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -232,7 +232,7 @@ def build_summary_data(
             for activity_type, groups in deduped_groups_by_activity_type.items():
                 for group in list(groups):
                     if (
-                        activity_type == ActivityType.SET_REGRESSION.value
+                        activity_type == ActivityType.SET_REGRESSION
                         and len(project_ctx.regressed_today) < 4
                     ):
                         project_ctx.regressed_today.append(group)

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -294,6 +294,77 @@ class DailySummaryTest(
         assert project_context_map.escalated_today == [self.group3]
         assert project_context_map.regressed_today == [self.group2]
 
+    def test_build_summary_data_group_regressed_and_escalated(self):
+        """
+        Test that if a group has regressed and then escalated in the same day, we only list it once as escalating
+        """
+        self.populate_event_data()
+        Activity.objects.create_group_activity(
+            self.group2,
+            ActivityType.SET_ESCALATING,
+            data={
+                "event_id": self.group2.get_latest_event().event_id,
+                "version": self.release.version,
+            },
+        )
+        self.group2.substatus = GroupSubStatus.ESCALATING
+        self.group2.save()
+        summary = build_summary_data(
+            timestamp=to_timestamp(self.now),
+            duration=ONE_DAY,
+            organization=self.organization,
+            daily=True,
+        )
+        project_id = self.project.id
+        project_context_map = cast(
+            DailySummaryProjectContext, summary.projects_context_map[project_id]
+        )
+        assert project_context_map.escalated_today == [self.group2, self.group3]
+        assert project_context_map.regressed_today == []
+
+    def test_build_summary_data_group_regressed_twice_and_escalated(self):
+        """
+        Test that if a group has regressed, been resolved, regresssed again and then escalated in the same day, we only list it once as escalating
+        """
+        self.populate_event_data()
+        self.group2.status = GroupStatus.RESOLVED
+        self.group2.substatus = None
+        self.group2.resolved_at = self.now + timedelta(minutes=1)
+        self.group2.save()
+        Activity.objects.create_group_activity(
+            self.group2,
+            ActivityType.SET_REGRESSION,
+            data={
+                "event_id": self.group2.get_latest_event().event_id,
+                "version": self.release.version,
+            },
+        )
+        self.group2.status = GroupStatus.UNRESOLVED
+        self.group2.substatus = GroupSubStatus.REGRESSED
+        self.group2.save()
+        Activity.objects.create_group_activity(
+            self.group2,
+            ActivityType.SET_ESCALATING,
+            data={
+                "event_id": self.group2.get_latest_event().event_id,
+                "version": self.release.version,
+            },
+        )
+        self.group2.substatus = GroupSubStatus.ESCALATING
+        self.group2.save()
+        summary = build_summary_data(
+            timestamp=to_timestamp(self.now),
+            duration=ONE_DAY,
+            organization=self.organization,
+            daily=True,
+        )
+        project_id = self.project.id
+        project_context_map = cast(
+            DailySummaryProjectContext, summary.projects_context_map[project_id]
+        )
+        assert project_context_map.escalated_today == [self.group2, self.group3]
+        assert project_context_map.regressed_today == []
+
     @mock.patch("sentry.tasks.summaries.daily_summary.deliver_summary")
     def test_prepare_summary_data(self, mock_deliver_summary):
         """Test that if the summary has data in it, we pass it along to be sent"""

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -282,7 +282,7 @@ class DailySummaryTest(
             },
         )
         summary = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -310,7 +310,7 @@ class DailySummaryTest(
         self.group2.substatus = GroupSubStatus.ESCALATING
         self.group2.save()
         summary = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -353,7 +353,7 @@ class DailySummaryTest(
         self.group2.substatus = GroupSubStatus.ESCALATING
         self.group2.save()
         summary = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,


### PR DESCRIPTION
If an issue's current substatus is either escalated or regressed, but it has past activity rows that are also escalated regressed (such as if an issue is resolved, regresses, is resolved, then regresses again), it was showing up multiple times as "Issues that escalated or regressed today". This PR dedupes those entries so it only shows a group that is currently either escalating or regressed once. 