### PR TITLE
Clear coalesced during disable shard

### DIFF
--- a/src/sentry/db/models/outboxes.py
+++ b/src/sentry/db/models/outboxes.py
@@ -452,8 +452,6 @@ def run_outbox_replications_for_self_hosted(*args: Any, **kwds: Any):
             next_outbox: OutboxBase | None = outbox_model.prepare_next_from_shard(shard_attrs)
             if next_outbox is None:
                 continue
-            if next_outbox.should_skip_shard():
-                continue
             try:
                 next_outbox.drain_shard(flush_all=True)
             except Exception:

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -611,6 +611,7 @@ class OutboxBase(Model):
             # meaning that failures during deletion could leave an old, staler outbox
             # alive.
             if not self.should_skip_shard():
+                deleted_count += 1
                 coalesced.delete()
 
             metrics.incr("outbox.processed", deleted_count, tags=tags)

--- a/src/sentry/tasks/deliver_from_outbox.py
+++ b/src/sentry/tasks/deliver_from_outbox.py
@@ -175,9 +175,6 @@ def process_outbox_batch(
         if not shard_outbox:
             continue
 
-        if shard_outbox.should_skip_shard():
-            continue
-
         try:
             processed_count += 1
             shard_outbox.drain_shard(flush_all=True)


### PR DESCRIPTION
1.  Move shard skipping logic into processing
2. When skipping shards, clean up the lowest coalesced item.  As more items get created, the lowest coalesced item moves up in subsequent runs, thus hopefully we keep culling under pressure.  It may be possible to scan even coalesced item and cull it during shard skipped phase, but that could also be costly, and there is not easy way to know if it is valuable to do so.  Take the cheap option.
3. Add tests ensuring no infinite loops or regressions during shard skipping.