### PR TITLE
feat(trace): ensure we sort errors chronologically

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
@@ -15,6 +15,7 @@ import {
   isAutogroupedNode,
   isMissingInstrumentationNode,
   isSpanNode,
+  isTraceErrorNode,
   isTransactionNode,
 } from './guards';
 import {
@@ -110,6 +111,14 @@ function assertMissingInstrumentationNode(
 ): asserts node is TraceTreeNode<TraceTree.MissingInstrumentationSpan> {
   if (!isMissingInstrumentationNode(node)) {
     throw new Error('node is not a missing instrumentation node');
+  }
+}
+
+function assertTraceErrorNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): asserts node is TraceTreeNode<TraceTree.TraceError> {
+  if (!isTraceErrorNode(node)) {
+    throw new Error('node is not a trace error node');
   }
 }
 
@@ -666,9 +675,6 @@ describe('TreeNode', () => {
         expect(tree.list[tree.list.length - 1].path).toEqual(['span:6', 'txn:event_id']);
       });
     });
-
-    it.todo('sibling autogrouped node paths');
-    it.todo('nested transactions autogrouped node paths');
   });
 });
 
@@ -693,7 +699,7 @@ describe('TraceTree', () => {
     expect(tree.list).toHaveLength(3);
   });
 
-  it('builds orphan errors as well', () => {
+  it('builds orphan errors', () => {
     const tree = TraceTree.FromTrace(
       makeTrace({
         transactions: [
@@ -709,6 +715,28 @@ describe('TraceTree', () => {
     );
 
     expect(tree.list).toHaveLength(4);
+  });
+
+  it('sorts orphan errors', () => {
+    const tree = TraceTree.FromTrace(
+      makeTrace({
+        transactions: [
+          makeTransaction({
+            start_timestamp: 0,
+            timestamp: 1,
+          }),
+          makeTransaction({
+            start_timestamp: 2,
+            timestamp: 3,
+          }),
+        ],
+        orphan_errors: [makeTraceError({timestamp: 1, level: 'error'})],
+      })
+    );
+
+    expect(tree.list).toHaveLength(4);
+    assertTraceErrorNode(tree.list[2]);
+    tree.print();
   });
 
   it('adjusts trace bounds by orphan error timestamp as well', () => {

--- a/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
@@ -717,6 +717,27 @@ describe('TraceTree', () => {
     expect(tree.list).toHaveLength(4);
   });
 
+  it('processes orphan errors without timestamps', () => {
+    const tree = TraceTree.FromTrace(
+      makeTrace({
+        transactions: [
+          makeTransaction({
+            children: [],
+          }),
+        ],
+        orphan_errors: [
+          {
+            level: 'error',
+            title: 'Error',
+            event_type: 'error',
+          } as TraceTree.TraceError,
+        ],
+      })
+    );
+
+    expect(tree.list).toHaveLength(3);
+  });
+
   it('sorts orphan errors', () => {
     const tree = TraceTree.FromTrace(
       makeTrace({
@@ -736,7 +757,6 @@ describe('TraceTree', () => {
 
     expect(tree.list).toHaveLength(4);
     assertTraceErrorNode(tree.list[2]);
-    tree.print();
   });
 
   it('adjusts trace bounds by orphan error timestamp as well', () => {

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.spec.tsx
@@ -634,35 +634,34 @@ describe('VirtualizedViewManger', () => {
       });
     });
 
-    describe('scrolls to orphan error', () => {
-      it('scrolls to orphan error', async () => {
-        manager.list = makeList();
-        const tree = TraceTree.FromTrace(
-          makeTrace({
-            transactions: [makeTransaction()],
-            orphan_errors: [
-              {
-                event_id: 'ded',
-                project_slug: 'project_slug',
-                project_id: 1,
-                issue: 'whoa rusty',
-                issue_id: 0,
-                span: '',
-                level: 'error',
-                title: 'ded fo good',
-              },
-            ],
-          })
-        );
+    it('scrolls to orphan error', async () => {
+      manager.list = makeList();
+      const tree = TraceTree.FromTrace(
+        makeTrace({
+          transactions: [makeTransaction()],
+          orphan_errors: [
+            {
+              event_id: 'ded',
+              project_slug: 'project_slug',
+              project_id: 1,
+              issue: 'whoa rusty',
+              issue_id: 0,
+              span: '',
+              level: 'error',
+              title: 'ded fo good',
+              timestamp: 1,
+            },
+          ],
+        })
+      );
 
-        const result = await manager.scrollToPath(tree, ['error:ded'], () => void 0, {
-          api: api,
-          organization,
-        });
-
-        expect(result?.node).toBe(tree.list[2]);
-        expect(manager.list.scrollToRow).toHaveBeenCalledWith(2);
+      const result = await manager.scrollToPath(tree, ['error:ded'], () => void 0, {
+        api: api,
+        organization,
       });
+
+      expect(result?.node).toBe(tree.list[2]);
+      expect(manager.list.scrollToRow).toHaveBeenCalledWith(2);
     });
   });
 });


### PR DESCRIPTION
We used to just shove this to the end of the list, which resulted in an experience where you would scroll to the bottom of the list and go "whoa". Since everything else is chronologically sorted, this should be as well, as it will make it easier to identify how they might relate to spans and transactions