### PR TITLE
fix(ui): Use `yellow300` for star icons

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -59,7 +59,7 @@ function EventOrGroupHeader({
         {!hideLevel && level && !hasIssuePriority && <GroupLevel level={level} />}
         {!hideIcons && isBookmarked && (
           <IconWrapper>
-            <IconStar isSolid color="yellow400" />
+            <IconStar isSolid color="yellow300" />
           </IconWrapper>
         )}
         <ErrorBoundary customComponent={<EventTitleError />} mini>

--- a/static/app/components/projects/bookmarkStar.tsx
+++ b/static/app/components/projects/bookmarkStar.tsx
@@ -44,7 +44,7 @@ function BookmarkStar({className, organization, project, onToggle}: Props) {
       borderless
       className={className}
       icon={
-        <IconStar color={isBookmarked ? 'yellow400' : 'subText'} isSolid={isBookmarked} />
+        <IconStar color={isBookmarked ? 'yellow300' : 'subText'} isSolid={isBookmarked} />
       }
     />
   );

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -93,7 +93,7 @@ function TeamMisery({
             }
             headers={[
               <FlexCenter key="transaction">
-                <StyledIconStar isSolid color="yellow400" /> {t('Key transaction')}
+                <StyledIconStar isSolid color="yellow300" /> {t('Key transaction')}
               </FlexCenter>,
               t('Project'),
               tct('Last [period]', {period}),
@@ -126,7 +126,7 @@ function TeamMisery({
                 <Fragment key={idx}>
                   <KeyTransactionTitleWrapper>
                     <div>
-                      <StyledIconStar isSolid color="yellow400" />
+                      <StyledIconStar isSolid color="yellow300" />
                     </div>
                     <TransactionWrapper>
                       <Link

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -278,7 +278,7 @@ class Table extends Component<Props, State> {
           const star = (
             <IconStar
               key="keyTransaction"
-              color="yellow400"
+              color="yellow300"
               isSolid
               data-test-id="key-transaction-header"
             />


### PR DESCRIPTION
**Before ——**
<img width="381" alt="Screenshot 2024-03-14 at 2 06 44 PM" src="https://github.com/getsentry/sentry/assets/44172267/978a3d89-d843-45dd-8f20-ffa670d31502">

**After ——**
<img width="381" alt="Screenshot 2024-03-14 at 2 06 35 PM" src="https://github.com/getsentry/sentry/assets/44172267/23db304c-bca3-44f8-bae7-74658aeda151">