### PR TITLE
feat(trace): collapse http.client auto.okhttp spans by default

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -213,7 +213,6 @@ function Trace({
           return;
         }
 
-        manager.onScrollEndOutOfBoundsCheck();
         setDetailNode(maybeNode.node);
         roving_dispatch({
           type: 'set index',
@@ -221,7 +220,7 @@ function Trace({
           node: maybeNode.node,
         });
 
-        manager.scrollRowIntoViewHorizontally(maybeNode.node);
+        manager.scrollRowIntoViewHorizontally(maybeNode.node, 0);
 
         if (search_state.query) {
           onTraceSearch(search_state.query);
@@ -2164,21 +2163,19 @@ function TraceEmpty() {
   const feedback = useFeedbackWidget({buttonRef: linkref});
   return (
     <LoadingContainer animate>
-      <NoMarginIndicator size={24}>
-        <div>{t('This trace does not contain any data?!')}</div>
-        <div>
-          {t('Seeing this often? Send us ')}
-          {feedback ? (
-            <a href="#" ref={linkref}>
-              {t('feedback')}
-            </a>
-          ) : (
-            <a href="mailto:support@sentry.io?subject=Trace%20does%20not%20contain%20data">
-              {t('feedback')}
-            </a>
-          )}
-        </div>
-      </NoMarginIndicator>
+      <div>{t('This trace does not contain any data?!')}</div>
+      <div>
+        {t('Seeing this often? Send us ')}
+        {feedback ? (
+          <a href="#" ref={linkref}>
+            {t('feedback')}
+          </a>
+        ) : (
+          <a href="mailto:support@sentry.io?subject=Trace%20does%20not%20contain%20data">
+            {t('feedback')}
+          </a>
+        )}
+      </div>
     </LoadingContainer>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -215,6 +215,17 @@ function maybeInsertMissingInstrumentationSpan(
   parent.spanChildren.push(missingInstrumentationSpan);
 }
 
+function shouldCollapseNodeByDefault(node: TraceTreeNode<TraceTree.NodeValue>) {
+  if (isSpanNode(node)) {
+    // Android creates TCP connection spans which are noisy and not useful in most cases
+    if (node.value.op === 'http.client' && node.value.origin === 'auto.http.okhttp') {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 // cls is not included as it is a cumulative layout shift and not a single point in time
 const RENDERABLE_MEASUREMENTS = ['fcp', 'fp', 'lcp', 'ttfb'];
 export class TraceTree {
@@ -339,7 +350,11 @@ export class TraceTree {
 
   get shape(): TraceType {
     const trace = this.root.children[0];
-    if (!trace || !isTraceNode(trace)) {
+    if (!trace) {
+      return TraceType.EMPTY_TRACE;
+    }
+
+    if (!isTraceNode(trace)) {
       throw new TypeError('Not trace node');
     }
 
@@ -943,6 +958,10 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
 
     if (isTransactionNode(this) || isTraceNode(this) || isSpanNode(this)) {
       this.expanded = true;
+    }
+
+    if (shouldCollapseNodeByDefault(this)) {
+      this.expanded = false;
     }
   }
 


### PR DESCRIPTION
@stefanosiano this is just for the new view, we'll need to tackle the old one separately 

cc @Abdkhan14, you are more familiar with that waterfall code, mind porting this change there?