### PR TITLE
fix(trace): render error on all nodes

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -111,7 +111,6 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
 
   useEffect(() => {
     // Run on mount.
-
     const {span, organization, event} = props;
     if (!('op' in span)) {
       return;
@@ -289,7 +288,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
   }
 
   function renderSpanErrorMessage() {
-    const {span, organization, errors, performanceIssues, event} = props;
+    const {span, organization, errors, performanceIssues} = props;
 
     const hasErrors = errors.length > 0 || performanceIssues.length > 0;
 
@@ -298,12 +297,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
     }
 
     return (
-      <IssueList
-        organization={organization}
-        issues={relatedIssues}
-        event_id={event.id}
-        node={props.node}
-      />
+      <IssueList organization={organization} issues={relatedIssues} node={props.node} />
     );
   }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
@@ -18,6 +18,7 @@ import {Row, Tags} from 'sentry/views/performance/traceDetails/styles';
 
 import type {TraceTree, TraceTreeNode} from '../../traceTree';
 
+import {IssueList} from './issues/issues';
 import {TraceDrawerComponents} from './styles';
 
 export function ErrorNodeDetails({
@@ -48,17 +49,26 @@ export function ErrorNodeDetails({
     return null;
   }, [data]);
 
+  // In error nodes, the `value` is the error object
+  const errors = useMemo(() => [node.value], [node.value]);
+
   return isLoading ? (
     <LoadingIndicator />
   ) : data ? (
     <TraceDrawerComponents.DetailContainer>
       <TraceDrawerComponents.HeaderContainer>
-        <TraceDrawerComponents.IconTitleWrapper>
+        <TraceDrawerComponents.Title>
           <TraceDrawerComponents.IconBorder errored>
             <IconFire color="errorText" size="md" />
           </TraceDrawerComponents.IconBorder>
-          <div style={{fontWeight: 'bold'}}>{t('Error')}</div>
-        </TraceDrawerComponents.IconTitleWrapper>
+          <div>
+            <div>{t('error')}</div>
+            <TraceDrawerComponents.TitleOp>
+              {' '}
+              {node.value.title}
+            </TraceDrawerComponents.TitleOp>
+          </div>
+        </TraceDrawerComponents.Title>
         <TraceDrawerComponents.Actions>
           <Button size="xs" onClick={_e => scrollToNode(node)}>
             {t('Show in view')}
@@ -69,6 +79,9 @@ export function ErrorNodeDetails({
         </TraceDrawerComponents.Actions>
       </TraceDrawerComponents.HeaderContainer>
 
+      {errors.length > 0 ? (
+        <IssueList organization={organization} issues={errors} node={node} />
+      ) : null}
       <TraceDrawerComponents.Table className="table key-value">
         <tbody>
           {stackTrace && (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -107,13 +107,12 @@ function Issue(props: IssueProps) {
 }
 
 type IssueListProps = {
-  event_id: string;
   issues: TraceErrorOrIssue[];
   node: TraceTreeNode<TraceTree.NodeValue>;
   organization: Organization;
 };
 
-export function IssueList({issues, node, organization, event_id}: IssueListProps) {
+export function IssueList({issues, node, organization}: IssueListProps) {
   if (!issues.length) {
     return null;
   }
@@ -126,7 +125,7 @@ export function IssueList({issues, node, organization, event_id}: IssueListProps
           key={index}
           issue={issue}
           organization={organization}
-          event_id={event_id}
+          event_id={issue.event_id}
         />
       ))}
     </StyledPanel>
@@ -149,7 +148,7 @@ function IssueListHeader({node}: {node: TraceTreeNode<TraceTree.NodeValue>}) {
       : isAutogroupedNode(node)
         ? node.performance_issues.length
         : isTraceErrorNode(node)
-          ? 1
+          ? 0
           : 0;
 
   return (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/parentAutogroup.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/parentAutogroup.tsx
@@ -1,12 +1,27 @@
+import {useMemo} from 'react';
+
 import {IconGroup} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types';
+import type {TraceErrorOrIssue} from 'sentry/utils/performance/quickTrace/types';
 import {Row} from 'sentry/views/performance/traceDetails/styles';
 
 import type {ParentAutogroupNode} from '../../traceTree';
 
+import {IssueList} from './issues/issues';
 import {TraceDrawerComponents} from './styles';
 
-export function ParentAutogroupNodeDetails({node}: {node: ParentAutogroupNode}) {
+export function ParentAutogroupNodeDetails({
+  node,
+  organization,
+}: {
+  node: ParentAutogroupNode;
+  organization: Organization;
+}) {
+  const issues: TraceErrorOrIssue[] = useMemo(() => {
+    return [...node.errors, ...node.performance_issues];
+  }, [node.errors, node.performance_issues]);
+
   return (
     <TraceDrawerComponents.DetailContainer>
       <TraceDrawerComponents.IconTitleWrapper>
@@ -15,6 +30,10 @@ export function ParentAutogroupNodeDetails({node}: {node: ParentAutogroupNode}) 
         </TraceDrawerComponents.IconBorder>
         <div style={{fontWeight: 'bold'}}>{t('Autogroup')}</div>
       </TraceDrawerComponents.IconTitleWrapper>
+
+      {node.errors.length > 0 || node.performance_issues.length > 0 ? (
+        <IssueList organization={organization} issues={issues} node={node} />
+      ) : null}
 
       <TraceDrawerComponents.Table className="table key-value">
         <tbody>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/siblingAutogroup.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/siblingAutogroup.tsx
@@ -1,12 +1,27 @@
+import {useMemo} from 'react';
+
 import {IconGroup} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import type {Organization} from 'sentry/types';
+import type {TraceErrorOrIssue} from 'sentry/utils/performance/quickTrace/types';
 import {Row} from 'sentry/views/performance/traceDetails/styles';
 
 import type {SiblingAutogroupNode} from '../../traceTree';
 
+import {IssueList} from './issues/issues';
 import {TraceDrawerComponents} from './styles';
 
-export function SiblingAutogroupNodeDetails({node}: {node: SiblingAutogroupNode}) {
+export function SiblingAutogroupNodeDetails({
+  node,
+  organization,
+}: {
+  node: SiblingAutogroupNode;
+  organization: Organization;
+}) {
+  const issues: TraceErrorOrIssue[] = useMemo(() => {
+    return [...node.errors, ...node.performance_issues];
+  }, [node.errors, node.performance_issues]);
+
   return (
     <TraceDrawerComponents.DetailContainer>
       <TraceDrawerComponents.IconTitleWrapper>
@@ -15,6 +30,10 @@ export function SiblingAutogroupNodeDetails({node}: {node: SiblingAutogroupNode}
         </TraceDrawerComponents.IconBorder>
         <div style={{fontWeight: 'bold'}}>{t('Autogroup')}</div>
       </TraceDrawerComponents.IconTitleWrapper>
+
+      {node.errors.length > 0 || node.performance_issues.length > 0 ? (
+        <IssueList organization={organization} issues={issues} node={node} />
+      ) : null}
 
       <TraceDrawerComponents.Table className="table key-value">
         <tbody>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction.tsx
@@ -199,8 +199,6 @@ export function TransactionNodeDetails({
   const {feedback} = contexts ?? {};
   const eventJsonUrl = `/api/0/projects/${organization.slug}/${node.value.project_slug}/events/${node.value.event_id}/json/`;
   const project = projects.find(proj => proj.slug === event?.projectSlug);
-  const {errors, performance_issues} = node.value;
-  const hasIssues = errors.length + performance_issues.length > 0;
   const startTimestamp = Math.min(node.value.start_timestamp, node.value.timestamp);
   const endTimestamp = Math.max(node.value.start_timestamp, node.value.timestamp);
   const {start: startTimeWithLeadingZero, end: endTimeWithLeadingZero} =
@@ -309,13 +307,8 @@ export function TransactionNodeDetails({
         </TraceDrawerComponents.Actions>
       </TraceDrawerComponents.HeaderContainer>
 
-      {hasIssues ? (
-        <IssueList
-          node={node}
-          organization={organization}
-          issues={relatedIssues}
-          event_id={event.id}
-        />
+      {node.value.errors.length > 0 || node.value.performance_issues.length > 0 ? (
+        <IssueList node={node} organization={organization} issues={relatedIssues} />
       ) : null}
 
       <TraceDrawerComponents.Table className="table key-value">

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/details.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/details.tsx
@@ -66,11 +66,11 @@ export default function NodeDetail({
   }
 
   if (isParentAutogroupedNode(node)) {
-    return <ParentAutogroupNodeDetails node={node} />;
+    return <ParentAutogroupNodeDetails organization={organization} node={node} />;
   }
 
   if (isSiblingAutogroupedNode(node)) {
-    return <SiblingAutogroupNodeDetails node={node} />;
+    return <SiblingAutogroupNodeDetails organization={organization} node={node} />;
   }
 
   if (isMissingInstrumentationNode(node)) {


### PR DESCRIPTION
Other events in the tree might have attached errors or perf issues and not just spans and we should display the issue list for all of them