### PR TITLE
Add rollout option for Rust `GroupingComponent` Assembly

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2087,31 +2087,16 @@ register(
 
 # Sampling rates for testing Rust-based grouping enhancers
 
-# Rate at which to parse enhancers in Rust in addition to Python
-register(
-    "grouping.rust_enhancers.parse_rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# Rate at which to run the Rust implementation of `apply_modifications_to_frames`
-# and compare the results
-register(
-    "grouping.rust_enhancers.modify_frames_rate",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# Rate at which to prefer the `apply_modifications_to_frames` result of the Rust implementation.
-register(
-    "grouping.rust_enhancers.prefer_rust_result",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Rate at which to run the Rust implementation of `assemble_stacktrace_component`
 # and compare the results
 register(
     "grouping.rust_enhancers.compare_components",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Rate at which to prefer the Rust implementation of `assemble_stacktrace_component`.
+register(
+    "grouping.rust_enhancers.prefer_rust_components",
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -464,7 +464,12 @@ def test_range_matching_direct():
 @pytest.mark.parametrize("action", ["+", "-"])
 @pytest.mark.parametrize("type", ["prefix", "sentinel"])
 @django_db_all  # because of `options` usage
-@override_options({"grouping.rust_enhancers.compare_components": 1.0})
+@override_options(
+    {
+        "grouping.rust_enhancers.compare_components": 1.0,
+        "grouping.rust_enhancers.prefer_rust_components": 1.0,
+    }
+)
 def test_sentinel_and_prefix(action, type):
     enhancements = Enhancements.from_config_string(f"function:foo {action}{type}")
 

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -81,8 +81,32 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
         rv.append("%s:" % key)
         dump_variant(value, rv, 1)
     output = "\n".join(rv)
-    log(repr(evt.get_hashes()))
+
+    hashes = evt.get_hashes()
+    log(repr(hashes))
 
     assert evt.get_grouping_config() == grouping_config
 
     insta_snapshot(output)
+
+    with override_options(
+        {
+            "grouping.rust_enhancers.prefer_rust_components": 1.0,
+        }
+    ):
+        evt = grouping_input.create_event(grouping_config)
+        evt.project = None
+
+        rust_hashes = evt.get_hashes()
+        assert rust_hashes.hashes == hashes.hashes
+
+        # rv = []
+        # for key, value in sorted(evt.get_grouping_variants().items()):
+        #     if rv:
+        #         rv.append("-" * 74)
+        #     rv.append("%s:" % key)
+        #     dump_variant(value, rv, 1)
+        # rust_output = "\n".join(rv)
+
+        # FIXME: the `hint` output does not (yet) fully match what Python produces
+        # assert rust_output == output


### PR DESCRIPTION
This will now short-circuit the Python code depending on a new option.

Also cleans up older obsolete options, and adds a metric.