### PR TITLE
ref(daily summary): Filter to unresolved issues

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1896,8 +1896,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:slack-thread": False,
     # Send Slack notifications to threads for Issue Alerts
     "organizations:slack-thread-issue-alert": False,
-    # Use SNQL table join
-    "organizations:snql-join": False,
+    # Use SNQL table join on weekly reports / daily summary
+    "organizations:snql-join-reports": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1896,6 +1896,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:slack-thread": False,
     # Send Slack notifications to threads for Issue Alerts
     "organizations:slack-thread-issue-alert": False,
+    # Use SNQL table join
+    "organizations:snql-join": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -258,7 +258,7 @@ default_manager.add("organizations:settings-legal-tos-ui", OrganizationFeature, 
 default_manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-thread", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:slack-thread-issue-alert", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:snql-join", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:snql-join-reports", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sourcemaps-bundle-flat-file-indexing", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sourcemaps-upload-release-as-artifact-bundle", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -258,6 +258,7 @@ default_manager.add("organizations:settings-legal-tos-ui", OrganizationFeature, 
 default_manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-thread", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:slack-thread-issue-alert", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:snql-join", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sourcemaps-bundle-flat-file-indexing", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sourcemaps-upload-release-as-artifact-bundle", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -189,7 +189,10 @@ def build_summary_data(
                 ctx=ctx, project=project, referrer=Referrer.DAILY_SUMMARY_KEY_ERRORS.value
             )
             if key_errors:
-                project_ctx.key_errors = [(e["group_id"], e["count()"]) for e in key_errors]
+                if features.has("organizations:snql-join", project.organization):
+                    project_ctx.key_errors = [(e["e.group_id"], e["count()"]) for e in key_errors]
+                else:
+                    project_ctx.key_errors = [(e["group_id"], e["count()"]) for e in key_errors]
 
             # Today's Top 3 Performance Issues
             key_performance_issues = project_key_performance_issues(

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -189,10 +189,12 @@ def build_summary_data(
                 ctx=ctx, project=project, referrer=Referrer.DAILY_SUMMARY_KEY_ERRORS.value
             )
             if key_errors:
-                if features.has("organizations:snql-join", project.organization):
-                    project_ctx.key_errors = [(e["e.group_id"], e["count()"]) for e in key_errors]
-                else:
-                    project_ctx.key_errors = [(e["group_id"], e["count()"]) for e in key_errors]
+                group_id_alias = (
+                    "e.group_id"
+                    if features.has("organizations:snql-join-reports", project.organization)
+                    else "group_id"
+                )
+                project_ctx.key_errors = [(e[group_id_alias], e["count()"]) for e in key_errors]
 
             # Today's Top 3 Performance Issues
             key_performance_issues = project_key_performance_issues(

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -190,7 +190,7 @@ def build_summary_data(
             )
             if key_errors:
                 group_id_alias = (
-                    "e.group_id"
+                    "events.group_id"
                     if features.has("organizations:snql-join-reports", project.organization)
                     else "group_id"
                 )

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -182,8 +182,8 @@ def project_key_errors(
             limit=Limit(3),
         )
         if features.has("organizations:snql-join-reports", project.organization):
-            events_entity = Entity("events", alias="e")
-            group_attributes_entity = Entity("group_attributes", alias="g")
+            events_entity = Entity("events", alias="events")
+            group_attributes_entity = Entity("group_attributes", alias="group_attributes")
             query = Query(
                 match=Join([Relationship(events_entity, "attributes", group_attributes_entity)]),
                 select=[Column("group_id", entity=events_entity), Function("count", [])],

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -165,7 +165,7 @@ def prepare_organization_report(
             project_ctx = cast(ProjectContext, ctx.projects_context_map[project.id])
             if key_errors:
                 group_id_alias = (
-                    "e.group_id"
+                    "event.group_id"
                     if features.has("organizations:snql-join-reports", project.organization)
                     else "group_id"
                 )

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -164,10 +164,13 @@ def prepare_organization_report(
 
             project_ctx = cast(ProjectContext, ctx.projects_context_map[project.id])
             if key_errors:
-                if features.has("organizations:snql-join", project.organization):
-                    project_ctx.key_errors = [(e["e.group_id"], e["count()"]) for e in key_errors]
-                else:
-                    project_ctx.key_errors = [(e["group_id"], e["count()"]) for e in key_errors]
+                group_id_alias = (
+                    "e.group_id"
+                    if features.has("organizations:snql-join-reports", project.organization)
+                    else "group_id"
+                )
+                project_ctx.key_errors = [(e[group_id_alias], e["count()"]) for e in key_errors]
+
                 if ctx.organization.slug == "sentry":
                     logger.info(
                         "project_key_errors.results",

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -279,6 +279,52 @@ class DailySummaryTest(
         assert project_context_map2.regressed_today == []
         assert project_context_map2.new_in_release == {}
 
+    @with_feature("organizations:snql-join")
+    def test_build_summary_data_filter_to_unresolved(self):
+        with self.options({"issues.group_attributes.send_kafka": True}):
+            for _ in range(3):
+                group1 = self.store_event_and_outcomes(
+                    self.project.id,
+                    self.now,
+                    fingerprint="group-1",
+                    category=DataCategory.ERROR,
+                    resolve=False,
+                )
+
+            for _ in range(3):
+                group2 = self.store_event_and_outcomes(
+                    self.project.id,
+                    self.now,
+                    fingerprint="group-2",
+                    category=DataCategory.ERROR,
+                    resolve=False,
+                )
+
+            for _ in range(3):
+                self.store_event_and_outcomes(
+                    self.project.id,
+                    self.now,
+                    fingerprint="group-3",
+                    category=DataCategory.ERROR,
+                    resolve=True,
+                )
+
+        summary = build_summary_data(
+            timestamp=self.now.timestamp(),
+            duration=ONE_DAY,
+            organization=self.organization,
+            daily=True,
+        )
+        project_id = self.project.id
+        project_context_map = cast(
+            DailySummaryProjectContext, summary.projects_context_map[project_id]
+        )
+        assert project_context_map.total_today == 9  # total outcomes from today
+        assert project_context_map.comparison_period_avg == 0
+        assert len(project_context_map.key_errors) == 2
+        assert (group1, None, 3) in project_context_map.key_errors
+        assert (group2, None, 3) in project_context_map.key_errors
+
     def test_build_summary_data_dedupes_groups(self):
         """
         Test that if a group has multiple escalated and/or regressed activity rows, we only use the group once

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -279,7 +279,7 @@ class DailySummaryTest(
         assert project_context_map2.regressed_today == []
         assert project_context_map2.new_in_release == {}
 
-    @with_feature("organizations:snql-join")
+    @with_feature("organizations:snql-join-reports")
     def test_build_summary_data_filter_to_unresolved(self):
         with self.options({"issues.group_attributes.send_kafka": True}):
             for _ in range(3):

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -202,6 +202,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         assert mock_send_email.call_count == 1
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
+    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_transferred_project(self, message_builder):
         self.login_as(user=self.user)
 
@@ -239,6 +240,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         assert message_builder.call_count == 1
 
     @with_feature("organizations:escalating-issues")
+    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_organization_project_issue_substatus_summaries(self):
         self.login_as(user=self.user)
 
@@ -283,6 +285,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         assert project_ctx.regression_substatus_count == 0
         assert project_ctx.total_substatus_count == 2
 
+    @freeze_time(before_now(days=2).replace(hour=0, minute=0, second=0, microsecond=0))
     def test_organization_project_issue_status(self):
         self.login_as(user=self.user)
         now = timezone.now()
@@ -319,7 +322,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
         with self.feature("organizations:snql-join-reports"):
             key_errors = project_key_errors(ctx, self.project, Referrer.REPORTS_KEY_ERRORS.value)
-            assert key_errors == [{"e.group_id": event1.group.id, "count()": 1}]
+            assert key_errors == [{"events.group_id": event1.group.id, "count()": 1}]
 
         # without the flag, resolved issues are not filtered out
         key_errors = project_key_errors(ctx, self.project, Referrer.REPORTS_KEY_ERRORS.value)

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -317,7 +317,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
         timestamp = now.timestamp()
         ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
-        with self.feature("organizations:snql-join"):
+        with self.feature("organizations:snql-join-reports"):
             key_errors = project_key_errors(ctx, self.project, Referrer.REPORTS_KEY_ERRORS.value)
             assert key_errors == [{"e.group_id": event1.group.id, "count()": 1}]
 

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -19,11 +19,13 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.services.hybrid_cloud.user_option import user_option_service
 from sentry.silo import SiloMode, unguarded_write
+from sentry.snuba.referrer import Referrer
 from sentry.tasks.summaries.utils import (
     ONE_DAY,
     OrganizationReportContext,
     ProjectContext,
     organization_project_issue_substatus_summaries,
+    project_key_errors,
 )
 from sentry.tasks.summaries.weekly_reports import (
     deliver_reports,
@@ -280,6 +282,51 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         assert project_ctx.ongoing_substatus_count == 1
         assert project_ctx.regression_substatus_count == 0
         assert project_ctx.total_substatus_count == 2
+
+    def test_organization_project_issue_status(self):
+        self.login_as(user=self.user)
+        now = timezone.now()
+        self.project.first_event = now - timedelta(days=3)
+        min_ago = iso_format(now - timedelta(minutes=1))
+        with self.options({"issues.group_attributes.send_kafka": True}):
+            event1 = self.store_event(
+                data={
+                    "event_id": "a" * 32,
+                    "message": "message",
+                    "timestamp": min_ago,
+                    "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+                    "fingerprint": ["group-1"],
+                },
+                project_id=self.project.id,
+            )
+            event2 = self.store_event(
+                data={
+                    "event_id": "b" * 32,
+                    "message": "message",
+                    "timestamp": min_ago,
+                    "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+                    "fingerprint": ["group-2"],
+                },
+                project_id=self.project.id,
+            )
+            group2 = event2.group
+            group2.status = GroupStatus.RESOLVED
+            group2.substatus = None
+            group2.resolved_at = now - timedelta(minutes=1)
+            group2.save()
+
+        timestamp = now.timestamp()
+        ctx = OrganizationReportContext(timestamp, ONE_DAY * 7, self.organization)
+        with self.feature("organizations:snql-join"):
+            key_errors = project_key_errors(ctx, self.project, Referrer.REPORTS_KEY_ERRORS.value)
+            assert key_errors == [{"e.group_id": event1.group.id, "count()": 1}]
+
+        # without the flag, resolved issues are not filtered out
+        key_errors = project_key_errors(ctx, self.project, Referrer.REPORTS_KEY_ERRORS.value)
+        assert key_errors == [
+            {"group_id": event1.group.id, "count()": 1},
+            {"group_id": group2.id, "count()": 1},
+        ]
 
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")


### PR DESCRIPTION
Update `project_key_errors` to filter out unresolved issues. This wasn't possible until recently, but now we can join the `group_attributes` entity which has `group_status` on it in snuba. Since the weekly reports and daily summaries use this function, fixing this kills 2 birds. I put this behind a feature flag to be cautious and not take down snuba.

Closes https://github.com/getsentry/team-core-product-foundations/issues/209