### PR TITLE
chore(analytics): Add tracking for links clicked in what's new section

### DIFF
--- a/static/app/components/sidebar/sidebarPanelItem.tsx
+++ b/static/app/components/sidebar/sidebarPanelItem.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
   /**
@@ -44,6 +46,7 @@ function SidebarPanelItem({
   titleAction,
   children,
 }: Props) {
+  const organization = useOrganization();
   return (
     <SidebarPanelItemRoot>
       {title && (
@@ -58,7 +61,14 @@ function SidebarPanelItem({
 
       {link && (
         <Text>
-          <ExternalLink href={link}>{cta || t('Read More')}</ExternalLink>
+          <ExternalLink
+            href={link}
+            onClick={() =>
+              trackAnalytics('whats_new.link_clicked', {organization, title})
+            }
+          >
+            {cta || t('Read More')}
+          </ExternalLink>
         </Text>
       )}
     </SidebarPanelItemRoot>

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -261,6 +261,7 @@ export type IssueEventParameters = {
   'tag.clicked': {
     is_clickable: boolean;
   };
+  'whats_new.link_clicked': {title?: string};
 };
 
 export type IssueEventKey = keyof IssueEventParameters;
@@ -354,4 +355,5 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_details.sourcemap_wizard_learn_more':
     'Issue Details: Sourcemap Wizard Learn More',
   'issue_details.set_priority': 'Issue Details: Set Priority',
+  'whats_new.link_clicked': "What's New: Link Clicked",
 };


### PR DESCRIPTION
this pr adds in tracking for the clicked links in the what's new section