### PR TITLE
feat(pagerduty): issue alert custom severity

### DIFF
--- a/src/sentry/integrations/pagerduty/actions/notification.py
+++ b/src/sentry/integrations/pagerduty/actions/notification.py
@@ -46,13 +46,7 @@ class PagerDutyNotifyServiceAction(IntegrationEventAction):
                 ],
             },
         }
-
-    @property
-    def label(self) -> str:
-        if self.has_feature_flag:
-            return self.new_label
-        else:
-            return self.old_label
+        self.__class__.label = self.new_label if self.has_feature_flag else self.old_label
 
     def _get_service(self):
         oi = self.get_organization_integration()

--- a/src/sentry/integrations/pagerduty/actions/notification.py
+++ b/src/sentry/integrations/pagerduty/actions/notification.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("sentry.integrations.pagerduty")
 class PagerDutyNotifyServiceAction(IntegrationEventAction):
     id = "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction"
     form_cls = PagerDutyNotifyServiceForm
-    label = "Send a notification to PagerDuty account {account} and service {service}with {severity} severity"
+    label = "Send a notification to PagerDuty account {account} and service {service} with {severity} severity"
     prompt = "Send a PagerDuty notification"
     provider = "pagerduty"
     integration_key = "account"

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from sentry.api.serializers import ExternalEventSerializer, serialize
 from sentry.eventstore.models import Event, GroupEvent
@@ -14,6 +14,8 @@ LEVEL_SEVERITY_MAP = {
     "error": "error",
     "fatal": "critical",
 }
+PAGERDUTY_DEFAULT_PRIORITY = "default"  # represents using LEVEL_SEVERITY_MAP
+PagerdutyPriority = Literal["default", "critical", "warning", "error", "info"]
 
 
 class PagerDutyClient(ApiClient):
@@ -31,7 +33,7 @@ class PagerDutyClient(ApiClient):
             headers = {"Content-Type": "application/json"}
         return self._request(method, *args, headers=headers, **kwargs)
 
-    def send_trigger(self, data, notification_uuid: str | None = None):
+    def send_trigger(self, data, severity: PagerdutyPriority, notification_uuid: str | None = None):
         # expected payload: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
         if isinstance(data, (Event, GroupEvent)):
             source = data.transaction or data.culprit or "<unknown>"
@@ -42,13 +44,17 @@ class PagerDutyClient(ApiClient):
             link_params = {"referrer": "pagerduty_integration"}
             if notification_uuid:
                 link_params["notification_uuid"] = notification_uuid
