### PR TITLE
ref(metrics-extraction): Remove extra sdk span

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1251,8 +1251,6 @@ class OnDemandMetricSpec:
     def query_hash(self) -> str:
         str_to_hash = self._query_str_for_hash
         hash = hashlib.shake_128(bytes(str_to_hash, encoding="utf-8")).hexdigest(4)
-        with sentry_sdk.start_span(op="OnDemandMetricSpec.query_hash", description=hash) as span:
-            span.set_tag("str_to_hash", str_to_hash)
         return hash
 
     def _field_for_hash(self) -> str | None:


### PR DESCRIPTION
### Summary
We don't need this span for investigation anymore and it's crowding the transaction details view for these transactions
