### PR TITLE
feat(ddm): Add option to disable querying of metrics for specific orgs

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -426,7 +426,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
         try:
             if organization.id in (options.get("custom-metrics-querying-killswitched-orgs") or ()):
                 return Response(
-                    status=401, data={"detail": "Your organization is not allowed to query metrics"}
+                    status=401, data={"detail": "The organization is not allowed to query metrics"}
                 )
 
             start, end = get_date_range_from_params(request.GET)

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -425,8 +425,8 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
     def post(self, request: Request, organization) -> Response:
         try:
             if organization.id in (options.get("custom-metrics-querying-killswitched-orgs") or ()):
-                raise MetricsQueryExecutionError(
-                    "Your organization is not allowed to query metrics"
+                return Response(
+                    status=401, data={"detail": "Your organization is not allowed to query metrics"}
                 )
 
             start, end = get_date_range_from_params(request.GET)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1814,6 +1814,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# IDs of orgs that will be disabled from querying metrics via `/metrics/query` endpoint.
+register(
+    "custom-metrics-querying-killswitched-orgs",
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # SDK Crash Detection
 #
 # The project ID belongs to the sentry organization: https://sentry.sentry.io/projects/cocoa-sdk-crashes/?project=4505469596663808.

--- a/tests/sentry/api/endpoints/test_organization_metrics_query.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_query.py
@@ -90,3 +90,19 @@ class OrganizationMetricsQueryTest(MetricsAPIBaseTestCase):
                 },
             ]
         ]
+
+    def test_query_with_killswitched_org(self):
+        with self.options({"custom-metrics-querying-killswitched-orgs": [self.organization.id]}):
+            self.get_error_response(
+                self.project.organization.slug,
+                status_code=500,
+                queries=[{"name": "query_1", "mql": f"sum({TransactionMRI.DURATION.value})"}],
+                formulas=[{"mql": "$query_1"}],
+                qs_params={
+                    "statsPeriod": "3h",
+                    "interval": "1h",
+                    "project": [self.project.id],
+                    "environment": [],
+                    "includeSeries": "false",
+                },
+            )

--- a/tests/sentry/api/endpoints/test_organization_metrics_query.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_query.py
@@ -95,7 +95,7 @@ class OrganizationMetricsQueryTest(MetricsAPIBaseTestCase):
         with self.options({"custom-metrics-querying-killswitched-orgs": [self.organization.id]}):
             self.get_error_response(
                 self.project.organization.slug,
-                status_code=500,
+                status_code=401,
                 queries=[{"name": "query_1", "mql": f"sum({TransactionMRI.DURATION.value})"}],
                 formulas=[{"mql": "$query_1"}],
                 qs_params={


### PR DESCRIPTION
This PR adds a killswitch to disable querying of metrics per organization.