### PR TITLE
feat(metrics): Search on non zero span groups in another query

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -190,7 +190,7 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
             "detail": ErrorDetail(string="Unsupported sort: id for MRI", code="parse_error")
         }
 
-    def test_span_exclusive_time_samples(self):
+    def test_span_exclusive_time_samples_zero_group(self):
         durations = [100, 200, 300]
         span_ids = [uuid4().hex[:16] for _ in durations]
         good_span_id = span_ids[1]
@@ -206,7 +206,6 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 duration=duration,
                 exclusive_time=duration,
                 timestamp=ts,
-                group=uuid4().hex[:16],  # we need a non 0 group
             )
 
         query = {
@@ -267,7 +266,6 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 span_id=span_id,
                 duration=duration,
                 timestamp=ts,
-                group=uuid4().hex[:16],  # we need a non 0 group
                 measurements={
                     measurement: duration + j + 1
                     for j, measurement in enumerate(
@@ -289,7 +287,6 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 uuid4().hex,
                 span_id=uuid4().hex[:16],
                 timestamp=ts,
-                group=uuid4().hex[:16],  # we need a non 0 group
             )
 
         for i, mri in enumerate(
@@ -527,7 +524,6 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 span_id=span_id,
                 duration=val,
                 timestamp=ts,
-                group=uuid4().hex[:16],  # we need a non 0 group
                 store_metrics_summary={
                     mri: [
                         {
@@ -547,7 +543,6 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
             uuid4().hex,
             span_id=uuid4().hex[:16],
             timestamp=before_now(days=10, minutes=10).replace(microsecond=0),
-            group=uuid4().hex[:16],  # we need a non 0 group
             store_metrics_summary={
                 "d:custom/other@millisecond": [
                     {
@@ -628,7 +623,6 @@ class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
                 duration=value,
                 exclusive_time=value,
                 timestamp=ts,
-                group=uuid4().hex[:16],  # we need a non 0 group
                 measurements={"score.total": value},
                 store_metrics_summary={
                     custom_mri: [


### PR DESCRIPTION
The spans samples query currently only searches on non zero span groups. Here we allow a second query to search on the zero span group. It's possible this second query can time out but we'll have to test to see.

This change also has the implication that the sorted spans query will get slower but that query already times out quite frequently already.