### PR TITLE
fix(grouping): Fix metrics for tracking avg number of calculations per event

### DIFF
--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -484,7 +484,8 @@ def record_hash_calculation_metrics(
 
     # Track the total number of grouping calculations done overall, so we can divide by the
     # count to get an average number of calculations per event
-    metrics.incr("grouping.hashes_calculated", amount=2 if has_secondary_hashes else 1)
+    metrics.incr("grouping.event_hashes_calculated")
+    metrics.incr("grouping.total_calculations", amount=2 if has_secondary_hashes else 1)
 
 
 def record_new_group_metrics(event: Event):


### PR DESCRIPTION
As part of the grouping config transition optimization work, we want to track the average number of calculations per event, under the theory that it should go down with the optimization in place. To that end, we've been collecting a `grouping.hashes_calculated` metric which increments by the number of calculations done for that event. While that's the correct numerator for our average, we don't have a reliable denominator, once which counts the number of times we run the overall hashing process. This adds a metric tracking that.

Notes:

- The name `grouping.hashes_calculated` could mean either the number of times a hash calculation was done (each using a single config) or an instance of an event getting all of its hashes calculated. I therefore chose to ditch that name entirely, in favor of two names (`grouping.total_calculations` and `grouping.event_hashes_calculated`, respectively) which clearly differentiate between the two meanings.

- I've tagged both metrics with transition status and optimization feature flag value, so we can compare the different cases.