### PR TITLE
fix: sanitize org name in outbound emails

### DIFF
--- a/src/sentry/templates/sentry/emails/auth-link-identity.html
+++ b/src/sentry/templates/sentry/emails/auth-link-identity.html
@@ -1,6 +1,7 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block main %}
   <h3>{{ provider.name }} SSO Enabled</h3>

--- a/src/sentry/templates/sentry/emails/auth-link-identity.html
+++ b/src/sentry/templates/sentry/emails/auth-link-identity.html
@@ -7,7 +7,7 @@
 
   <p>
     <strong>{{ provider.name }}</strong> Single Sign-On has been configured for the
-    <strong>{{ organization.name }}</strong> organization. Link your Sentry account to enable
+    <strong>{{ organization.name|sanitize_periods }}</strong> organization. Link your Sentry account to enable
     signing on with your <strong>{{ provider.name }}</strong> account.
   </p>
 

--- a/src/sentry/templates/sentry/emails/auth-sso-disabled.html
+++ b/src/sentry/templates/sentry/emails/auth-sso-disabled.html
@@ -1,6 +1,7 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block main %}
   <h3>Single Sign-On disabled</h3>

--- a/src/sentry/templates/sentry/emails/auth-sso-disabled.html
+++ b/src/sentry/templates/sentry/emails/auth-sso-disabled.html
@@ -7,7 +7,7 @@
 
   <p>
     <strong>{{ provider.name }}</strong> Single Sign-On has been disabled for the
-    <strong>{{ organization.name }}</strong> organization.
+    <strong>{{ organization.name|sanitize_periods }}</strong> organization.
   </p>
 
   {% if has_password %}

--- a/src/sentry/templates/sentry/emails/member-invite.html
+++ b/src/sentry/templates/sentry/emails/member-invite.html
@@ -5,7 +5,7 @@
 
 {% block main %}
     <h3>You've been invited to Sentry</h3>
-    <p>Your teammates at <strong>{{ organization.name|sanitize_periods|sanitize_periods }}</strong> are using Sentry to track and debug software errors.</p>
+    <p>Your teammates at <strong>{{ organization.name|sanitize_periods }}</strong> are using Sentry to track and debug software errors.</p>
 
     <p><a href="{{ url }}" class="btn">Join your team</a></p>
 

--- a/src/sentry/templates/sentry/emails/member-invite.html
+++ b/src/sentry/templates/sentry/emails/member-invite.html
@@ -5,7 +5,7 @@
 
 {% block main %}
     <h3>You've been invited to Sentry</h3>
-    <p>Your teammates at <strong>{{ organization.name }}</strong> are using Sentry to track and debug software errors.</p>
+    <p>Your teammates at <strong>{{ organization.name|sanitize_periods|sanitize_periods }}</strong> are using Sentry to track and debug software errors.</p>
 
     <p><a href="{{ url }}" class="btn">Join your team</a></p>
 

--- a/src/sentry/templates/sentry/emails/org-auth-token-created.html
+++ b/src/sentry/templates/sentry/emails/org-auth-token-created.html
@@ -6,7 +6,7 @@
 
 {% block main %}
   <h3>Security Notice</h3>
-  <p>User {{ actor.email }} has created a new Organization Auth Token "{{ token_name }}" for your Sentry organization {{ organization.name }}.</p>
+  <p>User {{ actor.email }} has created a new Organization Auth Token "{{ token_name }}" for your Sentry organization {{ organization.name|sanitize_periods }}.</p>
   <table>
     <tr>
       <td style="width:36px;vertical-align:top;padding-right:15px;">

--- a/src/sentry/templates/sentry/emails/org_delete_confirm.html
+++ b/src/sentry/templates/sentry/emails/org_delete_confirm.html
@@ -4,7 +4,7 @@
 
 {% block main %}
     <h3>Organization Queued for Deletion</h3>
-    <p>The <strong>{{ organization.name }}</strong> organization has been scheduled for deletion by:</p>
+    <p>The <strong>{{ organization.name|sanitize_periods }}</strong> organization has been scheduled for deletion by:</p>
     <p><pre>User: {{ username }}
 IP: {{ user_ip_address }}
 Date: {{ deletion_datetime }}</pre></p>

