### PR TITLE
fix(hc): Replace tuples as RPC return types

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -40,13 +40,14 @@ from sentry.models.orgauthtoken import is_org_auth_token_auth
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.notifications.helpers import collect_groups_by_project, get_subscription_from_attributes
-from sentry.notifications.types import GroupSubscriptionStatus, NotificationSettingEnum
+from sentry.notifications.types import NotificationSettingEnum
 from sentry.reprocessing2 import get_progress
 from sentry.search.events.constants import RELEASE_STAGE_ALIAS
 from sentry.search.events.filter import convert_search_filter_to_snuba_query, format_search_filter
 from sentry.services.hybrid_cloud.auth import AuthenticatedToken
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.notifications import notifications_service
+from sentry.services.hybrid_cloud.notifications.serial import deserialize_group_subscription_status
 from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.snuba.dataset import Dataset
@@ -573,7 +574,11 @@ class GroupSerializerBase(Serializer, ABC):
         enabled_settings = notifications_service.get_subscriptions_for_projects(
             user_id=user.id, project_ids=project_ids, type=NotificationSettingEnum.WORKFLOW
         )
-        query_groups = {group for group in groups if (not enabled_settings[group.project_id][2])}
+        query_groups = {
+            group
+            for group in groups
+            if (not enabled_settings[group.project_id].has_only_inactive_subscriptions)
+        }
         subscriptions_by_group_id: dict[int, GroupSubscription] = {
             subscription.group_id: subscription
             for subscription in GroupSubscription.objects.filter(
@@ -585,11 +590,7 @@ class GroupSerializerBase(Serializer, ABC):
         results = {}
         for project_id, group_set in groups_by_project.items():
             s = enabled_settings[project_id]
-            subscription_status = GroupSubscriptionStatus(
-                is_disabled=s[0],
-                is_active=s[1],
-                has_only_inactive_subscriptions=s[2],
-            )
+            subscription_status = deserialize_group_subscription_status(s)
             for group in group_set:
                 subscription = subscriptions_by_group_id.get(group.id)
                 if subscription:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -218,7 +218,7 @@ class InstallationEventWebhook:
                 external_id=external_id,
             )
             if contexts.integration is not None:
-                self._handle_delete(event, contexts.integration, contexts.org_integrations)
+                self._handle_delete(event, contexts.integration, contexts.installs)
             else:
                 # It seems possible for the GH or GHE app to be installed on their
                 # end, but the integration to not exist. Possibly from deleting in

--- a/src/sentry/integrations/jira/utils/api.py
+++ b/src/sentry/integrations/jira/utils/api.py
@@ -90,10 +90,8 @@ def handle_status_change(integration, data):
         logger.info("jira.missing-changelog-status", extra=log_context)
         return
 
-    _, org_integrations = integration_service.get_organization_contexts(
-        integration_id=integration.id
-    )
-    for oi in org_integrations:
+    contexts = integration_service.get_organization_contexts(integration_id=integration.id)
+    for oi in contexts.installs:
         install = integration.get_installation(organization_id=oi.organization_id)
         if isinstance(install, IssueSyncMixin):
             install.sync_status_inbound(issue_key, {"changelog": changelog, "issue": data["issue"]})

--- a/src/sentry/integrations/mixins/repositories.py
+++ b/src/sentry/integrations/mixins/repositories.py
@@ -122,9 +122,9 @@ class RepositoryMixin:
 
     def reinstall_repositories(self) -> None:
         """Reinstalls repositories associated with the integration."""
-        _, installs = integration_service.get_organization_contexts(integration_id=self.model.id)
+        contexts = integration_service.get_organization_contexts(integration_id=self.model.id)
 
-        for install in installs:
+        for install in contexts.installs:
             repository_service.reinstall_repositories_for_integration(
                 organization_id=install.organization_id,
                 integration_id=self.model.id,

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -798,13 +798,13 @@ class SlackActionEndpoint(Endpoint):
         if action_option in NOTIFICATION_SETTINGS_ACTION_OPTIONS:
             return self.handle_enable_notifications(slack_request)
 
-        _, org_integrations = integration_service.get_organization_contexts(
+        contexts = integration_service.get_organization_contexts(
             integration_id=slack_request.integration.id
         )
         use_block_kit = False
-        if len(org_integrations):
+        if len(contexts.installs):
             org_context = organization_service.get_organization_by_id(
-                id=org_integrations[0].organization_id, include_projects=False, include_teams=False
+                id=contexts.installs[0].organization_id, include_projects=False, include_teams=False
             )
             if org_context:
                 use_block_kit = any(
@@ -816,7 +816,7 @@ class SlackActionEndpoint(Endpoint):
                             )
                             else False
                         )
-                        for oi in org_integrations
+                        for oi in (contexts.installs)
                     ]
                 )
 

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -50,11 +50,9 @@ def get_org_integrations(
     can be shared by multiple orgs.
     """
 
-    _, org_integrations = integration_service.get_organization_contexts(
-        integration_id=integration_id
-    )
+    contexts = integration_service.get_organization_contexts(integration_id=integration_id)
 
-    return org_integrations
+    return contexts.installs
 
 
 def bind_org_context_from_integration(

--- a/src/sentry/services/hybrid_cloud/integration/model.py
+++ b/src/sentry/services/hybrid_cloud/integration/model.py
@@ -69,6 +69,11 @@ class RpcOrganizationIntegration(RpcModel):
         return "disabled"
 
 
+class RpcOrganizationIntegrationContextResult(RpcModel):
+    integration: RpcIntegration | None
+    installs: list[RpcOrganizationIntegration]
+
+
 class RpcIntegrationExternalProject(RpcModel):
     id: int
     organization_integration_id: int

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -11,6 +11,7 @@ from sentry.services.hybrid_cloud.integration import RpcIntegration, RpcOrganiza
 from sentry.services.hybrid_cloud.integration.model import (
     RpcIntegrationExternalProject,
     RpcIntegrationIdentityContext,
+    RpcOrganizationIntegrationContextResult,
 )
 from sentry.services.hybrid_cloud.pagination import RpcPaginationArgs, RpcPaginationResult
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
@@ -128,8 +129,6 @@ class IntegrationService(RpcService):
         )
         return ois[0] if len(ois) > 0 else None
 
-    @rpc_method
-    @abstractmethod
     def get_organization_context(
         self,
         *,
@@ -142,6 +141,14 @@ class IntegrationService(RpcService):
         Returns a tuple of RpcIntegration and RpcOrganizationIntegration. The integration is selected
         by either integration_id, or a combination of provider and external_id.
         """
+        contexts = self.get_organization_contexts(
+            organization_id=organization_id,
+            integration_id=integration_id,
+            provider=provider,
+            external_id=external_id,
+        )
+
+        return contexts.integration, (contexts.installs[0] if contexts.installs else None)
 
     @rpc_method
     @abstractmethod
@@ -152,10 +159,10 @@ class IntegrationService(RpcService):
         integration_id: int | None = None,
         provider: str | None = None,
         external_id: str | None = None,
-    ) -> tuple[RpcIntegration | None, list[RpcOrganizationIntegration]]:
+    ) -> RpcOrganizationIntegrationContextResult:
         """
-        Returns a tuple of RpcIntegration and RpcOrganizationIntegrations. The integrations are selected
-        by either integration_id, or a combination of provider and external_id.
+        The integrations are selected by either integration_id, or a combination of
+        provider and external_id.
         """
 
     @rpc_method

