### PR TITLE
feat(crons): Add status to broken monitor environments

### DIFF
--- a/fixtures/js-stubs/monitor.tsx
+++ b/fixtures/js-stubs/monitor.tsx
@@ -36,6 +36,7 @@ export function MonitorFixture(params: Partial<Monitor> = {}): Monitor {
         nextCheckIn: '2023-12-25T16:10:00Z',
         nextCheckInLatest: '2023-12-25T15:15:00Z',
         status: MonitorStatus.OK,
+        activeIncident: null,
       },
     ],
     alertRule: {

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -1,4 +1,5 @@
 import type {ObjectStatus, Project} from 'sentry/types';
+import type {ColorOrAlias} from 'sentry/utils/theme';
 
 export enum MonitorType {
   UNKNOWN = 'unknown',
@@ -69,7 +70,19 @@ export interface IntervalConfig extends BaseConfig {
 
 export type MonitorConfig = CrontabConfig | IntervalConfig;
 
+export interface MonitorEnvBrokenDetection {
+  envMutedTimestamp: string;
+  userNotifiedTimestamp: string;
+}
+
+export interface MonitorIncident {
+  brokenNotice: MonitorEnvBrokenDetection | null;
+  resolvingTimestamp: string;
+  startingTimestamp: string;
+}
+
 export interface MonitorEnvironment {
+  activeIncident: MonitorIncident | null;
   dateCreated: string;
   isMuted: boolean;
   lastCheckIn: string | null;
@@ -117,4 +130,13 @@ export interface CheckIn {
   id: string;
   status: CheckInStatus;
   groups?: {id: number; shortId: string}[];
+}
+
+/**
+ * Object used to store config for the display next to an environment in the timeline view
+ */
+export interface StatusNotice {
+  color: ColorOrAlias;
+  icon: React.ReactNode;
+  label: React.ReactNode;
 }

--- a/static/app/views/monitors/utils/constants.tsx
+++ b/static/app/views/monitors/utils/constants.tsx
@@ -1,9 +1,8 @@
 import type {StatusIndicatorProps} from 'sentry/components/statusIndicator';
 import {IconCheckmark, IconFire, IconTimer, IconUnsubscribed} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Aliases} from 'sentry/utils/theme';
 import type {StatsBucket} from 'sentry/views/monitors/components/overviewTimeline/types';
-import type {MonitorStatus} from 'sentry/views/monitors/types';
+import type {MonitorStatus, StatusNotice} from 'sentry/views/monitors/types';
 import {CheckInStatus} from 'sentry/views/monitors/types';
 
 // Orders the status in terms of ascending precedence for showing to the user
@@ -15,10 +14,7 @@ export const CHECKIN_STATUS_PRECEDENT = [
   CheckInStatus.ERROR,
 ] satisfies Array<keyof StatsBucket>;
 
-export const statusIconColorMap: Record<
-  MonitorStatus,
-  {color: keyof Aliases; icon: React.ReactNode; label: string}
-> = {
+export const statusIconColorMap: Record<MonitorStatus, StatusNotice> = {
   ok: {
     icon: <IconCheckmark color="successText" />,
     color: 'successText',


### PR DESCRIPTION
Adds a new type of status icon, label for monitors that have been marked as broken and those that have been automatically muted due to being broken.

Dependent on: https://github.com/getsentry/sentry/pull/66934

Closes: https://github.com/getsentry/team-crons/issues/137