+
+            if severity == PAGERDUTY_DEFAULT_PRIORITY:
+                severity = LEVEL_SEVERITY_MAP[level]
+
             payload = {
                 "routing_key": self.integration_key,
                 "event_action": "trigger",
                 "dedup_key": group.qualified_short_id,
                 "payload": {
                     "summary": summary,
-                    "severity": LEVEL_SEVERITY_MAP[level],
+                    "severity": severity,
                     "source": source,
                     "component": group.project.slug,
                     "custom_details": custom_details,

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -14,8 +14,8 @@ LEVEL_SEVERITY_MAP = {
     "error": "error",
     "fatal": "critical",
 }
-PAGERDUTY_DEFAULT_PRIORITY = "default"  # represents using LEVEL_SEVERITY_MAP
-PagerdutyPriority = Literal["default", "critical", "warning", "error", "info"]
+PAGERDUTY_DEFAULT_SEVERITY = "default"  # represents using LEVEL_SEVERITY_MAP
+PagerdutySeverity = Literal["default", "critical", "warning", "error", "info"]
 
 
 class PagerDutyClient(ApiClient):
@@ -37,7 +37,7 @@ class PagerDutyClient(ApiClient):
         self,
         data,
         notification_uuid: str | None = None,
-        severity: PagerdutyPriority | None = None,
+        severity: PagerdutySeverity | None = None,
     ):
         # expected payload: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
         if isinstance(data, (Event, GroupEvent)):
@@ -50,7 +50,7 @@ class PagerDutyClient(ApiClient):
             if notification_uuid:
                 link_params["notification_uuid"] = notification_uuid
 
-            if severity == PAGERDUTY_DEFAULT_PRIORITY:
+            if severity == PAGERDUTY_DEFAULT_SEVERITY:
                 severity = LEVEL_SEVERITY_MAP[level]
 
             payload = {

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -33,7 +33,12 @@ class PagerDutyClient(ApiClient):
             headers = {"Content-Type": "application/json"}
         return self._request(method, *args, headers=headers, **kwargs)
 
-    def send_trigger(self, data, severity: PagerdutyPriority, notification_uuid: str | None = None):
+    def send_trigger(
+        self,
+        data,
+        notification_uuid: str | None = None,
+        severity: PagerdutyPriority | None = None,
+    ):
         # expected payload: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
         if isinstance(data, (Event, GroupEvent)):
             source = data.transaction or data.culprit or "<unknown>"

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -173,36 +173,49 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         assert data["payload"]["custom_details"]["title"] == group_event.occurrence.issue_title
 
     def test_render_label(self):
-        rule = self.get_rule(
-            data={
-                "account": self.integration.id,
-                "service": self.service["id"],
-                "severity": "warning",
-            }
-        )
+        rule_data = {
+            "account": self.integration.id,
+            "service": self.service["id"],
+            "severity": "warning",
+        }
+        rule = self.get_rule(data=rule_data)
 
         assert (
             rule.render_label()
-            == "Send a notification to PagerDuty account Example and service Critical with warning severity"
+            == "Send a notification to PagerDuty account Example and service Critical"
         )
+
+        with self.feature("organizations:integrations-custom-alert-priorities"):
+            # reinitialize rule to utilize flag
+            rule = self.get_rule(data=rule_data)
+            assert (
+                rule.render_label()
+                == "Send a notification to PagerDuty account Example and service Critical with warning severity"
+            )
 
     def test_render_label_without_integration(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()
 
-        rule = self.get_rule(
-            data={
-                "account": self.integration.id,
-                "service": self.service["id"],
-                "severity": "default",
-            }
+        rule_data = {
+            "account": self.integration.id,
+            "service": self.service["id"],
+            "severity": "default",
+        }
+        rule = self.get_rule(data=rule_data)
+
+        assert (
+            rule.render_label()
+            == "Send a notification to PagerDuty account [removed] and service [removed]"
         )
 
-        label = rule.render_label()
-        assert (
-            label
-            == "Send a notification to PagerDuty account [removed] and service [removed] with default severity"
-        )
+        with self.feature("organizations:integrations-custom-alert-priorities"):
+            # reinitialize rule to utilize flag
+            rule = self.get_rule(data=rule_data)
+            assert (
+                rule.render_label()
+                == "Send a notification to PagerDuty account [removed] and service [removed] with default severity"
+            )
 
     def test_valid_service_options(self):
         # create new org that has the same pd account but different a service added

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -173,21 +173,36 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         assert data["payload"]["custom_details"]["title"] == group_event.occurrence.issue_title
 
     def test_render_label(self):
-        rule = self.get_rule(data={"account": self.integration.id, "service": self.service["id"]})
+        rule = self.get_rule(
+            data={
+                "account": self.integration.id,
+                "service": self.service["id"],
+                "severity": "warning",
+            }
+        )
 
         assert (
             rule.render_label()
-            == "Send a notification to PagerDuty account Example and service Critical"
+            == "Send a notification to PagerDuty account Example and service Critical with warning severity"
         )
 
     def test_render_label_without_integration(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()
 
-        rule = self.get_rule(data={"account": self.integration.id, "service": self.service["id"]})
+        rule = self.get_rule(
+            data={
+                "account": self.integration.id,
+                "service": self.service["id"],
+                "severity": "default",
+            }
+        )
 
         label = rule.render_label()
-        assert label == "Send a notification to PagerDuty account [removed] and service [removed]"
+        assert (
+            label
+            == "Send a notification to PagerDuty account [removed] and service [removed] with default severity"
+        )
 
     def test_valid_service_options(self):
         # create new org that has the same pd account but different a service added


### PR DESCRIPTION
Allow setting custom severity for Pagerduty actions for issue alerts.
<img width="950" alt="Screenshot 2024-03-18 at 10 10 30" src="https://github.com/getsentry/sentry/assets/70817427/a08c5f98-8ef0-4d2e-8dbc-8731adb3a916">

Essentially copies the Opsgenie implementation of custom issue alert priorities https://github.com/getsentry/sentry/pull/56140

Default severity utilizes the existing `LEVEL_SEVERITY_MAP`:
https://github.com/getsentry/sentry/blob/c72814cac787c42881b7938e74c0d994223b31f6/src/sentry/integrations/pagerduty/client.py#L10-L16

For https://github.com/getsentry/sentry/issues/54921