### PR TITLE
ref(event-tags): Various fixes to event-tags tree interface

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -71,11 +71,13 @@ describe('EventTagsTree', function () {
     });
 
     pillOnlyTags.forEach(tag => {
-      expect(screen.queryByText(tag)).not.toBeInTheDocument();
+      const tagComponent = screen.queryByText(tag);
+      expect(tagComponent).toBeInTheDocument();
+      expect(tagComponent).toHaveAttribute('aria-hidden', 'true');
     });
 
     treeBranchTags.forEach(tag => {
-      expect(screen.getByText(tag)).toBeInTheDocument();
+      expect(screen.getByText(tag, {selector: 'div'})).toBeInTheDocument();
     });
 
     const rows = screen.queryAllByTestId('tag-tree-row');

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -132,7 +132,8 @@ function TagTreeRow({
             <TreeBranchIcon />
           </Fragment>
         )}
-        <TreeKey>{tagKey}</TreeKey>
+        <TreeSearchKey aria-hidden>{originalTag.key}</TreeSearchKey>
+        <TreeKey title={originalTag.key}>{tagKey}</TreeKey>
       </TreeKeyTrunk>
       <TreeValueTrunk>
         <TreeValue>
@@ -360,6 +361,7 @@ const TreeColumn = styled('div')`
 const TreeRow = styled('div')`
   border-radius: ${space(0.5)};
   padding-left: ${space(1)};
+  position: relative;
   display: grid;
   grid-column: span 2;
   grid-template-columns: subgrid;
@@ -414,6 +416,14 @@ const TreeValue = styled('div')`
 
 const TreeKey = styled(TreeValue)`
   color: ${p => p.theme.gray300};
+`;
+
+/**
+ * Hidden element to allow browser searching for exact key name
+ */
+const TreeSearchKey = styled('span')`
+  font-size: 0;
+  position: absolute;
 `;
 
 const TreeValueDropdown = styled(DropdownMenu)`

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -410,6 +410,7 @@ const TreeValueTrunk = styled('div')`
 
 const TreeValue = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSizeSmall};
   word-break: break-word;
   grid-column: span 1;
 `;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -497,7 +497,7 @@ describe('groupEventDetails', () => {
   describe('changes to event tags ui', () => {
     async function assertNewTagsView() {
       expect(await screen.findByText('Event ID:')).toBeInTheDocument();
-      const contextSummary = screen.getByTestId('context-summary');
+      const contextSummary = screen.getByTestId('highlighted-event-data');
       const contextSummaryContainer = within(contextSummary);
       // 3 contexts in makeDefaultMockData.event.contexts, trace is ignored
       expect(contextSummaryContainer.queryAllByTestId('context-item')).toHaveLength(3);

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -5,7 +5,6 @@ import {CommitRow} from 'sentry/components/commitRow';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EventContexts} from 'sentry/components/events/contexts';
 import ContextSummary from 'sentry/components/events/contextSummary';
-import {CONTEXT_DOCS_LINK} from 'sentry/components/events/contextSummary/utils';
 import {EventDevice} from 'sentry/components/events/device';
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
@@ -37,13 +36,13 @@ import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import {DataSection} from 'sentry/components/events/styles';
 import {SuspectCommits} from 'sentry/components/events/suspectCommits';
 import {EventUserFeedback} from 'sentry/components/events/userFeedback';
-import ExternalLink from 'sentry/components/links/externalLink';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Group, Project} from 'sentry/types';
 import {IssueCategory, IssueType} from 'sentry/types';
 import type {EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
+import {objectIsEmpty} from 'sentry/utils';
 import {shouldShowCustomErrorResourceConfig} from 'sentry/utils/issueTypeConfig';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ResourcesAndMaybeSolutions} from 'sentry/views/issueDetails/resourcesAndMaybeSolutions';
@@ -131,16 +130,12 @@ function DefaultGroupEventDetailsContent({
           project={project}
         />
       )}
-      {hasNewTagsUI && (
+      {hasNewTagsUI && !objectIsEmpty(event.contexts) && (
         <EventDataSection
-          title={t('Context Summary')}
-          help={tct('A summary contexts derived from this event. [link:Learn more]', {
-            link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
-          })}
-          isHelpHoverable
-          data-test-id="context-summary"
-          guideTarget="context-summary"
-          type="context-summary"
+          title={t('Highlighted Event Data')}
+          data-test-id="highlighted-event-data"
+          guideTarget="highlighted-event-data"
+          type="highlighted-event-data"
         >
           <ContextSummary event={event} />
         </EventDataSection>


### PR DESCRIPTION
Changes added in this PR:

- Hide the 'context summary' when no context is available
- Rename 'context summary' to 'highlighted event data' and remove tooltip
- Change the font-size to 12px
- Ensure tag keys have their original key on hover
- Add hidden text for users using browser search for nested tag keys