### PR TITLE
fix(autofix): Ensure that log description text does not overflow

### DIFF
--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -160,6 +160,7 @@ const StepHeaderLeft = styled('div')`
   display: flex;
   align-items: center;
   flex: 1;
+  overflow: hidden;
 `;
 
 const StepHeaderDescription = styled('div')`


### PR DESCRIPTION
Before:

![CleanShot 2024-03-12 at 15 06 27](https://github.com/getsentry/sentry/assets/10888943/d3a77bac-b387-4271-84ac-eed71f23ea67)

After:

![CleanShot 2024-03-12 at 15 05 51](https://github.com/getsentry/sentry/assets/10888943/def7afd1-b212-4413-8655-ee30dc03f987)
