### PR TITLE
ref(opsgenie): verify integration key upon key save rather than upon alert rule save

### DIFF
--- a/src/sentry/api/endpoints/integrations/organization_integrations/details.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/details.py
@@ -118,9 +118,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
         )
         try:
             installation.update_organization_config(request.data)
-        except IntegrationError as e:
-            return self.respond({"detail": [str(e)]}, status=400)
-        except ApiError as e:
+        except (IntegrationError, ApiError) as e:
             return self.respond({"detail": [str(e)]}, status=400)
 
         return self.respond(status=200)

--- a/src/sentry/api/endpoints/integrations/organization_integrations/details.py
+++ b/src/sentry/api/endpoints/integrations/organization_integrations/details.py
@@ -21,7 +21,7 @@ from sentry.constants import ObjectStatus
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.scheduledeletion import ScheduledDeletion
 from sentry.services.hybrid_cloud.organization import RpcUserOrganizationContext
-from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.utils.audit import create_audit_entry
 from sentry.web.decorators import set_referrer_policy
 
@@ -119,6 +119,8 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
         try:
             installation.update_organization_config(request.data)
         except IntegrationError as e:
-            return self.respond({"detail": str(e)}, status=400)
+            return self.respond({"detail": [str(e)]}, status=400)
+        except ApiError as e:
+            return self.respond({"detail": [str(e)]}, status=400)
 
         return self.respond(status=200)

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any
 from uuid import uuid4
 
 from django.db import router, transaction
@@ -58,7 +58,6 @@ from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation, app_servi
 from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcOrganizationIntegration
 from sentry.shared_integrations.exceptions import (
-    ApiError,
     ApiTimeoutError,
     DuplicateDisplayNameError,
     IntegrationError,
@@ -1476,7 +1475,6 @@ def get_alert_rule_trigger_action_opsgenie_team(
     input_channel_id=None,
     integrations=None,
 ) -> tuple[str, str]:
-    from sentry.integrations.opsgenie.integration import OpsgenieIntegration
     from sentry.integrations.opsgenie.utils import get_team
 
     integration, oi = integration_service.get_organization_context(
@@ -1489,17 +1487,6 @@ def get_alert_rule_trigger_action_opsgenie_team(
     if not team:
         raise InvalidTriggerActionError("No Opsgenie team found.")
 
-    install = cast(
-        "OpsgenieIntegration",
-        integration.get_installation(organization_id=organization.id),
-    )
-    client = install.get_keyring_client(keyid=team["id"])
-
-    try:
-        client.authorize_integration(type="sentry")
-    except ApiError as e:
-        logger.info("opsgenie.authorization_error", extra={"error": str(e)})
-        raise InvalidTriggerActionError("Invalid integration key.")
     return team["id"], team["team"]
 
 

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -32,8 +32,8 @@ class OpsgenieClient(ApiClient):
     def _get_auth_headers(self):
         return {"Authorization": f"GenieKey {self.integration_key}"}
 
-    def get_teams(self) -> BaseApiResponseX:
-        path = "/teams"
+    def get_alerts(self, limit: int | None = 1) -> BaseApiResponseX:
+        path = f"/alerts?limit={limit}"
         return self.get(path=path, headers=self._get_auth_headers())
 
     def authorize_integration(self, type: str) -> BaseApiResponseX:

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Literal
-from urllib.parse import quote
 
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.client import ApiClient
@@ -33,13 +32,9 @@ class OpsgenieClient(ApiClient):
     def _get_auth_headers(self):
         return {"Authorization": f"GenieKey {self.integration_key}"}
 
-    # This doesn't work if the team name is "." or "..", which Opsgenie allows for some reason
-    # despite their API not working with these names.
-    def get_team_id(self, team_name: str) -> BaseApiResponseX:
-        params = {"identifierType": "name"}
-        quoted_name = quote(team_name)
-        path = f"/teams/{quoted_name}"
-        return self.get(path=path, headers=self._get_auth_headers(), params=params)
+    def get_teams(self) -> BaseApiResponseX:
+        path = "/teams"
+        return self.get(path=path, headers=self._get_auth_headers())
 
     def authorize_integration(self, type: str) -> BaseApiResponseX:
         body = {"type": type}

--- a/tests/sentry/integrations/opsgenie/test_integration.py
+++ b/tests/sentry/integrations/opsgenie/test_integration.py
@@ -135,6 +135,8 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
         integration = Integration.objects.get(provider=self.provider.key)
         org_integration = OrganizationIntegration.objects.get(integration_id=integration.id)
 
+        responses.add(responses.GET, url="https://api.opsgenie.com/v2/teams", status=200, json={})
+
         data = {"team_table": [{"id": "", "team": "cool-team", "integration_key": "1234-5678"}]}
         installation.update_organization_config(data)
         team_id = str(org_integration.id) + "-" + "cool-team"

--- a/tests/sentry/integrations/opsgenie/test_integration.py
+++ b/tests/sentry/integrations/opsgenie/test_integration.py
@@ -135,7 +135,9 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
         integration = Integration.objects.get(provider=self.provider.key)
         org_integration = OrganizationIntegration.objects.get(integration_id=integration.id)
 
-        responses.add(responses.GET, url="https://api.opsgenie.com/v2/teams", status=200, json={})
+        responses.add(
+            responses.GET, url="https://api.opsgenie.com/v2/alerts?limit=1", status=200, json={}
+        )
 
         data = {"team_table": [{"id": "", "team": "cool-team", "integration_key": "1234-5678"}]}
         installation.update_organization_config(data)
@@ -156,7 +158,9 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
         org_integration = OrganizationIntegration.objects.get(integration_id=integration.id)
         team_id = str(org_integration.id) + "-" + "cool-team"
 
-        responses.add(responses.GET, url="https://api.opsgenie.com/v2/teams", status=200, json={})
+        responses.add(
+            responses.GET, url="https://api.opsgenie.com/v2/alerts?limit=1", status=200, json={}
+        )
 
         # valid
         data = {"team_table": [{"id": "", "team": "cool-team", "integration_key": "1234"}]}
@@ -192,7 +196,7 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
                 {"id": "cool-team", "team": "cool-team", "integration_key": "1234"},
             ]
         }
-        responses.add(responses.GET, url="https://api.opsgenie.com/v2/teams", status=429)
+        responses.add(responses.GET, url="https://api.opsgenie.com/v2/alerts?limit=1", status=429)
 
         with pytest.raises(ApiRateLimitedError):
             installation.update_organization_config(data)
@@ -211,7 +215,7 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
                 {"id": "", "team": "rad-team", "integration_key": "4321"},
             ]
         }
