### PR TITLE
feat(metrics): Add formulas to dashboard

### DIFF
--- a/static/app/utils/metrics/dashboard.spec.tsx
+++ b/static/app/utils/metrics/dashboard.spec.tsx
@@ -34,7 +34,7 @@ describe('convertToDashboardWidget', () => {
           columns: ['project'],
           fields: ['p95(c:custom/login@second)'],
           conditions: 'event.type:transaction',
-          orderby: 'desc',
+          orderby: undefined,
         },
       ],
     });
@@ -65,7 +65,7 @@ describe('convertToDashboardWidget', () => {
           columns: [],
           fields: ['p95(d:transactions/measurements.duration@second)'],
           conditions: '',
-          orderby: 'desc',
+          orderby: undefined,
         },
       ],
     });
@@ -100,7 +100,7 @@ describe('convertToDashboardWidget', () => {
           columns: [],
           fields: ['p95(d:transactions/measurements.duration@second)'],
           conditions: '',
-          orderby: 'desc',
+          orderby: undefined,
         },
         {
           name: '',
@@ -108,7 +108,7 @@ describe('convertToDashboardWidget', () => {
           columns: [],
           fields: ['equation|$b / 2'],
           conditions: '',
-          orderby: 'desc',
+          orderby: undefined,
         },
       ],
     });
@@ -140,7 +140,7 @@ describe('getWidgetQuery', () => {
       columns: [],
       fields: ['sum(d:custom/sentry.events.symbolicator.query_task@second)'],
       conditions: 'status = "success"',
-      orderby: 'desc',
+      orderby: undefined,
     };
 
     expect(getWidgetQuery(metricsQuery)).toEqual(expectedWidgetQuery);
@@ -158,7 +158,7 @@ describe('toDisplayType', () => {
   });
 
   it('should return DisplayType.LINE if the displayType is invalid or unsupported', () => {
-    expect(DisplayType.LINE).toEqual(toDisplayType('desc'));
+    expect(DisplayType.LINE).toEqual(toDisplayType(undefined));
     expect(DisplayType.LINE).toEqual(toDisplayType(''));
   });
 });

--- a/static/app/utils/metrics/dashboard.spec.tsx
+++ b/static/app/utils/metrics/dashboard.spec.tsx
@@ -17,6 +17,7 @@ describe('convertToDashboardWidget', () => {
             query: 'event.type:transaction',
             mri: 'c:custom/login@second',
             op: 'p95',
+            id: 1,
           },
         ],
         MetricDisplayType.AREA
@@ -28,12 +29,12 @@ describe('convertToDashboardWidget', () => {
       limit: 10,
       queries: [
         {
-          name: '',
+          name: '1',
           aggregates: ['p95(c:custom/login@second)'],
           columns: ['project'],
           fields: ['p95(c:custom/login@second)'],
           conditions: 'event.type:transaction',
-          orderby: undefined,
+          orderby: 'desc',
         },
       ],
     });
