### PR TITLE
ci: Enable json formatting in vscode via biome

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,37 +17,7 @@
   "files.trimFinalNewlines": true,
   "files.insertFinalNewline": true,
 
-  "[javascript]": {
-    "editor.formatOnSave": true,
-    "editor.tabSize": 2,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.codeActionsOnSave": {
-      "quickfix.biome": "explicit",
-      "source.fixAll.eslint": "explicit"
-    }
-  },
-
-  "[typescript]": {
-    "editor.formatOnSave": true,
-    "editor.tabSize": 2,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.codeActionsOnSave": {
-      "quickfix.biome": "explicit",
-      "source.fixAll.eslint": "explicit"
-    }
-  },
-
-  "[typescriptreact]": {
-    "editor.formatOnSave": true,
-    "editor.tabSize": 2,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.codeActionsOnSave": {
-      "quickfix.biome": "explicit",
-      "source.fixAll.eslint": "explicit"
-    }
-  },
-
-  "[javascriptreact]": {
+  "[javascript][typescript][javascriptreact][typescriptreact]": {
     "editor.formatOnSave": true,
     "editor.tabSize": 2,
     "editor.defaultFormatter": "esbenp.prettier-vscode",
@@ -85,6 +55,17 @@
   },
 
   "[json]": {
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "editor.tabSize": 2,
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.codeActionsOnSave": {
+      "quickfix.biome": "explicit"
+    }
+  },
+
+  "[yaml]": {
     "editor.insertSpaces": true,
     "editor.detectIndentation": false,
     "editor.tabSize": 2,

--- a/biome.json
+++ b/biome.json
@@ -76,7 +76,7 @@
     ]
   },
   "formatter": {
-    "enabled": true,
+    "enabled": false,
     "formatWithErrors": true,
     "indentStyle": "space",
     "indentWidth": 2,
@@ -100,18 +100,28 @@
   "json": {
     "formatter": {
       "enabled": true
-    },
-    "parser": {
-      "allowComments": true,
-      "allowTrailingCommas": true
     }
   },
   "overrides": [
     {
       "include": [
+        "biome.json",
+        "config/tsconfig.*",
+        "tsconfig.json",
+        ".vscode/*"
+      ],
+      "json": {
+        "parser": {
+          "allowComments": true,
+          "allowTrailingCommas": true
+        }
+      }
+    },
+    {
+      "include": [
         "api-docs/*.ts",
         "build-utils/*.ts",
-        "config/webpack.chartcuterie.config.ts",
+        "config/*.ts",
         "scripts",
         "tests/js/sentry-test/loadFixtures.ts",
         "tests/js/jest-pegjs-transform.js",


### PR DESCRIPTION
We should tell vscode to use prettier for json files, but trailing commas and comments are only valid in specific config files. 

Also took the chance to use the weird `"[javascript][typescript][javascriptreact][typescriptreact]"` syntax to keep js,jsx,ts,tsx config fully in sync and consistent.