### PR TITLE
feat(grouping): Add grouping optimization tags to metrics in `save_error_events` 

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -59,6 +59,7 @@ from sentry.grouping.ingest import (
     find_existing_grouphash,
     find_existing_grouphash_new,
     get_hash_values,
+    is_in_transition,
     maybe_run_background_grouping,
     maybe_run_secondary_grouping,
     project_uses_optimized_grouping,
@@ -467,6 +468,7 @@ class EventManager:
         else:
             project = job["event"].project
             job["optimized_grouping"] = project_uses_optimized_grouping(project)
+            job["in_grouping_transition"] = is_in_transition(project)
             metric_tags = {
                 "platform": job["event"].platform or "unknown",
                 "sdk": normalized_sdk_tag_from_event(job["event"]),

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -472,6 +472,8 @@ class EventManager:
             metric_tags = {
                 "platform": job["event"].platform or "unknown",
                 "sdk": normalized_sdk_tag_from_event(job["event"]),
+                "using_transition_optimization": job["optimized_grouping"],
+                "in_transition": job["in_grouping_transition"],
             }
             # This metric allows differentiating from all calls to the `event_manager.save` metric
             # and adds support for differentiating based on platforms

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -186,7 +186,7 @@ def _calculate_background_grouping(
         return _calculate_event_grouping(project, event, config)
 
 
-def _is_in_transition(project: Project) -> bool:
+def is_in_transition(project: Project) -> bool:
     secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
     secondary_grouping_expiry = project.get_option("sentry:secondary_grouping_expiry")
 
@@ -204,7 +204,7 @@ def maybe_run_secondary_grouping(
     secondary_grouping_config = NULL_GROUPING_CONFIG
     secondary_hashes = NULL_HASHES
 
-    if _is_in_transition(project):
+    if is_in_transition(project):
         with metrics.timer("event_manager.secondary_grouping", tags=metric_tags):
             secondary_grouping_config = SecondaryGroupingConfigLoader().get_config_dict(project)
             secondary_hashes = _calculate_secondary_hash(project, job, secondary_grouping_config)
@@ -496,7 +496,7 @@ def record_calculation_metric_with_result(
     # Track the total number of grouping calculations done overall, so we can divide by the
     # count to get an average number of calculations per event
     tags = {
-        "in_transition": str(_is_in_transition(project)),
+        "in_transition": str(is_in_transition(project)),
         "using_transition_optimization": str(
             features.has(
                 "organizations:grouping-suppress-unnecessary-secondary-hash",

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -201,7 +201,7 @@ class EventManagerGroupingMetricsTest(TestCase):
                     )
 
     @mock.patch("sentry.event_manager.metrics.incr")
-    @mock.patch("sentry.grouping.ingest._is_in_transition", return_value=True)
+    @mock.patch("sentry.grouping.ingest.is_in_transition", return_value=True)
     def test_records_hash_comparison(self, _, mock_metrics_incr: MagicMock):
         project = self.project
         project.update_option("sentry:grouping_config", NEWSTYLE_CONFIG)


### PR DESCRIPTION
This adds tags tracking whether a project is in a grouping config transition and whether the org is using the optimized transition logic to the `metric_tags` used in `EventManager.save_error_events`. In support of that, it also:

- Renames `_is_in_transition` to remove the leading underscore, since it's no longer internal to `ingest.py`.

- Adds an `in_grouping_transition` property to `job` (the event container which gets passed around during ingest), so we have access to that information anywhere in `event_manager`.