### PR TITLE
fix(ci): Fix Prettier false negatives in local environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
     "fix": "yarn fix:biome && yarn fix:prettier && yarn fix:eslint",
     "fix:eslint": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx --fix",
     "fix:biome": "biome check . --apply",
-    "fix:prettier": "prettier **/*.md **/*.yaml **/*.{ts,tsx} --write",
+    "fix:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.{ts,tsx}\" --write",
     "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver",
     "dev-ui": "SENTRY_UI_DEV_ONLY=1 SENTRY_WEBPACK_PROXY_PORT=7999 yarn webpack serve",
     "dev-acceptance": "NO_DEV_SERVER=1 NODE_ENV=development yarn webpack --watch",

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "lint:js": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx",
     "lint:css": "stylelint 'static/app/**/*.[jt]sx'",
     "lint:biome": "biome check .",
-    "lint:prettier": "prettier **/*.md **/*.yaml **/*.{ts,tsx} --check",
+    "lint:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.{ts,tsx}\" --check",
     "fix": "yarn fix:biome && yarn fix:prettier && yarn fix:eslint",
     "fix:eslint": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx --fix",
     "fix:biome": "biome check . --apply",

--- a/src/sentry/templates/sentry/js-sdk-loader.ts
+++ b/src/sentry/templates/sentry/js-sdk-loader.ts
@@ -161,7 +161,7 @@ declare const __LOADER__IS_LAZY__: any;
     if (config.tracesSampleRate && integrationNames.indexOf('BrowserTracing') === -1) {
       if (SDK.browserTracingIntegration) {
         // (Post-)v8 version of the BrowserTracing integration
-        integrations.push(SDK.browserTracingIntegration({ enableInp: true }));
+        integrations.push(SDK.browserTracingIntegration({enableInp: true}));
       } else if (SDK.BrowserTracing) {
         // Pre v8 version of the BrowserTracing integration
         integrations.push(new SDK.BrowserTracing());


### PR DESCRIPTION
We're seeing a lot of CI failures where Prettier complains of errors that don't show up locally. Bizarre, but fixed by wrapping the wildcards in the command. Doesn't explain why opening the file in VS Code doesn't correct the problem, but one thing at a time.
