### PR TITLE
ref(assemble): Improve error message for too-large files

### DIFF
--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -103,7 +103,7 @@ def assemble_file(task, org_or_project, name, checksum, chunks, file_type) -> As
             org_or_project.id,
             checksum,
             ChunkFileState.ERROR,
-            detail=f"File %{name} exceeds maximum size (%{file_size} > %{max_file_size})",
+            detail=f"File {name} exceeds maximum size ({file_size} > {max_file_size})",
         )
 
         return None

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -96,13 +96,14 @@ def assemble_file(task, org_or_project, name, checksum, chunks, file_type) -> As
 
     # Reject all files that exceed the maximum allowed size for this organization.
     file_size = sum(x[2] for x in file_blobs)
-    if file_size > get_max_file_size(organization):
+    max_file_size = get_max_file_size(organization)
+    if file_size > max_file_size:
         set_assemble_status(
             task,
             org_or_project.id,
             checksum,
             ChunkFileState.ERROR,
-            detail="File exceeds maximum size",
+            detail=f"File %{name} exceeds maximum size (%{file_size} > %{max_file_size})",
         )
 
         return None


### PR DESCRIPTION
Now tells you the file as well as the maximum and actual file sizes.