### PR TITLE
ref(crons): Remove no longer used monitor env status

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -66,8 +66,6 @@ from rest_framework.response import Response
 
 DEFAULT_ORDERING = [
     MonitorStatus.ERROR,
-    MonitorStatus.TIMEOUT,
-    MonitorStatus.MISSED_CHECKIN,
     MonitorStatus.OK,
     MonitorStatus.ACTIVE,
     MonitorStatus.DISABLED,

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -159,11 +159,7 @@ def mark_failed_threshold(
         )
         fingerprint = incident.grouphash
 
-    elif monitor_env.status in [
-        MonitorStatus.ERROR,
-        MonitorStatus.MISSED_CHECKIN,
-        MonitorStatus.TIMEOUT,
-    ]:
+    elif monitor_env.status == MonitorStatus.ERROR:
         # if monitor environment has a failed status, use the failed
         # check-in and send occurrence
         previous_checkins = [

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -93,8 +93,6 @@ class MonitorStatus:
 
     OK = 4
     ERROR = 5
-    MISSED_CHECKIN = 6
-    TIMEOUT = 7
 
     @classmethod
     def as_choices(cls) -> Sequence[tuple[int, str]]:
@@ -110,8 +108,6 @@ class MonitorStatus:
             (cls.DELETION_IN_PROGRESS, "deletion_in_progress"),
             (cls.OK, "ok"),
             (cls.ERROR, "error"),
-            (cls.MISSED_CHECKIN, "missed_checkin"),
-            (cls.TIMEOUT, "timeout"),
         )
 
 

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -80,8 +80,6 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
         monitor_disabled = add_status_monitor("OK", "DISABLED")
         monitor_error_older_checkin = add_status_monitor("ERROR", "ACTIVE", last_checkin_older)
         monitor_error = add_status_monitor("ERROR")
-        monitor_missed_checkin = add_status_monitor("MISSED_CHECKIN")
-        monitor_timed_out = add_status_monitor("TIMEOUT")
 
         monitor_muted = add_status_monitor("ACTIVE")
         monitor_muted.update(is_muted=True)
@@ -94,8 +92,6 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
             [
                 monitor_error,
                 monitor_error_older_checkin,
-                monitor_timed_out,
-                monitor_missed_checkin,
                 monitor_ok,
                 monitor_active,
                 monitor_muted,
@@ -113,8 +109,6 @@ class ListOrganizationMonitorsTest(MonitorTestCase):
                 monitor_muted,
                 monitor_active,
                 monitor_ok,
-                monitor_missed_checkin,
-                monitor_timed_out,
                 monitor_error_older_checkin,
                 monitor_error,
             ],


### PR DESCRIPTION
Monitor environment's will no longer be in a MISSED_CHECKIN or TIMEOUT state, if they are in an incident it will be in the ERROR status.

Going to let monitors bake overnight and make sure we don't have
anywhere else we may be writing these status's