### PR TITLE
fix(crons): Ignore muted status when running `mark_ok`

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -175,7 +175,9 @@ def mark_failed_threshold(
         ]
 
         # get the existing grouphash from the monitor environment
-        fingerprint = monitor_env.incident_grouphash
+        incident = monitor_env.active_incident
+        if incident:
+            fingerprint = incident.grouphash
     else:
         # don't send occurrence for other statuses
         return False

--- a/src/sentry/monitors/logic/mark_ok.py
+++ b/src/sentry/monitors/logic/mark_ok.py
@@ -1,12 +1,6 @@
 from datetime import datetime
 
-from sentry.monitors.models import (
-    CheckInStatus,
-    MonitorCheckIn,
-    MonitorEnvironment,
-    MonitorIncident,
-    MonitorStatus,
-)
+from sentry.monitors.models import CheckInStatus, MonitorCheckIn, MonitorEnvironment, MonitorStatus
 
 
 def mark_ok(checkin: MonitorCheckIn, ts: datetime):
@@ -21,13 +15,7 @@ def mark_ok(checkin: MonitorCheckIn, ts: datetime):
         "next_checkin_latest": next_checkin_latest,
     }
 
-    if (
-        not monitor_env.monitor.is_muted
-        and not monitor_env.is_muted
-        and monitor_env.status != MonitorStatus.OK
-        and checkin.status == CheckInStatus.OK
-    ):
-        params["status"] = MonitorStatus.OK
+    if monitor_env.status != MonitorStatus.OK and checkin.status == CheckInStatus.OK:
         recovery_threshold = monitor_env.monitor.config.get("recovery_threshold", 1)
         if not recovery_threshold:
             recovery_threshold = 1
@@ -52,24 +40,14 @@ def mark_ok(checkin: MonitorCheckIn, ts: datetime):
 
         # Resolve any open incidents
         if incident_recovering:
-            # TODO(rjo100): Check for multiple open incidents where we only
-            # resolved if recovery_threshold was set and not faiure_issue_threshold
-            active_incidents = MonitorIncident.objects.filter(
-                monitor_environment=monitor_env,
-                resolving_checkin__isnull=True,
-            )
-
-            # Only send an occurrence if we have an active incident
-            for grouphash in active_incidents.values_list("grouphash", flat=True):
-                resolve_incident_group(grouphash, checkin.monitor.project_id)
-
-            active_incidents.update(
-                resolving_checkin=checkin,
-                resolving_timestamp=checkin.date_added,
-            )
-        else:
-            # Don't update status if incident isn't recovered
-            params.pop("status", None)
+            params["status"] = MonitorStatus.OK
+            incident = monitor_env.active_incident
+            if incident:
+                resolve_incident_group(incident.grouphash, checkin.monitor.project_id)
+                incident.update(
+                    resolving_checkin=checkin,
+                    resolving_timestamp=checkin.date_added,
+                )
 
     MonitorEnvironment.objects.filter(id=monitor_env.id).exclude(last_checkin__gt=ts).update(
         **params

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -636,22 +636,16 @@ class MonitorEnvironment(Model):
         )
 
     @property
-    def incident_grouphash(self):
+    def active_incident(self) -> MonitorIncident | None:
         """
-        Retrieve the grouphash for the current active incident. If there is no
-        active incident None will be returned.
+        Retrieve the current active incident. If there is no active incident None will be returned.
         """
-        active_incident = (
-            MonitorIncident.objects.filter(
+        try:
+            return MonitorIncident.objects.get(
                 monitor_environment_id=self.id, resolving_checkin__isnull=True
             )
-            .order_by("-date_added")
-            .first()
-        )
-        if active_incident:
-            return active_incident.grouphash
-
-        return None
+        except MonitorIncident.DoesNotExist:
+            return None
 
 
 @receiver(pre_save, sender=MonitorEnvironment)

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -698,7 +698,7 @@ class MarkFailedTestCase(TestCase):
         monitor_incident = monitor_incidents.first()
         assert monitor_incident.starting_checkin == first_checkin
         assert monitor_incident.starting_timestamp == first_checkin.date_added
-        assert monitor_incident.grouphash == monitor_environment.active_incident
+        assert monitor_incident.grouphash == monitor_environment.active_incident.grouphash
 
         # assert correct number of occurrences was sent
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == failure_issue_threshold
@@ -722,7 +722,7 @@ class MarkFailedTestCase(TestCase):
 
         # check that incident has not changed
         monitor_incident = MonitorIncident.objects.get(id=monitor_incident.id)
-        assert monitor_incident.grouphash == monitor_environment.active_incident
+        assert monitor_incident.grouphash == monitor_environment.active_incident.grouphash
 
         # assert correct number of occurrences was sent
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == failure_issue_threshold + 1
@@ -830,7 +830,7 @@ class MarkFailedTestCase(TestCase):
         monitor_incident = monitor_incidents.first()
         assert monitor_incident.starting_checkin == first_checkin
         assert monitor_incident.starting_timestamp == first_checkin.date_added
-        assert monitor_incident.grouphash == monitor_environment.active_incident
+        assert monitor_incident.grouphash == monitor_environment.active_incident.grouphash
 
         # assert correct number of occurrences was sent
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == failure_issue_threshold

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -698,7 +698,7 @@ class MarkFailedTestCase(TestCase):
         monitor_incident = monitor_incidents.first()
         assert monitor_incident.starting_checkin == first_checkin
         assert monitor_incident.starting_timestamp == first_checkin.date_added
-        assert monitor_incident.grouphash == monitor_environment.incident_grouphash
+        assert monitor_incident.grouphash == monitor_environment.active_incident
 
         # assert correct number of occurrences was sent
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == failure_issue_threshold
@@ -722,7 +722,7 @@ class MarkFailedTestCase(TestCase):
 
         # check that incident has not changed
         monitor_incident = MonitorIncident.objects.get(id=monitor_incident.id)
-        assert monitor_incident.grouphash == monitor_environment.incident_grouphash
+        assert monitor_incident.grouphash == monitor_environment.active_incident
 
         # assert correct number of occurrences was sent
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == failure_issue_threshold + 1
@@ -830,7 +830,7 @@ class MarkFailedTestCase(TestCase):
         monitor_incident = monitor_incidents.first()
         assert monitor_incident.starting_checkin == first_checkin
         assert monitor_incident.starting_timestamp == first_checkin.date_added
-        assert monitor_incident.grouphash == monitor_environment.incident_grouphash
+        assert monitor_incident.grouphash == monitor_environment.active_incident
 
         # assert correct number of occurrences was sent
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == failure_issue_threshold


### PR DESCRIPTION
If a monitor is in a bad state, we don't want to leave it stuck there just because it's muted - it should still be able to get resolved and close out the related issue, if one exists.
