### PR TITLE
ref(notification-actions): remove updating the count of notif actions

### DIFF
--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState} from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 
 import DropdownButton from 'sentry/components/dropdownButton';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
@@ -50,6 +50,10 @@ function NotificationActionManager({
 }: NotificationActionManagerProps) {
   const [notificationActions, setNotificationActions] =
     useState<Partial<NotificationAction>[]>(actions);
+
+  useEffect(() => {
+    setNotificationActions(actions);
+  }, [actions]);
 
   const removeNotificationAction = (index: number) => {
     // Removes notif action from state using the index

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -29,15 +29,15 @@ type NotificationActionManagerProps = {
    * TODO(enterprise): refactor to account for multiple projects
    */
   project: Project;
-  /**
-   * Updates the notification alert count for this project
-   */
-  updateAlertCount: (projectId: number, alertCount: number) => void;
   disabled?: boolean;
   /**
    * Optional list of roles to display as recipients of Sentry notifications
    */
   recipientRoles?: string[];
+  /**
+   * Updates the notification alert count for this project
+   */
+  updateAlertCount?: (projectId: number, alertCount: number) => void;
 };
 
 function NotificationActionManager({
@@ -45,7 +45,6 @@ function NotificationActionManager({
   availableActions,
   recipientRoles,
   project,
-  updateAlertCount = () => {},
   disabled = false,
 }: NotificationActionManagerProps) {
   const [notificationActions, setNotificationActions] =
@@ -60,7 +59,6 @@ function NotificationActionManager({
     const updatedActions = [...notificationActions];
     updatedActions.splice(index, 1);
     setNotificationActions(updatedActions);
-    updateAlertCount(parseInt(project.id, 10), updatedActions.length);
   };
 
   const updateNotificationAction = (index: number, updatedAction: NotificationAction) => {
@@ -211,12 +209,11 @@ function NotificationActionManager({
           // Add notification action
           const updatedActions = [...notificationActions, validActions[0].action];
           setNotificationActions(updatedActions);
-          updateAlertCount(parseInt(project.id, 10), updatedActions.length);
         },
       });
     });
     return dropdownMenuItems;
-  }, [actionsMap, availableServices, notificationActions, project, updateAlertCount]);
+  }, [actionsMap, availableServices, notificationActions]);
 
   let toolTipText: undefined | string = undefined;
   if (disabled) {


### PR DESCRIPTION
Corrected version of https://github.com/getsentry/sentry/pull/66620

When using this component in getsentry, we populate the `actions` prop asynchronously and need to update the state when that happens.

This PR removes requiring the function that will update the count of notification actions. We are removing this capability entirely, but since the use of this component is in getsentry, we need to make it optional in sentry first.