### PR TITLE
change ux for playing replays on issue details page

### DIFF
--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -116,6 +116,11 @@ describe('EventReplay', function () {
 
   beforeEach(function () {
     const project = ProjectFixture({platform: 'javascript'});
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      method: 'GET',
+      body: {},
+    });
 
     jest.mocked(useProjects).mockReturnValue({
       fetchError: null,

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -1,7 +1,8 @@
-import {useCallback} from 'react';
+import {Fragment, useCallback} from 'react';
 import ReactLazyLoad from 'react-lazyload';
 import styled from '@emotion/styled';
 
+import {LinkButton} from 'sentry/components/button';
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {REPLAY_LOADING_HEIGHT} from 'sentry/components/events/eventReplay/constants';
@@ -10,15 +11,19 @@ import LazyLoad from 'sentry/components/lazyLoad';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {ReplayGroupContextProvider} from 'sentry/components/replays/replayGroupContext';
 import {replayBackendPlatforms} from 'sentry/data/platformCategories';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import {getAnalyticsDataForEvent, getAnalyticsDataForGroup} from 'sentry/utils/events';
+import useReplayCountForIssues from 'sentry/utils/replayCount/useReplayCountForIssues';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {useHasOrganizationSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import {projectCanUpsellReplay} from 'sentry/utils/replays/projectSupportsReplay';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
+import useRouter from 'sentry/utils/useRouter';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 type Props = {
   event: Event;
@@ -38,6 +43,8 @@ function EventReplayContent({
 }: Props & {replayId: undefined | string}) {
   const organization = useOrganization();
   const {hasOrgSentReplays, fetching} = useHasOrganizationSentAnyReplayEvents();
+  const router = useRouter();
+  const {getReplayCountForIssue} = useReplayCountForIssues();
 
   const replayOnboardingPanel = useCallback(
     () => import('./replayInlineOnboardingPanel'),
@@ -100,8 +107,36 @@ function EventReplayContent({
     ),
   };
 
+  // don't try to construct the url if we don't have a group
+  const eventIdFromRouter = router.params.eventId;
+  const baseUrl = group
+    ? eventIdFromRouter
+      ? normalizeUrl(
+          `/organizations/${organization.slug}/issues/${group.id}/events/${eventIdFromRouter}/`
+        )
+      : normalizeUrl(`/organizations/${organization.slug}/issues/${group.id}/`)
+    : '';
+  const replayUrl = baseUrl ? `${baseUrl}replays/${location.search}/` : '';
+  const seeAllReplaysButton = replayUrl ? (
+    <LinkButton size="sm" to={replayUrl}>
+      {t('See All Replays')}
+    </LinkButton>
+  ) : undefined;
+  const replayCount = group ? getReplayCountForIssue(group.id, group.issueCategory) : -1;
+  const overlayContent =
+    seeAllReplaysButton && replayCount && replayCount > 1 ? (
+      <Fragment>
+        <div>
+          {tct('Replay captured [replayCount] users experiencing this issue', {
+            replayCount,
+          })}
+        </div>
+        {seeAllReplaysButton}
+      </Fragment>
+    ) : undefined;
+
   return (
-    <ReplaySectionMinHeight>
+    <ReplaySectionMinHeight actions={seeAllReplaysButton}>
       <ErrorBoundary mini>
         <ReplayGroupContextProvider groupId={group?.id} eventId={event.id}>
           <ReactLazyLoad debounce={50} height={448} offset={0} once>
@@ -110,6 +145,7 @@ function EventReplayContent({
                 {...commonProps}
                 component={replayClipPreview}
                 clipOffsets={CLIP_OFFSETS}
+                overlayContent={overlayContent}
               />
             ) : (
               <LazyLoad {...commonProps} component={replayPreview} />

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -33,7 +33,7 @@ type Props = {
   handleForwardClick?: () => void;
   isLarge?: boolean;
   onClickNextReplay?: () => void;
-  overlayText?: string;
+  overlayContent?: React.ReactNode;
   showNextAndPrevious?: boolean;
 } & ReturnType<typeof useReplayReader>;
 
@@ -65,14 +65,13 @@ function ReplayClipPreviewPlayer({
   isLarge,
   handleForwardClick,
   handleBackClick,
-  overlayText,
+  overlayContent,
   fetching,
   replay,
   replayRecord,
   fetchError,
   replayId,
   showNextAndPrevious,
-  onClickNextReplay,
 }: Props) {
   useRouteAnalyticsParams({
     event_replay_status: getReplayAnalyticsStatus({fetchError, replayRecord}),
@@ -125,9 +124,8 @@ function ReplayClipPreviewPlayer({
           replayRecord={replayRecord}
           handleBackClick={handleBackClick}
           handleForwardClick={handleForwardClick}
-          overlayText={overlayText}
+          overlayContent={overlayContent}
           showNextAndPrevious={showNextAndPrevious}
-          onClickNextReplay={onClickNextReplay}
           // if the player is large, we want to keep the priority as default
           playPausePriority={isLarge ? 'default' : undefined}
         />

--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -36,9 +36,8 @@ function ReplayPreviewPlayer({
   replayRecord,
   handleBackClick,
   handleForwardClick,
-  overlayText,
+  overlayContent,
   showNextAndPrevious,
-  onClickNextReplay,
   playPausePriority,
 }: {
   replayId: string;
@@ -46,8 +45,7 @@ function ReplayPreviewPlayer({
   fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
   handleBackClick?: () => void;
   handleForwardClick?: () => void;
-  onClickNextReplay?: () => void;
-  overlayText?: string;
+  overlayContent?: React.ReactNode;
   playPausePriority?: ComponentProps<typeof ReplayPlayPauseButton>['priority'];
   showNextAndPrevious?: boolean;
 }) {
@@ -102,10 +100,7 @@ function ReplayPreviewPlayer({
               </ContextContainer>
             ) : null}
             <StaticPanel>
-              <ReplayPlayer
-                overlayText={overlayText}
-                onClickNextReplay={onClickNextReplay}
-              />
+              <ReplayPlayer overlayContent={overlayContent} />
             </StaticPanel>
           </PlayerContextContainer>
           {isFullscreen && isSidebarOpen ? <Breadcrumbs /> : null}

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -2,14 +2,11 @@ import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useResizeObserver} from '@react-aria/utils';
 
-import {Button} from 'sentry/components/button';
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import BufferingOverlay from 'sentry/components/replays/player/bufferingOverlay';
 import FastForwardBadge from 'sentry/components/replays/player/fastForwardBadge';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {IconPlay} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -20,8 +17,7 @@ type Dimensions = ReturnType<typeof useReplayContext>['dimensions'];
 interface Props {
   className?: string;
   isPreview?: boolean;
-  onClickNextReplay?: () => void;
-  overlayText?: string;
+  overlayContent?: React.ReactNode;
 }
 
 function useVideoSizeLogger({
@@ -62,12 +58,7 @@ function useVideoSizeLogger({
   }, [organization, windowDimensions, videoDimensions, didLog, analyticsContext]);
 }
 
-function BasePlayerRoot({
-  className,
-  overlayText,
-  onClickNextReplay,
-  isPreview = false,
-}: Props) {
+function BasePlayerRoot({className, overlayContent, isPreview = false}: Props) {
   const {
     dimensions: videoDimensions,
     fastForwardSpeed,
@@ -129,15 +120,9 @@ function BasePlayerRoot({
 
   return (
     <Fragment>
-      {isFinished && overlayText && (
+      {isFinished && overlayContent && (
         <Overlay>
-          <OverlayInnerWrapper>
-            <UpNext>{t('Up Next')}</UpNext>
-            <OverlayText>{overlayText}</OverlayText>
-            <Button onClick={onClickNextReplay} icon={<IconPlay size="md" />}>
-              {t('Play Now')}
-            </Button>
-          </OverlayInnerWrapper>
+          <OverlayInnerWrapper>{overlayContent}</OverlayInnerWrapper>
         </Overlay>
       )}
       <StyledNegativeSpaceContainer ref={windowEl} className="sentry-block">
@@ -307,14 +292,6 @@ const StyledNegativeSpaceContainer = styled(NegativeSpaceContainer)`
   position: relative;
   width: 100%;
   height: 100%;
-`;
-
-const OverlayText = styled('div')`
-  font-size: ${p => p.theme.fontSizeExtraLarge};
-`;
-
-const UpNext = styled('div')`
-  line-height: 0;
 `;
 
 export default SentryPlayerRoot;

--- a/static/app/views/issueDetails/groupReplays/replayTableWrapper.tsx
+++ b/static/app/views/issueDetails/groupReplays/replayTableWrapper.tsx
@@ -15,12 +15,12 @@ type Props = {
   selectedReplayIndex: number;
   setSelectedReplayIndex: (index: number) => void;
   visibleColumns: ReplayColumn[];
-  nextReplayText?: string;
+  overlayContent?: React.ReactNode;
 } & React.ComponentProps<typeof ReplayTable>;
 
 function ReplayTableWrapper({
   replaySlug,
-  nextReplayText,
+  overlayContent,
   setSelectedReplayIndex,
   orgSlug,
   group,
@@ -37,7 +37,7 @@ function ReplayTableWrapper({
   return (
     <Fragment>
       <ReplayClipPreviewPlayer
-        overlayText={nextReplayText}
+        overlayContent={overlayContent}
         orgSlug={orgSlug}
         showNextAndPrevious
         handleForwardClick={
@@ -51,13 +51,6 @@ function ReplayTableWrapper({
           selectedReplayIndex > 0
             ? () => {
                 setSelectedReplayIndex(selectedReplayIndex - 1);
-              }
-            : undefined
-        }
-        onClickNextReplay={
-          nextReplayText
-            ? () => {
-                setSelectedReplayIndex(selectedReplayIndex + 1);
               }
             : undefined
         }


### PR DESCRIPTION
This PR changes the UX of the replay on issue details. Specifically, adding the overlay at the end of the video as well as the new `See All Replays` button.

Before:
![Screenshot 2024-03-18 at 1 19 27 PM](https://github.com/getsentry/sentry/assets/8533851/ff379e6f-b878-4e66-913a-98cc0310ce84)


After:
![Screenshot 2024-03-18 at 1 17 45 PM](https://github.com/getsentry/sentry/assets/8533851/6ea6dfc8-b3f0-48cc-b56b-fcf48b5793c5)
