### PR TITLE
fix(webvitals): Fix webvitals detail panel sort 

### DIFF
--- a/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
@@ -85,6 +85,7 @@ export function WebVitalsDetailPanel({
           }
       : {}),
     enabled: webVital !== null,
+    sortName: 'webVitalsDetailPanelSort',
   });
 
   const dataByOpportunity = useMemo(() => {


### PR DESCRIPTION
Gives webvital detail panel its own sort key so it doesnt clash with the main table on the landing page