### PR TITLE
ref(daily summary): Iterate through release projects to find new groups

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -94,7 +94,7 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
                         continue
 
                     release_text = self.linkify_release(release, project.organization)
-                    for error in errors[0:3]:
+                    for error in errors:
                         linked_issue_title = self.linkify_error_title(error)
                         release_text += f"• :new: {linked_issue_title}\n"
                         fields.append(self.make_field(release_text))

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -245,7 +245,9 @@ def build_summary_data(
                     if new_groups_in_release:
                         project_ctx.new_in_release[release.id] = [
                             group for group in new_groups_in_release
-                        ]
+                        ][
+                            :3
+                        ]  # limit to 3 issues per release
 
             new_in_release = json.dumps([group for group in project_ctx.new_in_release])
             logger.info(

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -243,9 +243,9 @@ def build_summary_data(
                         project=project, first_release=release
                     )
                     if new_groups_in_release:
-                        project_ctx.new_in_release = {
-                            release.id: [group for group in new_groups_in_release]
-                        }
+                        project_ctx.new_in_release[release.id] = [
+                            group for group in new_groups_in_release
+                        ]
 
             new_in_release = json.dumps([group for group in project_ctx.new_in_release])
             logger.info(

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -237,12 +237,15 @@ def build_summary_data(
                 "release_id", flat=True
             )
             releases = Release.objects.filter(id__in=release_projects, date_added__gte=ctx.end)
-            for release in releases[:2]:  # or whatever we limit this to
-                new_groups_in_release = Group.objects.filter(project=project, first_release=release)
-                if new_groups_in_release:
-                    project_ctx.new_in_release = {
-                        release.id: [group for group in new_groups_in_release]
-                    }
+            for release in releases:
+                if len(project_ctx.new_in_release) < 2:  # or whatever we limit this to
+                    new_groups_in_release = Group.objects.filter(
+                        project=project, first_release=release
+                    )
+                    if new_groups_in_release:
+                        project_ctx.new_in_release = {
+                            release.id: [group for group in new_groups_in_release]
+                        }
 
             new_in_release = json.dumps([group for group in project_ctx.new_in_release])
             logger.info(

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -217,7 +217,7 @@ class DailySummaryTest(
             mock_prepare_summary_data.delay.call_count == 1
         )  # note this didn't fire again, it just didn't increase from before
 
-    def test_build_summary_data_only(self):
+    def test_build_summary_data(self):
         self.populate_event_data()
 
         # add another release to make sure new issues in multiple releases show up


### PR DESCRIPTION
New issues in releases that went out in the last 24 hours are not populating for the daily summary even though we _do_ have issues first seen in new releases ([Redash query](https://redash.getsentry.net/queries/6316/source) that mimics the django query), but perhaps since it's being limited to the first 2 in the list it just never happens to have new groups in those. This PR changes it so it loops over new releases until it finds 2 (or less) that have groups first seen in them.

Hopefully closes https://github.com/getsentry/team-core-product-foundations/issues/164