### PR TITLE
feat(ddm): Implement dynamic grouping in the metrics API

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -326,9 +326,6 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
         },
     }
 
-    # Number of groups returned by default for each query.
-    default_limit = 20
-
     def _time_equal_within_bound(
         self, time_1: datetime, time_2: datetime, bound: timedelta
     ) -> bool:
@@ -365,7 +362,8 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
 
     def _validate_order(self, order: str | None) -> QueryOrder | None:
         if order is None:
-            return None
+            # By default, we want to show highest valued metrics.
+            return QueryOrder.DESC
 
         formula_order = QueryOrder.from_string(order)
         if formula_order is None:
@@ -376,9 +374,9 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
 
         return formula_order
 
-    def _validate_limit(self, limit: str | None) -> int:
+    def _validate_limit(self, limit: str | None) -> int | None:
         if not limit:
-            return self.default_limit
+            return None
 
         try:
             return int(limit)

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -417,6 +417,8 @@ class QueryResult:
     @property
     def limit(self) -> int | None:
         # The totals limit is the only one that controls the number of groups that are returned.
+        # TODO: we might want to return the limit that is actually returned to users. In that, we would need to check
+        #  if the queries run have a dynamic interval, since in that case we might need to return limit - 1.
         if self.totals_query:
             return self.totals_query.metrics_query.limit.limit
 

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -226,7 +226,7 @@ class ScheduledQuery:
             # return you at most 100 groups, thus that will be the limit chosen for the totals query. This means that
             # the executor will load 100 entries from totals which will result in the worst case in 100 * 100 = 10k
             # entries in the series query.
-            limit = int(SNUBA_QUERY_LIMIT / intervals_number)
+            limit = SNUBA_QUERY_LIMIT // intervals_number
             if limit <= 0:
                 raise InvalidMetricsQueryError("Your date range contains too many intervals")
 

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -12,7 +12,10 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.querying.common import SNUBA_QUERY_LIMIT
 from sentry.sentry_metrics.querying.data_v2.preparation.base import IntermediateQuery
-from sentry.sentry_metrics.querying.errors import MetricsQueryExecutionError
+from sentry.sentry_metrics.querying.errors import (
+    InvalidMetricsQueryError,
+    MetricsQueryExecutionError,
+)
 from sentry.sentry_metrics.querying.types import GroupKey, GroupsCollection, QueryOrder, QueryType
 from sentry.sentry_metrics.querying.units import MeasurementUnit, UnitFamily
 from sentry.sentry_metrics.querying.visitors import (
@@ -146,6 +149,7 @@ class ScheduledQuery:
     next: Union["ScheduledQuery", None] = None
     order: QueryOrder | None = None
     limit: int | None = None
+    dynamic_limit: bool = False
     unit_family: UnitFamily | None = None
     unit: MeasurementUnit | None = None
     scaling_factor: float | None = None
@@ -162,15 +166,20 @@ class ScheduledQuery:
         updated_metrics_query = self._filter_blocked_projects(
             updated_metrics_query, organization, projects, blocked_metrics_for_projects
         )
-        # We align the date range of the query, considering the supplied interval.
-        updated_metrics_query = self._align_date_range(updated_metrics_query)
+        # We align the date range of the query, considering the supplied interval. We also return
+        # the number of intervals request, which will be used later on to compute the dynamic groups in case no limit
+        # is supplied.
+        updated_metrics_query, intervals_number = self._align_date_range(updated_metrics_query)
 
         # We perform type-specific initializations, since based on the type we want to run
         # a different query.
+        dynamic_limit = False
         if self.type == ScheduledQueryType.SERIES:
             updated_metrics_query = self._initialize_series(updated_metrics_query)
         elif self.type == ScheduledQueryType.TOTALS:
-            updated_metrics_query = self._initialize_totals(updated_metrics_query)
+            updated_metrics_query, dynamic_limit = self._initialize_totals(
+                updated_metrics_query, intervals_number
+            )
 
         # We recursively apply the initialization transformations downstream.
         updated_next = None
@@ -179,7 +188,12 @@ class ScheduledQuery:
                 organization, projects, blocked_metrics_for_projects
             )
 
