### PR TITLE
ref(recap): Remove deprecated recap polling feature UI code

### DIFF
--- a/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
+++ b/static/app/data/forms/projectSecurityAndPrivacyGroups.tsx
@@ -54,22 +54,6 @@ const formGroups: JsonFormObject[] = [
             formatStoreCrashReports(value, organization.storeCrashReports),
           ]),
       },
-      {
-        name: 'recapServerUrl',
-        type: 'string',
-        placeholder: t('URL'),
-        label: t('Recap Server URL'),
-        help: t('URL to the Recap Server events should be polled from'),
-        visible: ({features}) => features.has('recap-server'),
-      },
-      {
-        name: 'recapServerToken',
-        type: 'string',
-        placeholder: t('Token'),
-        label: t('Recap Server Token'),
-        help: t('Auth Token to the configured Recap Server'),
-        visible: ({features}) => features.has('recap-server'),
-      },
     ],
   },
   {


### PR DESCRIPTION
1. Remove recap URLs from dashboard settings ✅ 
2. Remove hardcoded flag to hide dashboard settings UI for recap ✅ 
3. ➡️  Remove recap settings UI code
4. Remove cron job code that polls external servers