### PR TITLE
ref(projconfigs): Add more instrumentation

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -305,7 +305,10 @@ def get_project_config(
     """
     with sentry_sdk.push_scope() as scope:
         scope.set_tag("project", project.id)
-        with metrics.timer("relay.config.get_project_config.duration"):
+        with (
+            sentry_sdk.start_transaction(op="get_project_config"),
+            metrics.timer("relay.config.get_project_config.duration"),
+        ):
             return _get_project_config(project, full_config=full_config, project_keys=project_keys)
 
 
@@ -435,8 +438,9 @@ def _get_project_config(
 
     config = cfg["config"]
 
-    if exposed_features := get_exposed_features(project):
-        config["features"] = exposed_features
+    with sentry_sdk.start_span(op="get_exposed_features"):
+        if exposed_features := get_exposed_features(project):
+            config["features"] = exposed_features
 
     # NOTE: Omitting dynamicSampling because of a failure increases the number
     # of events forwarded by Relay, because dynamic sampling will stop filtering

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -99,15 +99,19 @@ def get_metric_extraction_config(project: Project) -> MetricExtractionConfig | N
      - On-demand metrics widgets.
     """
     # For efficiency purposes, we fetch the flags in batch and propagate them downstream.
-    enabled_features = on_demand_metrics_feature_flags(project.organization)
     sentry_sdk.set_tag("organization_id", project.organization_id)
+    with sentry_sdk.start_span(op="on_demand_metrics_feature_flags"):
+        enabled_features = on_demand_metrics_feature_flags(project.organization)
 
     prefilling = "organizations:on-demand-metrics-prefill" in enabled_features
 
-    alert_specs = _get_alert_metric_specs(project, enabled_features, prefilling)
-    widget_specs = _get_widget_metric_specs(project, enabled_features, prefilling)
+    with sentry_sdk.start_span(op="get_alert_metric_specs"):
+        alert_specs = _get_alert_metric_specs(project, enabled_features, prefilling)
+    with sentry_sdk.start_span(op="get_alert_metric_specs"):
+        widget_specs = _get_widget_metric_specs(project, enabled_features, prefilling)
 
-    metric_specs = _merge_metric_specs(alert_specs, widget_specs)
+    with sentry_sdk.start_span(op="merge_metric_specs"):
+        metric_specs = _merge_metric_specs(alert_specs, widget_specs)
     if not metric_specs:
         return None
 


### PR DESCRIPTION
Sometimes, project config builds take too long, but there aren't insights into all the pieces. This PR adds some more spans to cover these gaps.

Once we have more insights, we can consider removing some instrumentation.