### PR TITLE
fix(rate_limits): Remove special rate limits for group_index

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -40,7 +40,6 @@ from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.search.snuba.backend import assigned_or_suggested_filter
 from sentry.search.snuba.executors import get_search_filter
 from sentry.snuba import discover
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.validators import normalize_event_id
 

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -148,24 +148,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationEventPermission,)
     enforce_rate_limit = True
 
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(10, 1),
-            RateLimitCategory.USER: RateLimit(10, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(10, 1),
-        },
-        "PUT": {
-            RateLimitCategory.IP: RateLimit(5, 5),
-            RateLimitCategory.USER: RateLimit(5, 5),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 5),
-        },
-        "DELETE": {
-            RateLimitCategory.IP: RateLimit(5, 5),
-            RateLimitCategory.USER: RateLimit(5, 5),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 5),
-        },
-    }
-
     def _search(
         self, request: Request, organization, projects, environments, extra_query_kwargs=None
     ):

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -1903,14 +1903,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
         assert response.data[0]["owners"][2]["type"] == GROUP_OWNER_TYPE[GroupOwnerType.CODEOWNERS]
 
-    @override_settings(SENTRY_SELF_HOSTED=False)
-    def test_ratelimit(self):
-        self.login_as(user=self.user)
-        with freeze_time("2000-01-01"):
-            for i in range(10):
-                self.get_success_response()
-            self.get_error_response(status_code=status.HTTP_429_TOO_MANY_REQUESTS)
-
     def test_filter_not_unresolved(self):
         event = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4,10 +4,8 @@ from unittest.mock import Mock, call, patch
 from uuid import uuid4
 
 from dateutil.parser import parse as parse_datetime
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone as django_timezone
-from rest_framework import status
 
 from sentry import options
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType, PerformanceSlowDBQueryGroupType
@@ -48,7 +46,7 @@ from sentry.search.events.constants import (
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
-from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
+from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
@@ -3852,14 +3850,6 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         for group in groups:
             assert not Group.objects.filter(id=group.id).exists()
             assert not GroupHash.objects.filter(group_id=group.id).exists()
-
-    @override_settings(SENTRY_SELF_HOSTED=False)
-    def test_ratelimit(self):
-        self.login_as(user=self.user)
-        with freeze_time("2000-01-01"):
-            for i in range(5):
-                self.get_success_response()
-            self.get_error_response(status_code=status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_bulk_delete_performance_issues(self):
         groups = []

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -3591,14 +3591,6 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert tombstone.project == group1.project
         assert tombstone.data == group1.data
 
-    @override_settings(SENTRY_SELF_HOSTED=False)
-    def test_ratelimit(self):
-        self.login_as(user=self.user)
-        with freeze_time("2000-01-01"):
-            for i in range(5):
-                self.get_success_response()
-            self.get_error_response(status_code=status.HTTP_429_TOO_MANY_REQUESTS)
-
     def test_set_inbox(self):
         group1 = self.create_group()
         group2 = self.create_group()

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -39,6 +39,12 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         def get(self):
             return Response({"ok": True})
 
+    class TestEndpointCustomLimits(Endpoint):
+        enforce_rate_limit = True
+
+        def get(self):
+            return Response({"ok": True})
+
     class TestEndpointNoRateLimits(Endpoint):
         enforce_rate_limit = False
 
@@ -197,7 +203,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         request = self.factory.get("/")
         assert (
             get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
-            == "ip:default:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
+            == "ip:default:GET:127.0.0.1"
         )
         # Test when IP address is missing
         request.META["REMOTE_ADDR"] = None
@@ -207,7 +213,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         request.META["REMOTE_ADDR"] = "684D:1111:222:3333:4444:5555:6:77"
         assert (
             get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
-            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+            == "ip:default:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
         # Test for users
@@ -215,7 +221,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         request.user = self.user
         assert (
             get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
-            == f"user:default:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
+            == f"user:default:GET:{self.user.id}"
         )
 
         # Test for user auth tokens
@@ -224,21 +230,21 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         request.user = self.user
         assert (
             get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
-            == f"user:default:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
+            == f"user:default:GET:{self.user.id}"
         )
 
         # Test for sentryapp auth tokens:
         self.populate_sentry_app_request(request)
         assert (
             get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
-            == f"org:default:OrganizationGroupIndexEndpoint:GET:{self.organization.id}"
+            == f"org:default:GET:{self.organization.id}"
         )
 
         self.populate_internal_integration_request(request)
         # Fallback to IP address limit if we can't find the organization
         assert (
             get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
-            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+            == "ip:default:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
         # Test for
@@ -251,7 +257,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         request.auth = api_key
         assert (
             get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
-            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+            == "ip:default:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
     def test_enforce_rate_limit_is_false(self):

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -39,12 +39,6 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         def get(self):
             return Response({"ok": True})
 
-    class TestEndpointCustomLimits(Endpoint):
-        enforce_rate_limit = True
-
-        def get(self):
-            return Response({"ok": True})
-
     class TestEndpointNoRateLimits(Endpoint):
         enforce_rate_limit = False
 

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -9,10 +9,10 @@ from sentry.models.apitoken import ApiToken
 from sentry.models.user import User
 from sentry.ratelimits import get_rate_limit_config, get_rate_limit_key
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.ratelimits.utils import RateLimit, RateLimitCategory
 from sentry.services.hybrid_cloud.auth import AuthenticatedToken
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of, region_silo_test
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 CONCURRENT_RATE_LIMIT = 20
 


### PR DESCRIPTION
These specific rate limits were added 3 years ago before there was a default rate limit pool shared amongst endpoints. At this time we are dealing with inc-674 because it is being spammed by a customer every 3 seconds. 