### PR TITLE
fix(getting-started): Add `app` property to Vue 3 SDK init snippet

### DIFF
--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -52,7 +52,8 @@ type Params = DocsParams<PlatformOptions>;
 
 const getSentryInitLayout = (params: Params, siblingOption: string): string => {
   return `Sentry.init({
-    ${siblingOption === VueVersion.VUE2 ? `Vue,` : ''}dsn: "${params.dsn}",
+    ${siblingOption === VueVersion.VUE2 ? 'Vue,' : 'app,'}
+    dsn: "${params.dsn}",
     integrations: [${
       params.isPerformanceSelected
         ? `


### PR DESCRIPTION
A GH user [pointed out](https://github.com/getsentry/sentry-javascript/issues/6629) that our in-product getting started snippet for Vue 3 was missing for the `app` property. This PR adds the missing property (See [Sentry docs](https://docs.sentry.io/platforms/javascript/guides/vue/#configure))