### PR TITLE
perf: add tracing to missing spans in processing

### DIFF
--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -470,6 +470,7 @@ def pop_batched_events_from_redis(key: str) -> tuple[list[str], datetime | None,
     return reprocessing_store.pop_batched_events_by_key(key)
 
 
+@sentry_sdk.tracing.trace
 def mark_event_reprocessed(
     data: dict[str, Any] | None = None,
     group_id: str | None = None,

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -843,6 +843,7 @@ def _do_save_event(
             time_synthetic_monitoring_event(data, project_id, start_time)
 
 
+@sentry_sdk.tracing.trace
 def time_synthetic_monitoring_event(data: Event, project_id: int, start_time: float | None) -> bool:
     """
     For special events produced by the recurring synthetic monitoring


### PR DESCRIPTION
Reduces the missing spans in the processing pipeline.

Ref: https://github.com/getsentry/team-ingest/issues/400