### PR TITLE
test(staff): Stop defaulting to test user being staff

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -811,7 +811,7 @@ class Factories:
             email = uuid4().hex + "@example.com"
 
         kwargs.setdefault("username", email)
-        kwargs.setdefault("is_staff", True)
+        kwargs.setdefault("is_staff", False)
         kwargs.setdefault("is_active", True)
         kwargs.setdefault("is_superuser", False)
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -806,16 +806,15 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)
-    def create_user(email=None, **kwargs):
+    def create_user(email=None, is_superuser=False, is_staff=False, is_active=True, **kwargs):
         if email is None:
             email = uuid4().hex + "@example.com"
 
         kwargs.setdefault("username", email)
-        kwargs.setdefault("is_staff", False)
-        kwargs.setdefault("is_active", True)
-        kwargs.setdefault("is_superuser", False)
 
-        user = User(email=email, **kwargs)
+        user = User(
+            email=email, is_superuser=is_superuser, is_staff=is_staff, is_active=is_active, **kwargs
+        )
         if kwargs.get("password") is None:
             user.set_password("admin")
         user.save()

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -45,7 +45,7 @@ class Fixtures:
 
     @cached_property
     def user(self):
-        return self.create_user("admin@localhost", is_superuser=True)
+        return self.create_user("admin@localhost", is_superuser=True, is_staff=True)
 
     @cached_property
     def organization(self):

--- a/tests/sentry/api/endpoints/relocations/test_abort.py
+++ b/tests/sentry/api/endpoints/relocations/test_abort.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 from sentry.api.endpoints.relocations.abort import ERR_NOT_ABORTABLE_STATUS
-from sentry.api.exceptions import StaffRequired
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
@@ -127,9 +126,7 @@ class AbortRelocationTest(APITestCase):
     @with_feature("auth:enterprise-staff-cookie")
     def test_superuser_fails_with_flag(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.get_error_response(self.relocation.uuid, status_code=403)
-
-        assert response.data["detail"]["message"] == StaffRequired.message
+        self.get_error_response(self.relocation.uuid, status_code=403)
 
     def test_bad_no_auth(self):
         self.get_error_response(self.relocation.uuid, status_code=401)

--- a/tests/sentry/api/endpoints/relocations/test_details.py
+++ b/tests/sentry/api/endpoints/relocations/test_details.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from sentry.api.exceptions import StaffRequired
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
@@ -51,8 +50,7 @@ class GetRelocationDetailsTest(APITestCase):
     @with_feature("auth:enterprise-staff-cookie")
     def test_bad_superuser_fails_with_flag(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.get_error_response(self.relocation.uuid, status_code=403)
-        assert response.data["detail"]["message"] == StaffRequired.message
+        self.get_error_response(self.relocation.uuid, status_code=403)
 
     def test_bad_superuser_not_found(self):
         self.login_as(user=self.superuser, superuser=True)

--- a/tests/sentry/auth/test_staff.py
+++ b/tests/sentry/auth/test_staff.py
@@ -23,7 +23,6 @@ from sentry.auth.staff import (
 from sentry.auth.system import SystemToken
 from sentry.middleware.placeholder import placeholder_get_response
 from sentry.middleware.staff import StaffMiddleware
-from sentry.models.user import User
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import control_silo_test
@@ -62,6 +61,7 @@ class StaffTestCase(TestCase):
         super().setUp()
         self.current_datetime = django_timezone.now()
         self.default_token = "abcdefghijklmnog"
+        self.staff_user = self.create_user(is_staff=True)
 
     def build_request(
         self,
@@ -74,7 +74,7 @@ class StaffTestCase(TestCase):
         user=None,
     ):
         if user is None:
-            user = self.user
+            user = self.staff_user
         request = self.make_request(user=user)
         if cookie_token is not None:
             request.COOKIES[COOKIE_NAME] = signing.get_cookie_signer(
@@ -96,8 +96,7 @@ class StaffTestCase(TestCase):
         return request
 
     def test_ips(self):
-        user = User(is_staff=True)
-        request = self.make_request(user=user)
+        request = self.make_request(user=self.staff_user)
         request.META["REMOTE_ADDR"] = "10.0.0.1"
 
         # no ips = any host
@@ -114,8 +113,7 @@ class StaffTestCase(TestCase):
         assert staff.is_active is True
 
     def test_sso(self):
-        user = User(is_staff=True)
-        request = self.make_request(user=user)
+        request = self.make_request(user=self.staff_user)
 
         # no ips = any host
         staff = Staff(request)
@@ -180,15 +178,14 @@ class StaffTestCase(TestCase):
         assert staff.is_active is False
 
     def test_login_saves_session(self):
-        user = self.create_user("foo@example.com")
         request = self.make_request()
         staff = Staff(request, allowed_ips=())
-        staff.set_logged_in(user)
+        staff.set_logged_in(self.staff_user)
 
         # request.user wasn't set
         assert not staff.is_active
 
-        request.user = user
+        request.user = self.staff_user
         assert staff.is_active
 
         # See mypy issue: https://github.com/python/mypy/issues/9457
@@ -197,7 +194,7 @@ class StaffTestCase(TestCase):
         assert data["exp"] == (self.current_datetime + MAX_AGE).strftime("%s")
         assert data["idl"] == (self.current_datetime + IDLE_MAX_AGE).strftime("%s")
         assert len(data["tok"]) == 12
-        assert data["uid"] == str(user.id)
+        assert data["uid"] == str(self.staff_user.id)
 
     def test_logout_clears_session(self):
         request = self.build_request()


### PR DESCRIPTION
For the sake of testing and bugs that may slip through because a created user is implicitly a staff user, we should default to having to pass in `is_staff=True` if you want to create a user that's a staff