### PR TITLE
feat(feedback): Update the feedback details ui to highlight messages in purple

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -1,4 +1,5 @@
-import {type CSSProperties, Fragment} from 'react';
+import type {CSSProperties} from 'react';
+import {Fragment} from 'react';
 
 import Button from 'sentry/components/actions/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -1,26 +1,22 @@
-import type {CSSProperties} from 'react';
+import {type CSSProperties, Fragment} from 'react';
 
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  addSuccessMessage,
-} from 'sentry/actionCreators/indicator';
 import Button from 'sentry/components/actions/button';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackAssignedTo from 'sentry/components/feedback/feedbackItem/feedbackAssignedTo';
-import useMutateFeedback from 'sentry/components/feedback/useMutateFeedback';
+import useFeedbackActions from 'sentry/components/feedback/feedbackItem/useFeedbackActions';
 import {Flex} from 'sentry/components/profiling/flex';
+import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types';
-import {GroupStatus} from 'sentry/types';
-import {trackAnalytics} from 'sentry/utils/analytics';
+import {defined} from 'sentry/utils';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
-import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
   eventData: Event | undefined;
   feedbackItem: FeedbackIssue;
+  size: 'small' | 'medium' | 'large';
   className?: string;
   style?: CSSProperties;
 }
@@ -29,73 +25,139 @@ export default function FeedbackActions({
   className,
   eventData,
   feedbackItem,
+  size,
   style,
 }: Props) {
-  const organization = useOrganization();
-  const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
-
-  const {markAsRead, resolve} = useMutateFeedback({
-    feedbackIds: [feedbackItem.id],
-    organization,
-    projectIds: [feedbackItem.project.id],
-  });
-
-  const mutationOptions = {
-    onError: () => {
-      addErrorMessage(t('An error occurred while updating the feedback.'));
-    },
-    onSuccess: () => {
-      addSuccessMessage(t('Updated feedback'));
-    },
-  };
-
-  // reuse the issues ignored category for spam feedbacks
-  const isResolved = feedbackItem.status === GroupStatus.RESOLVED;
-  const isSpam = feedbackItem.status === GroupStatus.IGNORED;
-
   return (
-    <Flex gap={space(0.5)} align="center" className={className} style={style}>
+    <Flex gap={space(1)} align="center" className={className} style={style}>
       <ErrorBoundary mini>
-        <FeedbackAssignedTo feedbackIssue={feedbackItem} feedbackEvent={eventData} />
+        <FeedbackAssignedTo
+          feedbackIssue={feedbackItem}
+          feedbackEvent={eventData}
+          showActorName={['medium', 'large'].includes(size)}
+        />
       </ErrorBoundary>
 
-      <Button
-        onClick={() => {
-          addLoadingMessage(t('Updating feedback...'));
-          markAsRead(!feedbackItem.hasSeen, mutationOptions);
-        }}
-      >
-        {feedbackItem.hasSeen ? t('Mark Unread') : t('Mark Read')}
+      {size === 'large' ? <LargeWidth feedbackItem={feedbackItem} /> : null}
+      {size === 'medium' ? <MediumWidth feedbackItem={feedbackItem} /> : null}
+      {size === 'small' ? <SmallWidth feedbackItem={feedbackItem} /> : null}
+    </Flex>
+  );
+}
+
+function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
+  const {
+    isResolved,
+    onResolveClick,
+    hasSpamFeature,
+    isSpam,
+    onSpamClick,
+    hasSeen,
+    onMarkAsReadClick,
+  } = useFeedbackActions({feedbackItem});
+
+  return (
+    <Fragment>
+      <Button priority={isResolved ? 'danger' : 'primary'} onClick={onResolveClick}>
+        {isResolved ? t('Unresolve') : t('Resolve')}
       </Button>
+
       {hasSpamFeature && (
-        <Button
-          priority="default"
-          onClick={() => {
-            addLoadingMessage(t('Updating feedback...'));
-            const newStatus = isSpam ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
-            resolve(newStatus, mutationOptions);
-            if (!isSpam) {
-              // not currently spam, clicking the button will turn it into spam
-              trackAnalytics('feedback.mark-spam-clicked', {
-                organization,
-                type: 'details',
-              });
-            }
-          }}
-        >
+        <Button priority="default" onClick={onSpamClick}>
           {isSpam ? t('Move to Inbox') : t('Mark as Spam')}
         </Button>
       )}
-      <Button
-        priority={isResolved ? 'danger' : 'primary'}
-        onClick={() => {
-          addLoadingMessage(t('Updating feedback...'));
-          const newStatus = isResolved ? GroupStatus.UNRESOLVED : GroupStatus.RESOLVED;
-          resolve(newStatus, mutationOptions);
-        }}
-      >
+
+      <Button onClick={onMarkAsReadClick}>
+        {hasSeen ? t('Mark Unread') : t('Mark Read')}
+      </Button>
+    </Fragment>
+  );
+}
+
+function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
+  const {
+    isResolved,
+    onResolveClick,
+    hasSpamFeature,
+    isSpam,
+    onSpamClick,
+    hasSeen,
+    onMarkAsReadClick,
+  } = useFeedbackActions({feedbackItem});
+
+  return (
+    <Fragment>
+      <Button priority={isResolved ? 'danger' : 'primary'} onClick={onResolveClick}>
         {isResolved ? t('Unresolve') : t('Resolve')}
       </Button>
-    </Flex>
+
+      <DropdownMenu
+        position="bottom-end"
+        triggerProps={{
+          'aria-label': t('Action Menu'),
+          icon: <IconEllipsis />,
+          showChevron: false,
+          size: 'xs',
+        }}
+        items={[
+          hasSpamFeature
+            ? {
+                key: 'spam',
+                label: isSpam ? t('Move to Inbox') : t('Mark as Spam'),
+                onAction: onSpamClick,
+              }
+            : null,
+          {
+            key: 'read',
+            label: hasSeen ? t('Mark Unread') : t('Mark Read'),
+            onAction: onMarkAsReadClick,
+          },
+        ].filter(defined)}
+      />
+    </Fragment>
+  );
+}
+
+function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
+  const {
+    isResolved,
+    onResolveClick,
+    hasSpamFeature,
+    isSpam,
+    onSpamClick,
+    hasSeen,
+    onMarkAsReadClick,
+  } = useFeedbackActions({feedbackItem});
+
+  return (
+    <DropdownMenu
+      position="bottom-end"
+      triggerProps={{
+        'aria-label': t('Action Menu'),
+        icon: <IconEllipsis />,
+        showChevron: false,
+        size: 'xs',
+      }}
+      items={[
+        {
+          key: 'resolve',
+          label: isResolved ? t('Unresolve') : t('Resolve'),
+          onAction: onResolveClick,
+        },
+        hasSpamFeature
+          ? {
+              key: 'spam',
+              label: isSpam ? t('Move to Inbox') : t('Mark as Spam'),
+              onAction: onSpamClick,
+            }
+          : null,
+        {
+          key: 'read',
+          label: hasSeen ? t('Mark Unread') : t('Mark Read'),
+          onAction: onMarkAsReadClick,
+        },
+      ].filter(defined)}
+    />
   );
 }

