### PR TITLE
feat(trace): scroll row into view on indicator move end

### DIFF
--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -282,6 +282,7 @@ export class VirtualizedViewManager {
     this.dividerStartVec = null;
     this.previousDividerClientVec = null;
 
+    this.enqueueOnScrollEndOutOfBoundsCheck();
     this.container.removeEventListener('mouseup', this.onDividerMouseUp);
     this.container.removeEventListener('mousemove', this.onDividerMouseMove);
   }
@@ -664,7 +665,7 @@ export class VirtualizedViewManager {
     let max = Number.NEGATIVE_INFINITY;
     let innerMostNode: TraceTreeNode<any> | undefined;
 
-    for (let i = 0; i < this.columns.span_list.column_refs.length; i++) {
+    for (let i = 5; i < this.columns.span_list.column_refs.length - 5; i++) {
       const width = this.row_measurer.cache.get(this.columns.list.column_nodes[i]);
       if (width === undefined) {
         // this is unlikely to happen, but we should trigger a sync measure event if it does


### PR DESCRIPTION
Scrolls row into view after user has resized the area

https://github.com/getsentry/sentry/assets/9317857/add95c1e-a653-4b86-b0f6-5314155a5303

