### PR TITLE
ref(feedback): disable js loader tooltip

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -254,6 +254,8 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
           ]}
           value={setupMode()}
           onChange={setSetupMode}
+          disabledChoices={[['jsLoader', t('Coming soon!')]]}
+          tooltipPosition={'top-start'}
         />
       ) : (
         newDocs?.platformOptions &&

--- a/static/app/components/forms/controls/radioGroup.tsx
+++ b/static/app/components/forms/controls/radioGroup.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import type {PopperProps} from 'react-popper';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
@@ -30,6 +31,7 @@ interface BaseRadioGroupProps<C extends string> {
    * Switch the radio items to flow left to right, instead of vertically.
    */
   orientInline?: boolean;
+  tooltipPosition?: PopperProps<any>['placement'];
 }
 
 /**
@@ -53,6 +55,7 @@ function RadioGroup<C extends string>({
   label,
   onChange,
   orientInline,
+  tooltipPosition,
   ...props
 }: RadioGroupProps<C>) {
   return (
@@ -77,6 +80,7 @@ function RadioGroup<C extends string>({
             key={index}
             disabled={!disabledChoiceReason}
             title={disabledChoiceReason}
+            position={tooltipPosition}
           >
             <RadioLineItem index={index} aria-checked={value === id} disabled={disabled}>
               <Radio


### PR DESCRIPTION
disabling the JS loader radio option for now, until feedback is part of the loader -- this way we can release the new onboarding but not worry about the incorrect loader snippets showing up. there's also a tooltip saying "coming soon" to explain why it's disabled

https://github.com/getsentry/sentry/assets/56095982/5bbc8f66-fda7-47b0-8b9e-2b31b3d6f10f

