### PR TITLE
test(ui): Fix act warnings in org stats tests

### DIFF
--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -439,6 +439,7 @@ class UsageStatsProjects extends DeprecatedAsyncComponent<Props, State> {
               defaultQuery=""
               query={tableQuery}
               placeholder={t('Filter your projects')}
+              aria-label={t('Filter projects')}
               onSearch={this.handleSearch}
             />
           </Container>


### PR DESCRIPTION
Test needed to be updated to wait for all http requests to complete to avoid act warnings.

part of https://github.com/getsentry/frontend-tsc/issues/22
