### PR TITLE
Use symbolicator proguard processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ test-symbolicator:
 	@echo "--> Running symbolicator tests"
 	pytest tests/symbolicator -vv --cov . --cov-report="xml:.artifacts/symbolicator.coverage.xml"
 	pytest tests/relay_integration/lang/javascript/ -vv -m symbolicator
+	pytest tests/relay_integration/lang/java/ -vv -m symbolicator
 	@echo ""
 
 test-acceptance: node-version-check

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -7,6 +7,7 @@ from sentry.lang.java.utils import (
     get_jvm_images,
     get_proguard_images,
     has_proguard_file,
+    should_use_symbolicator_for_proguard,
 )
 from sentry.lang.javascript.utils import get_source_context, trim_line
 from sentry.models.artifactbundle import ArtifactBundleArchive
@@ -290,6 +291,9 @@ class JavaPlugin(Plugin2):
         return False
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
+        if should_use_symbolicator_for_proguard(data.get("project")):
+            return []
+
         if "java" in platforms:
             return [JavaSourceLookupStacktraceProcessor]
 

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -296,8 +296,11 @@ class JavaPlugin(Plugin2):
         return False
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
-        project = data.get("project")
-        if should_use_symbolicator_for_proguard(project):
+        from sentry.models.project import Project
+
+        project_id = data.get("project")
+        project = Project.objects.get_from_cache(id=project_id)
+        if should_use_symbolicator_for_proguard(project_id):
             symbolication_start_time = time()
 
             def on_symbolicator_request():

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -1,4 +1,7 @@
+from time import time
+
 import sentry_sdk
+from django.conf import settings
 
 from sentry.lang.java.processing import deobfuscate_exception_value, process_jvm_stacktraces
 from sentry.lang.java.proguard import open_proguard_mapper
@@ -10,12 +13,14 @@ from sentry.lang.java.utils import (
     should_use_symbolicator_for_proguard,
 )
 from sentry.lang.javascript.utils import get_source_context, trim_line
+from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorPlatform, SymbolicatorTaskKind
 from sentry.models.artifactbundle import ArtifactBundleArchive
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.eventerror import EventError
 from sentry.plugins.base.v2 import Plugin2
 from sentry.reprocessing import report_processing_issue
 from sentry.stacktraces.processing import StacktraceProcessor
+from sentry.tasks.symbolication import SymbolicationTimeout
 
 
 class JavaStacktraceProcessor(StacktraceProcessor):
@@ -291,8 +296,24 @@ class JavaPlugin(Plugin2):
         return False
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
-        if should_use_symbolicator_for_proguard(data.get("project")):
-            process_jvm_stacktraces(data)
+        project = data.get("project")
+        if should_use_symbolicator_for_proguard(project):
+            symbolication_start_time = time()
+
+            def on_symbolicator_request():
+                duration = time() - symbolication_start_time
+                if duration > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
+                    raise SymbolicationTimeout
+
+            symbolicator_platform = SymbolicatorPlatform.jvm
+            symbolicator = Symbolicator(
+                task_kind=SymbolicatorTaskKind(platform=symbolicator_platform),
+                on_request=on_symbolicator_request,
+                project=project,
+                event_id=data["event_id"],
+            )
+
+            process_jvm_stacktraces(symbolicator, data)
             return []
 
         if "java" in platforms:

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -290,6 +290,8 @@ class JavaPlugin(Plugin2):
         return False
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
+        if data.pop("processed_by_symbolicator", False):
+            return []
         if "java" in platforms:
             return [JavaSourceLookupStacktraceProcessor]
 

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -1,6 +1,6 @@
 import sentry_sdk
 
-from sentry.lang.java.processing import deobfuscate_exception_value
+from sentry.lang.java.processing import deobfuscate_exception_value, process_jvm_stacktraces
 from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.lang.java.utils import (
     deobfuscate_view_hierarchy,
@@ -292,6 +292,7 @@ class JavaPlugin(Plugin2):
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
         if should_use_symbolicator_for_proguard(data.get("project")):
+            process_jvm_stacktraces(data)
             return []
 
         if "java" in platforms:

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -124,6 +124,7 @@ def _handle_response_status(event_data: Any, response_json: dict[str, Any]) -> b
         error = SymbolicationFailed(type=EventError.NATIVE_INTERNAL_FAILURE)
 
     write_error(error, event_data)
+    return None
 
 
 def _get_release_package(project: Project, release_name: str | None) -> str | None:

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -134,7 +134,9 @@ def map_symbolicator_process_jvm_errors(
                     "mapping_uuid": uuid,
                 }
             )
-        elif ty == "no_line_info":
+        # according to the `test_error_on_resolving` test, a completely
+        # broken file should result in a `PROGUARD_MISSING_LINENO` error
+        elif ty == "no_line_info" or ty == "invalid":
             mapped_errors.append(
                 {
                     "symbolicator_type": ty,
@@ -142,9 +144,6 @@ def map_symbolicator_process_jvm_errors(
                     "mapping_uuid": uuid,
                 }
             )
-        elif ty == "invalid":
-            # WAT DO?
-            pass
 
     return mapped_errors
 

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -205,4 +205,13 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
                 "frames": raw_frames,
             }
 
