### PR TITLE
feat(integration): Save notification message and reply in thread

### DIFF
--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -65,7 +65,7 @@ class NewIssueAlertNotificationMessage(BaseNewNotificationMessage):
                 return RuleFireHistoryAndRuleActionUuidActionValidationError()
 
         # We can create a NotificationMessage if it has both, or neither, of rule fire history and action.
-        # The following is an XNOR check for incident and trigger
+        # The following is an XNOR check for rule fire history and action
         if (self.rule_fire_history_id is not None) != (self.rule_action_uuid is not None):
             return RuleFireHistoryAndRuleActionUuidActionValidationError()
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Sequence
+from logging import Logger, getLogger
 from typing import Any
 
 from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.repository import get_default_issue_alert_repository
-from sentry.integrations.repository.issue_alert import IssueAlertNotificationMessageRepository
+from sentry.integrations.repository.base import NotificationMessageValidationError
+from sentry.integrations.repository.issue_alert import (
+    IssueAlertNotificationMessageRepository,
+    NewIssueAlertNotificationMessage,
+)
 from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
@@ -16,14 +21,18 @@ from sentry.integrations.slack.message_builder.notifications.rule_save_edit impo
 from sentry.integrations.slack.utils import get_channel_id
 from sentry.models.integrations.integration import Integration
 from sentry.models.rule import Rule
+from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
 from sentry.rules import EventState
 from sentry.rules.actions import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
 from sentry.services.hybrid_cloud.integration import RpcIntegration
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.response import BaseApiResponse, MappingApiResponse
 from sentry.types.rules import RuleFuture
 from sentry.utils import json, metrics
+
+_default_logger: Logger = getLogger(__name__)
 
 
 class SlackNotifyServiceAction(IntegrationEventAction):
@@ -77,6 +86,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             additional_attachment = get_additional_attachment(
                 integration, self.project.organization
             )
+            payload = {}
             if features.has("organizations:slack-block-kit", event.group.project.organization):
                 blocks = SlackIssuesMessageBuilder(
                     group=event.group,
@@ -117,12 +127,77 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     "attachments": json.dumps(attachments),
                 }
 
+            rule_id = self.rule.id
+            rule_action_uuid = self.data.get("action_uuid", None)
+            if not rule_action_uuid:
+                # We are logging because this should never happen, all actions should have an uuid
+                # We can monitor for this, and create an alert if this ever appears
+                _default_logger.info(
+                    "integration.slack.actions: No action uuid",
+                    extra={
+                        "rule_id": rule_id,
+                        "notification_uuid": notification_uuid,
+                    },
+                )
+
+            rule_fire_history_id = None
+            try:
+                rule_fire_history_id = (
+                    RuleFireHistory.objects.filter(notification_uuid=notification_uuid)
+                    .values("id")
+                    .get()
+                )
+            except Exception as err:
+                _default_logger.info(
+                    "integration.slack.actions: Failed to get rule fire history", exc_info=err
+                )
+
+            new_notification_message_object = NewIssueAlertNotificationMessage(
+                rule_fire_history_id=rule_fire_history_id, rule_action_uuid=rule_action_uuid
+            )
+
+            # Only try to get the parent notification message if the organization is in the FF
+            # We need to search by rule action uuid, so only search if it exists
+            if (
+                features.has(
+                    "organizations:slack-thread-issue-alert", event.group.project.organization
+                )
+                and rule_action_uuid
+            ):
+                try:
+                    parent_notification_message = self._repository.get_parent_notification_message(
+                        rule_id=rule_id,
+                        group_id=event.group.id,
+                        rule_action_uuid=rule_action_uuid,
+                    )
+                except Exception:
+                    # if there's an error trying to grab a parent notification, don't let that error block this flow
+                    pass
+                else:
+                    # If a parent notification exists for this rule and action, then we can reply in a thread
+                    # Make sure we track that this reply will be in relation to the parent row
+                    new_notification_message_object.parent_notification_message_id = (
+                        parent_notification_message.id
+                    )
+                    # To reply to a thread, use the specific key in the payload as referenced by the docs
+                    # https://api.slack.com/methods/chat.postMessage#arg_thread_ts
+                    payload["thread_ts"] = parent_notification_message.message_identifier
+
             client = SlackClient(integration_id=integration.id)
             try:
-                client.post(
+                response = client.post(
                     "/chat.postMessage", data=payload, timeout=5, log_response_with_error=True
                 )
             except ApiError as e:
+                # Record the error code and details from the exception
+                new_notification_message_object.error_code = e.code
+                new_notification_message_object.error_details = {
+                    "url": e.url,
+                    "host": e.host,
+                    "path": e.path,
+                    "data": e.json if e.json else e.text,
+                }
+
                 log_params = {
                     "error": str(e),
                     "project_id": event.project_id,
@@ -137,6 +212,45 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     "rule.fail.slack_post",
                     extra=log_params,
                 )
+            else:
+                # Slack will always send back a ts identifier https://api.slack.com/methods/chat.postMessage#examples
+                # on a successful message
+                ts = None
+                # This is a workaround for typing, and the dynamic nature of the return value
+                if isinstance(response, BaseApiResponse):
+                    ts = response.json.get("ts")
+                elif isinstance(response, MappingApiResponse):
+                    ts = response.get("ts")
+                else:
+                    _default_logger.info(
+                        "failed to get ts from slack response",
+                        extra={
+                            "response_type": type(response).__name__,
+                        },
+                    )
+                new_notification_message_object.message_identifier = (
+                    str(ts) if ts is not None else None
+                )
+
+            if (
+                features.has(
+                    "organizations:slack-thread-issue-alert", event.group.project.organization
+                )
+                and rule_action_uuid
+            ):
+                try:
+                    self._repository.create_notification_message(
+                        data=new_notification_message_object
+                    )
+                except NotificationMessageValidationError as err:
+                    _default_logger.info(
+                        "integration.slack.actions: Validation error", exc_info=err
+                    )
+                except Exception:
+                    # if there's an error trying to save a notification message, don't let that error block this flow
+                    pass
+
+            # TODO: Why can't we just use self.rule?
             rule = rules[0] if rules else None
             self.record_notification_sent(event, channel, rule, notification_uuid)
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -177,14 +177,15 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     # we already log at the repository layer, no need to log again here
                     pass
                 else:
-                    # If a parent notification exists for this rule and action, then we can reply in a thread
-                    # Make sure we track that this reply will be in relation to the parent row
-                    new_notification_message_object.parent_notification_message_id = (
-                        parent_notification_message.id
-                    )
-                    # To reply to a thread, use the specific key in the payload as referenced by the docs
-                    # https://api.slack.com/methods/chat.postMessage#arg_thread_ts
-                    payload["thread_ts"] = parent_notification_message.message_identifier
+                    if parent_notification_message:
+                        # If a parent notification exists for this rule and action, then we can reply in a thread
+                        # Make sure we track that this reply will be in relation to the parent row
+                        new_notification_message_object.parent_notification_message_id = (
+                            parent_notification_message.id
+                        )
+                        # To reply to a thread, use the specific key in the payload as referenced by the docs
+                        # https://api.slack.com/methods/chat.postMessage#arg_thread_ts
+                        payload["thread_ts"] = parent_notification_message.message_identifier
 
             client = SlackClient(integration_id=integration.id)
             try:

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -174,6 +174,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     )
                 except Exception:
                     # if there's an error trying to grab a parent notification, don't let that error block this flow
+                    # we already log at the repository layer, no need to log again here
                     pass
                 else:
                     # If a parent notification exists for this rule and action, then we can reply in a thread
@@ -239,17 +240,24 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     "organizations:slack-thread-issue-alert", event.group.project.organization
                 )
                 and rule_action_uuid
+                and rule_id
             ):
                 try:
                     self._repository.create_notification_message(
                         data=new_notification_message_object
                     )
                 except NotificationMessageValidationError as err:
+                    extra = (
+                        new_notification_message_object.__dict__
+                        if new_notification_message_object
+                        else None
+                    )
                     _default_logger.info(
-                        "integration.slack.actions: Validation error", exc_info=err
+                        "integration.slack.actions: Validation error", exc_info=err, extra=extra
                     )
                 except Exception:
                     # if there's an error trying to save a notification message, don't let that error block this flow
+                    # we already log at the repository layer, no need to log again here
                     pass
 
             self.record_notification_sent(event, channel, rule, notification_uuid)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -761,9 +761,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if rule_id:
             block_id["rule"] = rule_id
 
-        if notification_uuid:
-            block_id["notification_uuid"] = notification_uuid
-
         return self._build_blocks(
             *blocks,
             fallback_text=self.build_fallback_text(obj, project.slug),

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -761,6 +761,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if rule_id:
             block_id["rule"] = rule_id
 
+        if notification_uuid:
+            block_id["notification_uuid"] = notification_uuid
+
         return self._build_blocks(
             *blocks,
             fallback_text=self.build_fallback_text(obj, project.slug),


### PR DESCRIPTION
When an issue alert sends a notification, save that notification message, and try to respond in a thread if there has already been a message sent for this grouping
