### PR TITLE
fix(org stats): Add router props to UsageStatsOrg

### DIFF
--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -347,7 +347,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
    * This method is replaced by the hook "component:enhanced-org-stats"
    */
   renderUsageStatsOrg() {
-    const {organization, router} = this.props;
+    const {organization, router, location, params, routes} = this.props;
     return (
       <UsageStatsOrg
         isSingleProject={this.isSingleProject}
@@ -359,6 +359,9 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
         chartTransform={this.chartTransform}
         handleChangeState={this.setStateOnUrl}
         router={router}
+        location={location}
+        params={params}
+        routes={routes}
       />
     );
   }

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -1,5 +1,6 @@
 import type {MouseEvent as ReactMouseEvent} from 'react';
 import {Fragment} from 'react';
+import type {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
@@ -33,7 +34,7 @@ import UsageChart, {CHART_OPTIONS_DATA_TRANSFORM, ChartDataTransform} from './us
 import UsageStatsPerMin from './usageStatsPerMin';
 import {formatUsageWithUnits, getFormatUsageOptions, isDisplayUtc} from './utils';
 
-export type UsageStatsOrganizationProps = {
+export interface UsageStatsOrganizationProps extends WithRouterProps {
   dataCategory: DataCategoryInfo['plural'];
   dataCategoryName: string;
   dataDatetime: DateTimeObject;
@@ -46,7 +47,7 @@ export type UsageStatsOrganizationProps = {
   organization: Organization;
   projectIds: number[];
   chartTransform?: string;
-} & DeprecatedAsyncComponent['props'];
+}
 
 type UsageStatsOrganizationState = {
   orgStats: UsageSeries | undefined;


### PR DESCRIPTION
Adds router props to UsageStatsOrg, it expects the full WithRouterProps and getsentry provides it https://github.com/getsentry/getsentry/blob/master/static/getsentry/gsApp/hooks/spendVisibility/enhancedUsageStatsOrganization.tsx#L395-L397

part of https://github.com/getsentry/frontend-tsc/issues/22