### PR TITLE
chore(issue-platform): Include stack info for `grouphash.not_found` error

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -151,6 +151,7 @@ def bulk_get_groups_from_fingerprints(
                 "project_id": project_id,
                 "fingerprint": fingerprint,
             },
+            stack_info=True,
         )
 
     return result

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -299,6 +299,7 @@ class TestProduceOccurrenceForStatusChange(TestCase, OccurrenceTestMixin):
                 "project_id": group.project_id,
                 "fingerprint": wrong_fingerprint["fingerprint"][0],
             },
+            stack_info=True,
         )
         assert group.status == initial_status
         assert group.substatus == initial_substatus

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -236,6 +236,7 @@ class StatusChangeBulkGetGroupsFromFingerprintsTest(IssueOccurrenceTestBase):
                 "project_id": project2.id,
                 "fingerprint": self.occurrence.fingerprint[0],
             },
+            stack_info=True,
         )
 
     def test_bulk_get_same_fingerprint(self) -> None:


### PR DESCRIPTION
Not sure which caller is calling this, including the stack trace
