### PR TITLE
feat(replay): add component name to rage click issue data if it exists

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -396,8 +396,8 @@ def _handle_breadcrumb(
                                 payload["message"],
                                 payload["data"]["url"],
                                 payload["data"]["node"],
-                                replay_event,
                                 payload["data"]["node"]["attributes"].get("data-sentry-component"),
+                                replay_event,
                             )
         # Log the event for tracking.
         log = event["data"].get("payload", {}).copy()

--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -397,6 +397,7 @@ def _handle_breadcrumb(
                                 payload["data"]["url"],
                                 payload["data"]["node"],
                                 replay_event,
+                                payload["data"]["node"]["attributes"].get("data-sentry-component"),
                             )
         # Log the event for tracking.
         log = event["data"].get("payload", {}).copy()

--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -22,8 +22,8 @@ def report_rage_click_issue_with_replay_event(
     selector: str,
     url: str,
     node: dict[str, Any],
-    replay_event: dict[str, Any],
     component_name: str | None,
+    replay_event: dict[str, Any],
 ):
     metrics.incr("replay.rage_click_issue_creation_with_replay_event")
 
@@ -35,8 +35,7 @@ def report_rage_click_issue_with_replay_event(
     clicked_element = selector.split(" > ")[-1]
     component_name = component_name
     evidence = [
-        IssueEvidence(name="Clicked Element", value=clicked_element, important=True),
-        IssueEvidence(name="Selector Path", value=selector, important=True),
+        IssueEvidence(name="Clicked Element", value=clicked_element, important=False),
     ]
     evidence_data = {
         # RRWeb node data of clicked element.
@@ -46,10 +45,19 @@ def report_rage_click_issue_with_replay_event(
     }
 
     if component_name:
-        evidence.append(
-            IssueEvidence(name="React Component Name", value=component_name, important=True),
+        # component name is important
+        evidence.extend(
+            [
+                IssueEvidence(name="Selector Path", value=selector, important=False),
+                IssueEvidence(name="React Component Name", value=component_name, important=True),
+            ],
         )
         evidence_data.update({"component_name": component_name})
+    else:
+        # selector path is important
+        evidence.append(
+            IssueEvidence(name="Selector Path", value=selector, important=True),
+        )
 
     new_issue_occurrence(
         culprit=url[:MAX_CULPRIT_LENGTH],

--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -38,11 +38,18 @@ def report_rage_click_issue_with_replay_event(
         IssueEvidence(name="Clicked Element", value=clicked_element, important=True),
         IssueEvidence(name="Selector Path", value=selector, important=True),
     ]
+    evidence_data = {
+        # RRWeb node data of clicked element.
+        "node": node,
+        # CSS selector path to clicked element.
+        "selector": selector,
+    }
 
     if component_name:
         evidence.append(
             IssueEvidence(name="React Component Name", value=component_name, important=True),
         )
+        evidence_data.update({"component_name": component_name})
 
     new_issue_occurrence(
         culprit=url[:MAX_CULPRIT_LENGTH],
@@ -57,12 +64,7 @@ def report_rage_click_issue_with_replay_event(
         subtitle=selector,
         timestamp=timestamp_utc,
         title=RAGE_CLICK_TITLE,
-        evidence_data={
-            # RRWeb node data of clicked element.
-            "node": node,
-            # CSS selector path to clicked element.
-            "selector": selector,
-        },
+        evidence_data=evidence_data,
         evidence_display=evidence,
         extra_event_data={
             "contexts": _make_contexts(replay_id, replay_event),

--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -23,6 +23,7 @@ def report_rage_click_issue_with_replay_event(
     url: str,
     node: dict[str, Any],
     replay_event: dict[str, Any],
+    component_name: str | None,
 ):
     metrics.incr("replay.rage_click_issue_creation_with_replay_event")
 
@@ -32,6 +33,16 @@ def report_rage_click_issue_with_replay_event(
 
     selector = selector
     clicked_element = selector.split(" > ")[-1]
+    component_name = component_name
+    evidence = [
+        IssueEvidence(name="Clicked Element", value=clicked_element, important=True),
+        IssueEvidence(name="Selector Path", value=selector, important=True),
+    ]
+
+    if component_name:
+        evidence.append(
+            IssueEvidence(name="React Component Name", value=component_name, important=True),
+        )
 
     new_issue_occurrence(
         culprit=url[:MAX_CULPRIT_LENGTH],
@@ -52,10 +63,7 @@ def report_rage_click_issue_with_replay_event(
             # CSS selector path to clicked element.
             "selector": selector,
         },
-        evidence_display=[
-            IssueEvidence(name="Clicked Element", value=clicked_element, important=True),
-            IssueEvidence(name="Selector Path", value=selector, important=True),
-        ],
+        evidence_display=evidence,
         extra_event_data={
             "contexts": _make_contexts(replay_id, replay_event),
             "level": RAGE_CLICK_LEVEL,

--- a/tests/sentry/replays/unit/test_ingest_dom_index.py
+++ b/tests/sentry/replays/unit/test_ingest_dom_index.py
@@ -427,6 +427,127 @@ def test_parse_replay_dead_click_actions(patch_rage_click_issue_with_replay_even
 
 
 @django_db_all
+def test_rage_click_issue_creation_no_component_name(
+    patch_rage_click_issue_with_replay_event, default_project
+):
+    events = [
+        {
+            "type": 5,
+            "timestamp": 1674291701348,
+            "data": {
+                "tag": "breadcrumb",
+                "payload": {
+                    "timestamp": 1.1,
+                    "type": "default",
+                    "category": "ui.slowClickDetected",
+                    "message": "div.container > div#root > div > ul > div",
+                    "data": {
+                        "endReason": "timeout",
+                        "timeafterclickms": 7000.0,
+                        "nodeId": 59,
+                        "url": "https://www.sentry.io",
+                        "node": {
+                            "id": 59,
+                            "tagName": "a",
+                            "attributes": {
+                                "id": "id",
+                                "class": "class1 class2",
+                                "role": "button",
+                                "aria-label": "test",
+                                "alt": "1",
+                                "data-testid": "2",
+                                "title": "3",
+                            },
+                            "textContent": "text",
+                        },
+                    },
+                },
+            },
+        },
+        {
+            "type": 5,
+            "timestamp": 1674291701348,
+            "data": {
+                "tag": "breadcrumb",
+                "payload": {
+                    "timestamp": 1.1,
+                    "type": "default",
+                    "category": "ui.slowClickDetected",
+                    "message": "div.container > div#root > div > ul > div",
+                    "data": {
+                        "clickcount": 5,
+                        "endReason": "timeout",
+                        "timeafterclickms": 7000.0,
+                        "nodeId": 59,
+                        "url": "https://www.sentry.io",
+                        "node": {
+                            "id": 59,
+                            "tagName": "a",
+                            "attributes": {
+                                "id": "id",
+                                "class": "class1 class2",
+                                "role": "button",
+                                "aria-label": "test",
+                                "alt": "1",
+                                "data-testid": "2",
+                                "title": "3",
+                            },
+                            "textContent": "text",
+                        },
+                    },
+                },
+            },
+        },
+        # New style slowClickDetected payload.
+        {
+            "type": 5,
+            "timestamp": 1674291701348,
+            "data": {
+                "tag": "breadcrumb",
+                "payload": {
+                    "timestamp": 1.1,
+                    "type": "default",
+                    "category": "ui.slowClickDetected",
+                    "message": "div.container > div#root > div > ul > div",
+                    "data": {
+                        "url": "https://www.sentry.io",
+                        "clickCount": 5,
+                        "endReason": "timeout",
+                        "timeAfterClickMs": 7000.0,
+                        "nodeId": 59,
+                        "node": {
+                            "id": 59,
+                            "tagName": "a",
+                            "attributes": {
+                                "id": "id",
+                                "class": "class1 class2",
+                                "role": "button",
+                                "aria-label": "test",
+                                "alt": "1",
+                                "data-testid": "2",
+                                "title": "3",
+                            },
+                            "textContent": "text",
+                        },
+                    },
+                },
+            },
+        },
+    ]
+
+    with Feature(
+        {
+            "organizations:session-replay-rage-click-issue-creation": True,
+        }
+    ):
+        default_project.update_option("sentry:replay_rage_click_issues", True)
+        parse_replay_actions(default_project.id, "1", 30, events, mock_replay_event())
+
+    # test that 2 rage click issues are still created
+    assert patch_rage_click_issue_with_replay_event.call_count == 2
+
+
+@django_db_all
 def test_parse_replay_click_actions_not_dead(
     patch_rage_click_issue_with_replay_event, default_project
 ):

--- a/tests/sentry/replays/unit/test_issue_creation.py
+++ b/tests/sentry/replays/unit/test_issue_creation.py
@@ -171,26 +171,37 @@ def test_report_rage_click_no_trace(default_project):
     assert Group.objects.get(message__contains="div.xyz > a")
 
 
-@pytest.mark.snuba
 @django_db_all
-def test_report_rage_click_no_component_name(default_project):
-    replay_id = "b58a67446c914f44a4e329763420047b"
+@patch("sentry.replays.usecases.ingest.issue_creation.new_issue_occurrence")
+def test_report_rage_click_no_component_name(mock_new_issue_occurrence, default_project):
     seq1_timestamp = datetime.now() - timedelta(minutes=10, seconds=52)
-    with Feature(
-        {
-            "organizations:replay-click-rage-ingest": True,
-        }
-    ):
-        report_rage_click_issue_with_replay_event(
-            project_id=default_project.id,
-            replay_id=replay_id,
-            selector="div.xyz > a",
-            timestamp=seq1_timestamp.timestamp(),
-            url="https://www.sentry.io",
-            node={"tagName": "a"},
-            component_name=None,
-            replay_event=mock_replay_event(),
-        )
 
-    # test that the Issue gets created with no component name
-    assert Group.objects.get(message__contains="div.xyz > a")
+    replay_id = "b58a67446c914f44a4e329763420047b"
+    report_rage_click_issue_with_replay_event(
+        project_id=default_project.id,
+        replay_id=replay_id,
+        selector="div.xyz > a",
+        timestamp=seq1_timestamp.timestamp(),
+        url="https://www.sentry.io",
+        node={"tagName": "a"},
+        component_name=None,
+        replay_event=mock_replay_event(),
+    )
+    issue_occurence_call = mock_new_issue_occurrence.call_args[1]
+    assert issue_occurence_call["culprit"] == "https://www.sentry.io"
+    assert issue_occurence_call["environment"] == "production"
+    assert issue_occurence_call["fingerprint"] == ["div.xyz > a"]
+
+    assert issue_occurence_call["evidence_data"] == {
+        "node": {"tagName": "a"},
+        "selector": "div.xyz > a",
+    }
+
+    assert (
+        issue_occurence_call["evidence_display"][0].to_dict()
+        == IssueEvidence(name="Clicked Element", value="a", important=False).to_dict()
+    )
+    assert (
+        issue_occurence_call["evidence_display"][1].to_dict()
+        == IssueEvidence(name="Selector Path", value="div.xyz > a", important=True).to_dict()
+    )

--- a/tests/sentry/replays/unit/test_issue_creation.py
+++ b/tests/sentry/replays/unit/test_issue_creation.py
@@ -189,6 +189,7 @@ def test_report_rage_click_no_component_name(default_project):
             url="https://www.sentry.io",
             node={"tagName": "a"},
             replay_event=mock_replay_event(trace_ids=[]),
+            component_name=None,
         )
 
     # test that the Issue gets created with no component name

--- a/tests/sentry/replays/unit/test_issue_creation.py
+++ b/tests/sentry/replays/unit/test_issue_creation.py
@@ -27,8 +27,8 @@ def test_report_rage_click_issue_with_replay_event(mock_new_issue_occurrence, de
         timestamp=seq1_timestamp.timestamp(),
         url="https://www.sentry.io",
         node={"tagName": "a"},
-        replay_event=mock_replay_event(),
         component_name="SmartSearchBar",
+        replay_event=mock_replay_event(),
     )
     issue_occurence_call = mock_new_issue_occurrence.call_args[1]
     assert issue_occurence_call["culprit"] == "https://www.sentry.io"
@@ -48,11 +48,11 @@ def test_report_rage_click_issue_with_replay_event(mock_new_issue_occurrence, de
 
     assert (
         issue_occurence_call["evidence_display"][0].to_dict()
-        == IssueEvidence(name="Clicked Element", value="a", important=True).to_dict()
+        == IssueEvidence(name="Clicked Element", value="a", important=False).to_dict()
     )
     assert (
         issue_occurence_call["evidence_display"][1].to_dict()
-        == IssueEvidence(name="Selector Path", value="div.xyz > a", important=True).to_dict()
+        == IssueEvidence(name="Selector Path", value="div.xyz > a", important=False).to_dict()
     )
     assert (
         issue_occurence_call["evidence_display"][2].to_dict()
@@ -111,8 +111,8 @@ def test_report_rage_click_long_url(default_project):
             timestamp=seq1_timestamp.timestamp(),
             url=f"https://www.sentry.io{'a' * 300}",
             node={"tagName": "a"},
-            replay_event=mock_replay_event(),
             component_name="SmartSearchBar",
+            replay_event=mock_replay_event(),
         )
 
     # test that the Issue gets created with the truncated url
@@ -139,8 +139,8 @@ def test_report_rage_click_no_environment(default_project):
             timestamp=seq1_timestamp.timestamp(),
             url="https://www.sentry.io",
             node={"tagName": "a"},
-            replay_event=mock_replay_event(),
             component_name="SmartSearchBar",
+            replay_event=mock_replay_event(),
         )
 
     assert Group.objects.get(message__contains="div.xyz > a")
@@ -163,8 +163,8 @@ def test_report_rage_click_no_trace(default_project):
             timestamp=seq1_timestamp.timestamp(),
             url="https://www.sentry.io",
             node={"tagName": "a"},
-            replay_event=mock_replay_event(trace_ids=[]),
             component_name="SmartSearchBar",
+            replay_event=mock_replay_event(trace_ids=[]),
         )
 
     # test that the Issue gets created
@@ -188,8 +188,8 @@ def test_report_rage_click_no_component_name(default_project):
             timestamp=seq1_timestamp.timestamp(),
             url="https://www.sentry.io",
             node={"tagName": "a"},
-            replay_event=mock_replay_event(trace_ids=[]),
             component_name=None,
+            replay_event=mock_replay_event(),
         )
 
     # test that the Issue gets created with no component name


### PR DESCRIPTION
- Add the React component name to the rage click issue evidence if it exists. 
- The selector is still in the evidence - we'll always display it, in case the React component name doesn't exist. 
- Add tests to make sure the issue still gets created if the component name doesn't exist.
- The order of evidence display would be 
``` 
Clicked Element
Selector Path
React Component Name
```

Relates to https://github.com/getsentry/sentry/issues/64673