### PR TITLE
feat(trace): fix autogrouping space timestamps and trace bar rendering

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -725,7 +725,7 @@ function RenderRow(props: {
           }}
         >
           <div
-            className={`TraceLeftColumnInner ${props.node.has_error ? 'Errored' : ''}`}
+            className={`TraceLeftColumnInner ${props.node.has_errors ? 'Errored' : ''}`}
             style={{
               paddingLeft: props.node.depth * props.manager.row_depth_padding,
             }}
@@ -743,7 +743,7 @@ function RenderRow(props: {
                 status={props.node.fetchStatus}
                 expanded={!props.node.expanded}
                 onClick={e => props.onExpand(e, props.node, !props.node.expanded)}
-                errored={props.node.has_error}
+                errored={props.node.has_errors}
               >
                 {COUNT_FORMATTER.format(props.node.groupCount)}
               </ChildrenButton>

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -530,7 +530,9 @@ export class TraceTree {
       const head = node;
       let tail = node;
       let groupMatchCount = 0;
-      const erroredChildren: TraceTreeNode<TraceTree.NodeValue>[] = [];
+
+      const errors: TraceErrorType[] = [];
+      const performance_issues: TracePerformanceIssue[] = [];
 
       while (
         tail &&
@@ -538,11 +540,11 @@ export class TraceTree {
         isSpanNode(tail.children[0]) &&
         tail.children[0].value.op === head.value.op
       ) {
-        if (
-          isTraceErrorNode(tail) &&
-          (tail.value.errors.length > 0 || tail.value.performance_issues.length > 0)
-        ) {
-          erroredChildren.push(tail);
+        if ((tail?.value?.errors?.length ?? 0) > 0) {
+          errors.push(...tail?.value?.errors);
+        }
+        if ((tail?.value?.performance_issues?.length ?? 0) > 0) {
+          performance_issues.push(...tail.value.performance_issues);
         }
 
         groupMatchCount++;
@@ -551,8 +553,11 @@ export class TraceTree {
 
       // Checking the tail node for errors as it is not included in the grouping
       // while loop, but is hidden when the autogrouped node is collapsed
-      if (tail.hasErrors()) {
-        erroredChildren.push(tail);
+      if ((tail?.value?.errors?.length ?? 0) > 0) {
+        errors.push(...tail?.value?.errors);
+      }
+      if ((tail?.value?.performance_issues?.length ?? 0) > 0) {
+        performance_issues.push(...tail.value.performance_issues);
       }
 
       if (groupMatchCount < 1) {
@@ -583,7 +588,8 @@ export class TraceTree {
       }
 
       autoGroupedNode.groupCount = groupMatchCount + 1;
-      autoGroupedNode.errored_children = erroredChildren;
+      autoGroupedNode.errors = errors;
+      autoGroupedNode.performance_issues = performance_issues;
       autoGroupedNode.space = [
         Math.min(head.value.start_timestamp, tail.value.timestamp) *
           autoGroupedNode.multiplier,
@@ -684,8 +690,23 @@ export class TraceTree {
               );
             }
 
-            if (child.hasErrors()) {
-              autoGroupedNode.errored_children.push(child);
+            if (child.has_errors) {
+              if (
+                child.value &&
+                'errors' in child.value &&
+                Array.isArray(child.value.errors)
+              ) {
+                autoGroupedNode.errors.push(...child.value.errors);
+              }
+              if (
+                child.value &&
+                'performance_issues' in child.value &&
+                Array.isArray(child.value.performance_issues)
+              ) {
+                autoGroupedNode.performance_issues.push(
+                  ...child.value.performance_issues
+                );
+              }
             }
 
             autoGroupedNode.children.push(node.children[j]);
@@ -1083,7 +1104,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     return this._depth;
   }
 
-  hasErrors(): boolean {
+  get has_errors(): boolean {
     return (
       this.value &&
       (('errors' in this.value && this.value.errors.length > 0) ||
@@ -1362,8 +1383,10 @@ export class MissingInstrumentationNode extends TraceTreeNode<TraceTree.MissingI
 export class ParentAutogroupNode extends TraceTreeNode<TraceTree.ChildrenAutogroup> {
   head: TraceTreeNode<TraceTree.Span>;
   tail: TraceTreeNode<TraceTree.Span>;
-  errored_children: TraceTreeNode<TraceTree.NodeValue>[] = [];
   groupCount: number = 0;
+
+  errors: TraceErrorType[] = [];
+  performance_issues: TracePerformanceIssue[] = [];
 
   private _autogroupedSegments: [number, number][] | undefined;
 
@@ -1388,8 +1411,8 @@ export class ParentAutogroupNode extends TraceTreeNode<TraceTree.ChildrenAutogro
     return this.tail.children;
   }
 
-  get has_error(): boolean {
-    return this.errored_children.length > 0;
+  get has_errors(): boolean {
+    return this.errors.length > 0 || this.performance_issues.length > 0;
   }
 
   get autogroupedSegments(): [number, number][] {
@@ -1414,7 +1437,9 @@ export class ParentAutogroupNode extends TraceTreeNode<TraceTree.ChildrenAutogro
 
 export class SiblingAutogroupNode extends TraceTreeNode<TraceTree.SiblingAutogroup> {
   groupCount: number = 0;
-  errored_children: TraceTreeNode<TraceTree.NodeValue>[] = [];
+  errors: TraceErrorType[] = [];
+  performance_issues: TracePerformanceIssue[] = [];
+
   private _autogroupedSegments: [number, number][] | undefined;
 
   constructor(
@@ -1426,8 +1451,8 @@ export class SiblingAutogroupNode extends TraceTreeNode<TraceTree.SiblingAutogro
     this.expanded = false;
   }
 
-  get has_error(): boolean {
-    return this.errored_children.length > 0;
+  get has_errors(): boolean {
+    return this.errors.length > 0 || this.performance_issues.length > 0;
   }
 
   get autogroupedSegments(): [number, number][] {


### PR DESCRIPTION
Fixes scroll jumping in positive X direction and outside of view, refactors autogrouped nodes to collect errors in the same way as other node types and fixes autogrouped space by collecting the min and max durations of the collected nodes