### PR TITLE
fix(onboarding): Use nodeProfilingIntegration import

### DIFF
--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -38,7 +38,7 @@ Sentry.AWSLambda.init({
   integrations: [${
     params.isProfilingSelected
       ? `
-      new ProfilingIntegration(),`
+      nodeProfilingIntegration(),`
       : ''
   }
 ],${

--- a/static/app/gettingStartedDocs/node/azurefunctions.tsx
+++ b/static/app/gettingStartedDocs/node/azurefunctions.tsx
@@ -40,7 +40,7 @@ Sentry..init({
   integrations: [${
     params.isProfilingSelected
       ? `
-    new ProfilingIntegration(),`
+    nodeProfilingIntegration(),`
       : ''
   }
   ],${

--- a/static/app/gettingStartedDocs/node/connect.tsx
+++ b/static/app/gettingStartedDocs/node/connect.tsx
@@ -40,7 +40,7 @@ Sentry.init({
   integrations: [${
     params.isProfilingSelected
       ? `
-      new ProfilingIntegration(),`
+      nodeProfilingIntegration(),`
       : ''
   }
 ],${

--- a/static/app/gettingStartedDocs/node/express.tsx
+++ b/static/app/gettingStartedDocs/node/express.tsx
@@ -50,7 +50,7 @@ Sentry.init({
   }${
     params.isProfilingSelected
       ? `
-      new ProfilingIntegration(),`
+      nodeProfilingIntegration(),`
       : ''
   }
 ],${

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -47,7 +47,7 @@ Sentry.GCPFunction.init({
   integrations: [${
     params.isProfilingSelected
       ? `
-      new ProfilingIntegration(),`
+      nodeProfilingIntegration(),`
       : ''
   }
 ],${

--- a/static/app/gettingStartedDocs/node/koa.tsx
+++ b/static/app/gettingStartedDocs/node/koa.tsx
@@ -50,7 +50,7 @@ Sentry.init({
   }${
     params.isProfilingSelected
       ? `
-      new ProfilingIntegration(),`
+      nodeProfilingIntegration(),`
       : ''
   }
 ],${

--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -39,7 +39,7 @@ Sentry.init({
   ${
     params.isProfilingSelected
       ? `integrations: [
-    new ProfilingIntegration(),
+    nodeProfilingIntegration(),
   ],`
       : ''
   }${

--- a/static/app/utils/gettingStartedDocs/node.ts
+++ b/static/app/utils/gettingStartedDocs/node.ts
@@ -102,7 +102,7 @@ export function getDefaultNodeImports({
     `const Sentry = require("@sentry/node");`,
   ];
   if (productSelection.profiling) {
-    imports.push(`import { ProfilingIntegration } from "@sentry/profiling-node";`);
+    imports.push(`import { nodeProfilingIntegration } from "@sentry/profiling-node";`);
   }
   return imports;
 }
@@ -117,7 +117,9 @@ export function getDefaulServerlessImports({
     `const Sentry = require("@sentry/serverless");`,
   ];
   if (productSelection.profiling) {
-    imports.push(`const { ProfilingIntegration } = require("@sentry/profiling-node");`);
+    imports.push(
+      `const { nodeProfilingIntegration } = require("@sentry/profiling-node");`
+    );
   }
   return imports;
 }
@@ -129,7 +131,7 @@ export function getProductIntegrations({
 }) {
   const integrations: string[] = [];
   if (productSelection.profiling) {
-    integrations.push(`new ProfilingIntegration(),`);
+    integrations.push(`nodeProfilingIntegration(),`);
   }
   return integrations;
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-docs/issues/9450

We deprecated the `ProfilingIntegration` export as part of https://github.com/getsentry/sentry-javascript/releases/tag/7.104.0. We should switch to `nodeProfilingIntegration()` everywhere as a result.