### PR TITLE
feat(trace): fetch data for eventId

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -370,7 +370,9 @@ function TraceViewContent(props: TraceViewContentProps) {
     [api, props.organization, tree, viewManager, searchState, onTraceSearch]
   );
 
-  const scrollQueueRef = useRef<TraceTree.NodePath[] | null>(null);
+  const scrollQueueRef = useRef<{eventId?: string; path?: TraceTree.NodePath[]} | null>(
+    null
+  );
 
   return (
     <TraceExternalLayout>


### PR DESCRIPTION
When a user comes off a eventId link, fetch the data for that event if possible so that we dont require the user to "zoom" into something they already clicked on in the previous page