### PR TITLE
test(ui): Fix act warnings in various tests for 18

### DIFF
--- a/static/app/components/organizations/projectPageFilter/index.spec.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.spec.tsx
@@ -190,21 +190,21 @@ describe('ProjectPageFilter', function () {
     expect(onReset).toHaveBeenCalled();
   });
 
-  it('responds to page filter changes, async e.g. from back button nav', function () {
+  it('responds to page filter changes, async e.g. from back button nav', async function () {
     render(<ProjectPageFilter />, {
       context: routerContext,
       organization,
     });
 
     // Confirm initial selection
-    expect(screen.getByRole('button', {name: 'My Projects'})).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'My Projects'})).toBeInTheDocument();
 
     // Edit store value
     act(() => updateProjects([2], router));
 
     // <ProjectPageFilter /> is updated
 
-    expect(screen.getByRole('button', {name: 'project-2'})).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'project-2'})).toBeInTheDocument();
   });
 
   it('displays a desynced state message', async function () {

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -189,7 +189,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     );
   });
 
-  it('calls session api when session.status is a group by', function () {
+  it('calls session api when session.status is a group by', async function () {
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sessions/',
       body: MetricsFieldFixture(`count_unique(user)`),
@@ -217,19 +217,21 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       </ReleaseWidgetQueries>
     );
 
-    expect(mock).toHaveBeenCalledWith(
-      '/organizations/org-slug/sessions/',
-      expect.objectContaining({
-        query: expect.objectContaining({
-          environment: ['prod'],
-          field: ['count_unique(user)'],
-          groupBy: ['session.status'],
-          interval: '30m',
-          project: [1],
-          statsPeriod: '14d',
-        }),
-      })
-    );
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith(
+        '/organizations/org-slug/sessions/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            environment: ['prod'],
+            field: ['count_unique(user)'],
+            groupBy: ['session.status'],
+            interval: '30m',
+            project: [1],
+            statsPeriod: '14d',
+          }),
+        })
+      );
+    });
   });
 
   it('appends dashboard filters to releases request', async function () {
@@ -606,7 +608,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     );
   });
 
