### PR TITLE
fix(routes): Bring back legacy org redirect

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1938,6 +1938,7 @@ function buildRoutes() {
       <Redirect from="/organizations/:orgId/teams/new/" to="/settings/:orgId/teams/" />
       <Route path="/organizations/:orgId/">
         {hook('routes:organization')}
+        <IndexRedirect to="/organizations/:orgId/issues/" />
         <Redirect from="/organizations/:orgId/teams/" to="/settings/:orgId/teams/" />
         <Redirect
           from="/organizations/:orgId/teams/your-teams/"


### PR DESCRIPTION
This was incorrectly removed in [0]

[0]: https://github.com/getsentry/sentry/commit/a936fb00da#diff-5154b281a07ffcda3774e4f467493dc58d9d725e94223f0d9641e82989819952L1989-R1907

This was removed because of a misunderstanding of how react-router does route tree traversal. It *will* traverse down paths that do not match looking for absolute path matches.

It appeared that this route was not doing anything since one would assume react-router would NOT have this behavior and would only traverse down branches that match the path prefix.

I've brought this behavior back in a way that makes more sense when reading the route tree so we don't remove this by mistake again