### PR TITLE
Update `assemble_stacktrace_component` docstring and test

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -353,10 +353,12 @@ class Enhancements:
     def assemble_stacktrace_component(
         self, components, frames, platform, exception_data=None, **kw
     ):
-        """This assembles a stacktrace grouping component out of the given
-        frame components and source frames.  Internally this invokes the
-        `update_frame_components_contributions` method but also handles cases
-        where the entire stacktrace should be discarded.
+        """
+        This assembles a `stacktrace` grouping component out of the given
+        `frame` components and source frames.
+
+        Internally this invokes the `update_frame_components_contributions` method
+        but also handles cases where the entire stacktrace should be discarded.
         """
         hint = None
         contributes = None

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -464,16 +464,15 @@ def test_range_matching_direct():
 @pytest.mark.parametrize("action", ["+", "-"])
 @pytest.mark.parametrize("type", ["prefix", "sentinel"])
 def test_sentinel_and_prefix(action, type):
-    rule = Enhancements.from_config_string(f"function:foo {action}{type}").rules[0]
+    enhancements = Enhancements.from_config_string(f"function:foo {action}{type}")
 
     frames = [{"function": "foo"}]
-    actions = _get_matching_frame_actions(rule, frames, "whatever")
-    assert len(actions) == 1
-
     component = GroupingComponent(id=None)
     assert not getattr(component, f"is_{type}_frame")
+    frame_components = [component]
 
-    actions[0][1].update_frame_components_contributions([component], frames, 0)
+    enhancements.assemble_stacktrace_component(frame_components, frames, "whatever")
+
     expected = action == "+"
     assert getattr(component, f"is_{type}_frame") is expected
 


### PR DESCRIPTION
Porting the second part of grouping enhancers to Rust, we were focussing on the `update_frame_components_contributions` function, though `assemble_stacktrace_component` is a much better candidate.

This PR makes sure we test it directly, instead of the internal-only `update_frame_components_contributions`.