### PR TITLE
fix(trace): Handle 0 prefixed span ids

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -568,8 +568,9 @@ def augment_transactions_with_spans(
         error_spans = set()
         projects = set()
         for error in errors:
-            error["trace.span"] = pad_span_id(error["trace.span"])
-            error_spans.add(error["trace.span"])
+            if "trace.span" in error:
+                error["trace.span"] = pad_span_id(error["trace.span"])
+                error_spans.add(error["trace.span"])
             projects.add(error["project.id"])
         ts_params = find_timestamp_params(transactions)
         if ts_params["min"]:

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -211,19 +211,16 @@ class TraceEvent:
                     for problem in self.event["issue_occurrences"]:
                         offender_span_ids = problem.evidence_data.get("offender_span_ids", [])
                         if event_span.get("span_id") in offender_span_ids:
-                            try:
-                                start_timestamp = float(event_span.get("precise.start_ts"))
-                                if start is None:
-                                    start = start_timestamp
-                                else:
-                                    start = min(start, start_timestamp)
-                                end_timestamp = float(event_span.get("precise.finish_ts"))
-                                if end is None:
-                                    end = end_timestamp
-                                else:
-                                    end = max(end, end_timestamp)
-                            except ValueError:
-                                pass
+                            start_timestamp = float(event_span.get("precise.start_ts"))
+                            if start is None:
+                                start = start_timestamp
+                            else:
+                                start = min(start, start_timestamp)
+                            end_timestamp = float(event_span.get("precise.finish_ts"))
+                            if end is None:
+                                end = end_timestamp
+                            else:
+                                end = max(end, end_timestamp)
                             suspect_spans.append(event_span.get("span_id"))
             else:
                 if self.nodestore_event is not None or self.span_serialized:
@@ -549,6 +546,12 @@ def build_span_query(trace_id, spans_params, query_spans):
     return parents_query
 
 
+def pad_span_id(span):
+    """Snuba might return the span id without leading 0s since they're stored as UInt64
+    which means a span like 0011 gets converted to an int, then back so we'll get `11` instead"""
+    return span.rjust(16, "0")
+
+
 def augment_transactions_with_spans(
     transactions: Sequence[SnubaTransaction],
     errors: Sequence[SnubaError],
@@ -562,8 +565,12 @@ def augment_transactions_with_spans(
         problem_project_map = {}
         issue_occurrences = []
         occurrence_spans = set()
-        error_spans = {e["trace.span"] for e in errors if e["trace.span"]}
-        projects = {e["project.id"] for e in errors if e["trace.span"]}
+        error_spans = set()
+        projects = set()
+        for error in errors:
+            error["trace.span"] = pad_span_id(error["trace.span"])
+            error_spans.add(error["trace.span"])
+            projects.add(error["project.id"])
         ts_params = find_timestamp_params(transactions)
         if ts_params["min"]:
             params["start"] = ts_params["min"] - timedelta(hours=1)
@@ -585,19 +592,10 @@ def augment_transactions_with_spans(
             if transaction["occurrence_id"] is not None:
                 problem_project_map[project].append(transaction["occurrence_id"])
 
-            # Need to strip the leading "0"s to match our query to the spans table
-            # This is cause spans are stored as UInt64, so a span like 0011
-            # converted to an int then converted to a hex will become 11
-            # so when we query snuba we need to remove the 00s ourselves as well
             if not transaction["trace.parent_span"]:
                 continue
-            transaction["trace.parent_span.stripped"] = (
-                str(hex(int(transaction["trace.parent_span"], 16))).lstrip("0x")
-                if transaction["trace.parent_span"].startswith("00")
-                else transaction["trace.parent_span"]
-            )
             # parent span ids of the segment spans
-            trace_parent_spans.add(transaction["trace.parent_span.stripped"])
+            trace_parent_spans.add(transaction["trace.parent_span"])
 
     with sentry_sdk.start_span(op="augment.transactions", description="get perf issue span ids"):
         for project, occurrences in problem_project_map.items():
@@ -653,18 +651,19 @@ def augment_transactions_with_spans(
             referrer=Referrer.API_TRACE_VIEW_GET_PARENTS.value
         )
 
+    parent_map = {}
     if "data" in parents_results:
-        parent_map = {parent["span_id"]: parent for parent in parents_results["data"]}
-    else:
-        parent_map = {}
+        for parent in parents_results["data"]:
+            parent["span_id"] = pad_span_id(parent["span_id"])
+            parent_map[parent["span_id"]] = parent
 
     with sentry_sdk.start_span(op="augment.transactions", description="linking transactions"):
         for transaction in transactions:
             # For a given transaction, if parent span id exists in the tranaction (so this is
             # not a root span), see if the indexed spans data can tell us what the parent
             # transaction id is.
-            if "trace.parent_span.stripped" in transaction:
-                parent = parent_map.get(transaction["trace.parent_span.stripped"])
+            if "trace.parent_span" in transaction:
+                parent = parent_map.get(transaction["trace.parent_span"])
                 if parent is not None:
                     transaction["trace.parent_transaction"] = parent["transaction.id"]
     with sentry_sdk.start_span(op="augment.transactions", description="linking perf issues"):

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -61,11 +61,13 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase):
         if tags is not None:
             data["tags"] = tags
         if file_io_performance_issue:
-            span = data["spans"][0]
-            if "data" not in span:
-                span["data"] = {}
-            span["op"] = "file.write"
-            span["data"].update({"duration": 1, "blocked_main_thread": True})
+            new_span = data["spans"][0].copy()
+            if "data" not in new_span:
+                new_span["data"] = {}
+            new_span["op"] = "file.write"
+            new_span["data"].update({"duration": 1, "blocked_main_thread": True})
+            new_span["span_id"] = "0012" * 4
+            data["spans"].append(new_span)
         with self.feature(self.FEATURES):
             with mock.patch.object(
                 PerformanceFileIOMainThreadGroupType,
@@ -173,7 +175,11 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase):
         )
 
         # First Generation
-        self.gen1_span_ids = [uuid4().hex[:16] for _ in range(3)]
+        # TODO: temporary, this is until we deprecate using this endpoint without useSpans
+        if isinstance(self, OrganizationEventsTraceEndpointTestUsingSpans):
+            self.gen1_span_ids = ["0014" * 4, *(uuid4().hex[:16] for _ in range(2))]
+        else:
+            self.gen1_span_ids = [uuid4().hex[:16] for _ in range(3)]
         self.gen1_project = self.create_project(organization=self.organization)
         self.gen1_events = [
             self.create_event(
@@ -812,8 +818,8 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         assert root["transaction.duration"] == 3000
         assert len(root["children"]) == 3
         assert len(root["performance_issues"]) == 1
-        # The perf issue is put on the first span
-        perf_issue_span = self.root_event.data["spans"][0]
+        # The perf issue is added as the last span
+        perf_issue_span = self.root_event.data["spans"][-1]
         assert root["performance_issues"][0]["suspect_spans"][0] == perf_issue_span["span_id"]
         assert root["performance_issues"][0]["start"] == perf_issue_span["start_timestamp"]
         assert root["performance_issues"][0]["end"] == perf_issue_span["timestamp"]
@@ -1611,20 +1617,6 @@ class OrganizationEventsTraceEndpointTestUsingSpans(OrganizationEventsTraceEndpo
         ) == sorted([p.id for p in mock_query_builder.mock_calls[0].args[1]["project_objects"]])
 
         assert response.status_code == 200, response.content
-
-    def test_simple(self):
-        self.load_trace()
-        with self.feature(self.FEATURES):
-            response = self.client_get(
-                data={"project": -1},
-            )
-        assert response.status_code == 200, response.content
-        trace_transaction = response.data["transactions"][0]
-        self.assert_trace_data(trace_transaction)
-        # We shouldn't have detailed fields here
-        assert "transaction.status" not in trace_transaction
-        assert "tags" not in trace_transaction
-        assert "measurements" not in trace_transaction
 
 
 @region_silo_test


### PR DESCRIPTION
- This improves the handling of the augment functions when span ids are prefixed by 0
- Fixes flakes with tests and usage where a span id starting with any number of `00` in them wouldn't be correctly associated
- Found an issue with the non useSpans usage of the endpoint, but skipping for now since the plan is to deprecate that usage