### PR TITLE
feat(_admin): Created Form Field for Add to Org Button

### DIFF
--- a/static/app/components/forms/fieldFromConfig.tsx
+++ b/static/app/components/forms/fieldFromConfig.tsx
@@ -30,6 +30,7 @@ import type {SelectAsyncFieldProps} from './fields/selectAsyncField';
 import SelectAsyncField from './fields/selectAsyncField';
 import type {SelectFieldProps} from './fields/selectField';
 import SelectField from './fields/selectField';
+import SentryOrganizationRoleSelectorField from './fields/sentryOrganizationRoleSelectorField';
 import type {RenderFieldProps} from './fields/sentryProjectSelectorField';
 import SentryProjectSelectorField from './fields/sentryProjectSelectorField';
 import type {TableFieldProps} from './fields/tableField';
@@ -105,6 +106,10 @@ function FieldFromConfig(props: FieldFromConfigProps): React.ReactElement | null
       return <ProjectMapperField {...(componentProps as ProjectMapperProps)} />;
     case 'sentry_project_selector':
       return <SentryProjectSelectorField {...(componentProps as RenderFieldProps)} />;
+    case 'sentry_organization_role_selector':
+      return (
+        <SentryOrganizationRoleSelectorField {...(componentProps as RenderFieldProps)} />
+      );
     case 'select_async':
       return <SelectAsyncField {...(componentProps as SelectAsyncFieldProps)} />;
     case 'file':

--- a/static/app/components/forms/fields/sentryOrganizationRoleSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryOrganizationRoleSelectorField.spec.tsx
@@ -1,0 +1,21 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+import selectEvent from 'sentry-test/selectEvent';
+
+import SentryOrganizationRoleSelectorField from './sentryOrganizationRoleSelectorField';
+
+describe('SentryOrganizationRoleSelectorField', () => {
+  it('can change role values', async () => {
+    const mock = jest.fn();
+
+    render(
+      <SentryOrganizationRoleSelectorField onChange={mock} name="Role" label="role" />
+    );
+
+    // Simulate selecting a role from the dropdown
+    await selectEvent.select(screen.getByText(/choose a role/i), 'Member');
+
+    // Verify the onChange handler was called with the correct arguments
+    // Assuming '2' is the id for the 'Member' role based on the ORG_ROLES mock
+    expect(mock).toHaveBeenCalledWith('member', expect.anything());
+  });
+});

--- a/static/app/components/forms/fields/sentryOrganizationRoleSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryOrganizationRoleSelectorField.tsx
@@ -1,0 +1,19 @@
+import {ORG_ROLES} from 'sentry/constants';
+import {t} from 'sentry/locale';
+
+import type {InputFieldProps} from './inputField';
+import SelectField from './selectField';
+
+function SentryOrganizationRoleSelectorField({
+  placeholder = t('Choose a role'),
+  ...props
+}: InputFieldProps) {
+  const projectOptions = ORG_ROLES?.map(role => ({
+    value: role.id,
+    label: role.name,
+  }));
+
+  return <SelectField placeholder={placeholder} options={projectOptions} {...props} />;
+}
+
+export default SentryOrganizationRoleSelectorField;

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -190,6 +190,10 @@ export type SentryProjectSelectorType = {
   avatarSize?: number;
 };
 
+export type SentryOrganizationRoleSelectorType = {
+  type: 'sentry_organization_role_selector';
+};
+
 export type SelectAsyncType = {
   type: 'select_async';
 } & SelectAsyncFieldProps;
@@ -204,6 +208,7 @@ export type Field = (
   | TableType
   | ProjectMapperType
   | SentryProjectSelectorType
+  | SentryOrganizationRoleSelectorType
   | SelectAsyncType
   | ChoiceMapperType
   | {type: (typeof FieldType)[number]}


### PR DESCRIPTION
Created a form field that will be used in the Add To Org Button in the _admin portal. It renders the dropdown.

![image](https://github.com/getsentry/sentry/assets/33237075/62d42134-7256-48d9-9803-00477533de26)
