### PR TITLE
feat(integrations): allow setting pagerduty and opsgenie customizable metric alert priorities through API

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -73,7 +73,9 @@ class AlertRuleTriggerActionSerializer(Serializer):
             "dateCreated": obj.date_added,
             "desc": self.human_desc(obj),
             "priority": (
-                obj.sentry_app_config.get("priority", None) if obj.sentry_app_config else None
+                obj.sentry_app_config.get("priority", None)
+                if isinstance(obj.sentry_app_config, dict)
+                else None
             ),
         }
 

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -16,7 +16,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
             else ""
         )
         if priority:
-            priority += " level "
+            priority += " level"
 
         if action.type == action.Type.EMAIL.value:
             if action.target:

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -72,6 +72,9 @@ class AlertRuleTriggerActionSerializer(Serializer):
             "sentryAppId": obj.sentry_app_id,
             "dateCreated": obj.date_added,
             "desc": self.human_desc(obj),
+            "priority": (
+                obj.sentry_app_config.get("priority", None) if obj.sentry_app_config else None
+            ),
         }
 
         # Check if action is a Sentry App that has Alert Rule UI Component settings

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -10,6 +10,14 @@ logger = logging.getLogger(__name__)
 class AlertRuleTriggerActionSerializer(Serializer):
     def human_desc(self, action):
         # Returns a human readable description to display in the UI
+        priority = (
+            action.sentry_app_config.get("priority")
+            if isinstance(action.sentry_app_config, dict)
+            else ""
+        )
+        if priority:
+            priority += " level "
+
         if action.type == action.Type.EMAIL.value:
             if action.target:
                 if action.target_type == action.TargetType.USER.value:
@@ -17,7 +25,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
                 elif action.target_type == action.TargetType.TEAM.value:
                     return "Send an email to members of #" + action.target.slug
         elif action.type == action.Type.PAGERDUTY.value:
-            return "Send a PagerDuty notification to " + action.target_display
+            return f"Send a {priority} PagerDuty notification to " + action.target_display
         elif action.type == action.Type.SLACK.value:
             return "Send a Slack notification to " + action.target_display
         elif action.type == action.Type.MSTEAMS.value:
@@ -25,6 +33,8 @@ class AlertRuleTriggerActionSerializer(Serializer):
         elif action.type == action.Type.SENTRY_APP.value:
             return "Send a notification via " + action.target_display
         elif action.type == action.Type.OPSGENIE.value:
+            if priority:
+                return f"Send a {priority} Opsgenie notification to " + action.target_display
             return "Send an Opsgenie notification to " + action.target_display
         elif action.type == action.Type.DISCORD.value:
             if not action.target_display:

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1223,7 +1223,7 @@ def create_alert_rule_trigger_action(
         )
 
     # store priority in the json sentry_app_config
-    if priority is not None:
+    if priority is not None and type in [ActionService.PAGERDUTY, ActionService.OPSGENIE]:
         if sentry_app_config:
             sentry_app_config.update({"priority": priority})
         else:
