### PR TITLE
chore(groupint): force stack_info on grouphash.not_found error

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -145,14 +145,16 @@ def bulk_get_groups_from_fingerprints(
         (project_id, fingerprint[0]) for project_id, fingerprint in project_fingerprint_pairs
     }
     for project_id, fingerprint in fingerprints_set - found_fingerprints:
-        logger.error(
-            "grouphash.not_found",
-            extra={
-                "project_id": project_id,
-                "fingerprint": fingerprint,
-            },
-            stack_info=True,
-        )
+        try:
+            raise Exception("grouphash.not_found")
+        except Exception:
+            logger.exception(
+                "grouphash.not_found",
+                extra={
+                    "project_id": project_id,
+                    "fingerprint": fingerprint,
+                },
+            )
 
     return result
 

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -299,7 +299,7 @@ class TestProduceOccurrenceForStatusChange(TestCase, OccurrenceTestMixin):
                 "project_id": group.project_id,
                 "fingerprint": wrong_fingerprint["fingerprint"][0],
             },
-            stack_info=True,
+            exc_info=True,
         )
         assert group.status == initial_status
         assert group.substatus == initial_substatus

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -236,7 +236,7 @@ class StatusChangeBulkGetGroupsFromFingerprintsTest(IssueOccurrenceTestBase):
                 "project_id": project2.id,
                 "fingerprint": self.occurrence.fingerprint[0],
             },
-            stack_info=True,
+            exc_info=True,
         )
 
     def test_bulk_get_same_fingerprint(self) -> None:


### PR DESCRIPTION
`stack_info=True` outside of an exception doesn't do much, this adds fake exception to force stacktrace 