### PR TITLE
fix(database): Fix query source wrapping on small screens

### DIFF
--- a/static/app/views/starfish/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/starfish/components/stackTraceMiniFrame.tsx
@@ -73,6 +73,7 @@ export function MissingFrame() {
 
 export const FrameContainer = styled('div')`
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: ${space(0.5)};
   padding: ${space(1.5)} ${space(2)};


### PR DESCRIPTION
Feedback welcome, but even _basic wrapping_ seems a lot better.

**Before:**
<img width="505" alt="Screenshot 2024-03-15 at 4 52 41 PM" src="https://github.com/getsentry/sentry/assets/989898/75793c49-217c-4f77-b788-1ec4faf8c14a">

**After:**
<img width="496" alt="Screenshot 2024-03-15 at 4 52 30 PM" src="https://github.com/getsentry/sentry/assets/989898/eb730cb8-d63b-4e4f-adc8-0b23be65cc04">

