### PR TITLE
fix(cardinality): The org id in the passive limit is a string

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -826,7 +826,7 @@ register("relay.cardinality-limiter.mode", default="enabled", flags=FLAG_AUTOMAT
 #
 # In passive mode Relay's cardinality limiter is active but it does not enforce the limits.
 #
-# Example: `{1: ["transactions"]}`
+# Example: `{'1': ["transactions"]}`
 # Forces the `transactions` cardinality limit into passive mode for the organization with id `1` (Sentry).
 register(
     "relay.cardinality-limiter.passive-limits-by-org", default={}, flags=FLAG_AUTOMATOR_MODIFIABLE

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -251,7 +251,7 @@ def get_metrics_config(project: Project) -> Mapping[str, Any] | None:
 
     if features.has("organizations:relay-cardinality-limiter", project.organization):
         passive_limits = options.get("relay.cardinality-limiter.passive-limits-by-org").get(
-            project.organization.id, []
+            str(project.organization.id), []
         )
 
         cardinality_limits: list[CardinalityLimit] = []

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -939,7 +939,7 @@ def test_project_config_cardinality_limits(default_project, insta_snapshot, pass
 
     if passive:
         options["relay.cardinality-limiter.passive-limits-by-org"] = {
-            default_project.organization.id: [
+            str(default_project.organization.id): [
                 "sessions",
                 "transactions",
                 "spans",


### PR DESCRIPTION
The org ID when loaded from features is often a string (e.g. JSON does not have integer keys)