### PR TITLE
fix(perf): Fix broken query description and source fetch

### DIFF
--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -36,15 +36,15 @@ export function DatabaseSpanDescription({
   groupId,
   preliminaryDescription,
 }: Omit<Props, 'op'>) {
-  // TODO: we're using all SpanIndexedFields here, but maybe we should only use what we need?
-  // Truncate to 20 fields otherwise discover will complain.
-  const fields = Object.values(SpanIndexedField);
-
   const {data: indexedSpans, isFetching: areIndexedSpansLoading} = useIndexedSpans({
     filters: {'span.group': groupId},
     sorts: [INDEXED_SPAN_SORT],
     limit: 1,
-    fields,
+    fields: [
+      SpanIndexedField.PROJECT_ID,
+      SpanIndexedField.TRANSACTION_ID,
+      SpanIndexedField.SPAN_DESCRIPTION,
+    ],
     referrer: 'api.starfish.span-description',
   });
   const indexedSpan = indexedSpans?.[0];


### PR DESCRIPTION
As of some point recently, `SpanIndexedField` has > 20 fields, which means that the call to fetch indexed data in the query description was making an illegal Discover call, since it only allows up to 20 fields. Every call was failing, so no query had a description or source 😭
