### PR TITLE
fix(replay): fix broken replay test

### DIFF
--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -526,7 +526,7 @@ describe('GroupReplays', () => {
 
     // Test seems to be flaky
     // eslint-disable-next-line jest/no-disabled-tests
-    it('Should switch replays when clicking and replay-play-from-replay-tab is enabled', async () => {
+    it('Should switch replays when clicking and replay-play-from-replay-tab is enabledd', async () => {
       ({router, organization, routerContext} = init({
         organizationProps: {features: ['replay-play-from-replay-tab', 'session-replay']},
       }));
@@ -603,13 +603,15 @@ describe('GroupReplays', () => {
         return act(() => userEvent.click(replayPlayPlause));
       });
 
-      expect(mockReplace).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pathname: '/organizations/org-slug/replays/',
-          query: {
-            selected_replay_index: 1,
-          },
-        })
+      await waitFor(() =>
+        expect(mockReplace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pathname: '/organizations/org-slug/replays/',
+            query: {
+              selected_replay_index: 1,
+            },
+          })
+        )
       );
     });
   });

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -598,10 +598,8 @@ describe('GroupReplays', () => {
       });
 
       const mockReplace = jest.mocked(browserHistory.replace);
-      await waitFor(() => {
-        const replayPlayPlause = screen.getAllByTestId('replay-table-play-button')[0];
-        return act(() => userEvent.click(replayPlayPlause));
-      });
+      const replayPlayPlause = screen.getAllByTestId('replay-table-play-button')[0];
+      await act(() => userEvent.click(replayPlayPlause));
 
       await waitFor(() =>
         expect(mockReplace).toHaveBeenCalledWith(

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -526,7 +526,7 @@ describe('GroupReplays', () => {
 
     // Test seems to be flaky
     // eslint-disable-next-line jest/no-disabled-tests
-    it('Should switch replays when clicking and replay-play-from-replay-tab is enabledd', async () => {
+    it('Should switch replays when clicking and replay-play-from-replay-tab is enabled', async () => {
       ({router, organization, routerContext} = init({
         organizationProps: {features: ['replay-play-from-replay-tab', 'session-replay']},
       }));

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -526,7 +526,7 @@ describe('GroupReplays', () => {
 
     // Test seems to be flaky
     // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('Should switch replays when clicking and replay-play-from-replay-tab is enabled', async () => {
+    it('Should switch replays when clicking and replay-play-from-replay-tab is enabled', async () => {
       ({router, organization, routerContext} = init({
         organizationProps: {features: ['replay-play-from-replay-tab', 'session-replay']},
       }));
@@ -597,15 +597,12 @@ describe('GroupReplays', () => {
         );
       });
 
-      // browserHistory.replace = jest.fn();
-
       const mockReplace = jest.mocked(browserHistory.replace);
       await waitFor(() => {
         const replayPlayPlause = screen.getAllByTestId('replay-table-play-button')[0];
         return act(() => userEvent.click(replayPlayPlause));
       });
 
-      await tick();
       expect(mockReplace).toHaveBeenCalledWith(
         expect.objectContaining({
           pathname: '/organizations/org-slug/replays/',

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -2,7 +2,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import GroupReplays from 'sentry/views/issueDetails/groupReplays';
@@ -599,7 +599,7 @@ describe('GroupReplays', () => {
 
       const mockReplace = jest.mocked(browserHistory.replace);
       const replayPlayPlause = screen.getAllByTestId('replay-table-play-button')[0];
-      await act(() => userEvent.click(replayPlayPlause));
+      await userEvent.click(replayPlayPlause);
 
       await waitFor(() =>
         expect(mockReplace).toHaveBeenCalledWith(


### PR DESCRIPTION
I think this works but it was flaky before so it's hard to know. Not sure why removing the tick seems to fix test locally.