### PR TITLE
fix(hybridcloud) Use the current region if available during provisioning

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -232,7 +232,7 @@ class OrganizationIndexEndpoint(Endpoint):
                 )
 
                 rpc_org = organization_provisioning_service.provision_organization_in_region(
-                    region_name=settings.SENTRY_MONOLITH_REGION,
+                    region_name=settings.SENTRY_REGION or settings.SENTRY_MONOLITH_REGION,
                     provisioning_options=provision_args,
                 )
                 org = Organization.objects.get(id=rpc_org.id)

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -4,9 +4,12 @@ import re
 from typing import Any
 from unittest.mock import patch
 
+from django.test import override_settings
+
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.models.authenticator import Authenticator
 from sentry.models.organization import Organization, OrganizationStatus
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team
@@ -14,7 +17,7 @@ from sentry.silo import SiloMode
 from sentry.slug.patterns import ORG_SLUG_PATTERN
 from sentry.testutils.cases import APITestCase, TwoFactorAPITestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, create_test_regions, region_silo_test
 
 
 class OrganizationIndexTest(APITestCase):
@@ -273,6 +276,27 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
             organization_id=response.data["id"], user_id=self.user.id
         )
         self.assert_org_member_mapping(org_member=org_member)
+
+
+@region_silo_test(regions=create_test_regions("de", "us"))
+class OrganizationsCreateInRegionTest(OrganizationIndexTest, HybridCloudTestMixin):
+    method = "post"
+
+    @override_settings(SENTRY_MONOLITH_REGION="us", SENTRY_REGION="de")
+    def test_success(self):
+        data = {"name": "hello world", "slug": "slug-world"}
+        response = self.get_success_response(**data)
+
+        organization_id = response.data["id"]
+        org = Organization.objects.get(id=organization_id)
+        assert org.name == "hello world"
+        owners = [owner.id for owner in org.get_owners()]
+        assert [self.user.id] == owners
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            mapping = OrganizationMapping.objects.get(organization_id=organization_id)
+        assert mapping
+        assert mapping.region_name == "de"
 
 
 @region_silo_test


### PR DESCRIPTION
When starting the organization create process in a region silo, we should use the current region name instead of monolith region as not all regions are the former monolith region.