### PR TITLE
feat(profiles): Deobfuscate Android with Symbolicator

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2182,12 +2182,7 @@ register(
 
 # Deobfuscate profiles using Symbolicator
 register(
-    "profiling.deobfuscate-using-symbolicator.enabled",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "profiling.deobfuscate-using-symbolicator.project-allowlist",
+    "profiling.deobfuscate-using-symbolicator.enable-for-project",
     type=Sequence,
     default=[],
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2179,3 +2179,16 @@ register(
     default=[],
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Deobfuscate profiles using Symbolicator
+register(
+    "profiling.deobfuscate-using-symbolicator.enabled",
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "profiling.deobfuscate-using-symbolicator.project-allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -786,7 +786,7 @@ def _deobfuscate(profile: Profile, project: Project) -> None:
                 m["signature"] = format_signature(types)
         return
 
-    if options.get("profiling.deobfuscate-using-symbolicator.enabled"):
+    if project.id in options.get("profiling.deobfuscate-using-symbolicator.enable-for-project"):
         return _deobfuscate_using_symbolicator(
             project=project,
             profile=profile,


### PR DESCRIPTION
Deobfuscation on workers is proving to be a challenge since it needs a lot of resources. It's better to pool those resources and cache proguard files in Symbolicator and let it do the work.

Recently, the processing team added that capability and this will allow us to test it on profiles.