### PR TITLE
chore(ci): Update github-script version to use node 20

### DIFF
--- a/.github/workflows/getsentry-dispatch.yml
+++ b/.github/workflows/getsentry-dispatch.yml
@@ -56,7 +56,7 @@ jobs:
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
       - name: Wait for PR merge commit
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: mergecommit
         with:
           github-token: ${{ steps.getsentry.outputs.token }}
@@ -68,7 +68,7 @@ jobs:
             });
 
       - name: Dispatch getsentry tests
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.getsentry.outputs.token }}
           script: |

--- a/.github/workflows/meta-deploys-detect-change-type.yml
+++ b/.github/workflows/meta-deploys-detect-change-type.yml
@@ -23,7 +23,7 @@ jobs:
           filters: .github/file-filters.yml
 
       - name: Create GitHub job
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/deploy`).updateChangeType({

--- a/.github/workflows/sentry-pull-request-bot.yml
+++ b/.github/workflows/sentry-pull-request-bot.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Check getsentry membership
         id: org
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             try {
@@ -45,7 +45,7 @@ jobs:
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
       - name: Wait for PR merge commit
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: mergecommit
         with:
           github-token: ${{ steps.getsentry.outputs.token }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Dispatch getsentry tests
         if: steps.org.outputs.result == 'true'
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.getsentry.outputs.token }}
           script: |

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -37,7 +37,7 @@ jobs:
             2>&1 | tee sync-report.txt
 
       - name: Read sync output into variable
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: github.event_name == 'pull_request'
         id: github-label-sync
         with:


### PR DESCRIPTION
Bumping github-script in order to move off of node16 which is now deprecated.
Moving to:
https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea
From:
https://github.com/actions/github-script/commit/d556feaca394842dc55e4734bf3bb9f685482fa0