### PR TITLE
Hook up Rust Enhancers to `assemble_stacktrace_component`

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -63,7 +63,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.2
 sentry-kafka-schemas>=0.1.61
-sentry-ophio==0.1.5
+sentry-ophio==0.2.3
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.49
 sentry-sdk>=1.40.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -178,7 +178,7 @@ sentry-devenv==1.2.3
 sentry-forked-django-stubs==4.2.7.post3
 sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.61
-sentry-ophio==0.1.5
+sentry-ophio==0.2.3
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.49
 sentry-sdk==1.40.6

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -120,7 +120,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.2
 sentry-kafka-schemas==0.1.61
-sentry-ophio==0.1.5
+sentry-ophio==0.2.3
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.49
 sentry-sdk==1.40.6

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -175,9 +175,7 @@ def parse_rust_enhancements(
 
 RustAssembleResult = tuple[bool | None, str | None, bool, list[RustComponent]]
 RustEnhancedFrames = list[tuple[str | None, bool | None]]
-RustExceptionData = dict[
-    str, Any
-]  # FIXME: the typing upstream in `ophio` are wrong. this should be `dict[str, bytes|None]`
+RustExceptionData = dict[str, bytes | None]
 
 
 def make_rust_exception_data(
@@ -263,7 +261,7 @@ def assemble_rust_components(
                 is_prefix_frame=c.is_prefix_frame or False,
                 is_sentinel_frame=c.is_sentinel_frame or False,
                 contributes=c.contributes,
-            )  # type: ignore # FIXME: upstream `ophio` types are wrong
+            )
             for c in components
         ]
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -16,9 +16,11 @@ from parsimonious.exceptions import ParseError
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import NodeVisitor
 from sentry_ophio.enhancers import Cache as RustCache
+from sentry_ophio.enhancers import Component as RustComponent
 from sentry_ophio.enhancers import Enhancements as RustEnhancements
 
 from sentry import projectoptions
+from sentry.features.rollout import in_random_rollout
 from sentry.grouping.component import GroupingComponent
 from sentry.stacktraces.functions import set_in_app
 from sentry.utils import metrics
@@ -96,7 +98,7 @@ LATEST_VERSION = VERSIONS[-1]
 
 class StacktraceState:
     def __init__(self):
-        self.vars = {"max-frames": 0, "min-frames": 0, "invert-stacktrace": 0}
+        self.vars = {"max-frames": 0, "min-frames": 0, "invert-stacktrace": False}
         self.setters = {}
 
     def set(self, var, value, rule=None):
