### PR TITLE
fix(feedback): only track analytics if sidebar is active

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -53,14 +53,6 @@ function FeedbackOnboardingSidebar(props: CommonSidebarProps) {
     allPlatforms: feedbackOnboardingPlatforms,
   });
 
-  useEffect(() => {
-    // this tracks clicks from any source: feedback index, issue details feedback tab, banner callout, etc
-    trackAnalytics('feedback.list-view-setup-sidebar', {
-      organization,
-      platform: currentProject?.platform ?? 'unknown',
-    });
-  }, [organization, currentProject]);
-
   const projectSelectOptions = useMemo(() => {
     const supportedProjectItems: SelectValue<string>[] = allProjects
       .sort((aProject, bProject) => {
@@ -88,6 +80,16 @@ function FeedbackOnboardingSidebar(props: CommonSidebarProps) {
       },
     ];
   }, [allProjects]);
+
+  useEffect(() => {
+    if (isActive) {
+      // this tracks clicks from any source: feedback index, issue details feedback tab, banner callout, etc
+      trackAnalytics('feedback.list-view-setup-sidebar', {
+        organization,
+        platform: currentProject?.platform ?? 'unknown',
+      });
+    }
+  }, [organization, currentProject, isActive]);
 
   if (!isActive || !hasProjectAccess || !currentProject) {
     return null;


### PR DESCRIPTION
was previously incorrectly tracking even if the sidebar wasn't active

![image](https://github.com/getsentry/sentry/assets/56095982/666acbd8-43c0-4d48-b74d-282222088286)
