### PR TITLE
fix(open-pr-comments): Update Regex for Snuba Query Error

### DIFF
--- a/src/sentry/tasks/integrations/github/language_parsers.py
+++ b/src/sentry/tasks/integrations/github/language_parsers.py
@@ -193,7 +193,7 @@ class JavascriptParser(LanguageParser):
     """
     function_declaration_regex = r"^@@.*@@[^=]*?\s*function\s+(?P<fnc>[^\(]*)\(.*$"
     arrow_function_regex = (
-        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^=]*)\s+=[^>|^\n]*[\(^\n*\)]?\s*=>.*$"
+        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^=\n]*)\s+=[^>\n]*[\(^\n*\)]?\s*=>.*$"
     )
     function_expression_regex = (
         r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(]*)\s+=.*\s+function.*\(.*$"

--- a/src/sentry/tasks/integrations/github/language_parsers.py
+++ b/src/sentry/tasks/integrations/github/language_parsers.py
@@ -196,10 +196,10 @@ class JavascriptParser(LanguageParser):
         r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^=\n]*)\s+=[^>\n]*[\(^\n*\)]?\s*=>.*$"
     )
     function_expression_regex = (
-        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(]*)\s+=.*\s+function.*\(.*$"
+        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(\n]*)\s+=.*\s+function.*\(.*$"
     )
     function_constructor_regex = (
-        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(]*)\s+=\s+new\s+Function\(.*$"
+        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(\n]*)\s+=\s+new\s+Function\(.*$"
     )
 
     regexes = [

--- a/tests/sentry/tasks/integrations/github/test_language_parsers.py
+++ b/tests/sentry/tasks/integrations/github/test_language_parsers.py
@@ -578,10 +578,10 @@ class JavascriptParserTestCase(TestCase):
             "SeeMoreCard",
         }
 
-    def test_arrow_functions(self):
+    def test_javascript_functions_after_const(self):
 
         patch = """
-          "@@ -149,6 +149,12 @@ export const Redacted Redacted\n   // Redacted.\n   // Redacted \n   const redacted = redacted;\n+  const redacted = redacted();\n+  // const redacted = true;\n+  const redacted = redacted()\n+    redacted; // Redacted\nconst \n@@ -165,24 +171,40 @@ export const RedactedRedactedRedactedRedactedRedacted
+          "@@ -305,9 +285,7 @@ export const Redacted Redacted\n   // Redacted.\n   // Redacted \n   const redacted = redacted;\n+  const redacted = redacted();\n+  // const redacted = true;\n+  const redacted = redacted()\n+    redacted; // Redacted\nconst \n@@ -165,24 +171,40 @@ export const RedactedRedactedRedactedRedactedRedacted
 
           // Redacted
 @@44,38@@ var arrow2 = (a, ...b) => 0;
@@ -589,6 +589,37 @@ class JavascriptParserTestCase(TestCase):
 
         assert JavascriptParser.extract_functions_from_patch(patch) == {
             "arrow2",
+        }
+
+        patch = """
+            "@@ -305,9 +285,7 @@ export const Redacted Redacted\n   // Redacted.\n   // Redacted \n   const redacted = redacted;\n+  const redacted = redacted();\n+  // const redacted = true;\n+  const redacted = redacted()\n+    redacted; // Redacted\nconst \n@@ -165,24 +171,40@@ export const RedactedRedactedRedactedRedactedRedacted
+
+            // Redacted
+@@44,38@@ const planet = async function(argument) {
+"""
+        assert JavascriptParser.extract_functions_from_patch(patch) == {
+            "planet",
+        }
+
+        patch = """
+            "@@ -305,9 +285,7 @@ export const Redacted Redacted\n   // Redacted.\n   // Redacted \n   const redacted = redacted;\n+  const redacted = redacted();\n+  // const redacted = true;\n+  const redacted = redacted()\n+    redacted; // Redacted\nconst \n@@ -165,24 +171,40@@ export const RedactedRedactedRedactedRedactedRedacted
+
+            // Redacted
+@@44,38@@ const constructor = new Function(
+"""
+        assert JavascriptParser.extract_functions_from_patch(patch) == {
+            "constructor",
+        }
+
+        patch = """
+            "@@ -305,9 +285,7 @@ export const Redacted Redacted\n   // Redacted.\n   // Redacted \n   const redacted = redacted;\n+  const redacted = redacted();\n+  // const redacted = true;\n+  const redacted = redacted()\n+    redacted; // Redacted\nconst \n@@ -165,24 +171,40@@ export const RedactedRedactedRedactedRedactedRedacted
+
+            // Redacted
+@@44,38@@ function hello(argument1, argument2)
+
+"""
+        assert JavascriptParser.extract_functions_from_patch(patch) == {
+            "hello",
         }
 
 

