### PR TITLE
security: require verified email to accept invite when logged in

### DIFF
--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -262,6 +262,17 @@ class AcceptOrganizationInvite(Endpoint):
                 data={"details": "unable to accept organization invite"},
             )
         else:
+            if self.request.user.is_authenticated:
+                user_verified_emails = {e.email for e in self.request.user.get_verified_emails()}
+
+                if invite_context.member.email not in user_verified_emails:
+                    return Response(
+                        status=403,
+                        data={
+                            "details": "Your account must have a verified email matching the email the invite was sent to."
+                        },
+                    )
+
             response = Response(status=status.HTTP_204_NO_CONTENT)
 
         helper.accept_invite()

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -86,6 +86,7 @@ class ApiInviteHelper:
             invite = organization_service.get_invite_by_id(
                 organization_id=organization_id, email=email, user_id=request.user.id
             )
+
         if invite is None:
             # Unable to locate the pending organization member. Cannot setup
             # the invite helper.
@@ -114,6 +115,7 @@ class ApiInviteHelper:
             organization_id=invite_details.invite_organization_id,
             user_id=request.user.id,
         )
+
         if invite_context is None:
             if logger:
                 logger.exception("Invalid pending invite cookie")

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -16,9 +16,9 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.outbox import outbox_context
+from sentry.models.useremail import UserEmail
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
-from sentry.models.useremail import UserEmail
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.options import override_options

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -332,7 +332,7 @@ class AcceptOrganizationInviteTest(APITestCase):
     def get_om_and_init_invite(self):
         with assume_test_silo_mode(SiloMode.REGION), outbox_runner():
             om = OrganizationMember.objects.create(
-                email="newuser@example.com",
+                email=self.user.email,
                 role="member",
                 token="abc",
                 organization=self.organization,
@@ -393,7 +393,7 @@ class AcceptOrganizationInviteTest(APITestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(id=om.id)
         assert om.user_id is None
-        assert om.email == "newuser@example.com"
+        assert om.email == "bar@example.com"
 
     @mock.patch("sentry.auth.authenticators.U2fInterface.try_enroll", return_value=True)
     def test_accept_pending_invite__u2f_enroll(self, try_enroll):
@@ -489,7 +489,7 @@ class AcceptOrganizationInviteTest(APITestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(id=om.id)
         assert om.user_id is None
-        assert om.email == "newuser@example.com"
+        assert om.email == "bar@example.com"
 
         assert log.exception.call_count == 1
         assert log.exception.call_args[0][0] == "Invalid pending invite cookie"
@@ -511,7 +511,7 @@ class AcceptOrganizationInviteTest(APITestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             om = OrganizationMember.objects.get(id=om.id)
         assert om.user_id is None
-        assert om.email == "newuser@example.com"
+        assert om.email == "bar@example.com"
 
     @mock.patch("sentry.api.endpoints.user_authenticator_enroll.logger")
     @mock.patch("sentry.auth.authenticators.U2fInterface.try_enroll", return_value=True)


### PR DESCRIPTION
See https://github.com/getsentry/sentry/issues/64707

Users do not expect to be able to accept an invite with an email that does not align to the original invite's target email when they are already logged in. This PR changes the current behavior to only accept the invite if the logged in account has the email as an existing verified email. 