+    assert len(exceptions) == len(response["exceptions"])
+
+    # NOTE: we are using the `data.exception.values` directory here
+    for exception, complete_exception in zip(
+        get_path(data, "exception", "values", filter=True, default=()), response["exceptions"]
+    ):
+        exception["type"] = complete_exception["type"]
+        exception["module"] = complete_exception["module"]
+
     return data

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -2,7 +2,7 @@ import logging
 import re
 from typing import Any
 
-from sentry.lang.java.utils import get_proguard_images, should_use_symbolicator_for_proguard
+from sentry.lang.java.utils import get_proguard_images
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.models.eventerror import EventError

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -192,7 +192,6 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any):
 
     for sinfo, complete_stacktrace in zip(stacktrace_infos, response["stacktraces"]):
         raw_frames = sinfo.stacktrace["frames"]
-        # sinfo.stacktrace["frames"] = complete_stacktrace["frames"]
         complete_frames = complete_stacktrace["frames"]
         sinfo.stacktrace["frames"] = []
 
@@ -201,7 +200,10 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any):
             # otherwise use the raw_frame itself.
             matching_frames = [frame for frame in complete_frames if frame["index"] == index]
             if matching_frames:
-                sinfo.stacktrace["frames"].extend(matching_frames)
+                for returned in matching_frames:
+                    new_frame = dict(raw_frame)
+                    _merge_frame(new_frame, returned)
+                    sinfo.stacktrace["frames"].append(new_frame)
             else:
                 sinfo.stacktrace["frames"].append(raw_frame)
 

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -1,6 +1,16 @@
+import logging
 import re
+from typing import Any
 
 from sentry.utils.safe import get_path
+from sentry.utils import metrics
+from sentry.lang.java.utils import get_proguard_images, should_use_symbolicator_for_proguard
+from sentry.lang.native.error import SymbolicationFailed, write_error
+from sentry.lang.native.symbolicator import Symbolicator
+from sentry.models.eventerror import EventError
+from sentry.stacktraces.processing import find_stacktraces_in_data
+
+logger = logging.getLogger(__name__)
 
 
 def deobfuscate_exception_value(data):
@@ -21,5 +31,182 @@ def deobfuscate_exception_value(data):
         exception["value"] = re.sub(
             re.escape(raw_method_name), deobfuscated_method_name, exception["value"]
         )
