### PR TITLE
fix(dropdown): Disable aria dropdown focus

### DIFF
--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -179,6 +179,9 @@ function DropdownMenu({
     {...overlayState, focusStrategy: 'first'},
     triggerRef
   );
+  // We manually handle focus in the dropdown menu, so we don't want the default autofocus behavior
+  // Avoids the menu from focusing before popper has placed it in the correct position
+  menuProps.autoFocus = false;
 
   const {buttonProps} = useButton(
     {
@@ -217,8 +220,6 @@ function DropdownMenu({
       <DropdownMenuList
         {...props}
         {...menuProps}
-        // We manually handle focus in the dropdown menu, so we don't want the aria focus
-        autoFocus={false}
         size={size}
         disabledKeys={disabledKeys ?? defaultDisabledKeys}
         overlayPositionProps={overlayProps}

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -217,7 +217,7 @@ function DropdownMenu({
       <DropdownMenuList
         {...props}
         {...menuProps}
-        // We manually handle focus in the dropdown menu, so we don't want the
+        // We manually handle focus in the dropdown menu, so we don't want the aria focus
         autoFocus={false}
         size={size}
         disabledKeys={disabledKeys ?? defaultDisabledKeys}

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -217,6 +217,8 @@ function DropdownMenu({
       <DropdownMenuList
         {...props}
         {...menuProps}
+        // We manually handle focus in the dropdown menu, so we don't want the
+        autoFocus={false}
         size={size}
         disabledKeys={disabledKeys ?? defaultDisabledKeys}
         overlayPositionProps={overlayProps}


### PR DESCRIPTION
We handle focus manually within the menu. 

Motivation: 
If you are scrolled down on a page, opening one of these dropdowns will scroll you back to the top of the page, possibly because autofocus is focusing on a menu that hasn't positioned yet.
