### PR TITLE
fix(staff): Open sudo modal asking for superuser

### DIFF
--- a/static/app/views/organizationContext.spec.tsx
+++ b/static/app/views/organizationContext.spec.tsx
@@ -181,6 +181,27 @@ describe('OrganizationContext', function () {
     expect(switchOrganization).toHaveBeenCalled();
   });
 
+  it('opens sudo modal for superusers for nonmember org with active staff', async function () {
+    ConfigStore.set('user', UserFixture({isSuperuser: true, isStaff: true}));
+    organization.access = [];
+
+    getOrgMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+
+    render(
+      <OrganizationContextProvider>
+        <OrganizationLoaderStub />
+        <OrganizationName />
+      </OrganizationContextProvider>
+    );
+
+    await waitFor(() => !OrganizationStore.getState().loading);
+
+    expect(openSudo).toHaveBeenCalled();
+  });
+
   it('opens sudo modal for superusers on 403s', async function () {
     ConfigStore.set('user', UserFixture({isSuperuser: true}));
 

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -141,10 +141,15 @@ export function OrganizationContextProvider({children}: Props) {
   // boot. We should fix the types here in the future
   const user: User | null = configStore.user;
 
-  // If we've had an error it may be possible for the user to use the sudo
-  // modal to load the organization.
+  // It may be possible for the user to use the sudo modal to load the organization.
   useEffect(() => {
     if (!error) {
+      // If the user has an active staff session, the response will not return a
+      // 403 but access scopes will be an empty list.
+      if (user?.isSuperuser && user?.isStaff && organization?.access?.length === 0) {
+        openSudo({isSuperuser: true, needsReload: true});
+      }
+
       return;
     }
 
@@ -156,7 +161,7 @@ export function OrganizationContextProvider({children}: Props) {
     // So let's log them. This may create some noise, especially the test case where
     // we specifically test this branch
     console.error(error); // eslint-disable-line no-console
-  }, [user, error]);
+  }, [user, error, organization]);
 
   // Switch organizations when the orgId changes
   const lastOrgId = useRef(orgSlug);


### PR DESCRIPTION
When staff is active, we no longer open the sudo modal when going to orgs we are not members of b/c fetching the org no longer 403s.

This fix makes is so the sudo modal now opens like before.

### Before

https://github.com/getsentry/sentry/assets/67301797/30fecfcb-cee7-41ec-a0ef-885f9904757e

### After

https://github.com/getsentry/sentry/assets/67301797/f945fa9b-0183-4063-aa9e-aa0429b88d85
