### PR TITLE
lint: Remove special-case for `react-hooks/exhaustive-deps` in CI rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,18 +1,10 @@
 /* eslint-env node */
 
 const isRelaxed = !!process.env.SENTRY_ESLINT_RELAXED;
-const isCi = !!process.env.CI;
 
 // Strict ruleset that runs on pre-commit and in local environments
 const ADDITIONAL_HOOKS_TO_CHECK_DEPS_FOR =
   '(useEffectAfterFirstRender|useMemoWithPrevious)';
-
-const strictRulesNotCi = {
-  'react-hooks/exhaustive-deps': [
-    'error',
-    {additionalHooks: ADDITIONAL_HOOKS_TO_CHECK_DEPS_FOR},
-  ],
-};
 
 module.exports = {
   root: true,
@@ -26,7 +18,10 @@ module.exports = {
     jest: true,
   },
   rules: {
-    ...(!isRelaxed && !isCi ? strictRulesNotCi : {}),
+    'react-hooks/exhaustive-deps': [
+      'error',
+      {additionalHooks: ADDITIONAL_HOOKS_TO_CHECK_DEPS_FOR},
+    ],
 
     // TODO(@anonrig): Remove this from eslint-sentry-config
     'space-infix-ops': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,10 +26,6 @@ module.exports = {
     jest: true,
   },
   rules: {
-    'react-hooks/exhaustive-deps': [
-      'warn',
-      {additionalHooks: ADDITIONAL_HOOKS_TO_CHECK_DEPS_FOR},
-    ],
     ...(!isRelaxed && !isCi ? strictRulesNotCi : {}),
 
     // TODO(@anonrig): Remove this from eslint-sentry-config

--- a/static/app/components/teamSelector.tsx
+++ b/static/app/components/teamSelector.tsx
@@ -377,7 +377,7 @@ function TeamSelector(props: Props) {
     }
     // We only want to do this once when the component is finished loading for teams and mounted.
     // If the user decides they do not want the default, we should not add the default value back.
-  }, [fetching, useTeamDefaultIfOnlyOne]);
+  }, [fetching, useTeamDefaultIfOnlyOne]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <SelectControl


### PR DESCRIPTION
This popped up as an issue in CI. I'm ignoring the warning because the team selector is a bit complex, and can have long lists. I'd rather not break it by adding dependencies and causing additional unexpected re-renders.

So just silencing the warning for now to make CI happy.

