### PR TITLE
fix(trace): fix scrolling to errors or perf issues

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -319,6 +319,11 @@ function TraceViewContent(props: TraceViewContentProps) {
   useQueryParamSync(syncQuery);
 
   const onOutsideClick = useCallback(() => {
+    if (tree.type !== 'trace') {
+      // Dont clear the URL in case the trace is still loading or failed for some reason,
+      // we want to keep the eventId in the URL so the user can share the URL with support
+      return;
+    }
     // we will drop eventId such that after users clicks outside and shares the URL,
     // we will no longer scroll to the event or node
     const {

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -1837,14 +1837,29 @@ function findInTreeFromSegment(
 function findInTreeByEventId(start: TraceTreeNode<TraceTree.NodeValue>, eventId: string) {
   return TraceTreeNode.Find(start, node => {
     if (isTransactionNode(node)) {
-      return node.value.event_id === eventId;
-    }
-    if (isSpanNode(node)) {
+      if (node.value.event_id === eventId) {
+        return true;
+      }
+      if (node.value.performance_issues.length > 0) {
+        for (const p of node.value.performance_issues) {
+          if (p.event_id === eventId) {
+            return true;
+          }
+        }
+      }
+      if (node.value.errors.length > 0) {
+        for (const e of node.value.errors) {
+          if (e.event_id === eventId) {
+            return true;
+          }
+        }
+      }
+    } else if (isSpanNode(node)) {
       return node.value.span_id === eventId;
-    }
-    if (isTraceErrorNode(node)) {
+    } else if (isTraceErrorNode(node)) {
       return node.value.event_id === eventId;
     }
+
     return false;
   });
 }


### PR DESCRIPTION
Sometimes we link to events that are not necessarily entries in the list (like errors or perf issues). If that happens, we need to make sure we also check for these entries.

@wmak this fixes the link you sent me :)