### PR TITLE
ref: fix `make install-js-dev` in getsentry

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -91,7 +91,7 @@ sudo-askpass() {
 }
 
 pip-install() {
-    pip install --constraint requirements-dev-frozen.txt "$@"
+    pip install --constraint "${HERE}/../requirements-dev-frozen.txt" "$@"
 }
 
 upgrade-pip() {


### PR DESCRIPTION
getsentry runs this script with an alternative cwd -- ensure we always look at the sentry requirements to bootstrap sentry-cli

<!-- Describe your PR here. -->