### PR TITLE
fix(issues): Truncate Slow DB Query evidence

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import MutableMapping
 from typing import Any, cast
 
-import sentry_sdk
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from arroyo.types import Message, Value
@@ -73,18 +72,15 @@ def produce_occurrence_to_kafka(
 
     try:
         _occurrence_producer.produce(ArroyoTopic(settings.KAFKA_INGEST_OCCURRENCES), payload)
-    except KafkaException as e:
-        with sentry_sdk.push_scope() as scope:
-            scope.set_context(
-                "Occurrence",
-                {
-                    "id": payload_data["id"],
-                    "type": payload_data["type"],
-                    "issue_title": payload_data["issue_title"],
-                },
-            )
-
-            sentry_sdk.capture_exception(e)
+    except KafkaException:
+        logger.exception(
+            "Failed to send occurrence to issue platform",
+            extra={
+                "id": payload_data["id"],
+                "type": payload_data["type"],
+                "issue_title": payload_data["issue_title"],
+            },
+        )
 
 
 def _prepare_occurrence_message(

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 from collections.abc import MutableMapping
 from typing import Any, cast
 
@@ -74,14 +73,7 @@ def produce_occurrence_to_kafka(
     try:
         _occurrence_producer.produce(ArroyoTopic(settings.KAFKA_INGEST_OCCURRENCES), payload)
     except KafkaException:
-        logger.exception(
-            "Failed to send occurrence to issue platform",
-            extra={
-                "total_payload_size": sys.getsizeof(payload),
-                "total_payload_data_size": sys.getsizeof(payload_data),
-                "payload_data_key_sizes": {k: sys.getsizeof(v) for k, v in payload_data.items()},
-            },
-        )
+        logger.exception("Failed to send occurrence to issue platform")
 
 
 def _prepare_occurrence_message(

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import MutableMapping
 from typing import Any, cast
 
+import sentry_sdk
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
 from arroyo.types import Message, Value
@@ -72,8 +73,18 @@ def produce_occurrence_to_kafka(
 
     try:
         _occurrence_producer.produce(ArroyoTopic(settings.KAFKA_INGEST_OCCURRENCES), payload)
-    except KafkaException:
-        logger.exception("Failed to send occurrence to issue platform")
+    except KafkaException as e:
+        with sentry_sdk.push_scope() as scope:
+            scope.set_context(
+                "Occurrence",
+                {
+                    "id": payload_data["id"],
+                    "type": payload_data["type"],
+                    "issue_title": payload_data["issue_title"],
+                },
+            )
+
+            sentry_sdk.capture_exception(e)
 
 
 def _prepare_occurrence_message(

--- a/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
@@ -20,6 +20,12 @@ from ..base import (
 from ..performance_problem import PerformanceProblem
 from ..types import Span
 
+# Truncating the evidence to prevent hitting Kafka's broken message size limit.
+#  A better solution would be to audit the usage of `description`,
+#  `evidence_data` and `evidence_display` and deduplicate those keys. Right now
+#  they are nearly identical
+MAX_EVIDENCE_VALUE_LENGTH = 10_000
+
 
 class SlowDBQueryDetector(PerformanceDetector):
     """
@@ -64,7 +70,7 @@ class SlowDBQueryDetector(PerformanceDetector):
                 type=type,
                 fingerprint=self._fingerprint(hash),
                 op=op,
-                desc=description,
+                desc=description[:MAX_EVIDENCE_VALUE_LENGTH],
                 cause_span_ids=[],
                 parent_span_ids=[],
                 offender_span_ids=spans_involved,
@@ -74,8 +80,10 @@ class SlowDBQueryDetector(PerformanceDetector):
                     "parent_span_ids": [],
                     "offender_span_ids": spans_involved,
                     "transaction_name": self._event.get("description", ""),
-                    "repeating_spans": get_span_evidence_value(span),
-                    "repeating_spans_compact": get_span_evidence_value(span, include_op=False),
+                    "repeating_spans": get_span_evidence_value(span)[:MAX_EVIDENCE_VALUE_LENGTH],
+                    "repeating_spans_compact": get_span_evidence_value(span, include_op=False)[
+                        :MAX_EVIDENCE_VALUE_LENGTH
+                    ],
                     "num_repeating_spans": str(len(spans_involved)),
                 },
                 evidence_display=[
@@ -84,7 +92,7 @@ class SlowDBQueryDetector(PerformanceDetector):
                         value=get_notification_attachment_body(
                             op,
                             description,
-                        ),
+                        )[:MAX_EVIDENCE_VALUE_LENGTH],
                         # Has to be marked important to be displayed in the notifications
                         important=True,
                     )


### PR DESCRIPTION
Should help with #inc-670 (see [S4S](https://sentry.my.sentry.io/organizations/sentry/issues/692411/))

We're seeing slow queries with descriptions in the 450,000 characters (yes you read correctly). In these cases, the evidence payload runs into Kafka's broker message limit. Since 450,000 is not really a reasonable length for a query that we can show anyway, truncating to 10,000 is pretty genenerous and should help us not run into this issue. N.B. that the in-app UI does not use evidence, it looks up the _full description_ from the event payload, so it doesn't affect in-app UI, only notifications which usually truncate these values anyway.