-        responses.add(responses.GET, url="https://api.opsgenie.com/v2/teams", status=401)
+        responses.add(responses.GET, url="https://api.opsgenie.com/v2/alerts?limit=1", status=401)
 
         with pytest.raises(ApiUnauthorized):
             installation.update_organization_config(data)

--- a/tests/sentry/integrations/opsgenie/test_integration.py
+++ b/tests/sentry/integrations/opsgenie/test_integration.py
@@ -154,6 +154,8 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
         org_integration = OrganizationIntegration.objects.get(integration_id=integration.id)
         team_id = str(org_integration.id) + "-" + "cool-team"
 
+        responses.add(responses.GET, url="https://api.opsgenie.com/v2/teams", status=200, json={})
+
         # valid
         data = {"team_table": [{"id": "", "team": "cool-team", "integration_key": "1234"}]}
         installation.update_organization_config(data)
@@ -182,9 +184,14 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
         integration.add_organization(self.organization, self.user)
         installation = integration.get_installation(self.organization.id)
 
-        data = {"team_table": [{"id": "", "team": "cool-team", "integration_key": "1234"}]}
-
+        data = {
+            "team_table": [
+                {"id": "", "team": "rad-team", "integration_key": "4321"},
+                {"id": "cool-team", "team": "cool-team", "integration_key": "1234"},
+            ]
+        }
         responses.add(responses.GET, url="https://api.opsgenie.com/v2/teams", status=429)
+
         with pytest.raises(ApiRateLimitedError):
             installation.update_organization_config(data)
 
@@ -196,9 +203,14 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
         integration.add_organization(self.organization, self.user)
         installation = integration.get_installation(self.organization.id)
 
-        data = {"team_table": [{"id": "", "team": "cool-team", "integration_key": "1234"}]}
-
+        data = {
+            "team_table": [
+                {"id": "cool-team", "team": "cool-team", "integration_key": "1234"},
+                {"id": "", "team": "rad-team", "integration_key": "4321"},
+            ]
+        }
         responses.add(responses.GET, url="https://api.opsgenie.com/v2/teams", status=401)
+
         with pytest.raises(ApiUnauthorized):
             installation.update_organization_config(data)
 


### PR DESCRIPTION
Opsgenie has a complex rate limiting strategy: https://docs.opsgenie.com/docs/api-rate-limiting 😞 

Currently, when someone saves a metric alert, if they have Opsgenie trigger actions, all of them are validated consecutively by POSTing to the [authenticate integration API](https://docs.opsgenie.com/docs/integration-api#authenticate-integration), which we appear to do in order to validate the integration key since we don't do anything with the response. Opsgenie doesn't have an API to verify integration keys, so our approach has been to hit an API to check if it's an authorized request.

Due to to Opsgenie's rate limiting strategy, it is easy for someone to get rate limited for this API because we are calling this POST repeatedly when saving an alert rule. The current response is "Invalid integration key" regardless of the actual status code of the API, which is not helpful.

We should be validating the integration key as it is saved rather than doing so upon alert save, because people might have multiple Opsgenie trigger actions per alert. Thus we can prevent invalid integration keys from being saved in the first place. I also switched the API we try to hit to check the validity of the integration key to a GET rather than a POST to hopefully increase the rate limit.

Also modified parsing the error so the error messages when filling out the form are more informative.

https://github.com/getsentry/sentry/assets/70817427/b037cb0f-dea8-4e53-a89c-775107a79a6b