### PR TITLE
feat(post-process): remove group owner cache

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -15,7 +15,6 @@ from sentry.api.serializers.models.projectownership import ProjectOwnershipSeria
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST
 from sentry.apidocs.examples import ownership_examples
 from sentry.apidocs.parameters import GlobalParams
-from sentry.models.groupowner import GroupOwner
 from sentry.models.project import Project
 from sentry.models.projectownership import ProjectOwnership
 from sentry.ownership.grammar import CODEOWNERS, create_schema_from_issue_owners
@@ -154,11 +153,6 @@ class ProjectOwnershipRequestSerializer(serializers.Serializer):
             new_values["auto_assignment"] = True
             new_values["suspect_committer_auto_assignment"] = False
         if auto_assignment == "Turn off Auto-Assignment":
-            autoassignment_types = ProjectOwnership._get_autoassignment_types(ownership)
-            if autoassignment_types:
-                GroupOwner.invalidate_autoassigned_owner_cache(
-                    ownership.project_id, autoassignment_types
-                )
             new_values["auto_assignment"] = False
             new_values["suspect_committer_auto_assignment"] = False
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1759,8 +1759,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:performance-screens-platform-selector": False,
     # Enable API aka HTTP aka Network Performance module
     "organizations:performance-http-view": False,
