### PR TITLE
ref(escalating): Remove TODOs from forecast task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1192,9 +1192,9 @@ CELERYBEAT_SCHEDULE_REGION = {
     "weekly-escalating-forecast": {
         "task": "sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",
         # TODO: Change this to run weekly once we verify the results
-        "schedule": crontab(minute="0", hour="*/6"),
+        "schedule": crontab(minute="0", hour="*/24"),
         # TODO: Increase expiry time to x4 once we change this to run weekly
-        "options": {"expires": 60 * 60 * 3},
+        "options": {"expires": 60 * 60 * 4},
     },
     "schedule_auto_transition_to_ongoing": {
         "task": "sentry.tasks.schedule_auto_transition_to_ongoing",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1191,10 +1191,8 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "weekly-escalating-forecast": {
         "task": "sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",
-        # TODO: Change this to run weekly once we verify the results
-        "schedule": crontab(minute="0", hour="*/24"),
-        # TODO: Increase expiry time to x4 once we change this to run weekly
-        "options": {"expires": 60 * 60 * 4},
+        "schedule": crontab(minute="0", hour="*/6"),
+        "options": {"expires": 60 * 60 * 3},
     },
     "schedule_auto_transition_to_ongoing": {
         "task": "sentry.tasks.schedule_auto_transition_to_ongoing",

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -30,7 +30,8 @@ ITERATOR_CHUNK = 10_000
 @instrumented_task(
     name="sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",
     queue="weekly_escalating_forecast",
-    max_retries=0,  # TODO: Increase this when the task is changed to run weekly
+    max_retries=2,  # TODO: Increase this when the task is changed to run weekly
+    default_retry_delay=60,
     silo_mode=SiloMode.REGION,
 )
 @monitor(monitor_slug="escalating-issue-forecast-job-monitor")

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -30,8 +30,7 @@ ITERATOR_CHUNK = 10_000
 @instrumented_task(
     name="sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",
     queue="weekly_escalating_forecast",
-    max_retries=2,  # TODO: Increase this when the task is changed to run weekly
-    default_retry_delay=60,
+    max_retries=0,
     silo_mode=SiloMode.REGION,
 )
 @monitor(monitor_slug="escalating-issue-forecast-job-monitor")


### PR DESCRIPTION
Remove TODOs from forecast task
Run forecast task every 6 hours instead of weekly since it's working well