### PR TITLE
feat(replays): Add default replay configurations to loader script description

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
@@ -278,7 +278,8 @@ describe('Loader Script Settings', function () {
 
     expect(
       screen.getByText(
-        'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+        'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.',
+        {exact: false}
       )
     ).toBeInTheDocument();
 
@@ -296,7 +297,8 @@ describe('Loader Script Settings', function () {
 
     expect(
       screen.queryByText(
-        'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+        'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.',
+        {exact: false}
       )
     ).not.toBeInTheDocument();
   });

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -226,7 +226,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
                 ? t('Only available in SDK version 7.x and above')
                 : data.dynamicSdkLoaderOptions.hasReplay
                   ? tct(
-                      'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle. The default configurations are [codeReplay:replaysSessionSampleRate: 0.1] and [codeError:replaysOnErrorSampleRate: 1]. To learn how to configure this, click [configDocs:here].',
+                      'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle. The default configurations are [codeReplay:replaysSessionSampleRate: 0.1] and [codeError:replaysOnErrorSampleRate: 1]. [configDocs:Read the docs] to learn how to configure this.',
                       {
                         codeReplay: <code />,
                         codeError: <code />,

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -225,8 +225,15 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
               !sdkVersionSupportsPerformanceAndReplay(data.browserSdkVersion)
                 ? t('Only available in SDK version 7.x and above')
                 : data.dynamicSdkLoaderOptions.hasReplay
-                  ? t(
-                      'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+                  ? tct(
+                      'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle. The default configurations are [codeReplay:replaysSessionSampleRate: 0.1] and [codeError:replaysOnErrorSampleRate: 1]. To learn how to configure this, click [configDocs:here].',
+                      {
+                        codeReplay: <code />,
+                        codeError: <code />,
+                        configDocs: (
+                          <ExternalLink href="https://docs.sentry.io/platforms/javascript/install/loader/#custom-configuration" />
+                        ),
+                      }
                     )
                   : undefined
             }


### PR DESCRIPTION
Adds the default replay configs to the loader script description.
![image](https://github.com/getsentry/sentry/assets/55311782/91eb34e8-82ad-4c76-b651-c04b2d3371df)

Fixes: https://github.com/getsentry/sentry/issues/63017
