### PR TITLE
fix(ui) Add option to allow authentication failures

### DIFF
--- a/static/app/actionCreators/organizations.spec.tsx
+++ b/static/app/actionCreators/organizations.spec.tsx
@@ -1,3 +1,4 @@
+import {browserHistory} from 'react-router';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {fetchOrganizations} from 'sentry/actionCreators/organizations';
@@ -41,5 +42,39 @@ describe('fetchOrganizations', function () {
     expect(organizations).toHaveLength(2);
     expect(usMock).toHaveBeenCalledTimes(1);
     expect(deMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores 401 errors from a region', async function () {
+    ConfigStore.set('regions', [
+      {name: 'us', url: 'https://us.example.org'},
+      {name: 'de', url: 'https://de.example.org'},
+    ]);
+    const usMock = MockApiClient.addMockResponse({
+      url: '/organizations/',
+      body: [usorg],
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.host === 'https://us.example.org';
+        },
+      ],
+    });
+    const deMock = MockApiClient.addMockResponse({
+      url: '/organizations/',
+      body: {detail: 'Authentication credentials required'},
+      status: 401,
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.host === 'https://de.example.org';
+        },
+      ],
+    });
+
+    const organizations = await fetchOrganizations(api);
+
+    expect(organizations).toHaveLength(2);
+    expect(usMock).toHaveBeenCalledTimes(1);
+    expect(deMock).toHaveBeenCalledTimes(1);
+    expect(window.location.reload).not.toHaveBeenCalled();
+    expect(browserHistory.replace).not.toHaveBeenCalled();
   });
 });

--- a/static/app/actionCreators/organizations.spec.tsx
+++ b/static/app/actionCreators/organizations.spec.tsx
@@ -71,7 +71,8 @@ describe('fetchOrganizations', function () {
 
     const organizations = await fetchOrganizations(api);
 
-    expect(organizations).toHaveLength(2);
+    expect(organizations).toHaveLength(1);
+    expect(organizations[0].slug).toEqual(usorg.slug);
     expect(usMock).toHaveBeenCalledTimes(1);
     expect(deMock).toHaveBeenCalledTimes(1);
     expect(window.location.reload).not.toHaveBeenCalled();

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -225,5 +225,10 @@ export async function fetchOrganizations(api: Client, query?: Record<string, any
       })
     )
   );
-  return results.reduce((acc, response) => acc.concat(response), []);
+  return results.reduce((acc, response) => {
+    if (response[0]) {
+      acc = acc.concat(response);
+    }
+    return acc;
+  }, []);
 }

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -221,11 +221,13 @@ export async function fetchOrganizations(api: Client, query?: Record<string, any
       api.requestPromise(`/organizations/`, {
         host: region.url,
         query,
+        // Authentication errors can happen as we span regions.
         allowAuthError: true,
       })
     )
   );
   return results.reduce((acc, response) => {
+    // Don't append error results to the org list.
     if (response[0]) {
       acc = acc.concat(response);
     }

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -221,6 +221,7 @@ export async function fetchOrganizations(api: Client, query?: Record<string, any
       api.requestPromise(`/organizations/`, {
         host: region.url,
         query,
+        allowAuthError: true,
       })
     )
   );

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -126,16 +126,20 @@ const ALLOWED_ANON_PAGES = [
 /**
  * Return true if we should skip calling the normal error handler
  */
-const globalErrorHandlers: ((resp: ResponseMeta) => boolean)[] = [];
+const globalErrorHandlers: ((resp: ResponseMeta, options: RequestOptions) => boolean)[] =
+  [];
 
 export const initApiClientErrorHandling = () =>
-  globalErrorHandlers.push((resp: ResponseMeta) => {
+  globalErrorHandlers.push((resp: ResponseMeta, options: RequestOptions) => {
     const pageAllowsAnon = ALLOWED_ANON_PAGES.find(regex =>
       regex.test(window.location.pathname)
     );
 
     // Ignore error unless it is a 401
     if (!resp || resp.status !== 401 || pageAllowsAnon) {
+      return false;
+    }
+    if (resp && options.allowAuthError && resp.status === 401) {
       return false;
     }
 
@@ -251,6 +255,11 @@ export type RequestCallbacks = {
 };
 
 export type RequestOptions = RequestCallbacks & {
+  /**
+   * Set true, if an authentication required error is allowed for
+   * a request.
+   */
+  allowAuthError?: boolean;
   /**
    * Values to attach to the body of the request.
    */
@@ -529,7 +538,7 @@ export class Client {
           const {status, statusText} = response;
           let {ok} = response;
           let errorReason = 'Request not OK'; // the default error reason
-          let twoHundredErrorReason;
+          let twoHundredErrorReason: string | undefined;
 
           // Try to get text out of the response no matter the status
           try {
@@ -617,8 +626,9 @@ export class Client {
             }
 
             const shouldSkipErrorHandler =
-              globalErrorHandlers.map(handler => handler(responseMeta)).filter(Boolean)
-                .length > 0;
+              globalErrorHandlers
+                .map(handler => handler(responseMeta, options))
+                .filter(Boolean).length > 0;
 
             if (!shouldSkipErrorHandler) {
               errorHandler(responseMeta, statusText, errorReason);


### PR DESCRIPTION
When loading an organization list from various regions, and in other scenarios we don't want to reload the page on authentication errors as it can create a reload loop.