### PR TITLE
Don't display Activated Metric Alerts in the Alerts list yet

### DIFF
--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -286,3 +286,8 @@ export enum RuleActionsCategories {
   SOME_DEFAULT = 'some_default',
   NO_DEFAULT = 'no_default',
 }
+
+export enum MonitorType {
+  CONTINUOUS = 0,
+  ACTIVATED = 1,
+}

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -482,7 +482,9 @@ describe('AlertRulesList', () => {
     const {routerContext, organization} = initializeOrg({organization: defaultOrg});
     render(<AlertRulesList />, {context: routerContext, organization});
 
-    await screen.findByText('Test Metric Alert 2'); // this fails the test if it doesn't find the text as well
+    expect(await screen.findByText('Test Metric Alert 2')).toBeInTheDocument();
+    expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
+
     expect(screen.queryByText('Omitted Test Metric Alert')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -33,7 +33,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 
 import FilterBar from '../../filterBar';
-import {CombinedAlertType, type CombinedMetricIssueAlerts} from '../../types';
+import type {CombinedMetricIssueAlerts} from '../../types';
 import {AlertRuleType} from '../../types';
 import {getTeamParams, isIssueAlert} from '../../utils';
 import AlertHeader from '../header';
@@ -237,9 +237,8 @@ function AlertRulesList() {
                 <Projects orgId={organization.slug} slugs={projectsFromResults}>
                   {({initiallyLoaded, projects}) =>
                     ruleList.map(rule => {
-                      // For now, filter out any ACTIVATED MetricAlerts
                       if (
-                        rule.type === CombinedAlertType.METRIC &&
+                        !isIssueAlert(rule) &&
                         rule.monitorType === MonitorType.ACTIVATED
                       ) {
                         return null;

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -237,6 +237,7 @@ function AlertRulesList() {
                 <Projects orgId={organization.slug} slugs={projectsFromResults}>
                   {({initiallyLoaded, projects}) =>
                     ruleList.map(rule => {
+                      // TODO - Delete this code once we support ACTIVATED monitorType for metric alerts
                       if (
                         !isIssueAlert(rule) &&
                         rule.monitorType === MonitorType.ACTIVATED

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -237,9 +237,13 @@ function AlertRulesList() {
                 <Projects orgId={organization.slug} slugs={projectsFromResults}>
                   {({initiallyLoaded, projects}) =>
                     ruleList.map(rule => {
-                      // TODO - Delete this code once we support ACTIVATED monitorType for metric alerts
+                      const isIssueAlertInstance = isIssueAlert(rule);
+                      const ruleKey = isIssueAlertInstance
+                        ? AlertRuleType.ISSUE
+                        : AlertRuleType.METRIC;
+
                       if (
-                        !isIssueAlert(rule) &&
+                        !isIssueAlertInstance &&
                         rule.monitorType === MonitorType.ACTIVATED
                       ) {
                         return null;
@@ -248,11 +252,7 @@ function AlertRulesList() {
                       return (
                         <RuleListRow
                           // Metric and issue alerts can have the same id
-                          key={`${
-                            isIssueAlert(rule)
-                              ? AlertRuleType.METRIC
-                              : AlertRuleType.ISSUE
-                          }-${rule.id}`}
+                          key={`${ruleKey}-${rule.id}`}
                           projectsLoaded={initiallyLoaded}
                           projects={projects as Project[]}
                           rule={rule}

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -238,7 +238,7 @@ function AlertRulesList() {
                   {({initiallyLoaded, projects}) =>
                     ruleList.map(rule => {
                       const isIssueAlertInstance = isIssueAlert(rule);
-                      const ruleKey = isIssueAlertInstance
+                      const keyPrefix = isIssueAlertInstance
                         ? AlertRuleType.ISSUE
                         : AlertRuleType.METRIC;
 
@@ -252,7 +252,7 @@ function AlertRulesList() {
                       return (
                         <RuleListRow
                           // Metric and issue alerts can have the same id
-                          key={`${ruleKey}-${rule.id}`}
+                          key={`${keyPrefix}-${rule.id}`}
                           projectsLoaded={initiallyLoaded}
                           projects={projects as Project[]}
                           rule={rule}

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import type {MonitorType} from 'sentry/types/alerts';
 import type {MEPAlertsQueryType} from 'sentry/views/alerts/wizard/options';
 import type {SchemaFormConfig} from 'sentry/views/settings/organizationIntegrations/sentryAppExternalForm';
 
@@ -97,6 +98,7 @@ export type UnsavedMetricRule = {
   triggers: Trigger[];
   comparisonDelta?: number | null;
   eventTypes?: EventTypes[];
+  monitorType?: MonitorType;
   owner?: string | null;
   queryType?: MEPAlertsQueryType | null;
 };

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -1,5 +1,5 @@
 import type {User} from 'sentry/types';
-import type {IssueAlertRule, MonitorType} from 'sentry/types/alerts';
+import type {IssueAlertRule} from 'sentry/types/alerts';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 
 type Data = [number, {count: number}[]][];
@@ -95,7 +95,6 @@ interface IssueAlert extends IssueAlertRule {
 interface MetricAlert extends MetricRule {
   type: CombinedAlertType.METRIC;
   latestIncident?: Incident | null;
-  monitorType?: MonitorType;
 }
 
 export type CombinedMetricIssueAlerts = IssueAlert | MetricAlert;

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -1,5 +1,5 @@
 import type {User} from 'sentry/types';
-import type {IssueAlertRule} from 'sentry/types/alerts';
+import type {IssueAlertRule, MonitorType} from 'sentry/types/alerts';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 
 type Data = [number, {count: number}[]][];
@@ -91,9 +91,11 @@ interface IssueAlert extends IssueAlertRule {
   type: CombinedAlertType.ISSUE;
   latestIncident?: Incident | null;
 }
+
 interface MetricAlert extends MetricRule {
   type: CombinedAlertType.METRIC;
   latestIncident?: Incident | null;
+  monitorType?: MonitorType;
 }
 
 export type CombinedMetricIssueAlerts = IssueAlert | MetricAlert;


### PR DESCRIPTION
## Description
Part of the activated alert rules work, this is the first phase of hooking up the UI to use the new API. This will be a noop in production because we are currently unable to create this alert type in the UI. The next PR will be to enable that.

This will omit the ACTIVATED monitor types in the UI until we're ready to edit / create this new alert type in the Alerts UI. This is a temporary measure while we update the `Releases` code to create Activated Alerts.
