### PR TITLE
feat(perf): Add more readouts to HTTP module domain summary page

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -121,6 +121,8 @@ export type Alignments = 'left' | 'right';
 
 export type CountUnit = 'count';
 
+export type PercentageUnit = 'percentage';
+
 export enum DurationUnit {
   NANOSECOND = 'nanosecond',
   MICROSECOND = 'microsecond',

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -155,6 +155,33 @@ describe('HTTPSummaryPage', function () {
     );
 
     expect(domainTransactionsListRequestMock).toHaveBeenNthCalledWith(
+      1,
+      `/organizations/${organization.slug}/events/`,
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          dataset: 'spansMetrics',
+          environment: [],
+          field: [
+            'span.domain',
+            'spm()',
+            'avg(span.self_time)',
+            'sum(span.self_time)',
+            'http_response_rate(3)',
+            'http_response_rate(4)',
+            'http_response_rate(5)',
+            'time_spent_percentage()',
+          ],
+          per_page: 50,
+          project: [],
+          query: 'span.module:http span.domain:"\\*.sentry.dev"',
+          referrer: 'api.starfish.http-module-domain-summary-metrics-ribbon',
+          statsPeriod: '10d',
+        },
+      })
+    );
+
+    expect(domainTransactionsListRequestMock).toHaveBeenNthCalledWith(
       2,
       `/organizations/${organization.slug}/events/`,
       expect.objectContaining({

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -26,6 +26,7 @@ import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
 import {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
+import {getTimeSpentExplanation} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
@@ -62,6 +63,9 @@ export function HTTPDomainSummaryPage() {
       `${SpanFunction.SPM}()`,
       `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
       `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
+      'http_response_rate(3)',
+      'http_response_rate(4)',
+      'http_response_rate(5)',
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
     ],
     enabled: Boolean(domain),
@@ -177,6 +181,38 @@ export function HTTPDomainSummaryPage() {
                       domainMetrics?.[0]?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]
                     }
                     unit={DurationUnit.MILLISECOND}
+                    isLoading={areDomainMetricsLoading}
+                  />
+
+                  <MetricReadout
+                    title={t('3XXs')}
+                    value={domainMetrics?.[0]?.[`http_response_rate(3)`]}
+                    unit="percentage"
+                    isLoading={areDomainMetricsLoading}
+                  />
+
+                  <MetricReadout
+                    title={t('4XXs')}
+                    value={domainMetrics?.[0]?.[`http_response_rate(4)`]}
+                    unit="percentage"
+                    isLoading={areDomainMetricsLoading}
+                  />
+
+                  <MetricReadout
+                    title={t('5XXs')}
+                    value={domainMetrics?.[0]?.[`http_response_rate(5)`]}
+                    unit="percentage"
+                    isLoading={areDomainMetricsLoading}
+                  />
+
+                  <MetricReadout
+                    title={DataTitles.timeSpent}
+                    value={domainMetrics?.[0]?.['sum(span.self_time)']}
+                    unit={DurationUnit.MILLISECOND}
+                    tooltip={getTimeSpentExplanation(
+                      domainMetrics?.[0]?.['time_spent_percentage()'],
+                      'db'
+                    )}
                     isLoading={areDomainMetricsLoading}
                   />
                 </MetricsRibbon>

--- a/static/app/views/performance/metricReadout.spec.tsx
+++ b/static/app/views/performance/metricReadout.spec.tsx
@@ -57,6 +57,13 @@ describe('MetricReadout', function () {
     expect(screen.getByText('1.1 MiB')).toBeInTheDocument();
   });
 
+  it('renders percentages', () => {
+    render(<MetricReadout title="Percentage" unit="percentage" value={0.2352} />);
+
+    expect(screen.getByRole('heading', {name: 'Percentage'})).toBeInTheDocument();
+    expect(screen.getByText('23.52%')).toBeInTheDocument();
+  });
+
   it('renders counts', () => {
     render(<MetricReadout title="Count" unit="count" value={7800123} />);
 

--- a/static/app/views/performance/metricReadout.tsx
+++ b/static/app/views/performance/metricReadout.tsx
@@ -7,12 +7,21 @@ import FileSize from 'sentry/components/fileSize';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Tooltip} from 'sentry/components/tooltip';
 import {defined} from 'sentry/utils';
-import type {CountUnit} from 'sentry/utils/discover/fields';
+import type {CountUnit, PercentageUnit} from 'sentry/utils/discover/fields';
 import {DurationUnit, RateUnit, SizeUnit} from 'sentry/utils/discover/fields';
-import {formatAbbreviatedNumber, formatRate} from 'sentry/utils/formatters';
+import {
+  formatAbbreviatedNumber,
+  formatPercentage,
+  formatRate,
+} from 'sentry/utils/formatters';
 import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
-type Unit = DurationUnit.MILLISECOND | SizeUnit.BYTE | RateUnit | CountUnit;
+type Unit =
+  | DurationUnit.MILLISECOND
+  | SizeUnit.BYTE
+  | RateUnit
+  | CountUnit
+  | PercentageUnit;
 
 interface Props {
   title: string;
@@ -80,6 +89,14 @@ function ReadoutContent({unit, value, tooltip, align = 'right', isLoading}: Prop
     renderedValue = (
       <NumberContainer align={align}>
         {formatAbbreviatedNumber(typeof value === 'string' ? parseInt(value, 10) : value)}
+      </NumberContainer>
+    );
+  }
+
+  if (unit === 'percentage') {
+    renderedValue = (
+      <NumberContainer align={align}>
+        {formatPercentage(typeof value === 'string' ? parseFloat(value) : value)}
       </NumberContainer>
     );
   }


### PR DESCRIPTION
- Add percentage support to `MetricReadout`
- Add more metric readouts: time spent, 3xx, 4xx, 5xx

**e.g.,**
<img width="664" alt="Screenshot 2024-03-13 at 6 00 14 PM" src="https://github.com/getsentry/sentry/assets/989898/a77e9ef5-46a2-4dc5-a1ad-54da44504327">
