### PR TITLE
ref(rules): Render label properly for issue category filter

### DIFF
--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, cast
+from typing import Any
 
 from django import forms
 
@@ -50,6 +50,6 @@ class IssueCategoryFilter(EventFilter):
         return self._passes(group)
 
     def render_label(self) -> str:
-        value = cast(str, self.data.get("value"))
+        value = self.data["value"]
         group_category_name = get_group_type_by_type_id(int(value)).description
         return self.label.format(value=group_category_name)

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -4,7 +4,7 @@ from typing import Any
 from django import forms
 
 from sentry.eventstore.models import GroupEvent
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
 from sentry.models.group import Group
 from sentry.rules import EventState
 from sentry.rules.filters import EventFilter
@@ -48,3 +48,8 @@ class IssueCategoryFilter(EventFilter):
             return False
 
         return self._passes(group)
+
+    def render_label(self) -> str:
+        value = int(self.data.get("value"))
+        group_category_name = get_group_type_by_type_id(value).description
+        return self.label.format(value=group_category_name)

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any
+from typing import Any, cast
 
 from django import forms
 
@@ -50,6 +50,6 @@ class IssueCategoryFilter(EventFilter):
         return self._passes(group)
 
     def render_label(self) -> str:
-        value = int(self.data.get("value"))
-        group_category_name = get_group_type_by_type_id(value).description
+        value = cast(str, self.data.get("value"))
+        group_category_name = get_group_type_by_type_id(int(value)).description
         return self.label.format(value=group_category_name)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1023,7 +1023,8 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             }
         ]
         self.rule.update(
-            data={"conditions": conditions, "filters": filters, "actions": actions, "frequency": 5}, label="my rule"
+            data={"conditions": conditions, "filters": filters, "actions": actions, "frequency": 5},
+            label="my rule",
         )
 
         actions[0]["channel"] = "#new_channel_name"

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -14,6 +14,7 @@ from sentry.integrations.slack.message_builder.notifications.rule_save_edit impo
     SlackRuleSaveEditMessageBuilder,
 )
 from sentry.integrations.slack.utils.channel import strip_channel_name
+from sentry.issues.grouptype import GroupCategory
 from sentry.models.actor import Actor, get_actor_for_user
 from sentry.models.environment import Environment
 from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityType
@@ -1004,7 +1005,15 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
     @responses.activate
     @with_feature("organizations:rule-create-edit-confirm-notification")
     def test_slack_confirmation_notification_contents(self):
-        conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
+        conditions = [
+            {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+        ]
+        filters = [
+            {
+                "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
+                "value": GroupCategory.ERROR.value,
+            }
+        ]
         actions = [
             {
                 "channel_id": "old_channel_id",
@@ -1014,7 +1023,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             }
         ]
         self.rule.update(
-            data={"conditions": conditions, "actions": actions, "frequency": 5}, label="my rule"
+            data={"conditions": conditions, "filters": filters, "actions": actions, "frequency": 5}, label="my rule"
         )
 
         actions[0]["channel"] = "#new_channel_name"
@@ -1066,6 +1075,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "actions": actions,
             "conditions": conditions,
             "frequency": 180,
+            "filters": filters,
             "environment": staging_env.name,
             "owner": get_actor_for_user(self.user).get_actor_identifier(),
         }
@@ -1081,6 +1091,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         rendered_blocks = json.loads(data["blocks"][0])
         assert rendered_blocks[0]["text"]["text"] == message
         changes = "*Changes*\n"
+        changes += "• Added condition 'The issue's category is equal to Error'\n"
         changes += "• Added action 'Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification'\n"
         changes += "• Removed action 'Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification'\n"
         changes += "• Changed frequency from *5 minutes* to *3 hours*\n"


### PR DESCRIPTION
Define `render_label` for the issue category filter so the label shows up properly. 

Before:
<img width="356" alt="Screenshot 2024-03-14 at 12 23 07 PM" src="https://github.com/getsentry/sentry/assets/29959063/6e4714f0-2047-44ec-a462-26ed42633806">
<img width="442" alt="Screenshot 2024-03-14 at 12 25 00 PM" src="https://github.com/getsentry/sentry/assets/29959063/cf38c44c-83ce-47ab-9b8f-45cfbe27afab">


After:
<img width="368" alt="Screenshot 2024-03-14 at 12 22 11 PM" src="https://github.com/getsentry/sentry/assets/29959063/856e2f80-ef53-48c8-8141-e4eadf8b813b">
<img width="487" alt="Screenshot 2024-03-14 at 12 24 37 PM" src="https://github.com/getsentry/sentry/assets/29959063/fde209fb-c184-4ab6-b30c-7656264abdd3">

Closes https://github.com/getsentry/team-core-product-foundations/issues/157