### PR TITLE
feat(staff): Use timestamp staff auth flow flag instead of bool

### DIFF
--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -281,7 +281,7 @@ class U2fInterface(AuthenticatorInterface):
             if _valid_staff_timestamp(request):
                 state = request.session["staff_webauthn_authentication_state"]
             else:
-                state = request.session.get["webauthn_authentication_state"]
+                state = request.session["webauthn_authentication_state"]
             if request.session.get("staff_webauthn_authentication_state") and request.session.get(
                 "webauthn_authentication_state"
             ):

--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -1,5 +1,6 @@
 import logging
 from base64 import urlsafe_b64encode
+from datetime import datetime, timedelta
 from functools import cached_property
 from time import time
 from urllib.parse import urlparse
@@ -41,6 +42,23 @@ def create_credential_object(registeredKey):
 
 def _get_url_prefix() -> str:
     return options.get("system.url-prefix")
+
+
+def _valid_staff_timestamp(request, limit: timedelta) -> bool:
+    """
+    Returns whether or not the staff timestamp exists and is valid within the
+    timedelta. If the timestamp is invalid, it is removed from the session.
+    """
+    timestamp = request.session.get("staff_auth_flow")
+    if not timestamp:
+        return False
+
+    flag_datetime = datetime.utcfromtimestamp(timestamp)
+    if datetime.now() - flag_datetime > limit:
+        del request.session["staff_auth_flow"]
+        return False
+
+    return True
 
 
 class U2fInterface(AuthenticatorInterface):
@@ -209,52 +227,62 @@ class U2fInterface(AuthenticatorInterface):
             "U2F activate",
             extra={
                 "user": request.user.id,
-                "staff_flag": request.session.get("staff_auth_flow", "missing"),
+                "staff_flag": (
+                    datetime.utcfromtimestamp(request.session["staff_auth_flow"])
+                    if "staff_auth_flow" in request.session
+                    else "missing"
+                ),
             },
         )
-        if request.session.get("staff_auth_flow", False):
+        if _valid_staff_timestamp(request, timedelta(minutes=2)):
             request.session["staff_webauthn_authentication_state"] = state
-            # Remove the staff U2F flag in case we don't validate the generated
-            # challenge/response and want to next use a non-staff U2F flow
-            del request.session["staff_auth_flow"]
         else:
             request.session["webauthn_authentication_state"] = state
+
         logger.info(
             "U2F activate after setting state",
             extra={
                 "user": request.user.id,
-                "staff_flag": request.session.get("staff_auth_flow", "missing"),
+                "staff_flag": (
+                    datetime.utcfromtimestamp(request.session["staff_auth_flow"])
+                    if "staff_auth_flow" in request.session
+                    else "missing"
+                ),
                 "has_state": "webauthn_authentication_state" in request.session,
                 "has_staff_state": "staff_webauthn_authentication_state" in request.session,
             },
         )
-
         return ActivationChallengeResult(challenge=cbor.encode(challenge["publicKey"]))
 
     def validate_response(self, request: HttpRequest, challenge, response):
         try:
             credentials = self.credentials()
-
             if hasattr(request, "user") and request.user.is_staff:
                 logger.info(
                     "Validating U2F for staff",
                     extra={
                         "user": request.user.id,
-                        "staff_flag": request.session.get("staff_auth_flow", "missing"),
+                        "staff_flag": (
+                            datetime.utcfromtimestamp(request.session["staff_auth_flow"])
+                            if "staff_auth_flow" in request.session
+                            else "missing"
+                        ),
                         "has_state": "webauthn_authentication_state" in request.session,
                         "has_staff_state": "staff_webauthn_authentication_state" in request.session,
                     },
                 )
-
-            # Only 1 U2F state should be set at a time
-            default_state = request.session.get("webauthn_authentication_state")
-            staff_state = request.session.get("staff_webauthn_authentication_state")
-            if default_state and staff_state:
+            if _valid_staff_timestamp(request, timedelta(minutes=2)):
+                state = request.session.get("staff_webauthn_authentication_state")
+            else:
+                state = request.session.get("webauthn_authentication_state")
+            if request.session.get("staff_webauthn_authentication_state") and request.session.get(
+                "webauthn_authentication_state"
+            ):
                 logger.info(
-                    "Both staff and non-staff U2F states are set", extra={"user": request.user.id}
+                    "Both staff and non-staff U2F states are set", extra={"user": request.user}
                 )
             self.webauthn_authentication_server.authenticate_complete(
-                state=default_state or staff_state,
+                state=state,
                 credentials=credentials,
                 credential_id=websafe_decode(response["keyHandle"]),
                 client_data=ClientData(websafe_decode(response["clientData"])),
@@ -267,4 +295,5 @@ class U2fInterface(AuthenticatorInterface):
             # Cleanup the U2F state from the session
             request.session.pop("webauthn_authentication_state", None)
             request.session.pop("staff_webauthn_authentication_state", None)
+            request.session.pop("staff_auth_flow", None)
         return True

--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -279,9 +279,9 @@ class U2fInterface(AuthenticatorInterface):
                     },
                 )
             if _valid_staff_timestamp(request):
