### PR TITLE
fix(devenv): avoid Popen.wait deadlock

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -29,6 +29,7 @@ def run_procs(
                 subprocess.Popen(
                     cmd,
                     stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
                     env={
                         **constants.user_environ,
                         **proc.base_env,
@@ -43,13 +44,10 @@ def run_procs(
 
     all_good = True
     for name, final_cmd, p in procs:
-        p.wait()
+        out, _ = p.communicate()
         if p.returncode != 0:
             all_good = False
-            if p.stdout is None:
-                out = ""
-            else:
-                out = p.stdout.read().decode()
+            out = "" if out is None else out.decode()
             print(
                 f"""
 ❌ {name}

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -47,7 +47,7 @@ def run_procs(
         out, _ = p.communicate()
         if p.returncode != 0:
             all_good = False
-            out = "" if out is None else out.decode()
+            out_str = "" if out is None else out.decode()
             print(
                 f"""
 ❌ {name}
@@ -56,7 +56,7 @@ failed command (code p.returncode):
     {proc.quote(final_cmd)}
 
 Output:
-{out}
+{out_str}
 
 """
             )


### PR DESCRIPTION
This deadlocks in devenv CI and has been blocking 1.3.0 release. Thanks Popen.wait.