### PR TITLE
feat(ddm): Apply group filters in top-level formula

### DIFF
--- a/src/sentry/sentry_metrics/querying/visitors/query_expression.py
+++ b/src/sentry/sentry_metrics/querying/visitors/query_expression.py
@@ -51,6 +51,15 @@ class TimeseriesConditionInjectionVisitor(QueryExpressionVisitor[QueryExpression
     def __init__(self, condition_group: ConditionGroup):
         self._condition_group = condition_group
 
+    def _visit_formula(self, formula: Formula) -> QueryExpression:
+        if self._condition_group:
+            current_filters = formula.filters if formula.filters else []
+            current_filters.extend(self._condition_group)
+
+            return formula.set_filters(current_filters)
+
+        return formula
+
     def _visit_timeseries(self, timeseries: Timeseries) -> QueryExpression:
         if self._condition_group:
             current_filters = timeseries.filters if timeseries.filters else []


### PR DESCRIPTION
This PR adds a slight optimization to the metrics API in which we are now adding the filters for the groups in the series query directly in the formula filters, if a formula is specified, otherwise we will keep on adding them to the timeseries.