### PR TITLE
fix(perf): Use `yellow300` for `TeamKeyTransaction` star

### DIFF
--- a/static/app/utils/discover/teamKeyTransactionField.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.tsx
@@ -60,7 +60,7 @@ function TeamKeyTransactionField({
             size="zero"
             icon={
               <IconStar
-                color={keyedTeamsCount ? 'yellow400' : 'gray200'}
+                color={keyedTeamsCount ? 'yellow300' : 'gray200'}
                 isSolid={keyedTeamsCount > 0}
                 data-test-id="team-key-transaction-column"
               />

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -434,7 +434,7 @@ class _Table extends Component<Props, State> {
             <TeamKeyTransactionWrapper>
               <IconStar
                 key="keyTransaction"
-                color="yellow400"
+                color="yellow300"
                 isSolid
                 data-test-id="team-key-transaction-header"
               />

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
@@ -60,7 +60,7 @@ function TeamKeyTransactionButton({
             icon={
               <IconStar
                 isSolid={!!keyedTeamsCount}
-                color={keyedTeamsCount ? 'yellow400' : 'subText'}
+                color={keyedTeamsCount ? 'yellow300' : 'subText'}
               />
             }
           >


### PR DESCRIPTION
**Before ——**
<img width="462" alt="Screenshot 2024-03-14 at 9 51 02 AM" src="https://github.com/getsentry/sentry/assets/44172267/5f7dd1b4-ab95-4930-8a45-24c13a68f48c">

**After ——**
<img width="462" alt="Screenshot 2024-03-14 at 9 50 33 AM" src="https://github.com/getsentry/sentry/assets/44172267/bf1f553b-6e2f-4fe1-bc05-3aa6c10dfdbf">