### PR TITLE
metrics(feedback): track missing error events in shim_to_feedback

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -303,11 +303,7 @@ def shim_to_feedback(
             feedback_event["tags"] = [list(item) for item in event.tags]
 
         else:
-            metrics.incr(
-                "feedback.user_report.missing_event",
-                sample_rate=1.0,
-                tags={"project_id": project.id},
-            )
+            metrics.incr("feedback.user_report.missing_event", sample_rate=1.0)
 
             feedback_event["timestamp"] = datetime.utcnow().timestamp()
             feedback_event["platform"] = "other"

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -303,6 +303,12 @@ def shim_to_feedback(
             feedback_event["tags"] = [list(item) for item in event.tags]
 
         else:
+            metrics.incr(
+                "feedback.user_report.missing_event",
+                sample_rate=1.0,
+                tags={"project_id": project.id},
+            )
+
             feedback_event["timestamp"] = datetime.utcnow().timestamp()
             feedback_event["platform"] = "other"
             feedback_event["level"] = report.get("level", "info")


### PR DESCRIPTION
https://github.com/getsentry/team-replay/issues/392

This concerns the old user report APIs, which are called by older SDK versions and some customers. Context for the feedback needs to be inferred from an associated error event, so we want to track when we are missing such events.