### PR TITLE
ref(daily summary): Add discover link, add more issue detail

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -5,7 +5,12 @@ from typing import Any
 
 from sentry_relay.processing import parse_release
 
-from sentry.integrations.message_builder import build_attachment_title, get_title_link
+from sentry import features
+from sentry.integrations.message_builder import (
+    build_attachment_text,
+    build_attachment_title,
+    get_title_link,
+)
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.models.project import Project
@@ -15,6 +20,7 @@ from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.tasks.summaries.utils import COMPARISON_PERIOD
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
+from sentry.utils.http import absolute_uri
 
 from .base import SlackNotificationsMessageBuilder
 
@@ -34,13 +40,33 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
     def linkify_error_title(self, group):
         link = get_title_link(group, None, False, False, self.notification, ExternalProviders.SLACK)
         title = build_attachment_title(group)
-        return f"<{link}|*{escape_slack_text(title)}*>"
+        attachment_text = self.get_attachment_text(group)
+        if not attachment_text:
+            return f"<{link}|*{escape_slack_text(title)}*>"
+        return f"<{link}|*{escape_slack_text(title)}*> {attachment_text}"
 
     def linkify_release(self, release, organization):
         path = f"/releases/{release.version}/"
         url = organization.absolute_url(path)
         release_description = parse_release(release.version).get("description")
         return f":rocket: *<{url}|Release {release_description}>*\n"
+
+    def get_attachment_text(self, group):
+        attachment_text = build_attachment_text(group)
+        if attachment_text and len(attachment_text) > 50:
+            attachment_text = attachment_text[0:49] + "..."
+        return attachment_text
+
+    def build_discover_url(self, project):
+        query_params = "?"
+        for field in ["title", "event.type", "project", "user.display", "timestamp"]:
+            query_params += f"field={field}&"
+        query_params += "name=All+Events"
+        query_params += f"&project={project.id}&query=event.type%3Aerror&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29"
+        url = absolute_uri(
+            f"/organizations/{project.organization.slug}/discover/homepage/{query_params}"
+        )
+        return url
 
     def build(self) -> SlackBlock:
         blocks = []
@@ -65,11 +91,17 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
             project_text = f"Here's what happened in the *{project.slug}* project today:"
             blocks.append(self.get_markdown_block(project_text))
 
+            fields = []
+            event_count_text = "*Today’s Event Count*: "
+            if features.has("organizations:discover", project.organization):
+                discover_url = self.build_discover_url(project)
+                event_count_text += f"<{discover_url}|{context.total_today}>"
+            else:
+                event_count_text += context.total_today
+            fields.append(self.make_field(event_count_text))
+
             # Calculate today's event count percentage against 14 day avg
             if context.comparison_period_avg > 0:  # avoid a zerodivisionerror
-                fields = []
-                event_count_text = f"*Today’s Event Count*: {context.total_today}"
-                fields.append(self.make_field(event_count_text))
                 percentage_diff = context.total_today / context.comparison_period_avg
                 if context.total_today > context.comparison_period_avg:
                     percentage_diff_text = (
@@ -82,7 +114,7 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
                     )
                     fields.append(self.make_field(percentage_diff_text))
 
-                blocks.append(self.get_section_fields_block(fields))
+            blocks.append(self.get_section_fields_block(fields))
 
             # Add release info if we have it
             if context.new_in_release:

--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -97,7 +97,7 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
                 discover_url = self.build_discover_url(project)
                 event_count_text += f"<{discover_url}|{context.total_today}>"
             else:
-                event_count_text += context.total_today
+                event_count_text += str(context.total_today)
             fields.append(self.make_field(event_count_text))
 
             # Calculate today's event count percentage against 14 day avg

--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
+from urllib.parse import urlencode
 
 from sentry_relay.processing import parse_release
 
@@ -58,13 +59,18 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
         return attachment_text
 
     def build_discover_url(self, project):
-        query_params = "?"
-        for field in ["title", "event.type", "project", "user.display", "timestamp"]:
-            query_params += f"field={field}&"
-        query_params += "name=All+Events"
-        query_params += f"&project={project.id}&query=event.type%3Aerror&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29"
+        query_params = {
+            "field": ["title", "event.type", "project", "user.display", "timestamp"],
+            "name": "All Events",
+            "project": project.id,
+            "query": "event.type:error",
+            "sort": "-timestamp",
+            "statsPeriod": "24h",
+            "yAxis": "count()",
+        }
+        query_string = urlencode(query_params, doseq=True)
         url = absolute_uri(
-            f"/organizations/{project.organization.slug}/discover/homepage/{query_params}"
+            f"/organizations/{project.organization.slug}/discover/homepage/?{query_string}"
         )
         return url
 

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -226,7 +226,7 @@ def build_summary_data(
                     )
 
             for activity_type, groups in deduped_groups_by_activity_type.items():
-                for group in list(groups)[:4]:
+                for group in list(groups)[:3]:
                     if activity_type == ActivityType.SET_REGRESSION:
                         project_ctx.regressed_today.append(group)
                     else:

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -337,6 +337,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
                 "release": release.version,
             },
             project_id=self.project.id,
+            assert_no_errors=False,
         )
         group = event.group
         assert group

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -337,7 +337,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
                 "release": release.version,
             },
             project_id=self.project.id,
-            assert_no_errors=False,
         )
         group = event.group
         assert group

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -2,6 +2,7 @@ import copy
 from datetime import UTC, datetime, timedelta
 from typing import cast
 from unittest import mock
+from urllib.parse import urlencode
 
 import responses
 from django.conf import settings
@@ -542,6 +543,16 @@ class DailySummaryTest(
                 project_context=top_projects_context_map,
             ).send()
         blocks, fallback_text = get_blocks_and_fallback_text()
+        query_params = {
+            "field": ["title", "event.type", "project", "user.display", "timestamp"],
+            "name": "All Events",
+            "project": self.project.id,
+            "query": "event.type:error",
+            "sort": "-timestamp",
+            "statsPeriod": "24h",
+            "yAxis": "count()",
+        }
+        query_string = urlencode(query_params, doseq=True)
         assert fallback_text == "Daily Summary for Your Projects (internal only!!!)"
         assert f":bell: *{fallback_text}*" in blocks[0]["text"]["text"]
         assert (
@@ -552,7 +563,7 @@ class DailySummaryTest(
         # check the today's event count section
         assert "*Today’s Event Count*" in blocks[3]["fields"][0]["text"]
         assert (
-            f"/organizations/{self.organization.slug}/discover/homepage/"
+            f"/organizations/{self.organization.slug}/discover/homepage/?{query_string}"
             in blocks[3]["fields"][0]["text"]
         )
         assert "higher than last 14d avg" in blocks[3]["fields"][1]["text"]


### PR DESCRIPTION
This PR addresses some minor changes to the daily summary. 
* Restricts the number of escalated and regressed issues per project to 3 each
* Adds a Discover link to the error issue count (if the org has Discover)
* Adds issue subtitle text, if available

Take this screenshot with a grain of salt, I hardcoded the event count 0000 to get this to show up and double check the link worked
<img width="589" alt="Screenshot 2024-03-15 at 5 00 41 PM" src="https://github.com/getsentry/sentry/assets/29959063/c8a5629e-4ed8-4b16-82e7-7db1350a0315">


Closes https://github.com/getsentry/team-core-product-foundations/issues/173, https://github.com/getsentry/team-core-product-foundations/issues/174, and https://github.com/getsentry/team-core-product-foundations/issues/172