### PR TITLE
feat(perf): Add HTTP module response code rate charts

### DIFF
--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -125,6 +125,35 @@ describe('HTTPSummaryPage', function () {
       })
     );
 
+    expect(domainChartsRequestMock).toHaveBeenNthCalledWith(
+      3,
+      `/organizations/${organization.slug}/events-stats/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          cursor: undefined,
+          dataset: 'spansMetrics',
+          environment: [],
+          excludeOther: 0,
+          field: [],
+          interval: '30m',
+          orderby: undefined,
+          partial: 1,
+          per_page: 50,
+          project: [],
+          query: 'span.module:http span.domain:"\\*.sentry.dev"',
+          referrer: 'api.starfish.http-module-domain-summary-response-code-chart',
+          statsPeriod: '10d',
+          topEvents: undefined,
+          yAxis: [
+            'http_response_rate(3)',
+            'http_response_rate(4)',
+            'http_response_rate(5)',
+          ],
+        },
+      })
+    );
+
     expect(domainTransactionsListRequestMock).toHaveBeenNthCalledWith(
       2,
       `/organizations/${organization.slug}/events/`,

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -20,6 +20,7 @@ import {
   isAValidSort,
 } from 'sentry/views/performance/http/domainTransactionsTable';
 import {DurationChart} from 'sentry/views/performance/http/durationChart';
+import {ResponseRateChart} from 'sentry/views/performance/http/responseRateChart';
 import {ThroughputChart} from 'sentry/views/performance/http/throughputChart';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
@@ -87,6 +88,16 @@ export function HTTPDomainSummaryPage() {
     yAxis: [`avg(${SpanMetricsField.SPAN_SELF_TIME})`],
     enabled: Boolean(domain),
     referrer: 'api.starfish.http-module-domain-summary-duration-chart',
+  });
+
+  const {
+    isLoading: isResponseCodeDataLoading,
+    data: responseCodeData,
+    error: responseCodeError,
+  } = useSpanMetricsSeries({
+    filters: filters,
+    yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
+    referrer: 'api.starfish.http-module-domain-summary-response-code-chart',
   });
 
   const {
@@ -172,21 +183,42 @@ export function HTTPDomainSummaryPage() {
               </HeaderContainer>
             </ModuleLayout.Full>
 
-            <ModuleLayout.Half>
+            <ModuleLayout.Third>
               <ThroughputChart
                 series={throughputData['spm()']}
                 isLoading={isThroughputDataLoading}
                 error={throughputError}
               />
-            </ModuleLayout.Half>
+            </ModuleLayout.Third>
 
-            <ModuleLayout.Half>
+            <ModuleLayout.Third>
               <DurationChart
                 series={durationData[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]}
                 isLoading={isDurationDataLoading}
                 error={durationError}
               />
-            </ModuleLayout.Half>
+            </ModuleLayout.Third>
+
+            <ModuleLayout.Third>
+              <ResponseRateChart
+                series={[
+                  {
+                    ...responseCodeData[`http_response_rate(3)`],
+                    seriesName: t('3XX'),
+                  },
+                  {
+                    ...responseCodeData[`http_response_rate(4)`],
+                    seriesName: t('4XX'),
+                  },
+                  {
+                    ...responseCodeData[`http_response_rate(5)`],
+                    seriesName: t('5XX'),
+                  },
+                ]}
+                isLoading={isResponseCodeDataLoading}
+                error={responseCodeError}
+              />
+            </ModuleLayout.Third>
 
             <ModuleLayout.Full>
               <DomainTransactionsTable

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -137,6 +137,35 @@ describe('HTTPLandingPage', function () {
       })
     );
 
+    expect(spanChartsRequestMock).toHaveBeenNthCalledWith(
+      3,
+      `/organizations/${organization.slug}/events-stats/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          cursor: undefined,
+          dataset: 'spansMetrics',
+          environment: [],
+          excludeOther: 0,
+          field: [],
+          interval: '30m',
+          orderby: undefined,
+          partial: 1,
+          per_page: 50,
+          project: [],
+          query: 'span.module:http has:span.domain',
+          referrer: 'api.starfish.http-module-landing-response-code-chart',
+          statsPeriod: '10d',
+          topEvents: undefined,
+          yAxis: [
+            'http_response_rate(3)',
+            'http_response_rate(4)',
+            'http_response_rate(5)',
+          ],
+        },
+      })
+    );
+
     expect(spanListRequestMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/events/`,
       expect.objectContaining({

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -16,6 +16,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
 import {DomainsTable, isAValidSort} from 'sentry/views/performance/http/domainsTable';
 import {DurationChart} from 'sentry/views/performance/http/durationChart';
+import {ResponseRateChart} from 'sentry/views/performance/http/responseRateChart';
 import {ThroughputChart} from 'sentry/views/performance/http/throughputChart';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
@@ -65,6 +66,16 @@ export function HTTPLandingPage() {
     filters: chartFilters,
     yAxis: [`avg(span.self_time)`],
     referrer: 'api.starfish.http-module-landing-duration-chart',
+  });
+
+  const {
+    isLoading: isResponseCodeDataLoading,
+    data: responseCodeData,
+    error: responseCodeError,
+  } = useSpanMetricsSeries({
+    filters: chartFilters,
+    yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
+    referrer: 'api.starfish.http-module-landing-response-code-chart',
   });
 
   const domainsListResponse = useSpanMetrics({
@@ -128,21 +139,42 @@ export function HTTPLandingPage() {
 
             {!onboardingProject && (
               <Fragment>
-                <ModuleLayout.Half>
+                <ModuleLayout.Third>
                   <ThroughputChart
                     series={throughputData['spm()']}
                     isLoading={isThroughputDataLoading}
                     error={throughputError}
                   />
-                </ModuleLayout.Half>
+                </ModuleLayout.Third>
 
-                <ModuleLayout.Half>
+                <ModuleLayout.Third>
                   <DurationChart
                     series={durationData[`avg(span.self_time)`]}
                     isLoading={isDurationDataLoading}
                     error={durationError}
                   />
-                </ModuleLayout.Half>
+                </ModuleLayout.Third>
+
+                <ModuleLayout.Third>
+                  <ResponseRateChart
+                    series={[
+                      {
+                        ...responseCodeData[`http_response_rate(3)`],
+                        seriesName: t('3XX'),
+                      },
+                      {
+                        ...responseCodeData[`http_response_rate(4)`],
+                        seriesName: t('4XX'),
+                      },
+                      {
+                        ...responseCodeData[`http_response_rate(5)`],
+                        seriesName: t('5XX'),
+                      },
+                    ]}
+                    isLoading={isResponseCodeDataLoading}
+                    error={responseCodeError}
+                  />
+                </ModuleLayout.Third>
 
                 <ModuleLayout.Full>
                   <DomainsTable response={domainsListResponse} sort={sort} />

--- a/static/app/views/performance/http/responseRateChart.spec.tsx
+++ b/static/app/views/performance/http/responseRateChart.spec.tsx
@@ -1,0 +1,48 @@
+import type {Series} from 'sentry/types/echarts';
+import {getAxisMaxForPercentageSeries} from 'sentry/views/performance/http/responseRateChart';
+
+describe('ResponseRateChart', function () {
+  describe('getAxisMaxForPercentageSeries', function () {
+    it('Returns nearest significant digit for small series', function () {
+      expect(getAxisMaxForPercentageSeries([HTTP_5XX_SERIES])).toBeCloseTo(0.0001);
+    });
+
+    it('Returns 1 for larger series', function () {
+      expect(getAxisMaxForPercentageSeries([HTTP_2XX_SERIES])).toBeCloseTo(1);
+    });
+
+    it('Takes all series into account', function () {
+      expect(
+        getAxisMaxForPercentageSeries([HTTP_2XX_SERIES, HTTP_5XX_SERIES])
+      ).toBeCloseTo(1);
+    });
+  });
+});
+
+const HTTP_2XX_SERIES: Series = {
+  seriesName: '5XX',
+  data: [
+    {
+      value: 0.9812,
+      name: '2024-03-12T13:30:00-04:00',
+    },
+    {
+      value: 0.9992,
+      name: '2024-03-12T14:00:00-04:00',
+    },
+  ],
+};
+
+const HTTP_5XX_SERIES: Series = {
+  seriesName: '5XX',
+  data: [
+    {
+      value: 0.00006713689346852019,
+      name: '2024-03-12T13:30:00-04:00',
+    },
+    {
+      value: 0.000041208717375685543,
+      name: '2024-03-12T14:00:00-04:00',
+    },
+  ],
+};

--- a/static/app/views/performance/http/responseRateChart.tsx
+++ b/static/app/views/performance/http/responseRateChart.tsx
@@ -1,0 +1,62 @@
+import type {Series} from 'sentry/types/echarts';
+import {formatPercentage} from 'sentry/utils/formatters';
+import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
+import {
+  HTTP_RESPONSE_3XX_COLOR,
+  HTTP_RESPONSE_4XX_COLOR,
+  HTTP_RESPONSE_5XX_COLOR,
+} from 'sentry/views/starfish/colours';
+import Chart from 'sentry/views/starfish/components/chart';
+import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+
+interface Props {
+  isLoading: boolean;
+  series: [Series, Series, Series];
+  error?: Error | null;
+}
+
+export function ResponseRateChart({series, isLoading, error}: Props) {
+  return (
+    <ChartPanel title={DataTitles.unsuccessfulHTTPCodes}>
+      <Chart
+        height={CHART_HEIGHT}
+        grid={{
+          left: '4px',
+          right: '0',
+          top: '8px',
+          bottom: '0',
+        }}
+        data={series}
+        loading={isLoading}
+        error={error}
+        chartColors={[
+          HTTP_RESPONSE_3XX_COLOR,
+          HTTP_RESPONSE_4XX_COLOR,
+          HTTP_RESPONSE_5XX_COLOR,
+        ]}
+        isLineChart
+        aggregateOutputFormat="percentage"
+        dataMax={getAxisMaxForPercentageSeries(series)}
+        tooltipFormatterOptions={{
+          valueFormatter: value => formatPercentage(value),
+        }}
+      />
+    </ChartPanel>
+  );
+}
+
+/**
+ * Given a set of `Series` objects that contain percentage data (i.e., every item in `data` has a `value` between 0 and 1) return an appropriate max value.
+ *
+ * e.g., for series with very low values (like 5xx rates), it rounds to the nearest significant digit. For other cases, it limits it to 100
+ */
+export function getAxisMaxForPercentageSeries(series: Series[]): number {
+  const maxValue = Math.max(
+    ...series.map(serie => Math.max(...serie.data.map(datum => datum.value)))
+  );
+
+  const maxNumberOfDecimalPlaces = Math.ceil(Math.min(0, Math.log10(maxValue)));
+
+  return Math.pow(10, maxNumberOfDecimalPlaces);
+}

--- a/static/app/views/starfish/colours.tsx
+++ b/static/app/views/starfish/colours.tsx
@@ -8,6 +8,10 @@ export const P95_COLOR = CHART_PALETTE[0][0];
 export const AVG_COLOR = CHART_PALETTE[0][0];
 export const ERRORS_COLOR = CHART_PALETTE[5][3];
 
+export const HTTP_RESPONSE_3XX_COLOR = CHART_PALETTE[2][0];
+export const HTTP_RESPONSE_4XX_COLOR = CHART_PALETTE[2][2];
+export const HTTP_RESPONSE_5XX_COLOR = CHART_PALETTE[2][1];
+
 export const COLD_START_COLOR = '#3C74DD';
 export const WARM_START_COLOR = '#3A2D96';
 

--- a/static/app/views/starfish/views/spans/types.tsx
+++ b/static/app/views/starfish/views/spans/types.tsx
@@ -19,7 +19,8 @@ export type DataKey =
   | 'avg(http.response_content_length)'
   | 'avg(http.decoded_response_content_length)'
   | 'avg(http.response_transfer_size)'
-  | 'bundleSize';
+  | 'bundleSize'
+  | 'unsuccessfulHTTPCodes';
 
 export const DataTitles: Record<DataKey, string> = {
   change: t('Change'),
@@ -39,6 +40,7 @@ export const DataTitles: Record<DataKey, string> = {
   'avg(http.response_content_length)': t('Avg Encoded Size'),
   'avg(http.decoded_response_content_length)': t('Avg Decoded Size'),
   'avg(http.response_transfer_size)': t('Avg Transfer Size'),
+  unsuccessfulHTTPCodes: t('Response Codes (3XX, 4XX, 5XX)'),
 };
 
 export const getThroughputTitle = (


### PR DESCRIPTION
**e.g.,**
<img width="540" alt="Screenshot 2024-03-13 at 2 15 16 PM" src="https://github.com/getsentry/sentry/assets/989898/743cb4e1-fc75-424c-a1d1-e6a4ecb6f4fa">
