### PR TITLE
ref(projconfigs): Use transaction name instead of op

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -306,7 +306,7 @@ def get_project_config(
     with sentry_sdk.push_scope() as scope:
         scope.set_tag("project", project.id)
         with (
-            sentry_sdk.start_transaction(op="get_project_config"),
+            sentry_sdk.start_transaction(name="get_project_config"),
             metrics.timer("relay.config.get_project_config.duration"),
         ):
             return _get_project_config(project, full_config=full_config, project_keys=project_keys)


### PR DESCRIPTION
While spans are easier to find with `op`, transactions are easier to find with `name`.