### PR TITLE
feat(integration): Add ability to save notification message for issue alert

### DIFF
--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from logging import Logger, getLogger
 
-from sentry.integrations.repository.base import BaseNotificationMessage
+from sentry.integrations.repository.base import (
+    BaseNewNotificationMessage,
+    BaseNotificationMessage,
+    NotificationMessageValidationError,
+)
 from sentry.models.notificationmessage import NotificationMessage
 from sentry.models.rulefirehistory import RuleFireHistory
 
@@ -32,6 +36,40 @@ class IssueAlertNotificationMessage(BaseNotificationMessage):
             rule_action_uuid=instance.rule_action_uuid,
             date_added=instance.date_added,
         )
+
+
+class NewIssueAlertNotificationMessageValidationError(NotificationMessageValidationError):
+    pass
+
+
+class RuleFireHistoryAndRuleActionUuidActionValidationError(
+    NewIssueAlertNotificationMessageValidationError
+):
+    message = "both rule fire history and rule action uuid need to exist together with a reference"
+
+
+@dataclass
+class NewIssueAlertNotificationMessage(BaseNewNotificationMessage):
+    rule_fire_history_id: int | None = None
+    rule_action_uuid: str | None = None
+
+    def get_validation_error(self) -> Exception | None:
+        error = super().get_validation_error()
+        if error is not None:
+            return error
+
+        if self.message_identifier is not None:
+            # If a message_identifier exists, that means a successful notification happened for a rule action and fire
+            # This means that neither of them can be empty
+            if self.rule_fire_history_id is None or self.rule_action_uuid is None:
+                return RuleFireHistoryAndRuleActionUuidActionValidationError()
+
+        # We can create a NotificationMessage if it has both, or neither, of rule fire history and action.
+        # The following is an XNOR check for incident and trigger
+        if (self.rule_fire_history_id is not None) != (self.rule_action_uuid is not None):
+            return RuleFireHistoryAndRuleActionUuidActionValidationError()
+
+        return None
 
 
 class IssueAlertNotificationMessageRepository:
@@ -76,5 +114,29 @@ class IssueAlertNotificationMessageRepository:
                     "group_id": group_id,
                     "rule_action_uuid": rule_action_uuid,
                 },
+            )
+            raise
+
+    def create_notification_message(
+        self, data: NewIssueAlertNotificationMessage
+    ) -> IssueAlertNotificationMessage:
+        if (error := data.get_validation_error()) is not None:
+            raise error
+
+        try:
+            new_instance = self._model.objects.create(
+                error_details=data.error_details,
+                error_code=data.error_code,
+                message_identifier=data.message_identifier,
+                parent_notification_message_id=data.parent_notification_message_id,
+                rule_fire_history_id=data.rule_fire_history_id,
+                rule_action_uuid=data.rule_action_uuid,
+            )
+            return IssueAlertNotificationMessage.from_model(instance=new_instance)
+        except Exception as e:
+            self._logger.exception(
+                "failed to create new issue alert notification alert",
+                exc_info=e,
+                extra=data.__dict__,
             )
             raise


### PR DESCRIPTION
We need to be able to store notification actions for issue alert, such that when we retrieve parent messages, we can find the parent thread