### PR TITLE
ref: pkg-config is not needed by the development environment any more

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -159,7 +159,6 @@ for pkg in \
     make \
     docker \
     chromedriver \
-    pkg-config \
     openssl; do
     if ! require "$pkg"; then
         die "You seem to be missing the system dependency: ${pkg}


### PR DESCRIPTION
currently direnv will fail after bootstrap due to this

this was previously needed when we built python packages from source (we don't do this any more!)

<!-- Describe your PR here. -->