-                state = request.session.get("staff_webauthn_authentication_state")
+                state = request.session["staff_webauthn_authentication_state"]
             else:
-                state = request.session.get("webauthn_authentication_state")
+                state = request.session.get["webauthn_authentication_state"]
             if request.session.get("staff_webauthn_authentication_state") and request.session.get(
                 "webauthn_authentication_state"
             ):

--- a/tests/sentry/auth/authenticators/test_u2f.py
+++ b/tests/sentry/auth/authenticators/test_u2f.py
@@ -103,9 +103,11 @@ class U2FInterfaceTest(TestCase):
         result = self.u2f.activate(self.request)
 
         assert isinstance(result, ActivationChallengeResult)
-        assert "staff_webauthn_authentication_state" not in self.request.session
-        assert len(self.request.session["webauthn_authentication_state"]["challenge"]) == 43
-        assert self.request.session["webauthn_authentication_state"]["user_verification"] is None
+        assert "webauthn_authentication_state" not in self.request.session
+        assert len(self.request.session["staff_webauthn_authentication_state"]["challenge"]) == 43
+        assert (
+            self.request.session["staff_webauthn_authentication_state"]["user_verification"] is None
+        )
 
     def test_validate_response_normal_state(self):
         self.test_try_enroll_webauthn()

--- a/tests/sentry/auth/authenticators/test_u2f.py
+++ b/tests/sentry/auth/authenticators/test_u2f.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 from fido2 import cbor
@@ -9,16 +10,28 @@ from pytest import raises
 from sentry.auth.authenticators.base import ActivationChallengeResult
 from sentry.auth.authenticators.u2f import U2fInterface
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import control_silo_test
 
 
 @control_silo_test
 class U2FInterfaceTest(TestCase):
+    CURRENT_TIME = datetime(2024, 3, 11, 0, 0)
+    VALID_TIMESTAMP = (CURRENT_TIME - timedelta(minutes=1)).timestamp()
+    INVALID_TIMESTAMP = (CURRENT_TIME - timedelta(minutes=3)).timestamp()
+
     def setUp(self):
         self.u2f = U2fInterface()
         self.login_as(user=self.user)
         rp = PublicKeyCredentialRpEntity("richardmasentry.ngrok.io", "Sentry")
         self.test_registration_server = Fido2Server(rp, verify_origin=lambda origin: True)
+        self.response = {
+            "keyHandle": "F5MKBNqJMnHX-g0jee03d0slMyvz0FMWAf1YzF9mjZhA6ePDEwt8QT2zNR-ungcffGGxpGtp4yXRC5gz8t1Lww",
+            "clientData": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRjJYS0tyZ19FY1h6OEljUjBUX3BzcUJqenc5X1VIYTFIU2premtFbTUzQSIsIm9yaWdpbiI6Imh0dHBzOi8vc2VudHJ5LmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlLCJvdGhlcl9rZXlzX2Nhbl9iZV9hZGRlZF9oZXJlIjoiZG8gbm90IGNvbXBhcmUgY2xpZW50RGF0YUpTT04gYWdhaW5zdCBhIHRlbXBsYXRlLiBTZWUgaHR0cHM6Ly9nb28uZ2wveWFiUGV4In0",
+            "signatureData": "MEUCIDe2DPI7E3tWa31JN_FG5m9rhc2v2lDRsWY-Yy7jgdT0AiEA5hkw8UGEfu-d_H5CEHuGC1Cj1wvFPqiRu-c_q50R6NM",
+            "authenticatorData": "ss7JfEqyMJeXvxXeO3AXn9tPTh1R4bNVGkMcr6WH-08BAAAD_A",
+        }
+        self.request = self.make_request(user=self.user)
 
     def test_start_enrollment_webauthn(self):
         self.u2f.webauthn_registration_server = self.test_registration_server
@@ -59,76 +72,95 @@ class U2FInterfaceTest(TestCase):
 
     def test_activate_webauthn(self):
         self.test_try_enroll_webauthn()
-        request = self.make_request(user=self.user)
-        result = self.u2f.activate(request)
+
+        result = self.u2f.activate(self.request)
 
         assert isinstance(result, ActivationChallengeResult)
-        assert len(request.session["webauthn_authentication_state"]["challenge"]) == 43
-        assert request.session["webauthn_authentication_state"]["user_verification"] is None
+        assert len(self.request.session["webauthn_authentication_state"]["challenge"]) == 43
+        assert self.request.session["webauthn_authentication_state"]["user_verification"] is None
 
