### PR TITLE
chore(grouping): Add log for matching primary and secondary configs

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1673,7 +1673,7 @@ def _save_aggregate_new(
     maybe_run_background_grouping(project, job)
 
     record_hash_calculation_metrics(
-        primary.config, primary.hashes, secondary.config, secondary.hashes
+        project, primary.config, primary.hashes, secondary.config, secondary.hashes
     )
 
     # Now that we've used the current and possibly secondary grouping config(s) to calculate the

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -468,6 +468,18 @@ def record_hash_calculation_metrics(
 
         metrics.incr("grouping.hash_comparison", tags=tags)
 
+        # TODO: This is temporary, just until we can figure out how we're recording a hash
+        # comparison metric showing projects calculating both primary and secondary hashes using the
+        # same config
+        if primary_config["id"] == secondary_config["id"]:
+            logger.info(
+                "Equal primary and secondary configs",
+                extra={
+                    "project": project.id,
+                    "primary_config": primary_config["id"],
+                },
+            )
+
     # Track the total number of grouping calculations done overall, so we can divide by the
     # count to get an average number of calculations per event
     metrics.incr("grouping.hashes_calculated", amount=2 if extract_hashes(secondary_hashes) else 1)

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -417,7 +417,11 @@ def get_hash_values(
     primary_grouping_config, primary_hashes = run_primary_grouping(project, job, metric_tags)
 
     record_hash_calculation_metrics(
-        primary_grouping_config, primary_hashes, secondary_grouping_config, secondary_hashes
+        project,
+        primary_grouping_config,
+        primary_hashes,
+        secondary_grouping_config,
+        secondary_hashes,
     )
 
     all_hashes = CalculatedHashes(
@@ -438,6 +442,7 @@ def get_hash_values(
 
 
 def record_hash_calculation_metrics(
+    project: Project,
     primary_config: GroupingConfig,
     primary_hashes: CalculatedHashes,
     secondary_config: GroupingConfig,


### PR DESCRIPTION
When we calculate both primary and secondary hashes for an event, we [log a metric comparing the values](https://github.com/getsentry/sentry/blob/7f577817d9319541a8058cab3d761b09a9cb45e0/src/sentry/grouping/ingest.py#L446-L464), to see how often config changes lead to hash changes. When we do this, we also track which configs are getting used, so we can break down likelihood of change by config. So far, so good.

What's weird, though, is that sometimes our metrics show a project using the same config twice, as both its primary and its secondary. There are only three projects which have matching `grouping_config` and `secondary_grouping_config` project options, and their transition periods have all long since expired, so we shouldn't be calculating two hashes for them. So then how is this happening? This PR adds a log so we can see which projects this is happening to. 