### PR TITLE
feat(replay): Fetch errors from the issuePlatform as well, so we get Rage and Perf issues on Replay Details

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -12,6 +12,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
 import useProjects from 'sentry/utils/useProjects';
@@ -213,12 +214,26 @@ describe('useReplayData', () => {
         timestamp: startedAt.toISOString(),
       }),
     ];
+    const mockErrorResponse3 = [
+      ReplayErrorFixture({
+        id: ERROR_IDS[0],
+        issue: 'JAVASCRIPT-123E',
+        timestamp: startedAt.toISOString(),
+      }),
+    ];
+    const mockErrorResponse4 = [
+      ReplayErrorFixture({
+        id: ERROR_IDS[1],
+        issue: 'JAVASCRIPT-789Z',
+        timestamp: startedAt.toISOString(),
+      }),
+    ];
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
       body: {data: mockReplayResponse},
     });
-    const mockedErrorsCall1 = MockApiClient.addMockResponse({
+    const mockedErrorEventsMetaCall1 = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replays-events-meta/`,
       body: {data: mockErrorResponse1},
       headers: {
@@ -228,11 +243,12 @@ describe('useReplayData', () => {
         ].join(','),
       },
       match: [
+        (_url, options) => options.query?.dataset === DiscoverDatasets.DISCOVER,
         (_url, options) => options.query?.query === `replayId:[${mockReplayResponse.id}]`,
         (_url, options) => options.query?.cursor === '0:0:0',
       ],
     });
-    const mockedErrorsCall2 = MockApiClient.addMockResponse({
+    const mockedErrorEventsMetaCall2 = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replays-events-meta/`,
       body: {data: mockErrorResponse2},
       headers: {
@@ -242,6 +258,37 @@ describe('useReplayData', () => {
         ].join(','),
       },
       match: [
+        (_url, options) => options.query?.dataset === DiscoverDatasets.DISCOVER,
+        (_url, options) => options.query?.query === `replayId:[${mockReplayResponse.id}]`,
+        (_url, options) => options.query?.cursor === '0:1:0',
+      ],
+    });
+    const mockedIssuePlatformEventsMetaCall1 = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays-events-meta/`,
+      body: {data: mockErrorResponse3},
+      headers: {
+        Link: [
+          '<http://localhost/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1"',
+          '<http://localhost/?cursor=0:2:0>; rel="next"; results="true"; cursor="0:1:0"',
+        ].join(','),
+      },
+      match: [
+        (_url, options) => options.query?.dataset === DiscoverDatasets.ISSUE_PLATFORM,
+        (_url, options) => options.query?.query === `replayId:[${mockReplayResponse.id}]`,
+        (_url, options) => options.query?.cursor === '0:0:0',
+      ],
+    });
+    const mockedIssuePlatformEventsMetaCall2 = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays-events-meta/`,
+      body: {data: mockErrorResponse4},
+      headers: {
+        Link: [
+          '<http://localhost/?cursor=0:0:1>; rel="previous"; results="true"; cursor="0:1:0"',
+          '<http://localhost/?cursor=0:2:0>; rel="next"; results="false"; cursor="0:2:0"',
+        ].join(','),
+      },
+      match: [
+        (_url, options) => options.query?.dataset === DiscoverDatasets.ISSUE_PLATFORM,
         (_url, options) => options.query?.query === `replayId:[${mockReplayResponse.id}]`,
         (_url, options) => options.query?.cursor === '0:1:0',
       ],
@@ -256,13 +303,20 @@ describe('useReplayData', () => {
       },
     });
 
-    await waitFor(() => expect(mockedErrorsCall1).toHaveBeenCalledTimes(1));
-    expect(mockedErrorsCall2).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedErrorEventsMetaCall1).toHaveBeenCalledTimes(1));
+    expect(mockedErrorEventsMetaCall2).toHaveBeenCalledTimes(1);
+    expect(mockedIssuePlatformEventsMetaCall1).toHaveBeenCalledTimes(1);
+    expect(mockedIssuePlatformEventsMetaCall2).toHaveBeenCalledTimes(1);
 
     expect(result.current).toStrictEqual(
       expect.objectContaining({
         attachments: [],
-        errors: [...mockErrorResponse1, ...mockErrorResponse2],
+        errors: [
+          ...mockErrorResponse1,
+          ...mockErrorResponse2,
+          ...mockErrorResponse3,
+          ...mockErrorResponse4,
+        ],
         replayRecord: expectedReplay,
       })
     );
