### PR TITLE
ref(rules): Add changes to rule edit confirmation notification

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -385,7 +385,6 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 rule_data["label"] = rule.label
                 rule_data["action_match"] = rule.data.get("action_match")
                 rule_data["filter_match"] = rule.data.get("filter_match")
-
                 changed_data = get_changed_data(rule, rule_data, rule_data_before)
                 send_confirmation_notification(rule=rule, new=False, changed=changed_data)
             return Response(serialize(updated_rule, request.user))

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -232,7 +232,11 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         rule_data_before = dict(rule.data)
         if rule.environment_id:
             rule_data_before["environment_id"] = rule.environment_id
+        if rule.owner:
+            rule_data_before["owner"] = rule.owner
         rule_data_before["label"] = rule.label
+        rule_data_before["action_match"] = rule.data.get("action_match")
+        rule_data_before["filter_match"] = rule.data.get("filter_match")
 
         serializer = DrfRuleSerializer(
             context={"project": project, "organization": project.organization},
@@ -376,7 +380,12 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 rule_data = dict(rule.data)
                 if rule.environment_id:
                     rule_data["environment_id"] = rule.environment_id
+                if rule.owner:
+                    rule_data["owner"] = rule.owner
                 rule_data["label"] = rule.label
+                rule_data["action_match"] = rule.data.get("action_match")
+                rule_data["filter_match"] = rule.data.get("filter_match")
+
                 changed_data = get_changed_data(rule, rule_data, rule_data_before)
                 send_confirmation_notification(rule=rule, new=False, changed=changed_data)
             return Response(serialize(updated_rule, request.user))

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -14,7 +14,7 @@ from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.endpoints.project_rules import find_duplicate_rule, send_confirmation_notification
 from sentry.api.fields.actor import ActorField
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.rule import RuleSerializer
+from sentry.api.serializers.models.rule import RuleSerializer, generate_rule_label
 from sentry.api.serializers.rest_framework.rule import RuleNodeField
 from sentry.api.serializers.rest_framework.rule import RuleSerializer as DrfRuleSerializer
 from sentry.apidocs.constants import (
@@ -228,6 +228,11 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         - Filters - help control noise by triggering an alert only if the issue matches the specified criteria.
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
+        rule_data_before = dict(rule.data)
+        rule_env_before = None
+        if rule.environment_id:
+            rule_env_before = rule.environment_id.copy()
+        rule_label_before = rule.label
         serializer = DrfRuleSerializer(
             context={"project": project, "organization": project.organization},
             data=request.data,
@@ -367,7 +372,55 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             if features.has(
                 "organizations:rule-create-edit-confirm-notification", project.organization
             ):
-                send_confirmation_notification(rule=rule, new=False)
+                # find what changed between rule_data_before and rule.data and store
+                changed_data = {
+                    "new_conditions": [],
+                    "removed_conditions": [],
+                    "new_actions": [],
+                    "removed_actions": [],
+                    "new_environments": [],
+                    "removed_environments": [],
+                    "changed_label": "",
+                }
+                # TODO decide if I want to bucket these by type (action/condition/etc)
+                # if not these dict keys can just be "new", "removed", and "changed_label"
+
+                # also TODO move this into a function
+                for condition in rule.data.get("conditions", []):
+                    if condition not in rule_data_before["conditions"]:
+                        label = generate_rule_label(rule.project, rule, condition)
+                        changed_data["new_conditions"].append(label)
+                
+                for condition in rule_data_before["conditions"]:
+                    if condition not in rule.data["conditions"]:
+                        label = generate_rule_label(rule.project, rule, condition)
+                        changed_data["removed_conditions"].append(label)
+
+                for action in rule.data.get("actions", []):
+                    if action not in rule_data_before["actions"]:
+                        label = generate_rule_label(rule.project, rule, action)
+                        changed_data["new_actions"].append(label)
+
+                for action in rule_data_before["actions"]:
+                    if action not in rule.data.get("actions", []):
+                        label = generate_rule_label(rule.project, rule, action)
+                        changed_data["removed_actions"].append(label)
+
+                if rule.environment_id and not rule_env_before:
+                    # convert to environment label/name
+                    changed_data["new_environments"].append(rule.environment_id)
+
+                if rule_env_before and not rule.environment_id:
+                    # convert to environment label/name
+                    changed_data["removed_environments"].append(rule_env_before)
+
+                if rule_label_before != rule.label:
+                    changed_data["changed_label"] = f"Rule name changed from {rule_label_before} to {rule.label}"
+
+                # TODO add changed action interval
+
+
+                send_confirmation_notification(rule=rule, new=False, changed=changed_data)
             return Response(serialize(updated_rule, request.user))
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -38,13 +38,14 @@ from sentry.tasks.integrations.slack import find_channel_id_for_rule
 from sentry.utils.safe import safe_execute
 
 
-def send_confirmation_notification(rule: Rule, new: bool):
+def send_confirmation_notification(rule: Rule, new: bool, changed):
     for action in rule.data.get("actions", ()):
         action_inst = instantiate_action(rule, action)
         safe_execute(
             action_inst.send_confirmation_notification,
             rule=rule,
             new=new,
+            changed=changed,
         )
 
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -38,7 +38,7 @@ from sentry.tasks.integrations.slack import find_channel_id_for_rule
 from sentry.utils.safe import safe_execute
 
 
-def send_confirmation_notification(rule: Rule, new: bool, changed):
+def send_confirmation_notification(rule: Rule, new: bool, changed: dict | None = None):
     for action in rule.data.get("actions", ()):
         action_inst = instantiate_action(rule, action)
         safe_execute(

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -14,7 +14,7 @@ from sentry.models.rulesnooze import RuleSnooze
 from sentry.services.hybrid_cloud.user.service import user_service
 
 
-def _generate_rule_label(project, rule, data):
+def generate_rule_label(project, rule, data):
     from sentry.rules import rules
 
     rule_cls = rules.get(data["id"])
@@ -202,7 +202,7 @@ class RuleSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs) -> RuleSerializerResponse:
         environment = attrs["environment"]
         all_conditions = [
-            dict(list(o.items()) + [("name", _generate_rule_label(obj.project, obj, o))])
+            dict(list(o.items()) + [("name", generate_rule_label(obj.project, obj, o))])
             for o in obj.data.get("conditions", [])
         ]
 
@@ -212,7 +212,7 @@ class RuleSerializer(Serializer):
                 actions.append(
                     dict(
                         list(action.items())
-                        + [("name", _generate_rule_label(obj.project, obj, action))]
+                        + [("name", generate_rule_label(obj.project, obj, action))]
                     )
                 )
             except serializers.ValidationError:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1839,7 +1839,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
     # Enable post create/edit rule confirmation notifications
-    "organizations:rule-create-edit-confirm-notification": False,
+    "organizations:rule-create-edit-confirm-notification": True,
     # Enable team member role provisioning through scim
     "organizations:scim-team-roles": False,
     # Enable detecting SDK crashes during event processing

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1839,7 +1839,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
     # Enable post create/edit rule confirmation notifications
-    "organizations:rule-create-edit-confirm-notification": True,
+    "organizations:rule-create-edit-confirm-notification": False,
     # Enable team member role provisioning through scim
     "organizations:scim-team-roles": False,
     # Enable detecting SDK crashes during event processing

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -139,14 +139,14 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         metrics.incr("notifications.sent", instance="slack.notification", skip_internal=False)
         yield self.future(send_notification, key=key)
 
-    def send_confirmation_notification(self, rule: Rule, new: bool):
+    def send_confirmation_notification(self, rule: Rule, new: bool, changed):
         integration = self.get_integration()
         if not integration:
             # Integration removed, rule still active.
             return
 
         channel = self.get_option("channel_id")
-        blocks = SlackRuleSaveEditMessageBuilder(rule=rule, new=new).build()
+        blocks = SlackRuleSaveEditMessageBuilder(rule=rule, new=new, changed=changed).build()
         payload = {
             "text": blocks.get("text"),
             "blocks": json.dumps(blocks.get("blocks")),

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -139,7 +139,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         metrics.incr("notifications.sent", instance="slack.notification", skip_internal=False)
         yield self.future(send_notification, key=key)
 
-    def send_confirmation_notification(self, rule: Rule, new: bool, changed):
+    def send_confirmation_notification(self, rule: Rule, new: bool, changed: dict[str, Any]):
         integration = self.get_integration()
         if not integration:
             # Integration removed, rule still active.

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -139,7 +139,9 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         metrics.incr("notifications.sent", instance="slack.notification", skip_internal=False)
         yield self.future(send_notification, key=key)
 
-    def send_confirmation_notification(self, rule: Rule, new: bool, changed: dict[str, Any]):
+    def send_confirmation_notification(
+        self, rule: Rule, new: bool, changed: dict[str, Any] | None = None
+    ):
         integration = self.get_integration()
         if not integration:
             # Integration removed, rule still active.

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -13,7 +13,7 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
         self,
         rule: Rule,
         new: bool,
-        changed: dict,
+        changed: dict | None = None,
     ) -> None:
         super().__init__()
         self.rule = rule

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -51,7 +51,7 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
 
         if not self.new and self.changed:
             changes_text = "*Changes*\n"
-            for label, changes in self.changed.items():
+            for changes in self.changed.values():
                 for change in changes:
                     changes_text += f"• {change}\n"
 

--- a/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/rule_save_edit.py
@@ -42,43 +42,20 @@ class SlackRuleSaveEditMessageBuilder(BlockSlackMessageBuilder):
         rule_url = self.linkify_rule()
         project = self.rule.project.slug
         if self.new:
-            rule_text = f"{rule_url} was created in the *{project}* project and will send notifications here."
+            rule_text = f"Alert rule {rule_url} was created in the *{project}* project and will send notifications here."
         else:
-            rule_text = f"{rule_url} in the *{project}* project was updated."
+            rule_text = f"Alert rule {rule_url} in the *{project}* project was updated."
+            # TODO potentially use old name if it's changed?
 
         blocks.append(self.get_markdown_block(rule_text))
 
         if not self.new and self.changed:
-            new = []
-            removed = []
-            fields = []
+            changes_text = "*Changes*\n"
             for label, changes in self.changed.items():
-                if label.startswith("new"):
-                    for change in changes:
-                        new.append(change)
-                elif label.startswith("removed"):
-                    for change in changes:
-                        removed.append(change)
-                elif label == "changed_label":
-                    if changes:
-                        print("what the heck")
-                        print(changes)
-                        blocks.append(self.get_markdown_block(changes))
+                for change in changes:
+                    changes_text += f"• {change}\n"
 
-
-            if new:
-                new_text = f"*Added*\n"
-                for new_change in new:
-                    new_text += f"•{new_change}\n"
-                fields.append(self.make_field(new_text))
-
-            if removed:
-                removed_text = "*Removed*\n"
-                for removed_change in removed:
-                    removed_text += f"•{removed_change}\n"
-                fields.append(self.make_field(removed_text))
-
-            blocks.append(self.get_section_fields_block(fields))
+            blocks.append(self.get_markdown_block(changes_text))
 
         settings_link = self.get_settings_url()
         blocks.append(self.get_context_block(settings_link))

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -7,6 +7,7 @@ from collections.abc import Generator
 from sentry.eventstore.models import GroupEvent
 from sentry.models.rule import Rule
 from sentry.rules.base import CallbackFuture, EventState, RuleBase
+from typing import Any
 
 logger = logging.getLogger("sentry.rules")
 
@@ -54,7 +55,7 @@ class EventAction(RuleBase, abc.ABC):
         >>>         print(future)
         """
 
-    def send_confirmation_notification(self, rule: Rule, new: bool):
+    def send_confirmation_notification(self, rule: Rule, new: bool, changed: dict[str, Any]):
         """
         Send a notification confirming that a rule was created or edited
         """

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import abc
 import logging
 from collections.abc import Generator
+from typing import Any
 
 from sentry.eventstore.models import GroupEvent
 from sentry.models.rule import Rule
 from sentry.rules.base import CallbackFuture, EventState, RuleBase
-from typing import Any
 
 logger = logging.getLogger("sentry.rules")
 

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -1,45 +1,72 @@
 from collections import defaultdict
-from typing import Any
+from typing import Any, DefaultDict
 
 from sentry.api.serializers.models.rule import generate_rule_label
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule
 
 
+def get_updated_rule_data(rule: Rule) -> dict[str, Any]:
+    rule_data = dict(rule.data)
+    if rule.environment_id:
+        rule_data["environment_id"] = rule.environment_id
+    if rule.owner:
+        rule_data["owner"] = rule.owner
+    rule_data["label"] = rule.label
+    return rule_data
+
+
+def check_value_changed(
+    rule_data: dict[str, Any], rule_data_before: dict[str, Any], key: str, word: str
+) -> str:
+    if rule_data.get(key) != rule_data_before.get(key):
+        old_value = rule_data_before.get(key)
+        new_value = rule_data.get(key)
+        return f"Changed {word} from *{old_value}* to *{new_value}*"
+    return ""
+
+
+def check_added_or_removed(
+    rule_data_after: dict[str, Any],
+    rule_data_before: dict[str, Any],
+    rule: Rule,
+    changed_data: DefaultDict[str, list[str]],
+    key: str,
+    rule_section_type: str,
+    added: bool,
+) -> DefaultDict[str, list[str]]:
+    verb = "Added" if added else "Removed"
+    for data in rule_data_before.get(key, []):
+        if data not in rule_data_after.get(key, []):
+            label = generate_rule_label(rule.project, rule, data)
+            changed_data[data["id"]].append(f"{verb} {rule_section_type} '{label}'")
+
+    return changed_data
+
+
 def get_changed_data(
-    rule: Rule, rule_data: dict[str, list[Any]], rule_data_before: dict[str, list[Any]]
-) -> dict[str, list[Any]]:
+    rule: Rule, rule_data: dict[str, Any], rule_data_before: dict[str, Any]
+) -> dict[str, Any]:
     """
     Generate a list per type of issue alert rule data of what changes occurred on edit.
     """
     changed_data = defaultdict(list)
+    changed_data = check_added_or_removed(
+        rule_data_before, rule_data, rule, changed_data, "conditions", "condition", added=True
+    )
+    changed_data = check_added_or_removed(
+        rule_data, rule_data_before, rule, changed_data, "conditions", "condition", added=False
+    )
+    changed_data = check_added_or_removed(
+        rule_data_before, rule_data, rule, changed_data, "actions", "action", added=True
+    )
+    changed_data = check_added_or_removed(
+        rule_data, rule_data_before, rule, changed_data, "actions", "action", added=False
+    )
 
-    for condition in rule_data.get("conditions", []):
-        if condition not in rule_data_before.get("conditions", []):
-            label = generate_rule_label(rule_data.get("project"), rule, condition)
-            changed_data[condition["id"]].append(f"Added condition '{label}'")
-
-    for condition in rule_data_before.get("conditions", []):
-        if condition not in rule_data.get("conditions", []):
-            label = generate_rule_label(rule.project, rule, condition)
-            changed_data[condition["id"]].append(f"Removed condition '{label}'")
-
-    for action in rule_data.get("actions", []):
-        if action not in rule_data_before.get("actions", []):
-            label = generate_rule_label(rule.project, rule, action)
-            changed_data[condition["id"]].append(f"Added action '{label}'")
-
-    for action in rule_data_before.get("actions", []):
-        if action not in rule_data.get("actions", []):
-            label = generate_rule_label(rule.project, rule, action)
-            changed_data[condition["id"]].append(f"Removed action '{label}'")
-
-    if rule_data.get("frequency") != rule_data_before.get("frequency"):
-        old_frequency = rule_data_before.get("frequency")
-        new_frequency = rule_data.get("frequency")
-        changed_data["changed_frequency"].append(
-            f"Changed frequency from *{old_frequency}* to *{new_frequency}*"
-        )
+    frequency_text = check_value_changed(rule_data, rule_data_before, "frequency", "frequency")
+    if frequency_text:
+        changed_data["changed_frequency"].append(frequency_text)
 
     if rule_data.get("environment_id") and not rule_data_before.get("environment_id"):
         environment = None
@@ -61,24 +88,17 @@ def get_changed_data(
         if environment:
             changed_data["environment"].append(f"Removed *{environment.name}* environment")
 
-    if rule_data_before.get("label") != rule_data.get("label"):
-        old_label = rule_data_before.get("label")
-        new_label = rule_data.get("label")
-        changed_data["changed_label"].append(
-            f"Changed rule name from *{old_label}* to *{new_label}*"
-        )
+    label_text = check_value_changed(rule_data, rule_data_before, "label", "rule name")
+    if label_text:
+        changed_data["changed_label"].append(label_text)
 
-    if rule_data_before.get("action_match") != rule_data.get("action_match"):
-        old_action_match = rule_data_before.get("action_match")
-        new_action_match = rule_data.get("action_match")
-        action_match_text = f"Changed trigger from *{old_action_match}* to *{new_action_match}*"
+    action_match_text = check_value_changed(rule_data, rule_data_before, "action_match", "trigger")
+    if action_match_text:
         changed_data["action_match"].append(action_match_text)
 
-    if rule_data_before.get("filter_match") != rule_data.get("filter_match"):
-        old_action_match = rule_data_before.get("filter_match")
-        new_action_match = rule_data.get("filter_match")
-        action_match_text = f"Changed filter from *{old_action_match}* to *{new_action_match}*"
-        changed_data["filter_match"].append(action_match_text)
+    filter_match_text = check_value_changed(rule_data, rule_data_before, "filter_match", "filter")
+    if filter_match_text:
+        changed_data["filter_match"].append(filter_match_text)
 
     if rule_data_before.get("owner") != rule_data.get("owner"):
         old_owner = rule_data_before.get("owner")

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -1,0 +1,68 @@
+from collections import defaultdict
+from typing import Any
+
+from sentry.api.serializers.models.rule import generate_rule_label
+from sentry.models.environment import Environment
+from sentry.models.rule import Rule
+
+
+def get_changed_data(
+    rule: Rule, rule_data: dict[str, list[Any]], rule_data_before: dict[str, list[Any]]
+) -> dict[str, list[Any]]:
+    changed_data = defaultdict(list)
+
+    for condition in rule_data.get("conditions", []):
+        if condition not in rule_data_before["conditions"]:
+            label = generate_rule_label(rule_data.get("project"), rule, condition)
+            changed_data[condition["id"]].append(f"Added condition '{label}'")
+
+    for condition in rule_data_before["conditions"]:
+        if condition not in rule_data["conditions"]:
+            label = generate_rule_label(rule.project, rule, condition)
+            changed_data[condition["id"]].append(f"Removed condition '{label}'")
+
+    for action in rule_data.get("actions", []):
+        if action not in rule_data_before["actions"]:
+            label = generate_rule_label(rule.project, rule, action)
+            changed_data[condition["id"]].append(f"Added action '{label}'")
+
+    for action in rule_data_before["actions"]:
+        if action not in rule_data.get("actions", []):
+            label = generate_rule_label(rule.project, rule, action)
+            changed_data[condition["id"]].append(f"Added action '{label}'")
+
+    if rule_data.get("frequency") != rule_data_before.get("frequency"):
+        old_frequency = rule_data_before.get("frequency")
+        new_frequency = rule_data.get("frequency")
+        changed_data["changed_frequency"].append(
+            f"Changed frequency from *{old_frequency}* to *{new_frequency}*"
+        )
+
+    if rule_data.get("environment_id") and not rule_data_before.get("environment_id"):
+        try:
+            environment = Environment.objects.get(id=rule_data.get("environment_id"))
+        except Environment.DoesNotExist:
+            pass
+
+        if environment:
+            changed_data["environment"].append(f"Added *{environment.name}* environment")
+
+    if rule_data_before.get("environment_id") and not rule_data.get("environment_id"):
+        try:
+            environment = Environment.objects.get(id=rule_data.get("environment_id"))
+        except Environment.DoesNotExist:
+            pass
+
+        if environment:
+            changed_data["environment"].append(f"Removed *{environment.name}* environment")
+
+    if rule_data_before.get("label") != rule_data.get("label"):
+        old_label = rule_data_before.get("label")
+        new_label = rule_data.get("label")
+        changed_data["changed_label"].append(
+            f"Changed rule name from *{old_label}* to *{new_label}*"
+        )
+
+    # TODO add actionMatch, filterMatch, and owner changes
+
+    return changed_data

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -63,6 +63,29 @@ def get_changed_data(
             f"Changed rule name from *{old_label}* to *{new_label}*"
         )
 
-    # TODO add actionMatch, filterMatch, and owner changes
+    if rule_data_before.get("action_match") != rule_data.get("action_match"):
+        old_action_match = rule_data_before.get("action_match")
+        new_action_match = rule_data.get("action_match")
+        action_match_text = f"Changed trigger from *{old_action_match}* to *{new_action_match}*"
+        changed_data["action_match"].append(action_match_text)
+
+    if rule_data_before.get("filter_match") != rule_data.get("filter_match"):
+        old_action_match = rule_data_before.get("filter_match")
+        new_action_match = rule_data.get("filter_match")
+        action_match_text = f"Changed filter from *{old_action_match}* to *{new_action_match}*"
+        changed_data["filter_match"].append(action_match_text)
+
+    if rule_data_before.get("owner") != rule_data.get("owner"):
+        old_owner = rule_data_before.get("owner")
+        old_actor = "Unassigned"
+        if old_owner:
+            old_actor = old_owner.resolve()
+
+        new_owner = rule_data.get("owner")
+        new_actor = "Unassigned"
+        if new_owner:
+            new_actor = new_owner.resolve()
+        owner_changed_text = f"Changed owner from *{old_actor}* to *{new_actor}*"
+        changed_data["owner"].append(owner_changed_text)
 
     return changed_data

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -50,7 +50,7 @@ def get_changed_data(
     """
     Generate a list per type of issue alert rule data of what changes occurred on edit.
     """
-    changed_data = defaultdict(list)
+    changed_data: DefaultDict[str, list[str]] = defaultdict(list)
     changed_data = check_added_or_removed(
         rule_data_before, rule_data, rule, changed_data, "conditions", "condition", added=True
     )

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -23,6 +23,7 @@ def check_value_changed(
         old_value = prior_state.get(key)
         new_value = present_state.get(key)
         return f"Changed {word} from *{old_value}* to *{new_value}*"
+    return None
 
 
 def generate_diff_labels(

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1013,7 +1013,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 "channel": "#old_channel_name",
             }
         ]
-        self.rule.update(data={"conditions": conditions, "actions": actions})
+        self.rule.update(data={"conditions": conditions, "actions": actions}, label="my rule")
 
         actions[0]["channel"] = "#new_channel_name"
         actions[0]["channel_id"] = "new_channel_id"
@@ -1054,13 +1054,18 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             content_type="application/json",
             body=json.dumps(payload),
         )
+        staging_env = self.create_environment(
+            self.project, name="staging", organization=self.organization
+        )
         payload = {
-            "name": "#new_channel_name",
+            "name": "new rule",
             "actionMatch": "any",
             "filterMatch": "any",
             "actions": actions,
             "conditions": conditions,
             "frequency": 30,
+            "environment": staging_env.name,
+            "owner": get_actor_for_user(self.user).get_actor_identifier(),
         }
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
@@ -1069,12 +1074,22 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         rule_label = response.data["name"]
         assert response.data["actions"][0]["channel_id"] == "new_channel_id"
         data = parse_qs(responses.calls[1].request.body)
-        message = f"<http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> in the *{self.project.slug}* project was updated."
+        message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> in the *{self.project.slug}* project was updated."
         assert data["text"][0] == message
         rendered_blocks = json.loads(data["blocks"][0])
         assert rendered_blocks[0]["text"]["text"] == message
+        changes = "*Changes*\n"
+        changes += "• Added action 'Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification'\n"
+        changes += "• Removed action 'Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification'\n"
+        changes += "• Changed frequency from *None* to *30*\n"
+        changes += f"• Added *{staging_env.name}* environment\n"
+        changes += "• Changed rule name from *my rule* to *new rule*\n"
+        changes += "• Changed trigger from *None* to *any*\n"
+        changes += "• Changed filter from *None* to *any*\n"
+        changes += f"• Changed owner from *Unassigned* to *{self.user.email}*\n"
+        assert rendered_blocks[1]["text"]["text"] == changes
         assert (
-            rendered_blocks[1]["elements"][0]["text"]
+            rendered_blocks[2]["elements"][0]["text"]
             == "<http://testserver/settings/account/notifications/alerts/|*Notification Settings*>"
         )
 

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -423,7 +423,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         rule_label = response.data["name"]
         assert response.data["actions"][0]["channel_id"] == self.channel_id
         data = parse_qs(responses.calls[1].request.body)
-        message = f"<http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> was created in the *{self.project.slug}* project and will send notifications here."
+        message = f"Alert rule <http://testserver/organizations/{self.organization.slug}/alerts/rules/{self.project.slug}/{rule_id}/details/|*{rule_label}*> was created in the *{self.project.slug}* project and will send notifications here."
         assert data["text"][0] == message
         rendered_blocks = json.loads(data["blocks"][0])
         assert rendered_blocks[0]["text"]["text"] == message


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/66285 to add details about what changed happened when a rule was edited to the notification.

<img width="748" alt="Screenshot 2024-03-12 at 4 40 24 PM" src="https://github.com/getsentry/sentry/assets/29959063/e0d7c5ca-35e5-4a66-bc67-e53c8d27dcce">


Note that I've made a couple follow up tickets to address poor rendering of issue type enums and frequency: https://github.com/getsentry/team-core-product-foundations/issues/158 and https://github.com/getsentry/team-core-product-foundations/issues/157