### PR TITLE
feat(grouping): Add grouphash search result to hash calculation metrics

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -61,6 +61,7 @@ from sentry.grouping.ingest import (
     get_hash_values,
     maybe_run_background_grouping,
     maybe_run_secondary_grouping,
+    record_calculation_metric_with_result,
     record_hash_calculation_metrics,
     record_new_group_metrics,
     run_primary_grouping,
@@ -1419,6 +1420,7 @@ def _save_aggregate(
     project = event.project
 
     primary_hashes, secondary_hashes, hashes = get_hash_values(project, job, metric_tags)
+    has_secondary_hashes = len(extract_hashes(secondary_hashes)) > 0
 
     # Now that we've used the current and possibly secondary grouping config(s) to calculate the
     # hashes, we're free to perform a config update if needed. Future events will use the new
@@ -1539,6 +1541,11 @@ def _save_aggregate(
 
                 span.set_tag("create_group_transaction.outcome", "new_group")
                 metric_tags["create_group_transaction.outcome"] = "new_group"
+                record_calculation_metric_with_result(
+                    project=project,
+                    has_secondary_hashes=has_secondary_hashes,
+                    result="new_group",
+                )
 
                 metrics.incr(
                     "group.created",
@@ -1593,6 +1600,18 @@ def _save_aggregate(
         new_hashes = [root_hierarchical_grouphash]
     else:
         new_hashes = []
+
+    primary_hash_values = set(extract_hashes(primary_hashes))
+    new_hash_values = {gh.hash for gh in new_hashes}
+    all_primary_hashes_are_new = primary_hash_values.issubset(new_hash_values)
+    record_calculation_metric_with_result(
+        project=project,
+        has_secondary_hashes=has_secondary_hashes,
+        # If at least one primary hash value isn't new, then we will have found it, since we check
+        # those before the secondary hash values. If the primary hash values are all new, then we
+        # must have found a secondary hash (or we'd be in the group-creation branch).
+        result="found_primary" if not all_primary_hashes_are_new else "found_secondary",
+    )
 
     if new_hashes:
         # There may still be secondary hashes that we did not use to find an
@@ -1651,6 +1670,7 @@ def _save_aggregate_new(
         group_info = handle_existing_grouphash(
             job, primary.existing_grouphash, primary.grouphashes, group_processing_kwargs
         )
+        result = "found_primary"
     # If we haven't, try again using the secondary config
     else:
         secondary = create_and_seek_grouphashes(job, maybe_run_secondary_grouping, metric_tags)
@@ -1661,10 +1681,13 @@ def _save_aggregate_new(
             group_info = handle_existing_grouphash(
                 job, secondary.existing_grouphash, all_grouphashes, group_processing_kwargs
             )
+            result = "found_secondary"
+
         else:
             group_info = create_group_with_grouphashes(
                 job, all_grouphashes, group_processing_kwargs
             )
+            result = "new_group"
 
     # From here on out, we're just doing housekeeping
 
@@ -1675,6 +1698,13 @@ def _save_aggregate_new(
 
     record_hash_calculation_metrics(
         project, primary.config, primary.hashes, secondary.config, secondary.hashes
+    )
+    # TODO: Once the legacy `_save_aggregate` goes away, the logic inside of
+    # `record_calculation_metric_with_result` can be pulled into `record_hash_calculation_metrics`
+    record_calculation_metric_with_result(
+        project=project,
+        has_secondary_hashes=len(extract_hashes(secondary.hashes)) > 0,
+        result=result,
     )
 
     # Now that we've used the current and possibly secondary grouping config(s) to calculate the

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -483,6 +483,16 @@ def record_hash_calculation_metrics(
                 },
             )
 
+
+# TODO: Once the legacy `_save_aggregate` goes away, this logic can be pulled into
+# `record_hash_calculation_metrics`. Right now it's split up because we don't know the value for
+# `result` at the time the legacy `_save_aggregate` (indirectly) calls `record_hash_calculation_metrics`
+def record_calculation_metric_with_result(
+    project: Project,
+    has_secondary_hashes: bool,
+    result: str,
+) -> None:
+
     # Track the total number of grouping calculations done overall, so we can divide by the
     # count to get an average number of calculations per event
     tags = {
@@ -493,6 +503,7 @@ def record_hash_calculation_metrics(
                 project.organization,
             )
         ),
+        "result": result,
     }
     metrics.incr("grouping.event_hashes_calculated", tags=tags)
     metrics.incr("grouping.total_calculations", amount=2 if has_secondary_hashes else 1, tags=tags)

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -140,6 +140,7 @@ class EventManagerGroupingMetricsTest(TestCase):
             assert set(total_calculations_calls[0].kwargs["tags"].keys()) == {
                 "in_transition",
                 "using_transition_optimization",
+                "result",
             }
 
             event_hashes_calculated_calls = get_relevant_metrics_calls(
@@ -149,6 +150,7 @@ class EventManagerGroupingMetricsTest(TestCase):
             assert set(event_hashes_calculated_calls[0].kwargs["tags"].keys()) == {
                 "in_transition",
                 "using_transition_optimization",
+                "result",
             }
 
     @mock.patch("sentry.event_manager.metrics.incr")
@@ -192,6 +194,7 @@ class EventManagerGroupingMetricsTest(TestCase):
                     metric_tags = total_calculations_calls[0].kwargs["tags"]
 
                     assert len(total_calculations_calls) == 1
+                    # The `result` tag is tested in `test_assign_to_group.py`
                     assert metric_tags["in_transition"] == expected_in_transition
                     assert (
                         metric_tags["using_transition_optimization"] == expected_using_optimization


### PR DESCRIPTION
This adds the result of the grouphash search we do in `_save_aggregate`/`_save_aggregate_new` to the metrics measuring the number of calculations we do per event. Possible values are `"new_group"`, `"found_primary"`, and `"found_secondary"`. Knowing this will let us track how often we do two calculations but only need to do one (because the primary hash is found).

Notes:

- In order to make this work with both `_save_aggregate` and `_save_aggregate_new`, I had to split the recording of this metric into its own function, `record_calculation_metric_with_result`. In `_save_aggregate_new`, we know the `result` value by the time we call `record_hash_calculation_metrics`, but that's not true in `_save_aggregate`, so the two metrics need to be added at different times - hence, two functions.

- I chose to add the tests for this into the `assign_to_group` tests rather than the test in `test_event_manager_grouping` which tests the other tags, because the `assign_to_group` tests already have logic to run through all the different combinations of different configs, the feature flag being on or off, matching grouphashes already existing or not, etc, etc. 