### PR TITLE
feat(integration): Allow MSTeams tenant in issue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1597,6 +1597,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable interface functionality to synchronize groups between sentry and
     # issues on external services.
     "organizations:integrations-issue-sync": True,
+    # Allow tenant type installations through issue alert actions
+    "organizations:integrations-msteams-tenant": False,
     # Enable comments of related issues on open PRs for beta languages
     "organizations:integrations-open-pr-comment-beta-langs": False,
     # Enable Opsgenie integration

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -295,6 +295,7 @@ default_manager.add("organizations:user-feedback-onboarding", OrganizationFeatur
 default_manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:widget-viewer-modal-minimap", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:replay-play-from-replay-tab", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:integrations-msteams-tenant", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.
 

--- a/src/sentry/integrations/msteams/actions/notification.py
+++ b/src/sentry/integrations/msteams/actions/notification.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.msteams.actions.form import MsTeamsNotifyServiceForm
 from sentry.integrations.msteams.card_builder.issues import MSTeamsIssueMessageBuilder
@@ -30,6 +31,10 @@ class MsTeamsNotifyServiceAction(IntegrationEventAction):
         }
 
     def get_integrations(self) -> list[RpcIntegration]:
+        # The MSTeams tenant limitation does not seem to be true anymore
+        # Test out the integration through FF to contain the exposure
+        if features.has("organizations:integrations-msteams-tenant", self.project.organization):
+            return [a for a in super().get_integrations()]
         # NOTE: We exclude installations of `tenant` type to NOT show up in the team choices dropdown in alert rule actions
         # as currently, there is no way to query the API for users or channels within a `tenant` to send alerts to.
         return [


### PR DESCRIPTION
Orgs that have MSTeams in tenant mode cannot use issue alert actions because we filter them out. Enable the logic for a specific few orgs to test out the integration first before exposing across SaaS.

Related to: https://github.com/getsentry/sentry/issues/66130
