### PR TITLE
ref(feedback): rename what's new banner analytic

### DIFF
--- a/static/app/components/feedback/feedbackWhatsNewBanner.tsx
+++ b/static/app/components/feedback/feedbackWhatsNewBanner.tsx
@@ -44,7 +44,7 @@ export default function FeedbackWhatsNewBanner({className, style}: Props) {
           external
           href="https://docs.sentry.io/product/user-feedback/setup/"
           priority="primary"
-          analyticsEventName="Clicked Feedback Onboarding Setup Button"
+          analyticsEventName="Clicked Feedback What's New Banner"
           analyticsEventKey="feedback.whats-new-banner-clicked"
           analyticsParams={{surface: 'whats-new-banner'}}
         >


### PR DESCRIPTION
- It was using the same name as another analytic
- Make it more in line with the other analytics we have in `feedbackAnalyticsEvents.tsx`
- Currently not being used for any charts right now so should be fine to rename