### PR TITLE
feat(trace): Use event id with the useSpans parameter

### DIFF
--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -377,7 +377,7 @@ class DiscoverDatasetConfig(DatasetConfig):
                 SnQLFunction(
                     "to_other",
                     required_args=[
-                        ColumnArg("column", allowed_columns=["release", "trace.parent_span"]),
+                        ColumnArg("column", allowed_columns=["release", "trace.parent_span", "id"]),
                         SnQLStringArg("value", unquote=True, unescape_quotes=True),
                     ],
                     optional_args=[

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1617,6 +1617,24 @@ class OrganizationEventsTraceEndpointTestUsingSpans(OrganizationEventsTraceEndpo
 
         assert response.status_code == 200, response.content
 
+    def test_event_id(self):
+        self.load_trace()
+        # When given an event_id even if its not the root transaction we should prioritize loading that specific event
+        # over loading roots
+        with self.feature(self.FEATURES):
+            response = self.client_get(
+                data={
+                    "project": -1,
+                    "timestamp": self.root_event.timestamp,
+                    # Limit of one means the only result is the target event
+                    "limit": 1,
+                    "eventId": self.gen1_events[0].event_id,
+                },
+            )
+        assert response.status_code == 200, response.content
+        trace_transaction = response.data["transactions"][0]
+        self.assert_event(trace_transaction, self.gen1_events[0], "root")
+
 
 @region_silo_test
 class OrganizationEventsTraceMetaEndpointTest(OrganizationEventsTraceEndpointBase):


### PR DESCRIPTION
- When event id is passed use it in the orderby for the base query so its guaranteed to show up if its a part of the trace that way when if we load 100 events, and link to event X. that event will be a part of the response