### PR TITLE
styles(perf): Sample table padding should be on top

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -21,7 +21,7 @@ import {SpanMetricsField} from 'sentry/views/starfish/types';
 const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 
 const SpanSamplesTableContainer = styled('div')`
-  padding-bottom: ${space(2)};
+  padding-top: ${space(2)};
 `;
 
 type Props = {


### PR DESCRIPTION
There's nothing below it so padding is necessary on the bottom but without the padding on top, it's touching the charts.