### PR TITLE
tests: Add a lock around silo mode in testing to avoid flakes

### DIFF
--- a/src/sentry/hybridcloud/apigateway/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway/apigateway.py
@@ -48,10 +48,6 @@ def proxy_request_if_needed(
     Main execution flow for the API Gateway.
     returns None if proxying is not required, or a response if the proxy was successful.
     """
-    import random
-    import time
-
-    time.sleep(random.random() / 2.0 + 0.5)
     current_silo_mode = SiloMode.get_current_mode()
 
     if current_silo_mode != SiloMode.CONTROL:

--- a/src/sentry/hybridcloud/apigateway/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway/apigateway.py
@@ -48,7 +48,12 @@ def proxy_request_if_needed(
     Main execution flow for the API Gateway.
     returns None if proxying is not required, or a response if the proxy was successful.
     """
+    import random
+    import time
+
+    time.sleep(random.random() / 2.0 + 0.5)
     current_silo_mode = SiloMode.get_current_mode()
+
     if current_silo_mode != SiloMode.CONTROL:
         return None
 

--- a/src/sentry/hybridcloud/apigateway/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway/apigateway.py
@@ -49,7 +49,6 @@ def proxy_request_if_needed(
     returns None if proxying is not required, or a response if the proxy was successful.
     """
     current_silo_mode = SiloMode.get_current_mode()
-
     if current_silo_mode != SiloMode.CONTROL:
         return None
 

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -108,8 +108,8 @@ def _monkey_patch_silo_lock_into_settings_override():
             SILO_LOCK.release()
         return old_disable(self)
 
-    override_settings.enable = new_enable
-    override_settings.disable = new_disable
+    override_settings.enable = new_enable  # type: ignore
+    override_settings.disable = new_disable  # type: ignore
 
 
 def create_test_regions(*names: str, single_tenants: Iterable[str] = ()) -> tuple[Region, ...]:

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -55,29 +55,27 @@ def monkey_patch_single_process_silo_mode_state():
             "to explicit pass 'fake' RPC boundaries."
         )
 
-        with SILO_LOCK:
-            old_mode = state.mode
-            old_region = state.region
-            state.mode = mode
-            state.region = region
-            try:
-                yield
-            finally:
-                state.mode = old_mode
-                state.region = old_region
+        old_mode = state.mode
+        old_region = state.region
+        state.mode = mode
+        state.region = region
+        try:
+            yield
+        finally:
+            state.mode = old_mode
+            state.region = old_region
 
     @contextlib.contextmanager
     def exit() -> Generator[None, None, None]:
-        with SILO_LOCK:
-            old_mode = state.mode
-            old_region = state.region
-            state.mode = None
-            state.region = None
-            try:
-                yield
-            finally:
-                state.mode = old_mode
-                state.region = old_region
+        old_mode = state.mode
+        old_region = state.region
+        state.mode = None
+        state.region = None
+        try:
+            yield
+        finally:
+            state.mode = old_mode
+            state.region = old_region
 
     def get_mode() -> SiloMode | None:
         return state.mode
@@ -96,8 +94,6 @@ def _monkey_patch_silo_lock_into_settings_override():
     when the SILO_MODE is manipulated.
     """
     from django.test.utils import override_settings
-
-    from sentry.silo import SILO_LOCK
 
     old_enable = override_settings.enable
     old_disable = override_settings.disable


### PR DESCRIPTION
I don't like any of this but given in how many places we rebind the `SILO_MODE` this seemed like a quick and dirty way to get this working again. The issue is that we have a lot of code that overrides `SILO_MODE` with the `override_settings` decorator and we also have code that rebinds it with the thread local affordance.

In cases where we actually rebind the global we now acquire the lock. As this is done via a django test helper I found the easiest way here to be another monkey patch.

The right solution would be to retire all uses of `override_settings` for the `SILO_MODE` and either switch over to the thread local solution or to explicitly acquire a lock there.

To demonstrate the issue you can add a sleep into the `proxy_request_if_needed` code:

```python
def proxy_request_if_needed(
    request: Request, view_func: Callable[..., HttpResponseBase], view_kwargs: dict[str, Any]
) -> HttpResponseBase | None:
    import random, time
    time.sleep(random.random() / 2.0 + 0.5)
    ...
```

Test that always fails with that sleep: `tests/relay_integration/lang/java/test_plugin.py::BasicResolvingIntegrationTest::test_basic_resolving`

This should fix a lot of these: https://sentry.sentry.io/issues/?project=2423079&query=%22Max+retries+exceeded+with+url%22+%22testserver%22&referrer=issue-list&statsPeriod=90d