@@ -1308,7 +1308,7 @@ def update_alert_rule_trigger_action(
         updated_fields["target_identifier"] = target_identifier
 
     # store priority in the json sentry_app_config
-    if priority is not None:
+    if priority is not None and type in [ActionService.PAGERDUTY, ActionService.OPSGENIE]:
         if updated_fields.get("sentry_app_config"):
             updated_fields["sentry_app_config"].update({"priority": priority})
         else:

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1185,6 +1185,7 @@ def create_alert_rule_trigger_action(
     sentry_app_config=None,
     installations: list[RpcSentryAppInstallation] | None = None,
     integrations: list[RpcIntegration] | None = None,
+    priority: str | None = None,
 ) -> AlertRuleTriggerAction:
     """
     Creates an AlertRuleTriggerAction
@@ -1221,6 +1222,13 @@ def create_alert_rule_trigger_action(
             trigger.alert_rule.organization, sentry_app_id, installations
         )
 
+    # store priority in the json sentry_app_config
+    if priority is not None:
+        if sentry_app_config:
+            sentry_app_config.update({"priority": priority})
+        else:
+            sentry_app_config = {"priority": priority}
+
     return AlertRuleTriggerAction.objects.create(
         alert_rule_trigger=trigger,
         type=type.value,
@@ -1245,6 +1253,7 @@ def update_alert_rule_trigger_action(
     sentry_app_config=None,
     installations: list[RpcSentryAppInstallation] | None = None,
     integrations: list[RpcIntegration] | None = None,
+    priority: str | None = None,
 ) -> AlertRuleTriggerAction:
     """
     Updates values on an AlertRuleTriggerAction
@@ -1297,6 +1306,14 @@ def update_alert_rule_trigger_action(
             updated_fields["target_display"] = target_display
 
         updated_fields["target_identifier"] = target_identifier
+
+    # store priority in the json sentry_app_config
+    if priority is not None:
+        if updated_fields.get("sentry_app_config"):
+            updated_fields["sentry_app_config"].update({"priority": priority})
+        else:
+            updated_fields["sentry_app_config"] = {"priority": priority}
+
     trigger_action.update(**updated_fields)
     return trigger_action
 

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -475,7 +475,9 @@ class AlertRuleTriggerAction(AbstractNotificationAction):
     alert_rule_trigger = FlexibleForeignKey("sentry.AlertRuleTrigger")
 
     date_added = models.DateTimeField(default=timezone.now)
-    sentry_app_config = JSONField(null=True)
+    sentry_app_config = JSONField(
+        null=True
+    )  # list of dicts if this is a sentry app, otherwise can be singular dict
     status = BoundedPositiveIntegerField(
         default=ObjectStatus.ACTIVE, choices=ObjectStatus.as_choices()
     )

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -167,8 +167,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                             "priority": f"Allowed priorities for Pagerduty are {str(PAGERDUTY_CUSTOM_PRIORITIES)}"
                         }
                     )
-            elif action_type == AlertRuleTriggerAction.Type.OPSGENIE:
-                if priority not in OPSGENIE_CUSTOM_PRIORITIES:
+            if action_type == AlertRuleTriggerAction.Type.OPSGENIE and priority not in OPSGENIE_CUSTOM_PRIORITIES:
                     raise serializers.ValidationError(
                         {
                             "priority": f"Allowed priorities for Opsgenie are {str(OPSGENIE_CUSTOM_PRIORITIES)}"

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -160,18 +160,24 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
 
             priority: str = attrs["priority"]
 
-            if action_type == AlertRuleTriggerAction.Type.PAGERDUTY and priority not in PAGERDUTY_CUSTOM_PRIORITIES:
-                    raise serializers.ValidationError(
-                        {
-                            "priority": f"Allowed priorities for Pagerduty are {str(PAGERDUTY_CUSTOM_PRIORITIES)}"
-                        }
-                    )
-            if action_type == AlertRuleTriggerAction.Type.OPSGENIE and priority not in OPSGENIE_CUSTOM_PRIORITIES:
-                    raise serializers.ValidationError(
-                        {
-                            "priority": f"Allowed priorities for Opsgenie are {str(OPSGENIE_CUSTOM_PRIORITIES)}"
-                        }
-                    )
+            if (
+                action_type == AlertRuleTriggerAction.Type.PAGERDUTY
+                and priority not in PAGERDUTY_CUSTOM_PRIORITIES
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "priority": f"Allowed priorities for Pagerduty are {str(PAGERDUTY_CUSTOM_PRIORITIES)}"
+                    }
+                )
+            if (
+                action_type == AlertRuleTriggerAction.Type.OPSGENIE
+                and priority not in OPSGENIE_CUSTOM_PRIORITIES
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "priority": f"Allowed priorities for Opsgenie are {str(OPSGENIE_CUSTOM_PRIORITIES)}"
+                    }
+                )
 
             # TODO(Ecosystem): Validate fields on schema config if alert-rule-action component exists
             # See NotifyEventSentryAppAction::self_validate for more details

