### PR TITLE
feat(ingest): DLQ all non-retriable messages even if schema is valid

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -87,7 +87,13 @@ def process_event(
     # keeping it around because it does provide some protection against
     # reprocessing good events if a single consumer is in a restart loop.
     deduplication_key = f"ev:{project_id}:{event_id}"
-    if cache.get(deduplication_key) is not None:
+
+    try:
+        cached_value = cache.get(deduplication_key)
+    except Exception as exc:
+        raise Retriable(exc)
+
+    if cached_value is not None:
         logger.warning(
             "pre-process-forwarder detected a duplicated event" " with id:%s for project:%s.",
             event_id,


### PR DESCRIPTION
Since ingest messages contain json bytes inside a msgpack payload the schema cannot be relied on to determine whether to DLQ, as the inner message can be invalid even if schema checking still passes. This now DLQs any exception that is not marked Retriable.
