### PR TITLE
fix(alerts): Move alert polling uuid out of state, act warnings

### DIFF
--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -9,6 +9,7 @@ import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixt
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
+  act,
   render,
   renderGlobalModal,
   screen,
@@ -329,7 +330,7 @@ describe('IssueRuleEditor', function () {
       });
 
       createWrapper();
-      await selectEvent.select(screen.getByText('Add action...'), 'Threads');
+      await selectEvent.select(await screen.findByText('Add action...'), 'Threads');
       await selectEvent.select(screen.getByText('Add action...'), 'Linear');
 
       expect(screen.getByText('Create a Linear issue with these')).toBeInTheDocument();
@@ -347,7 +348,7 @@ describe('IssueRuleEditor', function () {
         }),
       });
       createWrapper();
-      await userEvent.click(screen.getByText('Save Rule'));
+      await userEvent.click(await screen.findByRole('button', {name: 'Save Rule'}));
 
       await waitFor(() =>
         expect(mock).toHaveBeenCalledWith(
@@ -368,11 +369,11 @@ describe('IssueRuleEditor', function () {
         /The {oldest_or_newest} release associated/
       );
 
-      const filtersContainer = screen.getByTestId('rule-filters');
+      const filtersContainer = await screen.findByTestId('rule-filters');
 
       // Production environment is preselected because it's the first option.
       // staging should also be selectable.
-      selectEvent.select(
+      await selectEvent.select(
         within(filtersContainer).getAllByText('production')[0],
         'staging'
       );
@@ -402,14 +403,14 @@ describe('IssueRuleEditor', function () {
         body: {uuid},
       });
       const {router} = createWrapper();
-      await userEvent.click(screen.getByText('Save Rule'), {delay: null});
+      await userEvent.click(await screen.findByRole('button', {name: 'Save Rule'}), {
+        delay: null,
+      });
 
+      act(() => jest.advanceTimersByTime(1000));
       await waitFor(() => expect(addLoadingMessage).toHaveBeenCalledTimes(2));
-      jest.advanceTimersByTime(1000);
-
-      await waitFor(() => expect(mockSuccess).toHaveBeenCalledTimes(1));
-      jest.advanceTimersByTime(1000);
       await waitFor(() => expect(addSuccessMessage).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockSuccess).toHaveBeenCalledTimes(1));
       expect(router.push).toHaveBeenCalledWith({
         pathname: '/organizations/org-slug/alerts/rules/project-slug/1/details/',
       });
@@ -427,14 +428,14 @@ describe('IssueRuleEditor', function () {
         body: {uuid},
       });
       createWrapper();
-      await userEvent.click(screen.getByText('Save Rule'), {delay: null});
+      await userEvent.click(await screen.findByRole('button', {name: 'Save Rule'}), {
+        delay: null,
+      });
 
-      await waitFor(() => expect(addLoadingMessage).toHaveBeenCalledTimes(2));
-      jest.advanceTimersByTime(1000);
-
-      await waitFor(() => expect(pollingMock).toHaveBeenCalledTimes(1));
-
-      expect(screen.getByTestId('loading-mask')).toBeInTheDocument();
+      act(() => jest.advanceTimersByTime(1000));
+      expect(addLoadingMessage).toHaveBeenCalledTimes(2);
+      expect(pollingMock).toHaveBeenCalledTimes(1);
+      expect(await screen.findByTestId('loading-mask')).toBeInTheDocument();
     });
 
     it('failed status renders error message', async function () {
@@ -449,14 +450,15 @@ describe('IssueRuleEditor', function () {
         body: {uuid},
       });
       createWrapper();
-      await userEvent.click(screen.getByText('Save Rule'), {delay: null});
+      await userEvent.click(await screen.findByRole('button', {name: 'Save Rule'}), {
+        delay: null,
+      });
 
+      act(() => jest.advanceTimersByTime(1000));
       await waitFor(() => expect(addLoadingMessage).toHaveBeenCalledTimes(2));
-      jest.advanceTimersByTime(1000);
-
       await waitFor(() => expect(mockFailed).toHaveBeenCalledTimes(1));
-      expect(screen.getByText('An error occurred')).toBeInTheDocument();
       expect(addErrorMessage).toHaveBeenCalledTimes(1);
+      expect(addErrorMessage).toHaveBeenCalledWith('An error occurred');
     });
   });
 

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -153,7 +153,6 @@ type State = DeprecatedAsyncView['state'] & {
   incompatibleFilters: number[] | null;
   project: Project;
   sendingNotification: boolean;
-  uuid: null | string;
   acceptedNoisyAlert?: boolean;
   duplicateTargetRule?: UnsavedIssueAlertRule | IssueAlertRule | null;
   rule?: UnsavedIssueAlertRule | IssueAlertRule | null;
@@ -173,6 +172,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
   trackIncompatibleAnalytics: boolean = false;
   trackNoisyWarningViewed: boolean = false;
   isUnmounted = false;
+  uuid: string | null = null;
 
   get isDuplicateRule(): boolean {
     const {location} = this.props;
@@ -240,7 +240,6 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       detailedError: null,
       rule: {...defaultRule},
       environments: [],
-      uuid: null,
       project,
       sendingNotification: false,
       incompatibleConditions: null,
@@ -333,12 +332,12 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     }
 
     const {organization} = this.props;
-    const {uuid, project} = this.state;
+    const {project} = this.state;
     const origRule = this.state.rule;
 
     try {
       const response: RuleTaskResponse = await this.api.requestPromise(
-        `/projects/${organization.slug}/${project.slug}/rule-task/${uuid}/`
+        `/projects/${organization.slug}/${project.slug}/rule-task/${this.uuid}/`
       );
 
       const {status, rule, error} = response;
@@ -532,7 +531,8 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       // if we get a 202 back it means that we have an async task
       // running to lookup and verify the channel id for Slack.
       if (resp?.status === 202) {
-        this.setState({detailedError: null, loading: true, uuid: data.uuid});
+        this.uuid = data.uuid;
+        this.setState({detailedError: null, loading: true});
         this.fetchStatus();
         addLoadingMessage(t('Looking through all your channels...'));
       } else {

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -95,31 +95,31 @@ describe('Incident Rules Form', () => {
   describe('Viewing the rule', () => {
     const rule = MetricRuleFixture();
 
-    it('is enabled without org-level alerts:write', () => {
+    it('is enabled without org-level alerts:write', async () => {
       organization.access = [];
       project.access = [];
       createWrapper({rule});
 
-      expect(screen.queryByText(permissionAlertText)).toBeInTheDocument();
+      expect(await screen.findByText(permissionAlertText)).toBeInTheDocument();
       expect(screen.queryByLabelText('Save Rule')).toBeDisabled();
     });
 
-    it('is enabled with org-level alerts:write', () => {
+    it('is enabled with org-level alerts:write', async () => {
       organization.access = ['alerts:write'];
       project.access = [];
       createWrapper({rule});
 
+      expect(await screen.findByLabelText('Save Rule')).toBeEnabled();
       expect(screen.queryByText(permissionAlertText)).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Save Rule')).toBeEnabled();
     });
 
-    it('is enabled with project-level alerts:write', () => {
+    it('is enabled with project-level alerts:write', async () => {
       organization.access = [];
       project.access = ['alerts:write'];
       createWrapper({rule});
 
+      expect(await screen.findByLabelText('Save Rule')).toBeEnabled();
       expect(screen.queryByText(permissionAlertText)).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Save Rule')).toBeEnabled();
     });
   });
 
@@ -453,7 +453,6 @@ describe('Incident Rules Form', () => {
     });
 
     afterEach(() => {
-      jest.runOnlyPendingTimers();
       jest.useRealTimers();
     });
 
@@ -480,8 +479,9 @@ describe('Incident Rules Form', () => {
         onSubmitSuccess,
       });
 
+      act(jest.runAllTimers);
       await userEvent.type(
-        screen.getByPlaceholderText('Enter Alert Name'),
+        await screen.findByPlaceholderText('Enter Alert Name'),
         'Slack Alert Rule',
         {delay: null}
       );
@@ -504,7 +504,7 @@ describe('Incident Rules Form', () => {
       );
     });
 
-    it('pending status keeps loading true', () => {
+    it('pending status keeps loading true', async () => {
       const alertRule = MetricRuleFixture({name: 'Slack Alert Rule'});
       MockApiClient.addMockResponse({
         url: `/organizations/org-slug/alert-rules/${alertRule.id}/`,
@@ -526,7 +526,8 @@ describe('Incident Rules Form', () => {
         onSubmitSuccess,
       });
 
-      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+      act(jest.runAllTimers);
+      expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
       expect(onSubmitSuccess).not.toHaveBeenCalled();
     });
 
@@ -552,8 +553,9 @@ describe('Incident Rules Form', () => {
         rule: alertRule,
         onSubmitSuccess,
       });
+      act(jest.runAllTimers);
       await userEvent.type(
-        screen.getByPlaceholderText('Enter Alert Name'),
+        await screen.findByPlaceholderText('Enter Alert Name'),
         'Slack Alert Rule',
         {delay: null}
       );


### PR DESCRIPTION
Fixes act warnings for react 18 tests

Moves uuid into the component as a property, this fixes a race in tests for react 18. In production, there is a timeout for 1000ms but in tests we're using fake timers. setState + calling the polling endpoint right away which makes a race between updating state and getting the uuid back from state.

part of https://github.com/getsentry/frontend-tsc/issues/22
