### PR TITLE
ref(feedback): hide replay section if no replay or cta

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -14,7 +14,7 @@ import PanelItem from 'sentry/components/panels/panelItem';
 import {Flex} from 'sentry/components/profiling/flex';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import TextCopyInput from 'sentry/components/textCopyInput';
-import {IconChat, IconFire, IconLink, IconPlay, IconTag} from 'sentry/icons';
+import {IconChat, IconFire, IconLink, IconTag} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types';
@@ -88,13 +88,11 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
           </Section>
         )}
 
-        <Section icon={<IconPlay size="xs" />} title={t('Linked Replay')}>
-          <FeedbackReplay
-            eventData={eventData}
-            feedbackItem={feedbackItem}
-            organization={organization}
-          />
-        </Section>
+        <FeedbackReplay
+          eventData={eventData}
+          feedbackItem={feedbackItem}
+          organization={organization}
+        />
 
         <Section icon={<IconTag size="xs" />} title={t('Tags')}>
           <TagsSection tags={tags} />

--- a/static/app/components/feedback/feedbackItem/feedbackReplay.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackReplay.tsx
@@ -1,12 +1,10 @@
-import {Fragment} from 'react';
-
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
 import ReplayInlineCTAPanel from 'sentry/components/feedback/feedbackItem/replayInlineCTAPanel';
 import ReplaySection from 'sentry/components/feedback/feedbackItem/replaySection';
 import Placeholder from 'sentry/components/placeholder';
-import MissingReplayAlert from 'sentry/components/replays/alerts/missingReplayAlert';
-import ReplayUnsupportedAlert from 'sentry/components/replays/alerts/replayUnsupportedAlert';
 import {replayPlatforms} from 'sentry/data/platformCategories';
+import {IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event, Organization} from 'sentry/types';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
@@ -28,38 +26,35 @@ export default function FeedbackReplay({eventData, feedbackItem, organization}: 
     useHaveSelectedProjectsSentAnyReplayEvents();
   const platformSupported = replayPlatforms.includes(feedbackItem.platform);
 
-  if (!platformSupported && !(feedbackItem.platform === 'other')) {
-    return (
-      <ReplayUnsupportedAlert
-        primaryAction="create"
-        projectSlug={feedbackItem.project.slug}
-      />
-    );
-  }
-
   if (replayId && hasReplayId) {
     return (
-      <ErrorBoundary mini>
-        <ReplaySection
-          eventTimestampMs={new Date(feedbackItem.firstSeen).getTime()}
-          organization={organization}
-          replayId={replayId}
-        />
-      </ErrorBoundary>
+      <Section icon={<IconPlay size="xs" />} title={t('Linked Replay')}>
+        <ErrorBoundary mini>
+          <ReplaySection
+            eventTimestampMs={new Date(feedbackItem.firstSeen).getTime()}
+            organization={organization}
+            replayId={replayId}
+          />
+        </ErrorBoundary>
+      </Section>
     );
   }
 
   if ((replayId && hasReplayId === undefined) || isFetchingSentOneReplay) {
-    return <Placeholder />;
+    return (
+      <Section icon={<IconPlay size="xs" />} title={t('Linked Replay')}>
+        <Placeholder />
+      </Section>
+    );
   }
 
   if (!hasSentOneReplay && platformSupported) {
-    return <ReplayInlineCTAPanel />;
+    return (
+      <Section icon={<IconPlay size="xs" />} title={t('Linked Replay')}>
+        <ReplayInlineCTAPanel />
+      </Section>
+    );
   }
 
-  if (replayId) {
-    return <MissingReplayAlert orgSlug={organization.slug} />;
-  }
-
-  return <Fragment>{t('No replay captured')}</Fragment>;
+  return null;
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/66813

If the feedback doesn't have a replay (or isn't eligible for the CTA with the replay onboarding -- only for supported platforms), then don't show the replay section at all:
<img width="774" alt="SCR-20240312-olfz" src="https://github.com/getsentry/sentry/assets/56095982/b4827348-d7a6-4b0c-9089-76891d552a97">
