### PR TITLE
feat(replays): add issue platform events to replay events meta

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -10,7 +10,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.models.organization import Organization
-from sentry.snuba import discover
 
 
 @region_silo_endpoint
@@ -50,6 +49,8 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
         except NoProjects:
             return Response({"count": 0})
 
+        dataset = self.get_dataset(request)
+
         def data_fn(offset, limit):
             query_details = {
                 "selected_columns": self.get_field_list(organization, request),
@@ -67,7 +68,7 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
                 "transform_alias_to_input_format": True,
             }
 
-            return discover.query(**query_details)
+            return dataset.query(**query_details)
 
         return self.paginate(
             request=request,

--- a/tests/sentry/replays/test_organization_replay_events_meta.py
+++ b/tests/sentry/replays/test_organization_replay_events_meta.py
@@ -95,6 +95,7 @@ class OrganizationEventsMetaTest(APITestCase, SnubaTestCase, OccurrenceTestMixin
         with self.feature(self.features):
             response = self.client.get(self.url, query, format="json")
 
+        assert group_info is not None
         expected = [
             {
                 "error.type": "",

--- a/tests/sentry/replays/test_organization_replay_events_meta.py
+++ b/tests/sentry/replays/test_organization_replay_events_meta.py
@@ -1,15 +1,19 @@
+from datetime import datetime
+
 import pytest
 from django.urls import reverse
 
+from sentry.issues.grouptype import ReplayRageClickType
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 pytestmark = pytest.mark.sentry_metrics
 
 
 @region_silo_test
-class OrganizationEventsMetaTest(APITestCase, SnubaTestCase):
+class OrganizationEventsMetaTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     def setUp(self):
         super().setUp()
         self.min_ago = before_now(minutes=1)
@@ -62,6 +66,46 @@ class OrganizationEventsMetaTest(APITestCase, SnubaTestCase):
                 "timestamp": iso_format(self.min_ago) + "+00:00",
                 "title": "<unlabeled event>",
             },
+        ]
+
+        assert response.status_code == 200, response.content
+        assert sorted(response.data["data"], key=lambda v: v["id"]) == expected
+
+    def test_rage_clicks(self):
+        event_id_a = "a" * 32
+
+        _, group_info = self.process_occurrence(
+            **{
+                "project_id": self.project.id,
+                "event_id": event_id_a,
+                "fingerprint": ["c" * 32],
+                "issue_title": "Rage Click",
+                "type": ReplayRageClickType.type_id,
+                "detection_time": datetime.now().timestamp(),
+                "level": "info",
+            },
+            event_data={
+                "platform": "javascript",
+                "timestamp": iso_format(self.min_ago),
+                "received": iso_format(self.min_ago),
+            },
+        )
+
+        query = {"query": f"id:[{event_id_a}]", "dataset": "issuePlatform"}
+        with self.feature(self.features):
+            response = self.client.get(self.url, query, format="json")
+
+        expected = [
+            {
+                "error.type": "",
+                "error.value": "",
+                "id": event_id_a,
+                "issue.id": group_info.group.id,
+                "issue": group_info.group.qualified_short_id,
+                "project.name": self.project.slug,
+                "timestamp": iso_format(self.min_ago) + "+00:00",
+                "title": "Rage Click",
+            }
         ]
 
         assert response.status_code == 200, response.content


### PR DESCRIPTION
allow this endpoint to also query for issue platform events. this will let us return rage clicks. to use, just add `dataset=issuePlatform` to the query string. 

Helps with https://github.com/getsentry/team-replay/issues/395