### PR TITLE
ref(hc): Unblock outbox loop in org auth token update

### DIFF
--- a/src/sentry/services/hybrid_cloud/orgauthtoken/impl.py
+++ b/src/sentry/services/hybrid_cloud/orgauthtoken/impl.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sentry.models.orgauthtoken import OrgAuthToken
-from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
+from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox, outbox_context
 from sentry.services.hybrid_cloud.orgauthtoken.service import OrgAuthTokenService
 
 if TYPE_CHECKING:
@@ -24,7 +24,8 @@ class DatabaseBackedOrgAuthTokenService(OrgAuthTokenService):
         if token is None:
             return
 
-        token.update(date_last_used=date_last_used, project_last_used_id=project_last_used_id)
+        with outbox_context(flush=False):
+            token.update(date_last_used=date_last_used, project_last_used_id=project_last_used_id)
 
 
 class OutboxBackedOrgAuthTokenService(OrgAuthTokenService):


### PR DESCRIPTION
OrgAuthToken update creates re-entrant condition where it can trigger cascading updates in the same scope.

I really want to catch this in tests, but it's non trivial.  This PR atleast clears the current condition while we work on systematic separation and prevention.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
