### PR TITLE
meta: Include mkhl.direnv in the recommended vscode extension list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
   "recommendations": [
     "esbenp.prettier-vscode",
     "biomejs.biome",
+    "mkhl.direnv",
     "ms-python.python",
     "ms-python.black-formatter",
     "dbaeumer.vscode-eslint",


### PR DESCRIPTION
This is needed so vscode picks up env vars when it runs commands like linters in the background, things that direnv pick up and normally people don't think about.

It's especially needed by getsentry which uses an env var to find the sentry repo on your machine and run src/sentry/lint/engine.py across repos. Included here in sentry to keep parity between the settings.