### PR TITLE
ci: Remove relaxed mode from eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,6 @@
 **/dist/**/*
 **/vendor/**/*
 **/tests/**/fixtures/**/*
-/scripts/*.js
 !.github
 !.github/workflows/scripts/*
 *.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,26 +1,21 @@
 /* eslint-env node */
 
-const isRelaxed = !!process.env.SENTRY_ESLINT_RELAXED;
-
-// Strict ruleset that runs on pre-commit and in local environments
-const ADDITIONAL_HOOKS_TO_CHECK_DEPS_FOR =
-  '(useEffectAfterFirstRender|useMemoWithPrevious)';
-
 module.exports = {
   root: true,
-  extends: [isRelaxed ? 'sentry-app' : 'sentry-app/strict'],
+  extends: ['sentry-app/strict'],
   globals: {
-    require: false,
     expect: false,
-    sinon: false,
-    MockApiClient: true,
-    tick: true,
     jest: true,
+    MockApiClient: true,
+    require: false,
+    sinon: false,
+    tick: true,
   },
+
   rules: {
     'react-hooks/exhaustive-deps': [
       'error',
-      {additionalHooks: ADDITIONAL_HOOKS_TO_CHECK_DEPS_FOR},
+      {additionalHooks: '(useEffectAfterFirstRender|useMemoWithPrevious)'},
     ],
 
     // TODO(@anonrig): Remove this from eslint-sentry-config

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
-**/relay_integration/**/*
 **/tests/**/fixtures/**/*
 fixtures/**/*
+tests/relay_integration/**/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+**/relay_integration/**/*
+**/tests/**/fixtures/**/*
+fixtures/**/*

--- a/package.json
+++ b/package.json
@@ -227,11 +227,11 @@
     "lint:js": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx",
     "lint:css": "stylelint 'static/app/**/*.[jt]sx'",
     "lint:biome": "biome check .",
-    "lint:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.[jt]s?(x)\" --check",
+    "lint:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.[jt]s(x)?\" --check",
     "fix": "yarn fix:biome && yarn fix:prettier && yarn fix:eslint",
     "fix:eslint": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx --fix",
     "fix:biome": "biome check . --apply",
-    "fix:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.[jt]s?(x)\" --write",
+    "fix:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.[jt]s(x)?\" --write",
     "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver",
     "dev-ui": "SENTRY_UI_DEV_ONLY=1 SENTRY_WEBPACK_PROXY_PORT=7999 yarn webpack serve",
     "dev-acceptance": "NO_DEV_SERVER=1 NODE_ENV=development yarn webpack --watch",
@@ -266,9 +266,7 @@
       "last 3 iOS major versions",
       "Firefox ESR"
     ],
-    "test": [
-      "current node"
-    ]
+    "test": ["current node"]
   },
   "volta": {
     "extends": ".volta.json"

--- a/package.json
+++ b/package.json
@@ -227,11 +227,11 @@
     "lint:js": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx",
     "lint:css": "stylelint 'static/app/**/*.[jt]sx'",
     "lint:biome": "biome check .",
-    "lint:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.{ts,tsx}\" --check",
+    "lint:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.[jt]s?(x)\" --check",
     "fix": "yarn fix:biome && yarn fix:prettier && yarn fix:eslint",
     "fix:eslint": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx --fix",
     "fix:biome": "biome check . --apply",
-    "fix:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.{ts,tsx}\" --write",
+    "fix:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.[jt]s?(x)\" --write",
     "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver",
     "dev-ui": "SENTRY_UI_DEV_ONLY=1 SENTRY_WEBPACK_PROXY_PORT=7999 yarn webpack serve",
     "dev-acceptance": "NO_DEV_SERVER=1 NODE_ENV=development yarn webpack --watch",
@@ -266,7 +266,9 @@
       "last 3 iOS major versions",
       "Firefox ESR"
     ],
-    "test": ["current node"]
+    "test": [
+      "current node"
+    ]
   },
   "volta": {
     "extends": ".volta.json"


### PR DESCRIPTION
Quick update to remove `SENTRY_ESLINT_RELAXED` from the eslint config, and make that file look a little more similar to the getsentry version.

The GETSENTRY version of this is https://github.com/getsentry/getsentry/pull/13274

also i took the chance to update prettier, since it runs under eslint, to make sure that we're treating all js & ts files the same. Treating files the same is a followup of https://github.com/getsentry/sentry/pull/66837

