### PR TITLE
ref(rules): Translate int minutes to words

### DIFF
--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -46,11 +46,11 @@ def generate_diff_labels(
     return changed_data
 
 
-def get_frequency_label(value: str) -> str | None:
-    if not value:
+def get_frequency_label(value_str: str | None) -> str | None:
+    if not value_str:
         return None
 
-    value = int(value)
+    value = int(value_str)
     if value < 60:
         return f"{value} minutes"
     elif value >= 60 and value < 10080:

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1013,7 +1013,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 "channel": "#old_channel_name",
             }
         ]
-        self.rule.update(data={"conditions": conditions, "actions": actions}, label="my rule")
+        self.rule.update(
+            data={"conditions": conditions, "actions": actions, "frequency": 5}, label="my rule"
+        )
 
         actions[0]["channel"] = "#new_channel_name"
         actions[0]["channel_id"] = "new_channel_id"
@@ -1063,7 +1065,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "filterMatch": "any",
             "actions": actions,
             "conditions": conditions,
-            "frequency": 30,
+            "frequency": 180,
             "environment": staging_env.name,
             "owner": get_actor_for_user(self.user).get_actor_identifier(),
         }
@@ -1081,7 +1083,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         changes = "*Changes*\n"
         changes += "• Added action 'Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification'\n"
         changes += "• Removed action 'Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification'\n"
-        changes += "• Changed frequency from *None* to *30*\n"
+        changes += "• Changed frequency from *5 minutes* to *3 hours*\n"
         changes += f"• Added *{staging_env.name}* environment\n"
         changes += "• Changed rule name from *my rule* to *new rule*\n"
         changes += "• Changed trigger from *None* to *any*\n"


### PR DESCRIPTION
Based on the hardcoded values we have available as options [here](https://github.com/getsentry/sentry/blob/be87b8cea8131a46248e11507edd8d58d4d59f3d/static/app/views/alerts/rules/issue/index.tsx#L83-L93) translate the number of minutes to available values for human readability.

Before:
<img width="423" alt="Screenshot 2024-03-14 at 2 53 47 PM" src="https://github.com/getsentry/sentry/assets/29959063/411e07a6-2844-421b-a302-58bbdfcd7923">

After:
<img width="431" alt="Screenshot 2024-03-14 at 2 53 52 PM" src="https://github.com/getsentry/sentry/assets/29959063/f4631d4e-393f-404f-bf58-9b9d4cca2afa">


Closes https://github.com/getsentry/team-core-product-foundations/issues/158