### PR TITLE
fix(settings): Refactor feature hook render function

### DIFF
--- a/static/app/components/acl/feature.tsx
+++ b/static/app/components/acl/feature.tsx
@@ -91,7 +91,8 @@ interface RenderDisabledProps extends FeatureRenderProps {
 export type RenderDisabledFn = (props: RenderDisabledProps) => React.ReactNode;
 
 interface ChildRenderProps extends FeatureRenderProps {
-  renderDisabled?: undefined | boolean | RenderDisabledFn;
+  renderDisabled?: boolean | ((props: any) => React.ReactNode);
+  renderInstallButton?: (props: any) => React.ReactNode;
 }
 
 export type ChildrenRenderFn = (props: ChildRenderProps) => React.ReactNode;

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -117,14 +117,18 @@ function ProviderItem({provider, active, onConfigure}: Props) {
           <FeatureBadge>
             {!hasFeature &&
               // renderDisabled is overridden by renderDisabled above
-              (renderDisabled as any as typeof renderDisabledLock)({provider, features})}
+              (renderDisabled as typeof renderDisabledLock)({provider, features})}
           </FeatureBadge>
 
           <div>
             {active ? (
               <ActiveIndicator />
             ) : (
-              (renderInstallButton ?? defaultRenderInstallButton)({provider, hasFeature})
+              // renderInstallButton is overridden by renderDisabled above
+              (
+                (renderInstallButton as typeof defaultRenderInstallButton) ??
+                defaultRenderInstallButton
+              )({provider, hasFeature})
             )}
           </div>
         </PanelItem>

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -29,14 +29,6 @@ type LockedFeatureProps = {
   className?: string;
 };
 
-type FeatureRenderProps = {
-  features: string[];
-  hasFeature: boolean;
-  renderDisabled: (p: LockedFeatureProps) => React.ReactNode;
-  renderInstallButton: (p: RenderInstallButtonProps) => React.ReactNode;
-  children?: (p: FeatureRenderProps) => React.ReactNode;
-};
-
 type Props = {
   active: boolean;
   provider: AuthProvider;
@@ -103,12 +95,7 @@ function ProviderItem({provider, active, onConfigure}: Props) {
         children({...props, renderDisabled: renderDisabledLock as any})
       }
     >
-      {({
-        hasFeature,
-        features,
-        renderDisabled,
-        renderInstallButton,
-      }: FeatureRenderProps) => (
+      {({hasFeature, features, renderDisabled, renderInstallButton}) => (
         <PanelItem center>
           <ProviderInfo>
             <ProviderLogo
@@ -128,7 +115,9 @@ function ProviderItem({provider, active, onConfigure}: Props) {
           </ProviderInfo>
 
           <FeatureBadge>
-            {!hasFeature && renderDisabled({provider, features})}
+            {!hasFeature &&
+              // renderDisabled is overridden by renderDisabled above
+              (renderDisabled as any as typeof renderDisabledLock)({provider, features})}
           </FeatureBadge>
 
           <div>


### PR DESCRIPTION
React 18 types correctly enforce the child render function props. Instead of letting us override them as we were previously doing.

adds renderInstallButton to the props until we can make this into a hook or some other solution

fixes https://github.com/getsentry/frontend-tsc/issues/56
part of https://github.com/getsentry/frontend-tsc/issues/22