### PR TITLE
chore(sdk): Bump `sentry-sdk` to 1.40.6

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ sentry-kafka-schemas>=0.1.58
 sentry-ophio==0.1.5
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.49
-sentry-sdk>=1.39.2
+sentry-sdk>=1.40.6
 snuba-sdk>=2.0.29
 simplejson>=3.17.6
 sqlparse>=0.4.4

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -181,7 +181,7 @@ sentry-kafka-schemas==0.1.58
 sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.49
-sentry-sdk==1.39.2
+sentry-sdk==1.40.6
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ sentry-kafka-schemas==0.1.58
 sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.49
-sentry-sdk==1.39.2
+sentry-sdk==1.40.6
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
https://github.com/getsentry/sentry-python/releases/tag/1.40.6 has a fix for query sources I want to try out. I see there are some 2.0.0 experiments going on, though, does this interfere?