### PR TITLE
fix(gh-integration): Removed FF check for Open PR Comments & Missing Member Detection

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -363,7 +363,6 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
             disabledReason: t(
               'You must have a GitHub integration to enable this feature.'
             ),
-            visible: ({features}) => features.includes('integrations-open-pr-comment'),
           },
           {
             name: 'githubNudgeInvite',
@@ -376,7 +375,6 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
             disabledReason: t(
               'You must have a GitHub integration to enable this feature.'
             ),
-            visible: ({features}) => features.includes('integrations-gh-invite'),
           },
         ],
       },


### PR DESCRIPTION
After removing the ff's for Open PR Comments & Missing Member Detection as it is in GA, we forgot to remove the filter

#### Before
<img width="1255" alt="image" src="https://github.com/getsentry/sentry/assets/33237075/72388146-d6a4-4b79-aad1-880640d2a047">


#### After
<img width="1255" alt="image" src="https://github.com/getsentry/sentry/assets/33237075/816b5647-f207-48ca-8e0a-97ebdc4a2225">
 