### PR TITLE
perf: reduce redis calls on mark_event_reprocessed

### DIFF
--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -98,7 +98,7 @@ from sentry.eventstore.reprocessing import reprocessing_store
 from sentry.models.eventattachment import EventAttachment
 from sentry.snuba.dataset import Dataset
 from sentry.types.activity import ActivityType
-from sentry.utils import json, metrics, snuba
+from sentry.utils import metrics, snuba
 from sentry.utils.safe import get_path, set_path
 
 logger = logging.getLogger("sentry.reprocessing")
@@ -617,7 +617,6 @@ def get_progress(group_id: int, project_id: int | None = None) -> tuple[int, Any
 
             finish_reprocessing.delay(project_id=project_id, group_id=group_id)
 
-    info = json.loads(info)
     # Our internal sync counters are counting over *all* events, but the
     # progressbar in the frontend goes until max_events. Advance progressbar
     # proportionally.

--- a/tests/sentry/eventstore/processing/test_redis_cluster.py
+++ b/tests/sentry/eventstore/processing/test_redis_cluster.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from sentry.eventstore.reprocessing.redis import RedisReprocessingStore
+from sentry.testutils.helpers.redis import use_redis_cluster
+
+
+@use_redis_cluster()
+def test_mark_event_reprocessed():
+    group_id = 5
+    store = RedisReprocessingStore()
+    date_created = datetime.now()
+    store.start_reprocessing(
+        group_id=group_id, date_created=date_created, sync_count=10, event_count=20
+    )
+    pending, _ = store.get_pending(group_id=group_id)
+    assert pending == "10"
+    result = store.mark_event_reprocessed(group_id=group_id, num_events=0)
+    assert result is False
+    progress = store.get_progress(group_id=group_id)
+    assert progress is not None
+    assert progress.get("syncCount") == 10
+    assert progress.get("totalEvents") == 20


### PR DESCRIPTION
We were spending a lot of time going back and forth for expiring, expiring and decrementing values in redis. Using pipeline reduces that. This portion of the code also didn't had proper redis cluster testing. Now we have it.

Ref: https://github.com/getsentry/team-ingest/issues/400