@@ -64,7 +65,50 @@ describe('convertToDashboardWidget', () => {
           columns: [],
           fields: ['p95(d:transactions/measurements.duration@second)'],
           conditions: '',
-          orderby: undefined,
+          orderby: 'desc',
+        },
+      ],
+    });
+  });
+
+  it('should convert a metrics formula to a dashboard widget (transaction mri, with grouping)', () => {
+    expect(
+      convertToDashboardWidget(
+        [
+          {
+            id: 0,
+            groupBy: [],
+            query: '',
+            mri: 'd:transactions/measurements.duration@second',
+            op: 'p95',
+          },
+          {
+            formula: '$b / 2',
+          },
+        ],
+        MetricDisplayType.BAR
+      )
+    ).toEqual({
+      title: '',
+      displayType: DisplayType.BAR,
+      widgetType: 'custom-metrics',
+      limit: 10,
+      queries: [
+        {
+          name: '0',
+          aggregates: ['p95(d:transactions/measurements.duration@second)'],
+          columns: [],
+          fields: ['p95(d:transactions/measurements.duration@second)'],
+          conditions: '',
+          orderby: 'desc',
+        },
+        {
+          name: '',
+          aggregates: ['equation|$b / 2'],
+          columns: [],
+          fields: ['equation|$b / 2'],
+          conditions: '',
+          orderby: 'desc',
         },
       ],
     });
@@ -96,7 +140,7 @@ describe('getWidgetQuery', () => {
       columns: [],
       fields: ['sum(d:custom/sentry.events.symbolicator.query_task@second)'],
       conditions: 'status = "success"',
-      orderby: undefined,
+      orderby: 'desc',
     };
 
     expect(getWidgetQuery(metricsQuery)).toEqual(expectedWidgetQuery);
@@ -114,7 +158,7 @@ describe('toDisplayType', () => {
   });
 
   it('should return DisplayType.LINE if the displayType is invalid or unsupported', () => {
-    expect(DisplayType.LINE).toEqual(toDisplayType(undefined));
+    expect(DisplayType.LINE).toEqual(toDisplayType('desc'));
     expect(DisplayType.LINE).toEqual(toDisplayType(''));
   });
 });

--- a/static/app/utils/metrics/dashboard.tsx
+++ b/static/app/utils/metrics/dashboard.tsx
@@ -43,7 +43,8 @@ export function getWidgetQuery(metricsQuery: MetricsQuery & {id?: number}): Widg
     columns: metricsQuery.groupBy ?? [],
     fields: [field],
     conditions: metricsQuery.query ?? '',
-    orderby: 'desc',
+    // @ts-expect-error TODO: change type of orderby
+    orderby: undefined,
   };
 }
 
