### PR TITLE
perf: add tracing to nodestore

### DIFF
--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -272,6 +272,7 @@ class NodeStorage(local, Service):
             return self.cache.get_many(id_list)
         return {}
 
+    @sentry_sdk.tracing.trace
     def _set_cache_item(self, id, data):
         if self.cache and data:
             self.cache.set(id, data)

--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -66,6 +66,7 @@ class BigtableNodeStorage(NodeStorage):
         rv.update(self.store.get_many(id_list))
         return rv
 
+    @sentry_sdk.tracing.trace
     def _set_bytes(self, id, data, ttl=None):
         self.store.set(id, data, ttl)
 

--- a/src/sentry/nodestore/django/backend.py
+++ b/src/sentry/nodestore/django/backend.py
@@ -4,6 +4,7 @@ import logging
 import math
 import pickle
 
+import sentry_sdk
 from django.utils import timezone
 
 from sentry.db.models import create_or_update
@@ -50,6 +51,7 @@ class DjangoNodeStorage(NodeStorage):
         Node.objects.filter(id__in=id_list).delete()
         self._delete_cache_items(id_list)
 
+    @sentry_sdk.tracing.trace
     def _set_bytes(self, id, data, ttl=None):
         create_or_update(Node, id=id, values={"data": compress(data), "timestamp": timezone.now()})
 

--- a/src/sentry/nodestore/filesystem/backend.py
+++ b/src/sentry/nodestore/filesystem/backend.py
@@ -2,6 +2,7 @@ import datetime
 import os
 from datetime import timezone
 
+import sentry_sdk
 from django.conf import settings
 
 from sentry.nodestore.base import NodeStorage
@@ -27,6 +28,7 @@ class FileSystemNodeStorage(NodeStorage):
         with open(self.node_path(id), "rb") as file:
             return file.read()
 
+    @sentry_sdk.tracing.trace
     def _set_bytes(self, id: str, data: bytes, ttl=0):
         with open(self.node_path(id), "wb") as file:
             file.write(data)


### PR DESCRIPTION
Adds more traces to understand where we are spending a lot of time.

Ref: https://github.com/getsentry/team-ingest/issues/400