### PR TITLE
ref(event-tags): Allow tags tree to switch to single column when space constrained

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -5,7 +5,6 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {EventTags} from 'sentry/components/events/eventTags';
-import {COLUMN_COUNT} from 'sentry/components/events/eventTags/eventTagsTree';
 
 describe('EventTagsTree', function () {
   const {organization, project, router} = initializeOrg();
@@ -86,7 +85,7 @@ describe('EventTagsTree', function () {
     expect(rows).toHaveLength(expectedRowCount);
 
     const columns = screen.queryAllByTestId('tag-tree-column');
-    expect(columns).toHaveLength(COLUMN_COUNT);
+    expect(columns.length).toBeLessThanOrEqual(2);
 
     const linkDropdowns = screen.queryAllByLabelText('Tag Actions Menu');
     expect(linkDropdowns).toHaveLength(tags.length);

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -358,7 +358,7 @@ const TreeGarden = styled('div')<{columnCount: number}>`
 
 const TreeColumn = styled('div')`
   display: grid;
-  grid-template-columns: minmax(auto, 150px) 1fr;
+  grid-template-columns: auto 1fr;
   grid-column-gap: ${space(3)};
   &:not(:first-child) {
     border-left: 1px solid ${p => p.theme.gray200};

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -155,12 +155,12 @@ function TagTreeRow({
           preventOverflowOptions={{padding: 4}}
           className={isVisible ? '' : 'invisible'}
           position="bottom-end"
+          size="xs"
           onOpenChange={isOpen => setIsVisible(isOpen)}
           triggerProps={{
             'aria-label': t('Tag Actions Menu'),
             icon: <IconEllipsis />,
             showChevron: false,
-            size: 'xs',
             className: 'tag-button',
           }}
           items={[
@@ -438,7 +438,6 @@ const TreeSearchKey = styled('span')`
 const TreeValueDropdown = styled(DropdownMenu)`
   margin: 1px;
   height: 20px;
-  font-size: inherit;
   .tag-button {
     height: 20px;
     min-height: 20px;

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -358,7 +358,7 @@ const TreeGarden = styled('div')<{columnCount: number}>`
 
 const TreeColumn = styled('div')`
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: minmax(auto, 175px) 1fr;
   grid-column-gap: ${space(3)};
   &:not(:first-child) {
     border-left: 1px solid ${p => p.theme.gray200};

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -21,7 +21,6 @@ export default function HighlightsDataSection({event}: HighlightsSectionProps) {
     <EventDataSection
       title={t('Highlighted Event Data')}
       data-test-id="highlighted-event-data"
-      guideTarget="highlighted-event-data"
       type="highlighted-event-data"
     >
       <ContextSummary event={event} />

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -1,0 +1,30 @@
+import ContextSummary from 'sentry/components/events/contextSummary';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
+import {t} from 'sentry/locale';
+import type {Event, Group, Project} from 'sentry/types';
+import {objectIsEmpty} from 'sentry/utils';
+
+interface HighlightsSectionProps {
+  event: Event;
+  group: Group;
+  project: Project;
+}
+
+export default function HighlightsDataSection({event}: HighlightsSectionProps) {
+  const hasNewTagsUI = useHasNewTagsUI();
+  if (!hasNewTagsUI || objectIsEmpty(event.contexts)) {
+    return null;
+  }
+
+  return (
+    <EventDataSection
+      title={t('Highlighted Event Data')}
+      data-test-id="highlighted-event-data"
+      guideTarget="highlighted-event-data"
+      type="highlighted-event-data"
+    >
+      <ContextSummary event={event} />
+    </EventDataSection>
+  );
+}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {CommitRow} from 'sentry/components/commitRow';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EventContexts} from 'sentry/components/events/contexts';
-import ContextSummary from 'sentry/components/events/contextSummary';
 import {EventDevice} from 'sentry/components/events/device';
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
@@ -26,6 +25,7 @@ import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
+import HighlightsDataSection from 'sentry/components/events/highlights/highlightsDataSection';
 import {ActionableItems} from 'sentry/components/events/interfaces/crashContent/exception/actionableItems';
 import {actionableItemsEnabled} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
 import {CronTimelineSection} from 'sentry/components/events/interfaces/crons/cronTimelineSection';
@@ -42,7 +42,6 @@ import type {Event, Group, Project} from 'sentry/types';
 import {IssueCategory, IssueType} from 'sentry/types';
 import type {EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
-import {objectIsEmpty} from 'sentry/utils';
 import {shouldShowCustomErrorResourceConfig} from 'sentry/utils/issueTypeConfig';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ResourcesAndMaybeSolutions} from 'sentry/views/issueDetails/resourcesAndMaybeSolutions';
@@ -130,16 +129,7 @@ function DefaultGroupEventDetailsContent({
           project={project}
         />
       )}
-      {hasNewTagsUI && !objectIsEmpty(event.contexts) && (
-        <EventDataSection
-          title={t('Highlighted Event Data')}
-          data-test-id="highlighted-event-data"
-          guideTarget="highlighted-event-data"
-          type="highlighted-event-data"
-        >
-          <ContextSummary event={event} />
-        </EventDataSection>
-      )}
+      <HighlightsDataSection event={event} group={group} project={project} />
       {!hasNewTagsUI && (
         <EventTagsAndScreenshot event={event} projectSlug={project.slug} />
       )}


### PR DESCRIPTION
- lowers font size for dropdown
- converts to single column when space constrained (< 700px)
  - this should resolve the appearance on regressed issues
- refactors highlights into its own data section for some future changes