### PR TITLE
ref(ui): Remove render function from dropdown label

### DIFF
--- a/static/app/components/dropdownAutoComplete/list.tsx
+++ b/static/app/components/dropdownAutoComplete/list.tsx
@@ -6,7 +6,7 @@ import type {ItemsAfterFilter} from './types';
 
 type RowProps = Pick<
   React.ComponentProps<typeof Row>,
-  'itemSize' | 'inputValue' | 'getItemProps' | 'registerVisibleItem'
+  'itemSize' | 'getItemProps' | 'registerVisibleItem'
 >;
 
 type Props = {

--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -408,17 +408,14 @@ function Menu({
                       {!busy && (
                         <List
                           items={autoCompleteResults}
-                          {...{
-                            maxHeight,
-                            highlightedIndex,
-                            inputValue,
-                            onScroll,
-                            getItemProps,
-                            registerVisibleItem,
-                            virtualizedLabelHeight,
-                            virtualizedHeight,
-                            itemSize,
-                          }}
+                          maxHeight={maxHeight}
+                          highlightedIndex={highlightedIndex}
+                          onScroll={onScroll}
+                          getItemProps={getItemProps}
+                          registerVisibleItem={registerVisibleItem}
+                          virtualizedLabelHeight={virtualizedLabelHeight}
+                          virtualizedHeight={virtualizedHeight}
+                          itemSize={itemSize}
                         />
                       )}
                     </ItemList>

--- a/static/app/components/dropdownAutoComplete/row.tsx
+++ b/static/app/components/dropdownAutoComplete/row.tsx
@@ -14,7 +14,7 @@ type AutoCompleteChildrenArgs<T extends Item> = Parameters<
 
 type Props<T extends Item> = Pick<
   AutoCompleteChildrenArgs<T>,
-  'getItemProps' | 'registerVisibleItem' | 'inputValue'
+  'getItemProps' | 'registerVisibleItem'
 > &
   Omit<Parameters<AutoCompleteChildrenArgs<T>['getItemProps']>[0], 'index'> & {
     /**
@@ -36,7 +36,6 @@ function Row<T extends Item>({
   style,
   itemSize,
   isHighlighted,
-  inputValue,
   getItemProps,
   registerVisibleItem,
 }: Props<T>) {
@@ -66,7 +65,7 @@ function Row<T extends Item>({
       {...itemProps}
     >
       <InteractionStateLayer isHovered={isHighlighted} />
-      {typeof item.label === 'function' ? item.label({inputValue}) : item.label}
+      {item.label}
     </AutoCompleteItem>
   );
 }


### PR DESCRIPTION
The dropdown item label is not used as a render function anywhere including the type, this is the last typescript error for react 18.

part of https://github.com/getsentry/frontend-tsc/issues/22