### PR TITLE
chore(grouping): Small grouping helper fixes

### DIFF
--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -189,7 +189,7 @@ def _is_in_transition(project: Project) -> bool:
     secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
     secondary_grouping_expiry = project.get_option("sentry:secondary_grouping_expiry")
 
-    return secondary_grouping_config and (secondary_grouping_expiry or 0) >= time.time()
+    return bool(secondary_grouping_config) and (secondary_grouping_expiry or 0) >= time.time()
 
 
 def maybe_run_secondary_grouping(

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -185,7 +185,7 @@ def _calculate_background_grouping(
         return _calculate_event_grouping(project, event, config)
 
 
-def _should_run_secondary_grouping(project: Project) -> bool:
+def _is_in_transition(project: Project) -> bool:
     secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
     secondary_grouping_expiry = project.get_option("sentry:secondary_grouping_expiry")
 
@@ -203,7 +203,7 @@ def maybe_run_secondary_grouping(
     secondary_grouping_config = NULL_GROUPING_CONFIG
     secondary_hashes = NULL_HASHES
 
-    if _should_run_secondary_grouping(project):
+    if _is_in_transition(project):
         with metrics.timer("event_manager.secondary_grouping", tags=metric_tags):
             secondary_grouping_config = SecondaryGroupingConfigLoader().get_config_dict(project)
             secondary_hashes = _calculate_secondary_hash(project, job, secondary_grouping_config)

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -448,7 +448,9 @@ def record_hash_calculation_metrics(
     secondary_config: GroupingConfig,
     secondary_hashes: CalculatedHashes,
 ):
-    if extract_hashes(secondary_hashes):
+    has_secondary_hashes = len(extract_hashes(secondary_hashes)) > 0
+
+    if has_secondary_hashes:
         tags = {
             "primary_config": primary_config["id"],
             "secondary_config": secondary_config["id"],
@@ -482,7 +484,7 @@ def record_hash_calculation_metrics(
 
     # Track the total number of grouping calculations done overall, so we can divide by the
     # count to get an average number of calculations per event
-    metrics.incr("grouping.hashes_calculated", amount=2 if extract_hashes(secondary_hashes) else 1)
+    metrics.incr("grouping.hashes_calculated", amount=2 if has_secondary_hashes else 1)
 
 
 def record_new_group_metrics(event: Event):

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -140,7 +140,7 @@ class EventManagerGroupingMetricsTest(TestCase):
         assert hashes_calculated_calls[1].kwargs["amount"] == 2
 
     @mock.patch("sentry.event_manager.metrics.incr")
-    @mock.patch("sentry.grouping.ingest._should_run_secondary_grouping", return_value=True)
+    @mock.patch("sentry.grouping.ingest._is_in_transition", return_value=True)
     def test_records_hash_comparison(self, _, mock_metrics_incr: MagicMock):
         project = self.project
         project.update_option("sentry:grouping_config", NEWSTYLE_CONFIG)


### PR DESCRIPTION
This is a few small fixes to the helpers in `grouping.ingest`, extracted from an upcoming PR.

- Rename `_should_run_secondary_grouping` to `_is_in_transition`, since it will be used in other contexts besides just hash calculation.

- Fix a bug where `_should_run_secondary_grouping`/`_is_in_transition` returned `None` rather than `False` when the answer is no.

- Compute `has_secondary_hashes` in `record_hash_calculation_metrics` and use that rather than calling `extract_hashes` multiple times.