### PR TITLE
fix(ddm): add to dashboard multi chart mode

### DIFF
--- a/static/app/views/ddm/useCreateDashboard.tsx
+++ b/static/app/views/ddm/useCreateDashboard.tsx
@@ -16,15 +16,15 @@ export function useCreateDashboard() {
 
   const dashboardWidgets = useMemo(() => {
     // TODO(aknaus): Remove filtering once dashboard supports metrics formulas
-    const supportedWidgets = widgets.filter(
+    const supportedQueries = widgets.filter(
       widget => widget.type === MetricQueryType.QUERY
     ) as MetricQueryWidgetParams[];
-    if (isMultiChartMode) {
-      return [convertToDashboardWidget(supportedWidgets, widgets[0].displayType)];
+    if (!isMultiChartMode) {
+      return [convertToDashboardWidget(supportedQueries, widgets[0].displayType)];
     }
 
-    return supportedWidgets.map(widget =>
-      convertToDashboardWidget([widget], widget.displayType)
+    return supportedQueries.map(query =>
+      convertToDashboardWidget([query], query.displayType)
     );
   }, [widgets, isMultiChartMode]);
 


### PR DESCRIPTION
Fixes a case where multi chart mode was compressed into one widget, and multi query chart was exploded into multiple widgets