### PR TITLE
feat(mobile-score): Add score profile version string to metrics indexer

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -189,6 +189,8 @@ SHARED_TAG_STRINGS = {
     "is_application": PREFIX + 269,
     "platform": PREFIX + 270,
     "os.version": PREFIX + 271,
+    # Performance Score
+    "sentry.score_profile_version": PREFIX + 272,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }


### PR DESCRIPTION
`sentry.score_profile_version` is being added as a tag to filter on performance score calculations.

To be merged before: https://github.com/getsentry/relay/pull/3249