### PR TITLE
ref: remove calls to to_timestamp

### DIFF
--- a/src/sentry/analytics/__init__.py
+++ b/src/sentry/analytics/__init__.py
@@ -20,8 +20,8 @@ __all__ = (
 
 backend = LazyServiceWrapper(
     backend_base=Analytics,
-    backend_path=get_backend_path(options.get("analytics.backend")),
-    options=options.get("analytics.options"),
+    backend_path=get_backend_path(options.get("analytics.backend")),  # type: ignore[has-type]  # mypy is confused by a circular import
+    options=options.get("analytics.options"),  # type: ignore[has-type]  # mypy is confused by a circular import
 )
 
 record = backend.record

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 
 from sentry.analytics.attribute import Attribute
 from sentry.analytics.utils import get_data
-from sentry.utils.dates import to_timestamp
 
 
 class Event:
@@ -46,7 +45,7 @@ class Event:
     def serialize(self) -> Mapping[str, Any]:
         return {
             "uuid": b64encode(self.uuid.bytes),
-            "timestamp": to_timestamp(self.datetime),
+            "timestamp": self.datetime.timestamp(),
             "type": self.type,
             "data": self.data,
         }

--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -13,7 +13,6 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.serializers import serialize
 from sentry.constants import DATA_ROOT
 from sentry.utils import json
-from sentry.utils.dates import to_timestamp
 from sentry.utils.samples import create_sample_event_basic
 
 base_platforms_with_transactions = ["javascript", "python", "apple-ios"]
@@ -38,10 +37,10 @@ def fix_event_data(data):
     """
     timestamp = datetime.now(timezone.utc) - timedelta(minutes=1)
     timestamp = timestamp - timedelta(microseconds=timestamp.microsecond % 1000)
-    data["timestamp"] = to_timestamp(timestamp)
+    data["timestamp"] = timestamp.timestamp()
 
     start_timestamp = timestamp - timedelta(seconds=3)
-    data["start_timestamp"] = to_timestamp(start_timestamp)
+    data["start_timestamp"] = start_timestamp.timestamp()
 
     trace = uuid4().hex
     span_id = uuid4().hex[:16]

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -1,7 +1,5 @@
 import itertools
 
-from sentry.utils.dates import to_timestamp
-
 
 def value_from_row(row, tagkey):
     return tuple(row[k] for k in tagkey)
@@ -11,8 +9,8 @@ def zerofill(data, start, end, rollup, allow_partial_buckets=False, fill_default
     if fill_default is None:
         fill_default = []
     rv = []
-    end = int(to_timestamp(end))
-    rollup_start = (int(to_timestamp(start)) // rollup) * rollup
+    end = int(end.timestamp())
+    rollup_start = (int(start.timestamp()) // rollup) * rollup
     rollup_end = (end // rollup) * rollup
 
     # Fudge the end value when we're only getting a single window.
@@ -45,8 +43,8 @@ def zerofill(data, start, end, rollup, allow_partial_buckets=False, fill_default
 
 
 def calculate_time_frame(start, end, rollup):
-    rollup_start = (int(to_timestamp(start)) // rollup) * rollup
-    rollup_end = (int(to_timestamp(end)) // rollup) * rollup
+    rollup_start = (int(start.timestamp()) // rollup) * rollup
+    rollup_end = (int(end.timestamp()) // rollup) * rollup
     if rollup_end - rollup_start == rollup:
         rollup_end += 1
     return {"start": rollup_start, "end": rollup_end}

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -15,7 +15,6 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
 from sentry.tsdb.base import TSDBModel
-from sentry.utils.dates import to_timestamp
 from sentry.utils.pipeline import Pipeline
 
 logger = logging.getLogger("sentry.digests")
@@ -71,7 +70,7 @@ def event_to_record(
     return Record(
         event.event_id,
         Notification(event, [rule.id for rule in rules], notification_uuid),
-        to_timestamp(event.datetime),
+        event.datetime.timestamp(),
     )
 
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -118,7 +118,7 @@ from sentry.usage_accountant import record
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.canonical import CanonicalKeyDict
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 from sentry.utils.event import has_event_minified_stack_trace, has_stacktrace, is_handled
 from sentry.utils.eventuser import EventUser
 from sentry.utils.metrics import MutableTags
@@ -292,7 +292,7 @@ class ScoreClause(Func):
         if has_values:
             sql = "log(times_seen + %d) * 600 + %d" % (
                 self.times_seen,
-                to_timestamp(self.last_seen),
+                self.last_seen.timestamp(),
             )
         else:
             sql = "log(times_seen) * 600 + last_seen::abstime::int"

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -51,7 +51,7 @@ from sentry.snuba.entity_subscription import (
 from sentry.snuba.models import QuerySubscription
 from sentry.snuba.tasks import build_query_builder
 from sentry.utils import metrics, redis
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 
 logger = logging.getLogger(__name__)
 REDIS_TTL = int(timedelta(days=7).total_seconds())
@@ -898,7 +898,7 @@ def update_alert_rule_stats(
             )
 
     last_update_key = build_alert_rule_stat_keys(alert_rule, subscription)[0]
-    pipeline.set(last_update_key, int(to_timestamp(last_update)), ex=REDIS_TTL)
+    pipeline.set(last_update_key, int(last_update.timestamp()), ex=REDIS_TTL)
     pipeline.execute()
 
 

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -16,7 +16,6 @@ from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
 
 
@@ -204,7 +203,7 @@ def build_footer(
 
 def get_timestamp(group: Group, event: GroupEvent | None) -> float:
     ts = group.last_seen
-    return to_timestamp(max(ts, event.datetime) if event else ts)
+    return (max(ts, event.datetime) if event else ts).timestamp()
 
 
 def get_color(

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -8,7 +8,6 @@ from typing import Any, TypedDict
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
 from sentry.notifications.utils.actions import MessageAction
-from sentry.utils.dates import to_timestamp
 
 MAX_BLOCK_TEXT_LENGTH = 256
 
@@ -146,7 +145,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     def get_context_block(text: str, timestamp: datetime | None = None) -> SlackBlock:
         if timestamp:
             time = "<!date^{:.0f}^{} at {} | Sentry Issue>".format(
-                to_timestamp(timestamp), "{date_pretty}", "{time}"
+                timestamp.timestamp(), "{date_pretty}", "{time}"
             )
             text += f" | {time}"
 

--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -9,12 +9,11 @@ from sentry.integrations.slack.message_builder import (
 )
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
-from sentry.utils.dates import to_timestamp
 
 
 def get_started_at(timestamp: datetime) -> str:
     return "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
-        to_timestamp(timestamp), "{date_pretty}", "{time}"
+        timestamp.timestamp(), "{date_pretty}", "{time}"
     )
 
 

--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -1,7 +1,7 @@
 __all__ = ("Breadcrumbs",)
 
 from sentry.interfaces.base import Interface
-from sentry.utils.dates import parse_timestamp, to_datetime, to_timestamp
+from sentry.utils.dates import parse_timestamp, to_datetime
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.safe import get_path
 
@@ -60,7 +60,7 @@ class Breadcrumbs(Interface):
         crumb = dict(crumb)
         ts = parse_timestamp(crumb.get("timestamp"))
         if ts:
-            crumb["timestamp"] = to_timestamp(ts)
+            crumb["timestamp"] = ts.timestamp()
         else:
             crumb["timestamp"] = None
 

--- a/src/sentry/monitors/endpoints/base_monitor_stats.py
+++ b/src/sentry/monitors/endpoints/base_monitor_stats.py
@@ -11,7 +11,6 @@ from rest_framework.response import Response
 from sentry.api.base import BaseEndpointMixin, StatsMixin
 from sentry.api.helpers.environments import get_environments
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn
-from sentry.utils.dates import to_timestamp
 
 
 def normalize_to_epoch(timestamp: datetime, seconds: int):
@@ -21,7 +20,7 @@ def normalize_to_epoch(timestamp: datetime, seconds: int):
     i.e. if the rollup is minutes, the resulting timestamp would have
     the seconds and microseconds rounded down.
     """
-    epoch = int(to_timestamp(timestamp))
+    epoch = int(timestamp.timestamp())
     return epoch - (epoch % seconds)
 
 

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -16,7 +16,6 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.environments import get_environments
 from sentry.models.environment import Environment
 from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorEnvironment
-from sentry.utils.dates import to_timestamp
 
 
 def normalize_to_epoch(timestamp: datetime, seconds: int):
@@ -26,7 +25,7 @@ def normalize_to_epoch(timestamp: datetime, seconds: int):
     i.e. if the rollup is minutes, the resulting timestamp would have
     the seconds and microseconds rounded down.
     """
-    epoch = int(to_timestamp(timestamp))
+    epoch = int(timestamp.timestamp())
     return epoch - (epoch % seconds)
 
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -33,7 +33,6 @@ from sentry.notifications.utils.digest import (
 )
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.dates import to_timestamp
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -86,7 +85,7 @@ class DigestNotification(ProjectNotification):
         organization = project.organization
 
         return "<!date^{:.0f}^{count} {noun} detected {date} in| Digest Report for> <{project_link}|{project_name}>".format(
-            to_timestamp(context["start"]),
+            context["start"].timestamp(),
             count=len(context["counts"]),
             noun="issue" if len(context["counts"]) == 1 else "issues",
             project_link=organization.absolute_url(

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -46,7 +46,7 @@ from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.sessions import _make_stats, get_rollup_starts_and_buckets
 from sentry.snuba.sessions_v2 import QueryDefinition
 from sentry.utils import json
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 from sentry.utils.safe import get_path
 from sentry.utils.snuba import QueryOutsideRetentionError
 
@@ -1400,13 +1400,13 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         projects, org_id = self._get_projects_and_org_id([project_id])
 
-        start = to_datetime((to_timestamp(start) // rollup + 1) * rollup)
+        start = to_datetime((start.timestamp() // rollup + 1) * rollup)
 
         # since snuba end queries are exclusive of the time and we're bucketing to
         # 10 seconds, we need to round to the next 10 seconds since snuba is
         # exclusive on the end.
         end = to_datetime(
-            (to_timestamp(end) // SMALLEST_METRICS_BUCKET + 1) * SMALLEST_METRICS_BUCKET
+            (end.timestamp() // SMALLEST_METRICS_BUCKET + 1) * SMALLEST_METRICS_BUCKET
         )
 
         where = [

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -71,7 +71,7 @@ from sentry.search.events.types import (
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.utils import MetricMeta
-from sentry.utils.dates import outside_retention_with_modified_start, to_timestamp
+from sentry.utils.dates import outside_retention_with_modified_start
 from sentry.utils.snuba import (
     QueryOutsideRetentionError,
     is_duration_measurement,
@@ -1173,9 +1173,7 @@ class BaseQueryBuilder:
             value = self.resolve_measurement_value(unit, value)
 
         value = (
-            int(to_timestamp(value))
-            if isinstance(value, datetime) and name != "timestamp"
-            else value
+            int(value.timestamp()) if isinstance(value, datetime) and name != "timestamp" else value
         )
 
         if aggregate_filter.operator in {"=", "!="} and value == "":
@@ -1249,7 +1247,7 @@ class BaseQueryBuilder:
         # timestamp{,.to_{hour,day}} need a datetime string
         # last_seen needs an integer
         if isinstance(value, datetime) and name not in constants.TIMESTAMP_FIELDS:
-            value = int(to_timestamp(value)) * 1000
+            value = int(value.timestamp()) * 1000
 
         # Tags are never null, but promoted tags are columns and so can be null.
         # To handle both cases, use `ifNull` to convert to an empty string and

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -69,7 +69,6 @@ from sentry.snuba.metrics.query import (
     MetricsQuery,
 )
 from sentry.snuba.metrics.utils import get_num_intervals
-from sentry.utils.dates import to_timestamp
 from sentry.utils.snuba import DATASETS, bulk_snql_query, raw_snql_query
 
 
@@ -673,7 +672,7 @@ class MetricsQueryBuilder(QueryBuilder):
         # timestamp{,.to_{hour,day}} need a datetime string
         # last_seen needs an integer
         if isinstance(value, datetime) and name not in constants.TIMESTAMP_FIELDS:
-            value = int(to_timestamp(value)) * 1000
+            value = int(value.timestamp()) * 1000
 
         if name in constants.TIMESTAMP_FIELDS:
             if (

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -48,7 +48,6 @@ from sentry.search.events.constants import (
 )
 from sentry.search.events.fields import FIELD_ALIASES, FUNCTIONS, resolve_field
 from sentry.search.utils import parse_release
-from sentry.utils.dates import to_timestamp
 from sentry.utils.snuba import FUNCTION_TO_OPERATOR, OPERATOR_TO_FUNCTION, SNUBA_AND, SNUBA_OR
 from sentry.utils.strings import oxfordize_list
 from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCARD_NOT_ALLOWED
@@ -105,9 +104,7 @@ def convert_aggregate_filter_to_snuba_query(aggregate_filter, params):
     if params is not None and name in params.get("aliases", {}):
         return params["aliases"][name].converter(aggregate_filter)
 
-    value = (
-        int(to_timestamp(value)) if isinstance(value, datetime) and name != "timestamp" else value
-    )
+    value = int(value.timestamp()) if isinstance(value, datetime) and name != "timestamp" else value
 
     if aggregate_filter.operator in ("=", "!=") and aggregate_filter.value.value == "":
         return [["isNull", [name]], aggregate_filter.operator, 1]
@@ -637,7 +634,7 @@ def convert_search_filter_to_snuba_query(
             "timestamp.to_hour",
             "timestamp.to_day",
         }:
-            value = int(to_timestamp(value)) * 1000
+            value = int(value.timestamp()) * 1000
 
         if name in {"trace.span", "trace.parent_span"}:
             if search_filter.value.is_wildcard():

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -2,8 +2,6 @@ import functools
 import itertools
 import logging
 
-from sentry.utils.dates import to_timestamp
-
 logger = logging.getLogger("sentry.similarity")
 
 
@@ -138,7 +136,7 @@ class FeatureSet:
                     if features:
                         items.append((self.aliases[label], features))
 
-        return self.index.record(scope, key, items, timestamp=int(to_timestamp(event.datetime)))
+        return self.index.record(scope, key, items, timestamp=int(event.datetime.timestamp()))
 
     def classify(self, events, limit=None, thresholds=None):
         if not events:
@@ -185,7 +183,7 @@ class FeatureSet:
                 scope,
                 items,
                 limit=limit,
-                timestamp=int(to_timestamp(event.datetime)),
+                timestamp=int(event.datetime.timestamp()),
             )
         ]
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -29,7 +29,6 @@ from sentry.search.events.fields import (
 from sentry.search.events.types import HistogramParams, ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT
-from sentry.utils.dates import to_timestamp
 from sentry.utils.math import nice_int
 from sentry.utils.snuba import (
     SnubaTSResult,
@@ -119,7 +118,7 @@ def format_time(data, start, end, rollup, orderby):
             # ISO 8601 parser. It is only the inverse function of `datetime.isoformat`, which is
             # the format returned by snuba. This is significantly faster when compared to other
             # parsers like `dateutil.parser.parse` and `datetime.strptime`.
-            obj["time"] = int(to_timestamp(datetime.fromisoformat(obj["time"])))
+            obj["time"] = int(datetime.fromisoformat(obj["time"]).timestamp())
         if obj["time"] in data_by_time:
             data_by_time[obj["time"]].append(obj)
         else:
@@ -150,7 +149,7 @@ def zerofill(data, start, end, rollup, orderby, time_col_name=None):
             # ISO 8601 parser. It is only the inverse function of `datetime.isoformat`, which is
             # the format returned by snuba. This is significantly faster when compared to other
             # parsers like `dateutil.parser.parse` and `datetime.strptime`.
-            obj["time"] = int(to_timestamp(datetime.fromisoformat(obj["time"])))
+            obj["time"] = int(datetime.fromisoformat(obj["time"]).timestamp())
         if obj["time"] in data_by_time:
             data_by_time[obj["time"]].append(obj)
         else:

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -12,7 +12,7 @@ from snuba_sdk.query import Query
 from sentry import release_health
 from sentry.snuba.dataset import Dataset
 from sentry.utils import snuba
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 from sentry.utils.snuba import QueryOutsideRetentionError, parse_snuba_datetime, raw_query
 
 DATASET_BUCKET = 3600
@@ -279,7 +279,7 @@ def _get_project_releases_count(
 
 def _make_stats(start, rollup, buckets, default=0):
     rv = []
-    start = int(to_timestamp(start) // rollup + 1) * rollup
+    start = int(start.timestamp() // rollup + 1) * rollup
     for x in range(buckets):
         rv.append([start, default])
         start += rollup
@@ -578,7 +578,7 @@ def _get_project_release_stats(project_id, release, stat, rollup, start, end, en
     # since snuba end queries are exclusive of the time and we're bucketing to
     # a full hour, we need to round to the next hour since snuba is exclusive
     # on the end.
-    end = to_datetime((to_timestamp(end) // DATASET_BUCKET + 1) * DATASET_BUCKET)
+    end = to_datetime((end.timestamp() // DATASET_BUCKET + 1) * DATASET_BUCKET)
 
     filter_keys = {"project_id": [project_id]}
     conditions = [["release", "=", release]]

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -16,7 +16,7 @@ from sentry.search.events.builder import SessionsV2QueryBuilder, TimeseriesSessi
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.utils import to_intervals
-from sentry.utils.dates import parse_stats_period, to_timestamp
+from sentry.utils.dates import parse_stats_period
 from sentry.utils.outcomes import Outcome
 
 logger = logging.getLogger(__name__)
@@ -737,7 +737,7 @@ def massage_sessions_result_summary(
 
 
 def isoformat_z(date):
-    return datetime.fromtimestamp(int(to_timestamp(date))).isoformat() + "Z"
+    return datetime.fromtimestamp(int(date.timestamp())).isoformat() + "Z"
 
 
 def get_timestamps(query):
@@ -746,8 +746,8 @@ def get_timestamps(query):
     The timestamps are returned as ISO strings for now.
     """
     rollup = query.rollup
-    start = int(to_timestamp(query.start))
-    end = int(to_timestamp(query.end))
+    start = int(query.start.timestamp())
+    end = int(query.end.timestamp())
 
     return [datetime.fromtimestamp(ts).isoformat() + "Z" for ts in range(start, end, rollup)]
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -42,7 +42,6 @@ from sentry.tagstore.exceptions import (
 )
 from sentry.tagstore.types import GroupTagKey, GroupTagValue, TagKey, TagValue
 from sentry.utils import metrics, snuba
-from sentry.utils.dates import to_timestamp
 from sentry.utils.hashlib import md5_text
 from sentry.utils.snuba import (
     _prepare_start_end,
@@ -1395,7 +1394,7 @@ class SnubaTagStorage(TagStorage):
             if score_field == "times_seen":
                 # times_seen already an int
                 return int(getattr(tv, score_field))
-            return int(to_timestamp(getattr(tv, score_field)) * 1000)
+            return int(getattr(tv, score_field).timestamp() * 1000)
 
         return SequencePaginator(
             [(score_field_to_int(tv), tv) for tv in tag_values],
@@ -1474,10 +1473,7 @@ class SnubaTagStorage(TagStorage):
             )
 
         return SequencePaginator(
-            [
-                (int(to_timestamp(getattr(gtv, score_field)) * 1000), gtv)
-                for gtv in group_tag_values
-            ],
+            [(int(getattr(gtv, score_field).timestamp() * 1000), gtv) for gtv in group_tag_values],
             reverse=desc,
         )
 

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -41,7 +41,7 @@ from sentry.tasks.summaries.utils import (
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 from sentry.utils.outcomes import Outcome
 from sentry.utils.query import RangeQuerySetWrapper
 
@@ -62,7 +62,7 @@ HOUR_TO_SEND_REPORT = 16
 def schedule_organizations(timestamp: float | None = None, duration: int | None = None) -> None:
     if timestamp is None:
         # The time that the report was generated
-        timestamp = to_timestamp(timezone.now())
+        timestamp = timezone.now().timestamp()
 
     if duration is None:
         # The total timespan that the task covers

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -154,7 +154,7 @@ def build_summary_data(
         user_project_ownership(ctx)
 
     # build 'Today's Event Count vs. 14 day average'. we need 15 days of data for this
-    start = to_datetime(to_timestamp(ctx.end) - comparison_offset)
+    start = to_datetime(ctx.end.timestamp() - comparison_offset)
     with sentry_sdk.start_span(op="daily_summary.project_event_counts_for_organization"):
         event_counts = project_event_counts_for_organization(
             start=start, end=ctx.end, ctx=ctx, referrer=Referrer.DAILY_SUMMARY_OUTCOMES.value

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -40,7 +40,7 @@ from sentry.tasks.summaries.utils import (
 )
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json
-from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
+from sentry.utils.dates import floor_to_utc_day, to_datetime
 from sentry.utils.email import MessageBuilder
 from sentry.utils.outcomes import Outcome
 from sentry.utils.query import RangeQuerySetWrapper
@@ -65,7 +65,7 @@ def schedule_organizations(
 ) -> None:
     if timestamp is None:
         # The time that the report was generated
-        timestamp = to_timestamp(floor_to_utc_day(timezone.now()))
+        timestamp = floor_to_utc_day(timezone.now()).timestamp()
 
     if duration is None:
         # The total timespan that the task covers
@@ -125,7 +125,7 @@ def prepare_organization_report(
                 continue
             project_ctx = cast(ProjectContext, ctx.projects_context_map[project_id])
             total = data["total"]
-            timestamp = int(to_timestamp(parse_snuba_datetime(data["time"])))
+            timestamp = int(parse_snuba_datetime(data["time"]).timestamp())
             if data["category"] == DataCategory.TRANSACTION:
                 # Transaction outcome
                 if data["outcome"] == Outcome.RATE_LIMITED or data["outcome"] == Outcome.FILTERED:

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -460,7 +460,7 @@ def render_template_context(ctx, user_id):
         # Calculate series
         series = []
         for i in range(0, 7):
-            t = int(to_timestamp(ctx.start)) + ONE_DAY * i
+            t = int(ctx.start.timestamp()) + ONE_DAY * i
             project_series = [
                 {
                     "color": project_breakdown_colors[i],

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -130,7 +130,6 @@ from sentry.testutils.pytest.selenium import Browser
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.utils import json
 from sentry.utils.auth import SsoSession
-from sentry.utils.dates import to_timestamp
 from sentry.utils.json import dumps_htmlsafe
 from sentry.utils.performance_issues.performance_detection import detect_performance_problems
 from sentry.utils.retries import TimedRetryPolicy
@@ -1608,7 +1607,7 @@ class BaseMetricsTestCase(SnubaTestCase):
                 int(
                     session["started"]
                     if isinstance(session["started"], (int, float))
-                    else to_timestamp(session["started"])
+                    else session["started"].timestamp()
                 ),
                 value,
                 use_case_id=UseCaseID.SESSIONS,

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -6,7 +6,7 @@ from typing import Any, TypedDict
 from django.conf import settings
 from django.utils import timezone
 
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 from sentry.utils.services import Service
 
 ONE_MINUTE = 60
@@ -204,7 +204,7 @@ class BaseTSDB(Service):
         i.e. if the rollup is minutes, the resulting timestamp would have
         the seconds and microseconds rounded down.
         """
-        epoch = int(to_timestamp(timestamp))
+        epoch = int(timestamp.timestamp())
         return epoch - (epoch % seconds)
 
     def normalize_ts_to_epoch(self, epoch: int, seconds: int) -> int:
@@ -218,7 +218,7 @@ class BaseTSDB(Service):
         Given a ``timestamp`` (datetime object) normalize to an epoch rollup.
         """
         if isinstance(timestamp, datetime):
-            epoch = int(to_timestamp(timestamp))
+            epoch = int(timestamp.timestamp())
         else:
             epoch = int(timestamp)
         return int(epoch / seconds)
@@ -234,7 +234,7 @@ class BaseTSDB(Service):
         Identify the lowest granularity rollup available within the given time
         range.
         """
-        num_seconds = int(to_timestamp(end_timestamp)) - int(to_timestamp(start_timestamp))
+        num_seconds = int(end_timestamp.timestamp()) - int(start_timestamp.timestamp())
 
         # This loop attempts to find the smallest possible rollup that will
         # contain both the start and end timestamps. ``self.rollups`` is

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -3,7 +3,7 @@ from collections import Counter, defaultdict
 from django.utils import timezone
 
 from sentry.tsdb.base import BaseTSDB
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 
 
 class InMemoryTSDB(BaseTSDB):
@@ -89,7 +89,7 @@ class InMemoryTSDB(BaseTSDB):
                         int(self.data[model][(key, environment_id)][norm_epoch])
                         for environment_id in environment_ids
                     )
-                results.append((to_timestamp(timestamp), key, value))
+                results.append((timestamp.timestamp(), key, value))
 
         results_by_key = defaultdict(dict)
         for epoch, key, count in results:

--- a/src/sentry/utils/otp.py
+++ b/src/sentry/utils/otp.py
@@ -7,8 +7,6 @@ from urllib.parse import quote
 
 from django.utils.crypto import constant_time_compare, get_random_string
 
-from sentry.utils.dates import to_timestamp
-
 
 def generate_secret_key(length=32):
     return get_random_string(length, "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
@@ -26,7 +24,7 @@ def _get_ts(ts):
     if ts is None:
         return int(time.time())
     if isinstance(ts, datetime):
-        return int(to_timestamp(ts))
+        return int(ts.timestamp())
     return int(ts)
 
 

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -13,7 +13,6 @@ from sentry.interfaces.user import User as UserInterface
 from sentry.spans.grouping.utils import hash_values
 from sentry.utils import json
 from sentry.utils.canonical import CanonicalKeyDict
-from sentry.utils.dates import to_timestamp
 
 logger = logging.getLogger(__name__)
 epoch = datetime.fromtimestamp(0)
@@ -187,14 +186,14 @@ def load_data(
         timestamp = datetime.utcnow() - timedelta(minutes=1)
         timestamp = timestamp - timedelta(microseconds=timestamp.microsecond % 1000)
     timestamp = timestamp.replace(tzinfo=timezone.utc)
-    data.setdefault("timestamp", to_timestamp(timestamp))
+    data.setdefault("timestamp", timestamp.timestamp())
 
     if data.get("type") == "transaction":
         if start_timestamp is None:
             start_timestamp = timestamp - timedelta(seconds=3)
         else:
             start_timestamp = start_timestamp.replace(tzinfo=timezone.utc)
-        data["start_timestamp"] = to_timestamp(start_timestamp)
+        data["start_timestamp"] = start_timestamp.timestamp()
 
         if metrics_summary is not None:
             data["_metrics_summary"] = metrics_summary

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -37,7 +37,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
 from sentry.snuba.referrer import validate_referrer
 from sentry.utils import json, metrics
-from sentry.utils.dates import outside_retention_with_modified_start, to_timestamp
+from sentry.utils.dates import outside_retention_with_modified_start
 
 logger = logging.getLogger(__name__)
 
@@ -1573,7 +1573,7 @@ def get_snuba_translators(filter_keys, is_grouprelease=False):
     reverse = compose(
         reverse,
         lambda row: (
-            replace(row, "time", int(to_timestamp(parse_datetime(row["time"]))))
+            replace(row, "time", int(parse_datetime(row["time"]).timestamp()))
             if "time" in row
             else row
         ),
@@ -1582,7 +1582,7 @@ def get_snuba_translators(filter_keys, is_grouprelease=False):
     reverse = compose(
         reverse,
         lambda row: (
-            replace(row, "bucketed_end", int(to_timestamp(parse_datetime(row["bucketed_end"]))))
+            replace(row, "bucketed_end", int(parse_datetime(row["bucketed_end"]).timestamp()))
             if "bucketed_end" in row
             else row
         ),

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -10,7 +10,7 @@ from sentry.models.project import Project
 from sentry.tasks.summaries.utils import ONE_DAY, OrganizationReportContext, ProjectContext
 from sentry.tasks.summaries.weekly_reports import render_template_context
 from sentry.utils import loremipsum
-from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
+from sentry.utils.dates import floor_to_utc_day, to_datetime
 
 from .mail import MailPreviewView
 
@@ -27,16 +27,14 @@ class DebugWeeklyReportView(MailPreviewView):
         random = get_random(request)
 
         duration = 60 * 60 * 24 * 7
-        timestamp = to_timestamp(
-            floor_to_utc_day(
-                to_datetime(
-                    random.randint(
-                        to_timestamp(datetime(2015, 6, 1, 0, 0, 0, tzinfo=timezone.utc)),
-                        to_timestamp(datetime(2016, 7, 1, 0, 0, 0, tzinfo=timezone.utc)),
-                    )
+        timestamp = floor_to_utc_day(
+            to_datetime(
+                random.randint(
+                    datetime(2015, 6, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp(),
+                    datetime(2016, 7, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp(),
                 )
             )
-        )
+        ).timestamp()
         ctx = OrganizationReportContext(timestamp, duration, organization)
         ctx.projects_context_map.clear()
 

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -40,7 +40,7 @@ class DebugWeeklyReportView(MailPreviewView):
         ctx = OrganizationReportContext(timestamp, duration, organization)
         ctx.projects_context_map.clear()
 
-        start_timestamp = to_timestamp(ctx.start)
+        start_timestamp = ctx.start.timestamp()
 
         daily_maximum = random.randint(1000, 10000)
 

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -62,7 +62,7 @@ from sentry.testutils.helpers.notifications import (  # NOQA:S007
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json, loremipsum
 from sentry.utils.auth import AuthenticatedHttpRequest
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 from sentry.utils.email import MessageBuilder, inline_css
 from sentry.utils.http import absolute_uri
 from sentry.utils.samples import load_data
@@ -144,7 +144,7 @@ def make_group_metadata(random: Random) -> dict[str, Any]:
 
 
 def make_group_generator(random: Random, project: Project) -> Generator[Group, None, None]:
-    epoch = int(to_timestamp(datetime(2016, 6, 1, 0, 0, 0, tzinfo=timezone.utc)))
+    epoch = int(datetime(2016, 6, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp())
     for id in itertools.count(1):
         first_seen = epoch + random.randint(0, 60 * 60 * 24 * 30)
         last_seen = random.randint(first_seen, first_seen + (60 * 60 * 24 * 30))
@@ -547,7 +547,7 @@ def digest(request):
                     notification_uuid,
                 ),
                 # this is required for acceptance tests to pass as the EventManager won't accept a timestamp in the past
-                to_timestamp(datetime(2016, 6, 22, 16, 16, 0, tzinfo=timezone.utc)),
+                datetime(2016, 6, 22, 16, 16, 0, tzinfo=timezone.utc).timestamp(),
             )
         )
         state["groups"][perf_group.id] = perf_group
@@ -571,7 +571,7 @@ def digest(request):
                     notification_uuid,
                 ),
                 # this is required for acceptance tests to pass as the EventManager won't accept a timestamp in the past
-                to_timestamp(datetime(2016, 6, 22, 16, 16, 0, tzinfo=timezone.utc)),
+                datetime(2016, 6, 22, 16, 16, 0, tzinfo=timezone.utc).timestamp(),
             )
         )
         state["groups"][generic_group.id] = generic_group

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -506,7 +506,7 @@ def digest(request):
             data = event_manager.get_data()
 
             data["timestamp"] = random.randint(
-                int(to_timestamp(group.first_seen)), int(to_timestamp(group.last_seen))
+                int(group.first_seen.timestamp()), int(group.last_seen.timestamp())
             )
 
             event = eventstore.backend.create_event(
@@ -522,7 +522,7 @@ def digest(request):
                         ),
                         notification_uuid,
                     ),
-                    to_timestamp(event.datetime),
+                    event.datetime.timestamp(),
                 )
             )
 

--- a/tests/sentry/api/endpoints/test_sentry_app_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_stats.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
-from sentry.utils.dates import to_timestamp
 
 
 @control_silo_test
@@ -43,11 +42,9 @@ class GetSentryAppStatsTest(APITestCase):
         assert response.data["totalInstalls"] == 1
         assert response.data["totalUninstalls"] == 0
         install_epoch = int(
-            to_timestamp(
-                self.unowned_published_app_install.date_added.replace(
-                    microsecond=0, second=0, minute=0
-                )
-            )
+            self.unowned_published_app_install.date_added.replace(
+                microsecond=0, second=0, minute=0
+            ).timestamp()
         )
         assert (install_epoch, 1) in response.data["installStats"]
 
@@ -69,9 +66,9 @@ class GetSentryAppStatsTest(APITestCase):
         assert response.data["totalInstalls"] == 1
         assert response.data["totalUninstalls"] == 0
         install_epoch = int(
-            to_timestamp(
-                self.published_app_install.date_added.replace(microsecond=0, second=0, minute=0)
-            )
+            self.published_app_install.date_added.replace(
+                microsecond=0, second=0, minute=0
+            ).timestamp()
         )
         assert (install_epoch, 1) in response.data["installStats"]
 

--- a/tests/sentry/api/serializers/test_snuba.py
+++ b/tests/sentry/api/serializers/test_snuba.py
@@ -10,7 +10,7 @@ from sentry.utils.dates import to_timestamp
 class ZeroFillTest(unittest.TestCase):
     def run_test(self, filled_buckets, irregular_buckets, start, end, rollup, zerofilled_buckets):
         filled_buckets = [(start + (rollup * bucket), val) for bucket, val in filled_buckets]
-        buckets = [(to_timestamp(date), val) for date, val in filled_buckets + irregular_buckets]
+        buckets = [(date.timestamp(), val) for date, val in filled_buckets + irregular_buckets]
         sort_key = lambda row: row[0]
         buckets.sort(key=sort_key)
         zerofilled_buckets = [

--- a/tests/sentry/api/serializers/test_snuba.py
+++ b/tests/sentry/api/serializers/test_snuba.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from django.utils import timezone
 
 from sentry.api.serializers.snuba import zerofill
-from sentry.utils.dates import to_timestamp
 
 
 class ZeroFillTest(unittest.TestCase):
@@ -14,7 +13,7 @@ class ZeroFillTest(unittest.TestCase):
         sort_key = lambda row: row[0]
         buckets.sort(key=sort_key)
         zerofilled_buckets = [
-            (to_timestamp(start + (rollup * bucket)), []) for bucket in zerofilled_buckets
+            ((start + (rollup * bucket)).timestamp(), []) for bucket in zerofilled_buckets
         ]
         expected = buckets + zerofilled_buckets
         expected.sort(key=sort_key)
@@ -55,8 +54,8 @@ class ZeroFillTest(unittest.TestCase):
         start = timezone.now().replace(minute=5, second=0, microsecond=0)
         rollup = timedelta(minutes=10)
         buckets = [
-            (to_timestamp(start + timedelta(minutes=1)), [9]),
-            (to_timestamp(start + timedelta(minutes=16)), [3]),
+            ((start + timedelta(minutes=1)).timestamp(), [9]),
+            ((start + timedelta(minutes=16)).timestamp(), [3]),
         ]
         zerofilled_buckets = zerofill(
             buckets,
@@ -66,8 +65,8 @@ class ZeroFillTest(unittest.TestCase):
             allow_partial_buckets=True,
         )
         assert zerofilled_buckets == [
-            (to_timestamp(start - timedelta(minutes=5)), []),
-            (to_timestamp(start + timedelta(minutes=1)), [9]),
-            (to_timestamp(start + timedelta(minutes=5)), []),
-            (to_timestamp(start + timedelta(minutes=16)), [3]),
+            ((start - timedelta(minutes=5)).timestamp(), []),
+            ((start + timedelta(minutes=1)).timestamp(), [9]),
+            ((start + timedelta(minutes=5)).timestamp(), []),
+            ((start + timedelta(minutes=16)).timestamp(), [3]),
         ]

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -51,7 +51,6 @@ from sentry.testutils.cases import BaseMetricsTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
-from sentry.utils.dates import to_timestamp
 
 EMPTY = object()
 
@@ -2867,7 +2866,7 @@ class TestGetAlertRuleStats(TestCase):
         client = get_redis_client()
         pipeline = client.pipeline()
         timestamp = datetime.now(UTC).replace(microsecond=0)
-        pipeline.set("{alert_rule:1:project:2}:last_update", int(to_timestamp(timestamp)))
+        pipeline.set("{alert_rule:1:project:2}:last_update", int(timestamp.timestamp()))
         pipeline.set("{alert_rule:1:project:2}:resolve_triggered", 20)
         for key, value in [
             ("{alert_rule:1:project:2}:trigger:3:alert_triggered", 1),
@@ -2905,4 +2904,4 @@ class TestUpdateAlertRuleStats(TestCase):
             if v is not None
         ]
 
-        assert results == [int(to_timestamp(date)), 20, 10, 3, 15]
+        assert results == [int(date.timestamp()), 20, 10, 3, 15]

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -53,7 +53,6 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.group import GroupSubStatus
-from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
@@ -263,7 +262,7 @@ def build_test_message(
         "title": title,
         "fields": [],
         "footer": f"{project.slug.upper()}-1",
-        "ts": to_timestamp(timestamp),
+        "ts": timestamp.timestamp(),
         "title_link": title_link,
         "callback_id": '{"issue":' + str(group.id) + "}",
         "fallback": f"[{project.slug}] {title}",
@@ -1111,7 +1110,7 @@ class BuildIncidentAttachmentTest(TestCase):
         )
         title = f"Resolved: {alert_rule.name}"
         timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
-            to_timestamp(incident.date_started), "{date_pretty}", "{time}"
+            incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         link = (
             absolute_uri(
@@ -1151,7 +1150,7 @@ class BuildIncidentAttachmentTest(TestCase):
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
-            to_timestamp(incident.date_started), "{date_pretty}", "{time}"
+            incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         link = (
             absolute_uri(
@@ -1191,7 +1190,7 @@ class BuildIncidentAttachmentTest(TestCase):
         )
         title = f"Resolved: {alert_rule.name}"
         timestamp = "<!date^{:.0f}^Started {} at {} | Sentry Incident>".format(
-            to_timestamp(incident.date_started), "{date_pretty}", "{time}"
+            incident.date_started.timestamp(), "{date_pretty}", "{time}"
         )
         link = (
             absolute_uri(

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -10,7 +10,6 @@ from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import BaseIncidentsTest, BaseMetricsTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.utils.dates import to_timestamp
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -187,7 +186,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
         self.now = timezone.now().replace(minute=0, second=0, microsecond=0)
-        self._5_min_ago = to_timestamp(self.now - timedelta(minutes=5))
+        self._5_min_ago = (self.now - timedelta(minutes=5)).timestamp()
         self.date_started = self.now - timedelta(minutes=120)
 
     def create_incident_and_related_objects(self, field="sessions"):

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -34,7 +34,6 @@ from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.dates import to_timestamp
 from sentry.utils.outcomes import Outcome
 
 
@@ -191,13 +190,13 @@ class DailySummaryTest(
         self.create_member(teams=[self.team], user=user2, organization=self.organization)
 
         with self.tasks():
-            schedule_organizations(timestamp=to_timestamp(self.now))
+            schedule_organizations(timestamp=self.now.timestamp())
 
         # user2's local timezone is UTC and therefore it isn't sent now
         assert mock_prepare_summary_data.delay.call_count == 1
         for call_args in mock_prepare_summary_data.delay.call_args_list:
             assert call_args.args == (
-                to_timestamp(self.now),
+                self.now.timestamp(),
                 ONE_DAY,
                 self.organization.id,
                 [self.user.id],
@@ -223,7 +222,7 @@ class DailySummaryTest(
     def test_build_summary_data(self):
         self.populate_event_data()
         summary = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -264,7 +263,7 @@ class DailySummaryTest(
         self.populate_event_data()
         with self.tasks():
             prepare_summary_data(
-                to_timestamp(self.now), ONE_DAY, self.organization.id, [self.user.id]
+                self.now.timestamp(), ONE_DAY, self.organization.id, [self.user.id]
             )
 
         assert mock_deliver_summary.call_count == 1
@@ -274,7 +273,7 @@ class DailySummaryTest(
         """Test that if the summary has no data in it, we don't even try to send it"""
         with self.tasks():
             prepare_summary_data(
-                to_timestamp(self.now), ONE_DAY, self.organization.id, [self.user.id]
+                self.now.timestamp(), ONE_DAY, self.organization.id, [self.user.id]
             )
 
         assert mock_deliver_summary.call_count == 0
@@ -283,7 +282,7 @@ class DailySummaryTest(
     def test_deliver_summary(self, mock_send):
         self.populate_event_data()
         summary = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -307,7 +306,7 @@ class DailySummaryTest(
                 category=DataCategory.ERROR,
             )
         context = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -342,7 +341,7 @@ class DailySummaryTest(
         user2 = self.create_user()
         self.create_member(teams=[self.team], user=user2, organization=self.organization)
         context = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -355,7 +354,7 @@ class DailySummaryTest(
     def test_slack_notification_contents(self):
         self.populate_event_data()
         ctx = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -422,7 +421,7 @@ class DailySummaryTest(
                 category=DataCategory.ERROR,
             )
         context = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -446,7 +445,7 @@ class DailySummaryTest(
         """
         self.populate_event_data(use_release=False)
         ctx = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -474,7 +473,7 @@ class DailySummaryTest(
         """
         self.populate_event_data(performance_issues=False)
         ctx = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,
@@ -521,7 +520,7 @@ class DailySummaryTest(
         """
         self.populate_event_data(regressed_issue=False, escalated_issue=False)
         ctx = build_summary_data(
-            timestamp=to_timestamp(self.now),
+            timestamp=self.now.timestamp(),
             duration=ONE_DAY,
             organization=self.organization,
             daily=True,

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -39,7 +39,7 @@ from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_forma
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.group import GroupSubStatus
-from sentry.utils.dates import floor_to_utc_day, to_timestamp
+from sentry.utils.dates import floor_to_utc_day
 from sentry.utils.outcomes import Outcome
 
 DISABLED_ORGANIZATIONS_USER_OPTION_KEY = "reports:disabled-organizations"
@@ -566,7 +566,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         two_days_ago = now - timedelta(days=2)
         three_days_ago = now - timedelta(days=3)
 
-        timestamp = to_timestamp(floor_to_utc_day(now))
+        timestamp = floor_to_utc_day(now).timestamp()
 
         for outcome, category, num in [
             (Outcome.ACCEPTED, DataCategory.ERROR, 1),
@@ -657,7 +657,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     def test_message_builder_replays(self, message_builder):
         now = django_timezone.now()
         two_days_ago = now - timedelta(days=2)
-        timestamp = to_timestamp(floor_to_utc_day(now))
+        timestamp = floor_to_utc_day(now).timestamp()
 
         for outcome, category, num in [
             (Outcome.ACCEPTED, DataCategory.REPLAY, 6),
@@ -717,7 +717,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     def test_email_override_simple(self, message_builder, record):
         now = django_timezone.now()
         two_days_ago = now - timedelta(days=2)
-        timestamp = to_timestamp(floor_to_utc_day(now))
+        timestamp = floor_to_utc_day(now).timestamp()
 
         user = self.create_user(email="itwasme@dio.xyz")
         self.create_member(teams=[self.team], user=user, organization=self.organization)
@@ -772,7 +772,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     def test_email_override_no_target_user(self, message_builder, record):
         now = django_timezone.now()
         two_days_ago = now - timedelta(days=2)
-        timestamp = to_timestamp(floor_to_utc_day(now))
+        timestamp = floor_to_utc_day(now).timestamp()
 
         # create some extra projects; we expect to receive a report with all projects included
         self.create_project(organization=self.organization)
@@ -822,7 +822,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     def test_email_override_invalid_target_user(self, logger):
         now = django_timezone.now()
         two_days_ago = now - timedelta(days=2)
-        timestamp = to_timestamp(floor_to_utc_day(now))
+        timestamp = floor_to_utc_day(now).timestamp()
         org = self.create_organization()
         proj = self.create_project(organization=org)
 
@@ -862,7 +862,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     def test_dry_run_simple(self, message_builder, record):
         now = django_timezone.now()
         two_days_ago = now - timedelta(days=2)
-        timestamp = to_timestamp(floor_to_utc_day(now))
+        timestamp = floor_to_utc_day(now).timestamp()
         org = self.create_organization()
         proj = self.create_project(organization=org)
 

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -67,7 +67,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         member_set = set(project.teams.first().member_set.all())
 
         with self.tasks():
-            schedule_organizations(timestamp=to_timestamp(now))
+            schedule_organizations(timestamp=now.timestamp())
             assert len(mail.outbox) == len(member_set) == 1
 
             message = mail.outbox[0]
@@ -89,7 +89,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             )
 
         with self.tasks():
-            schedule_organizations(timestamp=to_timestamp(now))
+            schedule_organizations(timestamp=now.timestamp())
             assert len(mail.outbox) == len(member_set) == 1
 
             message = mail.outbox[0]
@@ -113,7 +113,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             project_id=project.id,
         )
         with self.tasks():
-            schedule_organizations(timestamp=to_timestamp(now))
+            schedule_organizations(timestamp=now.timestamp())
             assert len(mail.outbox) == 1
 
             message = mail.outbox[0]
@@ -233,7 +233,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         )
         project.transfer_to(organization=self.create_organization())
 
-        prepare_organization_report(to_timestamp(now), ONE_DAY * 7, self.organization.id)
+        prepare_organization_report(now.timestamp(), ONE_DAY * 7, self.organization.id)
         assert message_builder.call_count == 1
 
     @with_feature("organizations:escalating-issues")
@@ -268,7 +268,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         )
         event2.group.substatus = GroupSubStatus.NEW
         event2.group.save()
-        timestamp = to_timestamp(now)
+        timestamp = now.timestamp()
 
         ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
         organization_project_issue_substatus_summaries(ctx)
@@ -354,7 +354,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
         # store a crons issue just to make sure it's not counted in key_performance_issues
         self.create_group(type=MonitorCheckInFailure.type_id)
-        prepare_organization_report(to_timestamp(now), ONE_DAY * 7, self.organization.id)
+        prepare_organization_report(now.timestamp(), ONE_DAY * 7, self.organization.id)
 
         for call_args in message_builder.call_args_list:
             message_params = call_args.kwargs
@@ -463,10 +463,10 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             side_effect=ValueError("oh no!"),
         ), mock.patch("sentry.tasks.summaries.weekly_reports.send_email") as mock_send_email:
             with pytest.raises(Exception):
-                prepare_organization_report(to_timestamp(now), ONE_DAY * 7, self.organization.id)
+                prepare_organization_report(now.timestamp(), ONE_DAY * 7, self.organization.id)
                 mock_send_email.assert_not_called()
 
-        prepare_organization_report(to_timestamp(now), ONE_DAY * 7, self.organization.id)
+        prepare_organization_report(now.timestamp(), ONE_DAY * 7, self.organization.id)
         for call_args in message_builder.call_args_list:
             message_params = call_args.kwargs
             context = message_params["context"]
@@ -542,7 +542,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         group2.substatus = GroupSubStatus.ONGOING
         group2.save()
 
-        prepare_organization_report(to_timestamp(now), ONE_DAY * 7, self.organization.id)
+        prepare_organization_report(now.timestamp(), ONE_DAY * 7, self.organization.id)
 
         for call_args in message_builder.call_args_list:
             message_params = call_args.kwargs
@@ -648,7 +648,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             project_id=self.project.id,
         )
 
-        prepare_organization_report(to_timestamp(now), ONE_DAY * 7, self.organization.id)
+        prepare_organization_report(now.timestamp(), ONE_DAY * 7, self.organization.id)
         assert mock_send_email.call_count == 0
 
     @with_feature("organizations:session-replay")

--- a/tests/sentry/tsdb/test_base.py
+++ b/tests/sentry/tsdb/test_base.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.tsdb.base import ONE_DAY, ONE_HOUR, ONE_MINUTE, BaseTSDB
-from sentry.utils.dates import to_timestamp
 
 
 class BaseTSDBTest(TestCase):
@@ -50,25 +49,25 @@ class BaseTSDBTest(TestCase):
 
         assert self.tsdb.get_optimal_rollup_series(start) == (
             10,
-            [to_timestamp(start + timedelta(seconds=10) * i) for i in range(4)],
+            [(start + timedelta(seconds=10) * i).timestamp() for i in range(4)],
         )
 
         start = datetime.now(timezone.utc) - timedelta(minutes=30)
         assert self.tsdb.get_optimal_rollup_series(start) == (
             ONE_MINUTE,
-            [to_timestamp(start + timedelta(minutes=1) * i) for i in range(31)],
+            [(start + timedelta(minutes=1) * i).timestamp() for i in range(31)],
         )
 
         start = datetime.now(timezone.utc) - timedelta(hours=5)
         assert self.tsdb.get_optimal_rollup_series(start) == (
             ONE_HOUR,
-            [to_timestamp(start + timedelta(hours=1) * i) for i in range(6)],
+            [(start + timedelta(hours=1) * i).timestamp() for i in range(6)],
         )
 
         start = datetime.now(timezone.utc) - timedelta(days=7)
         assert self.tsdb.get_optimal_rollup_series(start) == (
             ONE_DAY,
-            [to_timestamp(start + timedelta(hours=24) * i) for i in range(8)],
+            [(start + timedelta(hours=24) * i).timestamp() for i in range(8)],
         )
 
     @freeze_time("2016-08-01 00:00:15")
@@ -84,8 +83,8 @@ class BaseTSDBTest(TestCase):
         assert self.tsdb.get_optimal_rollup_series(start, rollup=10) == (
             10,
             [
-                to_timestamp(datetime(2016, 8, 1, 0, 0, 0, tzinfo=timezone.utc)),
-                to_timestamp(datetime(2016, 8, 1, 0, 0, 10, tzinfo=timezone.utc)),
+                datetime(2016, 8, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp(),
+                datetime(2016, 8, 1, 0, 0, 10, tzinfo=timezone.utc).timestamp(),
             ],
         )
 
@@ -93,14 +92,14 @@ class BaseTSDBTest(TestCase):
         start = now - timedelta(seconds=ONE_MINUTE - 1)
         assert self.tsdb.get_optimal_rollup_series(start, rollup=ONE_MINUTE) == (
             ONE_MINUTE,
-            [to_timestamp(datetime(2016, 8, 1, 0, 0, 0, tzinfo=timezone.utc))],
+            [datetime(2016, 8, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp()],
         )
 
         now = datetime.now(timezone.utc) + timedelta(hours=11, seconds=45)
         start = now - timedelta(seconds=ONE_DAY - 1)
         assert self.tsdb.get_optimal_rollup_series(start, rollup=ONE_DAY) == (
             ONE_DAY,
-            [to_timestamp(datetime(2016, 8, 1, 0, tzinfo=timezone.utc))],
+            [datetime(2016, 8, 1, 0, tzinfo=timezone.utc).timestamp()],
         )
 
     @freeze_time("2016-08-01")
@@ -108,21 +107,21 @@ class BaseTSDBTest(TestCase):
 
         start = datetime.now(timezone.utc) - timedelta(seconds=30)
         assert self.tsdb.make_series(0, start) == [
-            (to_timestamp(start + timedelta(seconds=10) * i), 0) for i in range(4)
+            ((start + timedelta(seconds=10) * i).timestamp(), 0) for i in range(4)
         ]
 
         start = datetime.now(timezone.utc) - timedelta(minutes=30)
         assert self.tsdb.make_series(lambda timestamp: 1, start) == [
-            (to_timestamp(start + timedelta(minutes=1) * i), 1) for i in range(31)
+            ((start + timedelta(minutes=1) * i).timestamp(), 1) for i in range(31)
         ]
 
         counter = itertools.count()
         start = datetime.now(timezone.utc) - timedelta(hours=5)
         assert self.tsdb.make_series(lambda timestamp: next(counter), start) == [
-            (to_timestamp(start + timedelta(hours=1) * i), i) for i in range(6)
+            ((start + timedelta(hours=1) * i).timestamp(), i) for i in range(6)
         ]
 
         start = datetime.now(timezone.utc) - timedelta(days=7)
         assert self.tsdb.make_series(0, start) == [
-            (to_timestamp(start + timedelta(hours=24) * i), 0) for i in range(8)
+            ((start + timedelta(hours=24) * i).timestamp(), 0) for i in range(8)
         ]

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -8,7 +8,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.tsdb.base import ONE_DAY, ONE_HOUR, ONE_MINUTE, TSDBModel
 from sentry.tsdb.redis import CountMinScript, RedisTSDB, SuppressionWrapper
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 
 
 def test_suppression_wrapper():
@@ -85,7 +85,7 @@ class RedisTSDBTest(TestCase):
         dts = [now + timedelta(hours=i) for i in range(4)]
 
         def timestamp(d):
-            t = int(to_timestamp(d))
+            t = int(d.timestamp())
             return t - (t % 3600)
 
         self.db.incr(TSDBModel.project, 1, dts[0])
@@ -195,7 +195,7 @@ class RedisTSDBTest(TestCase):
         model = TSDBModel.users_affected_by_group
 
         def timestamp(d):
-            t = int(to_timestamp(d))
+            t = int(d.timestamp())
             return t - (t % 3600)
 
         self.db.record(model, 1, ("foo", "bar"), dts[0])
@@ -420,7 +420,7 @@ class RedisTSDBTest(TestCase):
             environment_id=0,
         ) == {"organization:1": [], "organization:2": []}
 
-        timestamp = int(to_timestamp(now) // rollup) * rollup
+        timestamp = int(now.timestamp() // rollup) * rollup
 
         assert self.db.get_most_frequent_series(
             model,

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -4,13 +4,12 @@ from sentry.constants import DataCategory
 from sentry.testutils.cases import OutcomesSnubaTest
 from sentry.tsdb.base import TSDBModel
 from sentry.tsdb.snuba import SnubaTSDB
-from sentry.utils.dates import to_timestamp
 from sentry.utils.outcomes import Outcome
 
 
 def floor_to_hour_epoch(value):
     value = value.replace(minute=0, second=0, microsecond=0)
-    return int(to_timestamp(value))
+    return int(value.timestamp())
 
 
 def floor_to_10s_epoch(value):
@@ -18,7 +17,7 @@ def floor_to_10s_epoch(value):
     floored_second = 10 * (seconds // 10)
 
     value = value.replace(second=floored_second, microsecond=0)
-    return int(to_timestamp(value))
+    return int(value.timestamp())
 
 
 class SnubaTSDBTest(OutcomesSnubaTest):

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -15,7 +15,6 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.link_header import parse_link_header
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.cursors import Cursor
-from sentry.utils.dates import to_timestamp
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -38,7 +37,7 @@ MOCK_DATETIME_PLUS_ONE_HOUR = MOCK_DATETIME + datetime.timedelta(hours=1)
 SNUBA_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 MOCK_DATETIME_START_OF_DAY = MOCK_DATETIME.replace(hour=0, minute=0, second=0)
 
-TIMESTAMP = to_timestamp(MOCK_DATETIME)
+TIMESTAMP = MOCK_DATETIME.timestamp()
 RECEIVED = TIMESTAMP
 SESSION_STARTED = TIMESTAMP // 3600 * 3600  # round to the hour
 

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -34,7 +34,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.tsdb.base import TSDBModel
 from sentry.utils import redis
-from sentry.utils.dates import to_timestamp
 
 # Use the default redis client as a cluster client in the similarity index
 index = _make_index_backend(redis.clusters.get("default").get_local_client(0))
@@ -136,7 +135,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                 times_seen=1,
                 first_release=None,
                 culprit="",
-                data={"type": "default", "last_received": to_timestamp(now), "metadata": {}},
+                data={"type": "default", "last_received": now.timestamp(), "metadata": {}},
             ),
             [
                 self.store_event(
@@ -405,7 +404,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
 
             expected: dict[float, float] = {}
             for event in events:
-                k = float((to_timestamp(event.datetime) // rollup_duration) * rollup_duration)
+                k = float((event.datetime.timestamp() // rollup_duration) * rollup_duration)
                 expected[k] = function(expected.get(k), event)
 
             return expected

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -13,12 +13,12 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.tsdb.base import TSDBModel
 from sentry.tsdb.snuba import SnubaTSDB
-from sentry.utils.dates import to_datetime, to_timestamp
+from sentry.utils.dates import to_datetime
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
 
 def timestamp(d):
-    t = int(to_timestamp(d))
+    t = int(d.timestamp())
     return t - (t % 3600)
 
 
@@ -338,7 +338,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
         # Minutely
         dts = [self.now + timedelta(minutes=i) for i in range(120)]
         # Expect every 10th minute to have a 1, else 0
-        expected = [(to_timestamp(d), 1 if i % 10 == 0 else 0) for i, d in enumerate(dts)]
+        expected = [(d.timestamp(), 1 if i % 10 == 0 else 0) for i, d in enumerate(dts)]
 
         assert self.db.get_range(
             TSDBModel.project,
@@ -676,7 +676,7 @@ class SnubaTSDBGroupProfilingTest(TestCase, SnubaTestCase, SearchIssueTestMixin)
 
         for step, delta, times in GRANULARITIES:
             series = [start + (delta * i) for i in range(times)]
-            series_ts = [int(to_timestamp(ts)) for ts in series]
+            series_ts = [int(ts.timestamp()) for ts in series]
 
             assert self.db.get_optimal_rollup(series[0], series[-1]) == step
 


### PR DESCRIPTION
`.timestamp()` has existed on `datetime.datetime` since python 3.3 \o/

<!-- Describe your PR here. -->