### PR TITLE
ref(integration): Break apart commonality

### DIFF
--- a/src/sentry/integrations/repository/metric_alert.py
+++ b/src/sentry/integrations/repository/metric_alert.py
@@ -5,7 +5,11 @@ from logging import Logger, getLogger
 
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import Incident
-from sentry.integrations.repository.base import BaseNewNotificationMessage, BaseNotificationMessage
+from sentry.integrations.repository.base import (
+    BaseNewNotificationMessage,
+    BaseNotificationMessage,
+    NotificationMessageValidationError,
+)
 from sentry.models.notificationmessage import NotificationMessage
 
 _default_logger: Logger = getLogger(__name__)
@@ -13,7 +17,9 @@ _default_logger: Logger = getLogger(__name__)
 
 @dataclass(frozen=True)
 class MetricAlertNotificationMessage(BaseNotificationMessage):
+    # TODO(Yash): do we really need this entire model, or can we whittle it down to what we need?
     incident: Incident | None = None
+    # TODO(Yash): do we really need this entire model, or can we whittle it down to what we need?
     trigger_action: AlertRuleTriggerAction | None = None
 
     @classmethod
@@ -34,18 +40,12 @@ class MetricAlertNotificationMessage(BaseNotificationMessage):
         )
 
 
-class NewMetricAlertNotificationMessageValidationError(Exception):
+class NewMetricAlertNotificationMessageValidationError(NotificationMessageValidationError):
     pass
 
 
 class IncidentAndTriggerActionValidationError(NewMetricAlertNotificationMessageValidationError):
     message = "both incident and trigger action need to exist together with a reference"
-
-
-class MessageIdentifierWithErrorValidationError(NewMetricAlertNotificationMessageValidationError):
-    message = (
-        "cannot create a new notification message with message identifier when an error exists"
-    )
 
 
 @dataclass
@@ -54,25 +54,19 @@ class NewMetricAlertNotificationMessage(BaseNewNotificationMessage):
     trigger_action_id: int | None = None
 
     def get_validation_error(self) -> Exception | None:
-        """
-        Helper method for getting any potential validation errors based on the state of the data.
-        There are particular restrictions about the various fields, and this is to help the user check before
-        trying to instantiate a new instance in the datastore.
-        """
-        if self.message_identifier is not None:
-            if self.error_code is not None or self.error_details is not None:
-                return MessageIdentifierWithErrorValidationError()
+        error = super().get_validation_error()
+        if error is not None:
+            return error
 
+        if self.message_identifier is not None:
+            # If a message_identifier exists, that means a successful notification happened for an incident and trigger
+            # This means that neither of them can be empty
             if self.incident_id is None or self.trigger_action_id is None:
                 return IncidentAndTriggerActionValidationError()
 
-        incident_exists_without_trigger = (
-            self.incident_id is not None and self.trigger_action_id is None
-        )
-        trigger_exists_without_incident = (
-            self.incident_id is None and self.trigger_action_id is not None
-        )
-        if incident_exists_without_trigger or trigger_exists_without_incident:
+        # We can create a NotificationMessage if it has both, or neither, of incident and trigger.
+        # The following is an XNOR check for incident and trigger
+        if (self.incident_id is not None) != (self.trigger_action_id is not None):
             return IncidentAndTriggerActionValidationError()
 
         return None

--- a/tests/sentry/integrations/repository/base/test_base_new_notification_message.py
+++ b/tests/sentry/integrations/repository/base/test_base_new_notification_message.py
@@ -1,0 +1,44 @@
+import pytest
+
+from sentry.integrations.repository.base import (
+    BaseNewNotificationMessage,
+    MessageIdentifierWithErrorValidationError,
+)
+
+
+class TestGetValidationError:
+    @classmethod
+    def _raises_error_for_obj(
+        cls, obj: BaseNewNotificationMessage, expected_error: type[Exception]
+    ) -> None:
+        error = obj.get_validation_error()
+        assert error is not None
+        with pytest.raises(expected_error):
+            raise error
+
+    def test_returns_error_when_message_identifier_has_error_code(self) -> None:
+        obj = BaseNewNotificationMessage(
+            message_identifier="abc",
+            error_code=400,
+        )
+        self._raises_error_for_obj(obj, MessageIdentifierWithErrorValidationError)
+
+    def test_returns_error_when_message_identifier_has_error_details(self) -> None:
+        obj = BaseNewNotificationMessage(
+            message_identifier="abc",
+            error_details={"some_key": 123},
+        )
+        self._raises_error_for_obj(obj, MessageIdentifierWithErrorValidationError)
+
+    def test_returns_error_when_message_identifier_has_error(self) -> None:
+        obj = BaseNewNotificationMessage(
+            message_identifier="abc",
+            error_code=400,
+            error_details={"some_key": 123},
+        )
+        self._raises_error_for_obj(obj, MessageIdentifierWithErrorValidationError)
+
+    def test_simple(self) -> None:
+        obj = BaseNewNotificationMessage()
+        error = obj.get_validation_error()
+        assert error is None

--- a/tests/sentry/integrations/repository/metric_alert/test_new_metric_alert_notification_message.py
+++ b/tests/sentry/integrations/repository/metric_alert/test_new_metric_alert_notification_message.py
@@ -1,8 +1,8 @@
 import pytest
 
+from sentry.integrations.repository.base import MessageIdentifierWithErrorValidationError
 from sentry.integrations.repository.metric_alert import (
     IncidentAndTriggerActionValidationError,
-    MessageIdentifierWithErrorValidationError,
     NewMetricAlertNotificationMessage,
 )
 


### PR DESCRIPTION
Break apart common code that will be leveraged for new work. There is some common logic between metric and issue alerts, so consolidating and testing that code will make it easier to work with for future iterations.