--- a/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
@@ -63,11 +63,15 @@ export default function FeedbackAssignedTo({
       disabled={false}
       id={feedbackIssue.id}
       assignedTo={feedbackIssue.assignedTo}
-      onAssign={() => assign(feedbackIssue.assignedTo)}
-      onClear={() => assign(null)}
+      onAssign={() => {
+        assign(feedbackIssue.assignedTo);
+      }}
+      onClear={() => {
+        assign(null);
+      }}
       owners={owners}
       group={feedbackIssue}
-      alignMenu={'left'}
+      alignMenu="left"
     >
       {({isOpen, getActorProps}) => (
         <Button size="xs" aria-label={t('Assigned dropdown')} {...getActorProps({})}>

--- a/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
@@ -1,4 +1,4 @@
-import {type ComponentProps, useEffect} from 'react';
+import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
@@ -53,25 +53,22 @@ export default function FeedbackAssignedTo({
 
   const owners = getOwnerList([], eventOwners ?? null, feedbackIssue.assignedTo);
 
-  const dropdownProps: Omit<
-    ComponentProps<typeof AssigneeSelectorDropdown>,
-    'children'
-  > = {
-    organization: organization,
-    disabled: false,
-    id: feedbackIssue.id,
-    assignedTo: feedbackIssue.assignedTo,
-    onAssign: () => assign(feedbackIssue.assignedTo),
-    onClear: () => assign(null),
-    owners: owners,
-    group: feedbackIssue,
-    alignMenu: 'left',
-  };
+  // A new `key` will make the component re-render when shwoActor changes
+  const key = showActorName ? 'showActor' : 'hideActor';
 
-  // `<AssigneeSelectorDropdown>` won't re-render when `children` change, so we need
-  // two options for when `showActorName` changes.
-  return showActorName ? (
-    <AssigneeSelectorDropdown key="showActor" {...dropdownProps}>
+  return (
+    <AssigneeSelectorDropdown
+      key={key}
+      organization={organization}
+      disabled={false}
+      id={feedbackIssue.id}
+      assignedTo={feedbackIssue.assignedTo}
+      onAssign={() => assign(feedbackIssue.assignedTo)}
+      onClear={() => assign(null)}
+      owners={owners}
+      group={feedbackIssue}
+      alignMenu={'left'}
+    >
       {({isOpen, getActorProps}) => (
         <Button size="xs" aria-label={t('Assigned dropdown')} {...getActorProps({})}>
           <ActorWrapper>
@@ -84,28 +81,11 @@ export default function FeedbackAssignedTo({
                 size={16}
               />
             )}
-            <ActorName>
-              {getAssignedToDisplayName(feedbackIssue) ?? t('Unassigned')}
-            </ActorName>
-            <IconChevron direction={isOpen ? 'up' : 'down'} size="sm" />
-          </ActorWrapper>
-        </Button>
-      )}
-    </AssigneeSelectorDropdown>
-  ) : (
-    <AssigneeSelectorDropdown key="hideActor" {...dropdownProps}>
-      {({isOpen, getActorProps}) => (
-        <Button size="xs" aria-label={t('Assigned dropdown')} {...getActorProps({})}>
-          <ActorWrapper>
-            {!feedbackIssue.assignedTo ? (
-              <IconUser size="sm" />
-            ) : (
-              <ActorAvatar
-                actor={feedbackIssue.assignedTo}
-                hasTooltip={false}
-                size={16}
-              />
-            )}
+            {showActorName ? (
+              <ActorName>
+                {getAssignedToDisplayName(feedbackIssue) ?? t('Unassigned')}
+              </ActorName>
+            ) : null}
             <IconChevron direction={isOpen ? 'up' : 'down'} size="sm" />
           </ActorWrapper>
         </Button>

--- a/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
@@ -53,7 +53,7 @@ export default function FeedbackAssignedTo({
 
   const owners = getOwnerList([], eventOwners ?? null, feedbackIssue.assignedTo);
 
-  // A new `key` will make the component re-render when shwoActor changes
+  // A new `key` will make the component re-render when showActorName changes
   const key = showActorName ? 'showActor' : 'hideActor';
 
   return (

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -7,11 +7,10 @@ import FeedbackActivitySection from 'sentry/components/feedback/feedbackItem/fee
 import FeedbackItemHeader from 'sentry/components/feedback/feedbackItem/feedbackItemHeader';
 import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
 import FeedbackReplay from 'sentry/components/feedback/feedbackItem/feedbackReplay';
-import FeedbackViewers from 'sentry/components/feedback/feedbackItem/feedbackViewers';
+import MessageSection from 'sentry/components/feedback/feedbackItem/messageSection';
 import {ScreenshotSection} from 'sentry/components/feedback/feedbackItem/screenshotSection';
 import TagsSection from 'sentry/components/feedback/feedbackItem/tagsSection';
 import PanelItem from 'sentry/components/panels/panelItem';
-import {Flex} from 'sentry/components/profiling/flex';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {IconChat, IconFire, IconLink, IconPlay, IconTag} from 'sentry/icons';
@@ -41,18 +40,8 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
     <Fragment>
       <FeedbackItemHeader eventData={eventData} feedbackItem={feedbackItem} />
       <OverflowPanelItem ref={overflowRef}>
-        <Section
-          title={t('Description')}
-          contentRight={
-            <Flex gap={space(1)} align="center">
-              <SmallTitle>{t('Viewers')}</SmallTitle>
-              <FeedbackViewers feedbackItem={feedbackItem} />
-            </Flex>
-          }
-        >
-          <Blockquote>
-            <pre>{feedbackItem.metadata.message}</pre>
-          </Blockquote>
+        <Section>
+          <MessageSection eventData={eventData} feedbackItem={feedbackItem} />
         </Section>
 
         {eventData && (
@@ -122,34 +111,6 @@ const OverflowPanelItem = styled(PanelItem)`
 
   flex-direction: column;
   flex-grow: 1;
-  gap: ${space(4)};
+  gap: ${space(2)};
   padding: ${space(2)} ${space(3)} 0 ${space(3)};
-`;
-
-const SmallTitle = styled('span')`
-  font-size: ${p => p.theme.fontSizeRelativeSmall};
-`;
-
-const Blockquote = styled('blockquote')`
-  margin: 0 ${space(4)};
-  position: relative;
-
-  &::after {
-    position: absolute;
-    border: 1px solid ${p => p.theme.purple300};
-    bottom: 0;
-    content: '';
-    left: -${space(1)};
-    top: 0;
-  }
-
-  & > pre {
-    margin: 0;
-    background: none;
-    font-family: inherit;
-    font-size: ${p => p.theme.fontSizeMedium};
-    line-height: 1.6;
-    padding: 0;
-    word-break: break-word;
-  }
 `;

--- a/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemHeader.tsx
@@ -1,17 +1,16 @@
+import {useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackActions from 'sentry/components/feedback/feedbackItem/feedbackActions';
-import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedbackItemUsername';
 import FeedbackShortId from 'sentry/components/feedback/feedbackItem/feedbackShortId';
-import FeedbackTimestampsTooltip from 'sentry/components/feedback/feedbackItem/feedbackTimestampsTooltip';
 import IssueTrackingSection from 'sentry/components/feedback/feedbackItem/issueTrackingSection';
 import {Flex} from 'sentry/components/profiling/flex';
-import TimeSince from 'sentry/components/timeSince';
 import {space} from 'sentry/styles/space';
 import type {Event, Group} from 'sentry/types';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
+import {useDimensions} from 'sentry/utils/useDimensions';
 
 interface Props {
   eventData: Event | undefined;
@@ -26,27 +25,30 @@ const fixIssueLinkSpacing = css`
   }
 `;
 
+type Dimensions = ReturnType<typeof useDimensions>;
+function dimensionsToSize({width}: Dimensions) {
+  if (width < 600) {
+    return 'small';
+  }
+  if (width < 800) {
+    return 'medium';
+  }
+  return 'large';
+}
+
 export default function FeedbackItemHeader({eventData, feedbackItem}: Props) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const dimensions = useDimensions({elementRef: wrapperRef});
+
   return (
-    <VerticalSpacing>
-      <Flex wrap="wrap" flex="1 1 auto" gap={space(1)} justify="space-between">
-        <FeedbackItemUsername feedbackIssue={feedbackItem} detailDisplay />
-
-        <TimeSince
-          date={feedbackItem.firstSeen}
-          style={{alignSelf: 'center', whiteSpace: 'nowrap'}}
-          tooltipProps={{
-            title: eventData ? (
-              <FeedbackTimestampsTooltip feedbackItem={feedbackItem} />
-            ) : undefined,
-            overlayStyle: {maxWidth: 300},
-          }}
-        />
-      </Flex>
-
+    <VerticalSpacing ref={wrapperRef}>
       <Flex wrap="wrap" flex="1 1 auto" gap={space(1)} justify="space-between">
         <FeedbackShortId feedbackItem={feedbackItem} />
-        <FeedbackActions eventData={eventData} feedbackItem={feedbackItem} />
+        <FeedbackActions
+          eventData={eventData}
+          feedbackItem={feedbackItem}
+          size={dimensionsToSize(dimensions)}
+        />
       </Flex>
 
       {eventData && (

--- a/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
@@ -6,7 +6,7 @@ import {space} from 'sentry/styles/space';
 const SectionWrapper = styled('section')`
   display: flex;
   flex-direction: column;
-  gap: ${space(1.5)};
+  gap: ${space(1)};
 `;
 
 const SectionTitle = styled('h3')`
@@ -34,19 +34,21 @@ export default function Section({
   contentRight,
 }: {
   children: ReactNode;
-  title: ReactNode;
   contentRight?: ReactNode;
   icon?: ReactNode;
+  title?: ReactNode;
 }) {
   return (
     <SectionWrapper>
-      <SectionTitle>
-        <LeftAlignedContent>
-          {icon}
-          {title}
-        </LeftAlignedContent>
-        {contentRight}
-      </SectionTitle>
+      {title ? (
+        <SectionTitle>
+          <LeftAlignedContent>
+            {icon}
+            {title}
+          </LeftAlignedContent>
+          {contentRight}
+        </SectionTitle>
+      ) : null}
       {children}
     </SectionWrapper>
   );

--- a/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
@@ -1,5 +1,6 @@
 import type {CSSProperties} from 'react';
 import {css} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -66,7 +67,7 @@ export default function FeedbackShortId({className, feedbackItem, style}: Props)
           size={12}
           title={feedbackItem.project.slug}
         />
-        <TextOverflow>{feedbackItem.shortId}</TextOverflow>
+        <ShortId>{feedbackItem.shortId}</ShortId>
       </Flex>
       <DropdownMenu
         triggerProps={{
@@ -94,3 +95,8 @@ export default function FeedbackShortId({className, feedbackItem, style}: Props)
     </Flex>
   );
 }
+
+const ShortId = styled(TextOverflow)`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+`;

--- a/static/app/components/feedback/feedbackItem/messageSection.tsx
+++ b/static/app/components/feedback/feedbackItem/messageSection.tsx
@@ -1,0 +1,77 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedbackItemUsername';
+import FeedbackTimestampsTooltip from 'sentry/components/feedback/feedbackItem/feedbackTimestampsTooltip';
+import FeedbackViewers from 'sentry/components/feedback/feedbackItem/feedbackViewers';
+import {Flex} from 'sentry/components/profiling/flex';
+import TimeSince from 'sentry/components/timeSince';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event} from 'sentry/types';
+import type {FeedbackIssue} from 'sentry/utils/feedback/types';
+
+interface Props {
+  eventData: Event | undefined;
+  feedbackItem: FeedbackIssue;
+}
+
+export default function MessageSection({eventData, feedbackItem}: Props) {
+  return (
+    <Fragment>
+      <Flex wrap="wrap" flex="1 1 auto" gap={space(1)} justify="space-between">
+        <FeedbackItemUsername feedbackIssue={feedbackItem} detailDisplay />
+
+        <StyledTimeSince
+          date={feedbackItem.firstSeen}
+          tooltipProps={{
+            title: eventData ? (
+              <FeedbackTimestampsTooltip feedbackItem={feedbackItem} />
+            ) : undefined,
+            overlayStyle: {maxWidth: 300},
+          }}
+        />
+      </Flex>
+      <Blockquote>
+        <pre>{feedbackItem.metadata.message}</pre>
+      </Blockquote>
+      <Flex justify="flex-end">
+        <Flex gap={space(1)} align="center">
+          <SeenBy>{t('Seen by')}</SeenBy>
+          <FeedbackViewers feedbackItem={feedbackItem} />
+        </Flex>
+      </Flex>
+    </Fragment>
+  );
+}
+
+const StyledTimeSince = styled(TimeSince)`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+  align-self: center;
+  white-space: nowrap;
+`;
+
+const SeenBy = styled('span')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+`;
+
+const Blockquote = styled('blockquote')`
+  margin: 0;
+  background: ${p => p.theme.purple100};
+
+  border-left: 2px solid ${p => p.theme.purple300};
+  padding: ${space(2)};
+
+  & > pre {
+    margin: 0;
+    background: none;
+    font-family: inherit;
+    font-size: ${p => p.theme.fontSizeMedium};
+    line-height: 1.6;
+    padding: 0;
+    word-break: break-word;
+    color: ${p => p.theme.purple400};
+  }
+`;

--- a/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
+++ b/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
@@ -1,0 +1,69 @@
+import {useCallback} from 'react';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import useMutateFeedback from 'sentry/components/feedback/useMutateFeedback';
+import {t} from 'sentry/locale';
+import {GroupStatus} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import type {FeedbackIssue} from 'sentry/utils/feedback/types';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface Props {
+  feedbackItem: FeedbackIssue
+}
+
+const mutationOptions = {
+  onError: () => {
+    addErrorMessage(t('An error occurred while updating the feedback.'));
+  },
+  onSuccess: () => {
+    addSuccessMessage(t('Updated feedback'));
+  },
+};
+
+export default function useActions({feedbackItem}:Props) {
+  const organization = useOrganization();
+  const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
+
+  const {markAsRead, resolve} = useMutateFeedback({
+    feedbackIds: [feedbackItem.id],
+    organization,
+    projectIds: [feedbackItem.project.id],
+  });
+
+  // reuse the issues ignored category for spam feedbacks
+  const isResolved = feedbackItem.status === GroupStatus.RESOLVED;
+  const isSpam = feedbackItem.status === GroupStatus.IGNORED;
+
+  return {
+    isResolved,
+    onResolveClick: useCallback(() => {
+      addLoadingMessage(t('Updating feedback...'));
+      const newStatus = isResolved ? GroupStatus.UNRESOLVED : GroupStatus.RESOLVED;
+      resolve(newStatus, mutationOptions);
+    }, [isResolved, resolve]),
+    hasSpamFeature,
+    isSpam,
+    onSpamClick: useCallback(() => {
+      addLoadingMessage(t('Updating feedback...'));
+      const newStatus = isSpam ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
+      resolve(newStatus, mutationOptions);
+      if (!isSpam) {
+        // not currently spam, clicking the button will turn it into spam
+        trackAnalytics('feedback.mark-spam-clicked', {
+          organization,
+          type: 'details',
+        });
+      }
+    }, [isSpam, organization, resolve]),
+    hasSeen: feedbackItem.hasSeen,
+    onMarkAsReadClick: useCallback(() => {
+      addLoadingMessage(t('Updating feedback...'));
+      markAsRead(!feedbackItem.hasSeen, mutationOptions);
+    }, [feedbackItem.hasSeen, markAsRead]),
+  };
+}


### PR DESCRIPTION
Matches figma designs: https://www.figma.com/file/i6GG14NOoRYdSiqDnqqafP/Specs%3A-User-Feedback-v2?type=design&node-id=988-2899&mode=design&t=CYQn8dNlbgZDl5P4-0

| before | after |
| --- | --- |
| <img width="607" alt="before" src="https://github.com/getsentry/sentry/assets/187460/71630cf3-fed5-47bb-a66e-b9f1130ce54e"> | <img width="603" alt="after" src="https://github.com/getsentry/sentry/assets/187460/3684a7ac-4e8c-49b4-8ae0-ce4432215b4c">



**Different widths in the app:**
| size | img |
| --- | --- |
| small | <img width="627" alt="small" src="https://github.com/getsentry/sentry/assets/187460/ba592218-4739-4cfd-b318-fb91f308d524"> |
| medium | <img width="658" alt="medium" src="https://github.com/getsentry/sentry/assets/187460/fc3c2878-ff1c-47b3-9d74-5c4888e53435">
| large | <img width="841" alt="large" src="https://github.com/getsentry/sentry/assets/187460/073b2717-0d6c-4d0d-b01e-ed8395d9415f">


Fixes https://github.com/getsentry/sentry/issues/66219