### PR TITLE
chore(slack): log trigger id for dialog issues

### DIFF
--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -228,7 +228,7 @@ class SlackRequest:
             raise SlackRequestError(status=status_.HTTP_403_FORBIDDEN)
 
     def _log_request(self) -> None:
-        self._info("slack.request")
+        self._info("slack.request", extra=self.request.data)
 
     def _error(self, key: str) -> None:
         logger.error(key, extra={**self.logging_data})

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -147,6 +147,7 @@ class SlackRequest:
             "slack_callback_id": _data.get("callback_id"),
             "slack_api_app_id": _data.get("api_app_id"),
         }
+        data["request_data"] = _data
 
         if self._integration:
             data["integration_id"] = self.integration.id
@@ -228,7 +229,7 @@ class SlackRequest:
             raise SlackRequestError(status=status_.HTTP_403_FORBIDDEN)
 
     def _log_request(self) -> None:
-        self._info("slack.request", extra=self.request.data)
+        self._info("slack.request")
 
     def _error(self, key: str) -> None:
         logger.error(key, extra={**self.logging_data})

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -430,6 +430,8 @@ class SlackActionEndpoint(Endpoint):
                         "error": str(e),
                         "organization_id": org.id,
                         "integration_id": slack_request.integration.id,
+                        "trigger_id": slack_request.data["trigger_id"],
+                        "dialog": "resolve",
                     },
                 )
 
@@ -447,6 +449,8 @@ class SlackActionEndpoint(Endpoint):
                 )
 
     def open_archive_dialog(self, slack_request: SlackActionRequest, group: Group) -> None:
+        org = group.project.organization
+
         callback_id = {
             "issue": group.id,
             "orig_response_url": slack_request.data["response_url"],
@@ -468,7 +472,16 @@ class SlackActionEndpoint(Endpoint):
             headers = {"content-type": "application/json; charset=utf-8"}
             slack_client.post("/views.open", data=json.dumps(payload), headers=headers)
         except ApiError as e:
-            logger.exception("slack.action.response-error", extra={"error": str(e)})
+            logger.exception(
+                "slack.action.response-error",
+                extra={
+                    "error": str(e),
+                    "organization_id": org.id,
+                    "integration_id": slack_request.integration.id,
+                    "trigger_id": slack_request.data["trigger_id"],
+                    "dialog": "archive",
+                },
+            )
 
     def construct_reply(self, attachment: SlackBody, is_message: bool = False) -> SlackBody:
         # XXX(epurkhiser): Slack is inconsistent about it's expected responses

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -49,6 +49,13 @@ class SlackRequestTest(TestCase):
             "slack_channel_id": "1",
             "slack_user_id": "2",
             "slack_api_app_id": "S1",
+            "request_data": {
+                "api_app_id": "S1",
+                "channel": {"id": "1"},
+                "team_id": "T001",
+                "type": "foo",
+                "user": {"id": "2"},
+            },
         }
 
     def test_disregards_None_logging_values(self):
@@ -58,6 +65,13 @@ class SlackRequestTest(TestCase):
             "slack_team_id": "T001",
             "slack_channel_id": "1",
             "slack_user_id": "2",
+            "request_data": {
+                "api_app_id": None,
+                "channel": {"id": "1"},
+                "team_id": "T001",
+                "type": "foo",
+                "user": {"id": "2"},
+            },
         }
 
     def test_validate_existence_of_data(self):
@@ -108,6 +122,13 @@ class SlackRequestTest(TestCase):
             "slack_channel_id": "1",
             "slack_user_id": "2",
             "slack_api_app_id": "S1",
+            "request_data": {
+                "api_app_id": "S1",
+                "channel": {"id": "1"},
+                "team": None,
+                "type": "foo",
+                "user": {"id": "2"},
+            },
         }
 
 


### PR DESCRIPTION
We are getting a lot of `expired_trigger_id` and `exchange_trigger_id` errors back from slack. If we log the trigger id we can confirm/deny our theory that we're taking too long to respond to Slack.