--- a/tests/sentry/tasks/integrations/github/test_language_parsers.py
+++ b/tests/sentry/tasks/integrations/github/test_language_parsers.py
@@ -585,33 +585,16 @@ class JavascriptParserTestCase(TestCase):
 
           // Redacted
 @@44,38@@ var arrow2 = (a, ...b) => 0;
-    """
 
-        assert JavascriptParser.extract_functions_from_patch(patch) == {
-            "arrow2",
-        }
 
-        patch = """
             "@@ -305,9 +285,7 @@ export const Redacted Redacted\n   // Redacted.\n   // Redacted \n   const redacted = redacted;\n+  const redacted = redacted();\n+  // const redacted = true;\n+  const redacted = redacted()\n+    redacted; // Redacted\nconst \n@@ -165,24 +171,40@@ export const RedactedRedactedRedactedRedactedRedacted
 
             // Redacted
 @@44,38@@ const planet = async function(argument) {
-"""
-        assert JavascriptParser.extract_functions_from_patch(patch) == {
-            "planet",
-        }
-
-        patch = """
             "@@ -305,9 +285,7 @@ export const Redacted Redacted\n   // Redacted.\n   // Redacted \n   const redacted = redacted;\n+  const redacted = redacted();\n+  // const redacted = true;\n+  const redacted = redacted()\n+    redacted; // Redacted\nconst \n@@ -165,24 +171,40@@ export const RedactedRedactedRedactedRedactedRedacted
 
             // Redacted
 @@44,38@@ const constructor = new Function(
-"""
-        assert JavascriptParser.extract_functions_from_patch(patch) == {
-            "constructor",
-        }
-
-        patch = """
             "@@ -305,9 +285,7 @@ export const Redacted Redacted\n   // Redacted.\n   // Redacted \n   const redacted = redacted;\n+  const redacted = redacted();\n+  // const redacted = true;\n+  const redacted = redacted()\n+    redacted; // Redacted\nconst \n@@ -165,24 +171,40@@ export const RedactedRedactedRedactedRedactedRedacted
 
             // Redacted
@@ -619,6 +602,9 @@ class JavascriptParserTestCase(TestCase):
 
 """
         assert JavascriptParser.extract_functions_from_patch(patch) == {
+            "arrow2",
+            "planet",
+            "constructor",
             "hello",
         }
 

--- a/tests/sentry/tasks/integrations/github/test_language_parsers.py
+++ b/tests/sentry/tasks/integrations/github/test_language_parsers.py
@@ -578,6 +578,19 @@ class JavascriptParserTestCase(TestCase):
             "SeeMoreCard",
         }
 
+    def test_arrow_functions(self):
+
+        patch = """
+          "@@ -149,6 +149,12 @@ export const Redacted Redacted\n   // Redacted.\n   // Redacted \n   const redacted = redacted;\n+  const redacted = redacted();\n+  // const redacted = true;\n+  const redacted = redacted()\n+    redacted; // Redacted\nconst \n@@ -165,24 +171,40 @@ export const RedactedRedactedRedactedRedactedRedacted
+
+          // Redacted
+@@44,38@@ var arrow2 = (a, ...b) => 0;
+    """
+
+        assert JavascriptParser.extract_functions_from_patch(patch) == {
+            "arrow2",
+        }
+
 
 class PHPParserTestCase(TestCase):
     def test_php_simple(self):


### PR DESCRIPTION
* I updated the regex query so when looking for a function name during arrow functions, we make sure we don't grab other tokens from the patch that exist before the declaration by ignoring matches that include an end line after a const declaration (and before any function keyword)
* Fixed unrelated regex bug with the ignore list to match how python regex syntax
* Wrote tests

Fixes:  https://github.com/getsentry/team-core-product-foundations/issues/162