-        return replace(self, metrics_query=updated_metrics_query, next=updated_next)
+        return replace(
+            self,
+            metrics_query=updated_metrics_query,
+            next=updated_next,
+            dynamic_limit=dynamic_limit,
+        )
 
     def _initialize_series(self, metrics_query: MetricsQuery) -> MetricsQuery:
         updated_metrics_query = metrics_query
@@ -189,7 +203,9 @@ class ScheduledQuery:
 
         return updated_metrics_query
 
-    def _initialize_totals(self, metrics_query: MetricsQuery) -> MetricsQuery:
+    def _initialize_totals(
+        self, metrics_query: MetricsQuery, intervals_number: int | None
+    ) -> tuple[MetricsQuery, bool]:
         updated_metrics_query = metrics_query
 
         # A totals query doesn't have an interval.
@@ -202,9 +218,25 @@ class ScheduledQuery:
                 replace(updated_metrics_query.rollup, orderby=self.order.to_snuba_order())
             )
 
-        updated_metrics_query = updated_metrics_query.set_limit(self.limit or SNUBA_QUERY_LIMIT)
+        limit = self.limit
+        dynamic_limit = False
+        if limit is None:
+            # If no limit is specified, we want to compute the optimal number of groups rounded down. The idea is that
+            # if you have a 10k limit of rows returned by Snuba and you request an interval of 100 elements, Snuba can
+            # return you at most 100 groups, thus that will be the limit chosen for the totals query. This means that
+            # the executor will load 100 entries from totals which will result in the worst case in 100 * 100 = 10k
+            # entries in the series query.
+            limit = int(SNUBA_QUERY_LIMIT / intervals_number)
+            if limit <= 0:
+                raise InvalidMetricsQueryError("Your date range contains too many intervals")
 
-        return updated_metrics_query
+            # We want to increase the limit by 1 to have a lookahead to determine whether more groups exist.
+            limit += 1
+            dynamic_limit = True
+
+        updated_metrics_query = updated_metrics_query.set_limit(limit)
+
+        return updated_metrics_query, dynamic_limit
 
     def is_empty(self) -> bool:
         return not self.metrics_query.scope.org_ids or not self.metrics_query.scope.project_ids
@@ -233,19 +265,22 @@ class ScheduledQuery:
         )
 
     @classmethod
-    def _align_date_range(cls, metrics_query: MetricsQuery) -> MetricsQuery:
+    def _align_date_range(cls, metrics_query: MetricsQuery) -> tuple[MetricsQuery, int | None]:
         # We use as a reference the interval supplied via the initial version of the query.
         interval = metrics_query.rollup.interval
         if interval:
-            modified_start, modified_end, _ = to_intervals(
+            modified_start, modified_end, intervals_number = to_intervals(
                 metrics_query.start,
                 metrics_query.end,
                 interval,
             )
             if modified_start and modified_end:
-                return metrics_query.set_start(modified_start).set_end(modified_end)
+                return (
+                    metrics_query.set_start(modified_start).set_end(modified_end),
+                    intervals_number,
+                )
 
-        return metrics_query
+        return metrics_query, None
 
 
 @dataclass(frozen=True)
@@ -253,6 +288,7 @@ class QueryResult:
     series_query: ScheduledQuery | None
     totals_query: ScheduledQuery | None
     result: Mapping[str, Any]
+    has_more: bool
 
     def __post_init__(self):
         if not self.series_query and not self.totals_query:
@@ -284,11 +320,12 @@ class QueryResult:
                 "modified_start": scheduled_query.metrics_query.start,
                 "modified_end": scheduled_query.metrics_query.end,
             },
