### PR TITLE
ref(event-tags): UI changes before internal release

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -153,7 +153,7 @@ function TagTreeRow({
         <TreeValueDropdown
           preventOverflowOptions={{padding: 4}}
           className={isVisible ? '' : 'invisible'}
-          position="bottom-start"
+          position="bottom-end"
           onOpenChange={isOpen => setIsVisible(isOpen)}
           triggerProps={{
             'aria-label': t('Tag Actions Menu'),

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -111,15 +111,10 @@ export function EventTags({
 
   return (
     <Fragment>
-      <StyledClippedBox clipHeight={150}>
-        {hasNewTagsUI ? (
-          <EventTagsTree
-            event={event}
-            tags={tags}
-            meta={meta}
-            projectSlug={projectSlug}
-          />
-        ) : (
+      {hasNewTagsUI ? (
+        <EventTagsTree event={event} tags={tags} meta={meta} projectSlug={projectSlug} />
+      ) : (
+        <StyledClippedBox clipHeight={150}>
           <Pills>
             {tags.map((tag, index) => (
               <EventTagsPill
@@ -137,8 +132,8 @@ export function EventTags({
               />
             ))}
           </Pills>
-        )}
-      </StyledClippedBox>
+        </StyledClippedBox>
+      )}
       {hasCustomTagsBanner && <EventTagCustomBanner />}
     </Fragment>
   );

--- a/static/app/components/events/eventTagsAndScreenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'sentry/actionCreators/events';
 import {openModal} from 'sentry/actionCreators/modal';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
 import {DataSection} from 'sentry/components/events/styles';
 import Link from 'sentry/components/links/link';
 import {t, tn} from 'sentry/locale';
@@ -38,6 +39,7 @@ type Props = React.ComponentProps<typeof Tags> & {
 export function EventTagsAndScreenshot({projectSlug, event, isShare = false}: Props) {
   const location = useLocation();
   const organization = useOrganization();
+  const hasNewTagsUI = useHasNewTagsUI();
   const {tags = []} = event;
   const hasContext = !objectIsEmpty(event.user ?? {}) || !objectIsEmpty(event.contexts);
   const {data: attachments} = useFetchEventAttachments(
@@ -121,7 +123,7 @@ export function EventTagsAndScreenshot({projectSlug, event, isShare = false}: Pr
 
   return (
     <Wrapper showScreenshot={showScreenshot} showTags={showTags}>
-      <TagWrapper>
+      <TagWrapper hasNewTagsUI={hasNewTagsUI}>
         {showTags && <Tags event={event} projectSlug={projectSlug} />}
       </TagWrapper>
       {showScreenshot && (
@@ -187,6 +189,6 @@ const ScreenshotWrapper = styled('div')`
   }
 `;
 
-const TagWrapper = styled('div')`
-  overflow: hidden;
+const TagWrapper = styled('div')<{hasNewTagsUI: boolean}>`
+  overflow: ${p => (p.hasNewTagsUI ? 'visible' : 'hidden')};
 `;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -141,7 +141,9 @@ function DefaultGroupEventDetailsContent({
           <ContextSummary event={event} />
         </EventDataSection>
       )}
-      <EventTagsAndScreenshot event={event} projectSlug={project.slug} />
+      {!hasNewTagsUI && (
+        <EventTagsAndScreenshot event={event} projectSlug={project.slug} />
+      )}
       {showMaybeSolutionsHigher && (
         <ResourcesAndMaybeSolutions event={event} project={project} group={group} />
       )}
@@ -172,6 +174,9 @@ function DefaultGroupEventDetailsContent({
       )}
       <GroupEventEntry entryType={EntryType.DEBUGMETA} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.REQUEST} {...eventEntryProps} />
+      {hasNewTagsUI && (
+        <EventTagsAndScreenshot event={event} projectSlug={project.slug} />
+      )}
       <EventContexts group={group} event={event} />
       <EventExtraData event={event} />
       <EventPackageData event={event} />


### PR DESCRIPTION
This PR makes some UI adjustments before the internal release of the event-tags tree view.
The changes are
- Bug fixes to prevent ClippedBox from hiding part of the dropdown
- Buggy behaviour when dropdown exceeds the maximum size of the div (by avoiding TagWrapper's `overflow: hidden`)
- Moves the tags to below the fold, just above context


<img width="1156" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/9ab14c3f-ef13-4470-8121-44477d8b17c0">
