### PR TITLE
feat(trace): autozoom on node when view loads

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -226,10 +226,7 @@ function Trace({
       }
 
       if (maybeNode.node.space) {
-        const start = maybeNode.node.space[0];
-        const width = maybeNode.node.space[1];
-        const margin = 0.2 * width;
-        manager.animateViewTo(start - margin, width + margin * 2);
+        manager.animateViewTo(maybeNode.node.space);
       }
 
       manager.onScrollEndOutOfBoundsCheck();

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -225,6 +225,13 @@ function Trace({
         return;
       }
 
+      if (maybeNode.node.space) {
+        const start = maybeNode.node.space[0];
+        const width = maybeNode.node.space[1];
+        const margin = 0.2 * width;
+        manager.animateViewTo(start - margin, width + margin * 2);
+      }
+
       manager.onScrollEndOutOfBoundsCheck();
       setDetailNode(maybeNode.node);
       roving_dispatch({

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -526,8 +526,12 @@ export class VirtualizedViewManager {
     }
   }
 
-  animateViewTo(x: number, width: number) {
-    this.setTraceView({x: x - this.to_origin, width: width});
+  animateViewTo(node_space: [number, number]) {
+    const start = node_space[0];
+    const width = node_space[1] > 0 ? node_space[1] : this.trace_view.width;
+    const margin = 0.2 * width;
+
+    this.setTraceView({x: start - margin - this.to_origin, width: width + margin * 2});
     this.draw();
   }
 

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -507,7 +507,6 @@ export class VirtualizedViewManager {
     }
   }
 
-  zoomIntoSpaceRaf: number | null = null;
   onBringRowIntoView(space: [number, number]) {
     if (this.zoomIntoSpaceRaf !== null) {
       window.cancelAnimationFrame(this.zoomIntoSpaceRaf);
@@ -527,6 +526,12 @@ export class VirtualizedViewManager {
     }
   }
 
+  animateViewTo(x: number, width: number) {
+    this.setTraceView({x: x - this.to_origin, width: width});
+    this.draw();
+  }
+
+  zoomIntoSpaceRaf: number | null = null;
   onZoomIntoSpace(space: [number, number]) {
     if (space[1] <= 0) {
       // @TODO implement scrolling to 0 width spaces


### PR DESCRIPTION
Autozooms on node with 20% margin on each side so as to preserve some context