### PR TITLE
ref: remove unnecessary timezone replaces in tests

### DIFF
--- a/tests/sentry/api/endpoints/test_team_alerts_triggered.py
+++ b/tests/sentry/api/endpoints/test_team_alerts_triggered.py
@@ -1,5 +1,3 @@
-from datetime import timezone
-
 from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.incidents.models.incident import (
     INCIDENT_STATUS,
@@ -53,11 +51,9 @@ class TeamAlertsTriggeredTotalsEndpointTest(APITestCase):
         for i in range(1, 9):
             assert (
                 response.data[
-                    str(
-                        before_now(days=i)
-                        .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-                        .isoformat()
-                    )
+                    before_now(days=i)
+                    .replace(hour=0, minute=0, second=0, microsecond=0)
+                    .isoformat()
                 ]
                 == 1
             )
@@ -65,11 +61,9 @@ class TeamAlertsTriggeredTotalsEndpointTest(APITestCase):
         for i in range(10, 90):
             assert (
                 response.data[
-                    str(
-                        before_now(days=i)
-                        .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-                        .isoformat()
-                    )
+                    before_now(days=i)
+                    .replace(hour=0, minute=0, second=0, microsecond=0)
+                    .isoformat()
                 ]
                 == 0
             )
@@ -80,22 +74,16 @@ class TeamAlertsTriggeredTotalsEndpointTest(APITestCase):
         assert len(response.data) == 7
         assert (
             response.data[
-                str(
-                    before_now(days=0)
-                    .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-                    .isoformat()
-                )
+                before_now(days=0).replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
             ]
             == 0
         )
         for i in range(1, 6):
             assert (
                 response.data[
-                    str(
-                        before_now(days=i)
-                        .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-                        .isoformat()
-                    )
+                    before_now(days=i)
+                    .replace(hour=0, minute=0, second=0, microsecond=0)
+                    .isoformat()
                 ]
                 == 1
             )
@@ -161,11 +149,7 @@ class TeamAlertsTriggeredTotalsEndpointTest(APITestCase):
         assert len(response.data) == 90
         assert (
             response.data[
-                str(
-                    before_now(days=2)
-                    .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-                    .isoformat()
-                )
+                before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
             ]
             == 1
         )
@@ -174,11 +158,9 @@ class TeamAlertsTriggeredTotalsEndpointTest(APITestCase):
             if i != 2:
                 assert (
                     response.data[
-                        str(
-                            before_now(days=i)
-                            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-                            .isoformat()
-                        )
+                        before_now(days=i)
+                        .replace(hour=0, minute=0, second=0, microsecond=0)
+                        .isoformat()
                     ]
                     == 0
                 )

--- a/tests/sentry/api/endpoints/test_team_issue_breakdown.py
+++ b/tests/sentry/api/endpoints/test_team_issue_breakdown.py
@@ -1,6 +1,4 @@
-from datetime import timedelta, timezone
-
-from django.utils.timezone import now
+from django.utils import timezone
 
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupenvironment import GroupEnvironment
@@ -8,6 +6,7 @@ from sentry.models.grouphistory import GroupHistoryStatus
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.dates import floor_to_utc_day
 
 
 @freeze_time()
@@ -42,21 +41,9 @@ class TeamIssueBreakdownTest(APITestCase):
         self.create_group_history(group=group2, status=GroupHistoryStatus.RESOLVED)
         self.create_group_history(group=group2, status=GroupHistoryStatus.IGNORED)
 
-        today = str(
-            now()
-            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-            .isoformat()
-        )
-        yesterday = str(
-            (now() - timedelta(days=1))
-            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-            .isoformat()
-        )
-        two_days_ago = str(
-            (now() - timedelta(days=2))
-            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-            .isoformat()
-        )
+        today = floor_to_utc_day(timezone.now()).isoformat()
+        yesterday = floor_to_utc_day(before_now(days=1)).isoformat()
+        two_days_ago = floor_to_utc_day(before_now(days=2)).isoformat()
         self.login_as(user=self.user)
         statuses = ["resolved", "regressed", "unresolved", "ignored"]
         response = self.get_success_response(
@@ -111,20 +98,16 @@ class TeamIssueBreakdownTest(APITestCase):
         GroupEnvironment.objects.create(group_id=group1.id, environment_id=env1.id)
 
         self.create_group_history(
-            group=group1, date_added=now(), status=GroupHistoryStatus.UNRESOLVED
+            group=group1, date_added=timezone.now(), status=GroupHistoryStatus.UNRESOLVED
         )
         self.create_group_history(
-            group=group1, date_added=now(), status=GroupHistoryStatus.RESOLVED
+            group=group1, date_added=timezone.now(), status=GroupHistoryStatus.RESOLVED
         )
         self.create_group_history(
-            group=group1, date_added=now(), status=GroupHistoryStatus.REGRESSED
+            group=group1, date_added=timezone.now(), status=GroupHistoryStatus.REGRESSED
         )
 
-        today = str(
-            now()
-            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-            .isoformat()
-        )
+        today = floor_to_utc_day(timezone.now()).isoformat()
         self.login_as(user=self.user)
         statuses = ["regressed", "resolved"]
         response = self.get_success_response(
@@ -181,21 +164,9 @@ class TeamIssueBreakdownTest(APITestCase):
         self.create_group_history(group=group2, status=GroupHistoryStatus.RESOLVED)
         self.create_group_history(group=group2, status=GroupHistoryStatus.IGNORED)
 
-        today = str(
-            now()
-            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-            .isoformat()
-        )
-        yesterday = str(
-            (now() - timedelta(days=1))
-            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-            .isoformat()
-        )
-        two_days_ago = str(
-            (now() - timedelta(days=2))
-            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-            .isoformat()
-        )
+        today = floor_to_utc_day(timezone.now()).isoformat()
+        yesterday = floor_to_utc_day(before_now(days=1)).isoformat()
+        two_days_ago = floor_to_utc_day(before_now(days=2)).isoformat()
         self.login_as(user=self.user)
         response = self.get_success_response(
             self.team.organization.slug, self.team.slug, statsPeriod="7d"

--- a/tests/sentry/api/serializers/test_group_stream.py
+++ b/tests/sentry/api/serializers/test_group_stream.py
@@ -1,4 +1,3 @@
-import datetime
 from unittest import mock
 
 from sentry import tsdb
@@ -68,7 +67,7 @@ class StreamGroupSerializerTestCase(
     @freeze_time(before_now(days=1).replace(hour=13, minute=30, second=0, microsecond=0))
     def test_profiling_issue(self):
         proj = self.create_project()
-        cur_time = before_now(minutes=5).replace(tzinfo=datetime.UTC)
+        cur_time = before_now(minutes=5)
         event, occurrence, group_info = self.store_search_issue(
             proj.id, 1, [f"{ProfileFileIOGroupType.type_id}-group100"], None, cur_time
         )

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -290,7 +290,6 @@ class TestRedisBuffer:
 @pytest.mark.parametrize(
     "value",
     [
-        datetime.datetime.today().replace(tzinfo=datetime.UTC),
         timezone.now(),
         datetime.date.today(),
     ],

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2843,10 +2843,8 @@ class ReleaseIssueTest(TestCase):
             event = manager.save(project_id)
         return event
 
-    def convert_timestamp(self, timestamp):
-        date = datetime.fromtimestamp(timestamp)
-        date = date.replace(tzinfo=UTC)
-        return date
+    def convert_timestamp(self, timestamp: float) -> datetime:
+        return datetime.fromtimestamp(timestamp, tz=UTC)
 
     def assert_release_project_environment(self, event, new_issues_count, first_seen, last_seen):
         release = Release.objects.get(

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -302,12 +302,12 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.one_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project, self.project2],
-            date_added=date_added.replace(tzinfo=UTC),
+            date_added=date_added,
         )
         self.two_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project2],
-            date_added=date_added.replace(tzinfo=UTC),
+            date_added=date_added,
         )
         self.three_alert_rule = self.create_alert_rule(
             organization=self.org, projects=[self.project]
@@ -351,12 +351,12 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.one_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project, self.project2],
-            date_added=date_added.replace(tzinfo=UTC),
+            date_added=date_added,
         )
         self.two_alert_rule = self.create_alert_rule(
             organization=self.org,
             projects=[self.project],
-            date_added=date_added.replace(tzinfo=UTC),
+            date_added=date_added,
         )
         self.three_alert_rule = self.create_alert_rule(
             organization=self.org, projects=[self.project2]

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import UTC, timedelta
+from datetime import timedelta
 from functools import cached_property
 from random import randint
 from unittest import mock
@@ -257,7 +257,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             timestamp = timezone.now() + time_delta
         else:
             timestamp = timezone.now()
-        timestamp = timestamp.replace(tzinfo=UTC, microsecond=0)
+        timestamp = timestamp.replace(microsecond=0)
 
         data = {}
 
@@ -2270,7 +2270,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
             timestamp = timezone.now() + time_delta
         else:
             timestamp = timezone.now()
-        timestamp = timestamp.replace(tzinfo=UTC, microsecond=0)
+        timestamp = timestamp.replace(microsecond=0)
 
         with (
             self.feature(["organizations:incidents", "organizations:performance-view"]),
@@ -2780,7 +2780,7 @@ class MetricsCrashRateAlertProcessUpdateV1Test(MetricsCrashRateAlertProcessUpdat
             timestamp = timezone.now() + time_delta
         else:
             timestamp = timezone.now()
-        timestamp = timestamp.replace(tzinfo=UTC, microsecond=0)
+        timestamp = timestamp.replace(microsecond=0)
 
         with (
             self.feature(["organizations:incidents", "organizations:performance-view"]),

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -1,6 +1,6 @@
 import itertools
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest import mock
 
 import pytest
@@ -54,7 +54,7 @@ from sentry.utils.snuba import SnubaTSResult
 
 @pytest.fixture
 def timestamp():
-    return datetime(2023, 8, 1, 12, 7, 42, 521000, tzinfo=timezone.utc)
+    return datetime(2023, 8, 1, 12, 7, 42, 521000, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -263,8 +263,8 @@ def test_detect_function_trends_query_timerange(functions_query, timestamp, proj
 
     assert functions_query.called
     params = functions_query.mock_calls[0].kwargs["params"]
-    assert params["start"] == datetime(2023, 8, 1, 11, 0, tzinfo=timezone.utc)
-    assert params["end"] == datetime(2023, 8, 1, 11, 1, tzinfo=timezone.utc)
+    assert params["start"] == datetime(2023, 8, 1, 11, 0, tzinfo=UTC)
+    assert params["end"] == datetime(2023, 8, 1, 11, 1, tzinfo=UTC)
 
 
 @mock.patch("sentry.tasks.statistical_detectors.query_transactions")
@@ -893,7 +893,7 @@ def test_detect_function_change_points(
     timestamp,
     project,
 ):
-    start_of_hour = timestamp.replace(minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+    start_of_hour = timestamp.replace(minute=0, second=0, microsecond=0)
 
     fingerprint = 12345
 
@@ -1294,9 +1294,7 @@ class FunctionsTasksTest(ProfilesSnubaTestCase):
         super().setUp()
 
         self.now = before_now(minutes=10)
-        self.hour_ago = (self.now - timedelta(hours=1)).replace(
-            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
-        )
+        self.hour_ago = (self.now - timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
         self.projects = [
             self.create_project(organization=self.organization, teams=[self.team], name="Foo"),
             self.create_project(organization=self.organization, teams=[self.team], name="Bar"),
@@ -1389,9 +1387,7 @@ class TestTransactionsQuery(MetricsAPIBaseTestCase):
         self.num_projects = 2
         self.num_transactions = 4
 
-        self.hour_ago = (self.now - timedelta(hours=1)).replace(
-            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
-        )
+        self.hour_ago = (self.now - timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
         self.hour_ago_seconds = int(self.hour_ago.timestamp())
         self.org = self.create_organization(owner=self.user)
         self.projects = [
@@ -1473,9 +1469,7 @@ class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
         self.num_projects = 2
         self.num_transactions = 4
 
-        self.hour_ago = (self.now - timedelta(hours=1)).replace(
-            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
-        )
+        self.hour_ago = (self.now - timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
         self.hour_ago_seconds = int(self.hour_ago.timestamp())
         self.org = self.create_organization(owner=self.user)
         self.projects = [

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import timedelta, timezone
+from datetime import timedelta
 from unittest import mock
 from uuid import uuid4
 
@@ -99,7 +99,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=timezone.utc),
+            self.day_ago,
         )
         assert group_info is not None
         self.store_search_issue(
@@ -107,14 +107,14 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(hours=1, minutes=1),
+            self.day_ago + timedelta(hours=1, minutes=1),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(hours=1, minutes=2),
+            self.day_ago + timedelta(hours=1, minutes=2),
         )
         with self.feature(
             [
@@ -142,7 +142,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(minutes=1),
+            self.day_ago + timedelta(minutes=1),
         )
         assert group_info is not None
         self.store_search_issue(
@@ -150,14 +150,14 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(minutes=1),
+            self.day_ago + timedelta(minutes=1),
         )
         self.store_search_issue(
             self.project.id,
             self.user.id,
             [f"{ProfileFileIOGroupType.type_id}-group1"],
             "prod",
-            self.day_ago.replace(tzinfo=timezone.utc) + timedelta(minutes=2),
+            self.day_ago + timedelta(minutes=2),
         )
         with self.feature(
             [

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -1,11 +1,11 @@
 import time
 from copy import deepcopy
-from datetime import timedelta, timezone
+from datetime import timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from django.utils.timezone import now
+from django.utils import timezone
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.rule import Rule
@@ -45,8 +45,8 @@ class PerfIssuePlatformEventMixin(PerformanceIssueTestCase):
         )
         event_data = load_data(
             "transaction-n-plus-one",
-            timestamp=timestamp.replace(tzinfo=timezone.utc),
-            start_timestamp=timestamp.replace(tzinfo=timezone.utc),
+            timestamp=timestamp,
+            start_timestamp=timestamp,
             fingerprint=[fingerprint],
         )
         event_data["user"] = {"id": uuid4().hex}
@@ -97,12 +97,12 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase):
                 event,
                 data["value"] + 1,
                 environment=self.environment.name,
-                timestamp=now() - timedelta(minutes=minutes),
+                timestamp=timezone.now() - timedelta(minutes=minutes),
             )
             self.increment(
                 event,
                 data["value"] + 1,
-                timestamp=now() - timedelta(minutes=minutes),
+                timestamp=timezone.now() - timedelta(minutes=minutes),
             )
 
         if passes:
@@ -166,12 +166,12 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase):
         self.increment(
             event,
             3,
-            timestamp=now() - timedelta(minutes=1),
+            timestamp=timezone.now() - timedelta(minutes=1),
         )
         self.increment(
             event,
             2,
-            timestamp=now() - timedelta(days=1, minutes=20),
+            timestamp=timezone.now() - timedelta(days=1, minutes=20),
         )
         data = {
             "interval": "1h",
@@ -331,7 +331,7 @@ class EventFrequencyPercentConditionTestCase(SnubaTestCase, RuleTestCase):
                 self.test_event,
                 max(1, int(minutes / 2)) - 1,
                 environment=self.environment.name,
-                timestamp=now() - timedelta(minutes=minutes),
+                timestamp=timezone.now() - timedelta(minutes=minutes),
             )
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
         environment_rule = self.get_rule(data=data, rule=Rule(environment_id=self.environment.id))
@@ -432,12 +432,12 @@ class EventFrequencyPercentConditionTestCase(SnubaTestCase, RuleTestCase):
         self.increment(
             event,
             1,
-            timestamp=now() - timedelta(minutes=1),
+            timestamp=timezone.now() - timedelta(minutes=1),
         )
         self.increment(
             event,
             1,
-            timestamp=now() - timedelta(days=1, minutes=20),
+            timestamp=timezone.now() - timedelta(days=1, minutes=20),
         )
         data = {
             "interval": "1h",
@@ -458,13 +458,17 @@ class EventFrequencyPercentConditionTestCase(SnubaTestCase, RuleTestCase):
         self.assertDoesNotPass(rule, event, is_new=False)
 
 
-@freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
+@freeze_time(
+    (timezone.now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0)
+)
 @region_silo_test
 class ErrorIssueFrequencyConditionTestCase(ErrorEventMixin, EventFrequencyConditionTestCase):
     pass
 
 
-@freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
+@freeze_time(
+    (timezone.now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0)
+)
 @region_silo_test
 class PerfIssuePlatformIssueFrequencyConditionTestCase(
     PerfIssuePlatformEventMixin,
@@ -473,7 +477,9 @@ class PerfIssuePlatformIssueFrequencyConditionTestCase(
     pass
 
 
-@freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
+@freeze_time(
+    (timezone.now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0)
+)
 @region_silo_test
 class ErrorIssueUniqueUserFrequencyConditionTestCase(
     ErrorEventMixin,
@@ -482,7 +488,9 @@ class ErrorIssueUniqueUserFrequencyConditionTestCase(
     pass
 
 
-@freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
+@freeze_time(
+    (timezone.now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0)
+)
 @region_silo_test
 class PerfIssuePlatformIssueUniqueUserFrequencyConditionTestCase(
     PerfIssuePlatformEventMixin,
@@ -491,7 +499,9 @@ class PerfIssuePlatformIssueUniqueUserFrequencyConditionTestCase(
     pass
 
 
-@freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
+@freeze_time(
+    (timezone.now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0)
+)
 @region_silo_test
 class ErrorIssueEventFrequencyPercentConditionTestCase(
     ErrorEventMixin, EventFrequencyPercentConditionTestCase
@@ -499,7 +509,9 @@ class ErrorIssueEventFrequencyPercentConditionTestCase(
     pass
 
 
-@freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))
+@freeze_time(
+    (timezone.now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0)
+)
 @region_silo_test
 class PerfIssuePlatformIssueEventFrequencyPercentConditionTestCase(
     PerfIssuePlatformEventMixin,


### PR DESCRIPTION
timezone.now() and before_now() return aware datetimes

<!-- Describe your PR here. -->