### PR TITLE
ref(feedback): spam detection default=True

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -143,7 +143,7 @@ register(
 
 register(
     key="sentry:feedback_ai_spam_detection",
-    default=False,
+    default=True,
 )
 
 


### PR DESCRIPTION
Spam detection will be opt-out for at least the internal release, so change the default option to `True`.