--- a/src/sentry/services/hybrid_cloud/notifications/model.py
+++ b/src/sentry/services/hybrid_cloud/notifications/model.py
@@ -20,3 +20,9 @@ class RpcExternalActor(RpcModel):
     external_name: str = ""
     # The unique identifier i.e user ID, channel ID.
     external_id: str | None = None
+
+
+class RpcGroupSubscriptionStatus(RpcModel):
+    is_disabled: bool
+    is_active: bool
+    has_only_inactive_subscriptions: bool

--- a/src/sentry/services/hybrid_cloud/notifications/serial.py
+++ b/src/sentry/services/hybrid_cloud/notifications/serial.py
@@ -1,5 +1,6 @@
 from sentry.models.integrations.external_actor import ExternalActor
-from sentry.services.hybrid_cloud.notifications import RpcExternalActor
+from sentry.notifications.types import GroupSubscriptionStatus
+from sentry.services.hybrid_cloud.notifications import RpcExternalActor, RpcGroupSubscriptionStatus
 
 
 def serialize_external_actor(actor: ExternalActor) -> RpcExternalActor:
@@ -12,4 +13,24 @@ def serialize_external_actor(actor: ExternalActor) -> RpcExternalActor:
         provider=actor.provider,
         external_name=actor.external_name,
         external_id=actor.external_id,