@@ -304,9 +358,16 @@ describe('useReplayData', () => {
       body: mockSegmentResponse,
     });
 
-    const mockedEventsMetaCall = MockApiClient.addMockResponse({
+    const mockedErrorEventsMetaCall = MockApiClient.addMockResponse({
       asyncDelay: 250, // Simulate 250ms response time
       url: `/organizations/${organization.slug}/replays-events-meta/`,
+      match: [MockApiClient.matchQuery({dataset: DiscoverDatasets.DISCOVER})],
+      body: {data: mockErrorResponse},
+    });
+    const mockedIssuePlatformEventsMetaCall = MockApiClient.addMockResponse({
+      asyncDelay: 250, // Simulate 250ms response time
+      url: `/organizations/${organization.slug}/replays-events-meta/`,
+      match: [MockApiClient.matchQuery({dataset: DiscoverDatasets.ISSUE_PLATFORM})],
       body: {data: mockErrorResponse},
     });
 
@@ -330,13 +391,17 @@ describe('useReplayData', () => {
 
     // Immediately we will see the replay call is made
     expect(mockedReplayCall).toHaveBeenCalledTimes(1);
-    expect(mockedEventsMetaCall).not.toHaveBeenCalledTimes(1);
-    expect(mockedSegmentsCall).not.toHaveBeenCalledTimes(1);
+    expect(mockedErrorEventsMetaCall).not.toHaveBeenCalled();
+    expect(mockedIssuePlatformEventsMetaCall).not.toHaveBeenCalled();
+    expect(mockedSegmentsCall).not.toHaveBeenCalled();
     expect(result.current).toEqual(expectedReplayData);
 
     // Afterwards we see the attachments & errors requests are made
     await waitFor(() => expect(mockedReplayCall).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(mockedEventsMetaCall).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockedErrorEventsMetaCall).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(mockedIssuePlatformEventsMetaCall).toHaveBeenCalledTimes(1)
+    );
     expect(mockedSegmentsCall).toHaveBeenCalledTimes(1);
     expect(result.current).toStrictEqual(
       expect.objectContaining({

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -3,6 +3,7 @@ import {useCallback, useMemo} from 'react';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import useFetchParallelPages from 'sentry/utils/api/useFetchParallelPages';
 import useFetchSequentialPages from 'sentry/utils/api/useFetchSequentialPages';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
@@ -140,6 +141,34 @@ function useReplayData({
         `/organizations/${orgSlug}/replays-events-meta/`,
         {
           query: {
+            dataset: DiscoverDatasets.DISCOVER,
+            start: replayRecord?.started_at.toISOString(),
+            end: finishedAtClone.toISOString(),
+            project: ALL_ACCESS_PROJECTS,
+            query: `replayId:[${replayRecord?.id}]`,
+            per_page,
+            cursor,
+          },
+        },
+      ];
+    },
+    [orgSlug, replayRecord]
+  );
+
+  const getPlatformErrorsQueryKey = useCallback(
+    ({cursor, per_page}): ApiQueryKey => {
+      // Clone the `finished_at` time and bump it up one second because finishedAt
+      // has the `ms` portion truncated, while replays-events-meta operates on
+      // timestamps with `ms` attached. So finishedAt could be at time `12:00:00.000Z`
+      // while the event is saved with `12:00:00.450Z`.
+      const finishedAtClone = new Date(replayRecord?.finished_at ?? '');
+      finishedAtClone.setSeconds(finishedAtClone.getSeconds() + 1);
+
+      return [
+        `/organizations/${orgSlug}/replays-events-meta/`,
+        {
+          query: {
+            dataset: DiscoverDatasets.ISSUE_PLATFORM,
             start: replayRecord?.started_at.toISOString(),
             end: finishedAtClone.toISOString(),
             project: ALL_ACCESS_PROJECTS,
@@ -174,6 +203,13 @@ function useReplayData({
       perPage: errorsPerPage,
     });
 
+  const {pages: platformErrorPages, isFetching: isFetchingPlatformErrors} =
+    useFetchSequentialPages<{data: ReplayError[]}>({
+      enabled: true,
+      getQueryKey: getPlatformErrorsQueryKey,
+      perPage: errorsPerPage,
+    });
+
   const clearQueryCache = useCallback(() => {
     () => {
       queryClient.invalidateQueries({
@@ -197,10 +233,16 @@ function useReplayData({
       isFetchingReplay ||
       isFetchingAttachments ||
       isFetchingErrors ||
-      isFetchingExtraErrors;
+      isFetchingExtraErrors ||
+      isFetchingPlatformErrors;
+
+    const allErrors = errorPages
+      .concat(extraErrorPages)
+      .concat(platformErrorPages)
+      .flatMap(page => page.data);
     return {
       attachments: attachmentPages.flat(2),
-      errors: errorPages.concat(extraErrorPages).flatMap(page => page.data),
+      errors: allErrors,
       fetchError: fetchReplayError ?? undefined,
       fetching,
       onRetry: clearQueryCache,
@@ -216,7 +258,9 @@ function useReplayData({
     isFetchingAttachments,
     isFetchingErrors,
     isFetchingExtraErrors,
+    isFetchingPlatformErrors,
     isFetchingReplay,
+    platformErrorPages,
     projectSlug,
     replayRecord,
   ]);

--- a/static/app/utils/replays/hydrateErrors.tsx
+++ b/static/app/utils/replays/hydrateErrors.tsx
@@ -1,8 +1,10 @@
+import * as Sentry from '@sentry/react';
 import invariant from 'invariant';
 
 import isValidDate from 'sentry/utils/date/isValidDate';
 import type {ErrorFrame, RawReplayError} from 'sentry/utils/replays/types';
 import {isErrorFrame} from 'sentry/utils/replays/types';
+import toArray from 'sentry/utils/toArray';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 export default function hydrateErrors(
@@ -27,7 +29,7 @@ export default function hydrateErrors(
               (Array.isArray(error['error.type'])
                 ? error['error.type'][0]
                 : error['error.type']) ?? '',
-            labels: error['error.type'].filter(Boolean),
+            labels: toArray(error['error.type']).filter(Boolean),
             projectSlug: error['project.name'],
           },
           message: error.title,
@@ -36,7 +38,8 @@ export default function hydrateErrors(
           timestampMs: time.getTime(),
           type: 'error', // For compatibility reasons. See BreadcrumbType
         };
-      } catch {
+      } catch (err) {
+        Sentry.captureException(err);
         return undefined;
       }
     })


### PR DESCRIPTION
This loads up issuePlatform errors (Rage Clicks and Perf Issues) into the Errors tab on Replay Details. 

It's not linking those Rage Clicks up with existing breadcrumbs, so you'll see similar info in the Breadcrumbs tab. What we could do is followup with some linking, so you can navigate from the breadcrumbs tab into issue details... it's possible now.

| Note | img |
| --- | --- |
| Rage Clicks in Errors tab | ![SCR-20240312-mfie](https://github.com/getsentry/sentry/assets/187460/b0388c5f-b1cc-4f54-bc0d-fc1098721484)
| Existing Rage Click in Breadcrumb (unchanged) | ![SCR-20240312-mfis](https://github.com/getsentry/sentry/assets/187460/76bc7ac6-9da5-48ec-b62a-a59568cac85d)
| Perf issues in Errors tab | ![SCR-20240312-mfyn](https://github.com/getsentry/sentry/assets/187460/8773d5cc-bf36-482b-876c-91e5cbd29ee4)


Depends on https://github.com/getsentry/sentry/pull/66735/files
Relates to https://github.com/getsentry/team-replay/issues/395
