### PR TITLE
test(ui): Fix act warnings in widget viewer

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -1345,7 +1345,7 @@ describe('Modals -> WidgetViewerModal', function () {
         renderModal({
           initialData,
           widget: {...mockWidget, queries: [{...mockQuery, orderby: 'release'}]},
-        })
+        }).then(() => void 0)
       );
       expect(screen.queryByRole('button', {name: 'Previous'})).not.toBeInTheDocument();
       expect(screen.queryByRole('button', {name: 'Next'})).not.toBeInTheDocument();

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -1345,6 +1345,7 @@ describe('Modals -> WidgetViewerModal', function () {
         renderModal({
           initialData,
           widget: {...mockWidget, queries: [{...mockQuery, orderby: 'release'}]},
+          // in react 17 act requires that nothing is returned
         }).then(() => void 0)
       );
       expect(screen.queryByRole('button', {name: 'Previous'})).not.toBeInTheDocument();


### PR DESCRIPTION
Mostly the same as before, one render needed to be wrapped in act which to me is a sign that something isn't rendering right. This setState seems to get called twice during the test https://github.com/getsentry/sentry/blob/d473b2b2808387cba898ce4019b310eb30f16122/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx#L191 but this doesn't seem like an easy fix.

part of https://github.com/getsentry/frontend-tsc/issues/22