### PR TITLE
perf(metrics): Only query necessary entities for mri tags

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -621,6 +621,12 @@ def _fetch_tags_or_values_for_mri(
     for entity_key in entity_keys or ():
         where = []
         metric_ids = metric_ids_by_entity_key[entity_key]
+
+        if not metric_ids and metric_mris:
+            # This means non of the specified MRIs exist on this entity,
+            # so we can skip querying it
+            continue
+
         if metric_ids:
             where.append(Condition(Column("metric_id"), Op.IN, list(metric_ids)))
 

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -179,7 +179,7 @@ def run_metrics_query(
     return result["data"]
 
 
-def _get_known_entity_of_metric_mri(metric_mri: str) -> EntityKey | None:
+def get_known_entity_of_metric_mri(metric_mri: str) -> EntityKey | None:
     # ToDo(ogi): Reimplement this
     try:
         SessionMRI(metric_mri)
@@ -191,6 +191,7 @@ def _get_known_entity_of_metric_mri(metric_mri: str) -> EntityKey | None:
         }[entity_prefix]
     except (ValueError, IndexError, KeyError):
         pass
+
     try:
         TransactionMRI(metric_mri)
         entity_prefix = metric_mri.split(":")[0]
@@ -201,6 +202,18 @@ def _get_known_entity_of_metric_mri(metric_mri: str) -> EntityKey | None:
         }[entity_prefix]
     except (ValueError, IndexError, KeyError):
         pass
+
+    try:
+        SpanMRI(metric_mri)
+        entity_prefix = metric_mri.split(":")[0]
+        return {
+            "c": EntityKey.GenericMetricsCounters,
+            "d": EntityKey.GenericMetricsDistributions,
+            "s": EntityKey.GenericMetricsSets,
+        }[entity_prefix]
+    except (ValueError, IndexError, KeyError):
+        pass
+
     try:
         entity_prefix, namespace = metric_mri.split(":")
         if namespace.startswith("custom"):
@@ -219,7 +232,7 @@ def _get_known_entity_of_metric_mri(metric_mri: str) -> EntityKey | None:
 def _get_entity_of_metric_mri(
     projects: Sequence[Project], metric_mri: str, use_case_id: UseCaseID
 ) -> EntityKey:
-    known_entity = _get_known_entity_of_metric_mri(metric_mri)
+    known_entity = get_known_entity_of_metric_mri(metric_mri)
     if known_entity is not None:
         return known_entity
 

--- a/tests/sentry/snuba/metrics/fields/test_base.py
+++ b/tests/sentry/snuba/metrics/fields/test_base.py
@@ -20,7 +20,7 @@ from sentry.snuba.metrics.fields.base import (
     COMPOSITE_ENTITY_CONSTITUENT_ALIAS,
     DERIVED_ALIASES,
     CompositeEntityDerivedMetric,
-    _get_known_entity_of_metric_mri,
+    get_known_entity_of_metric_mri,
 )
 from sentry.snuba.metrics.fields.snql import (
     abnormal_sessions,
@@ -647,10 +647,15 @@ class DerivedMetricAliasTestCase(TestCase):
         ("d:sessions/duration@second", EntityKey.MetricsDistributions),
         ("d:sessions/unknown_metric@second", None),
         ("e:sessions/all@none", None),  # derived metric
+        ("c:transactions/count_per_root_project@none", EntityKey.GenericMetricsCounters),
+        ("d:transactions/duration@millisecond", EntityKey.GenericMetricsDistributions),
+        ("s:transactions/user@none", EntityKey.GenericMetricsSets),
+        ("d:spans/duration@millisecond", EntityKey.GenericMetricsDistributions),
+        ("s:spans/user@none", EntityKey.GenericMetricsSets),
         ("", None),
         ("foo", None),
         ("foo:foo:foo", None),
     ],
 )
 def test_known_entity_of_metric_mri(metric_mri, expected_entity):
-    assert _get_known_entity_of_metric_mri(metric_mri) == expected_entity
+    assert get_known_entity_of_metric_mri(metric_mri) == expected_entity


### PR DESCRIPTION
The MRI tells us exactly which entity needs to be queried to find it. The additional queries to the other entities are guaranteed to return empty results. So leverage this fact and only query the necessary entities.

Empirically, this is about 10% of each transaction.