### PR TITLE
fix(metrics): Remap builtin span MRI

### DIFF
--- a/static/app/utils/metrics/mri.spec.tsx
+++ b/static/app/utils/metrics/mri.spec.tsx
@@ -24,7 +24,7 @@ describe('parseMRI', () => {
     }
   );
 
-  it.each(['transactions', 'custom'])(
+  it.each(['spans', 'transactions', 'custom'])(
     'should correctly parse a valid MRI string - use case %s',
     useCase => {
       const mri: MRI = `c:${useCase as UseCase}/xyz@test`;
@@ -38,7 +38,7 @@ describe('parseMRI', () => {
     }
   );
 
-  it.each(['sessions', 'spans'])(
+  it.each(['sessions'])(
     'should correctly parse a valid MRI string - use case %s',
     useCase => {
       const mri: MRI = `c:${useCase as UseCase}/xyz@test`;

--- a/static/app/utils/metrics/mri.spec.tsx
+++ b/static/app/utils/metrics/mri.spec.tsx
@@ -79,6 +79,14 @@ describe('parseMRI', () => {
       expect(parseMRI(mri)).toEqual(parsedMRI);
     }
   );
+
+  it.each([
+    ['d:transactions/duration@millisecond', 'transaction.duration'],
+    ['d:spans/duration@millisecond', 'span.duration'],
+    ['d:spans/exclusive_time@millisecond', 'span.self_time'],
+  ])('should remap certain mri names', (mri, name) => {
+    expect(parseMRI(mri)?.name).toEqual(name);
+  });
 });
 
 describe('getUseCaseFromMRI', () => {

--- a/static/app/utils/metrics/mri.tsx
+++ b/static/app/utils/metrics/mri.tsx
@@ -48,6 +48,14 @@ function parseName(name: string, useCase: UseCase): string {
     }
     return name;
   }
+  if (useCase === 'spans') {
+    if (name === 'exclusive_time') {
+      return 'span.self_time';
+    }
+    if (name === 'duration') {
+      return 'span.duration';
+    }
+  }
   return `${useCase}.${name}`;
 }
 

--- a/static/app/utils/metrics/mri.tsx
+++ b/static/app/utils/metrics/mri.tsx
@@ -55,6 +55,7 @@ function parseName(name: string, useCase: UseCase): string {
     if (name === 'duration') {
       return 'span.duration';
     }
+    return name;
   }
   return `${useCase}.${name}`;
 }


### PR DESCRIPTION
For consistency sake, we should use self time everywhere and not exclusive time even though they're the same thing.