### PR TITLE
fix(trendsv2): Convert request start to int

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -251,7 +251,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
             data[1]["data_start"] = data_start
             data[1]["data_end"] = data_end
             # user requested start and end
-            data[1]["request_start"] = params["start"].timestamp()
+            data[1]["request_start"] = int(params["start"].timestamp())
             data[1]["request_end"] = data_end
             return data
 


### PR DESCRIPTION
We don't need ms accuracy and this is causing downstream typing issues in Seer