### PR TITLE
fix(dashboards): Update errors and transactions to med fidelity

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -119,7 +119,7 @@ const mediumFidelityLadder = new GranularityLadder([
   [THIRTY_DAYS, '4h'],
   [TWENTY_FOUR_HOURS + 1, '1h'],
   [ONE_HOUR + 1, '15m'],
-  [0, '5m'],
+  [0, '1m'],
 ]);
 
 const lowFidelityLadder = new GranularityLadder([

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -534,7 +534,12 @@ function getEventsSeriesRequest(
   const {displayType, limit} = widget;
   const {environments, projects} = pageFilters;
   const {start, end, period: statsPeriod} = pageFilters.datetime;
-  const interval = getWidgetInterval(displayType, {start, end, period: statsPeriod});
+  const interval = getWidgetInterval(
+    displayType,
+    {start, end, period: statsPeriod},
+    undefined,
+    'medium'
+  );
   const isMEPEnabled = defined(mepSetting) && mepSetting !== MEPState.TRANSACTIONS_ONLY;
 
   let requestData;


### PR DESCRIPTION
Pins medium fidelity and updates the <=1hr interval to 1min. This ensures better investigation at the 1hr range without incurring more performance load at higher time ranges.

I checked the code to see if anything was hardcoding/expecting the 5m granularity, but I was unable to find any areas where this would be impactful when visualizing a 1 hour time range.

Closes #66645