### PR TITLE
feat(ddm): Add custom_metrics_access organization flag

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -432,6 +432,8 @@ class OrganizationSerializer(BaseOrganizationSerializer):
             org.flags.codecov_access = data["codecovAccess"]
         if "require2FA" in data:
             org.flags.require_2fa = data["require2FA"]
+        # This option is temporary since we will control custom metrics via a single feature flag in the future. This
+        # organization option is used just for people to opt-in to try out custom metrics.
         if "customMetricsAccess" in data:
             org.update_option("sentry:custom_metrics_access", data["customMetricsAccess"])
         if (

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -216,6 +216,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     isEarlyAdopter = serializers.BooleanField(required=False)
     aiSuggestedSolution = serializers.BooleanField(required=False)
     codecovAccess = serializers.BooleanField(required=False)
+    customMetricsAccess = serializers.BooleanField(required=False)
     githubOpenPRBot = serializers.BooleanField(required=False)
     githubNudgeInvite = serializers.BooleanField(required=False)
     githubPRBot = serializers.BooleanField(required=False)
@@ -431,6 +432,8 @@ class OrganizationSerializer(BaseOrganizationSerializer):
             org.flags.codecov_access = data["codecovAccess"]
         if "require2FA" in data:
             org.flags.require_2fa = data["require2FA"]
+        if "customMetricsAccess" in data:
+            org.update_option("sentry:custom_metrics_access", data["customMetricsAccess"])
         if (
             features.has("organizations:required-email-verification", org)
             and "requireEmailVerification" in data

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -425,6 +425,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "defaultRole": "owner",
             "require2FA": True,
             "allowJoinRequests": False,
+            "customMetricsAccess": True,
         }
 
         # needed to set require2FA
@@ -458,6 +459,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert options.get("sentry:scrape_javascript") is False
         assert options.get("sentry:join_requests") is False
         assert options.get("sentry:events_member_admin") is False
+        assert options.get("sentry:custom_metrics_access") is True
 
         # log created
         with assume_test_silo_mode_of(AuditLogEntry):


### PR DESCRIPTION
This PR adds a new organization flag called `sentry:custom_metrics_access` which will be used internally by `getsentry` to enable certain feature flags needed by custom metrics.