+
+    return data
+
+
+def _merge_frame_context(new_frame, symbolicated):
+    if symbolicated.get("pre_context"):
+        new_frame["pre_context"] = symbolicated["pre_context"]
+    if symbolicated.get("context_line"):
+        new_frame["context_line"] = symbolicated["context_line"]
+    if symbolicated.get("post_context"):
+        new_frame["post_context"] = symbolicated["post_context"]
+
+    return new_frame
+
+
+def _merge_frame(new_frame, symbolicated):
+    _merge_frame_context(new_frame, symbolicated)
+
+    if symbolicated.get("function"):
+        new_frame["function"] = symbolicated["function"]
+    if symbolicated.get("abs_path"):
+        new_frame["abs_path"] = symbolicated["abs_path"]
+    if symbolicated.get("filename"):
+        new_frame["filename"] = symbolicated["filename"]
+    if symbolicated.get("lineno"):
+        new_frame["lineno"] = symbolicated["lineno"]
+    if symbolicated.get("module"):
+        new_frame["module"] = symbolicated["module"]
+    if symbolicated.get("in_app") is not None:
+        new_frame["in_app"] = symbolicated["in_app"]
+
+
+def _handles_frame(frame, data):
+    # Skip frames without function or module
+    return "function" in frame and "module" in frame
+
+
+FRAME_FIELDS = ("abs_path", "lineno", "function", "module", "filename", "in_app")
+
+
+def _normalize_frame(raw_frame: Any) -> dict:
+    frame = {}
+    for key in FRAME_FIELDS:
+        if (value := raw_frame.get(key)) is not None:
+            frame[key] = value
+
+    return frame
+
+
+def get_frames_for_symbolication(frames, data):
+    return [dict(frame) for frame in reversed(frames)]
+
+
+def _get_exceptions_for_symbolication(data):
+    exceptions = []
+
+    for exc in get_path(data, "exception", "values", filter=True, default=()):
+        if exc.get("type") is not None and exc.get("module") is not None:
+            exceptions.append({"type": exc["type"], "module": exc["module"]})
+
+
+def _handle_response_status(event_data, response_json):
+    if not response_json:
+        error = SymbolicationFailed(type=EventError.NATIVE_INTERNAL_FAILURE)
+    elif response_json["status"] == "completed":
+        return True
+    elif response_json["status"] == "failed":
+        error = SymbolicationFailed(
+            message=response_json.get("message") or None,
+            type=EventError.NATIVE_SYMBOLICATOR_FAILED,
+        )
+    else:
+        logger.error("Unexpected symbolicator status: %s", response_json["status"])
+        error = SymbolicationFailed(type=EventError.NATIVE_INTERNAL_FAILURE)
+
+    write_error(error, event_data)
+
+
+def map_symbolicator_process_jvm_errors(errors):
+    if errors is None:
+        return []
+
+    mapped_errors = []
+
+    for error in errors:
+        ty = error["type"]
+        uuid = error["uuid"]
+
+        if ty == "missing":
+            mapped_errors.append(
+                {
+                    "symbolicator_type": ty,
+                    "type": EventError.PROGUARD_MISSING_MAPPING,
+                    "mapping_uuid": uuid,
+                }
+            )
+        elif ty == "no_line_info":
+            mapped_errors.append(
+                {
+                    "symbolicator_type": ty,
+                    "type": EventError.PROGUARD_MISSING_LINENO,
+                    "mapping_uuid": uuid,
+                }
+            )
+        elif ty == "invalid":
+            # WAT DO?
+            pass
+
+    return mapped_errors
+
+
+def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
+    modules = [{"uuid": id} for id in get_proguard_images(data)]
+
+    stacktrace_infos = find_stacktraces_in_data(data)
+    stacktraces = [
+        {
+            "frames": [
+                _normalize_frame(frame)
+                for frame in sinfo.stacktrace.get("frames") or ()
+                if _handles_frame(frame, data)
+            ],
+        }
+        for sinfo in stacktrace_infos
+    ]
+
+    exceptions = _get_exceptions_for_symbolication(data)
+
+    metrics.incr("proguard.symbolicator.events")
+
+    if not any(stacktrace["frames"] for stacktrace in stacktraces) and not exceptions:
+        metrics.incr("proguard.symbolicator.events.skipped")
+        return
+
+    metrics.incr("process.java.symbolicate.request")
+    response = symbolicator.process_jvm(
+        exceptions=exceptions,
+        stacktraces=stacktraces,
+        modules=modules,
+        release=data.get("release"),
+        dist=data.get("dist"),
+    )
+
+    if not _handle_response_status(data, response):
+        return data
+
+    processing_errors = response.get("errors", [])
+    if len(processing_errors) > 0:
+        data.setdefault("errors", []).extend(
+            map_symbolicator_process_jvm_errors(processing_errors)
+        )
+
+    assert len(stacktraces) == len(response["stacktraces"]), (stacktraces, response)
+
+    for sinfo, complete_stacktrace in zip(
+        stacktrace_infos, response["stacktraces"]
+    ):
+        processed_frame_idx = 0
+        new_frames = []
+        raw_frames = sinfo.stacktrace["frames"]
+        for sinfo_frame in sinfo.stacktrace["frames"]:
+            if not _handles_frame(sinfo_frame, data):
+                new_frames.append(sinfo_frame)
+                continue
+
+            complete_frame = complete_stacktrace["frames"][processed_frame_idx]
+            processed_frame_idx += 1
+
+            merged_frame = _merge_frame(sinfo_frame, complete_frame)
+            new_frames.append(merged_frame)
+
+        sinfo.stacktrace["frames"] = new_frames
+
+        if sinfo.container is not None:
+            sinfo.container["raw_stacktrace"] = {
+                "frames": raw_frames,
+            }
 
     return data

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -149,7 +149,7 @@ def map_symbolicator_process_jvm_errors(
     return mapped_errors
 
 
-def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any):
+def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     modules = []
     modules.extend([{"uuid": id, "type": "proguard"} for id in get_proguard_images(data)])
     modules.extend([{"uuid": id, "type": "source"} for id in get_jvm_images(data)])
@@ -185,6 +185,8 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any):
 
     if not _handle_response_status(data, response):
         return
+
+    data["processed_by_symbolicator"] = True
 
     processing_errors = response.get("errors", [])
     if len(processing_errors) > 0:
@@ -223,3 +225,5 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any):
     ):
         exception["type"] = complete_exception["type"]
         exception["module"] = complete_exception["module"]
+
+    return data

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -159,7 +159,7 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any):
         {
             "frames": [
                 _normalize_frame(frame, index)
-                for index, frame in enumerate(sinfo.stacktrace.get("frames")) or ()
+                for index, frame in enumerate(sinfo.stacktrace.get("frames") or ())
                 if _handles_frame(frame)
             ],
         }

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -193,8 +193,9 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
             complete_frame = complete_stacktrace["frames"][processed_frame_idx]
             processed_frame_idx += 1
 
-            _merge_frame(sinfo_frame, complete_frame)
-            new_frames.append(sinfo_frame)
+            new_frame = dict(sinfo_frame)
+            _merge_frame(new_frame, complete_frame)
+            new_frames.append(new_frame)
 
         sinfo.stacktrace["frames"] = new_frames
 

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -2,13 +2,13 @@ import logging
 import re
 from typing import Any
 
