### PR TITLE
fix(webvitals): Remove FID from performance score breakdown chart tooltip when there is no data

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
@@ -12,6 +12,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   ORDER,
   ORDER_WITH_INP,
+  ORDER_WITH_INP_WITHOUT_FID,
 } from 'sentry/views/performance/browser/webVitals/performanceScoreChart';
 import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/calculatePerformanceScore';
 import type {WebVitalsScoreBreakdown} from 'sentry/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsTimeseriesQuery';
@@ -91,7 +92,15 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
   const period = pageFilters.selection.datetime.period;
   const performanceScoreSubtext = (period && DEFAULT_RELATIVE_PERIODS[period]) ?? '';
 
-  const chartSeriesOrder = shouldReplaceFidWithInp ? ORDER_WITH_INP : ORDER;
+  const hasFid =
+    timeseriesData?.fid?.find(({value}) => value > 0) !== undefined ||
+    preMigrationTimeseriesData?.fid?.find(({value}) => value > 0) !== undefined;
+
+  const chartSeriesOrder = shouldReplaceFidWithInp
+    ? hasFid
+      ? ORDER_WITH_INP
+      : ORDER_WITH_INP_WITHOUT_FID
+    : ORDER;
 
   const preMigrationWeightedTimeseries = formatTimeSeriesResultsToChartData(
     preMigrationTimeseriesData,

--- a/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
+++ b/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
@@ -26,6 +26,7 @@ type Props = {
 
 export const ORDER = ['lcp', 'fcp', 'fid', 'cls', 'ttfb'];
 export const ORDER_WITH_INP = ['lcp', 'fcp', 'inp', 'cls', 'ttfb', 'fid'];
+export const ORDER_WITH_INP_WITHOUT_FID = ['lcp', 'fcp', 'inp', 'cls', 'ttfb'];
 
 export function PerformanceScoreChart({
   projectScore,


### PR DESCRIPTION
 If FID isnt present on the score breakdown chart, remove it from the series and tooltips.