### PR TITLE
ref(trace): wheel scroll railing

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1493,7 +1493,7 @@ const TraceStylingWrapper = styled('div')`
   height: 70vh;
   width: 100%;
   margin: auto;
-  overflow: hidden;
+  overscroll-behavior: none;
   position: relative;
   box-shadow: 0 0 0 1px ${p => p.theme.border};
   border-radius: 4px;

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -471,8 +471,12 @@ export class VirtualizedViewManager {
         width: newView[2],
       });
     } else {
+      if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+        return;
+      }
       const physical_delta_pct = event.deltaX / this.trace_physical_space.width;
       const view_delta = physical_delta_pct * this.trace_view.width;
+
       this.setTraceView({
         x: this.trace_view.x + view_delta,
       });

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -471,6 +471,10 @@ export class VirtualizedViewManager {
         width: newView[2],
       });
     } else {
+      // Browsers do not implement scroll railing consistently, so we need to
+      // implement it ourselves. We do this by checking that deltaY does not exceed
+      // deltaX. If that happens, we return and allow the scroll handler on the virtualized
+      // container to handle the scroll event.
       if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
         return;
       }

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -379,7 +379,7 @@ export class VirtualizedViewManager {
         if (scrollableElement) {
           scrollableElement.style.transform = `translateX(${this.columns.list.translate[0]}px)`;
           this.row_measurer.measure(node, scrollableElement as HTMLElement);
-          ref.addEventListener('wheel', this.onSyncedScrollbarScroll, {passive: true});
+          ref.addEventListener('wheel', this.onSyncedScrollbarScroll, {passive: false});
         }
       }
     }
@@ -622,6 +622,14 @@ export class VirtualizedViewManager {
     if (this.isScrolling) {
       return;
     }
+
+    const scrollingHorizontally = Math.abs(event.deltaX) >= Math.abs(event.deltaY);
+    if (event.deltaX !== 0 && event.deltaX !== -0 && scrollingHorizontally) {
+      event.preventDefault();
+    } else {
+      return;
+    }
+
     if (this.bringRowIntoViewAnimation !== null) {
       window.cancelAnimationFrame(this.bringRowIntoViewAnimation);
       this.bringRowIntoViewAnimation = null;
@@ -1494,6 +1502,7 @@ export const useVirtualizedList = (
       pointerEventsRaf.current = requestAnimationTimeout(() => {
         styleCache.current?.clear();
         renderCache.current?.clear();
+
         managerRef.current.isScrolling = false;
 
         const recomputedItems = findRenderedItems({


### PR DESCRIPTION
Browsers do not implement scroll railing consistently, chrome for example apparently breaks railing if the delta change is large enough, so we need to do it manually.

The reason we cant have a proper pan/zoom like on profiling is because scroll and wheel events do not map 1:1 and the reported distances might not match. If we wanted to overcome this, we'd need to move to a canvas rendering implementation.

