### PR TITLE
fix(migrations): Make enforce_unqiue_active_incidents dangerous

### DIFF
--- a/src/sentry/migrations/0671_enforce_unqiue_active_incidents.py
+++ b/src/sentry/migrations/0671_enforce_unqiue_active_incidents.py
@@ -16,7 +16,7 @@ class Migration(CheckedMigration):
     # - Adding indexes to large tables. Since this can take a long time, we'd generally prefer to
     #   have ops run this and not block the deploy. Note that while adding an index is a schema
     #   change, it's completely safe to run the operation after the code has deployed.
-    is_dangerous = False
+    is_dangerous = True
 
     dependencies = [
         ("sentry", "0670_monitor_incident_cleanup_duplicates"),


### PR DESCRIPTION
This was incorrectly marked as dangerous=False

Because of some errors in how migrations were being applied to the new crons database, this was correctly applied in the old default-db version of the table, but was skipped in the crons database.

Switching it to dangerous allows us to run it via the migration tool