### PR TITLE
feat(feedback): Adjust colors of feedback message area to make them more a11y friendly

### DIFF
--- a/static/app/components/feedback/feedbackItem/messageSection.tsx
+++ b/static/app/components/feedback/feedbackItem/messageSection.tsx
@@ -72,6 +72,6 @@ const Blockquote = styled('blockquote')`
     line-height: 1.6;
     padding: 0;
     word-break: break-word;
-    color: ${p => p.theme.purple400};
+    color: ${p => p.theme.textColor};
   }
 `;


### PR DESCRIPTION
It's an area with small text, and it's the most important thing on the page, so we should make sure it's really easy for people to read.

Before:
<img width="1134" alt="before" src="https://github.com/getsentry/sentry/assets/187460/e3449da6-edd6-488c-b063-b81d1af1551f">

After:
<img width="1140" alt="after" src="https://github.com/getsentry/sentry/assets/187460/4251a6f3-fd78-477f-ad0b-c2ce9e8d265a">
