### PR TITLE
ref(feedback): add platform to onboarding analytics

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -57,7 +57,7 @@ function FeedbackOnboardingSidebar(props: CommonSidebarProps) {
     // this tracks clicks from any source: feedback index, issue details feedback tab, banner callout, etc
     trackAnalytics('feedback.list-view-setup-sidebar', {
       organization,
-      platform: currentProject?.platform ?? 'other',
+      platform: currentProject?.platform ?? 'unknown',
     });
   }, [organization, currentProject]);
 

--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -1,5 +1,5 @@
 import type {ReactNode} from 'react';
-import {Fragment, useMemo, useState} from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
@@ -34,6 +34,7 @@ import platforms, {otherPlatform} from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PlatformKey, Project, SelectValue} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import useUrlParams from 'sentry/utils/useUrlParams';
@@ -51,6 +52,14 @@ function FeedbackOnboardingSidebar(props: CommonSidebarProps) {
     onboardingPlatforms: feedbackOnboardingPlatforms,
     allPlatforms: feedbackOnboardingPlatforms,
   });
+
+  useEffect(() => {
+    // this tracks clicks from any source: feedback index, issue details feedback tab, banner callout, etc
+    trackAnalytics('feedback.list-view-setup-sidebar', {
+      organization,
+      platform: currentProject?.platform ?? 'other',
+    });
+  }, [organization, currentProject]);
 
   const projectSelectOptions = useMemo(() => {
     const supportedProjectItems: SelectValue<string>[] = allProjects

--- a/static/app/components/feedback/useFeedbackOnboarding.tsx
+++ b/static/app/components/feedback/useFeedbackOnboarding.tsx
@@ -2,7 +2,6 @@ import {useCallback, useEffect} from 'react';
 
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import useSelectedProjectsHaveField from 'sentry/utils/project/useSelectedProjectsHaveField';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
@@ -29,10 +28,6 @@ export function useFeedbackOnboardingSidebarPanel() {
   useEffect(() => {
     if (location.hash === FEEDBACK_HASH || location.hash === CRASH_REPORT_HASH) {
       SidebarPanelStore.activatePanel(SidebarPanelKey.FEEDBACK_ONBOARDING);
-      // this tracks clicks from both feedback index and issue details feedback tab
-      trackAnalytics('feedback.list-view-setup-sidebar', {
-        organization,
-      });
     }
   }, [location.hash, organization]);
 

--- a/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
@@ -1,12 +1,10 @@
-import type {PlatformKey} from 'sentry/types';
-
 export type FeedbackEventParameters = {
   'feedback.details-integration-issue-clicked': {
     integration_key: string;
   };
   'feedback.index-setup-viewed': {};
   'feedback.list-item-selected': {};
-  'feedback.list-view-setup-sidebar': {platform: PlatformKey};
+  'feedback.list-view-setup-sidebar': {platform: string};
   'feedback.mark-spam-clicked': {type: 'bulk' | 'details'};
   'feedback.whats-new-banner-dismissed': {};
   'feedback.whats-new-banner-viewed': {};

--- a/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
@@ -1,10 +1,12 @@
+import type {PlatformKey} from 'sentry/types';
+
 export type FeedbackEventParameters = {
   'feedback.details-integration-issue-clicked': {
     integration_key: string;
   };
   'feedback.index-setup-viewed': {};
   'feedback.list-item-selected': {};
-  'feedback.list-view-setup-sidebar': {};
+  'feedback.list-view-setup-sidebar': {platform: PlatformKey};
   'feedback.mark-spam-clicked': {type: 'bulk' | 'details'};
   'feedback.whats-new-banner-dismissed': {};
   'feedback.whats-new-banner-viewed': {};


### PR DESCRIPTION
- move the location of the analytics to the sidebar so it's easier to grab the platform we're clicking
- add the platform parameter so we can track which platforms are being viewed