### PR TITLE
feat(issue-priority): Add frontend analytics for issue stream bulk prioritization

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -212,6 +212,9 @@ export type IssueEventParameters = {
   'issues_stream.sort_changed': {
     sort: string;
   };
+  'issues_stream.updated_priority': {
+    priority: PriorityLevel;
+  };
   'issues_tab.viewed': {
     num_issues: number;
     num_new_issues: number;
@@ -297,6 +300,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_search.empty': 'Issue Search: Empty',
   'issue.search_sidebar_clicked': 'Issue Search Sidebar Clicked',
   'issues_stream.archived': 'Issues Stream: Archived',
+  'issues_stream.updated_priority': 'Issues Stream: Updated Priority',
   'issues_stream.realtime_clicked': 'Issues Stream: Realtime Clicked',
   'issues_stream.issue_assigned': 'Assigned Issue from Issues Stream',
   'issues_stream.merged': 'Merged Issues from Issues Stream',

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -163,6 +163,13 @@ function IssueListActions({
       });
     }
 
+    if ('priority' in data) {
+      trackAnalytics('issues_stream.updated_priority', {
+        organization,
+        priority: data.priority,
+      });
+    }
+
     actionSelectedGroups(itemIds => {
       // If `itemIds` is undefined then it means we expect to bulk update all items
       // that match the query.


### PR DESCRIPTION
We are collecting analytics for when the pill dropdown is used, but not when using the checkboxes on the issue stream.