### PR TITLE
feat(feedback): Clarify internal activity section

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActivitySection.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActivitySection.tsx
@@ -110,7 +110,7 @@ function FeedbackActivitySection(props: Props) {
       onCreate={handleCreate}
       onUpdate={handleUpdate}
       placeholderText={t(
-        'Add details or updates to this feedback. \nTag users with @, or teams with #'
+        'Add details or updates to this feedback, visible only to your organization. \nTag users with @, or teams with #'
       )}
     />
   );

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -99,7 +99,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
           icon={<IconChat size="xs" />}
           title={
             <Fragment>
-              {t('Internal Notes')}
+              {t('Internal Activity')}
               <QuestionTooltip
                 size="xs"
                 title={t(

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -99,7 +99,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
           icon={<IconChat size="xs" />}
           title={
             <Fragment>
-              {t('Activity')}
+              {t('Internal Notes')}
               <QuestionTooltip
                 size="xs"
                 title={t(


### PR DESCRIPTION
This is to address a misunderstanding where someone mistakenly thought that posting comments in here would get sent back out to the user. We should be clear that this is an internal comment system... if/when we have public replies or something like that, it should be very clear that information will be sent out.

Updated section title and placeholder text in the textarea:
<img width="732" alt="SCR-20240308-kpmf" src="https://github.com/getsentry/sentry/assets/187460/c1422299-506b-452c-83b8-87025663e9c6">