-    def test_activate_staff_webauthn(self):
+    @freeze_time(CURRENT_TIME)
+    def test_activate_staff_webauthn_valid_timestamp(self):
         self.test_try_enroll_webauthn()
-        request = self.make_request(user=self.user)
-        request.session["staff_auth_flow"] = True
 
-        result = self.u2f.activate(request)
+        self.request.session["staff_auth_flow"] = self.VALID_TIMESTAMP
+
+        result = self.u2f.activate(self.request)
 
         assert isinstance(result, ActivationChallengeResult)
-        assert "webauthn_authentication_state" not in request.session
-        assert len(request.session["staff_webauthn_authentication_state"]["challenge"]) == 43
-        assert request.session["staff_webauthn_authentication_state"]["user_verification"] is None
+        assert "webauthn_authentication_state" not in self.request.session
+        assert len(self.request.session["staff_webauthn_authentication_state"]["challenge"]) == 43
+        assert (
+            self.request.session["staff_webauthn_authentication_state"]["user_verification"] is None
+        )
+
+    @freeze_time(CURRENT_TIME)
+    def test_activate_staff_webauthn_invalid_timestamp(self):
+        self.test_try_enroll_webauthn()
+
+        self.request.session["staff_auth_flow"] = self.INVALID_TIMESTAMP
+
+        result = self.u2f.activate(self.request)
+
+        assert isinstance(result, ActivationChallengeResult)
+        assert "staff_webauthn_authentication_state" not in self.request.session
+        assert len(self.request.session["webauthn_authentication_state"]["challenge"]) == 43
+        assert self.request.session["webauthn_authentication_state"]["user_verification"] is None
 
     def test_validate_response_normal_state(self):
         self.test_try_enroll_webauthn()
         mock_state = Mock()
         self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
-        request = self.make_request(user=self.user)
-        request.session["webauthn_authentication_state"] = "normal state"
-        response = {
-            "keyHandle": "F5MKBNqJMnHX-g0jee03d0slMyvz0FMWAf1YzF9mjZhA6ePDEwt8QT2zNR-ungcffGGxpGtp4yXRC5gz8t1Lww",
-            "clientData": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRjJYS0tyZ19FY1h6OEljUjBUX3BzcUJqenc5X1VIYTFIU2premtFbTUzQSIsIm9yaWdpbiI6Imh0dHBzOi8vc2VudHJ5LmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlLCJvdGhlcl9rZXlzX2Nhbl9iZV9hZGRlZF9oZXJlIjoiZG8gbm90IGNvbXBhcmUgY2xpZW50RGF0YUpTT04gYWdhaW5zdCBhIHRlbXBsYXRlLiBTZWUgaHR0cHM6Ly9nb28uZ2wveWFiUGV4In0",
-            "signatureData": "MEUCIDe2DPI7E3tWa31JN_FG5m9rhc2v2lDRsWY-Yy7jgdT0AiEA5hkw8UGEfu-d_H5CEHuGC1Cj1wvFPqiRu-c_q50R6NM",
-            "authenticatorData": "ss7JfEqyMJeXvxXeO3AXn9tPTh1R4bNVGkMcr6WH-08BAAAD_A",
-        }
 
-        assert self.u2f.validate_response(request, None, response)
+        self.request.session["webauthn_authentication_state"] = "normal state"
+
+        assert self.u2f.validate_response(self.request, None, self.response)
         _, kwargs = mock_state.call_args
         assert kwargs.get("state") == "normal state"
-        assert "webauthn_authentication_state" not in request.session
+        assert "webauthn_authentication_state" not in self.request.session
 
-    def test_validate_response_staff_state(self):
+    @freeze_time(CURRENT_TIME)
+    def test_validate_response_staff_state_valid_timestamp(self):
         self.test_try_enroll_webauthn()
         mock_state = Mock()
         self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
-        request = self.make_request(user=self.user)
-        request.session["staff_webauthn_authentication_state"] = "staff state"
-        response = {
-            "keyHandle": "F5MKBNqJMnHX-g0jee03d0slMyvz0FMWAf1YzF9mjZhA6ePDEwt8QT2zNR-ungcffGGxpGtp4yXRC5gz8t1Lww",
-            "clientData": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRjJYS0tyZ19FY1h6OEljUjBUX3BzcUJqenc5X1VIYTFIU2premtFbTUzQSIsIm9yaWdpbiI6Imh0dHBzOi8vc2VudHJ5LmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlLCJvdGhlcl9rZXlzX2Nhbl9iZV9hZGRlZF9oZXJlIjoiZG8gbm90IGNvbXBhcmUgY2xpZW50RGF0YUpTT04gYWdhaW5zdCBhIHRlbXBsYXRlLiBTZWUgaHR0cHM6Ly9nb28uZ2wveWFiUGV4In0",
-            "signatureData": "MEUCIDe2DPI7E3tWa31JN_FG5m9rhc2v2lDRsWY-Yy7jgdT0AiEA5hkw8UGEfu-d_H5CEHuGC1Cj1wvFPqiRu-c_q50R6NM",
-            "authenticatorData": "ss7JfEqyMJeXvxXeO3AXn9tPTh1R4bNVGkMcr6WH-08BAAAD_A",
-        }
 
