### PR TITLE
ref: use datetime.UTC instead of datetime.timezone.utc in tests

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -9,7 +9,7 @@ import re
 import time
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from typing import Any, Literal, Union
 from unittest import mock
@@ -35,7 +35,7 @@ from django.test import TransactionTestCase as DjangoTransactionTestCase
 from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
 from django.urls import resolve, reverse
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 from django.utils.functional import cached_property
 from requests.utils import CaseInsensitiveDict, get_encoding_from_headers
 from rest_framework import status
@@ -1115,7 +1115,7 @@ class AcceptanceTestCase(TransactionTestCase):
     def _setup_today(self):
         with mock.patch(
             "django.utils.timezone.now",
-            return_value=(datetime(2013, 5, 18, 15, 13, 58, 132928, tzinfo=timezone.utc)),
+            return_value=(datetime(2013, 5, 18, 15, 13, 58, 132928, tzinfo=UTC)),
         ):
             yield
 
@@ -1485,7 +1485,7 @@ class BaseSpansTestCase(SnubaTestCase):
         if span_id is None:
             span_id = self._random_span_id()
         if timestamp is None:
-            timestamp = datetime.now(tz=timezone.utc)
+            timestamp = timezone.now()
 
         payload = {
             "project_id": project_id,
@@ -1494,7 +1494,7 @@ class BaseSpansTestCase(SnubaTestCase):
             "duration_ms": int(duration),
             "exclusive_time_ms": int(exclusive_time),
             "is_segment": True,
-            "received": datetime.now(tz=timezone.utc).timestamp(),
+            "received": timezone.now().timestamp(),
             "start_timestamp_ms": int(timestamp.timestamp() * 1000),
             "sentry_tags": {"transaction": transaction or "/hello"},
             "retention_days": 90,
@@ -1534,7 +1534,7 @@ class BaseSpansTestCase(SnubaTestCase):
         if span_id is None:
             span_id = self._random_span_id()
         if timestamp is None:
-            timestamp = datetime.now(tz=timezone.utc)
+            timestamp = timezone.now()
 
         payload = {
             "project_id": project_id,
@@ -1543,7 +1543,7 @@ class BaseSpansTestCase(SnubaTestCase):
             "duration_ms": int(duration),
             "exclusive_time_ms": exclusive_time,
             "is_segment": False,
-            "received": datetime.now(tz=timezone.utc).timestamp(),
+            "received": timezone.now().timestamp(),
             "start_timestamp_ms": int(timestamp.timestamp() * 1000),
             "sentry_tags": {
                 "transaction": transaction or "/hello",
@@ -1782,7 +1782,7 @@ class BaseMetricsLayerTestCase(BaseMetricsTestCase):
     # This time has been specifically chosen to be 10:00:00 so that all tests will automatically have the data inserted
     # and queried with automatically inferred timestamps (e.g., usage of - 1 second, get_date_range()...) without
     # incurring into problems.
-    MOCK_DATETIME = (django_timezone.now() - timedelta(days=1)).replace(
+    MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
         hour=10, minute=0, second=0, microsecond=0
     )
 
@@ -2060,7 +2060,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         "s": EntityKey.MetricsSets.value,
     }
     METRIC_STRINGS = []
-    DEFAULT_METRIC_TIMESTAMP = datetime(2015, 1, 1, 10, 15, 0, tzinfo=timezone.utc)
+    DEFAULT_METRIC_TIMESTAMP = datetime(2015, 1, 1, 10, 15, 0, tzinfo=UTC)
 
     def setUp(self):
         super().setUp()
@@ -2262,7 +2262,7 @@ class BaseIncidentsTest(SnubaTestCase):
 
     @cached_property
     def now(self):
-        return django_timezone.now().replace(minute=0, second=0, microsecond=0)
+        return timezone.now().replace(minute=0, second=0, microsecond=0)
 
 
 @pytest.mark.snuba
@@ -2334,7 +2334,7 @@ class ProfilesSnubaTestCase(
             "platform": transaction["platform"],
             "profile_id": profile_id,
             "project_id": project.id,
-            "received": int(datetime.now(tz=timezone.utc).timestamp()),
+            "received": int(timezone.now().timestamp()),
             "retention_days": 90,
             "timestamp": int(timestamp),
             "transaction_name": transaction["transaction"],
@@ -2396,7 +2396,7 @@ class ReplaysSnubaTestCase(TestCase):
 # AcceptanceTestCase and TestCase are mutually exclusive base classses
 class ReplaysAcceptanceTestCase(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        self.now = datetime.now(timezone.utc)
+        self.now = datetime.now(UTC)
         super().setUp()
         self.drop_replays()
         patcher = mock.patch("django.utils.timezone.now", return_value=self.now)
@@ -2785,7 +2785,7 @@ class ActivityTestCase(TestCase):
         release = Release.objects.create(
             version=name * 40,
             organization_id=self.project.organization_id,
-            date_released=django_timezone.now(),
+            date_released=timezone.now(),
         )
         release.add_project(self.project)
         release.add_project(self.project2)

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -1,4 +1,4 @@
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
@@ -28,8 +28,8 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
         incident = self.create_incident(
             self.organization,
             title="Incident #1",
-            date_started=django_timezone.now(),
-            date_detected=django_timezone.now(),
+            date_started=timezone.now(),
+            date_detected=timezone.now(),
             projects=[self.project],
             alert_rule=alert_rule,
         )

--- a/tests/acceptance/test_organization_releases.py
+++ b/tests/acceptance/test_organization_releases.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.sentry_metrics
 
 @no_silo_test
 class OrganizationReleasesTest(AcceptanceTestCase):
-    release_date = datetime(2020, 5, 18, 15, 13, 58, 132928, tzinfo=timezone.utc)
+    release_date = datetime(2020, 5, 18, 15, 13, 58, 132928, tzinfo=UTC)
 
     def setUp(self):
         super().setUp()
@@ -29,7 +29,7 @@ class OrganizationReleasesTest(AcceptanceTestCase):
         self.create_project(organization=self.org, teams=[self.team], name="Bengal 3")
         self.login_as(self.user)
         self.path = f"/organizations/{self.org.slug}/releases/"
-        self.project.update(first_event=django_timezone.now())
+        self.project.update(first_event=timezone.now())
 
     @patch("sentry.api.serializers.models.organization.get_organization_volume", return_value=None)
     def test_list(self, _):

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from base64 import b64encode
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -11,7 +11,7 @@ import responses
 from dateutil.parser import parse as parse_date
 from django.core import mail
 from django.db import router
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 from rest_framework import status
 
 from sentry import audit_log
@@ -242,9 +242,9 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         data = {"trustedRelays": trusted_relays}
 
         with self.feature("organizations:relay"):
-            start_time = datetime.now(timezone.utc)
+            start_time = timezone.now()
             self.get_success_response(self.organization.slug, method="put", **data)
-            end_time = datetime.now(timezone.utc)
+            end_time = timezone.now()
             response = self.get_success_response(self.organization.slug)
 
         response_data = response.data.get("trustedRelays")
@@ -579,9 +579,9 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         data = {"trustedRelays": trusted_relays}
 
         with self.feature("organizations:relay"), outbox_runner():
-            start_time = datetime.now(timezone.utc)
+            start_time = timezone.now()
             response = self.get_success_response(self.organization.slug, **data)
-            end_time = datetime.now(timezone.utc)
+            end_time = timezone.now()
             response_data = response.data.get("trustedRelays")
 
         actual = get_trusted_relay_value(self.organization)
@@ -663,11 +663,11 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         changed_settings = {"trustedRelays": modified_trusted_relays}
 
         with self.feature("organizations:relay"), outbox_runner():
-            start_time = datetime.now(timezone.utc)
+            start_time = timezone.now()
             self.get_success_response(self.organization.slug, **initial_settings)
-            after_initial = datetime.now(timezone.utc)
+            after_initial = timezone.now()
             self.get_success_response(self.organization.slug, **changed_settings)
-            after_final = datetime.now(timezone.utc)
+            after_final = timezone.now()
 
         actual = get_trusted_relay_value(self.organization)
         assert len(actual) == len(modified_trusted_relays)
@@ -911,7 +911,7 @@ class OrganizationDeleteTest(OrganizationDetailsTestBase):
 
         schedule = RegionScheduledDeletion.objects.get(object_id=org.id, model_name="Organization")
         # Delay is 24 hours but to avoid wobbling microseconds we compare with 23 hours.
-        assert schedule.date_scheduled >= django_timezone.now() + timedelta(hours=23)
+        assert schedule.date_scheduled >= timezone.now() + timedelta(hours=23)
 
         # Make sure we've emailed all owners
         assert len(mail.outbox) == len(owners)

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -1,11 +1,11 @@
 import datetime
-from datetime import timedelta, timezone
+from datetime import UTC, timedelta
 from functools import cached_property
 from unittest import mock
 
 from django.conf import settings
 from django.db.models import F
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry import features
 from sentry.api.serializers import serialize
@@ -289,7 +289,7 @@ class ProjectWithTeamSerializerTest(TestCase):
 class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
     def setUp(self):
         super().setUp()
-        self.date = datetime.datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc)
+        self.date = datetime.datetime(2018, 1, 12, 3, 8, 25, tzinfo=UTC)
         self.user = self.create_user(username="foo")
         self.organization = self.create_organization(owner=self.user)
         team = self.create_team(organization=self.organization)
@@ -343,7 +343,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         assert result["firstEvent"] is None
         assert result["firstTransactionEvent"] is False
 
-        self.project.first_event = django_timezone.now()
+        self.project.first_event = timezone.now()
         self.project.update(flags=F("flags").bitor(Project.flags.has_transactions))
 
         result = serialize(self.project, self.user, ProjectSummarySerializer())
@@ -376,7 +376,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasSessions"] is False
 
-        self.project.first_event = django_timezone.now()
+        self.project.first_event = timezone.now()
         self.project.update(flags=F("flags").bitor(Project.flags.has_sessions))
 
         result = serialize(self.project, self.user, ProjectSummarySerializer())
@@ -386,7 +386,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasProfiles"] is False
 
-        self.project.first_event = django_timezone.now()
+        self.project.first_event = timezone.now()
         self.project.update(flags=F("flags").bitor(Project.flags.has_profiles))
 
         result = serialize(self.project, self.user, ProjectSummarySerializer())
@@ -396,7 +396,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasReplays"] is False
 
-        self.project.first_event = django_timezone.now()
+        self.project.first_event = timezone.now()
         self.project.update(flags=F("flags").bitor(Project.flags.has_replays))
 
         result = serialize(self.project, self.user, ProjectSummarySerializer())
@@ -406,7 +406,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasFeedbacks"] is False
 
-        self.project.first_event = django_timezone.now()
+        self.project.first_event = timezone.now()
         self.project.update(flags=F("flags").bitor(Project.flags.has_feedbacks))
 
         result = serialize(self.project, self.user, ProjectSummarySerializer())
@@ -416,7 +416,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasNewFeedbacks"] is False
 
-        self.project.first_event = django_timezone.now()
+        self.project.first_event = timezone.now()
         self.project.update(flags=F("flags").bitor(Project.flags.has_new_feedbacks))
 
         result = serialize(self.project, self.user, ProjectSummarySerializer())
@@ -426,7 +426,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasCustomMetrics"] is False
 
-        self.project.first_event = django_timezone.now()
+        self.project.first_event = timezone.now()
         self.project.update(flags=F("flags").bitor(Project.flags.has_custom_metrics))
 
         result = serialize(self.project, self.user, ProjectSummarySerializer())
@@ -436,7 +436,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasMonitors"] is False
 
-        self.project.first_event = django_timezone.now()
+        self.project.first_event = timezone.now()
         self.project.update(flags=F("flags").bitor(Project.flags.has_cron_monitors))
 
         result = serialize(self.project, self.user, ProjectSummarySerializer())
@@ -446,7 +446,7 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasMinifiedStackTrace"] is False
 
-        self.project.first_event = django_timezone.now()
+        self.project.first_event = timezone.now()
         self.project.update(flags=F("flags").bitor(Project.flags.has_minified_stack_trace))
 
         result = serialize(self.project, self.user, ProjectSummarySerializer())
@@ -696,7 +696,7 @@ class ProjectWithOrganizationSerializerTest(TestCase):
 class DetailedProjectSerializerTest(TestCase):
     def setUp(self):
         super().setUp()
-        self.date = datetime.datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc)
+        self.date = datetime.datetime(2018, 1, 12, 3, 8, 25, tzinfo=UTC)
         self.user = self.create_user(username="foo")
         self.organization = self.create_organization(owner=self.user)
         team = self.create_team(organization=self.organization)
@@ -761,7 +761,7 @@ class BulkFetchProjectLatestReleases(TestCase):
 
     def test_single_release(self):
         release = self.create_release(
-            self.project, date_added=django_timezone.now() - timedelta(minutes=5)
+            self.project, date_added=timezone.now() - timedelta(minutes=5)
         )
         assert bulk_fetch_project_latest_releases([self.project]) == [release]
         newer_release = self.create_release(self.project)
@@ -778,7 +778,7 @@ class BulkFetchProjectLatestReleases(TestCase):
 
     def test_multi_releases(self):
         release = self.create_release(
-            self.project, date_added=django_timezone.now() - timedelta(minutes=5)
+            self.project, date_added=timezone.now() - timedelta(minutes=5)
         )
         other_project_release = self.create_release(self.other_project)
         assert set(bulk_fetch_project_latest_releases([self.project, self.other_project])) == {

--- a/tests/sentry/auth/test_staff.py
+++ b/tests/sentry/auth/test_staff.py
@@ -1,10 +1,10 @@
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.auth import staff
 from sentry.auth.staff import (
@@ -30,7 +30,7 @@ from sentry.utils.auth import mark_sso_complete
 
 UNSET = object()
 
-BASETIME = datetime(2022, 3, 21, 0, 0, tzinfo=timezone.utc)
+BASETIME = datetime(2022, 3, 21, 0, 0, tzinfo=UTC)
 
 EXPIRE_TIME = timedelta(hours=4, minutes=1)
 
@@ -59,7 +59,7 @@ def override_org_id(new_org_id: int):
 class StaffTestCase(TestCase):
     def setUp(self):
         super().setUp()
-        self.current_datetime = django_timezone.now()
+        self.current_datetime = timezone.now()
         self.default_token = "abcdefghijklmnog"
         self.staff_user = self.create_user(is_staff=True)
 

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest import mock
 from unittest.mock import Mock, patch
 
@@ -6,7 +6,7 @@ import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
 from django.test import override_settings
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.auth.superuser import (
     COOKIE_DOMAIN,
@@ -41,7 +41,7 @@ from sentry.utils.auth import mark_sso_complete
 
 UNSET = object()
 
-BASETIME = datetime(2022, 3, 21, 0, 0, tzinfo=timezone.utc)
+BASETIME = datetime(2022, 3, 21, 0, 0, tzinfo=UTC)
 
 EXPIRE_TIME = timedelta(hours=4, minutes=1)
 
@@ -55,7 +55,7 @@ IDLE_EXPIRE_TIME = OUTSIDE_PRIVILEGE_ACCESS_EXPIRE_TIME = timedelta(hours=2)
 class SuperuserTestCase(TestCase):
     def setUp(self):
         super().setUp()
-        self.current_datetime = django_timezone.now()
+        self.current_datetime = timezone.now()
         self.default_token = "abcdefghjiklmnog"
         self.superuser = self.create_user(is_superuser=True)
 

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -1,9 +1,9 @@
 from collections.abc import Callable
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.dynamic_sampling import RuleType, generate_rules, get_redis_client_for_ds
 from sentry.dynamic_sampling.rules.base import NEW_MODEL_THRESHOLD_IN_MINUTES
@@ -32,7 +32,7 @@ from sentry.testutils.cases import BaseMetricsLayerTestCase, SnubaTestCase, Test
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import freeze_time
 
-MOCK_DATETIME = (django_timezone.now() - timedelta(days=1)).replace(
+MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
     hour=0, minute=0, second=0, microsecond=0
 )
 
@@ -40,7 +40,7 @@ MOCK_DATETIME = (django_timezone.now() - timedelta(days=1)).replace(
 class TasksTestCase(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
     @staticmethod
     def old_date():
-        return datetime.now(tz=timezone.utc) - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
+        return timezone.now() - timedelta(minutes=NEW_MODEL_THRESHOLD_IN_MINUTES + 1)
 
     @staticmethod
     def disable_all_biases(project):

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -16,7 +16,7 @@ from arroyo.types import Partition, Topic
 from django.conf import settings
 from django.core.cache import cache
 from django.test.utils import override_settings
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 from rest_framework.status import HTTP_404_NOT_FOUND
 
 from fixtures.github import (
@@ -287,7 +287,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         old_release = Release.objects.create(
             version="a",
             organization_id=self.project.organization_id,
-            date_added=django_timezone.now() - timedelta(minutes=30),
+            date_added=timezone.now() - timedelta(minutes=30),
         )
         old_release.add_project(self.project)
 
@@ -363,7 +363,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         # Create a release and a group associated with it
         old_release = self.create_release(
-            version="foobar", date_added=django_timezone.now() - timedelta(minutes=30)
+            version="foobar", date_added=timezone.now() - timedelta(minutes=30)
         )
         manager = EventManager(
             make_event(
@@ -423,7 +423,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         # Create a release and a group associated with it
         old_release = self.create_release(
-            version="a", date_added=django_timezone.now() - timedelta(minutes=30)
+            version="a", date_added=timezone.now() - timedelta(minutes=30)
         )
         manager = EventManager(
             make_event(
@@ -483,7 +483,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         # Create a release and a group associated with it
         old_release = self.create_release(
-            version="foo@1.0.0", date_added=django_timezone.now() - timedelta(minutes=30)
+            version="foo@1.0.0", date_added=timezone.now() - timedelta(minutes=30)
         )
         manager = EventManager(
             make_event(
@@ -726,7 +726,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         old_release = Release.objects.create(
             version="a",
             organization_id=self.project.organization_id,
-            date_added=django_timezone.now() - timedelta(minutes=30),
+            date_added=timezone.now() - timedelta(minutes=30),
         )
         old_release.add_project(self.project)
 
@@ -2988,17 +2988,15 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_boost_release_with_non_observed_release(self):
-        ts = datetime.now(UTC).timestamp()
+        ts = timezone.now().timestamp()
 
         project = self.create_project(platform="python")
-        release_1 = Release.get_or_create(
-            project=project, version="1.0", date_added=datetime.now(UTC)
-        )
+        release_1 = Release.get_or_create(project=project, version="1.0", date_added=timezone.now())
         release_2 = Release.get_or_create(
-            project=project, version="2.0", date_added=datetime.now(UTC) + timedelta(hours=1)
+            project=project, version="2.0", date_added=timezone.now() + timedelta(hours=1)
         )
         release_3 = Release.get_or_create(
-            project=project, version="3.0", date_added=datetime.now(UTC) + timedelta(hours=2)
+            project=project, version="3.0", date_added=timezone.now() + timedelta(hours=2)
         )
 
         for release, environment in (
@@ -3051,17 +3049,15 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_boost_release_boosts_only_latest_release(self):
-        ts = datetime.now(UTC).timestamp()
+        ts = timezone.now().timestamp()
 
         project = self.create_project(platform="python")
-        release_1 = Release.get_or_create(
-            project=project, version="1.0", date_added=datetime.now(UTC)
-        )
+        release_1 = Release.get_or_create(project=project, version="1.0", date_added=timezone.now())
         release_2 = Release.get_or_create(
             project=project,
             version="2.0",
             # We must make sure the new release_2.date_added > release_1.date_added.
-            date_added=datetime.now(UTC) + timedelta(hours=1),
+            date_added=timezone.now() + timedelta(hours=1),
         )
 
         # We add a transaction for latest release release_2.
@@ -3103,9 +3099,7 @@ class DSLatestReleaseBoostTest(TestCase):
     @freeze_time("2022-11-03 10:00:00")
     def test_boost_release_with_observed_release_and_different_environment(self):
         project = self.create_project(platform="python")
-        release = Release.get_or_create(
-            project=project, version="1.0", date_added=datetime.now(UTC)
-        )
+        release = Release.get_or_create(project=project, version="1.0", date_added=timezone.now())
 
         self.make_release_transaction(
             release_version=release.version,
@@ -3230,9 +3224,7 @@ class DSLatestReleaseBoostTest(TestCase):
     @freeze_time("2022-11-03 10:00:00")
     def test_release_not_boosted_with_observed_release_and_same_environment(self):
         project = self.create_project(platform="python")
-        release = Release.get_or_create(
-            project=project, version="1.0", date_added=datetime.now(UTC)
-        )
+        release = Release.get_or_create(project=project, version="1.0", date_added=timezone.now())
 
         for environment in (self.environment1.name, self.environment2.name):
             self.redis_client.set(
@@ -3251,14 +3243,12 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_release_not_boosted_with_deleted_release_after_event_received(self):
-        ts = datetime.now(UTC).timestamp()
+        ts = timezone.now().timestamp()
 
         project = self.create_project(platform="python")
-        release_1 = Release.get_or_create(
-            project=project, version="1.0", date_added=datetime.now(UTC)
-        )
+        release_1 = Release.get_or_create(project=project, version="1.0", date_added=timezone.now())
         release_2 = Release.get_or_create(
-            project=project, version="2.0", date_added=datetime.now(UTC) + timedelta(hours=1)
+            project=project, version="2.0", date_added=timezone.now() + timedelta(hours=1)
         )
 
         self.make_release_transaction(
@@ -3303,14 +3293,12 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_get_boosted_releases_with_old_and_new_cache_keys(self):
-        ts = datetime.now(UTC).timestamp()
+        ts = timezone.now().timestamp()
 
         project = self.create_project(platform="python")
 
         # Old cache key
-        release_1 = Release.get_or_create(
-            project=project, version="1.0", date_added=datetime.now(UTC)
-        )
+        release_1 = Release.get_or_create(project=project, version="1.0", date_added=timezone.now())
         self.redis_client.hset(
             f"ds::p:{project.id}:boosted_releases",
             f"{release_1.id}",
@@ -3319,7 +3307,7 @@ class DSLatestReleaseBoostTest(TestCase):
 
         # New cache key
         release_2 = Release.get_or_create(
-            project=project, version="2.0", date_added=datetime.now(UTC) + timedelta(hours=1)
+            project=project, version="2.0", date_added=timezone.now() + timedelta(hours=1)
         )
         self.redis_client.hset(
             f"ds::p:{project.id}:boosted_releases",
@@ -3375,7 +3363,7 @@ class DSLatestReleaseBoostTest(TestCase):
 
     @freeze_time("2022-11-03 10:00:00")
     def test_expired_boosted_releases_are_removed(self):
-        ts = datetime.now(UTC).timestamp()
+        ts = timezone.now().timestamp()
 
         # We want to test with multiple platforms.
         for platform in ("python", "java", None):
@@ -3390,7 +3378,7 @@ class DSLatestReleaseBoostTest(TestCase):
                 release = Release.get_or_create(
                     project=project,
                     version=release_version,
-                    date_added=datetime.now(UTC) + timedelta(hours=index),
+                    date_added=timezone.now() + timedelta(hours=index),
                 )
                 self.redis_client.set(
                     f"ds::p:{project.id}:r:{release.id}:e:{environment}", 1, 60 * 60 * 24
@@ -3406,7 +3394,7 @@ class DSLatestReleaseBoostTest(TestCase):
             release_3 = Release.get_or_create(
                 project=project,
                 version=f"3.0-{platform}",
-                date_added=datetime.now(UTC) + timedelta(hours=2),
+                date_added=timezone.now() + timedelta(hours=2),
             )
             self.make_release_transaction(
                 release_version=release_3.version,
@@ -3457,18 +3445,18 @@ class DSLatestReleaseBoostTest(TestCase):
     @freeze_time("2022-11-03 10:00:00")
     @mock.patch("sentry.dynamic_sampling.rules.helpers.latest_releases.BOOSTED_RELEASES_LIMIT", 2)
     def test_least_recently_boosted_release_is_removed_if_limit_is_exceeded(self):
-        ts = datetime.now(UTC).timestamp()
+        ts = timezone.now().timestamp()
 
         project = self.create_project(platform="python")
         release_1 = Release.get_or_create(
             project=project,
             version="1.0",
-            date_added=datetime.now(UTC),
+            date_added=timezone.now(),
         )
         release_2 = Release.get_or_create(
             project=project,
             version="2.0",
-            date_added=datetime.now(UTC) + timedelta(hours=1),
+            date_added=timezone.now() + timedelta(hours=1),
         )
 
         # We boost with increasing timestamps, so that we know that the smallest will be evicted.
@@ -3487,7 +3475,7 @@ class DSLatestReleaseBoostTest(TestCase):
         release_3 = Release.get_or_create(
             project=project,
             version="3.0",
-            date_added=datetime.now(UTC) + timedelta(hours=2),
+            date_added=timezone.now() + timedelta(hours=2),
         )
         self.make_release_transaction(
             release_version=release_3.version,
@@ -3527,12 +3515,10 @@ class DSLatestReleaseBoostTest(TestCase):
     @freeze_time()
     @mock.patch("sentry.dynamic_sampling.rules.helpers.latest_releases.BOOSTED_RELEASES_LIMIT", 2)
     def test_removed_boost_not_added_again_if_limit_is_exceeded(self):
-        ts = datetime.now(UTC).timestamp()
+        ts = timezone.now().timestamp()
 
         project = self.create_project(platform="python")
-        release_1 = Release.get_or_create(
-            project=project, version="1.0", date_added=datetime.now(UTC)
-        )
+        release_1 = Release.get_or_create(project=project, version="1.0", date_added=timezone.now())
 
         # We want to test that if we have the same release, but we send different environments that go over the
         # limit, and we evict an environment, but then we send a transaction with the evicted environment.

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 
 import requests
 
@@ -302,12 +302,12 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.one_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project, self.project2],
-            date_added=date_added.replace(tzinfo=timezone.utc),
+            date_added=date_added.replace(tzinfo=UTC),
         )
         self.two_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project2],
-            date_added=date_added.replace(tzinfo=timezone.utc),
+            date_added=date_added.replace(tzinfo=UTC),
         )
         self.three_alert_rule = self.create_alert_rule(
             organization=self.org, projects=[self.project]
@@ -351,12 +351,12 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.one_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project, self.project2],
-            date_added=date_added.replace(tzinfo=timezone.utc),
+            date_added=date_added.replace(tzinfo=UTC),
         )
         self.two_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project],
-            date_added=date_added.replace(tzinfo=timezone.utc),
+            date_added=date_added.replace(tzinfo=UTC),
         )
         self.three_alert_rule = self.create_alert_rule(
             organization=self.org, projects=[self.project2]

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 from django.urls import reverse
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.incidents.logic import (
     CRITICAL_TRIGGER_LABEL,
@@ -252,7 +252,7 @@ class TestHandleSubscriptionMetricsLogger(TestCase):
         return create_snuba_subscription(self.project, SUBSCRIPTION_METRICS_LOGGER, snuba_query)
 
     def build_subscription_update(self):
-        timestamp = django_timezone.now().replace(microsecond=0)
+        timestamp = timezone.now().replace(microsecond=0)
         data = {
             "count": 100,
             "crashed": 2.0,
@@ -293,7 +293,7 @@ class TestHandleSubscriptionMetricsLoggerV1(TestHandleSubscriptionMetricsLogger)
     """
 
     def build_subscription_update(self):
-        timestamp = django_timezone.now().replace(microsecond=0)
+        timestamp = timezone.now().replace(microsecond=0)
         values = {
             "data": [
                 {

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
@@ -388,14 +388,14 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
 
     def test_invalid_period(self):
         self.login_as(user=self.user)
-        first_seen = django_timezone.now() - timedelta(days=5)
+        first_seen = timezone.now() - timedelta(days=5)
         group = self.create_group(first_seen=first_seen)
         response = self.client.get(f"/api/0/issues/{group.id}/events/", data={"statsPeriod": "lol"})
         assert response.status_code == 400
 
     def test_invalid_query(self):
         self.login_as(user=self.user)
-        first_seen = django_timezone.now() - timedelta(days=5)
+        first_seen = timezone.now() - timedelta(days=5)
         group = self.create_group(first_seen=first_seen)
         response = self.client.get(
             f"/api/0/issues/{group.id}/events/",

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -1,11 +1,11 @@
 import functools
-from datetime import timedelta, timezone
+from datetime import UTC, timedelta
 from unittest.mock import Mock, call, patch
 from uuid import uuid4
 
 from dateutil.parser import parse as parse_datetime
 from django.urls import reverse
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry import options
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType, PerformanceSlowDBQueryGroupType
@@ -359,7 +359,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
 
     def test_invalid_query(self):
-        now = django_timezone.now()
+        now = timezone.now()
         self.create_group(last_seen=now - timedelta(seconds=1))
         self.login_as(user=self.user)
 
@@ -368,7 +368,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert "Invalid number" in response.data["detail"]
 
     def test_valid_numeric_query(self):
-        now = django_timezone.now()
+        now = timezone.now()
         self.create_group(last_seen=now - timedelta(seconds=1))
         self.login_as(user=self.user)
 
@@ -376,7 +376,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
 
     def test_invalid_sort_key(self):
-        now = django_timezone.now()
+        now = timezone.now()
         self.create_group(last_seen=now - timedelta(seconds=1))
         self.login_as(user=self.user)
 
@@ -417,7 +417,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
     def test_stats_period(self):
         # TODO(dcramer): this test really only checks if validation happens
         # on groupStatsPeriod
-        now = django_timezone.now()
+        now = timezone.now()
         self.create_group(last_seen=now - timedelta(seconds=1))
         self.create_group(last_seen=now)
 
@@ -757,7 +757,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
     def test_filters_based_on_retention(self):
         self.login_as(user=self.user)
 
-        self.create_group(last_seen=django_timezone.now() - timedelta(days=2))
+        self.create_group(last_seen=timezone.now() - timedelta(days=2))
 
         with self.options({"system.event-retention-days": 1}):
             response = self.get_success_response()
@@ -968,19 +968,19 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
             before_now_350_seconds  # Should match overridden value, not event value
-        ).replace(tzinfo=timezone.utc)
+        ).replace(tzinfo=UTC)
         assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
             before_now_100_seconds
-        ).replace(tzinfo=timezone.utc)
+        ).replace(tzinfo=UTC)
         assert response.data[0]["lifetime"]["count"] == "55"
 
         assert response.data[0]["filtered"]["count"] == "2"
         assert response.data[0]["filtered"]["firstSeen"] == parse_datetime(
             before_now_250_seconds
-        ).replace(tzinfo=timezone.utc)
+        ).replace(tzinfo=UTC)
         assert response.data[0]["filtered"]["lastSeen"] == parse_datetime(
             before_now_150_seconds
-        ).replace(tzinfo=timezone.utc)
+        ).replace(tzinfo=UTC)
 
         # Empty filter test:
         response = self.get_response(sort_by="date", limit=10, query="")
@@ -994,10 +994,10 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.data[0]["lifetime"]["count"] == "55"
         assert response.data[0]["lifetime"]["firstSeen"] == parse_datetime(
             before_now_350_seconds  # Should match overridden value, not event value
-        ).replace(tzinfo=timezone.utc)
+        ).replace(tzinfo=UTC)
         assert response.data[0]["lifetime"]["lastSeen"] == parse_datetime(
             before_now_100_seconds
-        ).replace(tzinfo=timezone.utc)
+        ).replace(tzinfo=UTC)
 
     def test_semver_seen_stats(self):
         release_1 = self.create_release(version="test@1.2.3")
@@ -1399,13 +1399,13 @@ class GroupListTest(APITestCase, SnubaTestCase):
         replaced_release = self.create_release(
             version="replaced_release",
             environments=[self.environment],
-            adopted=django_timezone.now(),
-            unadopted=django_timezone.now(),
+            adopted=timezone.now(),
+            unadopted=timezone.now(),
         )
         adopted_release = self.create_release(
             version="adopted_release",
             environments=[self.environment],
-            adopted=django_timezone.now(),
+            adopted=timezone.now(),
         )
         self.create_release(version="not_adopted_release", environments=[self.environment])
 
@@ -2064,7 +2064,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         GroupSnooze.objects.create(
             group=event.group,
             user_count=10,
-            until=django_timezone.now() + timedelta(days=1),
+            until=timezone.now() + timedelta(days=1),
             count=10,
             state={"times_seen": 0},
         )
@@ -2316,7 +2316,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
     def setUp(self):
         super().setUp()
-        self.min_ago = django_timezone.now() - timedelta(minutes=1)
+        self.min_ago = timezone.now() - timedelta(minutes=1)
 
     def get_response(self, *args, **kwargs):
         if not args:
@@ -2401,7 +2401,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     def test_resolve_ignored(self):
         group = self.create_group(status=GroupStatus.IGNORED)
         snooze = GroupSnooze.objects.create(
-            group=group, until=django_timezone.now() - timedelta(minutes=1)
+            group=group, until=timezone.now() - timedelta(minutes=1)
         )
 
         member = self.create_user()
@@ -2684,7 +2684,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         Group, when the project does not follow semantic versioning scheme
         """
         release_1 = self.create_release(
-            date_added=django_timezone.now() - timedelta(minutes=45), version="foobar 1"
+            date_added=timezone.now() - timedelta(minutes=45), version="foobar 1"
         )
         release_2 = self.create_release(version="foobar 2")
 
@@ -2708,7 +2708,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         # Add a new release that is between 1 and 2, to make sure that if a the same issue/group
         # occurs in that issue, then it should not have a resolution
         release_3 = self.create_release(
-            date_added=django_timezone.now() - timedelta(minutes=30), version="foobar 3"
+            date_added=timezone.now() - timedelta(minutes=30), version="foobar 3"
         )
 
         grp_resolution = GroupResolution.objects.filter(group=group)
@@ -2731,7 +2731,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         algorithm
         """
         release_1 = self.create_release(
-            date_added=django_timezone.now() - timedelta(minutes=45), version="foobar 1"
+            date_added=timezone.now() - timedelta(minutes=45), version="foobar 1"
         )
         release_2 = self.create_release(version="foobar 2")
 
@@ -2788,7 +2788,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         that was created after the last release associated with the group being resolved
         """
         release_1 = self.create_release(
-            date_added=django_timezone.now() - timedelta(minutes=45), version="foobar 1"
+            date_added=timezone.now() - timedelta(minutes=45), version="foobar 1"
         )
         release_2 = self.create_release(version="foobar 2")
         self.create_release(version="foobar 3")
@@ -3177,7 +3177,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     def test_set_unresolved_on_snooze(self):
         group = self.create_group(status=GroupStatus.IGNORED)
 
-        GroupSnooze.objects.create(group=group, until=django_timezone.now() - timedelta(days=1))
+        GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(days=1))
 
         self.login_as(user=self.user)
 
@@ -3193,7 +3193,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     def test_basic_ignore(self):
         group = self.create_group(status=GroupStatus.RESOLVED)
 
-        snooze = GroupSnooze.objects.create(group=group, until=django_timezone.now())
+        snooze = GroupSnooze.objects.create(group=group, until=timezone.now())
 
         self.login_as(user=self.user)
         assert not GroupHistory.objects.filter(
@@ -3220,7 +3220,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         snooze = GroupSnooze.objects.get(group=group)
         snooze.until = snooze.until
 
-        now = django_timezone.now()
+        now = timezone.now()
 
         assert snooze.count is None
         assert snooze.until is not None

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -2,7 +2,7 @@ import uuid
 import zoneinfo
 from collections import Counter
 from collections.abc import Mapping, Sequence
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from functools import cached_property
 from unittest import mock
 from unittest.mock import ANY
@@ -11,7 +11,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 from django.db.models import F
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.userreport import UserReportWithGroupSerializer
@@ -332,7 +332,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
                 IssueEvidence("Evidence 3", "Value 3", False),
             ],
             MonitorCheckInFailure,
-            datetime.now(UTC),
+            timezone.now(),
             "info",
             "/api/123",
         )
@@ -388,7 +388,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             {"Test": 123},
             [],  # no evidence
             MonitorCheckInFailure,
-            datetime.now(UTC),
+            timezone.now(),
             "info",
             "/api/123",
         )
@@ -660,8 +660,8 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         """
         from django.template.defaultfilters import date
 
-        timestamp = datetime.now(tz=timezone.utc)
-        local_timestamp_s = django_timezone.localtime(timestamp, zoneinfo.ZoneInfo("Europe/Vienna"))
+        timestamp = timezone.now()
+        local_timestamp_s = timezone.localtime(timestamp, zoneinfo.ZoneInfo("Europe/Vienna"))
         local_timestamp = date(local_timestamp_s, "N j, Y, g:i:s a e")
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -701,7 +701,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         recipient_context = notification.get_recipient_context(
             RpcActor.from_orm_user(self.user), {}
         )
-        assert recipient_context["timezone"] == timezone.utc
+        assert recipient_context["timezone"] == UTC
 
     def test_context_invalid_timezone_empty_string(self):
         self._test_invalid_timezone("")
@@ -945,8 +945,8 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
         )
         self.create_member(user=user2, organization=organization, teams=[team])
         self.group = self.create_group(
-            first_seen=django_timezone.now(),
-            last_seen=django_timezone.now(),
+            first_seen=timezone.now(),
+            last_seen=timezone.now(),
             project=project,
             message="hello  world",
             logger="root",
@@ -1356,7 +1356,7 @@ class MailAdapterGetDigestSubjectTest(BaseMailAdapterTest):
             get_digest_subject(
                 mock.Mock(qualified_short_id="BAR-1"),
                 Counter({mock.sentinel.group: 3}),
-                datetime(2016, 9, 19, 1, 2, 3, tzinfo=timezone.utc),
+                datetime(2016, 9, 19, 1, 2, 3, tzinfo=UTC),
             )
             == "BAR-1 - 1 new alert since Sept. 19, 2016, 1:02 a.m. UTC"
         )

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -1,7 +1,7 @@
 import uuid
 import zoneinfo
 from collections.abc import MutableMapping
-from datetime import timedelta, timezone
+from datetime import UTC, timedelta
 from unittest import mock
 
 import msgpack
@@ -10,7 +10,7 @@ from arroyo import Partition, Topic
 from arroyo.backends.kafka import KafkaPayload
 from confluent_kafka.admin import PartitionMetadata
 from django.test import override_settings
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.constants import ObjectStatus
 from sentry.grouping.utils import hash_from_values
@@ -45,7 +45,7 @@ def make_ref_time(**kwargs):
     """
     tz_name = kwargs.pop("timezone", "UTC")
 
-    ts = django_timezone.now().replace(**kwargs, tzinfo=zoneinfo.ZoneInfo(tz_name))
+    ts = timezone.now().replace(**kwargs, tzinfo=zoneinfo.ZoneInfo(tz_name))
 
     # Typically the task will not run exactly on the minute, but it will
     # run very close, let's say for our test that it runs 12 seconds after
@@ -55,7 +55,7 @@ def make_ref_time(**kwargs):
     # down to the minute.
     #
     # Task timestamps are in UTC, convert our reference time to UTC for this
-    task_run_ts = ts.astimezone(timezone.utc).replace(second=12, microsecond=0)
+    task_run_ts = ts.astimezone(UTC).replace(second=12, microsecond=0)
 
     # Fan-out tasks recieve a floored version of the timestamp
     sub_task_run_ts = task_run_ts.replace(second=0)
@@ -187,7 +187,7 @@ class MonitorTaskCheckMissingTest(TestCase):
 
         # Use UTC timezone for comparison so failed asserts are easier to read,
         # since next_checkin will bome back as UTC. This does NOT affect the assert
-        utc_ts = ts.astimezone(timezone.utc)
+        utc_ts = ts.astimezone(UTC)
 
         assert monitor_environment.next_checkin == utc_ts + timedelta(days=1)
         assert monitor_environment.next_checkin_latest == utc_ts + timedelta(days=1, minutes=1)
@@ -1030,7 +1030,7 @@ def test_clock_pulse(checkin_producer_mock):
 
 @mock.patch("sentry.monitors.tasks._dispatch_tasks")
 def test_monitor_task_trigger(dispatch_tasks):
-    now = django_timezone.now().replace(second=0, microsecond=0)
+    now = timezone.now().replace(second=0, microsecond=0)
 
     # Assumes a single partition for simplicitly. Multi-partition cases are
     # covered in further test cases.
@@ -1066,7 +1066,7 @@ def test_monitor_task_trigger_partition_desync(dispatch_tasks):
     timestamps in a non-monotonic order. In this scenario we want to make
     sure we still only trigger once
     """
-    now = django_timezone.now().replace(second=0, microsecond=0)
+    now = timezone.now().replace(second=0, microsecond=0)
 
     # First message in partition 0 with timestamp just after the minute
     # boundary triggers the task
@@ -1096,7 +1096,7 @@ def test_monitor_task_trigger_partition_sync(dispatch_tasks):
     When the kafka topic has multiple partitions we want to only tick our clock
     forward once all partitions have caught up. This test simulates that
     """
-    now = django_timezone.now().replace(second=0, microsecond=0)
+    now = timezone.now().replace(second=0, microsecond=0)
 
     # Tick for 4 partitions
     try_monitor_tasks_trigger(ts=now, partition=0)
@@ -1124,7 +1124,7 @@ def test_monitor_task_trigger_partition_tick_skip(dispatch_tasks):
     In a scenario where all partitions move multiple ticks past the slowest
     partition we may end up skipping a tick.
     """
-    now = django_timezone.now().replace(second=0, microsecond=0)
+    now = timezone.now().replace(second=0, microsecond=0)
 
     # Tick for 4 partitions
     try_monitor_tasks_trigger(ts=now, partition=0)
@@ -1196,7 +1196,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
-            date_added=django_timezone.now() - timedelta(days=14),
+            date_added=timezone.now() - timedelta(days=14),
         )
         incident = MonitorIncident.objects.create(
             monitor=monitor,
@@ -1212,7 +1212,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
                 status=CheckInStatus.ERROR,
-                date_added=django_timezone.now() - timedelta(days=i),
+                date_added=timezone.now() - timedelta(days=i),
             )
 
         detect_broken_monitor_envs()
@@ -1231,7 +1231,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
-            date_added=django_timezone.now() - timedelta(days=10),
+            date_added=timezone.now() - timedelta(days=10),
         )
         incident = MonitorIncident.objects.create(
             monitor=monitor,
@@ -1247,7 +1247,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
                 status=CheckInStatus.ERROR,
-                date_added=django_timezone.now() - timedelta(days=1),
+                date_added=timezone.now() - timedelta(days=1),
             )
 
         detect_broken_monitor_envs()
@@ -1262,7 +1262,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
-            date_added=django_timezone.now() - timedelta(days=14),
+            date_added=timezone.now() - timedelta(days=14),
         )
         incident = MonitorIncident.objects.create(
             monitor=monitor,
@@ -1278,7 +1278,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
                 status=CheckInStatus.ERROR,
-                date_added=django_timezone.now() - timedelta(days=i),
+                date_added=timezone.now() - timedelta(days=i),
             )
 
         detect_broken_monitor_envs()
@@ -1292,7 +1292,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
-            date_added=django_timezone.now() - timedelta(days=14),
+            date_added=timezone.now() - timedelta(days=14),
         )
         incident = MonitorIncident.objects.create(
             monitor=monitor,
@@ -1308,7 +1308,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
                 status=CheckInStatus.ERROR,
-                date_added=django_timezone.now() - timedelta(days=i),
+                date_added=timezone.now() - timedelta(days=i),
             )
 
         detect_broken_monitor_envs()
@@ -1325,7 +1325,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             monitor_environment=monitor_environment,
             project_id=self.project.id,
             status=CheckInStatus.ERROR,
-            date_added=django_timezone.now() - timedelta(days=14),
+            date_added=timezone.now() - timedelta(days=14),
         )
         incident = MonitorIncident.objects.create(
             monitor=monitor,
@@ -1341,7 +1341,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
                 status=CheckInStatus.ERROR,
-                date_added=django_timezone.now() - timedelta(days=i),
+                date_added=timezone.now() - timedelta(days=i),
             )
 
         detect_broken_monitor_envs()

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.api.invite_helper import ApiInviteHelper
 from sentry.models.options.organization_option import OrganizationOption
@@ -49,7 +49,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
 
     def test_no_existing_task(self):
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now)
         event = self.store_event(data={}, project_id=project.id)
         first_event_received.send(project=project, event=event, sender=type(project))
@@ -62,7 +62,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task.date_completed == project.first_event
 
     def test_existing_complete_task(self):
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now)
         task = OrganizationOnboardingTask.objects.create(
             organization=project.organization,
@@ -79,7 +79,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
     # Tests on the receivers
     def test_event_processed(self):
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now)
         event = self.store_event(
             data={
@@ -135,7 +135,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task is not None
 
     def test_project_created(self):
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
 
@@ -147,7 +147,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task is not None
 
     def test_first_event_received(self):
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
         event = self.store_event(
@@ -399,7 +399,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         assert task is not None
 
     def test_onboarding_complete(self):
-        now = django_timezone.now()
+        now = timezone.now()
         user = self.create_user(email="test@example.org")
         project = self.create_project(first_event=now)
         second_project = self.create_project(first_event=now)
@@ -511,7 +511,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         Test that an analytics event is NOT recorded when
         there no event with minified stack trace is received
         """
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
         data = load_data("javascript")
@@ -536,7 +536,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         Test that an analytics event is recorded when
         a first event with minified stack trace is received
         """
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now, platform="VueJS")
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"
@@ -592,7 +592,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         Test that an analytic event is triggered only once when
         multiple events with minified stack trace are received
         """
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"
@@ -652,7 +652,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         In this test we also check  if the has_minified_stack_trace is being set to "True" in old projects
         """
-        old_date = datetime(2022, 12, 10, tzinfo=timezone.utc)
+        old_date = datetime(2022, 12, 10, tzinfo=UTC)
         project = self.create_project(first_event=old_date, date_added=old_date)
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"
@@ -713,7 +713,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         Test that an analytics event is NOT recorded when
         no event with sourcemaps is received
         """
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
         data = load_data("javascript")
@@ -745,7 +745,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         Test that an analytics event is recorded when
         a first event with sourcemaps is received
         """
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now, platform="VueJS")
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"
@@ -792,7 +792,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         Test that an analytic event is triggered only once when
         multiple events with sourcemaps are received
         """
-        now = django_timezone.now()
+        now = timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"
@@ -844,7 +844,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         In this test we also check  if the has_sourcemaps is being set to "True" in old projects
         """
-        old_date = datetime(2022, 12, 10, tzinfo=timezone.utc)
+        old_date = datetime(2022, 12, 10, tzinfo=UTC)
         project = self.create_project(first_event=old_date, date_added=old_date)
         project_created.send(project=project, user=self.user, sender=type(project))
         url = "http://localhost:3000"

--- a/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data_v2/test_api.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import pytest
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
@@ -32,7 +32,7 @@ from sentry.testutils.helpers.datetime import freeze_time
 
 pytestmark = pytest.mark.sentry_metrics
 
-MOCK_DATETIME = (django_timezone.now() - timedelta(days=1)).replace(
+MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
     hour=10, minute=0, second=0, microsecond=0
 )
 

--- a/tests/sentry/snuba/test_discover_query.py
+++ b/tests/sentry/snuba/test_discover_query.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pytest
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.discover.arithmetic import ArithmeticValidationError
 from sentry.discover.models import TeamKeyTransaction
@@ -2447,13 +2447,13 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         replaced_release = self.create_release(
             version="replaced_release",
             environments=[self.environment],
-            adopted=django_timezone.now(),
-            unadopted=django_timezone.now(),
+            adopted=timezone.now(),
+            unadopted=timezone.now(),
         )
         adopted_release = self.create_release(
             version="adopted_release",
             environments=[self.environment],
-            adopted=django_timezone.now(),
+            adopted=timezone.now(),
         )
         self.create_release(version="not_adopted_release", environments=[self.environment])
 

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -1,10 +1,10 @@
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
 import responses
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.models.commit import Commit
@@ -445,15 +445,15 @@ class TestCommentWorkflow(GithubCommentTestCase):
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
     @patch("sentry.tasks.integrations.github.utils.metrics")
     @responses.activate
-    @freeze_time(datetime(2023, 6, 8, 0, 0, 0, tzinfo=timezone.utc))
+    @freeze_time(datetime(2023, 6, 8, 0, 0, 0, tzinfo=UTC))
     def test_comment_workflow_updates_comment(self, mock_metrics, mock_issues):
         groups = [g.id for g in Group.objects.all()]
         mock_issues.return_value = [{"group_id": id, "event_count": 10} for id in groups]
         pull_request_comment = PullRequestComment.objects.create(
             external_id=1,
             pull_request_id=self.pr.id,
-            created_at=django_timezone.now() - timedelta(hours=1),
-            updated_at=django_timezone.now() - timedelta(hours=1),
+            created_at=timezone.now() - timedelta(hours=1),
+            updated_at=timezone.now() - timedelta(hours=1),
             group_ids=[1, 2, 3, 4],
         )
 
@@ -461,8 +461,8 @@ class TestCommentWorkflow(GithubCommentTestCase):
         PullRequestComment.objects.create(
             external_id=2,
             pull_request_id=self.pr.id,
-            created_at=django_timezone.now() - timedelta(hours=1),
-            updated_at=django_timezone.now() - timedelta(hours=1),
+            created_at=timezone.now() - timedelta(hours=1),
+            updated_at=timezone.now() - timedelta(hours=1),
             group_ids=[],
             comment_type=CommentType.OPEN_PR,
         )
@@ -482,7 +482,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         )
         pull_request_comment.refresh_from_db()
         assert pull_request_comment.group_ids == [g.id for g in Group.objects.all()]
-        assert pull_request_comment.updated_at == django_timezone.now()
+        assert pull_request_comment.updated_at == timezone.now()
         mock_metrics.incr.assert_called_with("github_pr_comment.comment_updated")
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
@@ -656,12 +656,12 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         self.comment = PullRequestComment.objects.create(
             external_id="2",
             pull_request=self.pr,
-            created_at=django_timezone.now(),
-            updated_at=django_timezone.now(),
+            created_at=timezone.now(),
+            updated_at=timezone.now(),
             group_ids=[4, 5],
         )
         self.expired_pr = self.create_pr_issues()
-        self.expired_pr.date_added = django_timezone.now() - timedelta(days=35)
+        self.expired_pr.date_added = timezone.now() - timedelta(days=35)
         self.expired_pr.save()
         self.comment_reactions = {
             "reactions": {
@@ -678,8 +678,8 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         old_comment = PullRequestComment.objects.create(
             external_id="1",
             pull_request=self.expired_pr,
-            created_at=django_timezone.now() - timedelta(days=35),
-            updated_at=django_timezone.now() - timedelta(days=35),
+            created_at=timezone.now() - timedelta(days=35),
+            updated_at=timezone.now() - timedelta(days=35),
             group_ids=[1, 2, 3],
         )
 
@@ -754,8 +754,8 @@ class TestCommentReactionsTask(GithubCommentTestCase):
         no_error_comment = PullRequestComment.objects.create(
             external_id="3",
             pull_request=self.create_pr_issues(gh_repo=gh_repo),
-            created_at=django_timezone.now(),
-            updated_at=django_timezone.now(),
+            created_at=timezone.now(),
+            updated_at=timezone.now(),
             group_ids=[7, 8],
         )
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import time
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from hashlib import md5
 from typing import Any
 from unittest import mock
@@ -12,7 +12,7 @@ from unittest.mock import Mock, patch
 import pytest
 from django.db import router
 from django.test import override_settings
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry import buffer
 from sentry.buffer.redis import RedisBuffer
@@ -482,7 +482,7 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
 
     @patch("sentry.rules.processor.RuleProcessor")
     def test_group_last_seen_buffer(self, mock_processor):
-        first_event_date = datetime.now(timezone.utc) - timedelta(days=90)
+        first_event_date = timezone.now() - timedelta(days=90)
         event1 = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,
@@ -636,7 +636,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
                 "message": "Foo bar",
                 "exception": {"type": "Foo", "value": "oh no"},
                 "level": "error",
-                "timestamp": iso_format(django_timezone.now()),
+                "timestamp": iso_format(timezone.now()),
             },
             project_id=self.project.id,
             assert_no_errors=False,
@@ -670,7 +670,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
             data={
                 "message": "Foo bar",
                 "level": "info",
-                "timestamp": iso_format(django_timezone.now()),
+                "timestamp": iso_format(timezone.now()),
             },
             project_id=self.project.id,
             assert_no_errors=False,
@@ -691,7 +691,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
             data={
                 "message": "Foo bar",
                 "level": "info",
-                "timestamp": iso_format(django_timezone.now()),
+                "timestamp": iso_format(timezone.now()),
             },
             project_id=self.project.id,
             assert_no_errors=False,
@@ -714,7 +714,7 @@ class ResourceChangeBoundsTestMixin(BasePostProgressGroupMixin):
                 "message": "Foo bar",
                 "level": "error",
                 "exception": {"type": "Foo", "value": "oh no"},
-                "timestamp": iso_format(django_timezone.now()),
+                "timestamp": iso_format(timezone.now()),
             },
             project_id=self.project.id,
             assert_no_errors=False,
@@ -1391,7 +1391,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
 class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
     github_blame_return_value = {
         "commitId": "asdfwreqr",
-        "committedDate": (datetime.now(timezone.utc) - timedelta(days=2)),
+        "committedDate": (timezone.now() - timedelta(days=2)),
         "commitMessage": "placeholder commit message",
         "commitAuthorName": "",
         "commitAuthorEmail": "admin@localhost",
@@ -1452,7 +1452,7 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
                 repo=self.repo,
                 commit=CommitInfo(
                     commitId="asdfwreqr",
-                    committedDate=(datetime.now(timezone.utc) - timedelta(days=2)),
+                    committedDate=(timezone.now() - timedelta(days=2)),
                     commitMessage="placeholder commit message",
                     commitAuthorName="",
                     commitAuthorEmail="admin@localhost",
@@ -1587,9 +1587,7 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
         group.status = GroupStatus.IGNORED
         group.substatus = GroupSubStatus.UNTIL_CONDITION_MET
         group.save(update_fields=["status", "substatus"])
-        snooze = GroupSnooze.objects.create(
-            group=group, until=django_timezone.now() - timedelta(hours=1)
-        )
+        snooze = GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(hours=1))
 
         # Check for has_reappeared=True if is_new=False
         self.call_post_process_group(
@@ -1653,9 +1651,7 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
         group.status = GroupStatus.IGNORED
         group.substatus = GroupSubStatus.UNTIL_CONDITION_MET
         group.save(update_fields=["status", "substatus"])
-        snooze = GroupSnooze.objects.create(
-            group=group, until=django_timezone.now() - timedelta(hours=1)
-        )
+        snooze = GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(hours=1))
 
         # Check for has_reappeared=True if is_new=False
         self.call_post_process_group(
@@ -1724,9 +1720,7 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
         group = event.group
         assert group.status == GroupStatus.UNRESOLVED
         assert group.substatus == GroupSubStatus.ONGOING
-        snooze = GroupSnooze.objects.create(
-            group=group, until=django_timezone.now() + timedelta(hours=1)
-        )
+        snooze = GroupSnooze.objects.create(group=group, until=timezone.now() + timedelta(hours=1))
 
         self.call_post_process_group(
             is_new=True,
@@ -1778,7 +1772,7 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
         group = event.group
         group.status = GroupStatus.IGNORED
         group.substatus = GroupSubStatus.UNTIL_ESCALATING
-        group.update(first_seen=django_timezone.now() - timedelta(hours=1))
+        group.update(first_seen=timezone.now() - timedelta(hours=1))
         group.save()
         self.call_post_process_group(
             is_new=False,
@@ -2029,7 +2023,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
         group.update(
-            first_seen=django_timezone.now() - timedelta(hours=1),
+            first_seen=timezone.now() - timedelta(hours=1),
             times_seen=10,
             priority=PriorityLevel.LOW,
         )
@@ -2055,7 +2049,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
     def test_has_escalated_no_flag(self, mock_run_post_process_job, mock_threshold):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
-        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=10000)
+        group.update(first_seen=timezone.now() - timedelta(hours=1), times_seen=10000)
 
         self.call_post_process_group(
             is_new=True,
@@ -2075,7 +2069,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
     def test_has_escalated_old(self, mock_run_post_process_job, mock_threshold):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
-        group.update(first_seen=django_timezone.now() - timedelta(days=2), times_seen=10000)
+        group.update(first_seen=timezone.now() - timedelta(days=2), times_seen=10000)
 
         with self.feature("projects:first-event-severity-new-escalation"):
             self.call_post_process_group(
@@ -2098,7 +2092,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
         group.update(
-            first_seen=django_timezone.now() - timedelta(hours=1),
+            first_seen=timezone.now() - timedelta(hours=1),
             times_seen=10,
             priority=PriorityLevel.LOW,
         )
@@ -2122,7 +2116,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
     def test_has_escalated_locked(self, mock_run_post_process_job, mock_threshold):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
-        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=10000)
+        group.update(first_seen=timezone.now() - timedelta(hours=1), times_seen=10000)
         lock = locks.get(f"detect_escalation:{group.id}", duration=10, name="detect_escalation")
         with self.feature("projects:first-event-severity-new-escalation"), lock.acquire():
             self.call_post_process_group(
@@ -2149,7 +2143,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
         group.update(
-            first_seen=django_timezone.now() - timedelta(hours=1),
+            first_seen=timezone.now() - timedelta(hours=1),
             times_seen=10000,
             substatus=GroupSubStatus.ESCALATING,
             priority=PriorityLevel.MEDIUM,
@@ -2177,7 +2171,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
             event = self.create_event(data={}, project_id=self.project.id)
             group = event.group
             group.update(
-                first_seen=django_timezone.now() - timedelta(hours=1),
+                first_seen=timezone.now() - timedelta(hours=1),
                 times_seen=10000,
                 status=status,
                 substatus=substatus,
@@ -2202,7 +2196,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
     def test_no_escalation_less_than_floor(self, mock_run_post_process_job, mock_threshold):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
-        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=9)
+        group.update(first_seen=timezone.now() - timedelta(hours=1), times_seen=9)
         event.group = Group.objects.get(id=group.id)
 
         with self.feature("projects:first-event-severity-new-escalation"):
@@ -2224,7 +2218,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
         # the group is less than an hour old, but we use 1 hr for the hourly event rate anyway
-        group.update(first_seen=django_timezone.now() - timedelta(minutes=1), times_seen=10)
+        group.update(first_seen=timezone.now() - timedelta(minutes=1), times_seen=10)
         event.group = Group.objects.get(id=group.id)
 
         with self.feature("projects:first-event-severity-new-escalation"):
@@ -2244,7 +2238,7 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
     def test_zero_escalation_rate(self, mock_run_post_process_job, mock_threshold):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
-        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=10000)
+        group.update(first_seen=timezone.now() - timedelta(hours=1), times_seen=10000)
         with self.feature("projects:first-event-severity-new-escalation"):
             self.call_post_process_group(
                 is_new=True,

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1,5 +1,5 @@
 import copy
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from typing import cast
 from unittest import mock
 
@@ -8,7 +8,7 @@ from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 from django.db import router
 from django.db.models import F
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.constants import DataCategory
 from sentry.issues.grouptype import MonitorCheckInFailure, PerformanceNPlusOneGroupType
@@ -52,7 +52,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         with unguarded_write(using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
-        now = datetime.now(UTC)
+        now = timezone.now()
 
         project = self.create_project(
             organization=self.organization, teams=[self.team], date_added=now - timedelta(days=90)
@@ -75,7 +75,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
     @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_with_empty_string_user_option(self):
-        now = datetime.now(UTC)
+        now = timezone.now()
 
         project = self.create_project(
             organization=self.organization, teams=[self.team], date_added=now - timedelta(days=90)
@@ -101,7 +101,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         with unguarded_write(using=router.db_for_write(Project)):
             Project.objects.all().delete()
 
-        now = datetime.now(UTC)
+        now = timezone.now()
 
         project = self.create_project(
             organization=self.organization, teams=[self.team], date_added=now - timedelta(days=90)
@@ -203,7 +203,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     def test_transferred_project(self, message_builder):
         self.login_as(user=self.user)
 
-        now = django_timezone.now()
+        now = timezone.now()
         three_days_ago = now - timedelta(days=3)
 
         project = self.create_project(
@@ -240,7 +240,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     def test_organization_project_issue_substatus_summaries(self):
         self.login_as(user=self.user)
 
-        now = django_timezone.now()
+        now = timezone.now()
         min_ago = iso_format(now - timedelta(minutes=1))
 
         event1 = self.store_event(
@@ -284,7 +284,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_message_builder_simple(self, message_builder, record):
-        now = django_timezone.now()
+        now = timezone.now()
 
         two_days_ago = now - timedelta(days=2)
         three_days_ago = now - timedelta(days=3)
@@ -390,7 +390,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_message_builder_multiple_users_prevent_resend(self, message_builder, record):
-        now = django_timezone.now()
+        now = timezone.now()
 
         two_days_ago = now - timedelta(days=2)
         three_days_ago = now - timedelta(days=3)
@@ -507,7 +507,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     @with_feature("organizations:escalating-issues")
     def test_message_builder_substatus_simple(self, message_builder):
-        now = django_timezone.now()
+        now = timezone.now()
         three_days_ago = now - timedelta(days=3)
 
         self.create_member(
@@ -562,7 +562,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_message_builder_advanced(self, message_builder):
-        now = django_timezone.now()
+        now = timezone.now()
         two_days_ago = now - timedelta(days=2)
         three_days_ago = now - timedelta(days=3)
 
@@ -632,7 +632,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.send_email")
     def test_empty_report(self, mock_send_email):
-        now = django_timezone.now()
+        now = timezone.now()
 
         # date is out of range
         ten_days_ago = now - timedelta(days=10)
@@ -655,7 +655,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     @with_feature("organizations:session-replay-weekly_report")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_message_builder_replays(self, message_builder):
-        now = django_timezone.now()
+        now = timezone.now()
         two_days_ago = now - timedelta(days=2)
         timestamp = floor_to_utc_day(now).timestamp()
 
@@ -715,7 +715,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_email_override_simple(self, message_builder, record):
-        now = django_timezone.now()
+        now = timezone.now()
         two_days_ago = now - timedelta(days=2)
         timestamp = floor_to_utc_day(now).timestamp()
 
@@ -770,7 +770,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_email_override_no_target_user(self, message_builder, record):
-        now = django_timezone.now()
+        now = timezone.now()
         two_days_ago = now - timedelta(days=2)
         timestamp = floor_to_utc_day(now).timestamp()
 
@@ -820,7 +820,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.logger")
     def test_email_override_invalid_target_user(self, logger):
-        now = django_timezone.now()
+        now = timezone.now()
         two_days_ago = now - timedelta(days=2)
         timestamp = floor_to_utc_day(now).timestamp()
         org = self.create_organization()
@@ -860,7 +860,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_dry_run_simple(self, message_builder, record):
-        now = django_timezone.now()
+        now = timezone.now()
         two_days_ago = now - timedelta(days=2)
         timestamp = floor_to_utc_day(now).timestamp()
         org = self.create_organization()

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -1,9 +1,9 @@
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 from urllib3 import HTTPConnectionPool
 from urllib3.exceptions import HTTPError, ReadTimeoutError
 
@@ -28,7 +28,7 @@ from sentry.utils.snuba import (
 
 class SnubaUtilsTest(TestCase):
     def setUp(self):
-        self.now = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        self.now = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         self.proj1 = self.create_project()
         self.proj1env1 = self.create_environment(project=self.proj1, name="prod")
         self.proj1group1 = self.create_group(self.proj1)
@@ -301,7 +301,7 @@ class PrepareQueryParamsTest(TestCase):
 
 class QuantizeTimeTest(unittest.TestCase):
     def setUp(self):
-        self.now = django_timezone.now().replace(microsecond=0)
+        self.now = timezone.now().replace(microsecond=0)
 
     def test_quantizes_with_duration(self):
         key_hash = 0

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import pytest
 from django.test import override_settings
 from django.urls import reverse
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 from snuba_sdk.column import Column
 from snuba_sdk.function import Function
 
@@ -1372,13 +1372,13 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         replaced_release = self.create_release(
             version="replaced_release",
             environments=[self.environment],
-            adopted=django_timezone.now(),
-            unadopted=django_timezone.now(),
+            adopted=timezone.now(),
+            unadopted=timezone.now(),
         )
         adopted_release = self.create_release(
             version="adopted_release",
             environments=[self.environment],
-            adopted=django_timezone.now(),
+            adopted=timezone.now(),
         )
         self.create_release(version="not_adopted_release", environments=[self.environment])
 

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import requests
 from django.urls import reverse
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 from rest_framework.exceptions import ParseError
 
 from sentry.testutils.cases import APITestCase, SnubaTestCase
@@ -271,7 +271,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         self.store_event(
             data={
                 "event_id": uuid4().hex,
-                "timestamp": iso_format(django_timezone.now()),
+                "timestamp": iso_format(timezone.now()),
                 "tags": {"color": "red"},
             },
             project_id=self.project2.id,

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from unittest import mock
 
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.serializers import serialize
@@ -77,7 +77,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert result["priorityLockedAt"] is None
 
     def test_is_ignored_with_expired_snooze(self):
-        now = django_timezone.now()
+        now = timezone.now()
 
         user = self.create_user()
         group = self.create_group(status=GroupStatus.IGNORED)
@@ -88,7 +88,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert result["statusDetails"] == {}
 
     def test_is_ignored_with_valid_snooze(self):
-        now = django_timezone.now()
+        now = timezone.now()
 
         user = self.create_user()
         group = self.create_group(status=GroupStatus.IGNORED)
@@ -104,7 +104,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert result["statusDetails"]["actor"] is None
 
     def test_is_ignored_with_valid_snooze_and_actor(self):
-        now = django_timezone.now()
+        now = timezone.now()
 
         user = self.create_user()
         group = self.create_group(status=GroupStatus.IGNORED)
@@ -495,7 +495,7 @@ class PerformanceGroupSerializerSnubaTest(
         proj = self.create_project()
 
         first_group_fingerprint = f"{PerformanceNPlusOneGroupType.type_id}-group1"
-        timestamp = django_timezone.now() - timedelta(days=5)
+        timestamp = timezone.now() - timedelta(days=5)
         times = 5
         for _ in range(0, times):
             event_data = load_data(
@@ -525,8 +525,8 @@ class PerformanceGroupSerializerSnubaTest(
         result = serialize(
             first_group,
             serializer=GroupSerializerSnuba(
-                start=django_timezone.now() - timedelta(days=60),
-                end=django_timezone.now() + timedelta(days=10),
+                start=timezone.now() - timedelta(days=60),
+                end=timezone.now() + timedelta(days=10),
             ),
         )
 
@@ -547,7 +547,7 @@ class ProfilingGroupSerializerSnubaTest(
         environment = self.create_environment(project=proj)
 
         first_group_fingerprint = f"{ProfileFileIOGroupType.type_id}-group1"
-        timestamp = (django_timezone.now() - timedelta(days=5)).replace(hour=0, minute=0, second=0)
+        timestamp = (timezone.now() - timedelta(days=5)).replace(hour=0, minute=0, second=0)
         times = 5
         for incr in range(0, times):
             # for user_0 - user_4, first_group

--- a/tests/snuba/api/serializers/test_group_stream.py
+++ b/tests/snuba/api/serializers/test_group_stream.py
@@ -2,7 +2,7 @@ import time
 from datetime import timedelta
 from unittest import mock
 
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.serializers import serialize
@@ -216,8 +216,8 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
                 environment_ids=[dev_environment.id],
                 stats_period="14d",
                 expand=["sessions"],
-                start=django_timezone.now() - timedelta(days=30),
-                end=django_timezone.now() - timedelta(days=15),
+                start=timezone.now() - timedelta(days=30),
+                end=timezone.now() - timedelta(days=15),
                 organization_id=organization_id,
             ),
             request=self.make_request(),
@@ -232,7 +232,7 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
         )
         data = {
             "fingerprint": ["meow"],
-            "timestamp": iso_format(django_timezone.now()),
+            "timestamp": iso_format(timezone.now()),
             "type": "error",
             "exception": [{"type": "Foo"}],
         }

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest import mock
 
 import pytest
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry.release_health.base import OverviewStat
 from sentry.release_health.metrics import MetricsReleaseHealthBackend
@@ -48,7 +48,7 @@ def format_timestamp(dt):
 
 
 def make_24h_stats(ts, adjust_start=False):
-    ret_val = _make_stats(datetime.fromtimestamp(ts, timezone.utc), 3600, 24)
+    ret_val = _make_stats(datetime.fromtimestamp(ts, UTC), 3600, 24)
 
     if adjust_start:
         # HACK this adds another interval at the beginning in accordance with the new way of calculating intervals
@@ -498,7 +498,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         }
 
     def test_get_crash_free_breakdown(self):
-        start = django_timezone.now() - timedelta(days=4)
+        start = timezone.now() - timedelta(days=4)
 
         # it should work with and without environments
         for environments in [None, ["prod"]]:
@@ -511,7 +511,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
 
             # Last returned date is generated within function, should be close to now:
             last_date = data[-1]["date"]
-            assert django_timezone.now() - last_date < timedelta(seconds=1)
+            assert timezone.now() - last_date < timedelta(seconds=1)
 
             assert data == [
                 {
@@ -658,7 +658,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
     def _test_get_project_release_stats(
         self, stat: OverviewStat, release: str, expected_series, expected_totals
     ):
-        end = django_timezone.now()
+        end = timezone.now()
         start = end - timedelta(days=4)
         stats, totals = self.backend.get_project_release_stats(
             self.project.id,
@@ -1086,7 +1086,7 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
             )
 
     def test_get_current_and_previous_crash_free_rates(self):
-        now = django_timezone.now().replace(minute=15, second=23)
+        now = timezone.now().replace(minute=15, second=23)
         last_24h_start = now - 24 * timedelta(hours=1)
         last_48h_start = now - 2 * 24 * timedelta(hours=1)
 
@@ -1110,7 +1110,7 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
         }
 
     def test_get_current_and_previous_crash_free_rates_with_zero_sessions(self):
-        now = django_timezone.now().replace(minute=15, second=23)
+        now = timezone.now().replace(minute=15, second=23)
         last_48h_start = now - 2 * 24 * timedelta(hours=1)
         last_72h_start = now - 3 * 24 * timedelta(hours=1)
         last_96h_start = now - 4 * 24 * timedelta(hours=1)
@@ -1287,7 +1287,7 @@ class CheckNumberOfSessions(TestCase, SnubaTestCase):
 
         # now_dt should be set to 17:40 of some day not in the future and (system time - now_dt)
         # must be less than 90 days for the metrics DB TTL
-        ONE_DAY_AGO = datetime.now(tz=timezone.utc) - timedelta(days=1)
+        ONE_DAY_AGO = timezone.now() - timedelta(days=1)
         self.now_dt = ONE_DAY_AGO.replace(hour=17, minute=40, second=0)
         self._5_min_ago_dt = self.now_dt - timedelta(minutes=5)
         self._30_min_ago_dt = self.now_dt - timedelta(minutes=30)
@@ -1644,7 +1644,7 @@ class InitWithoutUserTestCase(TestCase, SnubaTestCase):
         assert inner["total_project_users_24h"] == 3
 
     def test_get_crash_free_breakdown(self):
-        start = django_timezone.now() - timedelta(days=4)
+        start = timezone.now() - timedelta(days=4)
         data = self.backend.get_crash_free_breakdown(
             project_id=self.project.id,
             release=self.session_release,
@@ -1655,7 +1655,7 @@ class InitWithoutUserTestCase(TestCase, SnubaTestCase):
         # Last returned date is generated within function, should be close to now:
         last_date = data[-1]["date"]
 
-        assert django_timezone.now() - last_date < timedelta(seconds=1)
+        assert timezone.now() - last_date < timedelta(seconds=1)
 
         assert data == [
             {
@@ -1682,7 +1682,7 @@ class InitWithoutUserTestCase(TestCase, SnubaTestCase):
         ]
 
     def test_get_project_release_stats_users(self):
-        end = django_timezone.now()
+        end = timezone.now()
         start = end - timedelta(days=4)
         stats, totals = self.backend.get_project_release_stats(
             self.project.id,

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -5,11 +5,11 @@ import hashlib
 import itertools
 import logging
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from unittest import mock
 from unittest.mock import patch
 
-from django.utils import timezone as django_timezone
+from django.utils import timezone
 
 from sentry import eventstream, tagstore, tsdb
 from sentry.eventstore.models import Event
@@ -60,7 +60,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         )
 
     def test_get_group_creation_attributes(self):
-        now = datetime.now(timezone.utc).replace(microsecond=0)
+        now = timezone.now().replace(microsecond=0)
         e1 = self.store_event(
             data={
                 "fingerprint": ["group1"],
@@ -119,7 +119,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         }
 
     def test_get_group_backfill_attributes(self):
-        now = datetime.now(timezone.utc).replace(microsecond=0)
+        now = timezone.now().replace(microsecond=0)
 
         assert get_group_backfill_attributes(
             get_caches(),
@@ -180,7 +180,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             return now + timedelta(seconds=offset)
 
         project = self.create_project()
-        project.date_added = django_timezone.now() - timedelta(minutes=10)
+        project.date_added = timezone.now() - timedelta(minutes=10)
         project.save()
         sequence = itertools.count(0)
         tag_values = itertools.cycle(["red", "green", "blue"])


### PR DESCRIPTION
this allows us to better resolve a name conflict with django.utils.timezone

UTC is new in python 3.11

automated with these scripts:

```python
import argparse
import ast


class V(ast.NodeVisitor):
    def __init__(self, mod: str, name: str, asname: str | None) -> None:
        self.mod = mod
        self.name = name
        self.asname = asname
        self.found = False

    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
        if (
            node.level == 0
            and node.module == self.mod
            and any(name.name == self.name and name.asname == self.asname for name in node.names)
        ):
            self.found = True
        self.generic_visit(node)


def main() -> int:
    parser = argparse.ArgumentParser()
    parser.add_argument("import_s")
    parser.add_argument("filename")
    args = parser.parse_args()

    o = ast.parse(args.import_s).body[0]
    assert isinstance(o, ast.ImportFrom), ast.dump(o)
    (name,) = o.names

    v = V(o.module, name.name, name.asname)
    with open(args.filename, "rb") as f:
        v.visit(ast.parse(f.read(), filename=args.filename))

    return not v.found


if __name__ == "__main__":
    raise SystemExit(main())
```

```bash
HERE="$(dirname "$0")"
sed -i -r 's/timezone\.utc/UTC/g' "$@"
grep -l '\bUTC\b' "$@" | xargs isort --add-import 'from datetime import UTC'
autoflake -i --remove-all "$@"

for fn in "$@"; do
    if \
        ! "$HERE/has-import" 'from datetime import timezone' "$fn" && \
        "$HERE/has-import" 'from django.utils import timezone as django_timezone' "$fn" \
    ; then
        sed -i -r 's/django_timezone\./timezone./g' "$fn"
        isort --add-import 'from django.utils import timezone' "$fn"
        autoflake -i --remove-all "$fn"
    fi
    if "$HERE/has-import" 'from django.utils import timezone' "$fn"; then
        sed -i -r 's/([^\.])datetime\.now\((tz=)?UTC\)/\1timezone.now()/g' "$fn"
        autoflake -i --remove-all "$fn"
    fi
done
```

<!-- Describe your PR here. -->