### PR TITLE
feat(bucket-encoding): Split options for sets and distributions

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -843,7 +843,8 @@ register(
 # when writing to Kafka.
 #
 # Key is the metric namespace (as used by Relay) and the value is the desired encoding.
-register("relay.metric-bucket-encodings", default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("relay.metric-bucket-set-encodings", default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("relay.metric-bucket-distribution-encodings", default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -14,7 +14,8 @@ RELAY_OPTIONS: list[str] = [
     "relay.span-usage-metric",
     "relay.cardinality-limiter.mode",
     "relay.cardinality-limiter.error-sample-rate",
-    "relay.metric-bucket-encodings",
+    "relay.metric-bucket-set-encodings",
+    "relay.metric-bucket-distribution-encodings",
 ]
 
 

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -39,14 +39,6 @@ def test_global_config():
     config["options"]["profiling.profile_metrics.unsampled_profiles.platforms"] = ["fake-platform"]
     config["options"]["profiling.profile_metrics.unsampled_profiles.sample_rate"] = 1.0
 
-    config["options"]["relay.metric-bucket-encodings"] = {
-        "sessions": "array",
-        "transactions": "array",
-        "spans": "array",
-        "custom": "array",
-        "profiles": "array",
-        "unsupported": "array",
-    }
     config["options"]["relay.span-usage-metric"] = True
     config["options"]["relay.cardinality-limiter.mode"] = "passive"
 


### PR DESCRIPTION
Relay PR: https://github.com/getsentry/relay/pull/3218

Renaming the option is fine, Relay will fall back to the safe default until updated. Furthermore the option is only used for testing in S4S currently.