### PR TITLE
feat(_admin): Add to Org Button

### DIFF
--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -75,6 +75,9 @@ class OrganizationMemberRequestSerializer(serializers.Serializer):
     email = AllowedEmailField(
         max_length=75, required=True, help_text="The email address to send the invitation to."
     )
+    user_id = serializers.CharField(
+        required=False, help_text="The user id to add to the organization. For superuser only."
+    )
     role = serializers.ChoiceField(
         choices=roles.get_choices(), default=organization_roles.get_default().id
     )  # deprecated, use orgRole
@@ -371,27 +374,39 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
                 status=400,
             )
 
-        with transaction.atomic(router.db_for_write(OrganizationMember)):
-            # remove any invitation requests for this email before inviting
-            existing_invite = OrganizationMember.objects.filter(
-                Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
-                | Q(invite_status=InviteStatus.REQUESTED_TO_JOIN.value),
-                email=result["email"],
-                organization=organization,
-            )
-            for om in existing_invite:
-                om.delete()
+        if getattr(request, "superuser", False):
+            with transaction.atomic(router.db_for_write(OrganizationMember)):
+                om = OrganizationMember.objects.create(
+                    organization=organization,
+                    user_email=result["email"],
+                    user_id=result["user_id"],
+                    role=result["role"],
+                    inviter_id=request.user.id,
+                    invite_status=InviteStatus.APPROVED.value,
+                )
+                om.save()
+        else:
+            with transaction.atomic(router.db_for_write(OrganizationMember)):
+                # remove any invitation requests for this email before inviting
+                existing_invite = OrganizationMember.objects.filter(
+                    Q(invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value)
+                    | Q(invite_status=InviteStatus.REQUESTED_TO_JOIN.value),
+                    email=result["email"],
+                    organization=organization,
+                )
+                for om in existing_invite:
+                    om.delete()
 
-            om = OrganizationMember(
-                organization=organization,
-                email=result["email"],
-                role=result["role"],
-                inviter_id=request.user.id,
-            )
+                om = OrganizationMember(
+                    organization=organization,
+                    email=result["email"],
+                    role=result["role"],
+                    inviter_id=request.user.id,
+                )
 
-            if settings.SENTRY_ENABLE_INVITES:
-                om.token = om.generate_token()
-            om.save()
+                if settings.SENTRY_ENABLE_INVITES:
+                    om.token = om.generate_token()
+                om.save()
 
         # Do not set team-roles when inviting members
         if "teamRoles" in result or "teams" in result:
@@ -402,12 +417,13 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             )
             save_team_assignments(om, teams)
 
-        if settings.SENTRY_ENABLE_INVITES and result.get("sendInvite"):
-            referrer = request.query_params.get("referrer")
-            om.send_invite_email(referrer)
-            member_invited.send_robust(
-                member=om, user=request.user, sender=self, referrer=request.data.get("referrer")
-            )
+        if not getattr(request, "superuser", False):
+            if settings.SENTRY_ENABLE_INVITES and result.get("sendInvite"):
+                referrer = request.query_params.get("referrer")
+                om.send_invite_email(referrer)
+                member_invited.send_robust(
+                    member=om, user=request.user, sender=self, referrer=request.data.get("referrer")
+                )
 
         self.create_audit_entry(
             request=request,

--- a/static/app/components/forms/fieldFromConfig.tsx
+++ b/static/app/components/forms/fieldFromConfig.tsx
@@ -30,6 +30,7 @@ import type {SelectAsyncFieldProps} from './fields/selectAsyncField';
 import SelectAsyncField from './fields/selectAsyncField';
 import type {SelectFieldProps} from './fields/selectField';
 import SelectField from './fields/selectField';
+import SentryOrganizationRoleSelectorField from './fields/sentryOrganizationRoleSelectorField';
 import type {RenderFieldProps} from './fields/sentryProjectSelectorField';
 import SentryProjectSelectorField from './fields/sentryProjectSelectorField';
 import type {TableFieldProps} from './fields/tableField';
@@ -105,6 +106,10 @@ function FieldFromConfig(props: FieldFromConfigProps): React.ReactElement | null
       return <ProjectMapperField {...(componentProps as ProjectMapperProps)} />;
     case 'sentry_project_selector':
       return <SentryProjectSelectorField {...(componentProps as RenderFieldProps)} />;
+    case 'sentry_organization_role_selector':
+      return (
+        <SentryOrganizationRoleSelectorField {...(componentProps as RenderFieldProps)} />
+      );
     case 'select_async':
       return <SelectAsyncField {...(componentProps as SelectAsyncFieldProps)} />;
     case 'file':

--- a/static/app/components/forms/fields/sentryOrganizationRoleSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryOrganizationRoleSelectorField.tsx
@@ -1,0 +1,19 @@
+import {ORG_ROLES} from 'sentry/constants';
+import {t} from 'sentry/locale';
+
+import type {InputFieldProps} from './inputField';
+import SelectField from './selectField';
+
+function SentryOrganizationRoleSelectorField({
+  placeholder = t('Choose a role'),
+  ...props
+}: InputFieldProps) {
+  const projectOptions = ORG_ROLES?.map(role => ({
+    value: role.id,
+    label: role.name,
+  }));
+
+  return <SelectField placeholder={placeholder} options={projectOptions} {...props} />;
+}
+
+export default SentryOrganizationRoleSelectorField;

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -190,6 +190,10 @@ export type SentryProjectSelectorType = {
   avatarSize?: number;
 };
 
+export type SentryOrganizationRoleSelectorType = {
+  type: 'sentry_organization_role_selector';
+};
+
 export type SelectAsyncType = {
   type: 'select_async';
 } & SelectAsyncFieldProps;
@@ -204,6 +208,7 @@ export type Field = (
   | TableType
   | ProjectMapperType
   | SentryProjectSelectorType
+  | SentryOrganizationRoleSelectorType
   | SelectAsyncType
   | ChoiceMapperType
   | {type: (typeof FieldType)[number]}


### PR DESCRIPTION
* Created new form field to use in the `AddToOrgModal` in `getsentry`
* Modified the `POST /api/0/organizations/{organization_slug}/members/` endpoint such that *superusers with write permissions* can directly add users to an organization

Addresses: https://github.com/getsentry/team-core-product-foundations/issues/160
