### PR TITLE
feat(ddm): Add capture message when a new custom metric is sent to a project

### DIFF
--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any, cast
 
+import sentry_sdk
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies import (
     CommitOffsets,
@@ -174,6 +175,11 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
 
             project = Project.objects.get_from_cache(id=project_id)
             if not project.flags.has_custom_metrics:
+                with sentry_sdk.push_scope() as scope:
+                    scope.set_tag("organization_id", org_id)
+                    scope.set_tag("project_id", project_id)
+                    sentry_sdk.capture_message("A new project has sent the first custom metric")
+
                 # We assume that the flag update is reflected in the cache, so that upcoming calls will get the up-to-
                 # date project with the `has_custom_metrics` flag set to true.
                 project.update(flags=F("flags").bitor(Project.flags.has_custom_metrics))

--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -179,7 +179,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
                     scope.set_tag("organization_id", org_id)
                     scope.set_tag("project_id", project_id)
                     sentry_sdk.capture_message(
-                        "A new project has sent the first custom metric",
+                        f"Project {project_id} of organization {org_id} has sent the first custom metric",
                         fingerprint=["new-first-custom-metric"],
                     )
 

--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -178,6 +178,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
                 with sentry_sdk.push_scope() as scope:
                     scope.set_tag("organization_id", org_id)
                     scope.set_tag("project_id", project_id)
+                    scope.fingerprint = [org_id, project_id]
                     sentry_sdk.capture_message("A new project has sent the first custom metric")
 
                 # We assume that the flag update is reflected in the cache, so that upcoming calls will get the up-to-

--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -180,7 +180,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
                     scope.set_tag("project_id", project_id)
                     sentry_sdk.capture_message(
                         "A new project has sent the first custom metric",
-                        fingerprint=[org_id, project_id],
+                        fingerprint=["new-first-custom-metric"],
                     )
 
                 # We assume that the flag update is reflected in the cache, so that upcoming calls will get the up-to-

--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -178,8 +178,10 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
                 with sentry_sdk.push_scope() as scope:
                     scope.set_tag("organization_id", org_id)
                     scope.set_tag("project_id", project_id)
-                    scope.fingerprint = [org_id, project_id]
-                    sentry_sdk.capture_message("A new project has sent the first custom metric")
+                    sentry_sdk.capture_message(
+                        "A new project has sent the first custom metric",
+                        fingerprint=[org_id, project_id],
+                    )
 
                 # We assume that the flag update is reflected in the cache, so that upcoming calls will get the up-to-
                 # date project with the `has_custom_metrics` flag set to true.


### PR DESCRIPTION
This PR adds a capture message event whenever Sentry receives the first custom metric for a project.