### PR TITLE
fix(api-pagination): Add BroadcastIndexEndpoint to allowlist

### DIFF
--- a/src/sentry/conf/api_pagination_allowlist_do_not_modify.py
+++ b/src/sentry/conf/api_pagination_allowlist_do_not_modify.py
@@ -104,4 +104,5 @@ SENTRY_API_PAGINATION_ALLOWLIST_DO_NOT_MODIFY = {
     "OrganizationMonitorScheduleSampleDataEndpoint",
     "GitlabIssueSearchEndpoint",
     "BitbucketSearchEndpoint",
+    "BroadcastIndexEndpoint",
 }


### PR DESCRIPTION
`BroadcastIndexEndpoint` doesn't _always_ paginate correctly, so added to allowlist