### PR TITLE
fix(api): Fallback to IP rate limiting if missing org

### DIFF
--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -140,7 +140,7 @@ def get_organization_id_from_token(token_id: int) -> int | None:
     installation = installations[0] if installations else None
 
     # Return None to avoid collisions caused by tokens not being associated with
-    # a SentryAppInstallation. We fall back on IP address rate limiting in this case.
+    # a SentryAppInstallation. We fallback to IP address rate limiting in this case.
     if not installation:
         logger.info("installation.not_found", extra={"token_id": token_id})
         return None

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -235,6 +235,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         )
 
         self.populate_internal_integration_request(request)
+        # Fallback to IP address limit if we can't find the organization
         assert (
             get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
             == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -1,4 +1,3 @@
-import re
 from concurrent.futures import ThreadPoolExecutor
 from functools import cached_property
 from time import sleep, time
@@ -118,8 +117,9 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
     def test_positive_rate_limit_response_headers(self, default_rate_limit_mock):
         request = self.factory.get("/")
 
-        with freeze_time("2000-01-01"), patch.object(
-            RatelimitMiddlewareTest.TestEndpoint, "enforce_rate_limit", True
+        with (
+            freeze_time("2000-01-01"),
+            patch.object(RatelimitMiddlewareTest.TestEndpoint, "enforce_rate_limit", True),
         ):
             default_rate_limit_mock.return_value = RateLimit(0, 100)
             response = self.middleware.process_view(request, self._test_endpoint, [], {})
@@ -184,7 +184,7 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
 
         self.populate_internal_integration_request(request)
         self.middleware.process_view(request, self._test_endpoint, [], {})
-        assert request.rate_limit_category == RateLimitCategory.ORGANIZATION
+        assert request.rate_limit_category == RateLimitCategory.IP
 
     def test_get_rate_limit_key(self):
         # Import an endpoint
@@ -235,10 +235,10 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         )
 
         self.populate_internal_integration_request(request)
-        key_pattern = re.compile(r"^org:default:OrganizationGroupIndexEndpoint:GET:[a-zA-Z]$")
-        key = get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
-        assert key
-        assert key_pattern.match(key)
+        assert (
+            get_rate_limit_key(view, request, rate_limit_group, rate_limit_config)
+            == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+        )
 
         # Test for
         request.user = AnonymousUser()


### PR DESCRIPTION
Fallback to IP ratelimiting when we fail to fetch the organization from an integration token.