### PR TITLE
ref(replay/issues): link full replay to errors tab from rage click issue

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -110,7 +110,6 @@ function EventReplayContent({
                 {...commonProps}
                 component={replayClipPreview}
                 clipOffsets={CLIP_OFFSETS}
-                issueCategory={group?.issueCategory}
               />
             ) : (
               <LazyLoad {...commonProps} component={replayPreview} />

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -64,7 +64,6 @@ function ReplayClipPreviewPlayer({
   analyticsContext,
   orgSlug,
   fullReplayButtonProps,
-  issueCategory,
   isLarge,
   handleForwardClick,
   handleBackClick,
@@ -126,7 +125,6 @@ function ReplayClipPreviewPlayer({
           replayId={replayId}
           fullReplayButtonProps={fullReplayButtonProps}
           replayRecord={replayRecord}
-          issueCategory={issueCategory}
           handleBackClick={handleBackClick}
           handleForwardClick={handleForwardClick}
           overlayText={overlayText}

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -17,7 +17,6 @@ import ReplayProcessingError from 'sentry/components/replays/replayProcessingErr
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {IssueCategory} from 'sentry/types';
 import type {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import type RequestError from 'sentry/utils/requestError/requestError';
@@ -33,7 +32,6 @@ type Props = {
   handleBackClick?: () => void;
   handleForwardClick?: () => void;
   isLarge?: boolean;
-  issueCategory?: IssueCategory;
   onClickNextReplay?: () => void;
   overlayText?: string;
   showNextAndPrevious?: boolean;

--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -16,7 +16,6 @@ import TimeAndScrubberGrid from 'sentry/components/replays/timeAndScrubberGrid';
 import {IconNext, IconPrevious} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {IssueCategory} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
@@ -36,7 +35,6 @@ function ReplayPreviewPlayer({
   replayId,
   fullReplayButtonProps,
   replayRecord,
-  issueCategory,
   handleBackClick,
   handleForwardClick,
   overlayText,
@@ -49,7 +47,6 @@ function ReplayPreviewPlayer({
   fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
   handleBackClick?: () => void;
   handleForwardClick?: () => void;
-  issueCategory?: IssueCategory;
   onClickNextReplay?: () => void;
   overlayText?: string;
   playPausePriority?: ComponentProps<typeof ReplayPlayPauseButton>['priority'];
@@ -68,15 +65,13 @@ function ReplayPreviewPlayer({
   });
   const isFullscreen = useIsFullscreen();
   const startOffsetMs = replay?.getStartOffsetMs() ?? 0;
-  const isRageClickIssue = issueCategory === IssueCategory.REPLAY;
 
   const fullReplayUrl = {
     pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${replayId}/`),
     query: {
       referrer: getRouteStringFromRoutes(routes),
-      t_main: isRageClickIssue ? TabKey.BREADCRUMBS : TabKey.ERRORS,
+      t_main: TabKey.ERRORS,
       t: (currentTime + startOffsetMs) / 1000,
-      f_b_type: isRageClickIssue ? 'rageOrDead' : undefined,
     },
   };
 


### PR DESCRIPTION
- closes https://github.com/getsentry/team-replay/issues/394
- from rage click issue details, link "see full replay" to the errors tab instead

https://github.com/getsentry/sentry/assets/56095982/12e8fa22-56a0-4276-b07a-e06e1db6ae0c

