### PR TITLE
feat(perf): Add HTTP module domain summary transactions table

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -94,6 +94,7 @@ type GridEditableProps<DataRow, ColumnKey> = {
     ) => React.ReactNode[];
   };
   location: Location;
+  'aria-label'?: string;
   emptyMessage?: React.ReactNode;
   error?: unknown | null;
   /**
@@ -102,13 +103,13 @@ type GridEditableProps<DataRow, ColumnKey> = {
    * in these buttons and updating props to the GridEditable instance.
    */
   headerButtons?: () => React.ReactNode;
-  height?: string | number;
 
+  height?: string | number;
   isLoading?: boolean;
+
   minimumColWidth?: number;
 
   scrollable?: boolean;
-
   stickyHeader?: boolean;
   /**
    * GridEditable (mostly) do not maintain any internal state and relies on the
@@ -431,7 +432,13 @@ class GridEditable<
   }
 
   render() {
-    const {title, headerButtons, scrollable, height} = this.props;
+    const {
+      title,
+      headerButtons,
+      scrollable,
+      height,
+      'aria-label': ariaLabel,
+    } = this.props;
     const showHeader = title || headerButtons;
     return (
       <Fragment>
@@ -446,6 +453,7 @@ class GridEditable<
           )}
           <Body>
             <Grid
+              aria-label={ariaLabel}
               data-test-id="grid-editable"
               scrollable={scrollable}
               height={height}

--- a/static/app/views/performance/http/domainTransactionsTable.tsx
+++ b/static/app/views/performance/http/domainTransactionsTable.tsx
@@ -1,0 +1,63 @@
+import type {Location} from 'history';
+
+import GridEditable, {type GridColumnHeader} from 'sentry/components/gridEditable';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types';
+import type {EventsMetaType} from 'sentry/utils/discover/eventView';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
+import type {MetricsResponse} from 'sentry/views/starfish/types';
+
+type Row = Pick<MetricsResponse, 'transaction'>;
+
+type Column = GridColumnHeader<'transaction'>;
+
+export function DomainTransactionsTable() {
+  const location = useLocation();
+  const organization = useOrganization();
+
+  return (
+    <GridEditable
+      aria-label={t('Transactions')}
+      isLoading={false}
+      error={null}
+      data={[] as Row[]}
+      columnOrder={[] as Column[]}
+      columnSortBy={[]}
+      grid={{
+        renderHeadCell: col =>
+          renderHeadCell({
+            column: col,
+            sort: undefined,
+            location,
+            sortParameterName: undefined,
+          }),
+        renderBodyCell: (column, row) =>
+          renderBodyCell(column, row, undefined, location, organization),
+      }}
+      location={location}
+    />
+  );
+}
+
+function renderBodyCell(
+  column: Column,
+  row: Row,
+  meta: EventsMetaType | undefined,
+  location: Location,
+  organization: Organization
+) {
+  if (!meta?.fields) {
+    return row[column.key];
+  }
+
+  const renderer = getFieldRenderer(column.key, meta.fields, false);
+
+  return renderer(row, {
+    location,
+    organization,
+    unit: meta.units?.[column.key],
+  });
+}

--- a/static/app/views/performance/http/domainTransactionsTable.tsx
+++ b/static/app/views/performance/http/domainTransactionsTable.tsx
@@ -1,9 +1,13 @@
+import {Fragment} from 'react';
+import {browserHistory} from 'react-router';
 import type {Location} from 'history';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   type GridColumnHeader,
 } from 'sentry/components/gridEditable';
+import type {CursorHandler} from 'sentry/components/pagination';
+import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -13,6 +17,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import type {MetricsResponse} from 'sentry/views/starfish/types';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 
 type Row = Pick<
@@ -80,33 +85,51 @@ interface Props {
   isLoading: boolean;
   error?: Error | null;
   meta?: EventsMetaType;
+  pageLinks?: string;
 }
 
-export function DomainTransactionsTable({data, isLoading, error, meta}: Props) {
+export function DomainTransactionsTable({
+  data,
+  isLoading,
+  error,
+  meta,
+  pageLinks,
+}: Props) {
   const location = useLocation();
   const organization = useOrganization();
 
+  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
+    browserHistory.push({
+      pathname,
+      query: {...query, [QueryParameterNames.TRANSACTIONS_CURSOR]: newCursor},
+    });
+  };
+
   return (
-    <GridEditable
-      aria-label={t('Transactions')}
-      isLoading={isLoading}
-      error={error}
-      data={data}
-      columnOrder={COLUMN_ORDER}
-      columnSortBy={[]}
-      grid={{
-        renderHeadCell: col =>
-          renderHeadCell({
-            column: col,
-            sort: undefined,
-            location,
-            sortParameterName: undefined,
-          }),
-        renderBodyCell: (column, row) =>
-          renderBodyCell(column, row, meta, location, organization),
-      }}
-      location={location}
-    />
+    <Fragment>
+      <GridEditable
+        aria-label={t('Transactions')}
+        isLoading={isLoading}
+        error={error}
+        data={data}
+        columnOrder={COLUMN_ORDER}
+        columnSortBy={[]}
+        grid={{
+          renderHeadCell: col =>
+            renderHeadCell({
+              column: col,
+              sort: undefined,
+              location,
+              sortParameterName: undefined,
+            }),
+          renderBodyCell: (column, row) =>
+            renderBodyCell(column, row, meta, location, organization),
+        }}
+        location={location}
+      />
+
+      <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
+    </Fragment>
   );
 }
 

--- a/static/app/views/performance/http/domainTransactionsTable.tsx
+++ b/static/app/views/performance/http/domainTransactionsTable.tsx
@@ -1,30 +1,54 @@
 import type {Location} from 'history';
 
-import GridEditable, {type GridColumnHeader} from 'sentry/components/gridEditable';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  type GridColumnHeader,
+} from 'sentry/components/gridEditable';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {RATE_UNIT_TITLE, RateUnit} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import type {MetricsResponse} from 'sentry/views/starfish/types';
 
-type Row = Pick<MetricsResponse, 'transaction'>;
+type Row = Pick<MetricsResponse, 'transaction' | 'spm()'>;
 
-type Column = GridColumnHeader<'transaction'>;
+type Column = GridColumnHeader<'transaction' | 'spm()'>;
 
-export function DomainTransactionsTable() {
+const COLUMN_ORDER: Column[] = [
+  {
+    key: 'transaction',
+    name: t('Transaction'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: 'spm()',
+    name: `${t('Requests')} ${RATE_UNIT_TITLE[RateUnit.PER_MINUTE]}`,
+    width: COL_WIDTH_UNDEFINED,
+  },
+];
+
+interface Props {
+  data: Row[];
+  isLoading: boolean;
+  error?: Error | null;
+  meta?: EventsMetaType;
+}
+
+export function DomainTransactionsTable({data, isLoading, error, meta}: Props) {
   const location = useLocation();
   const organization = useOrganization();
 
   return (
     <GridEditable
       aria-label={t('Transactions')}
-      isLoading={false}
-      error={null}
-      data={[] as Row[]}
-      columnOrder={[] as Column[]}
+      isLoading={isLoading}
+      error={error}
+      data={data}
+      columnOrder={COLUMN_ORDER}
       columnSortBy={[]}
       grid={{
         renderHeadCell: col =>
@@ -35,7 +59,7 @@ export function DomainTransactionsTable() {
             sortParameterName: undefined,
           }),
         renderBodyCell: (column, row) =>
-          renderBodyCell(column, row, undefined, location, organization),
+          renderBodyCell(column, row, meta, location, organization),
       }}
       location={location}
     />

--- a/static/app/views/performance/http/domainTransactionsTable.tsx
+++ b/static/app/views/performance/http/domainTransactionsTable.tsx
@@ -13,10 +13,29 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import type {MetricsResponse} from 'sentry/views/starfish/types';
+import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 
-type Row = Pick<MetricsResponse, 'transaction' | 'spm()'>;
+type Row = Pick<
+  MetricsResponse,
+  | 'transaction'
+  | 'spm()'
+  | 'http_response_rate(2)'
+  | 'http_response_rate(4)'
+  | 'http_response_rate(5)'
+  | 'avg(span.self_time)'
+  | 'sum(span.self_time)'
+  | 'time_spent_percentage()'
+>;
 
-type Column = GridColumnHeader<'transaction' | 'spm()'>;
+type Column = GridColumnHeader<
+  | 'transaction'
+  | 'spm()'
+  | 'http_response_rate(2)'
+  | 'http_response_rate(4)'
+  | 'http_response_rate(5)'
+  | 'avg(span.self_time)'
+  | 'time_spent_percentage()'
+>;
 
 const COLUMN_ORDER: Column[] = [
   {
@@ -27,6 +46,31 @@ const COLUMN_ORDER: Column[] = [
   {
     key: 'spm()',
     name: `${t('Requests')} ${RATE_UNIT_TITLE[RateUnit.PER_MINUTE]}`,
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: `http_response_rate(2)`,
+    name: t('2XXs'),
+    width: 50,
+  },
+  {
+    key: `http_response_rate(4)`,
+    name: t('4XXs'),
+    width: 50,
+  },
+  {
+    key: `http_response_rate(5)`,
+    name: t('5XXs'),
+    width: 50,
+  },
+  {
+    key: `avg(span.self_time)`,
+    name: DataTitles.avg,
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: 'time_spent_percentage()',
+    name: DataTitles.timeSpent,
     width: COL_WIDTH_UNDEFINED,
   },
 ];

--- a/static/app/views/performance/http/domainTransactionsTable.tsx
+++ b/static/app/views/performance/http/domainTransactionsTable.tsx
@@ -45,7 +45,7 @@ type Column = GridColumnHeader<
 const COLUMN_ORDER: Column[] = [
   {
     key: 'transaction',
-    name: t('Transaction'),
+    name: t('Found In'),
     width: COL_WIDTH_UNDEFINED,
   },
   {

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -127,4 +127,14 @@ describe('HTTPSummaryPage', function () {
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
   });
+
+  it('renders a list of queries', async function () {
+    render(<HTTPDomainSummaryPage />);
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+
+    expect(
+      screen.getByRole('table', {name: 'Domain Transactions Table'})
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -133,8 +133,6 @@ describe('HTTPSummaryPage', function () {
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
-    expect(
-      screen.getByRole('table', {name: 'Domain Transactions Table'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('table', {name: 'Transactions'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -198,7 +198,7 @@ describe('HTTPSummaryPage', function () {
 
     expect(screen.getByRole('table', {name: 'Transactions'})).toBeInTheDocument();
 
-    expect(screen.getByRole('columnheader', {name: 'Transaction'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Found In'})).toBeInTheDocument();
     expect(
       screen.getByRole('columnheader', {name: 'Requests Per Minute'})
     ).toBeInTheDocument();

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -36,7 +36,7 @@ describe('HTTPSummaryPage', function () {
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',
     search: '',
-    query: {domain: '*.sentry.dev', statsPeriod: '10d'},
+    query: {domain: '*.sentry.dev', statsPeriod: '10d', transactionsCursor: '0:20:0'},
     hash: '',
     state: undefined,
     action: 'PUSH',
@@ -145,7 +145,7 @@ describe('HTTPSummaryPage', function () {
           ],
           per_page: 20,
           project: [],
-          cursor: '',
+          cursor: '0:20:0',
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
           referrer: 'api.starfish.http-module-domain-summary-transactions-list',
           statsPeriod: '10d',

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -129,10 +129,27 @@ describe('HTTPSummaryPage', function () {
   });
 
   it('renders a list of queries', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.starfish.http-module-domain-summary-transactions-list',
+        }),
+      ],
+      body: {
+        data: [{transaction: '/api/users', 'spm()': 17.88}],
+      },
+    });
+
     render(<HTTPDomainSummaryPage />);
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
     expect(screen.getByRole('table', {name: 'Transactions'})).toBeInTheDocument();
+
+    expect(screen.getByRole('cell', {name: '/api/users'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '17.88'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -147,6 +147,7 @@ describe('HTTPSummaryPage', function () {
           project: [],
           cursor: '0:20:0',
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
+          sort: '-time_spent_percentage()',
           referrer: 'api.starfish.http-module-domain-summary-transactions-list',
           statsPeriod: '10d',
         },

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -14,7 +14,7 @@ jest.mock('sentry/utils/useOrganization');
 describe('HTTPSummaryPage', function () {
   const organization = OrganizationFixture();
 
-  let domainChartsRequestMock;
+  let domainChartsRequestMock, domainTransactionsListRequestMock;
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -46,7 +46,7 @@ describe('HTTPSummaryPage', function () {
   jest.mocked(useOrganization).mockReturnValue(organization);
 
   beforeEach(function () {
-    MockApiClient.addMockResponse({
+    domainTransactionsListRequestMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
       body: {
@@ -121,6 +121,34 @@ describe('HTTPSummaryPage', function () {
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'avg(span.self_time)',
+        },
+      })
+    );
+
+    expect(domainTransactionsListRequestMock).toHaveBeenNthCalledWith(
+      2,
+      `/organizations/${organization.slug}/events/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          dataset: 'spansMetrics',
+          environment: [],
+          field: [
+            'transaction',
+            'spm()',
+            'http_response_rate(2)',
+            'http_response_rate(4)',
+            'http_response_rate(5)',
+            'avg(span.self_time)',
+            'sum(span.self_time)',
+            'time_spent_percentage()',
+          ],
+          per_page: 20,
+          project: [],
+          cursor: '',
+          query: 'span.module:http span.domain:"\\*.sentry.dev"',
+          referrer: 'api.starfish.http-module-domain-summary-transactions-list',
+          statsPeriod: '10d',
         },
       })
     );

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -139,7 +139,27 @@ describe('HTTPSummaryPage', function () {
         }),
       ],
       body: {
-        data: [{transaction: '/api/users', 'spm()': 17.88}],
+        data: [
+          {
+            transaction: '/api/users',
+            'spm()': 17.88,
+            'http_response_rate(2)': 0.97,
+            'http_response_rate(4)': 0.025,
+            'http_response_rate(5)': 0.005,
+            'avg(span.self_time)': 204.5,
+            'sum(span.self_time)': 177238,
+          },
+        ],
+        meta: {
+          fields: {
+            'spm()': 'rate',
+            'avg(span.self_time)': 'duration',
+            'http_response_rate(2)': 'percentage',
+            'http_response_rate(4)': 'percentage',
+            'http_response_rate(5)': 'percentage',
+            'sum(span.self_time)': 'duration',
+          },
+        },
       },
     });
 
@@ -149,7 +169,22 @@ describe('HTTPSummaryPage', function () {
 
     expect(screen.getByRole('table', {name: 'Transactions'})).toBeInTheDocument();
 
+    expect(screen.getByRole('columnheader', {name: 'Transaction'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: 'Requests Per Minute'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: '2XXs'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: '4XXs'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: '5XXs'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Avg Duration'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Time Spent'})).toBeInTheDocument();
+
     expect(screen.getByRole('cell', {name: '/api/users'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '17.88'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '17.9/s'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '97%'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '2.5%'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '0.5%'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '204.50ms'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '2.95min'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -14,10 +14,9 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {DurationChart} from 'sentry/views/performance/database/durationChart';
-import {ThroughputChart} from 'sentry/views/performance/database/throughputChart';
-import {useSelectedDurationAggregate} from 'sentry/views/performance/database/useSelectedDurationAggregate';
 import {DomainTransactionsTable} from 'sentry/views/performance/http/domainTransactionsTable';
+import {DurationChart} from 'sentry/views/performance/http/durationChart';
+import {ThroughputChart} from 'sentry/views/performance/http/throughputChart';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
@@ -37,8 +36,6 @@ type Query = {
 export function HTTPDomainSummaryPage() {
   const location = useLocation<Query>();
   const organization = useOrganization();
-
-  const [selectedAggregate] = useSelectedDurationAggregate();
 
   const {domain} = location.query;
 
@@ -79,7 +76,7 @@ export function HTTPDomainSummaryPage() {
     error: durationError,
   } = useSpanMetricsSeries({
     filters,
-    yAxis: [`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
+    yAxis: [`avg(${SpanMetricsField.SPAN_SELF_TIME})`],
     enabled: Boolean(domain),
     referrer: 'api.starfish.http-module-domain-summary-duration-chart',
   });
@@ -158,9 +155,7 @@ export function HTTPDomainSummaryPage() {
                   <MetricReadout
                     title={DataTitles.avg}
                     value={
-                      domainMetrics?.[0]?.[
-                        `${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`
-                      ]
+                      domainMetrics?.[0]?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]
                     }
                     unit={DurationUnit.MILLISECOND}
                     isLoading={areDomainMetricsLoading}
@@ -179,9 +174,7 @@ export function HTTPDomainSummaryPage() {
 
             <ModuleLayout.Half>
               <DurationChart
-                series={
-                  durationData[`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`]
-                }
+                series={durationData[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]}
                 isLoading={isDurationDataLoading}
                 error={durationError}
               />

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -10,6 +10,7 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -25,6 +26,7 @@ import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {ModuleName, SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 
 type Query = {
@@ -44,6 +46,8 @@ export function HTTPDomainSummaryPage() {
     'span.module': ModuleName.HTTP,
     'span.domain': domain,
   };
+
+  const cursor = decodeScalar(location.query?.[QueryParameterNames.TRANSACTIONS_CURSOR]);
 
   const {data: domainMetrics, isLoading: areDomainMetricsLoading} = useSpanMetrics({
     filters,
@@ -85,6 +89,7 @@ export function HTTPDomainSummaryPage() {
     data: transactionsList,
     meta: transactionsListMeta,
     error: transactionsListError,
+    pageLinks: transactionsListPageLinks,
   } = useSpanMetrics({
     filters,
     fields: [
@@ -99,7 +104,7 @@ export function HTTPDomainSummaryPage() {
     ],
     sorts: [],
     limit: TRANSACTIONS_TABLE_ROW_COUNT,
-    cursor: '',
+    cursor,
     referrer: 'api.starfish.http-module-domain-summary-transactions-list',
   });
 
@@ -188,6 +193,7 @@ export function HTTPDomainSummaryPage() {
                 error={transactionsListError}
                 isLoading={isTransactionsListLoading}
                 meta={transactionsListMeta}
+                pageLinks={transactionsListPageLinks}
               />
             </ModuleLayout.Full>
           </ModuleLayout.Layout>

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -80,6 +80,20 @@ export function HTTPDomainSummaryPage() {
     referrer: 'api.starfish.http-module-domain-summary-duration-chart',
   });
 
+  const {
+    isLoading: isTransactionsListLoading,
+    data: transactionsList,
+    meta: transactionsListMeta,
+    error: transactionsListError,
+  } = useSpanMetrics({
+    filters,
+    fields: ['transaction', 'spm()'],
+    sorts: [],
+    limit: TRANSACTIONS_TABLE_ROW_COUNT,
+    cursor: '',
+    referrer: 'api.starfish.http-module-domain-summary-transactions-list',
+  });
+
   useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
 
   return (
@@ -160,7 +174,12 @@ export function HTTPDomainSummaryPage() {
             </ModuleLayout.Half>
 
             <ModuleLayout.Full>
-              <DomainTransactionsTable />
+              <DomainTransactionsTable
+                data={transactionsList}
+                error={transactionsListError}
+                isLoading={isTransactionsListLoading}
+                meta={transactionsListMeta}
+              />
             </ModuleLayout.Full>
           </ModuleLayout.Layout>
         </Layout.Main>
@@ -168,6 +187,8 @@ export function HTTPDomainSummaryPage() {
     </React.Fragment>
   );
 }
+
+const TRANSACTIONS_TABLE_ROW_COUNT = 20;
 
 const HeaderContainer = styled('div')`
   display: flex;

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -87,7 +87,16 @@ export function HTTPDomainSummaryPage() {
     error: transactionsListError,
   } = useSpanMetrics({
     filters,
-    fields: ['transaction', 'spm()'],
+    fields: [
+      'transaction',
+      'spm()',
+      'http_response_rate(2)',
+      'http_response_rate(4)',
+      'http_response_rate(5)',
+      'avg(span.self_time)',
+      'sum(span.self_time)',
+      'time_spent_percentage()',
+    ],
     sorts: [],
     limit: TRANSACTIONS_TABLE_ROW_COUNT,
     cursor: '',

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -16,6 +16,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {DurationChart} from 'sentry/views/performance/database/durationChart';
 import {ThroughputChart} from 'sentry/views/performance/database/throughputChart';
 import {useSelectedDurationAggregate} from 'sentry/views/performance/database/useSelectedDurationAggregate';
+import {DomainTransactionsTable} from 'sentry/views/performance/http/domainTransactionsTable';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
@@ -157,6 +158,10 @@ export function HTTPDomainSummaryPage() {
                 error={durationError}
               />
             </ModuleLayout.Half>
+
+            <ModuleLayout.Full>
+              <DomainTransactionsTable />
+            </ModuleLayout.Full>
           </ModuleLayout.Layout>
         </Layout.Main>
       </Layout.Body>

--- a/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
@@ -16,11 +16,7 @@ type Options = {
   column: GridColumnHeader<string>;
   location?: Location;
   sort?: Sort;
-  sortParameterName?:
-    | QueryParameterNames.ENDPOINTS_SORT
-    | QueryParameterNames.SPANS_SORT
-    | QueryParameterNames.DOMAINS_SORT
-    | typeof DEFAULT_SORT_PARAMETER_NAME;
+  sortParameterName?: QueryParameterNames | typeof DEFAULT_SORT_PARAMETER_NAME;
 };
 
 const DEFAULT_SORT_PARAMETER_NAME = 'sort';

--- a/static/app/views/starfish/views/queryParameters.tsx
+++ b/static/app/views/starfish/views/queryParameters.tsx
@@ -3,6 +3,8 @@ export enum QueryParameterNames {
   SPANS_SORT = 'spansSort',
   DOMAINS_CURSOR = 'domainsCursor',
   DOMAINS_SORT = 'domainsSort',
+  TRANSACTIONS_CURSOR = 'transactionsCursor',
+  TRANSACTIONS_SORT = 'transactionsSort',
   ENDPOINTS_CURSOR = 'endpointsCursor',
   ENDPOINTS_SORT = 'endpointsSort',
   PAGES_CURSOR = 'pagesCursor',


### PR DESCRIPTION
All the same stuff as the Queries module for now. More work coming soon!

**e.g.,**
<img width="1035" alt="Screenshot 2024-03-13 at 1 12 32 PM" src="https://github.com/getsentry/sentry/assets/989898/2e2b2e78-2418-4bd6-9adf-c12d251fe163">

Plus I snuck in a few small changes:

- `GridEditable` now accepts `aria-label`
- Removed the aggregate selector (that was a mistake in this module)

There's a bunch of repetitive code in here, so at some point this week I'll probably extract the column definitions and some other stuff into their own files.