### PR TITLE
ref(on-demand-metrics): Remove snapshots in tests

### DIFF
--- a/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@/dispatch@@/backend test /dispatch@something/@/dispatch@@.pysnap
+++ b/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@/dispatch@@/backend test /dispatch@something/@/dispatch@@.pysnap
@@ -1,6 +1,0 @@
----
-created: '2024-02-06T12:13:13.768289Z'
-creator: sentry
-source: tests/sentry/snuba/metrics/test_extraction.py
----
-{"category":"transaction","mri":"c:transactions/on_demand@none","field":null,"tags":[{"key":"query_hash","value":"32916cfa"}],"condition":{"op":"glob","name":"event.transaction","value":["*\\[dispatch:*"]}}

--- a/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@@dispatch@/backend @dispatch/@/@dispatch@.pysnap
+++ b/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@@dispatch@/backend @dispatch/@/@dispatch@.pysnap
@@ -1,6 +1,0 @@
----
-created: '2024-02-06T12:13:12.884044Z'
-creator: sentry
-source: tests/sentry/snuba/metrics/test_extraction.py
----
-{"category":"transaction","mri":"c:transactions/on_demand@none","field":null,"tags":[{"key":"query_hash","value":"0c6ddfa6"}],"condition":{"op":"glob","name":"event.transaction","value":["*\\?dispatch*"]}}

--- a/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@dispatch/@@/backend dispatch/@/@dispatch/@@.pysnap
+++ b/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@dispatch/@@/backend dispatch/@/@dispatch/@@.pysnap
@@ -1,6 +1,0 @@
----
-created: '2024-02-06T12:13:13.328092Z'
-creator: sentry
-source: tests/sentry/snuba/metrics/test_extraction.py
----
-{"category":"transaction","mri":"c:transactions/on_demand@none","field":null,"tags":[{"key":"query_hash","value":"8bb6b7dd"}],"condition":{"op":"glob","name":"event.transaction","value":["*dispatch\\]:*"]}}

--- a/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@dispatch}@@/test /dispatch}@/@dispatch/}@@.pysnap
+++ b/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@dispatch}@@/test /dispatch}@/@dispatch/}@@.pysnap
@@ -1,6 +1,0 @@
----
-created: '2024-02-06T12:13:13.108539Z'
-creator: sentry
-source: tests/sentry/snuba/metrics/test_extraction.py
----
-{"category":"transaction","mri":"c:transactions/on_demand@none","field":null,"tags":[{"key":"query_hash","value":"aa691637"}],"condition":{"op":"glob","name":"event.transaction","value":["*dispatch\\}:*"]}}

--- a/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@{dispatch@@/test {dispatch@something/@/{dispatch@@.pysnap
+++ b/tests/sentry/snuba/metrics/snapshots/test_extraction/test_spec_wildcard_escaping/title@@{dispatch@@/test {dispatch@something/@/{dispatch@@.pysnap
@@ -1,6 +1,0 @@
----
-created: '2024-02-06T12:13:13.545655Z'
-creator: sentry
-source: tests/sentry/snuba/metrics/test_extraction.py
----
-{"category":"transaction","mri":"c:transactions/on_demand@none","field":null,"tags":[{"key":"query_hash","value":"1685da56"}],"condition":{"op":"glob","name":"event.transaction","value":["*\\{dispatch:*"]}}

--- a/tests/sentry/snuba/metrics/test_extraction.py
+++ b/tests/sentry/snuba/metrics/test_extraction.py
@@ -16,7 +16,6 @@ from sentry.snuba.metrics.extraction import (
     to_standard_metrics_query,
 )
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json
 from sentry.utils.glob import glob_match
 
 
@@ -424,9 +423,7 @@ def test_spec_wildcard() -> None:
         ("title:*?dispatch*", "backend ?dispatch", r"*\?dispatch*"),
     ],
 )
-def test_spec_wildcard_escaping(
-    default_project, insta_snapshot, query, title, expected_pattern
-) -> None:
+def test_spec_wildcard_escaping(query, title, expected_pattern) -> None:
     spec = OnDemandMetricSpec("count()", query)
 
     assert spec._metric_type == "c"
@@ -441,10 +438,6 @@ def test_spec_wildcard_escaping(
     # We also validate using Relay's glob implementation to make sure the escaping
     # is interpreted correctly.
     assert glob_match(title, expected_pattern, ignorecase=True)
-
-    # We want to validate the json output, to make sure that characters are correctly escaped.
-    metric_spec = spec.to_metric_spec(default_project)
-    insta_snapshot(json.dumps(metric_spec))
 
 
 def test_spec_count_if() -> None:


### PR DESCRIPTION
This PR removed snapshots tests that were causing issues due to snapshots paths.