### PR TITLE
feat(metrics): Correctly expose the supported MRIs

### DIFF
--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -13,9 +13,10 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   isAllowedOp,
   isCustomMetric,
-  isMeasurement,
-  isSpanMetric,
+  isSpanMeasurement,
+  isSpanSelfTime,
   isTransactionDuration,
+  isTransactionMeasurement,
 } from 'sentry/utils/metrics';
 import {getReadableMetricType} from 'sentry/utils/metrics/formatters';
 import {formatMRI} from 'sentry/utils/metrics/mri';
@@ -35,11 +36,16 @@ type QueryBuilderProps = {
   projects: number[];
 };
 
+const isVisibleTransactionMetric = (metric: MetricMeta) =>
+  isTransactionDuration(metric) || isTransactionMeasurement(metric);
+
+const isVisibleSpanMetric = (metric: MetricMeta) =>
+  isSpanSelfTime(metric) || isSpanMeasurement(metric);
+
 const isShownByDefault = (metric: MetricMeta) =>
   isCustomMetric(metric) ||
-  isTransactionDuration(metric) ||
-  isMeasurement(metric) ||
-  isSpanMetric(metric);
+  isVisibleTransactionMetric(metric) ||
+  isVisibleSpanMetric(metric);
 
 function getOpsForMRI(mri: MRI, meta: MetricMeta[]) {
   return meta.find(metric => metric.mri === mri)?.operations.filter(isAllowedOp) ?? [];


### PR DESCRIPTION
The set of MRIs available in the drop down was not quite correct as some of them were internal while others should've been exposed. The full list has now been updated to include the following
- `d:transactions/duration@millisecond`
- all transaction measurements
- `d:spans/exclusive_time@millisecond`
- some span measurements (they don't follow the usual measurement naming)
- all custom spans