### PR TITLE
feat(webvitals): adds interaction target to inp span sample rows

### DIFF
--- a/static/app/views/performance/browser/webVitals/pageOverview.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.spec.tsx
@@ -123,6 +123,7 @@ describe('PageOverview', function () {
               'project',
               'browser.name',
               'span.self_time',
+              'span.description',
             ],
             query:
               'span.op:ui.interaction.click measurements.score.weight.inp:>0 origin.transaction:/',

--- a/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
@@ -9,6 +9,7 @@ import type {
   GridColumnSortBy,
 } from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
@@ -53,6 +54,11 @@ const columnOrder: GridColumnOrder[] = [
 ];
 
 const inpColumnOrder: GridColumnOrder[] = [
+  {
+    key: SpanIndexedField.SPAN_DESCRIPTION,
+    width: COL_WIDTH_UNDEFINED,
+    name: t('Interaction Target'),
+  },
   {key: 'profile.id', width: COL_WIDTH_UNDEFINED, name: t('Profile')},
   {key: 'replayId', width: COL_WIDTH_UNDEFINED, name: t('Replay')},
   {key: 'webVital', width: COL_WIDTH_UNDEFINED, name: t('Inp')},
@@ -319,6 +325,13 @@ export function PageOverviewWebVitalsDetailPanel({
         </AlignCenter>
       );
     }
+    if (key === SpanIndexedField.SPAN_DESCRIPTION) {
+      return (
+        <NoOverflow>
+          <Tooltip title={row[key]}>{row[key]}</Tooltip>
+        </NoOverflow>
+      );
+    }
     return <AlignRight>{row[key]}</AlignRight>;
   };
 
@@ -382,6 +395,7 @@ export function PageOverviewWebVitalsDetailPanel({
 const NoOverflow = styled('span')`
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const AlignRight = styled('span')<{color?: string}>`

--- a/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
+++ b/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
@@ -67,6 +67,11 @@ const PAGELOADS_COLUMN_ORDER: GridColumnOrder<keyof TransactionSampleRowWithScor
 const INTERACTION_SAMPLES_COLUMN_ORDER: GridColumnOrder<
   keyof InteractionSpanSampleRowWithScore
 >[] = [
+  {
+    key: SpanIndexedField.SPAN_DESCRIPTION,
+    width: COL_WIDTH_UNDEFINED,
+    name: t('Interaction Target'),
+  },
   {key: 'user.display', width: COL_WIDTH_UNDEFINED, name: t('User')},
   {key: SpanIndexedField.INP, width: COL_WIDTH_UNDEFINED, name: 'INP'},
   {key: 'profile.id', width: COL_WIDTH_UNDEFINED, name: t('Profile')},
@@ -371,6 +376,15 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
         </NoOverflow>
       );
     }
+
+    if (key === SpanIndexedField.SPAN_DESCRIPTION) {
+      return (
+        <NoOverflow>
+          <Tooltip title={row[key]}>{row[key]}</Tooltip>
+        </NoOverflow>
+      );
+    }
+
     return <NoOverflow>{row[key]}</NoOverflow>;
   }
 

--- a/static/app/views/performance/browser/webVitals/utils/queries/useInpSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/useInpSpanSamplesWebVitalsQuery.tsx
@@ -40,6 +40,7 @@ export function useInpSpanSamplesWebVitalsQuery({
       SpanIndexedField.PROJECT,
       SpanIndexedField.BROWSER_NAME,
       SpanIndexedField.SPAN_SELF_TIME,
+      SpanIndexedField.SPAN_DESCRIPTION,
     ],
     enabled,
     limit,

--- a/static/app/views/performance/browser/webVitals/utils/types.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/types.tsx
@@ -1,4 +1,5 @@
 import type {Sort} from 'sentry/utils/discover/fields';
+import {SpanIndexedField} from 'sentry/views/starfish/types';
 
 export type Row = {
   'count()': number;
@@ -42,13 +43,14 @@ type Score = {
 export type ScoreWithWeightsAndOpportunity = Score & Weight & Opportunity;
 
 export type InteractionSpanSampleRow = {
-  'measurements.inp': number;
+  [SpanIndexedField.INP]: number;
   'profile.id': string;
   projectSlug: string;
   replayId: string;
-  'span.op': string;
-  'span.self_time': number;
-  timestamp: string;
+  [SpanIndexedField.SPAN_DESCRIPTION]: string;
+  [SpanIndexedField.SPAN_OP]: string;
+  [SpanIndexedField.SPAN_SELF_TIME]: number;
+  [SpanIndexedField.TIMESTAMP]: string;
   'user.display': string;
 };
 


### PR DESCRIPTION
Adds the INP interaction target to INP span sample rows in the webvitals module
![image](https://github.com/getsentry/sentry/assets/83961295/b7da53f7-81f0-4012-b360-b5b1eb3be3f7)