-        assert self.u2f.validate_response(request, None, response)
+        self.request.session["staff_webauthn_authentication_state"] = "staff state"
+        self.request.session["staff_auth_flow"] = self.VALID_TIMESTAMP
+
+        assert self.u2f.validate_response(self.request, None, self.response)
         _, kwargs = mock_state.call_args
         assert kwargs.get("state") == "staff state"
-        assert "staff_webauthn_authentication_state" not in request.session
+        assert "staff_webauthn_authentication_state" not in self.request.session
 
+    @freeze_time(CURRENT_TIME)
+    def test_validate_response_staff_state_invalid_timestamp(self):
+        self.test_try_enroll_webauthn()
+        mock_state = Mock()
+        self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
+
+        self.request.session["webauthn_authentication_state"] = "non-staff state"
+        self.request.session["staff_auth_flow"] = self.INVALID_TIMESTAMP
+
+        assert self.u2f.validate_response(self.request, None, self.response)
+        _, kwargs = mock_state.call_args
+        assert kwargs.get("state") == "non-staff state"
+        assert "webauthn_authentication_state" not in self.request.session
+
+    @freeze_time(CURRENT_TIME)
     def test_validate_response_failing_still_clears_all_states(self):
         self.test_try_enroll_webauthn()
         mock_state = Mock(side_effect=ValueError("test"))
         self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
-        request = self.make_request(user=self.user)
-        request.session["webauthn_authentication_state"] = "normal state"
-        request.session["staff_webauthn_authentication_state"] = "staff state"
-        response = {
-            "keyHandle": "F5MKBNqJMnHX-g0jee03d0slMyvz0FMWAf1YzF9mjZhA6ePDEwt8QT2zNR-ungcffGGxpGtp4yXRC5gz8t1Lww",
-            "clientData": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRjJYS0tyZ19FY1h6OEljUjBUX3BzcUJqenc5X1VIYTFIU2premtFbTUzQSIsIm9yaWdpbiI6Imh0dHBzOi8vc2VudHJ5LmlvIiwiY3Jvc3NPcmlnaW4iOmZhbHNlLCJvdGhlcl9rZXlzX2Nhbl9iZV9hZGRlZF9oZXJlIjoiZG8gbm90IGNvbXBhcmUgY2xpZW50RGF0YUpTT04gYWdhaW5zdCBhIHRlbXBsYXRlLiBTZWUgaHR0cHM6Ly9nb28uZ2wveWFiUGV4In0",
-            "signatureData": "MEUCIDe2DPI7E3tWa31JN_FG5m9rhc2v2lDRsWY-Yy7jgdT0AiEA5hkw8UGEfu-d_H5CEHuGC1Cj1wvFPqiRu-c_q50R6NM",
-            "authenticatorData": "ss7JfEqyMJeXvxXeO3AXn9tPTh1R4bNVGkMcr6WH-08BAAAD_A",
-        }
+
+        self.request.session["webauthn_authentication_state"] = "non-staff state"
+        self.request.session["staff_webauthn_authentication_state"] = "staff state"
+        self.request.session["staff_auth_flow"] = self.VALID_TIMESTAMP
 
         with raises(ValueError):
-            self.u2f.validate_response(request, None, response)
-        assert "webauthn_authentication_state" not in request.session
-        assert "staff_webauthn_authentication_state" not in request.session
+            self.u2f.validate_response(self.request, None, self.response)
+        _, kwargs = mock_state.call_args
+        assert kwargs.get("state") == "staff state"
+        assert "webauthn_authentication_state" not in self.request.session
+        assert "staff_webauthn_authentication_state" not in self.request.session
+        assert "staff_auth_flow" not in self.request.session


### PR DESCRIPTION
We switch to using a timestamp flag in the request session instead of a boolean in https://github.com/getsentry/getsentry/pull/13228.

To handle this change, we validate that the flag is active within 2 minutes in `validate_response`, and use the corresponding state in the request session accordingly.

Note that we don't check whether the flag is active (and remove inactive flags) in `activate`. This is intentional because we want to fail validation at the U2F tap instead of when generating the challenge/response.