### PR TITLE
fix(app-start): Add process.load op to app starts spans ops

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
@@ -23,6 +23,7 @@ export const APP_START_SPANS = [
   'contentprovider.load',
   'application.load',
   'activity.load',
+  'process.load'
 ];
 
 type Props = {

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
@@ -23,7 +23,7 @@ export const APP_START_SPANS = [
   'contentprovider.load',
   'application.load',
   'activity.load',
-  'process.load'
+  'process.load',
 ];
 
 type Props = {


### PR DESCRIPTION
As done [here](https://github.com/getsentry/sentry-java/pull/3159/files#diff-33b87b32a4c1591f21a41acc23db2bc1227f84a2f04dbfbb10e0f7cc36bffd4aR36) and documented [here](https://github.com/getsentry/sentry-docs/pull/9334/files#diff-b64bdd062d62e6e1dadb6613b90a506c288621f0981ed9faf4a46855375cb350R47) there's a `process.load` span op on Android measuring the process init time.
