### PR TITLE
feat(metric-stats): Add metric_stats generic metrics namespace

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ sentry-arroyo>=2.16.2
 sentry-kafka-schemas>=0.1.61
 sentry-ophio==0.1.5
 sentry-redis-tools>=0.1.7
-sentry-relay>=0.8.49
+sentry-relay>=0.8.50
 sentry-sdk>=1.40.6
 snuba-sdk>=2.0.31
 simplejson>=3.17.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -180,7 +180,7 @@ sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.61
 sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
-sentry-relay==0.8.49
+sentry-relay==0.8.50
 sentry-sdk==1.40.6
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -122,7 +122,7 @@ sentry-arroyo==2.16.2
 sentry-kafka-schemas==0.1.61
 sentry-ophio==0.1.5
 sentry-redis-tools==0.1.7
-sentry-relay==0.8.49
+sentry-relay==0.8.50
 sentry-sdk==1.40.6
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1259,6 +1259,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "sentry-metrics.cardinality-limiter.limits.metric_stats.per-org",
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "sentry-metrics.cardinality-limiter.limits.generic-metrics.per-org",
     default=[
         {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1259,11 +1259,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "sentry-metrics.cardinality-limiter.limits.metric_stats.per-org",
-    default=[],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "sentry-metrics.cardinality-limiter.limits.generic-metrics.per-org",
     default=[
         {"window_seconds": 3600, "granularity_seconds": 600, "limit": 10000},

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -191,6 +191,12 @@ SHARED_TAG_STRINGS = {
     "os.version": PREFIX + 271,
     # Performance Score
     "sentry.score_profile_version": PREFIX + 272,
+    # Metric stats
+    "mri": PREFIX + 273,
+    "mri.type": PREFIX + 274,
+    "mri.namespace": PREFIX + 275,
+    "outcome": PREFIX + 276,
+    "reason": PREFIX + 277,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }
@@ -236,6 +242,12 @@ BUNDLE_ANALYSIS_METRIC_NAMES = {
     "d:bundle_analysis/bundle_size@byte": PREFIX + 700,
 }
 
+# 800-899
+METRIC_STATS_METRIC_NAMES = {
+    "g:metric_stats/volume@none": PREFIX + 800,
+    "g:metric_stats/cardinality@none": PREFIX + 801,
+}
+
 
 SHARED_STRINGS = {
     **SESSION_METRIC_NAMES,
@@ -243,8 +255,9 @@ SHARED_STRINGS = {
     **SPAN_METRICS_NAMES,
     **ESCALATING_ISSUES_METRIC_NAMES,
     **PROFILING_METRIC_NAMES,
-    **SHARED_TAG_STRINGS,
     **BUNDLE_ANALYSIS_METRIC_NAMES,
+    **METRIC_STATS_METRIC_NAMES,
+    **SHARED_TAG_STRINGS,
 }
 REVERSE_SHARED_STRINGS = {v: k for k, v in SHARED_STRINGS.items()}
 

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -244,7 +244,7 @@ BUNDLE_ANALYSIS_METRIC_NAMES = {
 
 # 800-899
 METRIC_STATS_METRIC_NAMES = {
-    "g:metric_stats/volume@none": PREFIX + 800,
+    "c:metric_stats/volume@none": PREFIX + 800,
     "g:metric_stats/cardinality@none": PREFIX + 801,
 }
 

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -195,8 +195,8 @@ SHARED_TAG_STRINGS = {
     "mri": PREFIX + 273,
     "mri.type": PREFIX + 274,
     "mri.namespace": PREFIX + 275,
-    "outcome": PREFIX + 276,
-    "reason": PREFIX + 277,
+    "outcome.id": PREFIX + 276,
+    "outcome.reason": PREFIX + 277,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }

--- a/src/sentry/sentry_metrics/use_case_id_registry.py
+++ b/src/sentry/sentry_metrics/use_case_id_registry.py
@@ -48,7 +48,6 @@ USE_CASE_ID_CARDINALITY_LIMIT_QUOTA_OPTIONS = {
     UseCaseID.SPANS: "sentry-metrics.cardinality-limiter.limits.spans.per-org",
     UseCaseID.CUSTOM: "sentry-metrics.cardinality-limiter.limits.custom.per-org",
     UseCaseID.PROFILES: "sentry-metrics.cardinality-limiter.limits.profiles.per-org",
-    UseCaseID.METRIC_STATS: "sentry-metrics.cardinality-limiter.limits.metric_stats.per-org",
 }
 
 USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS = {

--- a/src/sentry/sentry_metrics/use_case_id_registry.py
+++ b/src/sentry/sentry_metrics/use_case_id_registry.py
@@ -19,6 +19,7 @@ class UseCaseID(Enum):
     CUSTOM = "custom"
     PROFILES = "profiles"
     BUNDLE_ANALYSIS = "bundle_analysis"
+    METRIC_STATS = "metric_stats"
 
 
 # UseCaseKey will be renamed to MetricPathKey
@@ -30,6 +31,7 @@ METRIC_PATH_MAPPING: Mapping[UseCaseID, UseCaseKey] = {
     UseCaseID.CUSTOM: UseCaseKey.PERFORMANCE,
     UseCaseID.BUNDLE_ANALYSIS: UseCaseKey.PERFORMANCE,
     UseCaseID.PROFILES: UseCaseKey.PERFORMANCE,
+    UseCaseID.METRIC_STATS: UseCaseKey.PERFORMANCE,
 }
 
 # TODO: Remove this as soon as the entire indexer system is use case aware
@@ -46,6 +48,7 @@ USE_CASE_ID_CARDINALITY_LIMIT_QUOTA_OPTIONS = {
     UseCaseID.SPANS: "sentry-metrics.cardinality-limiter.limits.spans.per-org",
     UseCaseID.CUSTOM: "sentry-metrics.cardinality-limiter.limits.custom.per-org",
     UseCaseID.PROFILES: "sentry-metrics.cardinality-limiter.limits.profiles.per-org",
+    UseCaseID.METRIC_STATS: "sentry-metrics.cardinality-limiter.limits.metric_stats.per-org",
 }
 
 USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS = {

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -44,6 +44,10 @@ def test_global_config():
 
     config["options"]["profiling.generic_metrics.functions_ingestion.enabled"] = True
 
+    # Default coming from options `{}` is removed because empty in librelay
+    del config["options"]["relay.metric-bucket-distribution-encodings"]
+    del config["options"]["relay.metric-bucket-set-encodings"]
+
     normalized = normalize_global_config(config)
     assert normalized == config
 

--- a/tests/sentry/sentry_metrics/test_strings.py
+++ b/tests/sentry/sentry_metrics/test_strings.py
@@ -115,6 +115,7 @@ def test_shared_mri_string_range(mri, id):
             "escalating_issues": (500, 599),
             "profiles": (600, 699),
             "bundle_analysis": (700, 799),
+            "metric_stats": (800, 899),
         }[parsed_mri.namespace]
     except KeyError:
         raise Exception(f"Unknown namespace: {parsed_mri.namespace}")


### PR DESCRIPTION
Adds the `metrics_stats` namespace and some initial strings.

All strings added are currently unused.

Depends on a librelay release after: https://github.com/getsentry/relay/pull/3267
Epic: https://github.com/getsentry/relay/issues/3147