### PR TITLE
fix(feedback): set timeout on scroll so feedback always starts at the top

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -34,8 +34,13 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
 
   const overflowRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    overflowRef.current?.scrollTo({top: 0});
-  }, [feedbackItem.id]);
+    setTimeout(() => {
+      overflowRef.current?.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    }, 100);
+  }, [feedbackItem.id, overflowRef]);
 
   return (
     <Fragment>


### PR DESCRIPTION
Set a timeout on the scroll -- for some reason it wasn't going into effect before.

Now we'll always scroll to the top (smoothly) so the quote is the first thing you see:

Can also change the behavior to be instant, if the smooth scrolling behavior isn't preferred.

https://github.com/getsentry/sentry/assets/56095982/29d01b22-1902-4f9b-bb77-e81b887490d8

Followup to https://github.com/getsentry/sentry/pull/63837
Fixes https://github.com/getsentry/sentry/issues/66786
