### PR TITLE
feat(integration): Expand Issue Alert notification

### DIFF
--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -12,7 +12,7 @@ _default_logger: Logger = getLogger(__name__)
 
 @dataclass(frozen=True)
 class IssueAlertNotificationMessage(BaseNotificationMessage):
-    # TODO(Yash): do we really need this entire model, or can we whittle it down to what we need?
+    # TODO: https://github.com/getsentry/sentry/issues/66751
     rule_fire_history: RuleFireHistory | None = None
     rule_action_uuid: str | None = None
 

--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -1,10 +1,37 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from logging import Logger, getLogger
 
+from sentry.integrations.repository.base import BaseNotificationMessage
 from sentry.models.notificationmessage import NotificationMessage
+from sentry.models.rulefirehistory import RuleFireHistory
 
 _default_logger: Logger = getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class IssueAlertNotificationMessage(BaseNotificationMessage):
+    # TODO(Yash): do we really need this entire model, or can we whittle it down to what we need?
+    rule_fire_history: RuleFireHistory | None = None
+    rule_action_uuid: str | None = None
+
+    @classmethod
+    def from_model(cls, instance: NotificationMessage) -> IssueAlertNotificationMessage:
+        return IssueAlertNotificationMessage(
+            id=instance.id,
+            error_code=instance.error_code,
+            error_details=instance.error_details,
+            message_identifier=instance.message_identifier,
+            parent_notification_message_id=(
+                instance.parent_notification_message.id
+                if instance.parent_notification_message
+                else None
+            ),
+            rule_fire_history=instance.rule_fire_history,
+            rule_action_uuid=instance.rule_action_uuid,
+            date_added=instance.date_added,
+        )
 
 
 class IssueAlertNotificationMessageRepository:
@@ -21,3 +48,33 @@ class IssueAlertNotificationMessageRepository:
     @classmethod
     def default(cls) -> IssueAlertNotificationMessageRepository:
         return cls(logger=_default_logger)
+
+    def get_parent_notification_message(
+        self, rule_id: int, group_id: int, rule_action_uuid: str
+    ) -> IssueAlertNotificationMessage | None:
+        """
+        Returns the parent notification message for a metric rule if it exists, otherwise returns None.
+        Will raise an exception if the query fails and logs the error with associated data.
+        """
+        try:
+            instance: NotificationMessage = self._model.objects.get(
+                rule_fire_history__rule__id=rule_id,
+                rule_fire_history__group__id=group_id,
+                rule_action_uuid=rule_action_uuid,
+                parent_notification_message__isnull=True,
+                error_code__isnull=True,
+            )
+            return IssueAlertNotificationMessage.from_model(instance=instance)
+        except NotificationMessage.DoesNotExist:
+            return None
+        except Exception as e:
+            self._logger.exception(
+                "Failed to get parent notification for issue rule",
+                exc_info=e,
+                extra={
+                    "rule_id": rule_id,
+                    "group_id": group_id,
+                    "rule_action_uuid": rule_action_uuid,
+                },
+            )
+            raise

--- a/src/sentry/integrations/repository/metric_alert.py
+++ b/src/sentry/integrations/repository/metric_alert.py
@@ -17,9 +17,9 @@ _default_logger: Logger = getLogger(__name__)
 
 @dataclass(frozen=True)
 class MetricAlertNotificationMessage(BaseNotificationMessage):
-    # TODO(Yash): do we really need this entire model, or can we whittle it down to what we need?
+    # TODO: https://github.com/getsentry/sentry/issues/66751
     incident: Incident | None = None
-    # TODO(Yash): do we really need this entire model, or can we whittle it down to what we need?
+    # TODO: https://github.com/getsentry/sentry/issues/66751
     trigger_action: AlertRuleTriggerAction | None = None
 
     @classmethod

--- a/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
+++ b/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
@@ -1,0 +1,78 @@
+from uuid import uuid4
+
+from sentry.integrations.repository.issue_alert import (
+    IssueAlertNotificationMessage,
+    IssueAlertNotificationMessageRepository,
+)
+from sentry.models.notificationmessage import NotificationMessage
+from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.testutils.cases import TestCase
+
+
+class TestGetParentNotificationMessage(TestCase):
+    def setUp(self) -> None:
+        self.action_uuid = str(uuid4())
+        self.rule = self.create_project_rule(
+            project=self.project,
+            action_match=[
+                {
+                    "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+                    "service": "mail",
+                    "name": "Send a notification via mail",
+                    "uuid": self.action_uuid,
+                },
+            ],
+        )
+        self.rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.rule,
+            group=self.group,
+        )
+        self.parent_notification_message = NotificationMessage.objects.create(
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=self.action_uuid,
+            message_identifier="123abc",
+        )
+        self.repository = IssueAlertNotificationMessageRepository.default()
+
+    def test_returns_parent_notification_message(self) -> None:
+        instance = self.repository.get_parent_notification_message(
+            rule_id=self.rule.id,
+            group_id=self.group.id,
+            rule_action_uuid=self.action_uuid,
+        )
+
+        assert instance is not None
+        assert instance == IssueAlertNotificationMessage.from_model(
+            self.parent_notification_message
+        )
+
+    def test_returns_none_when_filter_does_not_exist(self) -> None:
+        instance = self.repository.get_parent_notification_message(
+            rule_id=9999,
+            group_id=self.group.id,
+            rule_action_uuid=self.action_uuid,
+        )
+
+        assert instance is None
+
+    def test_when_parent_has_child(self) -> None:
+        child = NotificationMessage.objects.create(
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=self.action_uuid,
+            message_identifier="456abc",
+            parent_notification_message=self.parent_notification_message,
+        )
+
+        assert child.id != self.parent_notification_message.id
+
+        instance = self.repository.get_parent_notification_message(
+            rule_id=self.rule.id,
+            group_id=self.group.id,
+            rule_action_uuid=self.action_uuid,
+        )
+
+        assert instance is not None
+        assert instance == IssueAlertNotificationMessage.from_model(
+            self.parent_notification_message
+        )


### PR DESCRIPTION
For Issue Alert notification messages, we need to be able to retrieve the parent message such that we can create a thread. Added logic to help achieve that query and flow, along with some tests.

Requires: https://github.com/getsentry/sentry/pull/66623
