### PR TITLE
ref(autofix): Rename additional_context to instruction

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -112,7 +112,7 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
         group: Group,
         repos: list[dict],
         serialized_event: dict[str, Any],
-        additional_context: str,
+        instruction: str,
         timeout_secs: int,
     ):
         response = requests.post(
@@ -128,7 +128,7 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
                         "short_id": group.qualified_short_id,
                         "events": [serialized_event],
                     },
-                    "additional_context": additional_context,
+                    "instruction": instruction,
                     "timeout_secs": timeout_secs,
                     "last_updated": datetime.now().isoformat(),
                     "invoking_user": (
@@ -204,7 +204,7 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
                 group,
                 repos,
                 serialized_event,
-                data.get("additional_context", ""),
+                data.get("instruction", data.get("additional_context", "")),
                 TIMEOUT_SECONDS,
             )
 

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -79,7 +79,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             "sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix"
         ) as mock_call:
             response = self.client.post(
-                url, data={"additional_context": "Yes", "event_id": event.event_id}, format="json"
+                url, data={"instruction": "Yes", "event_id": event.event_id}, format="json"
             )
             mock_call.assert_called_with(
                 ANY,
@@ -142,7 +142,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             "sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix"
         ) as mock_call:
             response = self.client.post(
-                url, data={"additional_context": "Yes", "event_id": event.event_id}, format="json"
+                url, data={"instruction": "Yes", "event_id": event.event_id}, format="json"
             )
             mock_call.assert_not_called()
 
@@ -193,7 +193,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             "sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix"
         ) as mock_call:
             response = self.client.post(
-                url, data={"additional_context": "Yes", "event_id": event.event_id}, format="json"
+                url, data={"instruction": "Yes", "event_id": event.event_id}, format="json"
             )
             mock_call.assert_not_called()
 


### PR DESCRIPTION
Renames additional_context to instruction for the autofix call. `data.get("instruction", data.get("additional_context", ""))` is so it works when FE/BE deploy separately for now
