### PR TITLE
ref: always use `sentry init` even in getsentry

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -134,7 +134,7 @@ def main(context: dict[str, str]) -> int:
     if not os.path.exists(f"{constants.home}/.sentry/config.yml") or not os.path.exists(
         f"{constants.home}/.sentry/sentry.conf.py"
     ):
-        proc.run((f"{venv_dir}/bin/{repo}", "init", "--dev"))
+        proc.run((f"{venv_dir}/bin/sentry", "init", "--dev"))
 
     # TODO: check healthchecks for redis and postgres to short circuit this
     proc.run(


### PR DESCRIPTION
getsentry init cannot succeed as it explicitly sets SENTRY_CONF to a python file:

```console
$ getsentry init --dev
INFO:The Sentry runner will report development issues to Sentry.io. Use SENTRY_DEVENV_NO_REPORT to avoid reporting issues.
Error: Found legacy '/Users/asottile/workspace/getsentry/getsentry/settings.py' file, so aborting.
```

<!-- Describe your PR here. -->