-    # Skip groupowner cache post processing
-    "organizations:post-process-skip-groupowner-cache": False,
     # Enable column that shows ttid ttfd contributing spans
     "organizations:mobile-ttid-ttfd-contribution": False,
     # Enable slow DB performance issue type

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -211,7 +211,6 @@ default_manager.add("organizations:performance-trendsv2-dev-only", OrganizationF
 default_manager.add("organizations:performance-use-metrics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-vitals-inp", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-http-view", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:post-process-skip-groupowner-cache", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:profiling-beta", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:profiling-browser", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:profiling-differential-flamegraph-page", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -227,11 +227,6 @@ class GroupAssigneeManager(BaseManager["GroupAssignee"]):
             ownership = ProjectOwnership.get_ownership_cached(group.project.id)
             if not ownership:
                 ownership = ProjectOwnership(project_id=group.project.id)
-            autoassignment_types = ProjectOwnership._get_autoassignment_types(ownership)
-            if autoassignment_types:
-                GroupOwner.invalidate_autoassigned_owner_cache(
-                    group.project.id, autoassignment_types, group.id
-                )
             GroupOwner.invalidate_assignee_exists_cache(group.project.id, group.id)
             GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(group.project.id, group.id)
 

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -110,23 +110,7 @@ class GroupOwner(Model):
         return f"groupowner_id:{group_id}:{project_id}:{':'.join([str(t) for t in autoassignment_types])}"
 
     @classmethod
-    def get_autoassigned_owner_cached(cls, group_id, project_id, autoassignment_types):
-        """
-        Cached read access to find the autoassigned GroupOwner.
-        """
-        cache_key = cls.get_autoassigned_owner_cache_key(group_id, project_id, autoassignment_types)
-        issue_owner = cache.get(cache_key)
-        if issue_owner is None:
-            issue_owner = cls.get_autoassigned_owner_no_cache(
-                group_id, project_id, autoassignment_types
-            )
-            # Store either the GroupOwner if exists or False for no owners
-            cache.set(cache_key, issue_owner, READ_CACHE_DURATION)
-
-        return issue_owner
-
-    @classmethod
-    def get_autoassigned_owner_no_cache(cls, group_id, project_id, autoassignment_types):
+    def get_autoassigned_owner(cls, group_id, project_id, autoassignment_types):
         """
         Non-cached read access to find the autoassigned GroupOwner.
         """

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -104,12 +104,6 @@ class GroupOwner(Model):
         return ActorTuple.from_actor_identifier(self.owner_id())
 
     @classmethod
-    def get_autoassigned_owner_cache_key(self, group_id, project_id, autoassignment_types):
-        if not len(autoassignment_types):
-            raise Exception("Requires the autoassignment types")
-        return f"groupowner_id:{group_id}:{project_id}:{':'.join([str(t) for t in autoassignment_types])}"
-
-    @classmethod
     def get_autoassigned_owner(cls, group_id, project_id, autoassignment_types):
         """
         Non-cached read access to find the autoassigned GroupOwner.
@@ -126,39 +120,6 @@ class GroupOwner(Model):
         if issue_owner is None:
             return False
         return issue_owner
-
-    @classmethod
-    def invalidate_autoassigned_owner_cache(cls, project_id, autoassignment_types, group_id=None):
-        """
-        If `group_id` is provided, clear the autoassigned owner cache for that group, else clear
-        the cache of all groups for a project that had an event within the READ_CACHE_DURATION
-        window.
-        """
-        if group_id:
-            cache_key = cls.get_autoassigned_owner_cache_key(
-                group_id, project_id, autoassignment_types
-            )
-            cache.delete(cache_key)
-            return
-
-        # Get all the groups for a project that had an event within the READ_CACHE_DURATION window.
-        # Any groups without events in that window would have expired their TTL in the cache.
-        queryset = Group.objects.filter(
-            project_id=project_id,
-            last_seen__gte=timezone.now() - timedelta(seconds=READ_CACHE_DURATION),
-        ).values_list("id", flat=True)
-
-        # Run cache invalidation in batches
-        group_id_iter = queryset.iterator(chunk_size=1000)
-        while True:
-            group_ids = list(itertools.islice(group_id_iter, 1000))
-            if not group_ids:
-                break
-            cache_keys = [
-                cls.get_autoassigned_owner_cache_key(group_id, project_id, autoassignment_types)
-                for group_id in group_ids
-            ]
-            cache.delete_many(cache_keys)
 
     @classmethod
     def invalidate_debounce_issue_owners_evaluation_cache(cls, project_id, group_id=None):

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -149,9 +149,6 @@ def process_resource_change(instance, change, **kwargs):
     if not ownership:
         ownership = ProjectOwnership(project_id=instance.project_id)
 
-    autoassignment_types = ProjectOwnership._get_autoassignment_types(ownership)
-    if ownership.auto_assignment:
-        GroupOwner.invalidate_autoassigned_owner_cache(instance.project_id, autoassignment_types)
     GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(instance.project_id)
 
 

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -392,9 +392,6 @@ def process_resource_change(instance, change, **kwargs):
         instance if change == "updated" else None,
         READ_CACHE_DURATION,
     )
-    autoassignment_types = ProjectOwnership._get_autoassignment_types(instance)
-    if len(autoassignment_types) > 0:
-        GroupOwner.invalidate_autoassigned_owner_cache(instance.project_id, autoassignment_types)
     GroupOwner.invalidate_assignee_exists_cache(instance.project.id)
     GroupOwner.invalidate_debounce_issue_owners_evaluation_cache(instance.project_id)
 

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -9,7 +9,6 @@ from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
-from sentry import features
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields import FlexibleForeignKey, JSONField
@@ -276,19 +275,9 @@ class ProjectOwnership(Model):
             logging_extra["autoassignment_types"] = autoassignment_types
 
             # Get the most recent GroupOwner that matches the following order: Suspect Committer, then Ownership Rule, then Code Owner
-            organization = group.project.organization
-            if features.has(
-                "organizations:post-process-skip-groupowner-cache", organization, actor=None
-            ):
-                issue_owner = GroupOwner.get_autoassigned_owner_no_cache(
-                    group.id, project_id, autoassignment_types
-                )
-                logging_extra["use_groupowner_cache"] = False
-            else:
-                issue_owner = GroupOwner.get_autoassigned_owner_cached(
-                    group.id, project_id, autoassignment_types
-                )
-                logging_extra["use_groupowner_cache"] = True
+            issue_owner = GroupOwner.get_autoassigned_owner(
+                group.id, project_id, autoassignment_types
+            )
 
             if issue_owner is False:
                 logger.info("handle_auto_assignment.no_issue_owner", extra=logging_extra)


### PR DESCRIPTION
Now that the group owner cache has been skipped for EA orgs without a problem for a few days, we can roll this out to everyone