### PR TITLE
fix(contexts): Coerce large number values in context to strings

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -93,6 +93,9 @@ class ContextType:
             # we still want to display the info the UI
             if value is not None:
                 ctx_data[force_str(key)] = value
+            # Numbers exceeding 15 place values will be converted to strings to avoid rendering issues
+            if isinstance(value, (int, float)) and len(str_value := force_str(value)) > 15:
+                ctx_data[force_str(key)] = str_value
         self.data = ctx_data
 
     def to_json(self):

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -97,3 +97,28 @@ def test_gpu(make_ctx_snapshot):
     make_ctx_snapshot(
         {"gpu": {"name": "AMD Radeon Pro 560", "vendor_name": "Apple", "version": "Metal"}}
     )
+
+
+def test_large_numbers():
+    data = {
+        "large_numbers": {
+            "decimal_number": 123456.789,
+            "number": 123456789,
+            "negative_number": -123456789,
+            "big_decimal_number": 123456789.123456789,
+            "big_number": 123456789123456789,
+            "big_negative_number": -123456789123456789,
+        }
+    }
+    numeric_keys = {"decimal_number", "number", "negative_number"}
+    string_keys = {"big_decimal_number", "big_number", "big_negative_number"}
+
+    mgr = EventManager(data={"contexts": data})
+    mgr.normalize()
+    evt = eventstore.backend.create_event(data=mgr.get_data())
+    interface = evt.interfaces.get("contexts")
+    ctx_data = interface.to_json()["large_numbers"]
+    for key in numeric_keys:
+        assert isinstance(ctx_data[key], (int, float))
+    for key in string_keys:
+        assert isinstance(ctx_data[key], str)


### PR DESCRIPTION
Fixes #66692 

When the frontend parses the JSON containing numbers larger than `Number.MAX_SAFE_INTEGER`, it rounds them off producing inaccuracies for users debugging with this context. Rather than attempt to override our JSON parsing (which is done through `react-query`), this just coerces the returned values into strings. We forfeit the formatting but save ensure accuracy.

Here's an example with what the SDK might send.

```python
scope.set_context(
    "large_numbers",
    {
        "decimal_number": 123456.789,
        "number": 123456789,
        "negative_number": -123456789,
        "big_decimal_number": 123456789.123456789,
        "big_number": 123456789123456789,
        "big_negative_number": -123456789123456789,
        "bug_report_number": 608548899684111178,
    },
)
```


**before**
<img width="389" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/56befa51-ae69-4223-ab6e-06f7adc7bd30">


**after**
<img width="386" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/45fac537-d520-4ac0-9318-bc5bd4f5d6ba">


