### PR TITLE
feat(integrations): custom pagerduty + opsgenie metric alert priorities FE

### DIFF
--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -316,6 +316,9 @@ class ActionsPanel extends PureComponent<Props> {
       value: getActionUniqueKey(availableAction),
       label: getFullActionTitle(availableAction),
     }));
+    const hasPriorityFlag = organization.features.includes(
+      'integrations-custom-alert-priorities'
+    );
 
     const levels = [
       {value: 0, label: 'Critical Status'},
@@ -456,7 +459,8 @@ class ActionsPanel extends PureComponent<Props> {
                         'inputChannelId'
                       )}
                     />
-                    {availableAction &&
+                    {hasPriorityFlag &&
+                    availableAction &&
                     (availableAction.type === 'opsgenie' ||
                       availableAction.type === 'pagerduty') ? (
                       <SelectControl

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -28,7 +28,12 @@ import type {
   MetricActionTemplate,
   Trigger,
 } from 'sentry/views/alerts/rules/metric/types';
-import {ActionLabel, TargetLabel} from 'sentry/views/alerts/rules/metric/types';
+import {
+  ActionLabel,
+  DefaultPriorities,
+  PriorityOptions,
+  TargetLabel,
+} from 'sentry/views/alerts/rules/metric/types';
 
 type Props = {
   availableActions: MetricActionTemplate[] | null;
@@ -256,6 +261,21 @@ class ActionsPanel extends PureComponent<Props> {
     onChange(triggerIndex, triggers, replaceAtArrayIndex(actions, index, newAction));
   };
 
+  handleChangePriority = (
+    triggerIndex: number,
+    index: number,
+    value: SelectValue<keyof typeof PriorityOptions>
+  ) => {
+    const {triggers, onChange} = this.props;
+    const {actions} = triggers[triggerIndex];
+    const newAction = {
+      ...actions[index],
+      priority: value.value,
+    };
+
+    onChange(triggerIndex, triggers, replaceAtArrayIndex(actions, index, newAction));
+  };
+
   /**
    * Update the Trigger's Action fields from the SentryAppRuleModal together
    * only after the user clicks "Save Changes".
@@ -436,6 +456,26 @@ class ActionsPanel extends PureComponent<Props> {
                         'inputChannelId'
                       )}
                     />
+                    {availableAction &&
+                    (availableAction.type === 'opsgenie' ||
+                      availableAction.type === 'pagerduty') ? (
+                      <SelectControl
+                        isDisabled={disabled || loading}
+                        value={action.priority}
+                        placeholder={
+                          DefaultPriorities[availableAction.type][triggerIndex]
+                        }
+                        options={PriorityOptions[availableAction.type].map(priority => ({
+                          value: priority,
+                          label: priority,
+                        }))}
+                        onChange={this.handleChangePriority.bind(
+                          this,
+                          triggerIndex,
+                          actionIdx
+                        )}
+                      />
+                    ) : null}
                   </PanelItemSelects>
                   <DeleteActionButton
                     triggerIndex={triggerIndex}

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -185,6 +185,17 @@ export const TargetLabel = {
   [TargetType.TEAM]: t('Team'),
 };
 
+export const PriorityOptions = {
+  [ActionType.PAGERDUTY]: ['critical', 'warning', 'error', 'info'],
+  [ActionType.OPSGENIE]: ['P1', 'P2', 'P3', 'P4', 'P5'],
+};
+
+// default priorities per threshold (0 = critical, 1 = warning)
+export const DefaultPriorities = {
+  [ActionType.PAGERDUTY]: {[0]: 'critical', [1]: 'warning'},
+  [ActionType.OPSGENIE]: {[0]: 'P3', [1]: 'P3'},
+};
+
 /**
  * This is an available action template that is associated to a Trigger in a
  * Metric Alert Rule. They are defined by the available-actions API.
@@ -267,6 +278,11 @@ type SavedActionFields = {
    *  Could not fetch details from SentryApp. Show the rule but make it disabled.
    */
   disabled?: boolean;
+
+  /**
+   * Priority of the Opsgenie action or severity of the Pagerduty action
+   */
+  priority?: string;
 };
 
 type UnsavedAction = {

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -193,7 +193,7 @@ export const PriorityOptions = {
 // default priorities per threshold (0 = critical, 1 = warning)
 export const DefaultPriorities = {
   [ActionType.PAGERDUTY]: {[0]: 'critical', [1]: 'warning'},
-  [ActionType.OPSGENIE]: {[0]: 'P3', [1]: 'P3'},
+  [ActionType.OPSGENIE]: {[0]: 'P1', [1]: 'P2'},
 };
 
 /**


### PR DESCRIPTION
Completes custom metric alert priority work for Pagerduty and Opsgenie. The (feature flagged) frontend allows for settings these values, and defaults to the original logic:
- Pagerduty: critical status => `critical` severity, warning => `warning` severity
- Opsgenie: critical status => `P1` priority, warning => `P2` priority

https://github.com/getsentry/sentry/assets/70817427/bd7c0851-2d29-4408-987b-94ac67b85c1c

Note that we don't show the priority in the description of the action unless it has been explicitly set to something.

For https://github.com/getsentry/sentry/issues/58830
For https://github.com/getsentry/sentry/issues/54921