### PR TITLE
feat(trace): scroll row into view on search move

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -262,22 +262,6 @@ function TraceViewContent(props: TraceViewContentProps) {
     [tree]
   );
 
-  const previousResultIndexRef = useRef<number | undefined>(searchState.resultIndex);
-  useLayoutEffect(() => {
-    if (previousResultIndexRef.current === searchState.resultIndex) {
-      return;
-    }
-    if (!viewManager.list) {
-      return;
-    }
-
-    if (typeof searchState.resultIndex !== 'number') {
-      return;
-    }
-    viewManager.list.scrollToRow(searchState.resultIndex);
-    previousResultIndexRef.current = searchState.resultIndex;
-  }, [searchState.resultIndex, viewManager.list]);
-
   const onSearchChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       if (!event.currentTarget.value) {
@@ -388,7 +372,6 @@ function TraceViewContent(props: TraceViewContentProps) {
             setDetailNode={onSetDetailNode}
             searchResultsIteratorIndex={searchState.resultIndex}
             searchResultsMap={searchState.resultsLookup}
-            previousResultIndexRef={previousResultIndexRef}
             onTraceSearch={onTraceSearch}
             manager={viewManager}
           />

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -691,9 +691,31 @@ export class VirtualizedViewManager {
     }
   }
 
-  scrollRowIntoViewHorizontally(node: TraceTreeNode<any>, duration: number = 600) {
+  isOutsideOfViewOnKeyDown(node: TraceTreeNode<any>, offset_px: number): boolean {
+    const width = this.row_measurer.cache.get(node);
+    if (width === undefined) {
+      // this is unlikely to happen, but we should trigger a sync measure event if it does
+      return false;
+    }
+    const translation = this.columns.list.translate[0];
+
+    return (
+      translation + node.depth * this.row_depth_padding < 0 ||
+      translation + node.depth * this.row_depth_padding + offset_px >
+        this.columns.list.width * this.container_physical_space.width
+    );
+  }
+
+  scrollRowIntoViewHorizontally(
+    node: TraceTreeNode<any>,
+    duration: number = 600,
+    offset_px: number = 0
+  ) {
     const VISUAL_OFFSET = this.row_depth_padding / 2;
-    const target = Math.min(-node.depth * this.row_depth_padding + VISUAL_OFFSET, 0);
+    const target = Math.min(
+      -node.depth * this.row_depth_padding + VISUAL_OFFSET + offset_px,
+      0
+    );
     this.animateScrollColumnTo(target, duration);
   }
 
@@ -805,7 +827,7 @@ export class VirtualizedViewManager {
 
     if (segments.length === 1 && segments[0] === 'trace:root') {
       rerender();
-      list.scrollToRow(0);
+      this.scrollToRow(0);
       return Promise.resolve({index: 0, node: tree.root.children[0]});
     }
 
@@ -825,7 +847,9 @@ export class VirtualizedViewManager {
         return null;
       }
 
-      // Reassing the parent to the current node
+      // Reassing the parent to the current node so that
+      // searching narrows down to the current level
+      // and we dont need to search the entire tree each time
       parent = current;
 
       if (isTransactionNode(current)) {
@@ -860,11 +884,18 @@ export class VirtualizedViewManager {
       }
 
       rerender();
-      list.scrollToRow(index);
+      this.scrollToRow(index);
       return {index, node: current};
     };
 
     return scrollToRow();
+  }
+
+  scrollToRow(index: number) {
+    if (!this.list) {
+      return;
+    }
+    this.list.scrollToRow(index);
   }
 
   computeTransformXFromTimestamp(timestamp: number): number {


### PR DESCRIPTION
When a user scrolls via keyboard nav or search roving, ensure the rows are centered in the view. This makes for a nicer experience with deep trees as users isn't required to manually scroll the row into view after navigating to it