-from sentry.utils.safe import get_path
-from sentry.utils import metrics
 from sentry.lang.java.utils import get_proguard_images, should_use_symbolicator_for_proguard
 from sentry.lang.native.error import SymbolicationFailed, write_error
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.models.eventerror import EventError
 from sentry.stacktraces.processing import find_stacktraces_in_data
+from sentry.utils import metrics
+from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
 
@@ -179,15 +179,11 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
     processing_errors = response.get("errors", [])
     if len(processing_errors) > 0:
-        data.setdefault("errors", []).extend(
-            map_symbolicator_process_jvm_errors(processing_errors)
-        )
+        data.setdefault("errors", []).extend(map_symbolicator_process_jvm_errors(processing_errors))
 
     assert len(stacktraces) == len(response["stacktraces"]), (stacktraces, response)
 
-    for sinfo, complete_stacktrace in zip(
-        stacktrace_infos, response["stacktraces"]
-    ):
+    for sinfo, complete_stacktrace in zip(stacktrace_infos, response["stacktraces"]):
         processed_frame_idx = 0
         new_frames = []
         raw_frames = sinfo.stacktrace["frames"]

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -62,6 +62,8 @@ def _merge_frame(new_frame: dict[str, Any], symbolicated: dict[str, Any]):
     if symbolicated.get("in_app") is not None:
         new_frame["in_app"] = symbolicated["in_app"]
 
+    new_frame["lineno"] = symbolicated.get("lineno") or 0
+
 
 def _handles_frame(frame: dict[str, Any]) -> bool:
     return "function" in frame and "module" in frame

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -74,8 +74,10 @@ def _merge_frame(new_frame: dict[str, Any], symbolicated: dict[str, Any]):
         new_frame["in_app"] = symbolicated["in_app"]
 
 
-def _handles_frame(frame: dict[str, Any]) -> bool:
-    return "function" in frame and "module" in frame
+def _handles_frame(frame: dict[str, Any], platform: str) -> bool:
+    return (
+        "function" in frame and "module" in frame and (frame.get("platform") or platform) == "java"
+    )
 
 
 FRAME_FIELDS = ("abs_path", "lineno", "function", "module", "filename", "in_app")
@@ -169,7 +171,7 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
             "frames": [
                 _normalize_frame(frame, index)
                 for index, frame in enumerate(sinfo.stacktrace.get("frames") or ())
-                if _handles_frame(frame)
+                if _handles_frame(frame, data.get("platform", "unknown"))
             ],
         }
         for sinfo in stacktrace_infos

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -51,18 +51,27 @@ def _merge_frame(new_frame: dict[str, Any], symbolicated: dict[str, Any]):
 
     if symbolicated.get("function"):
         new_frame["function"] = symbolicated["function"]
+
     if symbolicated.get("abs_path"):
         new_frame["abs_path"] = symbolicated["abs_path"]
+
+    # Clear abs_path if Symbolicator unset it
+    elif new_frame.get("abs_path"):
+        del new_frame["abs_path"]
+
     if symbolicated.get("filename"):
         new_frame["filename"] = symbolicated["filename"]
-    if symbolicated.get("lineno"):
+
+    # Clear abs_path if Symbolicator unset it
+    elif new_frame.get("filename"):
+        del new_frame["filename"]
+
+    if symbolicated.get("lineno") is not None:
         new_frame["lineno"] = symbolicated["lineno"]
     if symbolicated.get("module"):
         new_frame["module"] = symbolicated["module"]
     if symbolicated.get("in_app") is not None:
         new_frame["in_app"] = symbolicated["in_app"]
-
-    new_frame["lineno"] = symbolicated.get("lineno") or 0
 
 
 def _handles_frame(frame: dict[str, Any]) -> bool:

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -170,8 +170,9 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         exceptions=exceptions,
         stacktraces=stacktraces,
         modules=modules,
-        release=data.get("release"),
-        dist=data.get("dist"),
+        # TODO:
+        release_package=None,
+        # release_package=data.get("release"),
     )
 
     if not _handle_response_status(data, response):

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -37,18 +37,7 @@ def deobfuscate_exception_value(data: Any) -> Any:
     return data
 
 
-def _merge_frame_context(new_frame: dict[str, Any], symbolicated: dict[str, Any]):
-    if symbolicated.get("pre_context"):
-        new_frame["pre_context"] = symbolicated["pre_context"]
-    if symbolicated.get("context_line"):
-        new_frame["context_line"] = symbolicated["context_line"]
-    if symbolicated.get("post_context"):
-        new_frame["post_context"] = symbolicated["post_context"]
-
-
 def _merge_frame(new_frame: dict[str, Any], symbolicated: dict[str, Any]):
-    _merge_frame_context(new_frame, symbolicated)
-
     if symbolicated.get("function"):
         new_frame["function"] = symbolicated["function"]
 
@@ -72,6 +61,13 @@ def _merge_frame(new_frame: dict[str, Any], symbolicated: dict[str, Any]):
         new_frame["module"] = symbolicated["module"]
     if symbolicated.get("in_app") is not None:
         new_frame["in_app"] = symbolicated["in_app"]
