### PR TITLE
feat(ddm): Add endpoint for enrolling in beta

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -216,7 +216,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     isEarlyAdopter = serializers.BooleanField(required=False)
     aiSuggestedSolution = serializers.BooleanField(required=False)
     codecovAccess = serializers.BooleanField(required=False)
-    customMetricsAccess = serializers.BooleanField(required=False)
     githubOpenPRBot = serializers.BooleanField(required=False)
     githubNudgeInvite = serializers.BooleanField(required=False)
     githubPRBot = serializers.BooleanField(required=False)
@@ -432,10 +431,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
             org.flags.codecov_access = data["codecovAccess"]
         if "require2FA" in data:
             org.flags.require_2fa = data["require2FA"]
-        # This option is temporary since we will control custom metrics via a single feature flag in the future. This
-        # organization option is used just for people to opt-in to try out custom metrics.
-        if "customMetricsAccess" in data:
-            org.update_option("sentry:custom_metrics_access", data["customMetricsAccess"])
         if (
             features.has("organizations:required-email-verification", org)
             and "requireEmailVerification" in data

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -402,6 +402,7 @@ from .endpoints.organization_metrics import (
     OrganizationMetricsCodeLocationsEndpoint,
     OrganizationMetricsDataEndpoint,
     OrganizationMetricsDetailsEndpoint,
+    OrganizationMetricsEnrollEndpoint,
     OrganizationMetricsQueryEndpoint,
     OrganizationMetricsSamplesEndpoint,
     OrganizationMetricsTagDetailsEndpoint,
@@ -1977,6 +1978,11 @@ ORGANIZATION_URLS = [
                 ),
             ]
         ),
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^/]+)/metrics/enroll/$",
+        OrganizationMetricsEnrollEndpoint.as_view(),
+        name="sentry-api-0-organization-metrics-enroll",
     ),
     re_path(
         r"^(?P<organization_slug>[^/]+)/metrics/code-locations/$",

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -425,7 +425,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "defaultRole": "owner",
             "require2FA": True,
             "allowJoinRequests": False,
-            "customMetricsAccess": True,
         }
 
         # needed to set require2FA
@@ -459,7 +458,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert options.get("sentry:scrape_javascript") is False
         assert options.get("sentry:join_requests") is False
         assert options.get("sentry:events_member_admin") is False
-        assert options.get("sentry:custom_metrics_access") is True
 
         # log created
         with assume_test_silo_mode_of(AuditLogEntry):

--- a/tests/sentry/api/endpoints/test_organization_metrics_enroll.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics_enroll.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from django.urls import reverse
+
+from sentry.models.apitoken import ApiToken
+from sentry.silo import SiloMode
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+
+
+@region_silo_test
+class OrganizationMetricsEnrollTest(APITestCase):
+    endpoint = "sentry-api-0-organization-metrics-enroll"
+    method = "put"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def test_enroll(self):
+        self.get_success_response(self.organization.slug, status_code=200)
+        assert self.organization.get_option("sentry:custom_metrics_access")
+
+        self.get_success_response(self.organization.slug, status_code=200)
+        assert not self.organization.get_option("sentry:custom_metrics_access")
+
+    def test_permissions(self):
+        for scope in ["org:read", "org:write", "org:admin"]:
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                token = ApiToken.objects.create(user=self.user, scope_list=[scope])
+
+            url = reverse(self.endpoint, args=(self.project.organization.slug,))
+            response = getattr(self.client, self.method)(
+                url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+            )
+            assert response.status_code == 200, f"Expected 200 response with scop {scope}"


### PR DESCRIPTION
This PR adds a new special `metrics/enroll` endpoint which will be used when enrolling people in the metrics beta (applies to Sentry saas).