### PR TITLE
chore(api): Create new app service param for api token

### DIFF
--- a/src/sentry/services/hybrid_cloud/app/model.py
+++ b/src/sentry/services/hybrid_cloud/app/model.py
@@ -148,3 +148,4 @@ class SentryAppInstallationFilterArgs(TypedDict, total=False):
     uuids: list[str]
     status: int
     api_token_id: str
+    api_installation_token_id: str


### PR DESCRIPTION
Creates a new sentry app param that we can use for rate limiting.

Using the new param, if we fail to fetch the relevant `SentryAppInstallation` from a token id, we now also check if `SentryAppInstallationToken` contains the token id which then links to the relevant `SentryAppInstallation`.