### PR TITLE
feat(notifications): Add Quota Thresholds notification preference

### DIFF
--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -21,6 +21,7 @@ NOTIFICATION_SETTINGS_TYPE_DEFAULTS = {
     NotificationSettingEnum.QUOTA_MONITOR_SEATS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_WARNINGS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.QUOTA_SPEND_ALLOCATIONS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.QUOTA_THRESHOLDS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.SPIKE_PROTECTION: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.REPORTS: NotificationSettingsOptionEnum.ALWAYS,
 }

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -19,6 +19,9 @@ class NotificationSettingEnum(ValueEqualityEnum):
     QUOTA = "quota"
     # Notifications for when 80% reserved quota is reached
     QUOTA_WARNINGS = "quotaWarnings"
+    # Notifications for when a specific threshold is reached
+    # If set, this overrides any notification preferences for QUOTA and QUOTA_WARNINGS.
+    QUOTA_THRESHOLDS = "quotaThresholds"
     QUOTA_ERRORS = "quotaErrors"
     QUOTA_TRANSACTIONS = "quotaTransactions"
     QUOTA_ATTACHMENTS = "quotaAttachments"
@@ -113,6 +116,10 @@ VALID_VALUES_FOR_KEY = {
         NotificationSettingsOptionEnum.NEVER,
     },
     NotificationSettingEnum.QUOTA_SPEND_ALLOCATIONS: {
+        NotificationSettingsOptionEnum.ALWAYS,
+        NotificationSettingsOptionEnum.NEVER,
+    },
+    NotificationSettingEnum.QUOTA_THRESHOLDS: {
         NotificationSettingsOptionEnum.ALWAYS,
         NotificationSettingsOptionEnum.NEVER,
     },

--- a/tests/sentry/api/endpoints/test_notification_defaults.py
+++ b/tests/sentry/api/endpoints/test_notification_defaults.py
@@ -17,6 +17,7 @@ class NotificationDefaultTest(APITestCase):
                 "approval": "always",
                 "deploy": "committed_only",
                 "quota": "always",
+                "quotaThresholds": "always",
                 "quotaAttachments": "always",
                 "quotaErrors": "always",
                 "quotaReplays": "always",


### PR DESCRIPTION
This adds quota thresholds option to the notifications platform in preparation for the work to allow setting of custom quota thresholds.

Setting and exposing this option will be done in a later pull request.