--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -160,8 +160,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
 
             priority: str = attrs["priority"]
 
-            if action_type == AlertRuleTriggerAction.Type.PAGERDUTY:
-                if priority not in PAGERDUTY_CUSTOM_PRIORITIES:
+            if action_type == AlertRuleTriggerAction.Type.PAGERDUTY and priority not in PAGERDUTY_CUSTOM_PRIORITIES:
                     raise serializers.ValidationError(
                         {
                             "priority": f"Allowed priorities for Pagerduty are {str(PAGERDUTY_CUSTOM_PRIORITIES)}"

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -28,6 +28,14 @@ PAGERDUTY_CUSTOM_PRIORITIES = {
 }  # known as severities in pagerduty
 
 
+PAGERDUTY_CUSTOM_PRIORITIES = {
+    "critical",
+    "warning",
+    "error",
+    "info",
+}  # known as severities in pagerduty
+
+
 class PagerDutyServiceDict(TypedDict):
     integration_id: int
     integration_key: str

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -28,14 +28,6 @@ PAGERDUTY_CUSTOM_PRIORITIES = {
 }  # known as severities in pagerduty
 
 
-PAGERDUTY_CUSTOM_PRIORITIES = {
-    "critical",
-    "warning",
-    "error",
-    "info",
-}  # known as severities in pagerduty
-
-
 class PagerDutyServiceDict(TypedDict):
     integration_id: int
     integration_key: str

--- a/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import responses
 
 from sentry.api.serializers import serialize
@@ -112,22 +110,3 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
         result = serialize(action)
         self.assert_action_serialized(action, result)
         assert result["desc"] == "Send a Discord notification to "
-
-    @patch(
-        "sentry.incidents.logic.get_target_identifier_display_for_integration",
-        return_value=("123", "test"),
-    )
-    def test_priority(self, mock_get):
-        alert_rule = self.create_alert_rule()
-        trigger = create_alert_rule_trigger(alert_rule, "hi", 1000)
-        priority = "critical"
-        action = create_alert_rule_trigger_action(
-            trigger,
-            AlertRuleTriggerAction.Type.PAGERDUTY,
-            AlertRuleTriggerAction.TargetType.SPECIFIC,
-            priority=priority,
-            target_identifier="123",
-        )
-        result = serialize(action)
-        self.assert_action_serialized(action, result)
-        assert result["priority"] == priority

--- a/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
@@ -136,7 +136,11 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
         assert result["desc"] == "Send a critical level PagerDuty notification to test"
 
     @responses.activate
-    def test_opsgenie_priority(self):
+    @patch(
+        "sentry.incidents.logic.get_alert_rule_trigger_action_opsgenie_team",
+        return_value=("123", "test"),
+    )
+    def test_opsgenie_priority(self, mock_get):
         alert_rule = self.create_alert_rule()
         trigger = create_alert_rule_trigger(alert_rule, "hi", 1000)
         priority = "critical"

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -31,6 +31,8 @@ from sentry.incidents.serializers import (
     AlertRuleTriggerActionSerializer,
     AlertRuleTriggerSerializer,
 )
+from sentry.integrations.opsgenie.utils import OPSGENIE_CUSTOM_PRIORITIES
+from sentry.integrations.pagerduty.utils import PAGERDUTY_CUSTOM_PRIORITIES
 from sentry.models.actor import ACTOR_TYPES, get_actor_for_user
 from sentry.models.environment import Environment
 from sentry.models.user import User
@@ -908,6 +910,98 @@ class TestAlertRuleTriggerActionSerializer(TestAlertRuleSerializerBase):
             },
             {"nonFieldErrors": ["User does not belong to this organization"]},
         )
