### PR TITLE
feat(trace): use react query for fetching trace data

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -31,7 +31,7 @@ import type {
   TraceFullDetailed,
   TraceSplitResults,
 } from 'sentry/utils/performance/quickTrace/types';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -121,7 +121,7 @@ export function TraceView() {
             {metaResults => (
               <TraceViewContent
                 status={trace.status}
-                trace={trace.data}
+                trace={trace.data ?? null}
                 traceSlug={traceSlug}
                 organization={organization}
                 location={location}
@@ -140,7 +140,7 @@ type TraceViewContentProps = {
   location: Location;
   metaResults: TraceMetaQueryChildrenProps;
   organization: Organization;
-  status: 'pending' | 'resolved' | 'error' | 'initial';
+  status: UseApiQueryResult<any, any>['status'];
   trace: TraceSplitResults<TraceFullDetailed> | null;
   traceEventView: EventView;
   traceSlug: string;
@@ -172,7 +172,7 @@ function TraceViewContent(props: TraceViewContentProps) {
       return errorTree;
     }
 
-    if (props.status === 'pending' || rootEvent.status === 'loading') {
+    if (props.status === 'loading' || rootEvent.status === 'loading') {
       const loadingTrace =
         loadingTraceRef.current ??
         TraceTree.Loading(
@@ -202,7 +202,7 @@ function TraceViewContent(props: TraceViewContentProps) {
   ]);
 
   const traceType = useMemo(() => {
-    if (props.status !== 'resolved' || !tree) {
+    if (props.status !== 'success' || !tree) {
       return null;
     }
     return tree.shape;

--- a/static/app/views/performance/newTraceDetails/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/useTrace.tsx
@@ -1,6 +1,5 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useMemo} from 'react';
 import type {Location} from 'history';
-import * as qs from 'query-string';
 
 import type {Client} from 'sentry/api';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
@@ -10,8 +9,8 @@ import type {
   TraceFullDetailed,
   TraceSplitResults,
 } from 'sentry/utils/performance/quickTrace/types';
+import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
-import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -37,7 +36,13 @@ export function getTraceQueryParams(
   query: Location['query'],
   filters: Partial<PageFilters> = {},
   options: {limit?: number} = {}
-) {
+): {
+  limit: number;
+  project: string;
+  statsPeriod: string | undefined;
+  timestamp: string | undefined;
+  useSpans: number;
+} {
   const normalizedParams = normalizeDateTimeParams(query, {
     allowAbsolutePageDatetime: true,
   });
@@ -70,71 +75,28 @@ type UseTraceParams = {
   limit?: number;
 };
 
-type RequestState<T> = {
-  data: T | null;
-  status: 'resolved' | 'pending' | 'error' | 'initial';
-  error?: Error | null;
-};
-
 const DEFAULT_OPTIONS = {};
 export function useTrace(
   options: Partial<UseTraceParams> = DEFAULT_OPTIONS
-): RequestState<TraceSplitResults<TraceFullDetailed> | null> {
-  const api = useApi();
+): UseApiQueryResult<TraceSplitResults<TraceFullDetailed>, any> {
   const filters = usePageFilters();
   const location = useLocation();
   const organization = useOrganization();
   const params = useParams<{traceSlug?: string}>();
-
-  const [trace, setTrace] = useState<
-    RequestState<TraceSplitResults<TraceFullDetailed> | null>
-  >({
-    status: 'initial',
-    data: null,
-  });
 
   const queryParams = useMemo(() => {
     return getTraceQueryParams(location.query, filters.selection, options);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options]);
 
-  useEffect(() => {
-    if (!params.traceSlug) {
-      return undefined;
+  return useApiQuery(
+    [
+      `/organizations/${organization.slug}/events-trace/${params.traceSlug ?? ''}/`,
+      {query: queryParams},
+    ],
+    {
+      staleTime: Infinity,
+      enabled: !!params.traceSlug && !!organization.slug,
     }
-
-    let unmounted = false;
-
-    setTrace({
-      status: 'pending',
-      data: null,
-    });
-
-    fetchTrace(api, {
-      traceId: params.traceSlug,
-      orgSlug: organization.slug,
-      query: qs.stringify(queryParams),
-    })
-      .then(resp => {
-        if (unmounted) return;
-        setTrace({
-          status: 'resolved',
-          data: resp,
-        });
-      })
-      .catch(e => {
-        if (unmounted) return;
-        setTrace({
-          status: 'error',
-          data: null,
-          error: e,
-        });
-      });
-
-    return () => {
-      unmounted = true;
-    };
-  }, [api, organization.slug, params.traceSlug, queryParams]);
-
-  return trace;
+  );
 }


### PR DESCRIPTION
React query caches the response so if users navigate to this page while they do perf investigation, the data will be pulled from cache and instantly populated. 

@Abdkhan14, we should do the same for the meta query, right now those top level user/browser and duration fields are refetched on each navigation, which isnt ideal and we should change that, but it's a good start as the majority of the data will at least be here.