### PR TITLE
meta: Update VSCode settings to match getsentry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,10 +7,10 @@
     "**/*.pyc": true,
     "build": true,
     "htmlcov": true,
+    "model-manifest.json": true,
     "node_modules": true,
     "src/sentry/locale": true,
-    "src/sentry/static/sentry/dist/": true,
-    "model-manifest.json": true
+    "src/sentry/static/sentry/dist/": true
   },
   "search.followSymlinks": false,
   "files.trimTrailingWhitespace": true,
@@ -20,7 +20,7 @@
   "[javascript]": {
     "editor.formatOnSave": true,
     "editor.tabSize": 2,
-    "editor.defaultFormatter": "biomejs.biome",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
       "quickfix.biome": "explicit",
       "source.fixAll.eslint": "explicit"
@@ -30,20 +30,12 @@
   "[typescript]": {
     "editor.formatOnSave": true,
     "editor.tabSize": 2,
-    "editor.defaultFormatter": "biomejs.biome",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
       "quickfix.biome": "explicit",
       "source.fixAll.eslint": "explicit"
     }
   },
-  // Exclude Specific Files from Auto-Imports
-  "typescript.preferences.autoImportFileExcludePatterns": [
-    "**/config/chartcuterie/*",
-    "**/node_modules/@testing-library/*",
-    "**/node_modules/@tanstack/react-query"
-  ],
-  // Avoid relative imports
-  "typescript.preferences.importModuleSpecifier": "non-relative",
 
   "[typescriptreact]": {
     "editor.formatOnSave": true,
@@ -65,14 +57,10 @@
     }
   },
 
-  "[less]": {
-    "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "explicit"
-    }
-  },
-
   "[python]": {
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.tabSize": 4,
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
@@ -80,12 +68,28 @@
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
 
+  // auto-formatting breaks Django templates
+  // see https://github.com/Microsoft/vscode/issues/44342
   "[html]": {
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.tabSize": 2,
     "editor.formatOnSave": false
   },
 
+  "[less]": {
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
+  },
+
   "[json]": {
-    "editor.defaultFormatter": "biomejs.biome",
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.tabSize": 2,
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
       "quickfix.biome": "explicit"
     }
@@ -97,6 +101,21 @@
     }
   },
 
+  "[dockerfile]": {
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.tabSize": 4,
+    "editor.formatOnSave": true
+  },
+
+  // Exclude Specific Files from Auto-Imports
+  "typescript.preferences.autoImportFileExcludePatterns": [
+    "**/config/chartcuterie/*",
+    "**/node_modules/@testing-library/*",
+    "**/node_modules/@tanstack/react-query"
+  ],
+  // Avoid relative imports
+  "typescript.preferences.importModuleSpecifier": "non-relative",
   "editor.tabSize": 4,
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,


### PR DESCRIPTION
This aligns the settings file between sentry and getsentry.

The GETSENTRY pr is https://github.com/getsentry/getsentry/pull/13256

Things got re-ordered in both repos, so the files are almost exactly the same.

List of changes to this file are:
- consistently use `esbenp.prettier-vscode` for `javascript`, `typescript` and `json` types, to match the existing `typescriptreact` and `javascriptreact` settings
- Python sets 3 more values: `editor.insertSpaces`, `editor.detectIndentation`, `editor.tabSize`, matches getsentry
- Html sets 3 more values: `editor.insertSpaces`, `editor.detectIndentation`, `editor.tabSize`, matches getsentry
- Json sets a bunch more values (see below), matches getsentry
- Dockerfile settings added, matches getsentry


**Why are we messing with this?**
Keeping sentry and getsentry in sync wrt settings will make it easier for developers to contribute to both codebases with minimal overhead. We often forget about updating both repo's when a single change is made.