### PR TITLE
feat(ui): Remove render function from dropdown label

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -10,7 +10,6 @@ import UserAvatar from 'sentry/components/avatar/userAvatar';
 import type {GetActorPropsFn} from 'sentry/components/deprecatedDropdownMenu';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
 import type {ItemsBeforeFilter} from 'sentry/components/dropdownAutoComplete/types';
-import Highlight from 'sentry/components/highlight';
 import Link from 'sentry/components/links/link';
 import TextOverflow from 'sentry/components/textOverflow';
 import {IconAdd, IconClose} from 'sentry/icons';
@@ -292,7 +291,7 @@ export class AssigneeSelectorDropdown extends Component<
     return {
       value: {type: 'member', assignee: member},
       searchKey: `${member.email} ${member.name}`,
-      label: ({inputValue}) => (
+      label: (
         <MenuItemWrapper
           data-test-id="assignee-option"
           key={buildUserId(member.id)}
@@ -303,11 +302,9 @@ export class AssigneeSelectorDropdown extends Component<
           </IconContainer>
           <div>
             <AssigneeLabel>
-              <Highlight text={inputValue}>
-                {sessionUser.id === member.id
-                  ? `${member.name || member.email} ${t('(You)')}`
-                  : member.name || member.email}
-              </Highlight>
+              {sessionUser.id === member.id
+                ? `${member.name || member.email} ${t('(You)')}`
+                : member.name || member.email}
             </AssigneeLabel>
             {suggestedReason && (
               <SuggestedAssigneeReason>{suggestedReason}</SuggestedAssigneeReason>
@@ -334,15 +331,13 @@ export class AssigneeSelectorDropdown extends Component<
     return {
       value: {type: 'team', assignee: team},
       searchKey: team.slug,
-      label: ({inputValue}) => (
+      label: (
         <MenuItemWrapper data-test-id="assignee-option" key={id} onSelect={handleSelect}>
           <IconContainer>
             <TeamAvatar team={team} size={24} />
           </IconContainer>
           <div>
-            <AssigneeLabel>
-              <Highlight text={inputValue}>{display}</Highlight>
-            </AssigneeLabel>
+            <AssigneeLabel>{display}</AssigneeLabel>
             {suggestedReason && (
               <SuggestedAssigneeReason>{suggestedReason}</SuggestedAssigneeReason>
             )}

--- a/static/app/components/dropdownAutoComplete/list.tsx
+++ b/static/app/components/dropdownAutoComplete/list.tsx
@@ -6,7 +6,7 @@ import type {ItemsAfterFilter} from './types';
 
 type RowProps = Pick<
   React.ComponentProps<typeof Row>,
-  'itemSize' | 'inputValue' | 'getItemProps' | 'registerVisibleItem'
+  'itemSize' | 'getItemProps' | 'registerVisibleItem'
 >;
 
 type Props = {

--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -408,17 +408,14 @@ function Menu({
                       {!busy && (
                         <List
                           items={autoCompleteResults}
-                          {...{
-                            maxHeight,
-                            highlightedIndex,
-                            inputValue,
-                            onScroll,
-                            getItemProps,
-                            registerVisibleItem,
-                            virtualizedLabelHeight,
-                            virtualizedHeight,
-                            itemSize,
-                          }}
+                          maxHeight={maxHeight}
+                          highlightedIndex={highlightedIndex}
+                          onScroll={onScroll}
+                          getItemProps={getItemProps}
+                          registerVisibleItem={registerVisibleItem}
+                          virtualizedLabelHeight={virtualizedLabelHeight}
+                          virtualizedHeight={virtualizedHeight}
+                          itemSize={itemSize}
                         />
                       )}
                     </ItemList>

--- a/static/app/components/dropdownAutoComplete/row.tsx
+++ b/static/app/components/dropdownAutoComplete/row.tsx
@@ -14,7 +14,7 @@ type AutoCompleteChildrenArgs<T extends Item> = Parameters<
 
 type Props<T extends Item> = Pick<
   AutoCompleteChildrenArgs<T>,
-  'getItemProps' | 'registerVisibleItem' | 'inputValue'
+  'getItemProps' | 'registerVisibleItem'
 > &
   Omit<Parameters<AutoCompleteChildrenArgs<T>['getItemProps']>[0], 'index'> & {
     /**
@@ -36,7 +36,6 @@ function Row<T extends Item>({
   style,
   itemSize,
   isHighlighted,
-  inputValue,
   getItemProps,
   registerVisibleItem,
 }: Props<T>) {
@@ -66,7 +65,7 @@ function Row<T extends Item>({
       {...itemProps}
     >
       <InteractionStateLayer isHovered={isHighlighted} />
-      {typeof item.label === 'function' ? item.label({inputValue}) : item.label}
+      {item.label}
     </AutoCompleteItem>
   );
 }

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -7,11 +7,11 @@ import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import {openConfirmModal} from 'sentry/components/confirm';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
+import type {ItemsBeforeFilter} from 'sentry/components/dropdownAutoComplete/types';
 import DropdownBubble from 'sentry/components/dropdownBubble';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import Highlight from 'sentry/components/highlight';
 import IdBadge from 'sentry/components/idBadge';
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -257,9 +257,9 @@ function RuleListRow({
     onOwnerChange(slug, rule, ownerValue);
   }
 
-  const unassignedOption = {
+  const unassignedOption: ItemsBeforeFilter[number] = {
     value: '',
-    label: () => (
+    label: (
       <MenuItemWrapper>
         <PaddedIconUser size="lg" />
         <Label>{t('Unassigned')}</Label>
@@ -275,17 +275,15 @@ function RuleListRow({
     return userTeams.some(team => team.id === projTeam.id);
   });
   const dropdownTeams = filteredProjectTeams
-    .map((team, idx) => ({
+    .map<ItemsBeforeFilter[number]>((team, idx) => ({
       value: team.id,
       searchKey: team.slug,
-      label: ({inputValue}) => (
+      label: (
         <MenuItemWrapper data-test-id="assignee-option" key={idx}>
           <IconContainer>
             <TeamAvatar team={team} size={24} />
           </IconContainer>
-          <Label>
-            <Highlight text={inputValue}>{`#${team.slug}`}</Highlight>
-          </Label>
+          <Label>#{team.slug}</Label>
         </MenuItemWrapper>
       ),
     }))

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -120,9 +120,8 @@ function getDropdownOption({
   team: Team;
 }): ItemsBeforeFilter[number] {
   const isIdpProvisioned = isAddingTeamToMember && team.flags['idp:provisioned'];
-  const buttonHelpText = getButtonHelpText(isIdpProvisioned);
   const label = isIdpProvisioned ? (
-    <Tooltip title={buttonHelpText}>
+    <Tooltip title={getButtonHelpText(isIdpProvisioned)}>
       <DropdownTeamBadgeDisabled avatarSize={18} team={team} />
     </Tooltip>
   ) : (

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -5,7 +5,7 @@ import debounce from 'lodash/debounce';
 import {openCreateTeamModal} from 'sentry/actionCreators/modal';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
-import type {Item} from 'sentry/components/dropdownAutoComplete/types';
+import type {Item, ItemsBeforeFilter} from 'sentry/components/dropdownAutoComplete/types';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {TeamBadge} from 'sentry/components/idBadge/teamBadge';
 import Link from 'sentry/components/links/link';
@@ -118,25 +118,22 @@ function renderDropdownOption({
   isAddingTeamToMember: boolean;
   isAddingTeamToProject: boolean;
   team: Team;
-}) {
+}): ItemsBeforeFilter[number] {
   const isIdpProvisioned = isAddingTeamToMember && team.flags['idp:provisioned'];
   const buttonHelpText = getButtonHelpText(isIdpProvisioned);
+  const label = isIdpProvisioned ? (
+    <Tooltip title={buttonHelpText}>
+      <DropdownTeamBadgeDisabled avatarSize={18} team={team} />
+    </Tooltip>
+  ) : (
+    <DropdownTeamBadge avatarSize={18} team={team} />
+  );
 
   return {
     index,
     value: team.slug,
     searchKey: team.slug,
-    label: () => {
-      if (isIdpProvisioned) {
-        return (
-          <Tooltip title={buttonHelpText}>
-            <DropdownTeamBadgeDisabled avatarSize={18} team={team} />
-          </Tooltip>
-        );
-      }
-
-      return <DropdownTeamBadge avatarSize={18} team={team} />;
-    },
+    label,
     disabled: disabled || isIdpProvisioned,
   };
 }

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -66,7 +66,7 @@ export function DropdownAddTeam({
   onCreateTeam?: (team: Team) => void;
   project?: Project;
 }) {
-  const dropdownItems = teams
+  const dropdownItems: ItemsBeforeFilter = teams
     .filter(team => !selectedTeams.some(slug => slug === team.slug))
     .map((team, index) =>
       getDropdownOption({

--- a/static/app/views/settings/components/teamSelect/utils.tsx
+++ b/static/app/views/settings/components/teamSelect/utils.tsx
@@ -69,7 +69,7 @@ export function DropdownAddTeam({
   const dropdownItems = teams
     .filter(team => !selectedTeams.some(slug => slug === team.slug))
     .map((team, index) =>
-      renderDropdownOption({
+      getDropdownOption({
         isAddingTeamToMember,
         isAddingTeamToProject,
         team,
@@ -107,7 +107,7 @@ export function DropdownAddTeam({
   );
 }
 
-function renderDropdownOption({
+function getDropdownOption({
   disabled,
   index,
   isAddingTeamToMember,


### PR DESCRIPTION
Removes render function from dropdown labels and the two places that were using it. It can currently only be used with dropdown autocomplete which is a bit confusing since our other dropdowns re-use the same types.

Ideally this would be handled via css selector or context instead of rerendering every row on each letter which we can re-add later.

Challenges with keeping it:
The typescript types we use for all 3 dropdowns indicate that we can use a render function as the label but that is only true for dropdown autocomplete. Removing the feature makes the dropdowns a bit less complicated and speeds up search for large orgs with 3k+ projects.

before:
![image](https://github.com/getsentry/sentry/assets/1400464/0e7ff86e-f5d9-4f9a-b7d6-87bab03e56a3)

after:
![image](https://github.com/getsentry/sentry/assets/1400464/7e25b67e-bbaf-4650-b4a4-d1fdac838c5c)

part of https://github.com/getsentry/frontend-tsc/issues/22
