### PR TITLE
ref: Let functional components call useProjects() & useOrganization()

### DIFF
--- a/static/app/views/performance/transactionEvents.spec.tsx
+++ b/static/app/views/performance/transactionEvents.spec.tsx
@@ -2,11 +2,16 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {WebVital} from 'sentry/utils/fields';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import TransactionEvents from 'sentry/views/performance/transactionSummary/transactionEvents';
+
+jest.mock('sentry/utils/useOrganization');
+jest.mock('sentry/utils/useProjects');
 
 // XXX(epurkhiser): This appears to also be tested by ./transactionSummary/transactionEvents/index.spec.tsx
 
@@ -159,8 +164,18 @@ describe('Performance > TransactionSummary', function () {
     const {organization, router, routerContext} = initializeData();
 
     ProjectsStore.loadInitialData(organization.projects);
+    jest.mocked(useOrganization).mockReturnValue(organization);
+    jest.mocked(useProjects).mockReturnValue({
+      projects: organization.projects,
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
 
-    render(<TransactionEvents organization={organization} location={router.location} />, {
+    render(<TransactionEvents location={router.location} />, {
       context: routerContext,
     });
 
@@ -193,10 +208,22 @@ describe('Performance > TransactionSummary', function () {
     const {organization, router, routerContext} = initializeData();
 
     ProjectsStore.loadInitialData(organization.projects);
+    jest.mocked(useOrganization).mockReturnValue(organization);
+    jest.mocked(useProjects).mockReturnValue({
+      projects: organization.projects,
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
 
-    render(<TransactionEvents organization={organization} location={router.location} />, {
+    render(<TransactionEvents location={router.location} />, {
       context: routerContext,
     });
+
+    await waitFor(() => screen.findByText('operation duration'));
 
     expect(await screen.findByText('operation duration')).toBeInTheDocument();
     expect(screen.getAllByRole('columnheader')).toHaveLength(6);
@@ -208,10 +235,22 @@ describe('Performance > TransactionSummary', function () {
     const {organization, router, routerContext} = initializeData();
 
     ProjectsStore.loadInitialData(organization.projects);
+    jest.mocked(useOrganization).mockReturnValue(organization);
+    jest.mocked(useProjects).mockReturnValue({
+      projects: organization.projects,
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
 
-    render(<TransactionEvents organization={organization} location={router.location} />, {
+    render(<TransactionEvents location={router.location} />, {
       context: routerContext,
     });
+
+    await waitFor(() => screen.findAllByRole('columnheader'));
 
     const tableHeader = await screen.findAllByRole('columnheader');
     expect(tableHeader).toHaveLength(6);
@@ -239,8 +278,18 @@ describe('Performance > TransactionSummary', function () {
     });
 
     ProjectsStore.loadInitialData(organization.projects);
+    jest.mocked(useOrganization).mockReturnValue(organization);
+    jest.mocked(useProjects).mockReturnValue({
+      projects: organization.projects,
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
 
-    render(<TransactionEvents organization={organization} location={router.location} />, {
+    render(<TransactionEvents location={router.location} />, {
       context: routerContext,
     });
 

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
@@ -7,8 +7,8 @@ import {t, tn} from 'sentry/locale';
 import type {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import type EventView from 'sentry/utils/discover/eventView';
+import useProjects from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
-import withProjects from 'sentry/utils/withProjects';
 
 type BaseProps = {
   organization: Organization;
@@ -77,15 +77,14 @@ function TeamKeyTransactionButton({
 
 type WrapperProps = BaseProps & {
   eventView: EventView;
-  projects: Project[];
 };
 
-function TeamKeyTransactionButtonWrapper({
+export default function TeamKeyTransactionButtonWrapper({
   eventView,
   organization,
-  projects,
   ...props
 }: WrapperProps) {
+  const {projects} = useProjects();
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
 
   if (eventView.project.length !== 1) {
@@ -127,5 +126,3 @@ function TeamKeyTransactionButtonWrapper({
     </TeamKeyTransactionManager.Provider>
   );
 }
-
-export default withProjects(TeamKeyTransactionButtonWrapper);

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/index.tsx
@@ -1,10 +1,9 @@
 import type {Location} from 'history';
 
 import {t} from 'sentry/locale';
-import type {Organization, Project} from 'sentry/types';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 
 import PageLayout from '../pageLayout';
 import Tab from '../tabs';
@@ -14,12 +13,11 @@ import {generateAnomaliesEventView} from './utils';
 
 type Props = {
   location: Location;
-  organization: Organization;
-  projects: Project[];
 };
 
-function TransactionAnomalies(props: Props) {
-  const {location, organization, projects} = props;
+export default function TransactionAnomalies({location}: Props) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
 
   return (
     <MEPSettingProvider>
@@ -46,5 +44,3 @@ function getDocumentTitle(transactionName: string): string {
 
   return [t('Summary'), t('Performance')].join(' - ');
 }
-
-export default withProjects(withOrganization(TransactionAnomalies));

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -11,7 +11,10 @@ import {
   SPAN_OP_BREAKDOWN_FIELDS,
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'sentry/utils/discover/fields';
+import useOrganization from 'sentry/utils/useOrganization';
 import EventsTable from 'sentry/views/performance/transactionSummary/transactionEvents/eventsTable';
+
+jest.mock('sentry/utils/useOrganization');
 
 type Data = {
   features?: string[];
@@ -93,6 +96,7 @@ describe('Performance GridEditable Table', function () {
   ];
   let fields = EVENTS_TABLE_RESPONSE_FIELDS;
   const organization = OrganizationFixture();
+  jest.mocked(useOrganization).mockReturnValue(organization);
   const transactionName = 'transactionName';
   let data;
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
@@ -6,17 +6,19 @@ import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import TransactionEvents from 'sentry/views/performance/transactionSummary/transactionEvents';
 
 import {EVENTS_TABLE_RESPONSE_FIELDS, MOCK_EVENTS_TABLE_DATA} from './eventsTable.spec';
 
+jest.mock('sentry/utils/useOrganization');
+jest.mock('sentry/utils/useProjects');
+
 function WrappedComponent({data}) {
   return (
     <MEPSettingProvider>
-      <TransactionEvents
-        organization={data.organization}
-        location={data.router.location}
-      />
+      <TransactionEvents location={data.router.location} />
     </MEPSettingProvider>
   );
 }
@@ -132,6 +134,16 @@ const initializeData = (settings?: InitializeDataSettings) => {
   };
   const data = _initializeData(settings);
   act(() => void ProjectsStore.loadInitialData(data.organization.projects));
+  jest.mocked(useOrganization).mockReturnValue(data.organization);
+  jest.mocked(useProjects).mockReturnValue({
+    projects: data.organization.projects,
+    onSearch: jest.fn(),
+    placeholders: [],
+    fetching: false,
+    hasMore: null,
+    fetchError: null,
+    initiallyLoaded: false,
+  });
   return data;
 };
 
@@ -164,10 +176,10 @@ describe('Performance > Transaction Summary > Transaction Events > Index', () =>
     const data = initializeData();
 
     render(<WrappedComponent data={data} />, {context: data.routerContext});
+
     const percentileButton = await screen.findByRole('button', {
       name: /percentile p100/i,
     });
-
     await userEvent.click(percentileButton);
 
     const p50 = screen.getByRole('option', {name: 'p50'});

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -4,7 +4,7 @@ import type {Location} from 'history';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
-import type {Organization, Project} from 'sentry/types';
+import type {Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -17,8 +17,8 @@ import {WebVital} from 'sentry/utils/fields';
 import {removeHistogramQueryStrings} from 'sentry/utils/performance/histogram';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 
 import {
   decodeFilterFromLocation,
@@ -44,12 +44,11 @@ type PercentileValues = Record<EventsDisplayFilterName, number>;
 
 type Props = {
   location: Location;
-  organization: Organization;
-  projects: Project[];
 };
 
-function TransactionEvents(props: Props) {
-  const {location, organization, projects} = props;
+export default function TransactionEvents({location}: Props) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
 
   return (
     <PageLayout
@@ -268,5 +267,3 @@ function generateEventView({
     location
   );
 }
-
-export default withProjects(withOrganization(TransactionEvents));

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -19,7 +19,7 @@ import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization, Project} from 'sentry/types';
+import type {Organization} from 'sentry/types';
 import {defined, generateQueryWithTag} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
@@ -34,8 +34,8 @@ import type {MetricsEnhancedPerformanceDataContext} from 'sentry/utils/performan
 import {useMEPDataContext} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {decodeScalar} from 'sentry/utils/queryString';
 import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
+import useProjects from 'sentry/utils/useProjects';
 import {useRoutes} from 'sentry/utils/useRoutes';
-import withProjects from 'sentry/utils/withProjects';
 import type {Actions} from 'sentry/views/discover/table/cellAction';
 import {updateQuery} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
@@ -81,20 +81,18 @@ type Props = {
   onChangeFilter: (newFilter: SpanOperationBreakdownFilter) => void;
   organization: Organization;
   projectId: string;
-  projects: Project[];
   spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
   totalValues: Record<string, number> | null;
   transactionName: string;
   unfilteredTotalValues?: Record<string, number> | null;
 };
 
-function SummaryContent({
+export default function SummaryContent({
   eventView,
   location,
   totalValues,
   spanOperationBreakdownFilter,
   organization,
-  projects,
   isLoading,
   error,
   projectId,
@@ -104,6 +102,7 @@ function SummaryContent({
 }: Props) {
   const routes = useRoutes();
   const mepDataContext = useMEPDataContext();
+  const {projects} = useProjects();
 
   function handleSearch(query: string) {
     const queryParams = normalizeDateTimeParams({
@@ -600,5 +599,3 @@ const StyledSearchBar = styled(SearchBar)`
 const StyledIconWarning = styled(IconWarning)`
   display: block;
 `;
-
-export default withProjects(SummaryContent);

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -5,7 +5,7 @@ import type {Location} from 'history';
 import {loadOrganizationTags} from 'sentry/actionCreators/tags';
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import {t} from 'sentry/locale';
-import type {Organization, PageFilters, Project} from 'sentry/types';
+import type {Organization, PageFilters} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -25,9 +25,9 @@ import {removeHistogramQueryStrings} from 'sentry/utils/performance/histogram';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
-import withOrganization from 'sentry/utils/withOrganization';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import withPageFilters from 'sentry/utils/withPageFilters';
-import withProjects from 'sentry/utils/withProjects';
 import {
   getTransactionMEPParamsIfApplicable,
   getUnfilteredTotalsEventView,
@@ -56,15 +56,13 @@ type TotalValues = Record<string, number>;
 
 type Props = {
   location: Location;
-  organization: Organization;
-  projects: Project[];
   selection: PageFilters;
 };
 
-function TransactionOverview(props: Props) {
+function TransactionOverview({location, selection}: Props) {
   const api = useApi();
-
-  const {location, selection, organization, projects} = props;
+  const organization = useOrganization();
+  const {projects} = useProjects();
 
   useEffect(() => {
     loadOrganizationTags(api, organization.slug, selection);
@@ -341,4 +339,4 @@ function getTotalsEventView(
   ]);
 }
 
-export default withPageFilters(withProjects(withOrganization(TransactionOverview)));
+export default withPageFilters(TransactionOverview);

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.tsx
@@ -1,9 +1,8 @@
 import type {Location} from 'history';
 
 import {t} from 'sentry/locale';
-import type {Organization, Project} from 'sentry/types';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 
 import PageLayout from '../pageLayout';
 import Tab from '../tabs';
@@ -13,13 +12,11 @@ import {generateSpansEventView} from './utils';
 
 type Props = {
   location: Location;
-  organization: Organization;
-  projects: Project[];
 };
 
-function TransactionSpans(props: Props) {
-  const {location, organization, projects} = props;
-
+export default function TransactionSpans({location}: Props) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
   return (
     <PageLayout
       location={location}
@@ -43,5 +40,3 @@ function getDocumentTitle(transactionName: string): string {
 
   return [t('Summary'), t('Performance')].join(' - ');
 }
-
-export default withProjects(withOrganization(TransactionSpans));

--- a/static/app/views/performance/transactionSummary/transactionTags/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.tsx
@@ -1,12 +1,11 @@
 import type {Location} from 'history';
 
 import {t} from 'sentry/locale';
-import type {Organization, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 
 import PageLayout from '../pageLayout';
 import Tab from '../tabs';
@@ -15,12 +14,11 @@ import TagsPageContent from './content';
 
 type Props = {
   location: Location;
-  organization: Organization;
-  projects: Project[];
 };
 
-function TransactionTags(props: Props) {
-  const {location, organization, projects} = props;
+export default function TransactionTags({location}: Props) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
 
   return (
     <PageLayout
@@ -73,5 +71,3 @@ function generateEventView({
 
   return eventView;
 }
-
-export default withProjects(withOrganization(TransactionTags));

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
@@ -68,7 +68,7 @@ function WrappedComponent({
 }) {
   return (
     <OrganizationContext.Provider value={organization}>
-      <TransactionVitals location={location} organization={organization} />
+      <TransactionVitals location={location} />
     </OrganizationContext.Provider>
   );
 }

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
@@ -1,15 +1,14 @@
 import type {Location} from 'history';
 
 import {t} from 'sentry/locale';
-import type {Organization, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {isAggregateField} from 'sentry/utils/discover/fields';
 import type {WebVital} from 'sentry/utils/fields';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 
 import PageLayout from '../pageLayout';
 import Tab from '../tabs';
@@ -19,12 +18,11 @@ import VitalsContent from './content';
 
 type Props = {
   location: Location;
-  organization: Organization;
-  projects: Project[];
 };
 
-function TransactionVitals(props: Props) {
-  const {location, organization, projects} = props;
+export default function TransactionVitals({location}: Props) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
 
   return (
     <PageLayout
@@ -91,5 +89,3 @@ function generateEventView({
     location
   );
 }
-
-export default withProjects(withOrganization(TransactionVitals));

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -33,8 +33,8 @@ import TrendsDiscoverQuery from 'sentry/utils/performance/trends/trendsDiscoverQ
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import {
   DisplayModes,
   transactionSummaryRouteWithQuery,
@@ -67,8 +67,6 @@ import {
 
 type Props = {
   location: Location;
-  organization: Organization;
-  projects: Project[];
   setError: (msg: string | undefined) => void;
   trendChangeType: TrendChangeType;
   trendView: TrendView;
@@ -206,18 +204,18 @@ function handleFilterDuration(
   });
 }
 
-function ChangedTransactions(props: Props) {
+export default function ChangedTransactions(props: Props) {
   const {
     location,
     trendChangeType,
     previousTrendFunction,
     previousTrendColumn,
-    organization,
-    projects,
     setError,
     withBreakpoint,
   } = props;
   const api = useApi();
+  const organization = useOrganization();
+  const {projects} = useProjects();
 
   const {isLoading: isCardinalityCheckLoading, outcome} = useMetricsCardinalityContext();
 
@@ -306,6 +304,8 @@ function ChangedTransactions(props: Props) {
                           statsPeriod={trendView.statsPeriod}
                           transaction={selectedTransaction}
                           isLoading={isLoading}
+                          projects={projects}
+                          organization={organization}
                           {...props}
                         />
                       </ChartContainer>
@@ -742,5 +742,3 @@ const TooltipContent = styled('div')`
 const StyledIconArrow = styled(IconArrow)`
   margin: 0 ${space(1)};
 `;
-
-export default withProjects(withOrganization(ChangedTransactions));

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -19,6 +19,8 @@ import {
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {WebVital} from 'sentry/utils/fields';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import TrendsIndex from 'sentry/views/performance/trends/';
 import {defaultTrendsSelectionDate} from 'sentry/views/performance/trends/content';
 import {
@@ -26,6 +28,9 @@ import {
   TRENDS_FUNCTIONS,
   TRENDS_PARAMETERS,
 } from 'sentry/views/performance/trends/utils';
+
+jest.mock('sentry/utils/useOrganization');
+jest.mock('sentry/utils/useProjects');
 
 const trendsViewQuery = {
   query: `tpm():>0.01 transaction.duration:>0 transaction.duration:<${DEFAULT_MAX_DURATION}`,
@@ -111,6 +116,15 @@ function _initializeData(
   }
 
   act(() => ProjectsStore.loadInitialData(data.projects));
+  jest.mocked(useProjects).mockReturnValue({
+    projects: data.projects,
+    onSearch: jest.fn(),
+    placeholders: [],
+    fetching: false,
+    hasMore: null,
+    fetchError: null,
+    initiallyLoaded: false,
+  });
   return data;
 }
 
@@ -148,6 +162,16 @@ function initializeTrendsData(
   });
 
   act(() => ProjectsStore.loadInitialData(initialData.organization.projects));
+  jest.mocked(useOrganization).mockReturnValue(initialData.organization);
+  jest.mocked(useProjects).mockReturnValue({
+    projects: initialData.organization.projects,
+    onSearch: jest.fn(),
+    placeholders: [],
+    fetching: false,
+    hasMore: null,
+    fetchError: null,
+    initiallyLoaded: false,
+  });
 
   return initialData;
 }

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -25,7 +25,7 @@ import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKe
 import {IconCheckmark, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization, Project} from 'sentry/types';
+import type {Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import type EventView from 'sentry/utils/discover/eventView';
@@ -34,7 +34,7 @@ import {Browser} from 'sentry/utils/performance/vitals/constants';
 import {decodeScalar} from 'sentry/utils/queryString';
 import Teams from 'sentry/utils/teams';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import withProjects from 'sentry/utils/withProjects';
+import useProjects from 'sentry/utils/useProjects';
 
 import Breadcrumb from '../breadcrumb';
 import {getTransactionSearchQuery} from '../utils';
@@ -57,7 +57,6 @@ type Props = {
   eventView: EventView;
   location: Location;
   organization: Organization;
-  projects: Project[];
   router: InjectedRouter;
   vitalName: WebVital;
 };
@@ -69,7 +68,8 @@ function getSummaryConditions(query: string) {
   return parsed.formatString();
 }
 
-function VitalDetailContent(props: Props) {
+export default function VitalDetailContent(props: Props) {
+  const {projects} = useProjects();
   const [error, setError] = useState<string | undefined>(undefined);
 
   function handleSearch(query: string) {
@@ -90,7 +90,7 @@ function VitalDetailContent(props: Props) {
   }
 
   function renderCreateAlertButton() {
-    const {eventView, organization, projects, vitalName} = props;
+    const {eventView, organization, vitalName} = props;
 
     return (
       <CreateAlertFromViewButton
@@ -173,7 +173,7 @@ function VitalDetailContent(props: Props) {
   }
 
   function renderContent(vital: WebVital) {
-    const {location, organization, eventView, projects} = props;
+    const {location, organization, eventView} = props;
 
     const {fields, start, end, statsPeriod, environment, project} = eventView;
 
@@ -297,8 +297,6 @@ function VitalDetailContent(props: Props) {
     </Fragment>
   );
 }
-
-export default withProjects(VitalDetailContent);
 
 const StyledDescription = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/projectCrumb.tsx
@@ -19,7 +19,6 @@ import {CrumbLink} from '.';
 type Props = RouteComponentProps<{projectId?: string}, {}> & {
   organization: Organization;
   project: Project;
-  projects: Project[];
 };
 
 function ProjectCrumb({

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -17,8 +17,10 @@ import {
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
 import OrganizationGeneralSettings from 'sentry/views/settings/organizationGeneralSettings';
 
+jest.mock('sentry/utils/useOrganization');
 jest.mock('sentry/utils/analytics');
 
 describe('OrganizationGeneralSettings', function () {
@@ -26,7 +28,6 @@ describe('OrganizationGeneralSettings', function () {
   const {organization, router} = initializeOrg();
 
   const defaultProps = {
-    organization,
     router,
     location: router.location,
     params: {orgId: organization.slug},
@@ -36,6 +37,7 @@ describe('OrganizationGeneralSettings', function () {
   };
 
   beforeEach(function () {
+    jest.mocked(useOrganization).mockReturnValue(organization);
     OrganizationsStore.addOrReplace(organization);
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/auth-provider/`,

--- a/static/app/views/settings/organizationGeneralSettings/index.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-import type {RouteComponentProps} from 'react-router';
-import {browserHistory} from 'react-router';
+import {browserHistory, RouteComponentProps} from 'react-router';
 
 import {addLoadingMessage} from 'sentry/actionCreators/indicator';
 import {

--- a/static/app/views/settings/organizationGeneralSettings/index.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {browserHistory, RouteComponentProps} from 'react-router';
+import {browserHistory, type RouteComponentProps} from 'react-router';
 
 import {addLoadingMessage} from 'sentry/actionCreators/indicator';
 import {


### PR DESCRIPTION
Don't call withProjects on a functional component

Note that i didn't remove any existing ProjectsStore test setup code because that stuff could be used by downstream class-based components. Its tedious sort out whether that is the case right now or not, so for now there are 2 ways to do mocks.