-  it('can send multiple API requests', function () {
+  it('can send multiple API requests', async function () {
     const metricsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
       body: SessionsFieldFixture(`session.all`),
@@ -627,7 +629,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       </ReleaseWidgetQueries>
     );
     // Child should be rendered and 2 requests should be sent.
-    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(metricsMock).toHaveBeenCalledTimes(2);
     expect(metricsMock).toHaveBeenNthCalledWith(
       1,
@@ -700,7 +702,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     );
   });
 
-  it('adjusts interval based on date window', function () {
+  it('adjusts interval based on date window', async function () {
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
       body: SessionsFieldFixture(`session.all`),
@@ -717,7 +719,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       </ReleaseWidgetQueries>
     );
 
-    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(mock).toHaveBeenCalledTimes(1);
     expect(mock).toHaveBeenCalledWith(
       expect.anything(),
@@ -732,7 +734,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     );
   });
 
-  it('does not re-fetch when renaming legend alias / adding falsy fields', () => {
+  it('does not re-fetch when renaming legend alias / adding falsy fields', async () => {
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
       body: SessionsFieldFixture(`session.all`),
@@ -750,7 +752,9 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       </ReleaseWidgetQueries>
     );
 
-    expect(mock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
 
     rerender(
       <ReleaseWidgetQueries
@@ -773,10 +777,12 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     );
 
     // no additional request has been sent, the total count of requests is still 1
-    expect(mock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('does not re-fetch when dashboard filter remains the same', () => {
+  it('does not re-fetch when dashboard filter remains the same', async () => {
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
       body: SessionsFieldFixture(`session.all`),
@@ -795,7 +801,9 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       </ReleaseWidgetQueries>
     );
 
-    expect(mock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
 
     rerender(
       <ReleaseWidgetQueries
@@ -810,6 +818,8 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     );
 
     // no additional request has been sent, the total count of requests is still 1
-    expect(mock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -1,6 +1,6 @@
 import type {InitializeDataSettings} from 'sentry-test/performance/initializePerformanceData';
 import {initializeData as _initializeData} from 'sentry-test/performance/initializePerformanceData';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -127,7 +127,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     }
   });
 
-  it('Check requests when changing widget props', function () {
+  it('Check requests when changing widget props', async function () {
     const data = initializeData();
 
     wrapper = render(
@@ -137,7 +137,9 @@ describe('Performance > Widgets > WidgetContainer', function () {
       />
     );
 
-    expect(eventStatsMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(eventStatsMock).toHaveBeenCalledTimes(1);
+    });
 
     // Change eventView reference
     data.eventView = data.eventView.clone();
@@ -149,7 +151,9 @@ describe('Performance > Widgets > WidgetContainer', function () {
       />
     );
 
-    expect(eventStatsMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(eventStatsMock).toHaveBeenCalledTimes(1);
+    });
 
     // Change eventView statsperiod
     const modifiedData = initializeData({
@@ -163,7 +167,9 @@ describe('Performance > Widgets > WidgetContainer', function () {
       />
     );
 
-    expect(eventStatsMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(eventStatsMock).toHaveBeenCalledTimes(2);
+    });
 
     expect(eventStatsMock).toHaveBeenNthCalledWith(
       2,
@@ -180,7 +186,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
   });
 
-  it('Check requests when changing widget props for GenericDiscoverQuery based widget', function () {
+  it('Check requests when changing widget props for GenericDiscoverQuery based widget', async function () {
     const data = initializeData();
 
     wrapper = render(
@@ -192,7 +198,9 @@ describe('Performance > Widgets > WidgetContainer', function () {
       </MEPSettingProvider>
     );
 
-    expect(eventsTrendsStats).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(eventsTrendsStats).toHaveBeenCalledTimes(1);
+    });
 
     // Change eventView reference
     data.eventView = data.eventView.clone();
@@ -206,7 +214,9 @@ describe('Performance > Widgets > WidgetContainer', function () {
       </MEPSettingProvider>
     );
 
-    expect(eventsTrendsStats).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(eventsTrendsStats).toHaveBeenCalledTimes(1);
+    });
 
     // Change eventView statsperiod
     const modifiedData = initializeData({
@@ -222,7 +232,9 @@ describe('Performance > Widgets > WidgetContainer', function () {
       </MEPSettingProvider>
     );
 
-    expect(eventsTrendsStats).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(eventsTrendsStats).toHaveBeenCalledTimes(2);
+    });
 
     expect(eventsTrendsStats).toHaveBeenNthCalledWith(
       2,

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
@@ -48,7 +48,7 @@ describe('TeamKeyTransactionButton', function () {
     act(() => void TeamStore.loadInitialData(teams, false, null));
   });
 
-  it('fetches key transactions with project param', function () {
+  it('fetches key transactions with project param', async function () {
     const getTeamKeyTransactionsMock = MockApiClient.addMockResponse({
       method: 'GET',
       url: '/organizations/org-slug/key-transactions-list/',
@@ -68,7 +68,9 @@ describe('TeamKeyTransactionButton', function () {
       />
     );
 
-    expect(getTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(getTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('renders with all teams checked', async function () {

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
@@ -4,7 +4,14 @@ import {
   generateSuspectSpansResponse,
   initializeData as _initializeData,
 } from 'sentry-test/performance/initializePerformanceData';
-import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import SpanDetails from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails';
@@ -375,7 +382,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
       });
 
-      it('renders a search bar', function () {
+      it('renders a search bar', async function () {
         const data = initializeData({
           features: FEATURES,
           query: {project: '1', transaction: 'transaction'},
@@ -386,11 +393,11 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           organization: data.organization,
         });
 
-        const searchBarNode = screen.getByPlaceholderText('Filter Transactions');
+        const searchBarNode = await screen.findByPlaceholderText('Filter Transactions');
         expect(searchBarNode).toBeInTheDocument();
       });
 
-      it('disables reset button when no min or max query parameters were set', function () {
+      it('disables reset button when no min or max query parameters were set', async function () {
         const data = initializeData({
           features: FEATURES,
           query: {project: '1', transaction: 'transaction'},
@@ -401,14 +408,14 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           organization: data.organization,
         });
 
-        const resetButton = screen.getByRole('button', {
+        const resetButton = await screen.findByRole('button', {
           name: /reset view/i,
         });
         expect(resetButton).toBeInTheDocument();
         expect(resetButton).toBeDisabled();
       });
 
-      it('enables reset button when min and max are set', function () {
+      it('enables reset button when min and max are set', async function () {
         const data = initializeData({
           features: FEATURES,
           query: {project: '1', transaction: 'transaction', min: '10', max: '100'},
@@ -419,13 +426,13 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           organization: data.organization,
         });
 
-        const resetButton = screen.getByRole('button', {
+        const resetButton = await screen.findByRole('button', {
           name: /reset view/i,
         });
         expect(resetButton).toBeEnabled();
       });
 
-      it('clears min and max query parameters when reset button is clicked', function () {
+      it('clears min and max query parameters when reset button is clicked', async function () {
         const data = initializeData({
           features: FEATURES,
           query: {project: '1', transaction: 'transaction', min: '10', max: '100'},
@@ -436,10 +443,10 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           organization: data.organization,
         });
 
-        const resetButton = screen.getByRole('button', {
+        const resetButton = await screen.findByRole('button', {
           name: /reset view/i,
         });
-        resetButton.click();
+        await userEvent.click(resetButton);
         expect(browserHistory.push).toHaveBeenCalledWith(
           expect.not.objectContaining({min: expect.any(String), max: expect.any(String)})
         );
@@ -494,12 +501,12 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           'Self Time Breakdown'
         );
 
-        (await within(displayToggle).findByRole('button')).click();
-        (
+        await userEvent.click(await within(displayToggle).findByRole('button'));
+        await userEvent.click(
           await within(displayToggle).findByRole('option', {
             name: 'Self Time Distribution',
           })
-        ).click();
+        );
 
         expect(browserHistory.push).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -584,7 +591,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         expect(nodes[0]).toBeInTheDocument();
       });
 
-      it('sends min and max to span example query', function () {
+      it('sends min and max to span example query', async function () {
         const mock = MockApiClient.addMockResponse({
           url: '/organizations/org-slug/events-spans/',
           body: {},
@@ -599,18 +606,20 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           organization: data.organization,
         });
 
-        expect(mock).toHaveBeenLastCalledWith(
-          '/organizations/org-slug/events-spans/',
-          expect.objectContaining({
-            query: expect.objectContaining({
-              min_exclusive_time: '10',
-              max_exclusive_time: '120',
-            }),
-          })
-        );
+        await waitFor(() => {
+          expect(mock).toHaveBeenLastCalledWith(
+            '/organizations/org-slug/events-spans/',
+            expect.objectContaining({
+              query: expect.objectContaining({
+                min_exclusive_time: '10',
+                max_exclusive_time: '120',
+              }),
+            })
+          );
+        });
       });
 
-      it('sends min and max to suspect spans query', function () {
+      it('sends min and max to suspect spans query', async function () {
         const mock = MockApiClient.addMockResponse({
           url: '/organizations/org-slug/events-spans-performance/',
           body: {},
@@ -625,15 +634,17 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           organization: data.organization,
         });
 
-        expect(mock).toHaveBeenLastCalledWith(
-          '/organizations/org-slug/events-spans-performance/',
-          expect.objectContaining({
-            query: expect.objectContaining({
-              min_exclusive_time: '10',
-              max_exclusive_time: '120',
-            }),
-          })
-        );
+        await waitFor(() => {
+          expect(mock).toHaveBeenLastCalledWith(
+            '/organizations/org-slug/events-spans-performance/',
+            expect.objectContaining({
+              query: expect.objectContaining({
+                min_exclusive_time: '10',
+                max_exclusive_time: '120',
+              }),
+            })
+          );
+        });
       });
     });
   });

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -182,7 +182,7 @@ describe('ReleasesList', () => {
       />
     );
     expect(
-      screen.getByText("There are no releases that match: 'abc'.")
+      await screen.findByText("There are no releases that match: 'abc'.")
     ).toBeInTheDocument();
 
     location = {query: {sort: ReleasesSortOption.SESSIONS, statsPeriod: '7d'}};
@@ -195,7 +195,7 @@ describe('ReleasesList', () => {
       />
     );
     expect(
-      screen.getByText('There are no releases with data in the last 7 days.')
+      await screen.findByText('There are no releases with data in the last 7 days.')
     ).toBeInTheDocument();
 
     location = {query: {sort: ReleasesSortOption.USERS_24_HOURS, statsPeriod: '7d'}};
@@ -208,7 +208,7 @@ describe('ReleasesList', () => {
       />
     );
     expect(
-      screen.getByText(
+      await screen.findByText(
         'There are no releases with active user data (users in the last 24 hours).'
       )
     ).toBeInTheDocument();
@@ -223,7 +223,7 @@ describe('ReleasesList', () => {
       />
     );
     expect(
-      screen.getByText(
+      await screen.findByText(
         'There are no releases with active session data (sessions in the last 24 hours).'
       )
     ).toBeInTheDocument();
@@ -238,7 +238,7 @@ describe('ReleasesList', () => {
       />
     );
     expect(
-      screen.getByText('There are no releases with semantic versioning.')
+      await screen.findByText('There are no releases with semantic versioning.')
     ).toBeInTheDocument();
   });
 
@@ -443,20 +443,22 @@ describe('ReleasesList', () => {
     );
   });
 
-  it('calls api with only explicitly permitted query params', () => {
+  it('calls api with only explicitly permitted query params', async () => {
     render(<ReleasesList {...props} />, {
       context: routerContext,
       organization,
     });
 
-    expect(endpointMock).toHaveBeenCalledWith(
-      '/organizations/org-slug/releases/',
-      expect.objectContaining({
-        query: expect.not.objectContaining({
-          somethingBad: 'XXX',
-        }),
-      })
-    );
+    await waitFor(() => {
+      expect(endpointMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/releases/',
+        expect.objectContaining({
+          query: expect.not.objectContaining({
+            somethingBad: 'XXX',
+          }),
+        })
+      );
+    });
   });
 
   it('calls session api for health data', async () => {


### PR DESCRIPTION
mostly wrapping things in waitFor or using findBy. switching one area to use userEvent.click other wise has to be wrapped in act manually.

part of https://github.com/getsentry/frontend-tsc/issues/22