### PR TITLE
feat(tracing): Add average to event details

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -1,5 +1,9 @@
+from collections import defaultdict
+from datetime import datetime, timedelta
+
 from rest_framework.request import Request
 from rest_framework.response import Response
+from snuba_sdk import Column, Condition, Function, Op
 
 from sentry import eventstore
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -10,6 +14,56 @@ from sentry.api.serializers.models.event import SqlFormatEventSerializer
 from sentry.api.utils import handle_query_errors
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
+from sentry.search.events.builder import SpansMetricsQueryBuilder
+from sentry.snuba.dataset import Dataset
+
+
+def add_comparison_to_event(event, average_column):
+    if "spans" not in event.data:
+        return
+    group_to_span_map = defaultdict(list)
+    end = datetime.now()
+    start = end - timedelta(hours=24)
+    for span in event.data["spans"]:
+        group = span.get("sentry_tags", {}).get("group")
+        if group is not None:
+            group_to_span_map[group].append(span)
+
+    # Nothing to add comparisons to
+    if len(group_to_span_map) == 0:
+        return
+
+    with handle_query_errors():
+        builder = SpansMetricsQueryBuilder(
+            dataset=Dataset.PerformanceMetrics,
+            params={
+                "start": start,
+                "end": end,
+                "project_objects": [event.project],
+                "organization_id": event.organization.id,
+            },
+            selected_columns=[
+                "group",
+                f"avg({average_column}) as avg",
+            ],
+            # orderby shouldn't matter, just picking something so results are consistent
+            orderby=["group"],
+        )
+        builder.add_conditions(
+            [
+                Condition(
+                    Column(builder.resolve_column_name("group")),
+                    Op.IN,
+                    Function("tuple", list(group_to_span_map.keys())),
+                )
+            ]
+        )
+        result = builder.run_query("Get avg for spans")
+        for result in result["data"]:
+            group = result["group"]
+            avg = result["avg"]
+            for span in group_to_span_map[group]:
+                span["span.average_time"] = avg
 
 
 @region_silo_endpoint
@@ -42,6 +96,10 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
+
+        average_column = request.GET.get("averageColumn")
+        if average_column in ["span.self_time"]:
+            add_comparison_to_event(event, average_column)
 
         # TODO: Remove `for_group` check once performance issues are moved to the issue platform
         if hasattr(event, "for_group") and event.group:

--- a/src/sentry/data/samples/transaction.json
+++ b/src/sentry/data/samples/transaction.json
@@ -86,7 +86,9 @@
         "duration": 0.02,
         "offset": 0.02
       },
-      "span_id": "c048b4fffdc4279d"
+      "span_id": "c048b4fffdc4279d",
+      "sentry_tags": {
+      }
     },
     {
       "same_process_as_parent": true,
@@ -101,7 +103,10 @@
         "duration": 0.1,
         "offset": 1.0
       },
-      "span_id": "d047a3a8edc3276a"
+      "span_id": "d047a3a8edc3276a",
+      "sentry_tags": {
+	"group": "26b881987e4bad99"
+      }
     }
   ],
   "transaction": "/country_by_code/",

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -4,11 +4,14 @@ import pytest
 from django.urls import NoReverseMatch, reverse
 
 from sentry.models.group import Group
-from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.search.events import constants
+from sentry.testutils.cases import APITestCase, MetricsEnhancedPerformanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
+
+pytestmark = pytest.mark.sentry_metrics
 
 
 def format_project_event(project_slug, event_id):
@@ -291,3 +294,40 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase, Occurrenc
         assert response.data["projectSlug"] == self.project.slug
         assert response.data["occurrence"] is not None
         assert response.data["occurrence"]["id"] == occurrence.id
+
+
+class EventComparisonTest(MetricsEnhancedPerformanceTestCase):
+    endpoint = "sentry-api-0-organization-event-details"
+
+    def setUp(self):
+        self.init_snuba()
+        self.ten_mins_ago = before_now(minutes=10)
+        self.transaction_data = load_data("transaction", timestamp=self.ten_mins_ago)
+        event = self.store_event(self.transaction_data, self.project)
+        self.url = reverse(
+            self.endpoint,
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": event.event_id,
+            },
+        )
+        self.login_as(user=self.user)
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.ten_mins_ago,
+            tags={"group": "26b881987e4bad99"},
+        )
+
+    def test_get(self):
+        response = self.client.get(self.url, {"averageColumn": "span.self_time"})
+        assert response.status_code == 200, response.content
+        entries = response.data["entries"]  # type: ignore
+        for entry in entries:
+            if entry["type"] == "spans":
+                for span in entry["data"]:
+                    if span["span_id"] == "26b881987e4bad99":
+                        assert span["span.average_time"] == 1.0
+                    if span["span_id"] == "c048b4fffdc4279d":
+                        assert "span.average_time" not in span


### PR DESCRIPTION
- This adds a param to the org event details endpoint `averageColumn` that currently accepts 1 param `span.self_time`
- When this param is passed we'll collect all the group ids for spans in the transaction and get their average span self time