### PR TITLE
fix(ddm): Fix units normalization for coefficients

### DIFF
--- a/src/sentry/sentry_metrics/querying/common.py
+++ b/src/sentry/sentry_metrics/querying/common.py
@@ -1,3 +1,5 @@
+from snuba_sdk import ArithmeticOperator
+
 # Snuba can return at most 10.000 rows.
 SNUBA_QUERY_LIMIT = 10000
 # Intervals in seconds which are used by the product to query data.
@@ -11,3 +13,8 @@ DEFAULT_QUERY_INTERVALS = [
     60 * 5,  # 5 min
     60,  # 1 min
 ]
+# Operators in formulas that use coefficients.
+COEFFICIENT_OPERATORS = {
+    ArithmeticOperator.DIVIDE.value,
+    ArithmeticOperator.MULTIPLY.value,
+}

--- a/src/sentry/sentry_metrics/querying/visitors/query_expression.py
+++ b/src/sentry/sentry_metrics/querying/visitors/query_expression.py
@@ -19,7 +19,6 @@ from sentry.sentry_metrics.querying.units import (
 from sentry.sentry_metrics.querying.visitors.base import (
     QueryConditionVisitor,
     QueryExpressionVisitor,
-    TVisited,
 )
 from sentry.snuba.metrics import parse_mri
 
@@ -402,7 +401,7 @@ class NumericScalarsNormalizationVisitor(QueryExpressionVisitor[QueryExpression]
     def __init__(self, unit: Unit):
         self._unit = unit
 
-    def _visit_formula(self, formula: Formula) -> TVisited:
+    def _visit_formula(self, formula: Formula) -> QueryExpression:
         has_coefficient_operators = formula.function_name in COEFFICIENT_OPERATORS
 
         # In case the formula has a coefficient operator with all scalars, we want to scale the entire formula by

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -1533,7 +1533,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert meta[0][1]["scaling_factor"] is None
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    def test_query_with_basic_formula_and_unitless_formula_functions(self):
+    def test_query_with_basic_formula_and_coefficient_operators(self):
         mri_1 = "d:custom/page_load@nanosecond"
         mri_2 = "d:custom/load_time@microsecond"
         for mri, value in ((mri_1, 20), (mri_2, 15)):
@@ -1556,6 +1556,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             ("$query_2 * 2", 30000.0, UnitFamily.DURATION.value, "nanosecond"),
             ("$query_1 / 2", 10.0, UnitFamily.DURATION.value, "nanosecond"),
             ("$query_2 / 2", 7500.0, UnitFamily.DURATION.value, "nanosecond"),
+            ("$query_2 * (2 + 1)", 45000.0, UnitFamily.DURATION.value, "nanosecond"),
         ):
             query_1 = self.mql("avg", mri_1)
             query_2 = self.mql("sum", mri_2)

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -1349,6 +1349,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         for formula, expected_result, expected_unit_family in (
             # (($query_2 * 1000) + 10000.0)
             ("($query_2 + 10)", 30000.0, UnitFamily.DURATION.value),
+            # (($query_2 * 1000) + (10 * 2) * 1000)
+            ("($query_2 + (10 * 2))", 40000.0, UnitFamily.DURATION.value),
             # (10000.0 + ($query_2 * 1000))
             ("(10 + $query_2)", 30000.0, UnitFamily.DURATION.value),
             # (($query_2 + 1000) + (10000.0 + 20000.0))
@@ -1551,7 +1553,9 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             ("$query_1 * $query_2 + 25", 325.0, None, None),
             ("$query_1 * $query_2 / 1", 300.0, None, None),
             ("$query_1 * 2", 40.0, UnitFamily.DURATION.value, "nanosecond"),
+            ("$query_2 * 2", 30000.0, UnitFamily.DURATION.value, "nanosecond"),
             ("$query_1 / 2", 10.0, UnitFamily.DURATION.value, "nanosecond"),
+            ("$query_2 / 2", 7500.0, UnitFamily.DURATION.value, "nanosecond"),
         ):
             query_1 = self.mql("avg", mri_1)
             query_2 = self.mql("sum", mri_2)


### PR DESCRIPTION
This PR fixes a small problem in the previous normalization algorithm which was naively scaling all scalars irrespectively of the operator. For example, it would scale `a * 2` as `a * 1000 * 2 * 1000` which is wrong. With this PR we are scaling correctly only when needed.

The PR handles more complex cases like `a + (10 * 2)` if `a` is scaled by `1000`, the algorithm will compute the scaling as `a * 1000 + (10 * 2) * 1000`. If on the other hand the expression is `a + (10 + 2)` the algorithm will compute the scaling as `a * 1000 + (10 * 1000 + 2 * 1000)`. This is following the correct algebra semantics.

Closes: https://github.com/getsentry/sentry/issues/66578