+            has_more=False,
         )
 
     @classmethod
     def from_scheduled_query(
-        cls, scheduled_query: ScheduledQuery, query_result: Mapping[str, Any]
+        cls, scheduled_query: ScheduledQuery, query_result: Mapping[str, Any], has_more: bool
     ) -> "QueryResult":
         # We add these fields as top level, so that when merging `QueryResult`(s) we are able to do that easily.
         extended_result = {
@@ -302,6 +339,7 @@ class QueryResult:
                 series_query=scheduled_query,
                 totals_query=None,
                 result=extended_result,
+                has_more=has_more,
             )
         elif scheduled_query.type == ScheduledQueryType.TOTALS:
             extended_result["totals"] = query_result
@@ -309,6 +347,7 @@ class QueryResult:
                 series_query=None,
                 totals_query=scheduled_query,
                 result=extended_result,
+                has_more=has_more,
             )
 
         raise MetricsQueryExecutionError(
@@ -325,6 +364,7 @@ class QueryResult:
             # We merge the dictionaries and in case of duplicated keys, the ones from `other` will be used, as per
             # Python semantics.
             result={**self.result, **other.result},
+            has_more=self.has_more or other.has_more,
         )
 
     @property
@@ -435,21 +475,15 @@ class QueryResult:
 
 @dataclass
 class PartialQueryResult:
-    scheduled_queries: list[ScheduledQuery]
-    executed_results: list[Mapping[str, Any]]
-
-    def add(self, new_query: ScheduledQuery, new_result: Mapping[str, Any]):
-        self.scheduled_queries.append(new_query)
-        self.executed_results.append(new_result)
-        return self
+    previous_queries: list[tuple[ScheduledQuery, Mapping[str, Any], bool]]
 
     def to_query_result(self) -> QueryResult:
         # For now, we naively return the first scheduled query and result, but this is just because
         # we currently support only the chaining of at most two queries, meaning that a partial result
         # can accumulate only one query.
+        last_scheduled_query, last_query_result, has_more = self.previous_queries[0]
         return QueryResult.from_scheduled_query(
-            scheduled_query=self.scheduled_queries[0],
-            query_result=self.executed_results[0],
+            scheduled_query=last_scheduled_query, query_result=last_query_result, has_more=has_more
         )
 
 
@@ -569,27 +603,39 @@ class QueryExecutor:
             if scheduled_query is None:
                 continue
 
+            # If the query is a totals query and has dynamic limit, we want to check if we were able to load more groups
+            # or not.
+            has_more = False
+            if scheduled_query.type == ScheduledQueryType.TOTALS and scheduled_query.dynamic_limit:
+                data = query_result["data"]
+                has_more = len(data) == scheduled_query.limit
+                # We take only the first n - 1 elements, since we have 1 element more of lookahead which is used to
+                # determine if there are more groups.
+                query_result["data"] = data[: scheduled_query.limit - 1]
+
             previous_result = self._query_results[query_index]
             if scheduled_query.next is None:
                 if previous_result is None:
                     self._query_results[query_index] = QueryResult.from_scheduled_query(
-                        scheduled_query, query_result
+                        scheduled_query, query_result, has_more
                     )
                 elif isinstance(previous_result, PartialQueryResult):
                     first_result = previous_result.to_query_result()
-                    second_result = QueryResult.from_scheduled_query(scheduled_query, query_result)
+                    second_result = QueryResult.from_scheduled_query(
+                        scheduled_query, query_result, has_more
+                    )
                     merged_result = first_result.merge(second_result)
                     merged_result.align_series_to_totals(self._organization)
                     self._query_results[query_index] = merged_result
             else:
+                previous_query = (scheduled_query, query_result, has_more)
                 if previous_result is None:
                     self._query_results[query_index] = PartialQueryResult(
-                        scheduled_queries=[scheduled_query],
-                        executed_results=[query_result],
+                        previous_queries=[previous_query],
                     )
                 elif isinstance(previous_result, PartialQueryResult):
