### PR TITLE
feat(perf): Add `http_response_code_rate` span metrics function

### DIFF
--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -353,7 +353,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                         ),
                         alias,
                     ),
-                    default_result_type="integer",
+                    default_result_type="percentage",
                 ),
                 fields.MetricsFunction(
                     "http_error_rate",

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -355,6 +355,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     ),
                     default_result_type="percentage",
                 ),
+                # TODO: Deprecated, use `http_response_rate(5)` instead
                 fields.MetricsFunction(
                     "http_error_rate",
                     snql_distribution=lambda args, alias: function_aliases.resolve_division(
@@ -384,6 +385,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     snql_distribution=self._resolve_http_response_count,
                     default_result_type="integer",
                 ),
+                # TODO: Deprecated, use `http_response_count(5)` instead
                 fields.MetricsFunction(
                     "http_error_count",
                     snql_distribution=self._resolve_http_error_count,

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -622,25 +622,14 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         self,
         args: Mapping[str, str | Column | SelectType | int | float],
         alias: str | None = None,
-        extra_condition: Function | None = None,
     ) -> SelectType:
-        base_condition = Function(
+        condition = Function(
             "startsWith",
             [
                 self.builder.column("span.status_code"),
                 args["code"],
             ],
         )
-        if extra_condition:
-            condition = Function(
-                "and",
-                [
-                    base_condition,
-                    extra_condition,
-                ],
-            )
-        else:
-            condition = base_condition
 
         return self._resolve_count_if(
             Function(

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -332,12 +332,12 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     default_result_type="percentage",
                 ),
                 fields.MetricsFunction(
-                    "http_response_code_rate",
+                    "http_response_rate",
                     required_args=[
                         SnQLStringArg("code"),
                     ],
                     snql_distribution=lambda args, alias: function_aliases.resolve_division(
-                        self._resolve_http_response_code_count(args),
+                        self._resolve_http_response_count(args),
                         Function(
                             "countIf",
                             [
@@ -377,11 +377,11 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     default_result_type="percentage",
                 ),
                 fields.MetricsFunction(
-                    "http_response_code_count",
+                    "http_response_count",
                     required_args=[
                         SnQLStringArg("code"),
                     ],
-                    snql_distribution=self._resolve_http_response_code_count,
+                    snql_distribution=self._resolve_http_response_count,
                     default_result_type="integer",
                 ),
                 fields.MetricsFunction(
@@ -618,7 +618,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             alias,
         )
 
-    def _resolve_http_response_code_count(
+    def _resolve_http_response_count(
         self,
         args: Mapping[str, str | Column | SelectType | int | float],
         alias: str | None = None,

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -332,6 +332,30 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     default_result_type="percentage",
                 ),
                 fields.MetricsFunction(
+                    "http_response_code_rate",
+                    required_args=[
+                        SnQLStringArg("code"),
+                    ],
+                    snql_distribution=lambda args, alias: function_aliases.resolve_division(
+                        self._resolve_http_response_code_count(args),
+                        Function(
+                            "countIf",
+                            [
+                                Column("value"),
+                                Function(
+                                    "equals",
+                                    [
+                                        Column("metric_id"),
+                                        self.resolve_metric("span.self_time"),
+                                    ],
+                                ),
+                            ],
+                        ),
+                        alias,
+                    ),
+                    default_result_type="integer",
+                ),
+                fields.MetricsFunction(
                     "http_error_rate",
                     snql_distribution=lambda args, alias: function_aliases.resolve_division(
                         self._resolve_http_error_count(args),

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1019,6 +1019,64 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["device.class"] == "Unknown"
         assert meta["fields"]["device.class"] == "string"
 
+    def test_http_response_code_count(self):
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"span.status_code": "200"},
+        )
+
+        self.store_span_metric(
+            2,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"span.status_code": "301"},
+        )
+
+        self.store_span_metric(
+            3,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"span.status_code": "307"},
+        )
+
+        self.store_span_metric(
+            4,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"span.status_code": "404"},
+        )
+
+        self.store_span_metric(
+            5,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={"span.status_code": "501"},
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "http_response_code_count(200)",  # By exact code
+                    "http_response_code_count(3)",  # By code class
+                    "http_response_code_count(4)",
+                    "http_response_code_count(5)",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["http_response_code_count(200)"] == 1
+        assert data[0]["http_response_code_count(3)"] == 2
+        assert data[0]["http_response_code_count(4)"] == 1
+        assert data[0]["http_response_code_count(5)"] == 1
+
 
 @region_silo_test
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1019,7 +1019,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["device.class"] == "Unknown"
         assert meta["fields"]["device.class"] == "string"
 
-    def test_http_response_code_count(self):
+    def test_http_response_code_rate(self):
         self.store_span_metric(
             1,
             internal_metric=constants.SELF_TIME_LIGHT,
@@ -1028,7 +1028,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
 
         self.store_span_metric(
-            2,
+            3,
             internal_metric=constants.SELF_TIME_LIGHT,
             timestamp=self.min_ago,
             tags={"span.status_code": "301"},
@@ -1038,14 +1038,14 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             3,
             internal_metric=constants.SELF_TIME_LIGHT,
             timestamp=self.min_ago,
-            tags={"span.status_code": "307"},
+            tags={"span.status_code": "404"},
         )
 
         self.store_span_metric(
             4,
             internal_metric=constants.SELF_TIME_LIGHT,
             timestamp=self.min_ago,
-            tags={"span.status_code": "404"},
+            tags={"span.status_code": "503"},
         )
 
         self.store_span_metric(
@@ -1058,10 +1058,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         response = self.do_request(
             {
                 "field": [
-                    "http_response_code_count(200)",  # By exact code
-                    "http_response_code_count(3)",  # By code class
-                    "http_response_code_count(4)",
-                    "http_response_code_count(5)",
+                    "http_response_code_rate(200)",  # By exact code
+                    "http_response_code_rate(3)",  # By code class
+                    "http_response_code_rate(4)",
+                    "http_response_code_rate(5)",
                 ],
                 "query": "",
                 "project": self.project.id,
@@ -1072,10 +1072,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
-        assert data[0]["http_response_code_count(200)"] == 1
-        assert data[0]["http_response_code_count(3)"] == 2
-        assert data[0]["http_response_code_count(4)"] == 1
-        assert data[0]["http_response_code_count(5)"] == 1
+        assert data[0]["http_response_code_rate(200)"] == 0.2
+        assert data[0]["http_response_code_rate(3)"] == 0.2
+        assert data[0]["http_response_code_rate(4)"] == 0.2
+        assert data[0]["http_response_code_rate(5)"] == 0.4
 
 
 @region_silo_test

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1077,6 +1077,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["http_response_code_rate(4)"] == 0.2
         assert data[0]["http_response_code_rate(5)"] == 0.4
 
+        meta = response.data["meta"]
+        assert meta["dataset"] == "spansMetrics"
+        assert meta["fields"]["http_response_code_rate(200)"] == "percentage"
+
 
 @region_silo_test
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1019,7 +1019,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["device.class"] == "Unknown"
         assert meta["fields"]["device.class"] == "string"
 
-    def test_http_response_code_rate(self):
+    def test_http_response_rate(self):
         self.store_span_metric(
             1,
             internal_metric=constants.SELF_TIME_LIGHT,
@@ -1058,10 +1058,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         response = self.do_request(
             {
                 "field": [
-                    "http_response_code_rate(200)",  # By exact code
-                    "http_response_code_rate(3)",  # By code class
-                    "http_response_code_rate(4)",
-                    "http_response_code_rate(5)",
+                    "http_response_rate(200)",  # By exact code
+                    "http_response_rate(3)",  # By code class
+                    "http_response_rate(4)",
+                    "http_response_rate(5)",
                 ],
                 "query": "",
                 "project": self.project.id,
@@ -1072,14 +1072,14 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
-        assert data[0]["http_response_code_rate(200)"] == 0.2
-        assert data[0]["http_response_code_rate(3)"] == 0.2
-        assert data[0]["http_response_code_rate(4)"] == 0.2
-        assert data[0]["http_response_code_rate(5)"] == 0.4
+        assert data[0]["http_response_rate(200)"] == 0.2
+        assert data[0]["http_response_rate(3)"] == 0.2
+        assert data[0]["http_response_rate(4)"] == 0.2
+        assert data[0]["http_response_rate(5)"] == 0.4
 
         meta = response.data["meta"]
         assert meta["dataset"] == "spansMetrics"
-        assert meta["fields"]["http_response_code_rate(200)"] == "percentage"
+        assert meta["fields"]["http_response_rate(200)"] == "percentage"
 
 
 @region_silo_test


### PR DESCRIPTION
Preparation for upcoming HTTP module. This lets us have columns like "5XXs" rate in the table.

- adds a new `http_response_count_rate` function, backed by `http_response_code_count` function
- accepts one argument, and does a prefix match so it's possible to get `http_response_code_count(200)` and get the 200s rate _or_ do `http_response_code_count(5)` and get the rate of all 500s

## Questions

I have lots, since this is my first PR of this kind. Beyond the obvious "does any of this make sense":

1. Should I change the existing `http_error_rate` function in any way? I can make it rely on the new `http_response_code_rate` function, or leave it alone, or deprecate it
2. What kind of documentation does this function need?
3. Does the name `http_response_code_rate` make sense? Is this API comfortable?
