### PR TITLE
feat(new-trace): Used react-query to fetch trace-meta.

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -54,8 +54,8 @@ import Trace from './trace';
 import TraceHeader from './traceHeader';
 import {TraceTree, type TraceTreeNode} from './traceTree';
 import TraceWarnings from './traceWarnings';
-import {useMeta} from './useMeta';
 import {useTrace} from './useTrace';
+import {useTraceMeta} from './useTraceMeta';
 
 const DOCUMENT_TITLE = [t('Trace Details'), t('Performance')].join(' — ');
 
@@ -107,7 +107,7 @@ export function TraceView() {
   }, [queryParams, traceSlug]);
 
   const trace = useTrace();
-  const meta = useMeta();
+  const meta = useTraceMeta();
 
   return (
     <SentryDocumentTitle title={DOCUMENT_TITLE} orgSlug={organization.slug}>

--- a/static/app/views/performance/newTraceDetails/traceHeader.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader.tsx
@@ -11,9 +11,9 @@ import {space} from 'sentry/styles/space';
 import type {EventTransaction, Organization} from 'sentry/types';
 import {getShortEventId} from 'sentry/utils/events';
 import {getDuration} from 'sentry/utils/formatters';
-import type {TraceMetaQueryChildrenProps} from 'sentry/utils/performance/quickTrace/traceMetaQuery';
 import type {
   TraceFullDetailed,
+  TraceMeta,
   TraceSplitResults,
 } from 'sentry/utils/performance/quickTrace/types';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
@@ -25,7 +25,7 @@ import {BrowserDisplay} from '../transactionDetails/eventMetas';
 import {MetaData} from '../transactionDetails/styles';
 
 type TraceHeaderProps = {
-  metaResults: TraceMetaQueryChildrenProps;
+  metaResults: UseApiQueryResult<TraceMeta | null, any>;
   organization: Organization;
   rootEventResults: UseApiQueryResult<EventTransaction, RequestError>;
   traces: TraceSplitResults<TraceFullDetailed> | null;
@@ -37,8 +37,8 @@ export default function TraceHeader({
   traces,
   organization,
 }: TraceHeaderProps) {
-  const errors = metaResults.meta?.errors || 0;
-  const performanceIssues = metaResults.meta?.performance_issues || 0;
+  const errors = metaResults.data?.errors || 0;
+  const performanceIssues = metaResults.data?.performance_issues || 0;
   const errorsAndIssuesCount = errors + performanceIssues;
   const traceInfo = getTraceInfo(traces?.transactions, traces?.orphan_errors);
 
@@ -113,8 +113,8 @@ export default function TraceHeader({
             bodyText={
               metaResults.isLoading ? (
                 <LoadingIndicator size={20} mini />
-              ) : metaResults.meta ? (
-                metaResults.meta.transactions + metaResults.meta.errors
+              ) : metaResults.data ? (
+                metaResults.data.transactions + metaResults.data.errors
               ) : (
                 '\u2014'
               )
@@ -146,7 +146,7 @@ export default function TraceHeader({
             >
               {metaResults.isLoading ? (
                 <LoadingIndicator size={20} mini />
-              ) : errorsAndIssuesCount > 0 ? (
+              ) : errorsAndIssuesCount >= 0 ? (
                 errorsAndIssuesCount
               ) : (
                 '\u2014'

--- a/static/app/views/performance/newTraceDetails/useMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/useMeta.tsx
@@ -19,7 +19,6 @@ function getMetaQueryParams(
   project: string;
   statsPeriod: string | undefined;
   timestamp: string | undefined;
-  useSpans: number;
 } {
   const normalizedParams = normalizeDateTimeParams(query, {
     allowAbsolutePageDatetime: true,
@@ -32,7 +31,7 @@ function getMetaQueryParams(
     statsPeriod = filters.datetime.period;
   }
 
-  return {statsPeriod, project, timestamp, useSpans: 1};
+  return {statsPeriod, project, timestamp};
 }
 
 export function useMeta(): UseApiQueryResult<TraceMeta | null, any> {

--- a/static/app/views/performance/newTraceDetails/useMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/useMeta.tsx
@@ -1,0 +1,59 @@
+import {useMemo} from 'react';
+import type {Location} from 'history';
+
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
+import type {PageFilters} from 'sentry/types';
+import type {TraceMeta} from 'sentry/utils/performance/quickTrace/types';
+import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useParams} from 'sentry/utils/useParams';
+
+function getMetaQueryParams(
+  query: Location['query'],
+  filters: Partial<PageFilters> = {}
+): {
+  project: string;
+  statsPeriod: string | undefined;
+  timestamp: string | undefined;
+  useSpans: number;
+} {
+  const normalizedParams = normalizeDateTimeParams(query, {
+    allowAbsolutePageDatetime: true,
+  });
+  let statsPeriod = decodeScalar(normalizedParams.statsPeriod);
+  const project = decodeScalar(normalizedParams.project, ALL_ACCESS_PROJECTS + '');
+  const timestamp = decodeScalar(normalizedParams.timestamp);
+
+  if (statsPeriod === undefined && !timestamp && filters.datetime?.period) {
+    statsPeriod = filters.datetime.period;
+  }
+
+  return {statsPeriod, project, timestamp, useSpans: 1};
+}
+
+export function useMeta(): UseApiQueryResult<TraceMeta | null, any> {
+  const filters = usePageFilters();
+  const location = useLocation();
+  const organization = useOrganization();
+  const params = useParams<{traceSlug?: string}>();
+
+  const queryParams = useMemo(() => {
+    return getMetaQueryParams(location.query, filters.selection);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return useApiQuery(
+    [
+      `/organizations/${organization.slug}/events-trace-meta/${params.traceSlug ?? ''}/`,
+      {query: queryParams},
+    ],
+    {
+      staleTime: Infinity,
+      enabled: !!params.traceSlug && !!organization.slug,
+    }
+  );
+}

--- a/static/app/views/performance/newTraceDetails/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceMeta.tsx
@@ -34,7 +34,7 @@ function getMetaQueryParams(
   return {statsPeriod, project, timestamp};
 }
 
-export function useMeta(): UseApiQueryResult<TraceMeta | null, any> {
+export function useTraceMeta(): UseApiQueryResult<TraceMeta | null, any> {
   const filters = usePageFilters();
   const location = useLocation();
   const organization = useOrganization();


### PR DESCRIPTION
Switched away from passing meta-query results as render props.