+
+    def test_invalid_priority(self):
+        self.run_fail_validation_test(
+            {
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.MSTEAMS
+                ).slug,
+                "targetType": ACTION_TARGET_TYPE_TO_STRING[
+                    AlertRuleTriggerAction.TargetType.SPECIFIC
+                ],
+                "priority": "P1",
+            },
+            {
+                "priority": [
+                    ErrorDetail("Can only be set for Pagerduty or Opsgenie", code="invalid")
+                ]
+            },
+        )
+        self.run_fail_validation_test(
+            {
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.PAGERDUTY
+                ).slug,
+                "targetType": ACTION_TARGET_TYPE_TO_STRING[
+                    AlertRuleTriggerAction.TargetType.SPECIFIC
+                ],
+                "priority": "P1",
+            },
+            {
+                "priority": [
+                    ErrorDetail(
+                        f"Allowed priorities for Pagerduty are {str(PAGERDUTY_CUSTOM_PRIORITIES)}",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+        self.run_fail_validation_test(
+            {
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.OPSGENIE
+                ).slug,
+                "targetType": ACTION_TARGET_TYPE_TO_STRING[
+                    AlertRuleTriggerAction.TargetType.SPECIFIC
+                ],
+                "priority": "critical",
+            },
+            {
+                "priority": [
+                    ErrorDetail(
+                        f"Allowed priorities for Opsgenie are {str(OPSGENIE_CUSTOM_PRIORITIES)}",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+    @patch(
+        "sentry.incidents.logic.get_target_identifier_display_for_integration",
+        return_value=("test", "test"),
+    )
+    def test_pagerduty_valid_priority(self, mock_get):
+        params = {
+            "type": AlertRuleTriggerAction.get_registered_type(
+                AlertRuleTriggerAction.Type.PAGERDUTY
+            ).slug,
+            "targetType": ACTION_TARGET_TYPE_TO_STRING[AlertRuleTriggerAction.TargetType.SPECIFIC],
+            "targetIdentifier": "123",
+            "priority": "critical",
+        }
+        serializer = AlertRuleTriggerActionSerializer(data=params, context=self.context)
+        assert serializer.is_valid()
+        action = serializer.save()
+        assert action.sentry_app_config["priority"] == "critical"
+
+    @patch(
+        "sentry.incidents.logic.get_target_identifier_display_for_integration",
+        return_value=("test", "test"),
+    )
+    def test_opsgenie_valid_priority(self, mock_get):
+        params = {
+            "type": AlertRuleTriggerAction.get_registered_type(
+                AlertRuleTriggerAction.Type.OPSGENIE
+            ).slug,
+            "targetType": ACTION_TARGET_TYPE_TO_STRING[AlertRuleTriggerAction.TargetType.SPECIFIC],
+            "targetIdentifier": "123",
+            "priority": "P1",
+        }
+        serializer = AlertRuleTriggerActionSerializer(data=params, context=self.context)
+        assert serializer.is_valid()
+        action = serializer.save()
+        assert action.sentry_app_config["priority"] == "P1"
 
     def test_discord(self):
         self.run_fail_validation_test(

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -2225,7 +2225,8 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
         assert action.integration_id == integration.id
         assert action.sentry_app_config["priority"] == priority  # priority stored in config
 
-    def test_unsupported_priority(self):
+    @patch("sentry.integrations.msteams.utils.get_channel_id", return_value="some_id")
+    def test_unsupported_priority(self, mock_get_channel_id):
         integration, _ = self.create_provider_integration_for(
             self.organization, self.user, external_id="1", provider="msteams"
         )
@@ -2247,7 +2248,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
         assert action.target_type == target_type.value
         assert action.target_identifier == channel_id
         assert action.target_display == channel_name
-        assert action.integration_id == integration
+        assert action.integration_id == integration.id
         assert action.sentry_app_config is None  # priority is not stored inside
 
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1577,6 +1577,35 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
                 integration_id=integration.id,
             )
 
+    @patch(
+        "sentry.incidents.logic.get_target_identifier_display_for_integration",
+        return_value=("123", "test"),
+    )
+    def test_supported_priority(self, mock_get):
+        alert_rule = self.create_alert_rule()
+        trigger = create_alert_rule_trigger(alert_rule, "hi", 1000)
+        priority = "critical"
+        action = create_alert_rule_trigger_action(
+            trigger,
+            AlertRuleTriggerAction.Type.PAGERDUTY,
+            AlertRuleTriggerAction.TargetType.SPECIFIC,
+            priority=priority,
+            target_identifier="123",
+        )
+        assert action.sentry_app_config["priority"] == priority
+
+    def test_unsupported_priority(self):
+        # doesn't save priority if the action type doesn't use it
+        alert_rule = self.create_alert_rule()
+        trigger = create_alert_rule_trigger(alert_rule, "hi", 1000)
+        action = create_alert_rule_trigger_action(
+            trigger,
+            AlertRuleTriggerAction.Type.EMAIL,
+            AlertRuleTriggerAction.TargetType.SPECIFIC,
+            priority="critical",
+        )
+        assert action.sentry_app_config is None
+
 
 @region_silo_test
 class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
@@ -2144,6 +2173,82 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
                 target_identifier=channel_id,
                 integration_id=integration.id,
             )
+
+    @responses.activate
+    def test_supported_priority(self):
+        metadata = {
+            "api_key": "1234-ABCD",
+            "base_url": "https://api.opsgenie.com/",
+            "domain_name": "test-app.app.opsgenie.com",
+        }
+        team = {"id": "123-id", "team": "cool-team", "integration_key": "1234-5678"}
+        integration, org_integration = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="opsgenie",
+            name="test-app",
+            external_id="test-app",
+            metadata=metadata,
+        )
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            org_integration.config = {"team_table": [team]}
+            org_integration.save()
+
+        resp_data = {
+            "result": "Integration [sentry] is valid",
+            "took": 1,
+            "requestId": "hello-world",
+        }
+        responses.add(
+            responses.POST,
+            url="https://api.opsgenie.com/v2/integrations/authenticate",
+            json=resp_data,
+        )
+
+        type = AlertRuleTriggerAction.Type.OPSGENIE
+        target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
+        priority = "P1"
+        action = update_alert_rule_trigger_action(
+            self.action,
+            type,
+            target_type,
+            target_identifier=team["id"],
+            integration_id=integration.id,
+            priority=priority,
+        )
+
+        assert action.alert_rule_trigger == self.trigger
+        assert action.type == type.value
+        assert action.target_type == target_type.value
+        assert action.target_identifier == team["id"]
+        assert action.target_display == "cool-team"
+        assert action.integration_id == integration.id
+        assert action.sentry_app_config["priority"] == priority  # priority stored in config
+
+    def test_unsupported_priority(self):
+        integration, _ = self.create_provider_integration_for(
+            self.organization, self.user, external_id="1", provider="msteams"
+        )
+        type = AlertRuleTriggerAction.Type.MSTEAMS
+        target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
+        channel_name = "some_channel"
+        channel_id = "some_id"
+
+        action = update_alert_rule_trigger_action(
+            self.action,
+            type,
+            target_type,
+            target_identifier=channel_name,
+            integration_id=integration.id,
+            priority="critical",
+        )
+        assert action.alert_rule_trigger == self.trigger
+        assert action.type == type.value
+        assert action.target_type == target_type.value
+        assert action.target_identifier == channel_id
+        assert action.target_display == channel_name
+        assert action.integration_id == integration
+        assert action.sentry_app_config is None  # priority is not stored inside
 
 
 @region_silo_test


### PR DESCRIPTION
Allow setting custom `severity` for Pagerduty and `priority` for Opsgenie `AlertRuleTriggerActions` through the API as well as returning it. We're not adding a new field on the `AlertRuleTriggerAction` model to store the priority -- there's already a json field called `sentry_app_config` that we will be putting it in. But we are adding a new field to the serializers so it's visible and not confusing to users.

For https://github.com/getsentry/sentry/issues/58830
For https://github.com/getsentry/sentry/issues/54921