### PR TITLE
chore(billing): Add comments on quota notification enum options

### DIFF
--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -15,13 +15,15 @@ class NotificationSettingEnum(ValueEqualityEnum):
     ISSUE_ALERTS = "alerts"
     WORKFLOW = "workflow"
     APPROVAL = "approval"
+    # Notifications for when 100% reserved quota is reached
     QUOTA = "quota"
+    # Notifications for when 80% reserved quota is reached
+    QUOTA_WARNINGS = "quotaWarnings"
     QUOTA_ERRORS = "quotaErrors"
     QUOTA_TRANSACTIONS = "quotaTransactions"
     QUOTA_ATTACHMENTS = "quotaAttachments"
     QUOTA_REPLAYS = "quotaReplays"
     QUOTA_MONITOR_SEATS = "quotaMonitorSeats"
-    QUOTA_WARNINGS = "quotaWarnings"
     QUOTA_SPEND_ALLOCATIONS = "quotaSpendAllocations"
     SPIKE_PROTECTION = "spikeProtection"
     MISSING_MEMBERS = "missingMembers"


### PR DESCRIPTION
Adding comment to clarify what these quota notifications refer to. 

I will soon add a new quota notification preference called `QUOTA_THRESHOLDS` to allow notifications on custom quota threshold preferences.