### PR TITLE
fix(integration): fixing GitLab integration handling raw files

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -334,26 +334,14 @@ class GitLabProxyApiClient(IntegrationProxyClient):
         Path requires file path and ref
         file_path must also be URL encoded Ex. lib%2Fclass%2Erb
         """
-        from base64 import b64decode
 
         project_id = repo.config["project_id"]
         encoded_path = quote(path, safe="")
-        request_path = GitLabApiClientPath.file.format(project=project_id, path=encoded_path)
-        headers = (
-            {
-                "Accept": "application/vnd.github.raw",
-                "Content-Type": "application/raw; charset=utf-8",
-            }
-            if codeowners
-            else {}
-        )
-        contents = self.get(request_path, params={"ref": ref}, raw_response=True, headers=headers)
+        request_path = GitLabApiClientPath.file_raw.format(project=project_id, path=encoded_path)
 
-        result = (
-            contents.content.decode("utf-8")
-            if codeowners
-            else b64decode(contents["content"]).decode("utf-8")
-        )
+        contents = self.get(request_path, params={"ref": ref}, raw_response=True)
+        result = contents.content.decode("utf-8")
+
         return result
 
     def get_blame_for_files(

--- a/src/sentry/integrations/gitlab/utils.py
+++ b/src/sentry/integrations/gitlab/utils.py
@@ -28,6 +28,7 @@ class GitLabApiClientPath:
     compare = "/projects/{project}/repository/compare"
     diff = "/projects/{project}/repository/commits/{sha}/diff"
     file = "/projects/{project}/repository/files/{path}"
+    file_raw = "/projects/{project}/repository/files/{path}/raw"
     group = "/groups/{group}"
     group_projects = "/groups/{group}/projects"
     hooks = "/hooks"


### PR DESCRIPTION
GitLab doesn't seem to care about neither `Accept: application/vnd.github.raw` nor `Content-Type: application/raw; charset=utf-8` headers.

[In GitLab you get a raw file by appending `/raw` to the path.](https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository) 

Payload returned as the code requests it now:
```bash
$ curlie -H 'Accept: application/vnd.github.raw' -H 'Content-Type: application/raw; charset=utf-8' -H "PRIVATE-TOKEN: ${GITLAB_TEST_TOKEN}" 'https://gitlab.com/api/v4/projects/55797033/repository/files/CODEOWNERS?ref=main' -s
{
    "file_name": "CODEOWNERS",
    "file_path": "CODEOWNERS",
    "size": 19,
    "encoding": "base64",
    "content_sha256": "72e752e1b726a82a80dc0ccce3ed4cfe4bc3463501840eb9f065b01c68dc71b0",
    "ref": "main",
    "blob_id": "95764c49420646c81fc0369f10586799bcaa6787",
    "commit_id": "6554434b90c0e867a42eef748416982826c98dd8",
    "last_commit_id": "6554434b90c0e867a42eef748416982826c98dd8",
    "execute_filemode": false,
    "content": "KiBAYmFydGVrLm9ncnljemFrCg=="
}
```

Payload returned with `/raw`
```bash
$ curlie -H "PRIVATE-TOKEN: ${GITLAB_TEST_TOKEN}" 'https://gitlab.com/api/v4/projects/55797033/repository/files/CODEOWNERS/raw?ref=main' -s
* @bartek.ogryczak
``` 