-                    self._query_results[query_index] = previous_result.add(
-                        scheduled_query, query_result
+                    self._query_results[query_index] = previous_result.previous_queries.append(
+                        previous_query
                     )
 
             # We bump the next query after the results have been merged, so that the next call to the function will

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -604,6 +604,7 @@ class QueryExecutor:
         # previous result in the `_query_results` array.
         bulk_results = self._bulk_run_query(bulk_requests)
         for query_index, query_result in zip(mappings, bulk_results):
+            query_result = cast(dict[str, Any], query_result)
             scheduled_query = self._scheduled_queries[query_index]
             if scheduled_query is None:
                 continue

--- a/src/sentry/sentry_metrics/querying/data_v2/execution.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/execution.py
@@ -220,7 +220,7 @@ class ScheduledQuery:
 
         limit = self.limit
         dynamic_limit = False
-        if limit is None:
+        if limit is None and intervals_number is not None:
             # If no limit is specified, we want to compute the optimal number of groups rounded down. The idea is that
             # if you have a 10k limit of rows returned by Snuba and you request an interval of 100 elements, Snuba can
             # return you at most 100 groups, thus that will be the limit chosen for the totals query. This means that
@@ -635,15 +635,13 @@ class QueryExecutor:
                     merged_result.align_series_to_totals(self._organization)
                     self._query_results[query_index] = merged_result
             else:
-                previous_query = (scheduled_query, query_result, has_more)
+                current_query = (scheduled_query, query_result, has_more)
                 if previous_result is None:
                     self._query_results[query_index] = PartialQueryResult(
-                        previous_queries=[previous_query],
+                        previous_queries=[current_query],
                     )
                 elif isinstance(previous_result, PartialQueryResult):
-                    self._query_results[query_index] = previous_result.previous_queries.append(
-                        previous_query
-                    )
+                    previous_result.previous_queries.append(current_query)
 
             # We bump the next query after the results have been merged, so that the next call to the function will
             # execute the next queries in the chain.

--- a/src/sentry/sentry_metrics/querying/data_v2/transformation/metrics_api.py
+++ b/src/sentry/sentry_metrics/querying/data_v2/transformation/metrics_api.py
@@ -172,6 +172,7 @@ class MetricsAPIQueryTransformer(QueryTransformer[Mapping[str, Any]]):
                     group_bys=group_bys,
                     order=query_result.order.value if query_result.order else None,
                     limit=query_result.limit,
+                    has_more=query_result.has_more,
                     unit_family=query_result.unit_family.value
                     if query_result.unit_family
                     else None,

--- a/tests/sentry/api/endpoints/test_organization_metrics_query.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_query.py
@@ -52,8 +52,9 @@ class OrganizationMetricsQueryTest(MetricsAPIBaseTestCase):
                 {"name": "aggregate_value", "type": "Float64"},
                 {
                     "group_bys": [],
-                    "limit": 20,
-                    "order": None,
+                    "limit": 3334,
+                    "has_more": False,
+                    "order": "DESC",
                     "scaling_factor": None,
                     "unit": None,
                     "unit_family": None,
@@ -82,8 +83,9 @@ class OrganizationMetricsQueryTest(MetricsAPIBaseTestCase):
                 {"name": "aggregate_value", "type": "Float64"},
                 {
                     "group_bys": [],
-                    "limit": 20,
-                    "order": None,
+                    "limit": 3334,
+                    "has_more": False,
+                    "order": "DESC",
                     "scaling_factor": None,
                     "unit": None,
                     "unit_family": None,

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from django.utils import timezone as django_timezone
@@ -925,6 +926,68 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_meta[0]["order"] == "ASC"
         second_meta = sorted(meta[1], key=lambda value: value.get("name", ""))
         assert second_meta[0]["limit"] == 2
+        assert second_meta[0]["order"] == "DESC"
+
+    @with_feature("organizations:ddm-metrics-api-unit-normalization")
+    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @patch("sentry.sentry_metrics.querying.data_v2.execution.SNUBA_QUERY_LIMIT", 3)
+    def test_query_with_multiple_aggregations_and_single_group_by_and_dynamic_limit(
+        self,
+    ) -> None:
+        query_1 = self.mql("min", TransactionMRI.DURATION.value, group_by="platform")
+        query_2 = self.mql("max", TransactionMRI.DURATION.value, group_by="platform")
+        plan = (
+            MetricsQueriesPlan()
+            .declare_query("query_1", query_1)
+            .declare_query("query_2", query_2)
+            .apply_formula("$query_1", order=QueryOrder.DESC)
+            .apply_formula("$query_2", order=QueryOrder.DESC)
+        )
+
+        # With a snuba limit of 3 and 3 intervals we expect to only have 1 group returned. Currently,
+        # the test is failing because totals are correctly queried but series data is returned up to
+        # 3 elements and since filters are not properly applied, any 3 entries are returned out of all
+        # the groups * intervals combinations. Once the bug will be fixed on the snuba side, we should
+        # expect to get back 3 correct entires from the series query.
+        results = self.run_query(
+            metrics_queries_plan=plan,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"]
+        assert len(data) == 2
+        first_query = sorted(data[0], key=lambda value: value["by"]["platform"])
+        assert len(first_query) == 1
+        assert first_query[0]["by"] == {"platform": "windows"}
+        assert first_query[0]["series"] == [
+            None,
+            self.to_reference_unit(5.0),
+            self.to_reference_unit(4.0),
+        ]
+        assert first_query[0]["totals"] == self.to_reference_unit(4.0)
+        second_query = sorted(data[1], key=lambda value: value["by"]["platform"])
+        assert len(second_query) == 1
+        assert second_query[0]["by"] == {"platform": "ios"}
+        assert second_query[0]["series"] == [
+            None,
+            self.to_reference_unit(6.0),
+            self.to_reference_unit(3.0),
+        ]
+        assert second_query[0]["totals"] == self.to_reference_unit(6.0)
+        meta = results["meta"]
+        assert len(meta) == 2
+        first_meta = sorted(meta[0], key=lambda value: value.get("name", ""))
+        assert first_meta[0]["limit"] == 2
+        assert first_meta[0]["has_more"]
+        assert first_meta[0]["order"] == "DESC"
+        second_meta = sorted(meta[1], key=lambda value: value.get("name", ""))
+        assert second_meta[0]["limit"] == 2
+        assert first_meta[0]["has_more"]
         assert second_meta[0]["order"] == "DESC"
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -948,7 +948,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         # the test is failing because totals are correctly queried but series data is returned up to
         # 3 elements and since filters are not properly applied, any 3 entries are returned out of all
         # the groups * intervals combinations. Once the bug will be fixed on the snuba side, we should
-        # expect to get back 3 correct entires from the series query.
+        # expect to get back 3 correct entries from the series query.
         results = self.run_query(
             metrics_queries_plan=plan,
             start=self.now() - timedelta(minutes=30),


### PR DESCRIPTION
This PR implements a new dynamic limiting mechanism that can figure out the best number of groups to return to stay within the limits of snuba results size.

The new mechanism works in the following way:
1. If no limit is passed, the new limit is calculated as `int(snuba_limit / number_intervals)` (e.g., a limit of 10k and 100 intervals will result in a limit of 100 for the totals query, meaning at most 100 groups).
2. The totals query is run with a limit of `n + 1` because we want to use the + 1 as a lookahead to see if there are more groups (to notify the API user).
3. The totals query results are taken and the last result is removed, since we want to return `n` groups.
4. From there on the system behaves as usual, the series query is scheduled with the groups added as conditions.
5. At the end, if the query had more groups than we returned, we add the `has_more` field to each query's metadata.

Closes: https://github.com/getsentry/sentry/issues/67044