+    )
+
+
+def serialize_group_subscription_status(
+    status: GroupSubscriptionStatus,
+) -> RpcGroupSubscriptionStatus:
+    return RpcGroupSubscriptionStatus(
+        is_disabled=status.is_disabled,
+        is_active=status.is_active,
+        has_only_inactive_subscriptions=status.has_only_inactive_subscriptions,
+    )
+
+
+def deserialize_group_subscription_status(
+    status: RpcGroupSubscriptionStatus,
+) -> GroupSubscriptionStatus:
+    return GroupSubscriptionStatus(
+        is_disabled=status.is_disabled,
+        is_active=status.is_active,
+        has_only_inactive_subscriptions=status.has_only_inactive_subscriptions,
     )

--- a/src/sentry/services/hybrid_cloud/notifications/service.py
+++ b/src/sentry/services/hybrid_cloud/notifications/service.py
@@ -11,6 +11,7 @@ from sentry.notifications.types import (
     NotificationSettingsOptionEnum,
 )
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
+from sentry.services.hybrid_cloud.notifications import RpcGroupSubscriptionStatus
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.silo import SiloMode
 from sentry.types.integrations import ExternalProviderEnum, ExternalProviders
@@ -78,7 +79,7 @@ class NotificationsService(RpcService):
         user_id: int,
         project_ids: list[int],
         type: NotificationSettingEnum,
-    ) -> Mapping[int, tuple[bool, bool, bool]]:
+    ) -> Mapping[int, RpcGroupSubscriptionStatus]:
         pass
 
     @rpc_method

--- a/src/sentry/services/hybrid_cloud/user/model.py
+++ b/src/sentry/services/hybrid_cloud/user/model.py
@@ -150,3 +150,8 @@ class UserIdEmailArgs(TypedDict):
 class RpcVerifyUserEmail(RpcModel):
     exists: bool = False
     email: str = ""
+
+
+class RpcUserCreationResult(RpcModel):
+    user: RpcUser
+    was_newly_created: bool

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -17,7 +17,12 @@ from sentry.services.hybrid_cloud.user import (
     UserSerializeType,
     UserUpdateArgs,
 )
-from sentry.services.hybrid_cloud.user.model import RpcAvatar, RpcVerifyUserEmail, UserIdEmailArgs
+from sentry.services.hybrid_cloud.user.model import (
+    RpcAvatar,
+    RpcUserCreationResult,
+    RpcVerifyUserEmail,
+    UserIdEmailArgs,
+)
 from sentry.silo import SiloMode
 
 
@@ -133,8 +138,6 @@ class UserService(RpcService):
     def get_first_superuser(self) -> RpcUser | None:
         pass
 
-    @rpc_method
-    @abstractmethod
     def get_or_create_user_by_email(
         self,
         *,
@@ -142,6 +145,19 @@ class UserService(RpcService):
         ident: str | None = None,
         referrer: str | None = None,
     ) -> tuple[RpcUser, bool]:
+        """DEPRECATED. To be removed after usage in getsentry is replaced."""
+        result = self.get_or_create_user_by_email_v2(email=email, ident=ident, referrer=referrer)
+        return result.user, result.was_newly_created
+
+    @rpc_method
+    @abstractmethod
+    def get_or_create_user_by_email_v2(
+        self,
+        *,
+        email: str,
+        ident: str | None = None,
+        referrer: str | None = None,
+    ) -> RpcUserCreationResult:
         pass
 
     @rpc_method

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -416,16 +416,14 @@ class BaseApiClient(TrackResponseMixin):
             self.disable_integration(buffer)
 
     def disable_integration(self, buffer: IntegrationRequestBuffer) -> None:
-        rpc_integration, rpc_org_integrations = integration_service.get_organization_contexts(
-            integration_id=self.integration_id
-        )
-        if rpc_integration and rpc_integration.status == ObjectStatus.DISABLED:
+        contexts = integration_service.get_organization_contexts(integration_id=self.integration_id)
+        if contexts.integration and contexts.integration.status == ObjectStatus.DISABLED:
             return
 
         org = None
-        if len(rpc_org_integrations) > 0:
+        if len(contexts.installs) > 0:
             org_context = organization_service.get_organization_by_id(
-                id=rpc_org_integrations[0].organization_id,
+                id=contexts.installs[0].organization_id,
                 include_projects=False,
                 include_teams=False,
             )
@@ -436,18 +434,18 @@ class BaseApiClient(TrackResponseMixin):
             "integration_id": self.integration_id,
             "buffer_record": buffer._get_all_from_buffer(),
         }
-        if len(rpc_org_integrations) == 0 and rpc_integration is None:
+        if len(contexts.installs) == 0 and contexts.integration is None:
             extra["provider"] = "unknown"
             extra["organization_id"] = "unknown"
-        elif len(rpc_org_integrations) == 0:
-            extra["provider"] = rpc_integration.provider
+        elif len(contexts.installs) == 0:
+            extra["provider"] = contexts.integration.provider
             extra["organization_id"] = "unknown"
-        elif rpc_integration is None:
+        elif contexts.integration is None:
             extra["provider"] = "unknown"
-            extra["organization_id"] = rpc_org_integrations[0].organization_id
+            extra["organization_id"] = contexts.installs[0].organization_id
         else:
-            extra["provider"] = rpc_integration.provider
-            extra["organization_id"] = rpc_org_integrations[0].organization_id
+            extra["provider"] = contexts.integration.provider
+            extra["organization_id"] = contexts.installs[0].organization_id
 
         self.logger.info(
             "integration.disabled",
@@ -455,22 +453,22 @@ class BaseApiClient(TrackResponseMixin):
         )
 
         if org and (
-            (rpc_integration.provider == "slack" and buffer.is_integration_fatal_broken())
-            or (rpc_integration.provider == "github")
+            (contexts.integration.provider == "slack" and buffer.is_integration_fatal_broken())
+            or (contexts.integration.provider == "github")
             or (
                 features.has("organizations:gitlab-disable-on-broken", org)
-                and rpc_integration.provider == "gitlab"
+                and contexts.integration.provider == "gitlab"
             )
         ):
             integration_service.update_integration(
-                integration_id=rpc_integration.id, status=ObjectStatus.DISABLED
+                integration_id=contexts.integration.id, status=ObjectStatus.DISABLED
             )
-            notify_disable(org, rpc_integration.provider, self._get_redis_key())
+            notify_disable(org, contexts.integration.provider, self._get_redis_key())
             buffer.clear()
             create_system_audit_entry(
                 organization_id=org.id,
                 target_object=org.id,
                 event=audit_log.get_event_id("INTEGRATION_DISABLED"),
-                data={"provider": rpc_integration.provider},
+                data={"provider": contexts.integration.provider},
             )
         return


### PR DESCRIPTION
For each RPC service that returns a tuple of constant size, introduce an RpcModel to replace it.

The motive is to be able to represent the return types in an OpenAPI schema. Although constant-size tuples are supported under Pydantic for purposes of serialization, OpenAPI does not let us represent a logical type by constraining an array length.