### PR TITLE
ref: remove unused expiration_datetime from social_auth

### DIFF
--- a/src/sentry/services/hybrid_cloud/usersocialauth/model.py
+++ b/src/sentry/services/hybrid_cloud/usersocialauth/model.py
@@ -6,7 +6,7 @@
 from typing import Any, TypedDict
 
 from sentry.services.hybrid_cloud import RpcModel
-from social_auth.utils import expiration_datetime, get_backend, tokens
+from social_auth.utils import get_backend, tokens
 
 
 class RpcUserSocialAuth(RpcModel):
@@ -22,9 +22,6 @@ class RpcUserSocialAuth(RpcModel):
     @property
     def tokens(self):
         return tokens(instance=self)
-
-    def expiration_datetime(self):
-        return expiration_datetime(instance=self)
 
 
 class UserSocialAuthFilterArgs(TypedDict, total=False):

--- a/src/social_auth/models.py
+++ b/src/social_auth/models.py
@@ -53,11 +53,6 @@ class UserSocialAuth(models.Model):
 
         return tokens(instance=self)
 
-    def expiration_datetime(self):
-        from .utils import expiration_datetime
-
-        return expiration_datetime(instance=self)
-
     def revoke_token(self, drop_token=True):
         """Attempts to revoke permissions for provider."""
         if "access_token" in self.tokens:

--- a/src/social_auth/utils.py
+++ b/src/social_auth/utils.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import logging
-import time
-from datetime import datetime, timedelta
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs as urlparse_parse_qs
@@ -40,32 +38,6 @@ def tokens(instance: UserSocialAuth | RpcUserSocialAuth) -> dict[str, Any]:
         return backend.AUTH_BACKEND.tokens(instance)
     else:
         return {}
-
-
-def expiration_datetime(instance: UserSocialAuth | RpcUserSocialAuth) -> timedelta | None:
-    """Return provider session live seconds. Returns a timedelta ready to
-    use with session.set_expiry().
-
-    If provider returns a timestamp instead of session seconds to live, the
-    timedelta is inferred from current time (using UTC timezone). None is
-    returned if there's no value stored or it's invalid.
-    """
-    if instance.extra_data and "expires" in instance.extra_data:
-        try:
-            expires = int(instance.extra_data["expires"])
-        except (ValueError, TypeError):
-            return None
-
-        now = datetime.utcnow()
-
-        # Detect if expires is a timestamp
-        if expires > time.mktime(now.timetuple()):
-            # expires is a datetime
-            return datetime.fromtimestamp(expires) - now
-        else:
-            # expires is a timedelta
-            return timedelta(seconds=expires)
-    return None
 
 
 def sanitize_log_data(secret, data=None, leave_characters=LEAVE_CHARS):


### PR DESCRIPTION
this was misusing the deprecated utcnow() and is not used in sentry or getsentry

<!-- Describe your PR here. -->