### PR TITLE
chore(crons): When creating an issue occurrence, set the received date of the event correctly

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -718,7 +718,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span):
             # 04
             # Update monitor status
             if check_in.status == CheckInStatus.ERROR:
-                mark_failed(check_in, ts=start_time)
+                mark_failed(check_in, ts=start_time, received=item.ts)
             else:
                 mark_ok(check_in, ts=start_time)
 

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -310,7 +310,7 @@ def create_issue_platform_occurrence(
         "platform": "other",
         "project_id": monitor_env.monitor.project_id,
         # We set this to the time that the checkin that triggered the occurrence was written to the ingest topic
-        "received": received.isoformat(),
+        "received": (received if received else current_timestamp).isoformat(),
         "sdk": None,
         "tags": {
             "monitor.id": str(monitor_env.monitor.guid),


### PR DESCRIPTION


Currently, we set the received date of an event to the current time. Instead, we'd like to make this the date that the checkin that caused us to send an issue occurrence was written to the kafka ingest topic.

For cases where we send multiple checkins when marking failed, they will all have the same timestamp

<!-- Describe your PR here. -->