### PR TITLE
fix(seer): Handle non json responses from seer

### DIFF
--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -1,5 +1,6 @@
 from typing import TypedDict
 
+import sentry_sdk
 from django.conf import settings
 from urllib3 import Retry
 
@@ -52,7 +53,11 @@ def detect_breakpoints(breakpoint_request) -> BreakpointResponse:
         body=json.dumps(breakpoint_request),
         headers={"content-type": "application/json;charset=utf-8"},
     )
-    return json.loads(response.data)
+    try:
+        return json.loads(response.data)
+    except ValueError as e:
+        sentry_sdk.capture_exception(e)
+        return {"data": []}
 
 
 class SimilarIssuesEmbeddingsRequestNotRequired(TypedDict, total=False):

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -8,6 +8,10 @@ from sentry.net.http import connection_from_url
 from sentry.utils import json
 
 
+class SeerException(Exception):
+    pass
+
+
 class BreakpointData(TypedDict):
     project: str
     # For legacy reasons, the group name is always
@@ -53,11 +57,27 @@ def detect_breakpoints(breakpoint_request) -> BreakpointResponse:
         body=json.dumps(breakpoint_request),
         headers={"content-type": "application/json;charset=utf-8"},
     )
-    try:
-        return json.loads(response.data)
-    except ValueError as e:
-        sentry_sdk.capture_exception(e)
-        return {"data": []}
+
+    if response.status >= 200 and response.status < 300:
+        try:
+            return json.loads(response.data)
+        except ValueError as e:
+            # seer failed to return valid json, report the error
+            # and assume no breakpoints were found
+            sentry_sdk.capture_exception(e)
+            return {"data": []}
+
+    with sentry_sdk.push_scope() as scope:
+        scope.set_context(
+            "seer_response",
+            {
+                "data": response.data,
+            },
+        )
+        sentry_sdk.capture_exception(SeerException(f"Seer response: {response.status}"))
+
+    # assume no breakpoints if an error was returned from seer
+    return {"data": []}
 
 
 class SimilarIssuesEmbeddingsRequestNotRequired(TypedDict, total=False):

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -1,50 +1,93 @@
-from unittest import TestCase, mock
+from unittest import mock
 
+import pytest
 from urllib3.response import HTTPResponse
 
-from sentry.seer.utils import SimilarIssuesEmbeddingsRequest, get_similar_issues_embeddings
+from sentry.seer.utils import (
+    SimilarIssuesEmbeddingsRequest,
+    detect_breakpoints,
+    get_similar_issues_embeddings,
+)
 from sentry.utils import json
 
 
-class TestSimilarIssuesEmbeddingsUtils(TestCase):
-    @mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
-    def test_simple_similar_issues_embeddings(self, mock_seer_request):
-        """Test that valid responses are decoded and returned."""
+@mock.patch("sentry.seer.utils.seer_connection_pool.urlopen")
+def test_detect_breakpoints(mock_urlopen):
+    data = {
+        "data": [
+            {
+                "project": "1",
+                "transaction": "foo",
+                "aggregate_range_1": 1.0,
+                "aggregate_range_2": 2.0,
+                "unweighted_t_value": 0.5,
+                "unweighted_p_value": 0.5,
+                "trend_percentage": 1.0,
+                "absolute_percentage_change": 1.0,
+                "trend_difference": 1.0,
+                "breakpoint": 100,
+            },
+        ],
+    }
+    mock_urlopen.return_value = HTTPResponse(json.dumps(data), status=200)
 
-        expected_return_value = {
-            "responses": [
-                {
-                    "message_similarity": 0.95,
-                    "parent_group_id": 6,
-                    "should_group": True,
-                    "stacktrace_similarity": 0.99,
-                }
-            ]
-        }
-        mock_seer_request.return_value = HTTPResponse(
-            json.dumps(expected_return_value).encode("utf-8")
-        )
+    assert detect_breakpoints({}) == data
 
-        params: SimilarIssuesEmbeddingsRequest = {
-            "group_id": 1,
-            "project_id": 1,
-            "stacktrace": "string",
-            "message": "message",
-        }
-        response = get_similar_issues_embeddings(params)
-        assert response == expected_return_value
 
-    @mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
-    def test_empty_similar_issues_embeddings(self, mock_seer_request):
-        """Test that empty responses are returned."""
+@pytest.mark.parametrize(
+    ["body", "status"],
+    [
+        pytest.param("this is not json", 200, id="200 with non json body"),
+        pytest.param("this is not json", 400, id="400 with non json body"),
+        pytest.param("{}", 400, id="400 with json body"),
+    ],
+)
+@mock.patch("sentry_sdk.capture_exception")
+@mock.patch("sentry.seer.utils.seer_connection_pool.urlopen")
+def test_detect_breakpoints_errors(mock_urlopen, mock_capture_exception, body, status):
+    mock_urlopen.return_value = HTTPResponse(body, status=status)
 
-        mock_seer_request.return_value = HTTPResponse([])
+    assert detect_breakpoints({}) == {"data": []}
+    assert mock_capture_exception.called
 
-        params: SimilarIssuesEmbeddingsRequest = {
-            "group_id": 1,
-            "project_id": 1,
-            "stacktrace": "string",
-            "message": "message",
-        }
-        response = get_similar_issues_embeddings(params)
-        assert response == {"responses": []}
+
+@mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
+def test_simple_similar_issues_embeddings(mock_seer_request):
+    """Test that valid responses are decoded and returned."""
+
+    expected_return_value = {
+        "responses": [
+            {
+                "message_similarity": 0.95,
+                "parent_group_id": 6,
+                "should_group": True,
+                "stacktrace_similarity": 0.99,
+            }
+        ]
+    }
+    mock_seer_request.return_value = HTTPResponse(json.dumps(expected_return_value).encode("utf-8"))
+
+    params: SimilarIssuesEmbeddingsRequest = {
+        "group_id": 1,
+        "project_id": 1,
+        "stacktrace": "string",
+        "message": "message",
+    }
+    response = get_similar_issues_embeddings(params)
+    assert response == expected_return_value
+
+
+@mock.patch("sentry.seer.utils.seer_staging_connection_pool.urlopen")
+def test_empty_similar_issues_embeddings(mock_seer_request):
+    """Test that empty responses are returned."""
+
+    mock_seer_request.return_value = HTTPResponse([])
+
+    params: SimilarIssuesEmbeddingsRequest = {
+        "group_id": 1,
+        "project_id": 1,
+        "stacktrace": "string",
+        "message": "message",
+    }
+    response = get_similar_issues_embeddings(params)
+    assert response == {"responses": []}


### PR DESCRIPTION
Seer can send some non json responses in some error cases, so for now at least handle them and return no results while we figure out what the problems are.