+
+    if symbolicated.get("pre_context"):
+        new_frame["pre_context"] = symbolicated["pre_context"]
+    if symbolicated.get("context_line"):
+        new_frame["context_line"] = symbolicated["context_line"]
+    if symbolicated.get("post_context"):
+        new_frame["post_context"] = symbolicated["post_context"]
 
 
 def _handles_frame(frame: dict[str, Any], platform: str) -> bool:

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -243,8 +243,10 @@ class Symbolicator:
 
         :param exceptions: The event's exceptions. These must contain a `type` and a `module`.
         :param stacktraces: The event's stacktraces. Frames must contain a `function` and a `module`.
-        :param modules: ProGuard modules to use for deobfuscation. They must contain a `uuid`.
+        :param modules: ProGuard modules and source bundles. They must contain a `uuid` and have a
+                        `type` of either "proguard" or "source".
         :param release_package: The name of the release's package. This is optional.
+                                Used for determining whether frames are in-app.
         :param apply_source_context: Whether to add source context to frames.
         """
         source = get_internal_source(self.project)

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -30,9 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 class SymbolicatorPlatform(Enum):
-    jvm: jvm
-    js: js
-    native: native
+    jvm = "jvm"
+    js = "js"
+    native = "native"
 
 
 @dataclass(frozen=True)
@@ -66,11 +66,11 @@ class Symbolicator:
         URLS = settings.SYMBOLICATOR_POOL_URLS
         pool = SymbolicatorPools.default.value
         if task_kind.is_low_priority:
-            if task_kind.platform == SymbolicatorPlatform.js:
+            if task_kind.platform == SymbolicatorPlatform.js.value:
                 pool = SymbolicatorPools.lpq_js.value
             else:
                 pool = SymbolicatorPools.lpq.value
-        elif task_kind.platform == SymbolicatorPlatform.js:
+        elif task_kind.platform == SymbolicatorPlatform.js.value:
             pool = SymbolicatorPools.js.value
 
         base_url = (

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -30,9 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 class SymbolicatorPlatform(Enum):
-    jvm: "jvm"
-    js: "js"
-    native: "native"
+    jvm: jvm
+    js: js
+    native: native
 
 
 @dataclass(frozen=True)

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -66,11 +66,11 @@ class Symbolicator:
         URLS = settings.SYMBOLICATOR_POOL_URLS
         pool = SymbolicatorPools.default.value
         if task_kind.is_low_priority:
-            if task_kind.platform == SymbolicatorPlatform.js.value:
+            if task_kind.platform == SymbolicatorPlatform.js:
                 pool = SymbolicatorPools.lpq_js.value
             else:
                 pool = SymbolicatorPools.lpq.value
-        elif task_kind.platform == SymbolicatorPlatform.js.value:
+        elif task_kind.platform == SymbolicatorPlatform.js:
             pool = SymbolicatorPools.js.value
 
         base_url = (

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -29,17 +29,23 @@ MAX_ATTEMPTS = 3
 logger = logging.getLogger(__name__)
 
 
+class SymbolicatorPlatform(Enum):
+    jvm: "jvm"
+    js: "js"
+    native: "native"
+
+
 @dataclass(frozen=True)
 class SymbolicatorTaskKind:
-    is_js: bool = False
+    platform: SymbolicatorPlatform
     is_low_priority: bool = False
     is_reprocessing: bool = False
 
     def with_low_priority(self, is_low_priority: bool) -> SymbolicatorTaskKind:
         return dataclasses.replace(self, is_low_priority=is_low_priority)
 
-    def with_js(self, is_js: bool) -> SymbolicatorTaskKind:
-        return dataclasses.replace(self, is_js=is_js)
+    def with_platform(self, platform: SymbolicatorPlatform) -> SymbolicatorTaskKind:
+        return dataclasses.replace(self, platform=platform)
 
 
 class SymbolicatorPools(Enum):
@@ -60,11 +66,11 @@ class Symbolicator:
         URLS = settings.SYMBOLICATOR_POOL_URLS
         pool = SymbolicatorPools.default.value
         if task_kind.is_low_priority:
-            if task_kind.is_js:
+            if task_kind.platform == SymbolicatorPlatform.js:
                 pool = SymbolicatorPools.lpq_js.value
             else:
                 pool = SymbolicatorPools.lpq.value
-        elif task_kind.is_js:
+        elif task_kind.platform == SymbolicatorPlatform.js:
             pool = SymbolicatorPools.js.value
 
         base_url = (

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -30,6 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 class SymbolicatorPlatform(Enum):
+    """The platforms for which we want to
+    invoke Symbolicator."""
+
     jvm = "jvm"
     js = "js"
     native = "native"
@@ -37,6 +40,11 @@ class SymbolicatorPlatform(Enum):
 
 @dataclass(frozen=True)
 class SymbolicatorTaskKind:
+    """Bundles information about a symbolication task:
+    the platform, whether it's on the low priority queue, and
+    whether it's an existing event being reprocessed.
+    """
+
     platform: SymbolicatorPlatform
     is_low_priority: bool = False
     is_reprocessing: bool = False

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -65,6 +65,7 @@ class Symbolicator:
     ):
         URLS = settings.SYMBOLICATOR_POOL_URLS
         pool = SymbolicatorPools.default.value
+        # TODO: Add a pool for JVM
         if task_kind.is_low_priority:
             if task_kind.platform == SymbolicatorPlatform.js:
                 pool = SymbolicatorPools.lpq_js.value

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -571,6 +571,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enable use of Symbolicator proguard processing for specific projects.
+register("symbolicator.proguard-processing-projects", type=Sequence, default=[])
+# Enable use of Symbolicator proguard processing for fraction of projects.
+register("symbolicator.proguard-processing-sample-rate", default=0.0)
+
 # Post Process Error Hook Sampling
 register(
     "post-process.use-error-hook-sampling", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -16,7 +16,7 @@ from sentry.constants import DataCategory
 from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.lang.javascript.processing import _handles_frame as is_valid_javascript_frame
 from sentry.lang.native.processing import _merge_image
-from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorTaskKind
+from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorTaskKind, SymbolicatorPlatform
 from sentry.lang.native.utils import native_images_from_data
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.eventerror import EventError
@@ -480,9 +480,12 @@ def run_symbolicate(
         if duration > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
             raise SymbolicationTimeout
 
-    is_js = platform in SHOULD_SYMBOLICATE_JS
+    if platform in SHOULD_SYMBOLICATE_JS:
+        symbolicator_platform = SymbolicatorPlatform.js
+    else:
+        symbolicator_platform = SymbolicatorPlatform.native
     symbolicator = Symbolicator(
-        task_kind=SymbolicatorTaskKind(is_js=is_js),
+        task_kind=SymbolicatorTaskKind(platform=symbolicator_platform),
         on_request=on_symbolicator_request,
         project=project,
         event_id=profile["event_id"],

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -16,7 +16,7 @@ from sentry.constants import DataCategory
 from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.lang.javascript.processing import _handles_frame as is_valid_javascript_frame
 from sentry.lang.native.processing import _merge_image
-from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorTaskKind, SymbolicatorPlatform
+from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorPlatform, SymbolicatorTaskKind
 from sentry.lang.native.utils import native_images_from_data
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.eventerror import EventError

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -169,7 +169,7 @@ def _do_preprocess_event(
             "organization", Organization.objects.get_from_cache(id=project.organization_id)
         )
 
-    is_js, symbolication_function = get_symbolication_function(data)
+    platform, symbolication_function = get_symbolication_function(data)
     if symbolication_function:
         symbolication_function_name = getattr(symbolication_function, "__name__", "none")
 
@@ -186,7 +186,7 @@ def _do_preprocess_event(
 
             is_low_priority = should_demote_symbolication(project_id)
             task_kind = SymbolicatorTaskKind(
-                is_js=is_js, is_low_priority=is_low_priority, is_reprocessing=from_reprocessing
+                platform=platform, is_low_priority=is_low_priority, is_reprocessing=from_reprocessing
             )
             submit_symbolicate(
                 task_kind,

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -186,7 +186,9 @@ def _do_preprocess_event(
 
             is_low_priority = should_demote_symbolication(project_id)
             task_kind = SymbolicatorTaskKind(
-                platform=platform, is_low_priority=is_low_priority, is_reprocessing=from_reprocessing
+                platform=platform,
+                is_low_priority=is_low_priority,
+                is_reprocessing=from_reprocessing,
             )
             submit_symbolicate(
                 task_kind,

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -102,13 +102,13 @@ def get_native_symbolication_function(data: Any) -> Callable[[Symbolicator, Any]
 def get_symbolication_function(
     data: Any,
 ) -> tuple[SymbolicatorPlatform, Callable[[Symbolicator, Any], Any] | None]:
-    # from sentry.lang.java.processing import process_jvm_stacktraces
-    # from sentry.lang.java.utils import should_use_symbolicator_for_proguard
+    from sentry.lang.java.processing import process_jvm_stacktraces
+    from sentry.lang.java.utils import should_use_symbolicator_for_proguard
 
     if data["platform"] in ("javascript", "node"):
         return SymbolicatorPlatform.js, process_js_stacktraces
-    # elif data["platform"] == "java" and should_use_symbolicator_for_proguard(data.get("project")):
-    #     return SymbolicatorPlatform.jvm, process_jvm_stacktraces
+    elif data["platform"] == "java" and should_use_symbolicator_for_proguard(data.get("project")):
+        return SymbolicatorPlatform.jvm, process_jvm_stacktraces
     else:
         return SymbolicatorPlatform.native, get_native_symbolication_function(data)
 
@@ -362,6 +362,11 @@ def submit_symbolicate(
             task = symbolicate_js_event_low_priority
         else:
             task = symbolicate_js_event
+    elif task_kind.platform == SymbolicatorPlatform.jvm:
+        if task_kind.is_low_priority:
+            task = symbolicate_jvm_event_low_priority
+        else:
+            task = symbolicate_jvm_event
     elif task_kind.is_reprocessing:
         if task_kind.is_low_priority:
             task = symbolicate_event_from_reprocessing_low_priority

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -102,13 +102,13 @@ def get_native_symbolication_function(data: Any) -> Callable[[Symbolicator, Any]
 def get_symbolication_function(
     data: Any,
 ) -> tuple[SymbolicatorPlatform, Callable[[Symbolicator, Any], Any] | None]:
-    from sentry.lang.java.processing import process_jvm_stacktraces
-    from sentry.lang.java.utils import should_use_symbolicator_for_proguard
+    # from sentry.lang.java.processing import process_jvm_stacktraces
+    # from sentry.lang.java.utils import should_use_symbolicator_for_proguard
 
     if data["platform"] in ("javascript", "node"):
         return SymbolicatorPlatform.js, process_js_stacktraces
-    elif data["platform"] == "java" and should_use_symbolicator_for_proguard(data.get("project")):
-        return SymbolicatorPlatform.jvm.value, process_jvm_stacktraces
+    # elif data["platform"] == "java" and should_use_symbolicator_for_proguard(data.get("project")):
+    #     return SymbolicatorPlatform.jvm.value, process_jvm_stacktraces
     else:
         return SymbolicatorPlatform.native.value, get_native_symbolication_function(data)
 

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -108,9 +108,9 @@ def get_symbolication_function(
     if data["platform"] in ("javascript", "node"):
         return SymbolicatorPlatform.js, process_js_stacktraces
     # elif data["platform"] == "java" and should_use_symbolicator_for_proguard(data.get("project")):
-    #     return SymbolicatorPlatform.jvm.value, process_jvm_stacktraces
+    #     return SymbolicatorPlatform.jvm, process_jvm_stacktraces
     else:
-        return SymbolicatorPlatform.native.value, get_native_symbolication_function(data)
+        return SymbolicatorPlatform.native, get_native_symbolication_function(data)
 
 
 class SymbolicationTimeout(Exception):
@@ -190,6 +190,7 @@ def _do_symbolicate_event(
             has_attachments=has_attachments,
         )
 
+    symbolication_function: Callable[[Symbolicator, Any], Any] | None = None
     if task_kind.platform == SymbolicatorPlatform.js:
         symbolication_function = process_js_stacktraces
     elif task_kind.platform == SymbolicatorPlatform.jvm:

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -107,10 +107,10 @@ def get_symbolication_function(
 
     if data["platform"] in ("javascript", "node"):
         return SymbolicatorPlatform.js, process_js_stacktraces
-    elif data["platform"] == "java" and should_use_symbolicator_for_proguard(data):
-        return SymbolicatorPlatform.jvm, process_jvm_stacktraces
+    elif data["platform"] == "java" and should_use_symbolicator_for_proguard(data.get("project")):
+        return SymbolicatorPlatform.jvm.value, process_jvm_stacktraces
     else:
-        return SymbolicatorPlatform.native, get_native_symbolication_function(data)
+        return SymbolicatorPlatform.native.value, get_native_symbolication_function(data)
 
 
 class SymbolicationTimeout(Exception):

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -10,6 +10,7 @@ from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.files.file import File
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.relay import RelayStoreHelper
 from sentry.utils import json
 
@@ -496,6 +497,80 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert event.culprit == (
             "org.slf4j.helpers.Util$ClassContextSecurityManager " "in getExtraClassContext"
         )
+
+    def test_basic_resolving_symbolicator(self):
+        with override_options({"symbolicator.proguard-processing-sample-rate": 1.0}):
+            self.upload_proguard_mapping(PROGUARD_UUID, PROGUARD_SOURCE)
+
+            event_data = {
+                "user": {"ip_address": "31.172.207.97"},
+                "extra": {},
+                "project": self.project.id,
+                "platform": "java",
+                "debug_meta": {"images": [{"type": "proguard", "uuid": PROGUARD_UUID}]},
+                "exception": {
+                    "values": [
+                        {
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "function": "a",
+                                        "abs_path": None,
+                                        "module": "org.a.b.g$a",
+                                        "filename": None,
+                                        "lineno": 67,
+                                    },
+                                    {
+                                        "function": "a",
+                                        "abs_path": None,
+                                        "module": "org.a.b.g$a",
+                                        "filename": None,
+                                        "lineno": 69,
+                                    },
+                                ]
+                            },
+                            "module": "org.a.b",
+                            "type": "g$a",
+                            "value": "Attempt to invoke virtual method 'org.a.b.g$a.a' on a null object reference",
+                        }
+                    ]
+                },
+                "timestamp": iso_format(before_now(seconds=1)),
+            }
+
+            event = self.post_and_retrieve_event(event_data)
+            if not self.use_relay():
+                # We measure the number of queries after an initial post,
+                # because there are many queries polluting the array
+                # before the actual "processing" happens (like, auth_user)
+                with self.assertWriteQueries(
+                    {
+                        "nodestore_node": 2,
+                        "sentry_eventuser": 1,
+                        "sentry_groupedmessage": 1,
+                        "sentry_userreport": 1,
+                    }
+                ):
+                    self.post_and_retrieve_event(event_data)
+
+            exc = event.interfaces["exception"].values[0]
+            bt = exc.stacktrace
+            frames = bt.frames
+
+            assert exc.type == "Util$ClassContextSecurityManager"
+            assert (
+                exc.value
+                == "Attempt to invoke virtual method 'org.slf4j.helpers.Util$ClassContextSecurityManager.getExtraClassContext' on a null object reference"
+            )
+            assert exc.module == "org.slf4j.helpers"
+            assert frames[0].function == "getClassContext"
+            assert frames[0].module == "org.slf4j.helpers.Util$ClassContextSecurityManager"
+            assert frames[1].function == "getExtraClassContext"
+            assert frames[1].module == "org.slf4j.helpers.Util$ClassContextSecurityManager"
+
+            assert event.culprit == (
+                "org.slf4j.helpers.Util$ClassContextSecurityManager " "in getExtraClassContext"
+            )
 
     def test_resolving_does_not_fail_when_no_value(self):
         self.upload_proguard_mapping(PROGUARD_UUID, PROGUARD_SOURCE)

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -822,6 +822,12 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert frames[3].filename == "MainActivity.java"
         assert frames[3].module == "io.sentry.sample.MainActivity"
 
+    @requires_symbolicator
+    @pytest.mark.symbolicator
+    def test_resolving_inline_symbolicator(self):
+        with override_options({"symbolicator.proguard-processing-sample-rate": 1.0}):
+            self.test_resolving_inline()
+
     def test_resolving_inline_with_native_frames(self):
         self.upload_proguard_mapping(PROGUARD_INLINE_UUID, PROGUARD_INLINE_SOURCE)
 

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -1243,6 +1243,12 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         ]
         assert frames[6].post_context == ["        }", "    }", "}", ""]
 
+    @requires_symbolicator
+    @pytest.mark.symbolicator
+    def test_basic_source_lookup_symbolicator(self):
+        with override_options({"symbolicator.proguard-processing-sample-rate": 1.0}):
+            self.test_basic_source_lookup()
+
     def test_source_lookup_with_proguard(self):
         self.upload_proguard_mapping(PROGUARD_SOURCE_LOOKUP_UUID, PROGUARD_SOURCE_LOOKUP_SOURCE)
         debug_id1 = str(uuid4())

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -927,6 +927,12 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         assert frames[5].function == "__start_thread"
         assert frames[5].package == "/apex/com.android.art/lib64/libart.so"
 
+    @requires_symbolicator
+    @pytest.mark.symbolicator
+    def test_resolving_inline_with_native_frames_symbolicator(self):
+        with override_options({"symbolicator.proguard-processing-sample-rate": 1.0}):
+            self.test_resolving_inline_with_native_frames()
+
     def test_error_on_resolving(self):
         url = reverse(
             "sentry-api-0-dsym-files",
@@ -993,10 +999,15 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
         event = self.post_and_retrieve_event(event_data)
 
         assert len(event.data["errors"]) == 1
-        assert event.data["errors"][0] == {
-            "mapping_uuid": "071207ac-b491-4a74-957c-2c94fd9594f2",
-            "type": "proguard_missing_lineno",
-        }
+        error = event.data["errors"][0]
+        assert error["mapping_uuid"] == "071207ac-b491-4a74-957c-2c94fd9594f2"
+        assert error["type"] == "proguard_missing_lineno"
+
+    @requires_symbolicator
+    @pytest.mark.symbolicator
+    def test_error_on_resolving_symbolicator(self):
+        with override_options({"symbolicator.proguard-processing-sample-rate": 1.0}):
+            self.test_error_on_resolving()
 
     def upload_jvm_bundle(self, debug_id, source_files):
         files = {}

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from django.test import override_settings
 
-from sentry.lang.native.symbolicator import SymbolicatorTaskKind
+from sentry.lang.native.symbolicator import SymbolicatorPlatform, SymbolicatorTaskKind
 from sentry.plugins.base.v2 import Plugin2
 from sentry.tasks.store import preprocess_event
 from sentry.tasks.symbolication import (
@@ -262,7 +262,9 @@ def test_submit_symbolicate_queue_switch(
     is_low_priority = mock_should_demote_symbolication(default_project.id)
     assert is_low_priority
     with TaskRunner():
-        task_kind = SymbolicatorTaskKind(is_low_priority=is_low_priority)
+        task_kind = SymbolicatorTaskKind(
+            platform=SymbolicatorPlatform.native, is_low_priority=is_low_priority
+        )
         mock_submit_symbolicate(
             task_kind,
             cache_key="e:1",


### PR DESCRIPTION
This adds Symbolicator bindings for proguard/JVM processing. All of it is gated behind the config settings `"symbolicator.proguard-processing-projects"` and `"symbolicator.proguard-processing-sample-rate"`.

The implementation passes all the tests in `java/test_plugin`.

Currently, proguard symbolication uses the same Celery queue and Symbolicator pool as native. This may need to change before we use this in earnest.