### PR TITLE
fix(hybridcloud) Fix load-mocks not generating mapping records

### DIFF
--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -50,7 +50,7 @@ def handle_db_failure(func, using=None, wrap_in_transaction=True):
 
 
 def create_default_projects(**kwds):
-    if not in_test_environment() and not is_self_hosted():
+    if not (in_test_environment() or is_self_hosted() or settings.DEBUG):
         # No op in production SaaS environments.
         return
 

--- a/tests/sentry/utils/mockdata/test_core.py
+++ b/tests/sentry/utils/mockdata/test_core.py
@@ -1,5 +1,6 @@
 from sentry.models.broadcast import Broadcast
 from sentry.models.environment import Environment
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.team import Team
@@ -39,6 +40,9 @@ def test_get_organization() -> None:
     org = mockdata.get_organization()
     assert org
     assert "default" == org.slug
+
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        assert OrganizationMapping.objects.get(slug=org.slug)
 
 
 @region_silo_test


### PR DESCRIPTION
The default organization was not getting a mapping record generated, this causes a variety of breakage in the application. I've also restored the internal project for getsentry local development as that configuration is neither a single-tenant or in test mode.