@@ -171,7 +173,27 @@ def parse_rust_enhancements(
     return rust_enhancements
 
 
+RustAssembleResult = tuple[bool | None, str | None, bool, list[RustComponent]]
 RustEnhancedFrames = list[tuple[str | None, bool | None]]
+RustExceptionData = dict[
+    str, Any
+]  # FIXME: the typing upstream in `ophio` are wrong. this should be `dict[str, bytes|None]`
+
+
+def make_rust_exception_data(
+    exception_data: dict[str, Any],
+) -> RustExceptionData:
+    e = exception_data or {}
+    e = {
+        "ty": e.get("type"),
+        "value": e.get("value"),
+        "mechanism": get_path(e, "mechanism", "type"),
+    }
+    for key in e.keys():
+        value = e[key]
+        if isinstance(value, str):
+            e[key] = value.encode("utf-8")
+    return e
 
 
 def apply_rust_enhancements(
@@ -188,19 +210,8 @@ def apply_rust_enhancements(
         return None
 
     try:
-        e = exception_data or {}
-        e = {
-            "ty": e.get("type"),
-            "value": e.get("value"),
-            "mechanism": get_path(e, "mechanism", "type"),
-        }
-        for key in e.keys():
-            value = e[key]
-            if isinstance(value, str):
-                e[key] = value.encode("utf-8")
-
         rust_enhanced_frames = rust_enhancements.apply_modifications_to_frames(
-            iter(match_frames), e
+            match_frames, make_rust_exception_data(exception_data)
         )
         metrics.incr("rust_enhancements.modifications_run")
         return rust_enhanced_frames
@@ -226,6 +237,85 @@ def compare_rust_enhancers(
                 scope.set_extra("python_frames", python_frames)
                 scope.set_extra("rust_enhanced_frames", rust_enhanced_frames)
                 sentry_sdk.capture_message("Rust Enhancements mismatch")
+
+
+def assemble_rust_components(
+    rust_enhancements: RustEnhancements | None,
+    match_frames: list[dict[str, bytes]],
+    exception_data: dict[str, Any],
+    components: list[GroupingComponent],
+) -> RustAssembleResult | None:
+    """
+    If `RustEnhancements` were successfully parsed and usage is enabled,
+    this will update all the frame `components` contributions.
+
+    This primarily means updating the `contributes`, `hint` as well as other attributes
+    of each frames `GroupingComponent`.
+    Instead of modifying the input `components` directly, the results are returned
+    as a list of `RustComponent`.
+    """
+    if not rust_enhancements:
+        return None
+
+    try:
+        rust_components = [
+            RustComponent(
+                is_prefix_frame=c.is_prefix_frame or False,
+                is_sentinel_frame=c.is_sentinel_frame or False,
+                contributes=c.contributes,
+            )  # type: ignore # FIXME: upstream `ophio` types are wrong
+            for c in components
+        ]
+
+        rust_results = rust_enhancements.assemble_stacktrace_component(
+            match_frames, make_rust_exception_data(exception_data), rust_components
+        )
+
+        return (
+            rust_results.contributes,
+            rust_results.hint,
+            rust_results.invert_stacktrace,
+            rust_components,
+        )
+    except Exception:
+        logger.exception("failed running Rust Enhancements component contributions")
+        return None
+
+
+def compare_rust_components(
+    component: GroupingComponent,
+    invert_stacktrace: bool,
+    rust_results: RustAssembleResult | None,
+    frames: Sequence[dict[str, Any]],
+):
+    """
+    Compares the results of `rust_results` with the component modifications
+    applied by Python code directly to `components`.
+
+    This will log an internal error on every mismatch.
+    """
+    if not rust_results:
+        return
+
+    contributes, hint, invert, rust_components_ = rust_results
+
+    python_components = [
+        (c.contributes, c.is_prefix_frame, c.is_sentinel_frame) for c in component.values
+    ]
+    rust_components = [
+        (c.contributes, c.is_prefix_frame, c.is_sentinel_frame) for c in rust_components_
+    ]
+
+    python_res = (component.contributes, component.hint, invert_stacktrace, python_components)
+    rust_res = (contributes, hint, invert, rust_components)
+
+    if python_res != rust_res:
+        with sentry_sdk.push_scope() as scope:
+            scope.set_extra("python_res", python_res)
+            scope.set_extra("rust_res", rust_res)
+            scope.set_extra("frames", frames)
+
+            sentry_sdk.capture_message("Rust Enhancements mismatch")
 
 
 class Enhancements:
@@ -314,12 +404,11 @@ class Enhancements:
 
         compare_rust_enhancers(frames, rust_enhanced_frames)
 
-    def update_frame_components_contributions(self, components, frames, platform, exception_data):
-        in_memory_cache: dict[str, str] = {}
-
-        match_frames = [create_match_frame(frame, platform) for frame in frames]
-
+    def update_frame_components_contributions(
+        self, components, frames, match_frames, platform, exception_data
+    ):
         stacktrace_state = StacktraceState()
+        in_memory_cache: dict[str, str] = {}
         # Apply direct frame actions and update the stack state alongside
         for rule in self._updater_rules:
             for idx, action in rule.get_matching_frame_actions(
@@ -360,10 +449,18 @@ class Enhancements:
         Internally this invokes the `update_frame_components_contributions` method
         but also handles cases where the entire stacktrace should be discarded.
         """
+        match_frames = [create_match_frame(frame, platform) for frame in frames]
+
+        rust_results = None
+        if in_random_rollout("grouping.rust_enhancers.compare_components"):
+            rust_results = assemble_rust_components(
+                self.rust_enhancements, match_frames, exception_data, components
+            )
+
         hint = None
         contributes = None
         stacktrace_state = self.update_frame_components_contributions(
-            components, frames, platform, exception_data
+            components, frames, match_frames, platform, exception_data
         )
 
         min_frames = stacktrace_state.get("min-frames")
@@ -378,12 +475,14 @@ class Enhancements:
                 hint = stacktrace_state.add_to_hint(hint, var="min-frames")
                 contributes = False
 
-        inverted_hierarchy = stacktrace_state.get("invert-stacktrace")
+        invert_stacktrace = stacktrace_state.get("invert-stacktrace")
         component = GroupingComponent(
             id="stacktrace", values=components, hint=hint, contributes=contributes, **kw
         )
 
-        return component, inverted_hierarchy
+        compare_rust_components(component, invert_stacktrace, rust_results, frames)
+
+        return component, invert_stacktrace
 
     def as_dict(self, with_rules=False):
         rv = {

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2059,6 +2059,13 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Rate at which to run the Rust implementation of `assemble_stacktrace_component`
+# and compare the results
+register(
+    "grouping.rust_enhancers.compare_components",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Rate to move from outbox based webhook delivery to webhookpayload.
 register(
     "hybridcloud.webhookpayload.rollout",

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -8,6 +8,7 @@ from sentry.grouping.component import GroupingComponent
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.enhancer.matchers import create_match_frame
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -30,7 +31,6 @@ def dump_obj(obj):
 
 
 @pytest.mark.parametrize("version", [1, 2])
-@django_db_all
 def test_basic_parsing(insta_snapshot, version):
     enhancement = Enhancements.from_config_string(
         """
@@ -463,6 +463,8 @@ def test_range_matching_direct():
 
 @pytest.mark.parametrize("action", ["+", "-"])
 @pytest.mark.parametrize("type", ["prefix", "sentinel"])
+@django_db_all  # because of `options` usage
+@override_options({"grouping.rust_enhancers.compare_components": 1.0})
 def test_sentinel_and_prefix(action, type):
     enhancements = Enhancements.from_config_string(f"function:foo {action}{type}")
 

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -2,6 +2,7 @@ import pytest
 
 from sentry.grouping.api import get_default_grouping_config_dict
 from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
+from sentry.testutils.pytest.fixtures import django_db_all
 from tests.sentry.grouping import with_fingerprint_input
 
 GROUPING_CONFIG = get_default_grouping_config_dict()
@@ -158,6 +159,7 @@ app:true                                        -> {{ default }}
 
 
 @with_fingerprint_input("input")
+@django_db_all  # because of `options` usage
 def test_event_hash_variant(insta_snapshot, input):
     config, evt = input.create_event()
 

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -10,6 +10,8 @@ from sentry.grouping.api import (
 )
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
 from tests.sentry.grouping import with_grouping_input
 
@@ -59,6 +61,8 @@ def dump_variant(variant, lines=None, indent=0):
 
 @with_grouping_input("grouping_input")
 @pytest.mark.parametrize("config_name", CONFIGURATIONS.keys(), ids=lambda x: x.replace("-", "_"))
+@django_db_all  # because of `options` usage
+@override_options({"grouping.rust_enhancers.compare_components": 1.0})
 def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
     grouping_config = get_default_grouping_config_dict(config_name)
     evt = grouping_input.create_event(grouping_config)


### PR DESCRIPTION
The code is gated behind a random rollout option and runs in comparison mode at first.
A second rollout option will be added to fully use the results from Rust code later on.