### PR TITLE
fix(devenv): downgrade to colima 0.6.6

### DIFF
--- a/devenv/config.ini
+++ b/devenv/config.ini
@@ -28,16 +28,16 @@ linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/downl
 linux_arm64_sha256 = 3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec
 
 [colima]
-darwin_x86_64 = https://github.com/abiosoft/colima/releases/download/v0.6.8/colima-Darwin-x86_64
-darwin_x86_64_sha256 = e5aa67eb339616effe1604ecdcfcbc0e4899a3584048921b5bc063b850fa0b44
-darwin_arm64 = https://github.com/abiosoft/colima/releases/download/v0.6.8/colima-Darwin-arm64
-darwin_arm64_sha256 = bcac7db4452136ed649acde7dc93204574293db7c5bff93bc813122173281385
-linux_x86_64 = https://github.com/abiosoft/colima/releases/download/v0.6.8/colima-Linux-x86_64
-linux_x86_64_sha256 = 8c5f7b041fb8b37f4760bf20dc5cbb44eee6aa9ef4db5845826ecbba1cb422d4
-linux_arm64 = https://github.com/abiosoft/colima/releases/download/v0.6.8/colima-Linux-aarch64
-linux_arm64_sha256 = e3bc5267cbe57ab43f181994330b7f89dc486ba80bc734ea9d1644db13458274
+darwin_x86_64 = https://github.com/abiosoft/colima/releases/download/v0.6.6/colima-Darwin-x86_64
+darwin_x86_64_sha256 = 84e72678945aacba5805fe363f6c7c87dc73e05cbbfdfc09f9b57cedf110865d
+darwin_arm64 = https://github.com/abiosoft/colima/releases/download/v0.6.6/colima-Darwin-arm64
+darwin_arm64_sha256 = b2729edcf99470071240ab6986349346211e25944a5dc317bba8fa27ed0f25e5
+linux_x86_64 = https://github.com/abiosoft/colima/releases/download/v0.6.6/colima-Linux-x86_64
+linux_x86_64_sha256 = bf9e370c4bacbbebdfaa46de04d0e01fe2649a8e366f282cf35ae7dd84559a25
+linux_arm64 = https://github.com/abiosoft/colima/releases/download/v0.6.6/colima-Linux-aarch64
+linux_arm64_sha256 = 6ecba675e90d154f22e20200fa5684f20ad1495b73c0462f1bd7da4e9d0beaf8
 # used for autoupdate
-version = v0.6.8
+version = v0.6.6
 
 # kept here only for compatibility with older `devenv`
 [python]

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -168,7 +168,8 @@ def ensure_interface(ports: dict[str, int | tuple[str, int]]) -> dict[str, tuple
 
 def ensure_docker_cli_context(context: str):
     # this is faster than running docker context use ...
-    config_file = os.path.expanduser("~/.docker/config.json")
+    config_dir = os.path.expanduser("~/.docker")
+    config_file = f"{config_dir}/config.json"
     config = {}
 
     if os.path.exists(config_file):
@@ -177,6 +178,7 @@ def ensure_docker_cli_context(context: str):
 
     config["currentContext"] = context
 
+    os.makedirs(config_dir, exist_ok=True)
     with open(config_file, "w") as f:
         f.write(json.dumps(config))
 

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -168,8 +168,7 @@ def ensure_interface(ports: dict[str, int | tuple[str, int]]) -> dict[str, tuple
 
 def ensure_docker_cli_context(context: str):
     # this is faster than running docker context use ...
-    config_dir = os.path.expanduser("~/.docker")
-    config_file = f"{config_dir}/config.json"
+    config_file = os.path.expanduser("~/.docker/config.json")
     config = {}
 
     if os.path.exists(config_file):
@@ -178,7 +177,7 @@ def ensure_docker_cli_context(context: str):
 
     config["currentContext"] = context
 
-    os.makedirs(config_dir, exist_ok=True)
+    os.makedirs(os.path.dirname(config_file), exist_ok=True)
     with open(config_file, "w") as f:
         f.write(json.dumps(config))
 


### PR DESCRIPTION
haven't done a full reset on my macos-14 M1 in a while so haven't noticed till now but 0.6.8 stalls during disk conversion

`colima delete` and remove `~/Library/Caches/lima`, `~/.colima` to get to a state where you can then repro with colima start

ref: https://github.com/abiosoft/colima/issues/930