--- a/src/sentry/templates/sentry/emails/org_delete_confirm.html
+++ b/src/sentry/templates/sentry/emails/org_delete_confirm.html
@@ -1,6 +1,7 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block main %}
     <h3>Organization Queued for Deletion</h3>

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -214,7 +214,7 @@
         </h1>
       </td>
       <td class="align-right">
-        <strong>Weekly Update for {{ organization.name }}</strong><br />
+        <strong>Weekly Update for {{ organization.name|sanitize_periods }}</strong><br />
         {{ start }} &ndash; {{ end }}
       </td>
     </tr>

--- a/src/sentry/templates/sentry/emails/setup_2fa.html
+++ b/src/sentry/templates/sentry/emails/setup_2fa.html
@@ -5,7 +5,7 @@
 {% block main %}
     <h3>Setup Two-Factor Authentication</h3>
     <p>
-        The {{ organization.name|title }} organization now requires all members to enable
+        The {{ organization.name|sanitize_periods|title }} organization now requires all members to enable
         two-factor authentication. Effective immediately, you will be unable to access
         this organization or receive its notifications until you enable at least
         one form of 2FA.

--- a/src/sentry/templates/sentry/emails/setup_2fa.html
+++ b/src/sentry/templates/sentry/emails/setup_2fa.html
@@ -1,6 +1,7 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block main %}
     <h3>Setup Two-Factor Authentication</h3>

--- a/src/sentry/templates/sentry/emails/setup_email.html
+++ b/src/sentry/templates/sentry/emails/setup_email.html
@@ -1,6 +1,7 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block main %}
     <h3>Confirm Email</h3>

--- a/src/sentry/templates/sentry/emails/setup_email.html
+++ b/src/sentry/templates/sentry/emails/setup_email.html
@@ -5,7 +5,7 @@
 {% block main %}
     <h3>Confirm Email</h3>
     <p>
-        The {{ organization.name|title }} organization now requires all members to confirm
+        The {{ organization.name|sanitize_periods|title }} organization now requires all members to confirm
         their primary email address. Effective immediately, you will be unable to access
         this organization or receive its notifications until you confirm this email
         address.

--- a/src/sentry/templates/sentry/emails/slack-migration.html
+++ b/src/sentry/templates/sentry/emails/slack-migration.html
@@ -6,7 +6,7 @@
 
 {% block main %}
   <h3>You're All Upgraded</h3>
-    Well, you're looking fresh. Your organization <strong>{{organization.name}}</strong>'s Sentry-Slack Integration for your workspace
+    Well, you're looking fresh. Your organization <strong>{{organization.name|sanitize_periods}}</strong>'s Sentry-Slack Integration for your workspace
     <strong>{{integration.name}}</strong> is all up to date and ready to report errors. If you're confused, curious, or just looking
     for some light reading, see <a href="{{ doc_link }}">our docs</a>.
   <br />

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -321,6 +321,7 @@ def get_item(dictionary, key):
 
 
 @register.filter
+@stringfilter
 def sanitize_periods(value):
     """
     Primarily used in email templates when a field may contain a domain name to prevent

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -318,3 +318,16 @@ def random_int(a, b=None):
 @register.filter
 def get_item(dictionary, key):
     return dictionary.get(key, "")
+
+
+@register.filter
+def sanitize_periods(value):
+    """
+    Primarily used in email templates when a field may contain a domain name to prevent
+    email clients from creating a clickable link to the domain.
+    """
+    word_joiner = "\u2060"
+
+    # Adding the Unicode character before every period
+    output_string = value.replace(".", word_joiner + ".")
+    return output_string

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -164,3 +164,9 @@ def test_get_item(a_dict, key, expected):
     prefix = '{% load sentry_helpers %} {{ something|get_item:"' + key + '" }}'
     result = engines["django"].from_string(prefix).render(context={"something": a_dict}).strip()
     assert result == expected
+
+
+def test_sanitize_periods():
+    input = '{% load sentry_helpers %} {{ "example.com"|sanitize_periods}}'
+    result = engines["django"].from_string(input).render().strip()
+    assert result == "example\u2060.com"


### PR DESCRIPTION
Attempt to prevent mail clients from auto-linking organization names that look or contain a domain name by inserting the _word joiner_ unicode character before each period.