### PR TITLE
test(ui): Fix cell action container test, act warnings

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -254,7 +254,9 @@ class CellAction extends Component<Props, State> {
     const cellActions = makeCellActions(this.props);
 
     return (
-      <Container data-test-id="cell-action-container">
+      <Container
+        data-test-id={cellActions === null ? undefined : 'cell-action-container'}
+      >
         {children}
         {cellActions?.length && (
           <DropdownMenu

--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -245,7 +245,7 @@ describe('Performance > Table', function () {
       });
     });
 
-    it('hides cell actions when withStaticFilters is true', function () {
+    it('hides cell actions when withStaticFilters is true', async function () {
       const data = initializeData({
         query: 'event.type:transaction transaction:/api*',
       });
@@ -261,6 +261,7 @@ describe('Performance > Table', function () {
         />
       );
 
+      expect(await screen.findAllByTestId('grid-body-row')).toHaveLength(3);
       const cellActionContainers = screen.queryByTestId('cell-action-container');
       expect(cellActionContainers).not.toBeInTheDocument();
     });
@@ -319,12 +320,12 @@ describe('Performance > Table', function () {
         />
       );
 
-      await screen.findByTestId('grid-editable');
+      expect(await screen.findByTestId('grid-editable')).toBeInTheDocument();
       const indicatorContainer = screen.queryByTestId('unparameterized-indicator');
       expect(indicatorContainer).not.toBeInTheDocument();
     });
 
-    it('sends MEP param when setting enabled', function () {
+    it('sends MEP param when setting enabled', async function () {
       const data = initializeData(
         {
           query: 'event.type:transaction transaction:/api*',
@@ -343,6 +344,7 @@ describe('Performance > Table', function () {
         />
       );
 
+      expect(await screen.findByTestId('grid-editable')).toBeInTheDocument();
       expect(eventsMock).toHaveBeenCalledTimes(1);
       expect(eventsMock).toHaveBeenNthCalledWith(
         1,

--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -261,7 +261,7 @@ describe('Performance > Table', function () {
         />
       );
 
-      expect(await screen.findAllByTestId('grid-body-row')).toHaveLength(3);
+      expect(await screen.findByTestId('grid-editable')).toBeInTheDocument();
       const cellActionContainers = screen.queryByTestId('cell-action-container');
       expect(cellActionContainers).not.toBeInTheDocument();
     });


### PR DESCRIPTION
- `cell-action-container` test id is always present if you wait for the component to finish loading. 
- fixes other act warnings for react 18.

part of https://github.com/getsentry/frontend-tsc/issues/22
