### PR TITLE
Move metrics out of inner `normalize_message_for_grouping`

### DIFF
--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -199,7 +199,7 @@ def normalize_message_for_grouping(message: str, event: Event, share_analytics: 
     if trimmed != message:
         trimmed += "..."
 
-    trimmed_value_counter = defaultdict(int)
+    trimmed_value_counter: defaultdict[str, int] = defaultdict(int)
 
     def _handle_match(match: Match[str]) -> str:
         # Find the first (should be only) non-None match entry, and sub in the placeholder. For

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -1,5 +1,6 @@
 import dataclasses
 import re
+from collections import defaultdict
 from itertools import islice
 from re import Match
 from typing import Any
@@ -198,15 +199,15 @@ def normalize_message_for_grouping(message: str, event: Event, share_analytics: 
     if trimmed != message:
         trimmed += "..."
 
+    trimmed_value_counter = defaultdict(int)
+
     def _handle_match(match: Match[str]) -> str:
         # Find the first (should be only) non-None match entry, and sub in the placeholder. For
         # example, given the groupdict item `('hex', '0x40000015')`, this returns '<hex>' as a
         # replacement for the original value in the string.
         for key, value in match.groupdict().items():
             if value is not None:
-                # `key` can only be one of the keys from `_parameterization_regex`, thus, not a large
-                # cardinality. Tracking the key helps distinguish what kinds of replacements are happening.
-                metrics.incr("grouping.value_trimmed_from_message", tags={"key": key})
+                trimmed_value_counter[key] += 1
                 # For `quoted_str` and `bool` we want to preserve the `=` symbol, which we include in
                 # the match in order not to replace random quoted strings and the words 'true' and 'false'
                 # in contexts other than key-value pairs
@@ -255,6 +256,12 @@ def normalize_message_for_grouping(message: str, event: Event, share_analytics: 
                         event_id=event.event_id,
                     )
                 normalized = experiment_output
+
+    for key, value in trimmed_value_counter.items():
+        # `key` can only be one of the keys from `_parameterization_regex`, thus, not a large
+        # cardinality. Tracking the key helps distinguish what kinds of replacements are happening.
+        metrics.incr("grouping.value_trimmed_from_message", amount=value, tags={"key": key})
+
     return normalized
 
 


### PR DESCRIPTION
Profiling in S4S has revealed that the metric being emitted from within `_handle_match` is quite hot.

One idea to improve this is to move metrics gathering out of that inner function.

This would only help if multiple groups are being matched in a single message line, so I am not entirely sure if this will make any difference.

See https://sentry-st.sentry.io/profiling/summary/sentry-for-sentry/?project=1513938&sort=-count%28%29&statsPeriod=7d&transaction=sentry.tasks.store.save_event which reports that ~13% of the profile are spent in these metrics.