### PR TITLE
test(ui): Fix act warnings in group replays

### DIFF
--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -130,11 +130,10 @@ describe('GroupReplays', () => {
   describe('Replay Feature Disabled', () => {
     const mockGroup = GroupFixture();
 
-    ({router, organization, routerContext} = init({
-      organizationProps: {features: []},
-    }));
-
     it("should show a message when the organization doesn't have access to the replay feature", () => {
+      ({router, organization, routerContext} = init({
+        organizationProps: {features: []},
+      }));
       render(<GroupReplays group={mockGroup} />, {
         context: routerContext,
         organization,
@@ -275,12 +274,13 @@ describe('GroupReplays', () => {
         router,
       });
 
+      expect(
+        await screen.findByText('Invalid number: asdf. Expected number.')
+      ).toBeInTheDocument();
+
       await waitFor(() => {
-        expect(mockReplayCountApi).toHaveBeenCalledTimes(1);
+        expect(mockReplayCountApi).toHaveBeenCalled();
         expect(mockReplayApi).toHaveBeenCalledTimes(1);
-        expect(
-          screen.getByText('Invalid number: asdf. Expected number.')
-        ).toBeInTheDocument();
       });
     });
 
@@ -306,14 +306,15 @@ describe('GroupReplays', () => {
         router,
       });
 
+      expect(
+        await screen.findByText(
+          'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
+        )
+      ).toBeInTheDocument();
+
       await waitFor(() => {
-        expect(mockReplayCountApi).toHaveBeenCalledTimes(1);
+        expect(mockReplayCountApi).toHaveBeenCalled();
         expect(mockReplayApi).toHaveBeenCalledTimes(1);
-        expect(
-          screen.getByText(
-            'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
-          )
-        ).toBeInTheDocument();
       });
     });
 
@@ -343,7 +344,7 @@ describe('GroupReplays', () => {
 
       expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
       await waitFor(() => {
-        expect(mockReplayCountApi).toHaveBeenCalledTimes(1);
+        expect(mockReplayCountApi).toHaveBeenCalled();
         expect(mockReplayApi).toHaveBeenCalledTimes(1);
       });
     });
@@ -507,21 +508,19 @@ describe('GroupReplays', () => {
         router,
       });
 
-      await waitFor(() => {
-        expect(mockReplayCountApi).toHaveBeenCalledWith(
-          mockReplayCountUrl,
-          expect.objectContaining({
-            query: {
-              returnIds: true,
-              data_source: 'discover',
-              query: `issue.id:[${mockGroup.id}]`,
-              statsPeriod: '14d',
-              project: -1,
-            },
-          })
-        );
-      });
-      expect(screen.getByText('See Full Replay')).toBeInTheDocument();
+      expect(await screen.findByText('See Full Replay')).toBeInTheDocument();
+      expect(mockReplayCountApi).toHaveBeenCalledWith(
+        mockReplayCountUrl,
+        expect.objectContaining({
+          query: {
+            returnIds: true,
+            data_source: 'discover',
+            query: `issue.id:[${mockGroup.id}]`,
+            statsPeriod: '14d',
+            project: -1,
+          },
+        })
+      );
     });
 
     // Test seems to be flaky


### PR DESCRIPTION
fixes a few different errors in this one test, some act warnings but some the 500 response from the api seems to get called multiple times.

part of https://github.com/getsentry/frontend-tsc/issues/22