### PR TITLE
fix(perf): Fix bad layout of sample panel when docked to bottom

### DIFF
--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -233,13 +233,13 @@ function SpanSummaryPage({params}: Props) {
                 />
               </ModuleLayout.Full>
             )}
-
-            <SampleList
-              groupId={span[SpanMetricsField.SPAN_GROUP]}
-              transactionName={transaction}
-              transactionMethod={transactionMethod}
-            />
           </ModuleLayout.Layout>
+
+          <SampleList
+            groupId={span[SpanMetricsField.SPAN_GROUP]}
+            transactionName={transaction}
+            transactionMethod={transactionMethod}
+          />
         </Layout.Main>
       </Layout.Body>
     </ModulePageProviders>


### PR DESCRIPTION
It doesn't render correctly inside a grid layout! Needs to be lifted out. Ideally the CSS would position it correctly regardless of context, but one thing at a time.
