### PR TITLE
feat(sdk-crashes): Keep lineno

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event_cocoa.py
+++ b/fixtures/sdk_crash_detection/crash_event_cocoa.py
@@ -92,6 +92,7 @@ def get_frames(
             "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
             "platform": "platform",
             "post_context": ["should_be_removed"],
+            "lineno": 143,
         },
     ]
 

--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -54,6 +54,7 @@ EVENT_DATA_ALLOWLIST = {
                     "image_addr": Allow.SIMPLE_TYPE,
                     "package": Allow.SIMPLE_TYPE,
                     "platform": Allow.SIMPLE_TYPE,
+                    "lineno": Allow.SIMPLE_TYPE,
                 }
             },
             "value": Allow.NEVER.with_explanation("The exception value could contain PII."),

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -236,6 +236,7 @@ def test_strip_event_data_keeps_exception_stacktrace(store_and_strip_event):
         "image_addr": "0x1a4e8f000",
         "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
         "platform": "platform",
+        "lineno": 143,
     }
 
 


### PR DESCRIPTION
We can keep `lineno` as it doesn't contain any PII.

