### PR TITLE
feat: improve dx for testing redis cluster

### DIFF
--- a/src/sentry/testutils/helpers/redis.py
+++ b/src/sentry/testutils/helpers/redis.py
@@ -1,11 +1,24 @@
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any
 
+from django.test.utils import override_settings
 
-def get_redis_cluster_default_options(id: str, high_watermark: int = 100) -> dict[str, Any]:
-    return {
+from sentry.testutils.helpers import override_options
+
+
+@contextmanager
+def use_redis_cluster(
+    cluster_id: str = "cluster",
+    high_watermark: int = 100,
+    with_settings: dict[str, Any] | None = None,
+) -> Generator[None, None, None]:
+    # Cluster id needs to be different than "default" to distinguish redis instance with redis cluster.
+
+    options = {
         "backpressure.high_watermarks.redis": high_watermark,
         "redis.clusters": {
-            id: {
+            cluster_id: {
                 "is_redis_cluster": True,
                 "hosts": [
                     {"host": "0.0.0.0", "port": 7000},
@@ -18,3 +31,10 @@ def get_redis_cluster_default_options(id: str, high_watermark: int = 100) -> dic
             }
         },
     }
+
+    settings = dict(with_settings or {})
+    settings["SENTRY_PROCESSING_SERVICES"] = {"redis": {"redis": cluster_id}}
+
+    with override_settings(**settings):
+        with override_options(options):
+            yield

--- a/tests/sentry/processing/backpressure/test_redis.py
+++ b/tests/sentry/processing/backpressure/test_redis.py
@@ -6,8 +6,7 @@ from sentry.processing.backpressure.monitor import (
     check_service_health,
     load_service_definitions,
 )
-from sentry.testutils.helpers import override_options
-from sentry.testutils.helpers.redis import get_redis_cluster_default_options
+from sentry.testutils.helpers.redis import use_redis_cluster
 
 
 @override_settings(SENTRY_PROCESSING_SERVICES={"redis": {"redis": "default"}})
@@ -24,8 +23,7 @@ def test_rb_cluster_returns_some_usage() -> None:
     assert 0.0 < memory.percentage < 1.0
 
 
-@override_settings(SENTRY_PROCESSING_SERVICES={"redis": {"redis": "cluster"}})
-@override_options(get_redis_cluster_default_options(id="cluster"))
+@use_redis_cluster()
 def test_redis_cluster_cluster_returns_some_usage() -> None:
     services = load_service_definitions()
     redis_service = services["redis"]
@@ -39,8 +37,7 @@ def test_redis_cluster_cluster_returns_some_usage() -> None:
     assert 0.0 < memory.percentage < 1.0
 
 
-@override_settings(SENTRY_PROCESSING_SERVICES={"redis": {"redis": "cluster"}})
-@override_options(get_redis_cluster_default_options(id="cluster", high_watermark=100))
+@use_redis_cluster(high_watermark=100)
 def test_redis_health():
     services = load_service_definitions()
     assert isinstance(services["redis"], Redis)
@@ -51,8 +48,7 @@ def test_redis_health():
     assert len(redis_services) == 0
 
 
-@override_settings(SENTRY_PROCESSING_SERVICES={"redis": {"redis": "cluster"}})
-@override_options(get_redis_cluster_default_options(id="cluster", high_watermark=0))
+@use_redis_cluster(high_watermark=0)
 def test_redis_unhealthy_state():
     services = load_service_definitions()
     assert isinstance(services["redis"], Redis)

--- a/tests/sentry/ratelimits/test_redis_cluster.py
+++ b/tests/sentry/ratelimits/test_redis_cluster.py
@@ -1,17 +1,12 @@
 import uuid
 
-from django.test.utils import override_settings
-
 from sentry.ratelimits.redis import RedisRateLimiter
-from sentry.testutils.helpers import override_options
-from sentry.testutils.helpers.redis import get_redis_cluster_default_options
+from sentry.testutils.helpers.redis import use_redis_cluster
 
 
-@override_settings(
-    SENTRY_PROCESSING_SERVICES={"redis": {"redis": "cluster"}},
-    SENTRY_RATE_LIMIT_REDIS_CLUSTER="cluster",
+@use_redis_cluster(
+    cluster_id="cluster", with_settings={"SENTRY_RATE_LIMIT_REDIS_CLUSTER": "cluster"}
 )
-@override_options(get_redis_cluster_default_options(id="cluster"))
 def test_integration_is_limited_with_value_with() -> None:
     rate_limiter = RedisRateLimiter()
     key = uuid.uuid4().hex


### PR DESCRIPTION
Makes the developer experience a little bit better when we're required to use a redis cluster. Here's the new syntax:

```python
@use_redis_cluster(high_watermark=100)
def test_redis_health():
    services = load_service_definitions()
    assert isinstance(services["redis"], Redis)
    unhealthy_services = check_service_health(services=services)
    redis_services = unhealthy_services.get("redis")
    assert isinstance(redis_services, list)
    assert len(redis_services) == 0
```