@@ -54,7 +55,8 @@ export function getWidgetEquation(equation: string): WidgetQuery {
     columns: [],
     fields: [`equation|${equation}`],
     conditions: '',
-    orderby: 'desc',
+    // @ts-expect-error TODO: change type of orderby
+    orderby: undefined,
   };
 }
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -41,6 +41,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import withProjects from 'sentry/utils/withProjects';
+import {defaultMetricWidget} from 'sentry/views/dashboards/metrics/utils';
 import {
   cloneDashboard,
   getCurrentPageFilters,
@@ -54,7 +55,6 @@ import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {MetricsDashboardContextProvider} from 'sentry/views/dashboards/widgetCard/metricsContext';
 import {MetricsDataSwitcherAlert} from 'sentry/views/performance/landing/metricsDataSwitcherAlert';
 
-import {defaultMetricWidget} from '../../utils/metrics/dashboard';
 import {generatePerformanceEventView} from '../performance/data';
 import {MetricsDataSwitcher} from '../performance/landing/metricsDataSwitcher';
 import {DiscoverQueryPageSource} from '../performance/utils';
@@ -497,13 +497,12 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   handleAddMetricWidget = (layout?: Widget['layout']) => {
-    const {dashboard, selection, router, location} = this.props;
+    const {dashboard, router, location} = this.props;
 
     const widgetCopy = cloneDeep(
       assignTempId({
         layout,
-        ...defaultMetricWidget(selection),
-        widgetType: WidgetType.METRICS,
+        ...defaultMetricWidget(),
       })
     );
 

--- a/static/app/views/dashboards/metrics/utils.tsx
+++ b/static/app/views/dashboards/metrics/utils.tsx
@@ -236,6 +236,23 @@ export function getMetricWidgetTitle(queries: DashboardMetricsExpression[]) {
     .join(', ');
 }
 
+export function defaultMetricWidget(): Widget {
+  return expressionsToWidget(
+    [
+      {
+        id: 0,
+        type: MetricQueryType.QUERY,
+        mri: 'd:transactions/duration@millisecond',
+        op: 'avg',
+        query: '',
+        orderBy: 'desc',
+      },
+    ],
+    '',
+    DisplayType.LINE
+  );
+}
+
 export function filterQueriesByDisplayType(
   queries: DashboardMetricsQuery[],
   displayType: DisplayType

--- a/static/app/views/ddm/formulaInput.tsx
+++ b/static/app/views/ddm/formulaInput.tsx
@@ -140,6 +140,7 @@ export function FormulaInput({
         monospace
         hasError={showErrors && errors.length > 0}
         defaultValue={value}
+        placeholder="e.g. (a / b) * 100"
         onChange={e => {
           setValue(e.target.value);
           handleChange(e);

--- a/static/app/views/ddm/metricFormulaContextMenu.tsx
+++ b/static/app/views/ddm/metricFormulaContextMenu.tsx
@@ -1,23 +1,40 @@
 import {useMemo} from 'react';
+import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
+import Feature from 'sentry/components/acl/feature';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {IconClose, IconCopy, IconEllipsis} from 'sentry/icons';
+import {IconClose, IconCopy, IconDashboard, IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {isCustomMeasurement} from 'sentry/utils/metrics';
 import {hasCustomMetrics} from 'sentry/utils/metrics/features';
+import type {MetricFormulaWidgetParams} from 'sentry/utils/metrics/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useDDMContext} from 'sentry/views/ddm/context';
+import {useCreateDashboard} from 'sentry/views/ddm/useCreateDashboard';
+import type {useFormulaDependencies} from 'sentry/views/ddm/utils/useFormulaDependencies';
 
 type ContextMenuProps = {
+  formulaDependencies: ReturnType<typeof useFormulaDependencies>;
+  formulaWidget: MetricFormulaWidgetParams;
   widgetIndex: number;
 };
 
-export function MetricFormulaContextMenu({widgetIndex}: ContextMenuProps) {
+export function MetricFormulaContextMenu({
+  widgetIndex,
+  formulaWidget,
+  formulaDependencies,
+}: ContextMenuProps) {
   const organization = useOrganization();
   const {removeWidget, duplicateWidget, widgets} = useDDMContext();
   const canDelete = widgets.length > 1;
+
+  const createDashboardWidget = useCreateDashboardWidget(
+    formulaWidget,
+    formulaDependencies
+  );
 
   const items = useMemo<MenuItemProps[]>(
     () => [
@@ -34,6 +51,35 @@ export function MetricFormulaContextMenu({widgetIndex}: ContextMenuProps) {
         },
       },
       {
+        leadingItems: [<IconDashboard key="icon" />],
+        key: 'add-dashboard',
+        label: (
+          <Feature
+            organization={organization}
+            hookName="feature-disabled:dashboards-edit"
+            features="dashboards-edit"
+          >
+            {({hasFeature}) => (
+              <AddToDashboardItem disabled={!hasFeature}>
+                {t('Add to Dashboard')}
+              </AddToDashboardItem>
+            )}
+          </Feature>
+        ),
+        disabled: !createDashboardWidget,
+        onAction: () => {
+          if (!organization.features.includes('dashboards-edit')) {
+            return;
+          }
+          trackAnalytics('ddm.add-to-dashboard', {
+            organization,
+            source: 'widget',
+          });
+          Sentry.metrics.increment('ddm.widget.dashboard');
+          createDashboardWidget?.();
+        },
+      },
+      {
         leadingItems: [<IconClose key="icon" />],
         key: 'delete',
         label: t('Remove Query'),
@@ -44,7 +90,14 @@ export function MetricFormulaContextMenu({widgetIndex}: ContextMenuProps) {
         },
       },
     ],
-    [canDelete, organization, duplicateWidget, widgetIndex, removeWidget]
+    [
+      organization,
+      createDashboardWidget,
+      canDelete,
+      duplicateWidget,
+      widgetIndex,
+      removeWidget,
+    ]
   );
 
   if (!hasCustomMetrics(organization)) {
@@ -64,3 +117,23 @@ export function MetricFormulaContextMenu({widgetIndex}: ContextMenuProps) {
     />
   );
 }
+
+export function useCreateDashboardWidget(
+  formulaWidget: MetricFormulaWidgetParams,
+  formulaDependencies: ReturnType<typeof useFormulaDependencies>
+) {
+  const {dependencies, isError} = formulaDependencies[formulaWidget.id];
+
+  const widgetArray = useMemo(() => [formulaWidget], [formulaWidget]);
+  const createDashboard = useCreateDashboard(widgetArray, formulaDependencies, false);
+
+  if (!formulaWidget.formula || isError || dependencies.some(isCustomMeasurement)) {
+    return undefined;
+  }
+
+  return createDashboard;
+}
+
+const AddToDashboardItem = styled('div')<{disabled: boolean}>`
+  color: ${p => (p.disabled ? p.theme.disabled : p.theme.textColor)};
+`;

--- a/static/app/views/ddm/pageHeaderActions.tsx
+++ b/static/app/views/ddm/pageHeaderActions.tsx
@@ -26,6 +26,7 @@ import {useDDMContext} from 'sentry/views/ddm/context';
 import {getCreateAlert} from 'sentry/views/ddm/metricQueryContextMenu';
 import {QuerySymbol} from 'sentry/views/ddm/querySymbol';
 import {useCreateDashboard} from 'sentry/views/ddm/useCreateDashboard';
+import {useFormulaDependencies} from 'sentry/views/ddm/utils/useFormulaDependencies';
 
 interface Props {
   addCustomMetric: () => void;
@@ -35,7 +36,7 @@ interface Props {
 export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Props) {
   const router = useRouter();
   const organization = useOrganization();
-  const createDashboard = useCreateDashboard();
+  const formulaDependencies = useFormulaDependencies();
   const {
     isDefaultQuery,
     setDefaultQuery,
@@ -44,6 +45,11 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
     selectedWidgetIndex,
     isMultiChartMode,
   } = useDDMContext();
+  const createDashboard = useCreateDashboard(
+    widgets,
+    formulaDependencies,
+    isMultiChartMode
+  );
 
   const handleToggleDefaultQuery = useCallback(() => {
     if (isDefaultQuery) {

--- a/static/app/views/ddm/queries.tsx
+++ b/static/app/views/ddm/queries.tsx
@@ -26,6 +26,7 @@ import {MetricFormulaContextMenu} from 'sentry/views/ddm/metricFormulaContextMen
 import {MetricQueryContextMenu} from 'sentry/views/ddm/metricQueryContextMenu';
 import {QueryBuilder} from 'sentry/views/ddm/queryBuilder';
 import {getQuerySymbol, QuerySymbol} from 'sentry/views/ddm/querySymbol';
+import {useFormulaDependencies} from 'sentry/views/ddm/utils/useFormulaDependencies';
 
 export function Queries() {
   const {
@@ -42,6 +43,7 @@ export function Queries() {
 
   const organization = useOrganization();
   const {selection} = usePageFilters();
+  const formulaDependencies = useFormulaDependencies();
 
   // Make sure all charts are connected to the same group whenever the widgets definition changes
   useLayoutEffect(() => {
@@ -108,6 +110,7 @@ export function Queries() {
                 showQuerySymbols={showQuerySymbols}
                 isSelected={isMultiChartMode && index === selectedWidgetIndex}
                 canBeHidden={visibleWidgets.length > 1}
+                formulaDependencies={formulaDependencies}
               />
             )}
           </Row>
@@ -222,6 +225,7 @@ function Query({
 interface FormulaProps {
   availableVariables: Set<string>;
   canBeHidden: boolean;
+  formulaDependencies: ReturnType<typeof useFormulaDependencies>;
   index: number;
   isSelected: boolean;
   onChange: (index: number, data: Partial<MetricWidgetQueryParams>) => void;
@@ -239,6 +243,7 @@ function Formula({
   canBeHidden,
   isSelected,
   showQuerySymbols,
+  formulaDependencies,
 }: FormulaProps) {
   const handleToggle = useCallback(() => {
     onToggleVisibility(index);
@@ -270,7 +275,11 @@ function Formula({
         value={widget.formula}
         onChange={formula => handleChange({formula})}
       />
-      <MetricFormulaContextMenu widgetIndex={index} />
+      <MetricFormulaContextMenu
+        widgetIndex={index}
+        formulaWidget={widget}
+        formulaDependencies={formulaDependencies}
+      />
     </QueryWrapper>
   );
 }

--- a/static/app/views/ddm/scratchpad.tsx
+++ b/static/app/views/ddm/scratchpad.tsx
@@ -6,12 +6,8 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {Field} from 'sentry/components/ddm/metricSamplesTable';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {getMetricsCorrelationSpanUrl, unescapeMetricsFormula} from 'sentry/utils/metrics';
-import {
-  MetricQueryType,
-  type MetricQueryWidgetParams,
-  type MetricWidgetQueryParams,
-} from 'sentry/utils/metrics/types';
+import {getMetricsCorrelationSpanUrl} from 'sentry/utils/metrics';
+import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
 import type {MetricsQueryApiQueryParams} from 'sentry/utils/metrics/useMetricsQuery';
 import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -19,37 +15,11 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {DDM_CHART_GROUP, MIN_WIDGET_WIDTH} from 'sentry/views/ddm/constants';
 import {useDDMContext} from 'sentry/views/ddm/context';
-import {getEquationSymbol} from 'sentry/views/ddm/equationSymbol copy';
-import {parseFormula} from 'sentry/views/ddm/formulaParser/parser';
-import {type TokenList, TokenType} from 'sentry/views/ddm/formulaParser/types';
-import {getQuerySymbol} from 'sentry/views/ddm/querySymbol';
 import {useGetCachedChartPalette} from 'sentry/views/ddm/utils/metricsChartPalette';
+import {useFormulaDependencies} from 'sentry/views/ddm/utils/useFormulaDependencies';
+import {widgetToQuery} from 'sentry/views/ddm/utils/widgetToQuery';
 
 import {MetricWidget} from './widget';
-
-interface WidgetDependencies {
-  dependencies: MetricsQueryApiQueryParams[];
-  isError: boolean;
-}
-
-function widgetToQuery(
-  widget: MetricWidgetQueryParams,
-  isQueryOnly = false
-): MetricsQueryApiQueryParams {
-  return widget.type === MetricQueryType.FORMULA
-    ? {
-        name: getEquationSymbol(widget.id),
-        formula: widget.formula,
-      }
-    : {
-        name: getQuerySymbol(widget.id),
-        mri: widget.mri,
-        op: widget.op,
-        groupBy: widget.groupBy,
-        query: widget.query,
-        isQueryOnly: isQueryOnly || widget.isHidden,
-      };
-}
 
 export function MetricScratchpad() {
   const {
@@ -107,54 +77,7 @@ export function MetricScratchpad() {
       ? StyledSingleWidgetWrapper
       : StyledMetricDashboard;
 
-  const queriesLookup = useMemo(() => {
-    const lookup = new Map<string, MetricQueryWidgetParams>();
-    widgets.forEach(widget => {
-      if (widget.type === MetricQueryType.QUERY) {
-        lookup.set(getQuerySymbol(widget.id), widget);
-      }
-    });
-    return lookup;
-  }, [widgets]);
-
-  const getFormulaQueryDependencies = useCallback(
-    (formula: string): WidgetDependencies => {
-      let tokens: TokenList = [];
-
-      try {
-        tokens = parseFormula(unescapeMetricsFormula(formula));
-      } catch {
-        // We should not end up here, but if we do, we should not crash the UI
-        return {dependencies: [], isError: true};
-      }
-
-      const dependencies: MetricsQueryApiQueryParams[] = [];
-      let isError = false;
-
-      tokens.forEach(token => {
-        if (token.type === TokenType.VARIABLE) {
-          const widget = queriesLookup.get(token.content);
-          if (widget) {
-            dependencies.push(widgetToQuery(widget, true));
-          } else {
-            isError = true;
-          }
-        }
-      });
-
-      return {dependencies, isError};
-    },
-    [queriesLookup]
-  );
-
-  const formulaDependencies = useMemo(() => {
-    return widgets.reduce((acc: Record<number, WidgetDependencies>, widget) => {
-      if (widget.type === MetricQueryType.FORMULA) {
-        acc[widget.id] = getFormulaQueryDependencies(widget.formula);
-      }
-      return acc;
-    }, {});
-  }, [getFormulaQueryDependencies, widgets]);
+  const formulaDependencies = useFormulaDependencies();
 
   const filteredWidgets = useMemo(() => {
     return widgets.filter(
@@ -233,14 +156,16 @@ function MultiChartWidgetQueries({
   children,
 }: {
   children: (queries: MetricsQueryApiQueryParams[]) => JSX.Element;
-  formulaDependencies: Record<number, WidgetDependencies>;
+  formulaDependencies: ReturnType<typeof useFormulaDependencies>;
   widget: MetricWidgetQueryParams;
 }) {
   const queries = useMemo(() => {
     return [
       widgetToQuery(widget),
       ...(widget.type === MetricQueryType.FORMULA
-        ? formulaDependencies[widget.id]?.dependencies
+        ? formulaDependencies[widget.id]?.dependencies?.map(dependency =>
+            widgetToQuery(dependency, true)
+          )
         : []),
     ];
   }, [widget, formulaDependencies]);

--- a/static/app/views/ddm/useCreateDashboard.tsx
+++ b/static/app/views/ddm/useCreateDashboard.tsx
@@ -2,31 +2,70 @@ import {useMemo} from 'react';
 
 import {openCreateDashboardFromScratchpad} from 'sentry/actionCreators/modal';
 import {convertToDashboardWidget} from 'sentry/utils/metrics/dashboard';
-import {MetricQueryType, type MetricQueryWidgetParams} from 'sentry/utils/metrics/types';
+import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
-import {useDDMContext} from 'sentry/views/ddm/context';
+import type {Widget} from 'sentry/views/dashboards/types';
+import type {useFormulaDependencies} from 'sentry/views/ddm/utils/useFormulaDependencies';
 
-export function useCreateDashboard() {
+export function useCreateDashboard(
+  widgets: MetricWidgetQueryParams[],
+  formulaDependencies: ReturnType<typeof useFormulaDependencies>,
+  isMultiChartMode: boolean
+) {
   const router = useRouter();
   const organization = useOrganization();
-  const {widgets, isMultiChartMode} = useDDMContext();
   const {selection} = usePageFilters();
 
   const dashboardWidgets = useMemo(() => {
-    // TODO(aknaus): Remove filtering once dashboard supports metrics formulas
-    const supportedQueries = widgets.filter(
-      widget => widget.type === MetricQueryType.QUERY
-    ) as MetricQueryWidgetParams[];
     if (!isMultiChartMode) {
-      return [convertToDashboardWidget(supportedQueries, widgets[0].displayType)];
+      const queryIdsInArray = new Set<number>();
+      const widgetsWithDependencies = widgets.reduce<MetricWidgetQueryParams[]>(
+        (acc, widget) => {
+          if (widget.type === MetricQueryType.FORMULA) {
+            const {dependencies, isError} = formulaDependencies[widget.id];
+            if (isError) {
+              return acc;
+            }
+            // Only add dependencies that are not already in the list of widgets
+            const filteredDependencies: MetricWidgetQueryParams[] = [];
+            dependencies.forEach(dependency => {
+              if (!queryIdsInArray.has(dependency.id)) {
+                filteredDependencies.push(dependency);
+                queryIdsInArray.add(dependency.id);
+              }
+            });
+
+            return [...filteredDependencies, ...acc, widget];
+          }
+
+          if (queryIdsInArray.has(widget.id)) {
+            return acc;
+          }
+          queryIdsInArray.add(widget.id);
+          return [...acc, widget];
+        },
+        []
+      );
+      return [convertToDashboardWidget(widgetsWithDependencies, widgets[0].displayType)];
     }
 
-    return supportedQueries.map(query =>
-      convertToDashboardWidget([query], query.displayType)
-    );
-  }, [widgets, isMultiChartMode]);
+    return widgets
+      .map(widget => {
+        if (widget.type !== MetricQueryType.FORMULA) {
+          return convertToDashboardWidget([widget], widget.displayType);
+        }
+
+        const {dependencies, isError} = formulaDependencies[widget.id];
+
+        if (isError) {
+          return null;
+        }
+        return convertToDashboardWidget([...dependencies, widget], widget.displayType);
+      })
+      .filter((widget): widget is Widget => widget !== null);
+  }, [isMultiChartMode, widgets, formulaDependencies]);
 
   return useMemo(() => {
     return function () {

--- a/static/app/views/ddm/utils/useFormulaDependencies.tsx
+++ b/static/app/views/ddm/utils/useFormulaDependencies.tsx
@@ -1,0 +1,67 @@
+import {useCallback, useMemo} from 'react';
+
+import {unescapeMetricsFormula} from 'sentry/utils/metrics';
+import {MetricQueryType, type MetricQueryWidgetParams} from 'sentry/utils/metrics/types';
+import {useDDMContext} from 'sentry/views/ddm/context';
+import {parseFormula} from 'sentry/views/ddm/formulaParser/parser';
+import {type TokenList, TokenType} from 'sentry/views/ddm/formulaParser/types';
+import {getQuerySymbol} from 'sentry/views/ddm/querySymbol';
+
+interface FormulaDependencies {
+  dependencies: MetricQueryWidgetParams[];
+  isError: boolean;
+}
+
+export function useFormulaDependencies() {
+  const {widgets} = useDDMContext();
+  const queriesLookup = useMemo(() => {
+    const lookup = new Map<string, MetricQueryWidgetParams>();
+    widgets.forEach(widget => {
+      if (widget.type === MetricQueryType.QUERY) {
+        lookup.set(getQuerySymbol(widget.id), widget);
+      }
+    });
+    return lookup;
+  }, [widgets]);
+
+  const getFormulaQueryDependencies = useCallback(
+    (formula: string): FormulaDependencies => {
+      let tokens: TokenList = [];
+
+      try {
+        tokens = parseFormula(unescapeMetricsFormula(formula));
+      } catch {
+        // We should not end up here, but if we do, we should not crash the UI
+        return {dependencies: [], isError: true};
+      }
+
+      const dependencies: MetricQueryWidgetParams[] = [];
+      let isError = false;
+
+      tokens.forEach(token => {
+        if (token.type === TokenType.VARIABLE) {
+          const widget = queriesLookup.get(token.content);
+          if (widget) {
+            dependencies.push(widget);
+          } else {
+            isError = true;
+          }
+        }
+      });
+
+      return {dependencies, isError};
+    },
+    [queriesLookup]
+  );
+
+  const formulaDependencies = useMemo(() => {
+    return widgets.reduce((acc: Record<number, FormulaDependencies>, widget) => {
+      if (widget.type === MetricQueryType.FORMULA) {
+        acc[widget.id] = getFormulaQueryDependencies(widget.formula);
+      }
+      return acc;
+    }, {});
+  }, [getFormulaQueryDependencies, widgets]);
+
+  return formulaDependencies;
+}

--- a/static/app/views/ddm/utils/widgetToQuery.tsx
+++ b/static/app/views/ddm/utils/widgetToQuery.tsx
@@ -1,0 +1,23 @@
+import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
+import type {MetricsQueryApiQueryParams} from 'sentry/utils/metrics/useMetricsQuery';
+import {getEquationSymbol} from 'sentry/views/ddm/equationSymbol copy';
+import {getQuerySymbol} from 'sentry/views/ddm/querySymbol';
+
+export function widgetToQuery(
+  widget: MetricWidgetQueryParams,
+  isQueryOnly = false
+): MetricsQueryApiQueryParams {
+  return widget.type === MetricQueryType.FORMULA
+    ? {
+        name: getEquationSymbol(widget.id),
+        formula: widget.formula,
+      }
+    : {
+        name: getQuerySymbol(widget.id),
+        mri: widget.mri,
+        op: widget.op,
+        groupBy: widget.groupBy,
+        query: widget.query,
+        isQueryOnly: isQueryOnly || widget.isHidden,
+      };
+}


### PR DESCRIPTION
Enable adding formulas to dashboards from the metrics page.
Note: As dashboard do not support hidden queries yet, all queries that are used in a formula will be visible in the resulting chart for now. 

- closes https://github.com/getsentry/sentry/issues/66674