### PR TITLE
ref(replay): replace zendesk button with feedback widget for mobile replays

### DIFF
--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
 import UserBadge from 'sentry/components/idBadge/userBadge';
 import FullViewport from 'sentry/components/layouts/fullViewport';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -26,6 +27,7 @@ type Props = {
   projectSlug: string | null;
   replayErrors: ReplayError[];
   replayRecord: undefined | ReplayRecord;
+  isVideoReplay?: boolean;
 };
 
 export default function Page({
@@ -34,6 +36,7 @@ export default function Page({
   replayRecord,
   projectSlug,
   replayErrors,
+  isVideoReplay,
 }: Props) {
   const title = replayRecord
     ? `${replayRecord.id} — Session Replay — ${orgSlug}`
@@ -76,7 +79,7 @@ export default function Page({
       <DetailsPageBreadcrumbs orgSlug={orgSlug} replayRecord={replayRecord} />
 
       <ButtonActionsWrapper>
-        <FeedbackButton />
+        {isVideoReplay ? <FeedbackWidgetButton /> : <FeedbackButton />}
         <ConfigureReplayCard />
         <DropdownMenu
           position="bottom-end"

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -146,7 +146,7 @@ function ReplayDetails({params: {replaySlug}}: Props) {
 
   const isVideoReplay = Boolean(
     organization.features.includes('session-replay-mobile-player') &&
-      replay?.isVideoReplay
+      replay?.isVideoReplay()
   );
 
   return (

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -144,6 +144,11 @@ function ReplayDetails({params: {replaySlug}}: Props) {
     );
   }
 
+  const videoEvents = replay?.getVideoEvents();
+  const isVideoReplay = Boolean(
+    organization.features.includes('session-replay-mobile-player') && videoEvents?.length
+  );
+
   return (
     <ReplayContextProvider
       analyticsContext="replay_details"
@@ -154,6 +159,7 @@ function ReplayDetails({params: {replaySlug}}: Props) {
     >
       <ReplayTransactionContext replayRecord={replayRecord}>
         <Page
+          isVideoReplay={isVideoReplay}
           orgSlug={orgSlug}
           replayRecord={replayRecord}
           projectSlug={projectSlug}

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -144,9 +144,9 @@ function ReplayDetails({params: {replaySlug}}: Props) {
     );
   }
 
-  const videoEvents = replay?.getVideoEvents();
   const isVideoReplay = Boolean(
-    organization.features.includes('session-replay-mobile-player') && videoEvents?.length
+    organization.features.includes('session-replay-mobile-player') &&
+      replay?.isVideoReplay
   );
 
   return (


### PR DESCRIPTION
For mobile replays, replaces the `Contact Us` button in replay details with the 'Give Feedback' widget button:

https://github.com/getsentry/sentry/assets/56095982/5915f8ed-13b9-456f-a34d-e7c10522c551

