### PR TITLE
ref(alerts): Render label issue category

### DIFF
--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -51,8 +51,6 @@ class IssueCategoryFilter(EventFilter):
 
     def render_label(self) -> str:
         value = self.data["value"]
-        group_category_name = ""
-        for id, title in CATEGORY_CHOICES.items():
-            if id == value:
-                group_category_name = title.title()
+        title = CATEGORY_CHOICES.get(value)
+        group_category_name = title.title() if title else ""
         return self.label.format(value=group_category_name)

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -4,7 +4,7 @@ from typing import Any
 from django import forms
 
 from sentry.eventstore.models import GroupEvent
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
 from sentry.models.group import Group
 from sentry.rules import EventState
 from sentry.rules.filters import EventFilter
@@ -48,3 +48,8 @@ class IssueCategoryFilter(EventFilter):
             return False
 
         return self._passes(group)
+
+    def render_label(self) -> str:
+        value = self.data["value"]
+        group_category_name = get_group_type_by_type_id(int(value)).description
+        return self.label.format(value=group_category_name)

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -4,7 +4,7 @@ from typing import Any
 from django import forms
 
 from sentry.eventstore.models import GroupEvent
-from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
+from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.rules import EventState
 from sentry.rules.filters import EventFilter
@@ -51,5 +51,8 @@ class IssueCategoryFilter(EventFilter):
 
     def render_label(self) -> str:
         value = self.data["value"]
-        group_category_name = get_group_type_by_type_id(int(value)).description
+        group_category_name = ""
+        for id, title in CATEGORY_CHOICES.items():
+            if id == value:
+                group_category_name = title.title()
         return self.label.format(value=group_category_name)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1011,7 +1011,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         filters = [
             {
                 "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
-                "value": GroupCategory.ERROR.value,
+                "value": GroupCategory.PERFORMANCE.value,
             }
         ]
         actions = [
@@ -1092,7 +1092,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         rendered_blocks = json.loads(data["blocks"][0])
         assert rendered_blocks[0]["text"]["text"] == message
         changes = "*Changes*\n"
-        changes += "• Added condition 'The issue's category is equal to Error'\n"
+        changes += "• Added condition 'The issue's category is equal to Performance'\n"
         changes += "• Added action 'Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification'\n"
         changes += "• Removed action 'Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification'\n"
         changes += "• Changed frequency from *5 minutes* to *3 hours*\n"

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -14,6 +14,7 @@ from sentry.integrations.slack.message_builder.notifications.rule_save_edit impo
     SlackRuleSaveEditMessageBuilder,
 )
 from sentry.integrations.slack.utils.channel import strip_channel_name
+from sentry.issues.grouptype import GroupCategory
 from sentry.models.actor import Actor, get_actor_for_user
 from sentry.models.environment import Environment
 from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityType
@@ -1004,7 +1005,15 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
     @responses.activate
     @with_feature("organizations:rule-create-edit-confirm-notification")
     def test_slack_confirmation_notification_contents(self):
-        conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
+        conditions = [
+            {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+        ]
+        filters = [
+            {
+                "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
+                "value": GroupCategory.ERROR.value,
+            }
+        ]
         actions = [
             {
                 "channel_id": "old_channel_id",
@@ -1014,7 +1023,8 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             }
         ]
         self.rule.update(
-            data={"conditions": conditions, "actions": actions, "frequency": 5}, label="my rule"
+            data={"conditions": conditions, "filters": filters, "actions": actions, "frequency": 5},
+            label="my rule",
         )
 
         actions[0]["channel"] = "#new_channel_name"
@@ -1066,6 +1076,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "actions": actions,
             "conditions": conditions,
             "frequency": 180,
+            "filters": filters,
             "environment": staging_env.name,
             "owner": get_actor_for_user(self.user).get_actor_identifier(),
         }
@@ -1081,6 +1092,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         rendered_blocks = json.loads(data["blocks"][0])
         assert rendered_blocks[0]["text"]["text"] == message
         changes = "*Changes*\n"
+        changes += "• Added condition 'The issue's category is equal to Error'\n"
         changes += "• Added action 'Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification'\n"
         changes += "• Removed action 'Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification'\n"
         changes += "• Changed frequency from *5 minutes* to *3 hours*\n"


### PR DESCRIPTION
Redo of https://github.com/getsentry/sentry/pull/66999 that actually gets the groupcategory name correctly. It's unfortunate that for errors the groupcategory enum value is the same as the grouptype type_id, so I didn't catch the mistake before. 

Fixes https://sentry.sentry.io/issues/5070923494/