### PR TITLE
ref(ddm): Add code locations endpoint with pagination

### DIFF
--- a/src/sentry/api/endpoints/organization_ddm.py
+++ b/src/sentry/api/endpoints/organization_ddm.py
@@ -75,7 +75,7 @@ class OrganizationDDMMetaEndpoint(OrganizationEndpoint):
             end=end,
             organization=organization,
             projects=projects,
-        )
+        )[1]
 
     def _get_metric_correlations(
         self,

--- a/src/sentry/api/serializers/models/metrics_code_locations.py
+++ b/src/sentry/api/serializers/models/metrics_code_locations.py
@@ -7,6 +7,7 @@ class MetricCodeLocationsSerializer(Serializer):
 
     def _compute_attrs(self, item):
         return {
+            "project_id": item.query.project_id,
             "mri": item.query.metric_mri,
             "timestamp": item.query.timestamp,
             "frames": [location.__dict__ for location in item.frames],
@@ -29,6 +30,7 @@ class MetricCodeLocationsSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         return {
+            "projectId": attrs["project_id"],
             "mri": attrs["mri"],
             "timestamp": attrs["timestamp"],
             "frames": [

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -388,9 +388,9 @@ from .endpoints.organization_member_unreleased_commits import (
 )
 from .endpoints.organization_metrics import (
     OrganizationMetricDetailsEndpoint,
+    OrganizationMetricsCodeLocationsEndpoint,
     OrganizationMetricsDataEndpoint,
     OrganizationMetricsDetailsEndpoint,
-    OrganizationMetricsMetadataEndpoint,
     OrganizationMetricsQueryEndpoint,
     OrganizationMetricsSamplesEndpoint,
     OrganizationMetricsTagDetailsEndpoint,
@@ -1978,9 +1978,9 @@ ORGANIZATION_URLS = [
         name="sentry-api-0-organization-ddm-meta",
     ),
     re_path(
-        r"^(?P<organization_slug>[^/]+)/metrics/metadata/$",
-        OrganizationMetricsMetadataEndpoint.as_view(),
-        name="sentry-api-0-organization-metrics-metadata",
+        r"^(?P<organization_slug>[^/]+)/metrics/code-locations/$",
+        OrganizationMetricsCodeLocationsEndpoint.as_view(),
+        name="sentry-api-0-organization-metrics-code-locations",
     ),
     re_path(
         r"^(?P<organization_slug>[^/]+)/metrics/meta/$",

--- a/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
@@ -1,4 +1,3 @@
-import math
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -70,10 +69,6 @@ def get_cache_key_for_code_location(
 
 
 class CodeLocationsFetcher:
-    # The maximum number of keys that can be fetched by the fetcher.
-    #
-    # Note that each key might contain multiple code locations.
-    MAXIMUM_KEYS = 50
     # The size of the batch of keys that are fetched by endpoint.
     #
     # Batching is done via Redis pipeline and the goal is to improve the performance of the system.
@@ -83,45 +78,48 @@ class CodeLocationsFetcher:
     # The maximum number of code locations that we actually return per Redis set.
     MAX_LOCATIONS_SIZE = 5
 
-    # Given the limits above, we can expect, in the worst case MAXIMUM_KEYS * MAX_LOCATIONS_SIZE elements being
-    # returned because we further limit entries returned from Redis after loading them.
-
     def __init__(
         self,
         organization: Organization,
         projects: set[Project],
         metric_mris: set[str],
         timestamps: set[int],
+        offset: int | None,
+        limit: int | None,
     ):
         self._organization = organization
         self._projects = projects
         self._metric_mris = metric_mris
         self._timestamps = timestamps
+        self._offset = offset
+        self._limit = limit
 
         self._redis_client = get_redis_client_for_metrics_meta()
+        self._has_more = False
 
     def _code_location_queries(self) -> Generator[CodeLocationQuery, None, None]:
-        total_count = len(self._projects) * len(self._metric_mris) * len(self._timestamps)
-        step_size = (
-            1 if total_count <= self.MAXIMUM_KEYS else math.ceil(total_count / self.MAXIMUM_KEYS)
-        )
+        self._has_more = False
 
-        # We want to distribute evenly and deterministically the elements in the set of combinations. For example, if
-        # the total count of code locations queries you made is 100 and our maximum is 50, then we will sample 1 out of
-        # 2 elements out of the 100 queries, to be within the 50.
-        current_step = 0
+        index = 0
+        supports_pagination = self._offset is not None and self._limit is not None
         for project in self._projects:
             for metric_mri in self._metric_mris:
                 for timestamp in self._timestamps:
-                    if current_step % step_size == 0:
+                    # We want to emit the code location query in the interval [offset, offset + limit).
+                    if (not supports_pagination) or (
+                        self._offset <= index < self._offset + self._limit
+                    ):
                         yield CodeLocationQuery(
                             organization_id=self._organization.id,
                             project_id=project.id,
                             metric_mri=metric_mri,
                             timestamp=timestamp,
                         )
+                    elif index >= self._offset + self._limit:
+                        self._has_more = True
+                        break
 
-                    current_step += 1
+                    index += 1
 
     def _parse_code_location_payload(self, encoded_location: str) -> CodeLocationPayload:
         decoded_location = json.loads(encoded_location)
@@ -165,7 +163,7 @@ class CodeLocationsFetcher:
 
         return frames
 
-    def fetch(self) -> Sequence[MetricCodeLocations]:
+    def fetch(self) -> tuple[bool, Sequence[MetricCodeLocations]]:
         code_locations: list[MetricCodeLocations] = []
         for queries in self._in_batches(self._code_location_queries(), self.BATCH_SIZE):
             # We are assuming that code locations have each a unique query, thus we don't perform any merging or
@@ -174,7 +172,10 @@ class CodeLocationsFetcher:
 
         metrics.distribution("ddm.metrics_code_locations.fetched", value=len(code_locations))
 
-        return code_locations
+        # For pagination reasons, we return whether we have more results to load by checking how many queries we emitted
+        # and not how many code locations we loaded (since a query might load multiple code locations). This is not
+        # intuitive, but it's a temporary solution to allow pagination with Redis.
+        return self._has_more, code_locations
 
     @staticmethod
     def _in_batches(
@@ -200,10 +201,14 @@ def get_metric_code_locations(
     end: datetime,
     organization: Organization,
     projects: Sequence[Project],
-) -> Sequence[MetricCodeLocations]:
+    offset: int | None = None,
+    limit: int | None = None,
+) -> tuple[bool, Sequence[MetricCodeLocations]]:
     return CodeLocationsFetcher(
         organization=organization,
         projects=set(projects),
         metric_mris=set(metric_mris),
         timestamps=_get_day_timestamps(start, end),
+        offset=offset,
+        limit=limit,
     ).fetch()

--- a/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_code_locations.py
@@ -101,13 +101,14 @@ class CodeLocationsFetcher:
         self._has_more = False
 
         index = 0
-        supports_pagination = self._offset is not None and self._limit is not None
         for project in self._projects:
             for metric_mri in self._metric_mris:
                 for timestamp in self._timestamps:
                     # We want to emit the code location query in the interval [offset, offset + limit).
-                    if (not supports_pagination) or (
-                        self._offset <= index < self._offset + self._limit
+                    if (
+                        self._offset is None
+                        or self._limit is None
+                        or self._offset <= index < self._offset + self._limit
                     ):
                         yield CodeLocationQuery(
                             organization_id=self._organization.id,
@@ -115,7 +116,11 @@ class CodeLocationsFetcher:
                             metric_mri=metric_mri,
                             timestamp=timestamp,
                         )
-                    elif index >= self._offset + self._limit:
+                    elif (
+                        self._offset is not None
+                        and self._limit is not None
+                        and index >= self._offset + self._limit
+                    ):
                         self._has_more = True
                         break
 

--- a/tests/sentry/api/endpoints/test_organization_metrics_code_locations.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_code_locations.py
@@ -21,8 +21,8 @@ pytestmark = pytest.mark.sentry_metrics
 
 @region_silo_test
 @freeze_time("2023-11-21T10:30:30.000Z")
-class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
-    endpoint = "sentry-api-0-organization-metrics-metadata"
+class OrganizationMetricsCodeLocationsTest(APITestCase, BaseSpansTestCase):
+    endpoint = "sentry-api-0-organization-metrics-code-locations"
 
     def setUp(self):
         super().setUp()
@@ -107,7 +107,7 @@ class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
             statsPeriod="1d",
             codeLocations="true",
         )
-        code_locations = response.data["codeLocations"]
+        code_locations = response.data
 
         assert len(code_locations) == 2
 
@@ -150,9 +150,41 @@ class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
             statsPeriod="1d",
             codeLocations="true",
         )
-        code_locations = response.data["codeLocations"]
+        code_locations = response.data
 
         assert len(code_locations) == 6
+
+    def test_get_locations_with_pagination(self):
+        projects = [
+            self.create_project(organization=self.organization, name="project_1"),
+            self.create_project(organization=self.organization, name="project_2"),
+            self.create_project(organization=self.organization, name="project_3"),
+        ]
+        mris = [
+            "d:custom/sentry.process_profile.track_outcome@second",
+        ]
+
+        self._store_code_locations(self.organization, projects, mris, 2)
+
+        offset = 0
+        for expected_project in projects:
+            response = self.get_success_response(
+                self.organization.slug,
+                metric=mris,
+                project="-1",
+                statsPeriod="1d",
+                codeLocations="true",
+                per_page="2",
+                cursor=f"0:{offset}:0",
+            )
+            code_locations = response.data
+
+            assert len(code_locations) == 2
+            # We expect both code locations to belong to the same project at different timestamps.
+            assert code_locations[0]["projectId"] == expected_project.id
+            assert code_locations[1]["projectId"] == expected_project.id
+
+            offset += 2
 
     def test_get_locations_with_start_and_end(self):
         projects = [self.create_project(name="project_1")]
@@ -172,7 +204,7 @@ class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
             end=(self.current_time - timedelta(days=1)).isoformat(),
             codeLocations="true",
         )
-        code_locations = response.data["codeLocations"]
+        code_locations = response.data
 
         assert len(code_locations) == 1
 
@@ -203,7 +235,7 @@ class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
             end=(self.current_time - timedelta(days=2)).isoformat(),
             codeLocations="true",
         )
-        codeLocations = response.data["codeLocations"]
+        codeLocations = response.data
 
         assert len(codeLocations) == 0
 
@@ -251,7 +283,7 @@ class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
             statsPeriod="1d",
             codeLocations="true",
         )
-        code_locations = response.data["codeLocations"]
+        code_locations = response.data
 
         assert len(code_locations) == 1
 
@@ -307,7 +339,7 @@ class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
             codeLocations="true",
         )
 
-        code_locations = response.data["codeLocations"]
+        code_locations = response.data
 
         frame = code_locations[0]["frames"][0]
         assert frame["preContext"] == ["pre"]
@@ -333,68 +365,8 @@ class OrganizationMetricsMetadataTest(APITestCase, BaseSpansTestCase):
             codeLocations="true",
         )
 
-        code_locations = response.data["codeLocations"]
+        code_locations = response.data
 
         frame = code_locations[0]["frames"][0]
         assert frame["preContext"] == []
         assert frame["postContext"] == []
-
-    @patch(
-        "sentry.sentry_metrics.querying.metadata.metrics_code_locations.CodeLocationsFetcher.MAXIMUM_KEYS",
-        50,
-    )
-    @patch(
-        "sentry.sentry_metrics.querying.metadata.metrics_code_locations.CodeLocationsFetcher._in_batches"
-    )
-    def test_get_locations_with_too_many_combinations(self, _in_batches):
-        project = self.create_project(name="project_1")
-        mri = "d:custom/sentry.process_profile.track_outcome@second"
-
-        self.get_success_response(
-            self.organization.slug,
-            metric=[mri],
-            project=[project.id],
-            statsPeriod="90d",
-            codeLocations="true",
-        )
-
-        args, *_ = _in_batches.call_args
-        assert len(list(args[0])) == 46
-
-    @patch(
-        "sentry.sentry_metrics.querying.metadata.metrics_code_locations.CodeLocationsFetcher.MAX_SET_SIZE",
-        1,
-    )
-    def test_get_locations_with_more_locations_than_limit(self):
-        projects = [self.create_project(name="project_1")]
-        mris = [
-            "d:custom/sentry.process_profile.track_outcome@second",
-        ]
-
-        # We are storing two code locations with a limit of 1.
-        self._store_code_locations(self.organization, projects, mris, 2)
-
-        response = self.get_success_response(
-            self.organization.slug,
-            metric=mris,
-            project=[project.id for project in projects],
-            statsPeriod="1d",
-            codeLocations="true",
-        )
-        code_locations = response.data["codeLocations"]
-
-        assert len(code_locations) == 2
-
-        assert code_locations[0]["mri"] == mris[0]
-        assert code_locations[0]["timestamp"] == self._round_to_day(
-            self.current_time - timedelta(days=1)
-        )
-
-        assert code_locations[1]["mri"] == mris[0]
-        assert code_locations[1]["timestamp"] == self._round_to_day(self.current_time)
-
-        frames = code_locations[0]["frames"]
-        assert len(frames) == 1
-
-        frames = code_locations[0]["frames"]
-        assert len(frames) == 1


### PR DESCRIPTION
This PR changes the `metrics/metadata` endpoint to `metrics/code-locations` to align with the existing `metrics/samples`. The decision to remove the multiple metadata support in a single endpoint is also for pagination reasons since we are required to implement pagination for all list-based endpoints.

The pagination of this endpoint paginates around the combinations of `project, metric, timestamp` and not unique code location entries. This is done since we are not able to offer pagination at the code locations level due to our reliance on Redis sets. For this reason, we might have to implement frontend code to try and query different pages in case an empty response is returned.

The new code returns also the project in which the code location was emitted, to play more nicely with the multi-project selector of metrics.