### PR TITLE
fix(dashboards): Rename dashboard template sort from priority to trends

### DIFF
--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -295,7 +295,7 @@ _PREBUILT_DASHBOARDS: list[dict[str, Any]] = [
                         "aggregates": [],
                         "columns": ["assignee", "issue", "title"],
                         "conditions": "assigned_or_suggested:me is:unresolved",
-                        "orderby": "priority",
+                        "orderby": "trends",
                     },
                 ],
                 "widgetType": "issue",

--- a/static/app/views/dashboards/data.tsx
+++ b/static/app/views/dashboards/data.tsx
@@ -328,7 +328,7 @@ export const DASHBOARDS_TEMPLATES: DashboardTemplate[] = [
             aggregates: [],
             columns: ['assignee', 'issue', 'title'],
             conditions: 'assigned_or_suggested:me is:unresolved',
-            orderby: 'priority',
+            orderby: 'trends',
           },
         ],
       },


### PR DESCRIPTION
Priority sort was renamed to `trends` here: https://github.com/getsentry/sentry/pull/65752

However, there are some dashboard templates still referencing the old name, one in the frontend and one in the backend.

The backend one doesn't actually create any records, it just adds to the endpoint response. So changing it to `trends` will fix existing default dashboards. The frontend one will fix anyone clicking the dashboard template buttons.

These do not depend on each other in any way so it's safe to merge FE/BE together.

A migration PR will follow to fix existing records

![CleanShot 2024-03-13 at 09 47 38](https://github.com/getsentry/sentry/assets/10888943/7db1fa50-efa0-4cca-a0c4-b658361d854c)
