### PR TITLE
chore(auditlog) Add more context to audit logs missing actors

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -100,8 +100,9 @@ class AuditLogEntry(Model):
                     "Expected a user or actor key for audit log",
                     extra={
                         "event": self.event,
+                        "organization_id": self.organization_id,
+                        "event_data": self.data,
                     },
-                    stack_info=True,
                 )
                 # Fallback to IP address if user or actor label not available
                 self.actor_label = self.ip_address


### PR DESCRIPTION
I think that these log messages may be coming from scim provisioning but I'd like to confirm that before removing the error log.