### PR TITLE
ref(integrations): skip custom priority for resolved metric alerts

### DIFF
--- a/src/sentry/integrations/opsgenie/utils.py
+++ b/src/sentry/integrations/opsgenie/utils.py
@@ -47,8 +47,10 @@ def build_incident_attachment(
     return payload
 
 
-def attach_custom_priority(data: dict[str, Any], action: AlertRuleTriggerAction) -> dict[str, Any]:
-    if action.sentry_app_config is None:
+def attach_custom_priority(
+    data: dict[str, Any], action: AlertRuleTriggerAction, new_status: IncidentStatus
+) -> dict[str, Any]:
+    if new_status == IncidentStatus.CLOSED or action.sentry_app_config is None:
         return data
 
     priority = action.sentry_app_config.get("priority", OPSGENIE_DEFAULT_PRIORITY)
@@ -96,7 +98,7 @@ def send_incident_alert_notification(
     )
     client = install.get_keyring_client(keyid=team["id"])
     attachment = build_incident_attachment(incident, new_status, metric_value, notification_uuid)
-    attachment = attach_custom_priority(attachment, action)
+    attachment = attach_custom_priority(attachment, action, new_status)
 
     try:
         resp = client.send_notification(attachment)

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -123,9 +123,11 @@ def build_incident_attachment(
     }
 
 
-def attach_custom_severity(data: dict[str, Any], action: AlertRuleTriggerAction) -> dict[str, Any]:
+def attach_custom_severity(
+    data: dict[str, Any], action: AlertRuleTriggerAction, new_status: IncidentStatus
+) -> dict[str, Any]:
     # use custom severity (overrides default in build_incident_attachment)
-    if action.sentry_app_config is None:
+    if new_status == IncidentStatus.CLOSED or action.sentry_app_config is None:
         return data
 
     severity = action.sentry_app_config.get("priority", None)
@@ -187,7 +189,7 @@ def send_incident_alert_notification(
     attachment = build_incident_attachment(
         incident, integration_key, new_status, metric_value, notification_uuid
     )
-    attachment = attach_custom_severity(attachment, action)
+    attachment = attach_custom_severity(attachment, action, new_status)
 
     try:
         client.send_trigger(attachment)

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -232,12 +232,9 @@ class OpsgenieActionHandlerTest(FireTest):
     def test_custom_priority(self):
         # default critical incident priority is P1, custom set to P3
         self.action.update(sentry_app_config={"priority": "P3"})
-
         self.run_fire_test()
 
     @responses.activate
     def test_custom_priority_resolve(self):
-        # default critical incident priority is P1, custom set to P3
         self.action.update(sentry_app_config={"priority": "P3"})
-
         self.run_fire_test("resolve")

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -112,9 +112,11 @@ class OpsgenieActionHandlerTest(FireTest):
                 status=202,
             )
             expected_payload = {}
+            new_status = IncidentStatus.CLOSED
         else:
+            new_status = IncidentStatus.CRITICAL
             update_incident_status(
-                incident, IncidentStatus.CRITICAL, status_method=IncidentStatusMethod.RULE_TRIGGERED
+                incident, new_status, status_method=IncidentStatusMethod.RULE_TRIGGERED
             )
             responses.add(
                 responses.POST,
@@ -232,3 +234,10 @@ class OpsgenieActionHandlerTest(FireTest):
         self.action.update(sentry_app_config={"priority": "P3"})
 
         self.run_fire_test()
+
+    @responses.activate
+    def test_custom_priority_resolve(self):
+        # default critical incident priority is P1, custom set to P3
+        self.action.update(sentry_app_config={"priority": "P3"})
+
+        self.run_fire_test("resolve")

--- a/tests/sentry/incidents/action_handlers/test_opsgenie.py
+++ b/tests/sentry/incidents/action_handlers/test_opsgenie.py
@@ -124,10 +124,8 @@ class OpsgenieActionHandlerTest(FireTest):
                 json={},
                 status=202,
             )
-            expected_payload = build_incident_attachment(
-                incident, IncidentStatus(incident.status), metric_value=1000
-            )
-            expected_payload = attach_custom_priority(expected_payload, self.action)
+            expected_payload = build_incident_attachment(incident, new_status, metric_value=1000)
+            expected_payload = attach_custom_priority(expected_payload, self.action, new_status)
 
         handler = OpsgenieActionHandler(self.action, incident, self.project)
         metric_value = 1000

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -109,14 +109,15 @@ class PagerDutyActionHandlerTest(FireTest):
         )
         handler = PagerDutyActionHandler(self.action, incident, self.project)
         metric_value = 1000
+        new_status = IncidentStatus(incident.status)
         with self.tasks():
-            getattr(handler, method)(metric_value, IncidentStatus(incident.status))
+            getattr(handler, method)(metric_value, new_status)
         data = responses.calls[0].request.body
 
         expected_payload = build_incident_attachment(
-            incident, self.service["integration_key"], IncidentStatus(incident.status), metric_value
+            incident, self.service["integration_key"], new_status, metric_value
         )
-        expected_payload = attach_custom_severity(expected_payload, self.action)
+        expected_payload = attach_custom_severity(expected_payload, self.action, new_status)
 
         assert json.loads(data) == expected_payload
 
@@ -192,3 +193,9 @@ class PagerDutyActionHandlerTest(FireTest):
         # default closed incident severity is info, custom set to critical
         self.action.update(sentry_app_config={"priority": "critical"})
         self.run_fire_test()
+
+    @responses.activate
+    def test_custom_severity_resolved(self):
+        # default closed incident severity is info, custom set to critical
+        self.action.update(sentry_app_config={"priority": "critical"})
+        self.run_fire_test("resolve")

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -196,6 +196,5 @@ class PagerDutyActionHandlerTest(FireTest):
 
     @responses.activate
     def test_custom_severity_resolved(self):
-        # default closed incident severity is info, custom set to critical
         self.action.update(sentry_app_config={"priority": "critical"})
         self.run_fire_test("resolve")


### PR DESCRIPTION
The default Pagerduty `severity` for a resolved alert is `info`, and Opsgenie hits a different API to resolve an alert compared to when creating an alert. We don't want to override or pass extra params in these cases.

In the API and UI it is not possible to create actions for `IncidentStatuses` other than `critical` or `warning`, but in the incident resolved flow we fetch all (deduped) `AlertRuleTriggerActions` to fire them to resolve the incident in the appropriate places here:
https://github.com/getsentry/sentry/blob/ddb7940d3d6463e06586ef7c9060c62b1b197171/src/sentry/incidents/logic.py#L1067-L1089

This means we are calling the existing actions, and there might be Pagerduty and Opsgenie actions with a `priority` set, which we need to ignore.

For https://github.com/getsentry/sentry/issues/58830
For https://github.com/getsentry/sentry/issues/54921