### PR TITLE
fix(eventstore): Use more correct start date for eventstore

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -426,7 +426,9 @@ class SnubaEventStorage(EventStorage):
         prev_filter = deepcopy(filter)
         prev_filter.conditions = prev_filter.conditions or []
         prev_filter.conditions.extend(get_before_event_condition(event))
-        prev_filter.start = datetime.fromtimestamp(0)
+
+        # We only store 90 days of data, add a few extra days just in case
+        prev_filter.start = event.datetime - timedelta(days=100)
         # the previous event can have the same timestamp, add 1 second
         # to the end condition since it uses a less than condition
         prev_filter.end = event.datetime + timedelta(seconds=1)

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-import pytest
-
 from sentry.eventstore.base import Filter
 from sentry.eventstore.models import Event
 from sentry.eventstore.snuba.backend import SnubaEventStorage
@@ -221,7 +219,6 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
             event = self.eventstore.get_event_by_id(self.project2.id, "d" * 32)
             assert event is None
 
-    @pytest.mark.xfail(reason="fails in Snuba CI")
     def test_get_adjacent_event_ids(self):
         event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
 


### PR DESCRIPTION
Clickhouse behaves oddly when the normal epoch is used for dates:

https://github.com/ClickHouse/ClickHouse/issues/9335#issuecomment-590288224

This was working before by coincedence: an obsolete piece of code (query
splitters) in Snuba was clamping the date to a non-epoch value. When the query
splitters were removed, this started breaking.

Instead of simply asking for "all time" use a date that aligns with how our
data is actually stored.

This is also not a new issue, see https://github.com/getsentry/sentry/pull/30912