### PR TITLE
ci: Update prettier to run on all js files in addition to ts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+**/tests/**/fixtures/**/*
+fixtures/**/*
+tests/relay_integration/**/*

--- a/api-docs/index.ts
+++ b/api-docs/index.ts
@@ -1,11 +1,10 @@
 /* global process */
 /* eslint-env node */
 /* eslint import/no-unresolved:0 */
-import fs from 'node:fs';
-import path from 'node:path';
-
 import yaml from 'js-yaml';
 import JsonRefs from 'json-refs';
+import fs from 'node:fs';
+import path from 'node:path';
 
 function dictToString(dict) {
   const res = [];

--- a/api-docs/openapi-diff.ts
+++ b/api-docs/openapi-diff.ts
@@ -1,11 +1,10 @@
 /* eslint-env node */
 /* eslint import/no-unresolved:0 */
 
-import fs from 'node:fs';
-import https from 'node:https';
-
 import yaml from 'js-yaml';
 import jsonDiff from 'json-diff';
+import fs from 'node:fs';
+import https from 'node:https';
 
 async function main() {
   const openApiData = await new Promise((resolve, reject) =>

--- a/api-docs/watch.ts
+++ b/api-docs/watch.ts
@@ -3,7 +3,6 @@
 import {spawn} from 'node:child_process';
 import {join} from 'node:path';
 import {stderr, stdout} from 'node:process';
-
 import sane from 'sane';
 
 const watcherPy = sane(join(__dirname, '../src/sentry'));

--- a/build-utils/last-built-plugin.ts
+++ b/build-utils/last-built-plugin.ts
@@ -2,7 +2,6 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-
 import type webpack from 'webpack';
 
 type Options = {

--- a/config/webpack.chartcuterie.config.ts
+++ b/config/webpack.chartcuterie.config.ts
@@ -2,7 +2,6 @@
 
 import childProcess from 'node:child_process';
 import path from 'node:path';
-
 import webpack from 'webpack';
 
 import baseConfig from '../webpack.config';

--- a/package.json
+++ b/package.json
@@ -226,11 +226,11 @@
     "lint:js": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx",
     "lint:css": "stylelint 'static/app/**/*.[jt]sx'",
     "lint:biome": "biome check .",
-    "lint:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.{ts,tsx}\" --check",
+    "lint:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.[jt]s(x)?\" --check",
     "fix": "yarn fix:biome && yarn fix:prettier && yarn fix:eslint",
     "fix:eslint": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx --fix",
     "fix:biome": "biome check . --apply",
-    "fix:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.{ts,tsx}\" --write",
+    "fix:prettier": "prettier \"**/*.md\" \"**/*.yaml\" \"**/*.[jt]s(x)?\" --write",
     "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver",
     "dev-ui": "SENTRY_UI_DEV_ONLY=1 SENTRY_WEBPACK_PROXY_PORT=7999 yarn webpack serve",
     "dev-acceptance": "NO_DEV_SERVER=1 NODE_ENV=development yarn webpack --watch",
@@ -265,7 +265,9 @@
       "last 3 iOS major versions",
       "Firefox ESR"
     ],
-    "test": ["current node"]
+    "test": [
+      "current node"
+    ]
   },
   "volta": {
     "extends": ".volta.json"


### PR DESCRIPTION
We should always treat js,jsx,ts,tsx files the same in our codebase in terms of linting/formatting/etc.

While there shouldn't be any jsx files, and the only js files would be scripts or configs... in case things get added I want the tools to run against them. Also, it simplifies things when trying to figure out what tools are running if the globs are the same & comprehensive in all places.