### PR TITLE
fix(tests): test failed due to DST changes

### DIFF
--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -93,9 +93,7 @@ class DailySummaryTest(
             name="foo", organization=self.organization, teams=[self.team]
         )
         self.project2.first_event = self.three_days_ago
-        user_option_service.set_option(
-            user_id=self.user.id, key="timezone", value="America/Los_Angeles"
-        )
+        user_option_service.set_option(user_id=self.user.id, key="timezone", value="Etc/GMT+8")
         self.release = self.create_release(project=self.project, date_added=self.now)
 
     def populate_event_data(


### PR DESCRIPTION
https://github.com/getsentry/sentry/blob/bed23aee47d509ed189b484693b0f6428ed1a25d/src/sentry/tasks/summaries/daily_summary.py#L107
Current values for `local_datetime.hour` are
```
local_datetime.hour 0
local_datetime.hour 17
```
but expected value is 16 and the test expects a single match.