### PR TITLE
ref(replays): adjust 'read docs' link on empty state

### DIFF
--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -269,7 +269,7 @@ export function SetupReplaysCTA({
         {renderCTA()}
         <OnboardingCTAButton />
         <Button
-          href="https://docs.sentry.io/platforms/javascript/session-replay/"
+          href="https://docs.sentry.io/product/session-replay/getting-started/"
           external
         >
           {t('Read Docs')}


### PR DESCRIPTION
update the link to be more generic, since we'll be adding support for mobile platforms soon, and the current docs link goes to a javascript-specific set up page