### PR TITLE
ref(hooks): Fix the type of skip-help hook

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -299,7 +299,7 @@ export type InterfaceChromeHooks = {
  * Onboarding experience hooks
  */
 export type OnboardingHooks = {
-  'onboarding-wizard:skip-help': GenericOrganizationComponentHook;
+  'onboarding-wizard:skip-help': () => React.ComponentType<{}>;
   'onboarding:block-hide-sidebar': () => boolean;
   'onboarding:extra-chrome': GenericComponentHook;
   'onboarding:targeted-onboarding-header': (opts: {source: string}) => React.ReactNode;


### PR DESCRIPTION
It expects a function that returns a component to render

see getsentry 
https://github.com/getsentry/getsentry/blob/14e4f916467bbbf4ce47758c6f2b644457905c92/static/getsentry/gsApp/registerHooks.tsx#L159

i had changed this to be `() => <Component />` and the types were like that's fine. It was not fine. https://sentry.sentry.io/issues/5059700718/events/9859a81f791949cc9861ac30b3f01fd0/