### PR TITLE
fix(issue-priority): Ensure that priority feedback modal stays open when interacted with and update text

### DIFF
--- a/static/app/components/feedback/widget/useFeedbackWidget.tsx
+++ b/static/app/components/feedback/widget/useFeedbackWidget.tsx
@@ -8,9 +8,10 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 
 interface Props {
   buttonRef?: RefObject<HTMLButtonElement> | RefObject<HTMLAnchorElement>;
+  messagePlaceholder?: string;
 }
 
-export default function useFeedbackWidget({buttonRef}: Props) {
+export default function useFeedbackWidget({buttonRef, messagePlaceholder}: Props) {
   const config = useLegacyStore(ConfigStore);
   const client = getClient();
   // Note that this is only defined in environments where Feedback is enabled (getsentry)
@@ -25,7 +26,7 @@ export default function useFeedbackWidget({buttonRef}: Props) {
       colorScheme: config.theme === 'dark' ? ('dark' as const) : ('light' as const),
       buttonLabel: t('Give Feedback'),
       submitButtonLabel: t('Send Feedback'),
-      messagePlaceholder: t('What did you expect?'),
+      messagePlaceholder: messagePlaceholder ?? t('What did you expect?'),
       formTitle: t('Give Feedback'),
     };
 
@@ -44,7 +45,7 @@ export default function useFeedbackWidget({buttonRef}: Props) {
     }
 
     return undefined;
-  }, [buttonRef, config.theme, feedback]);
+  }, [buttonRef, config.theme, feedback, messagePlaceholder]);
 
   return feedback;
 }

--- a/static/app/components/group/groupPriority.tsx
+++ b/static/app/components/group/groupPriority.tsx
@@ -108,7 +108,10 @@ function PriorityChangeActor({
 
 function GroupPriorityFeedback() {
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const feedback = useFeedbackWidget({buttonRef});
+  const feedback = useFeedbackWidget({
+    buttonRef,
+    messagePlaceholder: t('How can we make priority better for you?'),
+  });
 
   if (!feedback) {
     return null;
@@ -171,6 +174,10 @@ export function GroupPriorityDropdown({
             })}
           </div>
         </DropdownMenuFooter>
+      }
+      shouldCloseOnInteractOutside={target =>
+        // Since this can open a feedback modal, we want to ignore interactions with it
+        !document.getElementById('sentry-feedback')?.contains(target)
       }
       position="bottom-end"
     />


### PR DESCRIPTION
- Previously, the feedback modal would close when trying to type into the modal because it would close the dropdown. This change makes sure that doesn't happen any longer
- Modifies the text of the feedback modal to better suit the priority feature


![CleanShot 2024-03-12 at 16 11 39](https://github.com/getsentry/sentry/assets/10888943/3298127b-616c-4753-9579-b0f411ebd045)
