### PR TITLE
fix(dashboards): Set default interval for errors/transactions to 1m

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -230,7 +230,7 @@ describe('add to dashboard modal', () => {
       expect.objectContaining({
         query: expect.objectContaining({
           environment: [],
-          interval: '5m',
+          interval: '1m',
           orderby: '',
           partial: '1',
           project: [1],

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -534,7 +534,11 @@ function getEventsSeriesRequest(
   const {displayType, limit} = widget;
   const {environments, projects} = pageFilters;
   const {start, end, period: statsPeriod} = pageFilters.datetime;
-  const interval = getWidgetInterval(displayType, {start, end, period: statsPeriod});
+  const interval = getWidgetInterval(
+    displayType,
+    {start, end, period: statsPeriod},
+    '1m'
+  );
   const isMEPEnabled = defined(mepSetting) && mepSetting !== MEPState.TRANSACTIONS_ONLY;
 
   let requestData;


### PR DESCRIPTION
Set the desired interval for errors and transactions to 1m instead of 5m.
This makes the most minimal change between our existing behaviour and the
desired behaviour (to have 1m intervals at 1h) because the desired interval won't
exceed the max bucket count here. The other intervals remain relatively the same
for other time ranges.

Closes https://github.com/getsentry/sentry/issues/66645