### PR TITLE
feat(issue-priority): Remove issues from stream when reprioritizing with priority dropdown

### DIFF
--- a/static/app/components/stream/group.spec.tsx
+++ b/static/app/components/stream/group.spec.tsx
@@ -92,7 +92,7 @@ describe('StreamGroup', function () {
 
   it('can change priority', async function () {
     const mockModifyGroup = MockApiClient.addMockResponse({
-      url: '/projects/org-slug/foo-project/issues/',
+      url: '/organizations/org-slug/issues/',
       method: 'PUT',
       body: {priority: PriorityLevel.HIGH},
     });
@@ -107,7 +107,7 @@ describe('StreamGroup', function () {
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'High'}));
     expect(within(priorityDropdown).getByText('High')).toBeInTheDocument();
     expect(mockModifyGroup).toHaveBeenCalledWith(
-      '/projects/org-slug/foo-project/issues/',
+      '/organizations/org-slug/issues/',
       expect.objectContaining({
         data: expect.objectContaining({
           priority: 'high',

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -33,6 +33,7 @@ import type {
   InboxDetails,
   NewQuery,
   Organization,
+  PriorityLevel,
   User,
 } from 'sentry/types';
 import {IssueCategory} from 'sentry/types';
@@ -63,6 +64,7 @@ type Props = {
   index?: number;
   memberList?: User[];
   narrowGroups?: boolean;
+  onPriorityChange?: (newPriority: PriorityLevel) => void;
   query?: string;
   queryFilterDescription?: string;
   showLastTriggered?: boolean;
@@ -93,6 +95,7 @@ function BaseGroupRow({
   useTintRow = true,
   narrowGroups = false,
   showLastTriggered = false,
+  onPriorityChange,
 }: Props) {
   const groups = useLegacyStore(GroupStore);
   const group = groups.find(item => item.id === id) as Group;
@@ -457,7 +460,9 @@ function BaseGroupRow({
           {organization.features.includes('issue-priority-ui') &&
           withColumns.includes('priority') ? (
             <PriorityWrapper narrowGroups={narrowGroups}>
-              {group.priority ? <GroupPriority group={group} /> : null}
+              {group.priority ? (
+                <GroupPriority group={group} onChange={onPriorityChange} />
+              ) : null}
             </PriorityWrapper>
           ) : null}
           {withColumns.includes('assignee') && (

--- a/static/app/views/issueDetails/groupPriority.tsx
+++ b/static/app/views/issueDetails/groupPriority.tsx
@@ -1,5 +1,9 @@
 import {bulkUpdate} from 'sentry/actionCreators/group';
-import {addLoadingMessage, clearIndicators} from 'sentry/actionCreators/indicator';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'sentry/actionCreators/indicator';
 import {GroupPriorityDropdown} from 'sentry/components/group/groupPriority';
 import {t} from 'sentry/locale';
 import IssueListCacheStore from 'sentry/stores/IssueListCacheStore';
@@ -11,13 +15,14 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 type GroupDetailsPriorityProps = {
   group: Group;
+  onChange?: (priority: PriorityLevel) => void;
 };
 
-function GroupPriority({group}: GroupDetailsPriorityProps) {
+function GroupPriority({group, onChange}: GroupDetailsPriorityProps) {
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();
 
-  const onChange = (priority: PriorityLevel) => {
+  const onChangePriority = (priority: PriorityLevel) => {
     if (priority === group.priority) {
       return;
     }
@@ -36,11 +41,20 @@ function GroupPriority({group}: GroupDetailsPriorityProps) {
       api,
       {
         orgId: organization.slug,
-        projectId: group.project.slug,
         itemIds: [group.id],
         data: {priority},
+        failSilently: true,
       },
-      {complete: clearIndicators}
+      {
+        success: () => {
+          clearIndicators();
+          onChange?.(priority);
+        },
+        error: () => {
+          clearIndicators();
+          addErrorMessage(t('Unable to update issue priority'));
+        },
+      }
     );
   };
 
@@ -51,7 +65,7 @@ function GroupPriority({group}: GroupDetailsPriorityProps) {
   return (
     <GroupPriorityDropdown
       groupId={group.id}
-      onChange={onChange}
+      onChange={onChangePriority}
       value={group.priority ?? PriorityLevel.MEDIUM}
       lastEditedBy={lastEditedBy}
     />

--- a/static/app/views/issueDetails/header.spec.tsx
+++ b/static/app/views/issueDetails/header.spec.tsx
@@ -191,7 +191,7 @@ describe('GroupHeader', () => {
   describe('priority', () => {
     it('can change priority', async function () {
       const mockModifyIssue = MockApiClient.addMockResponse({
-        url: `/projects/org-slug/project-slug/issues/`,
+        url: `/organizations/org-slug/issues/`,
         method: 'PUT',
         body: {},
       });

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -10,6 +10,7 @@ import useApi from 'sentry/utils/useApi';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
+import type {IssueUpdateData} from 'sentry/views/issueList/types';
 
 import NoGroupsHandler from './noGroupsHandler';
 import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from './utils';
@@ -21,6 +22,7 @@ type GroupListBodyProps = {
   groupStatsPeriod: string;
   loading: boolean;
   memberList: IndexedMembersByProject;
+  onActionTaken: (itemIds: string[], data: IssueUpdateData) => void;
   query: string;
   refetchGroups: () => void;
   selectedProjectIds: number[];
@@ -31,6 +33,7 @@ type GroupListProps = {
   groupIds: string[];
   groupStatsPeriod: string;
   memberList: IndexedMembersByProject;
+  onActionTaken: (itemIds: string[], data: IssueUpdateData) => void;
   query: string;
 };
 
@@ -44,6 +47,7 @@ function GroupListBody({
   error,
   refetchGroups,
   selectedProjectIds,
+  onActionTaken,
 }: GroupListBodyProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -75,6 +79,7 @@ function GroupListBody({
       query={query}
       displayReprocessingLayout={displayReprocessingLayout}
       groupStatsPeriod={groupStatsPeriod}
+      onActionTaken={onActionTaken}
     />
   );
 }
@@ -85,6 +90,7 @@ function GroupList({
   query,
   displayReprocessingLayout,
   groupStatsPeriod,
+  onActionTaken,
 }: GroupListProps) {
   const [isSavedSearchesOpen] = useSyncedLocalStorageState(
     SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY,
@@ -116,6 +122,7 @@ function GroupList({
             useFilteredStats
             canSelect={canSelect}
             narrowGroups={isSavedSearchesOpen}
+            onPriorityChange={priority => onActionTaken([id], {priority})}
           />
         );
       })}

--- a/static/app/views/issueList/overview.actions.spec.tsx
+++ b/static/app/views/issueList/overview.actions.spec.tsx
@@ -8,7 +8,13 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import Indicators from 'sentry/components/indicators';
 import GroupStore from 'sentry/stores/groupStore';
@@ -331,7 +337,7 @@ describe('IssueListOverview (actions)', function () {
       });
     });
 
-    it('removes issues after reprioritizing (when excluding priorities)', async function () {
+    it('removes issues after bulk reprioritizing (when excluding priorities)', async function () {
       const updateIssueMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/issues/',
         method: 'PUT',
@@ -369,7 +375,40 @@ describe('IssueListOverview (actions)', function () {
       expect(screen.queryByText('Medium priority issue')).not.toBeInTheDocument();
     });
 
-    it('does not remove issues after reprioritizing (when query includes all priorities)', async function () {
+    it('removes issues after reprioritizing single issue (when excluding priorities)', async function () {
+      const updateIssueMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        method: 'PUT',
+      });
+
+      render(<IssueListOverview {...defaultProps} />, {organization});
+
+      expect(screen.getByText('Medium priority issue')).toBeInTheDocument();
+
+      // After action, will refetch so need to mock that response
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        body: [highPriorityGroup],
+        headers: {Link: DEFAULT_LINKS_HEADER},
+      });
+
+      await userEvent.click(screen.getByText('Med'));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Low'}));
+
+      await waitFor(() => {
+        expect(updateIssueMock).toHaveBeenCalledWith(
+          '/organizations/org-slug/issues/',
+          expect.objectContaining({
+            query: expect.objectContaining({id: ['1']}),
+            data: {priority: PriorityLevel.LOW},
+          })
+        );
+      });
+
+      expect(screen.queryByText('Medium priority issue')).not.toBeInTheDocument();
+    });
+
+    it('does not remove issues after bulk reprioritizing (when query includes all priorities)', async function () {
       const updateIssueMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/issues/',
         method: 'PUT',

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1283,6 +1283,7 @@ class IssueListOverview extends Component<Props, State> {
                     loading={issuesLoading}
                     error={error}
                     refetchGroups={this.fetchData}
+                    onActionTaken={this.onActionTaken}
                   />
                 </VisuallyCompleteWithData>
               </PanelBody>


### PR DESCRIPTION
The main issue this solves is that changing the priority with the low/med/high dropdown did not remove low priorities from the stream in the same way that selecting and doing bulk edits did. Now we pass down the `onIssueAction` callback and call it from the priority dropdown so it works similarly.
 
While doing that, I also modified the loading states to ensure that the UX between bulk edits and single edits was more consistent. Previously, bulk edits did not show a loading indicator while the request was in flight.