### PR TITLE
ref(crons): Stop writing TIMEOUT and MISSED_CHECKIN status

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -197,11 +197,7 @@ def mark_failed_no_threshold(failed_checkin: MonitorCheckIn):
 
     monitor_env = failed_checkin.monitor_environment
 
-    failed_status_map = {
-        CheckInStatus.MISSED: MonitorStatus.MISSED_CHECKIN,
-        CheckInStatus.TIMEOUT: MonitorStatus.TIMEOUT,
-    }
-    monitor_env.update(status=failed_status_map.get(failed_checkin.status, MonitorStatus.ERROR))
+    monitor_env.update(status=MonitorStatus.ERROR)
 
     # Do not create event if monitor or monitor environment is muted
     if monitor_env.monitor.is_muted or monitor_env.is_muted:

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -131,7 +131,7 @@ class MarkFailedTestCase(TestCase):
                 "platform": "other",
                 "contexts": {
                     "monitor": {
-                        "status": "timeout",
+                        "status": "error",
                         "type": "cron_job",
                         "config": {
                             "schedule_type": 2,
@@ -187,7 +187,7 @@ class MarkFailedTestCase(TestCase):
 
         monitor.refresh_from_db()
         monitor_environment.refresh_from_db()
-        assert monitor_environment.status == MonitorStatus.MISSED_CHECKIN
+        assert monitor_environment.status == MonitorStatus.ERROR
 
         assert len(mock_insert_data_to_database_legacy.mock_calls) == 1
 
@@ -202,7 +202,7 @@ class MarkFailedTestCase(TestCase):
                 "platform": "other",
                 "contexts": {
                     "monitor": {
-                        "status": "missed_checkin",
+                        "status": "error",
                         "type": "cron_job",
                         "config": {
                             "schedule_type": 2,

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -104,7 +104,7 @@ class MonitorTaskCheckMissingTest(TestCase):
 
         # Monitor status is updated
         monitor_environment = MonitorEnvironment.objects.get(
-            id=monitor_environment.id, status=MonitorStatus.MISSED_CHECKIN
+            id=monitor_environment.id, status=MonitorStatus.ERROR
         )
 
         # last_checkin was NOT updated. We only update this for real user check-ins.
@@ -226,7 +226,7 @@ class MonitorTaskCheckMissingTest(TestCase):
 
         assert not MonitorEnvironment.objects.filter(
             id=monitor_environment.id,
-            status=MonitorStatus.MISSED_CHECKIN,
+            status=MonitorStatus.ERROR,
         ).exists()
 
         assert not MonitorCheckIn.objects.filter(
@@ -250,7 +250,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         )
 
         monitor_environment = MonitorEnvironment.objects.get(
-            id=monitor_environment.id, status=MonitorStatus.MISSED_CHECKIN
+            id=monitor_environment.id, status=MonitorStatus.ERROR
         )
 
         missed_checkin = MonitorCheckIn.objects.filter(
@@ -357,7 +357,7 @@ class MonitorTaskCheckMissingTest(TestCase):
 
         monitor_env = MonitorEnvironment.objects.get(
             id=monitor_environment.id,
-            status=MonitorStatus.MISSED_CHECKIN,
+            status=MonitorStatus.ERROR,
         )
 
         # The next checkin is at the 10 minute mark now
@@ -610,9 +610,9 @@ class MonitorTaskCheckMissingTest(TestCase):
         # assert regular monitor works
         mark_environment_missing(successful_monitor_environment.id, sub_task_run_ts)
 
-        # We still marked a monitor as missed
+        # We still put the monitor in an error state
         assert MonitorEnvironment.objects.filter(
-            id=successful_monitor_environment.id, status=MonitorStatus.MISSED_CHECKIN
+            id=successful_monitor_environment.id, status=MonitorStatus.ERROR
         ).exists()
         assert MonitorCheckIn.objects.filter(
             monitor_environment=successful_monitor_environment.id, status=CheckInStatus.MISSED
@@ -681,10 +681,10 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         # Check in is marked as timed out
         assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
 
-        # Monitor is marked as timed out
+        # Monitor is in an error state
         monitor_env = MonitorEnvironment.objects.filter(
             id=monitor_environment.id,
-            status=MonitorStatus.TIMEOUT,
+            status=MonitorStatus.ERROR,
         )
         assert monitor_env.exists()
 
@@ -845,10 +845,9 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         # First checkin is marked as timed out
         assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
 
-        # Monitor was marked as timed out
+        # Monitor is in an error state
         monitor_env = MonitorEnvironment.objects.filter(
-            id=monitor_environment.id,
-            status=MonitorStatus.TIMEOUT,
+            id=monitor_environment.id, status=MonitorStatus.ERROR
         )
         assert monitor_env.exists()
 
@@ -908,10 +907,10 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         # Check in is marked as timed out
         assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
 
-        # Monitor is marked as timed out
+        # Monitor is in an error state
         monitor_env = MonitorEnvironment.objects.filter(
             id=monitor_environment.id,
-            status=MonitorStatus.TIMEOUT,
+            status=MonitorStatus.ERROR,
         )
         assert monitor_env.exists()
 


### PR DESCRIPTION
When using the legacy method of creating monitor issues we were still updating the monitor environment status with TIMEOUT and MISSED_CHECKIN. In the future world where we only have incidents, these states will no longer make sense.

This is the first step towards removing TIMEOUT and MISSED_CHECKIN as denormalized status on the monitor environment.

In sentry SAAS we should never be hitting these, but there are some cases where monitors seem to exist for organizations that don't exist, which is why we land in this scenario.

The result of this change is more-or-less aesthetic, the status is primarily used to display this little indicator to the right of the environment name

<img width="573" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/3955f965-1b7e-4f91-8572-81c91e26e160">
