### PR TITLE
ref: replace usage of deprecated utcnow in testutils

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -8,7 +8,7 @@ import zipfile
 from base64 import b64encode
 from binascii import hexlify
 from collections.abc import Mapping, Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from hashlib import sha1
 from importlib import import_module
 from typing import Any
@@ -144,7 +144,6 @@ from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.signals import project_created
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset
-from sentry.testutils.helpers.datetime import iso_format
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
@@ -1351,7 +1350,7 @@ class Factories:
     def create_userreport(project, event_id=None, **kwargs):
         event = Factories.store_event(
             data={
-                "timestamp": iso_format(datetime.utcnow()),
+                "timestamp": datetime.now(UTC).isoformat(),
                 "event_id": event_id or "a" * 32,
                 "message": "testing",
             },

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 import pytest
+from django.utils import timezone
 from django.utils.functional import cached_property
 
 from sentry.eventstore.models import Event
@@ -112,7 +113,7 @@ class Fixtures:
             external_id="github:1",
             metadata={
                 "access_token": "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
-                "expires_at": iso_format(datetime.utcnow() + timedelta(days=14)),
+                "expires_at": iso_format(timezone.now() + timedelta(days=14)),
             },
         )
         integration.add_organization(self.organization, self.user)

--- a/src/sentry/testutils/pytest/fixtures.py
+++ b/src/sentry/testutils/pytest/fixtures.py
@@ -10,13 +10,13 @@ import os
 import re
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
 from string import Template
 
 import pytest
 import requests
 import yaml
 from django.core.cache import cache
+from django.utils import timezone
 
 import sentry
 
@@ -382,7 +382,7 @@ def insta_snapshot(request, log):
                     % (
                         yaml.safe_dump(
                             {
-                                "created": datetime.utcnow().isoformat() + "Z",
+                                "created": timezone.now().isoformat(),
                                 "creator": "sentry",
                                 "source": source,
                             },


### PR DESCRIPTION
removed in 3.14

<!-- Describe your PR here. -->