### PR TITLE
ref(notification-actions): remove updating the count of notif actions

### DIFF
--- a/static/app/components/notificationActions/notificationActionManager.spec.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.spec.tsx
@@ -78,7 +78,6 @@ describe('Adds, deletes, and updates notification actions', function () {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={notificationActions}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -117,7 +116,6 @@ describe('Adds, deletes, and updates notification actions', function () {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -169,7 +167,6 @@ describe('Adds, deletes, and updates notification actions', function () {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[0]]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -194,7 +191,6 @@ describe('Adds, deletes, and updates notification actions', function () {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -243,7 +239,6 @@ describe('Adds, deletes, and updates notification actions', function () {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[1]]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -281,7 +276,6 @@ describe('Adds, deletes, and updates notification actions', function () {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[1]]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -392,7 +386,6 @@ describe('Adds, deletes, and updates notification actions', function () {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[2]]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -434,7 +427,6 @@ describe('Adds, deletes, and updates notification actions', function () {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}
@@ -497,7 +489,6 @@ describe('Adds, deletes, and updates notification actions', function () {
     });
     render(
       <NotificationActionManager
-        updateAlertCount={jest.fn()}
         actions={[notificationActions[3]]}
         availableActions={availableActions}
         recipientRoles={['owner', 'manager']}

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -29,15 +29,15 @@ type NotificationActionManagerProps = {
    * TODO(enterprise): refactor to account for multiple projects
    */
   project: Project;
-  /**
-   * Updates the notification alert count for this project
-   */
-  updateAlertCount: (projectId: number, alertCount: number) => void;
   disabled?: boolean;
   /**
    * Optional list of roles to display as recipients of Sentry notifications
    */
   recipientRoles?: string[];
+  /**
+   * Updates the notification alert count for this project
+   */
+  updateAlertCount?: (projectId: number, alertCount: number) => void;
 };
 
 function NotificationActionManager({
@@ -45,7 +45,6 @@ function NotificationActionManager({
   availableActions,
   recipientRoles,
   project,
-  updateAlertCount = () => {},
   disabled = false,
 }: NotificationActionManagerProps) {
   const [notificationActions, setNotificationActions] =
@@ -56,7 +55,6 @@ function NotificationActionManager({
     const updatedActions = [...notificationActions];
     updatedActions.splice(index, 1);
     setNotificationActions(updatedActions);
-    updateAlertCount(parseInt(project.id, 10), updatedActions.length);
   };
 
   const updateNotificationAction = (index: number, updatedAction: NotificationAction) => {
@@ -207,12 +205,11 @@ function NotificationActionManager({
           // Add notification action
           const updatedActions = [...notificationActions, validActions[0].action];
           setNotificationActions(updatedActions);
-          updateAlertCount(parseInt(project.id, 10), updatedActions.length);
         },
       });
     });
     return dropdownMenuItems;
-  }, [actionsMap, availableServices, notificationActions, project, updateAlertCount]);
+  }, [actionsMap, availableServices, notificationActions]);
 
   let toolTipText: undefined | string = undefined;
   if (disabled) {


### PR DESCRIPTION
Remove requiring the function that will update the count of notification actions. We are removing this capability entirely, but since the use of this component is in getsentry, we need to make it optional in sentry first.