### PR TITLE
fix(metric-alerts): account for pagerduty and opsgenie using config field in serializer

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -100,7 +100,7 @@ class AlertRuleSerializer(Serializer):
 
         trigger_actions = AlertRuleTriggerAction.objects.filter(
             alert_rule_trigger__alert_rule_id__in=alert_rules.keys()
-        ).exclude(sentry_app_config__isnull=True, sentry_app_id__isnull=True)
+        ).exclude(Q(sentry_app_config__isnull=True) | Q(sentry_app_id__isnull=True))
 
         sentry_app_installations_by_sentry_app_id = app_service.get_related_sentry_app_components(
             organization_ids=[alert_rule.organization_id for alert_rule in alert_rules.values()],

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -1,10 +1,16 @@
+from unittest.mock import patch
+
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import (
     CombinedRuleSerializer,
     DetailedAlertRuleSerializer,
 )
-from sentry.incidents.logic import create_alert_rule_trigger
-from sentry.incidents.models.alert_rule import AlertRule, AlertRuleThresholdType
+from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
+from sentry.incidents.models.alert_rule import (
+    AlertRule,
+    AlertRuleThresholdType,
+    AlertRuleTriggerAction,
+)
 from sentry.models.rule import Rule
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.snuba.models import SnubaQueryEventType
@@ -195,6 +201,27 @@ class DetailedAlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
         trigger = create_alert_rule_trigger(alert_rule, "test", 1000)
         result = serialize([alert_rule, other_alert_rule], serializer=DetailedAlertRuleSerializer())
         assert result[0]["triggers"] == [serialize(trigger)]
+        assert result[1]["triggers"] == []
+
+    @patch(
+        "sentry.incidents.logic.get_target_identifier_display_for_integration",
+        return_value=(123, "test"),
+    )
+    def test_trigger_actions(self, mock_get):
+        alert_rule = self.create_alert_rule()
+        other_alert_rule = self.create_alert_rule()
+        trigger = create_alert_rule_trigger(alert_rule, "test", 1000)
+        trigger_action = create_alert_rule_trigger_action(
+            trigger,
+            AlertRuleTriggerAction.Type.PAGERDUTY,
+            AlertRuleTriggerAction.TargetType.SPECIFIC,
+            target_identifier="123",
+            integration_id=self.integration.id,
+            priority="error",
+        )
+        result = serialize([alert_rule, other_alert_rule], serializer=DetailedAlertRuleSerializer())
+        assert result[0]["triggers"] == [serialize(trigger)]
+        assert result[0]["triggers"][0]["actions"] == [serialize(trigger_action)]
         assert result[1]["triggers"] == []
 
 


### PR DESCRIPTION
Fixes SENTRY-30N8

Custom metric alert priorities for Pagerduty and Opsgenie borrows the `sentry_app_config` JSON field in AlertRuleTriggerAction. This error is happening because in this line
https://github.com/getsentry/sentry/blob/416b7f487c1ae5ee150f16ba0b9dfbded24bff6c/src/sentry/api/serializers/models/alert_rule.py#L103

we find trigger actions that don't have null `sentry_app_configs` AND don't have null `sentry_app_ids`, and pass those trigger actions into the following query
https://github.com/getsentry/sentry/blob/c3b2132cac1aa0a10d9452101823b1603d7f3171/src/sentry/api/serializers/models/alert_rule.py#L105-L109

However since we are simply borrowing this field, Pagerduty and Opsgenie `AlertRuleTriggerActions` with a null `sentry_app_id` can have a non-null `sentry_app_config` if somebody has setup a priority and these will get passed into the query, causing the error. If we replace the implied "and" with an "or" this will solve the problem.