### PR TITLE
feat(integrations): pagerduty and opsgenie customizable metric alert priorities

### DIFF
--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -7,11 +7,14 @@ from sentry.constants import ObjectStatus
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.metric_alerts import incident_attachment_info
+from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcOrganizationIntegration
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger("sentry.integrations.opsgenie")
+
+OPSGENIE_CUSTOM_PRIORITIES = {"P1", "P2", "P3", "P4", "P5"}
 
 
 def build_incident_attachment(
@@ -42,6 +45,15 @@ def build_incident_attachment(
         },
     }
     return payload
+
+
+def attach_custom_priority(data: dict[str, Any], action: AlertRuleTriggerAction):
+    if action.sentry_app_config is None:
+        return data
+
+    priority = action.sentry_app_config.get("priority", OPSGENIE_DEFAULT_PRIORITY)
+    data["priority"] = priority
+    return data
 
 
 def get_team(team_id: str | None, org_integration: RpcOrganizationIntegration | None):
@@ -84,6 +96,8 @@ def send_incident_alert_notification(
     )
     client = install.get_keyring_client(keyid=team["id"])
     attachment = build_incident_attachment(incident, new_status, metric_value, notification_uuid)
+    attachment = attach_custom_priority(attachment, action)
+
     try:
         resp = client.send_notification(attachment)
         logger.info(

--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -47,7 +47,7 @@ def build_incident_attachment(
     return payload
 
 
-def attach_custom_priority(data: dict[str, Any], action: AlertRuleTriggerAction):
+def attach_custom_priority(data: dict[str, Any], action: AlertRuleTriggerAction) -> dict[str, Any]:
     if action.sentry_app_config is None:
         return data
 

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -132,6 +132,8 @@ def attach_custom_severity(data: dict[str, Any], action: AlertRuleTriggerAction)
     if severity is not None:
         data["payload"]["severity"] = severity
 
+    return data
+
 
 def send_incident_alert_notification(
     action: AlertRuleTriggerAction,

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -20,6 +20,13 @@ from .client import PagerDutyClient
 
 logger = logging.getLogger("sentry.integrations.pagerduty")
 
+PAGERDUTY_CUSTOM_PRIORITIES = {
+    "critical",
+    "warning",
+    "error",
+    "info",
+}  # known as severities in pagerduty
+
 
 class PagerDutyServiceDict(TypedDict):
     integration_id: int
@@ -85,10 +92,10 @@ def build_incident_attachment(
     integration_key,
     new_status: IncidentStatus,
     metric_value: float | None = None,
-    notfiication_uuid: str | None = None,
+    notfication_uuid: str | None = None,
 ) -> dict[str, Any]:
     data = incident_attachment_info(
-        incident, new_status, metric_value, notfiication_uuid, referrer="metric_alert_pagerduty"
+        incident, new_status, metric_value, notfication_uuid, referrer="metric_alert_pagerduty"
     )
     severity = "info"
     if new_status == IncidentStatus.CRITICAL:
@@ -114,6 +121,16 @@ def build_incident_attachment(
         },
         "links": [{"href": data["title_link"], "text": data["title"]}],
     }
+
+
+def attach_custom_severity(data: dict[str, Any], action: AlertRuleTriggerAction) -> dict[str, Any]:
+    # use custom severity (overrides default in build_incident_attachment)
+    if action.sentry_app_config is None:
+        return data
+
+    severity = action.sentry_app_config.get("priority", None)
+    if severity is not None:
+        data["payload"]["severity"] = severity
 
 
 def send_incident_alert_notification(
@@ -168,6 +185,8 @@ def send_incident_alert_notification(
     attachment = build_incident_attachment(
         incident, integration_key, new_status, metric_value, notification_uuid
     )
+    attachment = attach_custom_severity(attachment, action)
+
     try:
         client.send_trigger(attachment)
         return True

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -97,7 +97,10 @@ class OpsgenieActionHandlerTest(FireTest):
 
     @responses.activate
     def run_test(self, incident, method):
-        from sentry.integrations.opsgenie.utils import build_incident_attachment
+        from sentry.integrations.opsgenie.utils import (
+            attach_custom_priority,
+            build_incident_attachment,
+        )
 
         alias = f"incident_{incident.organization_id}_{incident.identifier}"
 
@@ -122,6 +125,8 @@ class OpsgenieActionHandlerTest(FireTest):
             expected_payload = build_incident_attachment(
                 incident, IncidentStatus(incident.status), metric_value=1000
             )
+            expected_payload = attach_custom_priority(expected_payload, self.action)
+
         handler = OpsgenieActionHandler(self.action, incident, self.project)
         metric_value = 1000
         with self.tasks():
@@ -220,3 +225,10 @@ class OpsgenieActionHandlerTest(FireTest):
             external_id=str(self.action.target_identifier),
             notification_uuid="",
         )
+
+    @responses.activate
+    def test_custom_priority(self):
+        # default critical incident priority is P1, custom set to P3
+        self.action.update(sentry_app_config={"priority": "P3"})
+
+        self.run_fire_test()

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -188,7 +188,7 @@ class PagerDutyActionHandlerTest(FireTest):
         )
 
     @responses.activate
-    def test_custom_priority(self):
-        # default critical incident severity is critical, custom set to info
-        self.action.update(sentry_app_config={"priority": "info"})
+    def test_custom_severity(self):
+        # default closed incident severity is info, custom set to critical
+        self.action.update(sentry_app_config={"priority": "critical"})
         self.run_fire_test()

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -95,7 +95,10 @@ class PagerDutyActionHandlerTest(FireTest):
 
     @responses.activate
     def run_test(self, incident, method):
-        from sentry.integrations.pagerduty.utils import build_incident_attachment
+        from sentry.integrations.pagerduty.utils import (
+            attach_custom_severity,
+            build_incident_attachment,
+        )
 
         responses.add(
             method=responses.POST,
@@ -110,9 +113,12 @@ class PagerDutyActionHandlerTest(FireTest):
             getattr(handler, method)(metric_value, IncidentStatus(incident.status))
         data = responses.calls[0].request.body
 
-        assert json.loads(data) == build_incident_attachment(
+        expected_payload = build_incident_attachment(
             incident, self.service["integration_key"], IncidentStatus(incident.status), metric_value
         )
+        expected_payload = attach_custom_severity(expected_payload, self.action)
+
+        assert json.loads(data) == expected_payload
 
     def test_fire_metric_alert(self):
         self.run_fire_test()
@@ -180,3 +186,9 @@ class PagerDutyActionHandlerTest(FireTest):
             external_id=str(self.action.target_identifier),
             notification_uuid="",
         )
+
+    @responses.activate
+    def test_custom_priority(self):
+        # default critical incident severity is critical, custom set to info
+        self.action.update(sentry_app_config={"priority": "info"})
+        self.run_fire_test()


### PR DESCRIPTION
Allows sending Pagerduty and Opsgenie notifications with customizable severity / priority for metric alerts. This will be stored in the `sentry_app_config` field in the corresponding `AlertRuleTriggerAction` object, which is just a json dict. Ideally this field would be renamed to just `config` or something.

Follow up PRs will include modifying serializers so that the priority can be passed in and saved to the backend, and a frontend PR to allow setting these values and passing them to the backend.

For https://github.com/getsentry/sentry/issues/58830
For https://github.com/getsentry/sentry/issues/54921