### PR TITLE
fix(ui): Prevent guides from updating state before mount

### DIFF
--- a/static/app/components/assistant/guideAnchor.tsx
+++ b/static/app/components/assistant/guideAnchor.tsx
@@ -83,18 +83,20 @@ class BaseGuideAnchor extends Component<Props, State> {
   componentDidMount() {
     const {target} = this.props;
     registerAnchor(target);
+    this.unsubscribe = GuideStore.listen(
+      (data: GuideStoreState) => this.onGuideStateChange(data),
+      undefined
+    );
   }
 
   componentWillUnmount() {
     const {target} = this.props;
     unregisterAnchor(target);
-    this.unsubscribe();
+    this.unsubscribe?.();
   }
 
-  unsubscribe = GuideStore.listen(
-    (data: GuideStoreState) => this.onGuideStateChange(data),
-    undefined
-  );
+  // TODO(TS): Reflux returns "Function" instead of () => void
+  unsubscribe: Function | undefined;
 
   onGuideStateChange(data: GuideStoreState) {
     const active =


### PR DESCRIPTION
The guidestore previously was listening to state updates before the component had mounted, causing react 18 tests to error. We can wait until the component mounts to listen.

This was for some reason causing tests to fail in `static/app/views/issueList/overview.actions.spec.tsx`

```
Warning: Can't perform a React state update on a component that hasn't mounted yet. This indicates that you have a side-effect in your render function that asynchronously later calls tries to update the component. Move this work to useEffect instead.
        at BaseGuideAnchor (/Users/scooper/work/sentry/static/app/components/assistant/guideAnchor.tsx:74:1)
        at disabled (/Users/scooper/work/sentry/static/app/components/assistant/guideAnchor.tsx:261:23)
        at a
        at Link (/Users/scooper/work/sentry/node_modules/create-react-class/factory.js:823:37)
        at disabled (/Users/scooper/work/sentry/static/app/components/links/link.tsx:44:20)
        at commitMutationEffectsOnFiber (/Users/scooper/work/sentry/node_modules/react-dom/cjs/react-dom.development.js:24332:9)
        at children (/Users/scooper/work/sentry/static/app/components/tabs/tab.tsx:59:7)
        at li
        at commitMutationEffectsOnFiber (/Users/scooper/work/sentry/node_modules/react-dom/cjs/react-dom.development.js:24332:9)
        at item (/Users/scooper/work/sentry/static/app/components/tabs/tab.tsx:46:4)
        at ul
        at commitMutationEffectsOnFiber (/Users/scooper/work/sentry/node_modules/react-dom/cjs/react-dom.development.js:24332:9)
        at div
```

part of https://github.com/getsentry/frontend-tsc/issues/22