### PR TITLE
fix(grouping): Improve handling of matching grouping configs

### DIFF
--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -493,17 +493,15 @@ def record_hash_calculation_metrics(
 
             metrics.incr("grouping.hash_comparison", tags=tags)
 
-        # TODO: This is temporary, just until we can figure out how we're recording a hash
-        # comparison metric showing projects calculating both primary and secondary hashes using the
-        # same config
-        if primary_config["id"] == secondary_config["id"]:
-            logger.info(
-                "Equal primary and secondary configs",
-                extra={
-                    "project": project.id,
-                    "primary_config": primary_config["id"],
-                },
-            )
+        else:
+            if not _config_update_happened_recently(project, 30):
+                logger.info(
+                    "Equal primary and secondary configs",
+                    extra={
+                        "project": project.id,
+                        "primary_config": primary_config["id"],
+                    },
+                )
 
 
 # TODO: Once the legacy `_save_aggregate` goes away, this logic can be pulled into

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -471,20 +471,27 @@ def record_hash_calculation_metrics(
             "primary_config": primary_config["id"],
             "secondary_config": secondary_config["id"],
         }
-        current_values = primary_hashes.hashes
-        secondary_values = secondary_hashes.hashes
-        hashes_match = current_values == secondary_values
 
-        if hashes_match:
-            tags["result"] = "no change"
-        else:
-            shared_hashes = set(current_values) & set(secondary_values)
-            if len(shared_hashes) > 0:
-                tags["result"] = "partial change"
+        # If the configs are the same, *of course* the values are going to match, so no point in
+        # recording a metric
+        #
+        # TODO: If we fix the issue outlined in https://github.com/getsentry/sentry/pull/65116, we
+        # can ditch both this check and the logging below
+        if tags["primary_config"] != tags["secondary_config"]:
+            current_values = primary_hashes.hashes
+            secondary_values = secondary_hashes.hashes
+            hashes_match = current_values == secondary_values
+
+            if hashes_match:
+                tags["result"] = "no change"
             else:
-                tags["result"] = "full change"
+                shared_hashes = set(current_values) & set(secondary_values)
+                if len(shared_hashes) > 0:
+                    tags["result"] = "partial change"
+                else:
+                    tags["result"] = "full change"
 
-        metrics.incr("grouping.hash_comparison", tags=tags)
+            metrics.incr("grouping.hash_comparison", tags=tags)
 
         # TODO: This is temporary, just until we can figure out how we're recording a hash
         # comparison metric showing projects calculating both primary and secondary hashes using the


### PR DESCRIPTION
### Background

In theory, a project's primary and secondary configs should be different, as the secondary config only gets set (to the current config) when there's a new config to which to upgrade (which becomes primary).

However, we've been seeing cases where the values match. Specifically, when we record the [hash comparison metric](https://github.com/getsentry/sentry/blob/c7e33f856266f23f29ce00a200a762374c165412/src/sentry/grouping/ingest.py#L454-L472), we tag it with both configs. And when we graph that metric, a portion of the occurrences have configs which match. The screenshot below is taken from the legend of a pie chart, and while it's clear from the percentages that this doesn't happen that often, it does happen.

![image](https://github.com/getsentry/sentry/assets/14812505/12b36731-63e7-4cdb-930e-663acfda3c54)

This got me curious, so I [added a log](https://github.com/getsentry/sentry/pull/66994) to track when this happens. Looking at the logs once they came in, a pattern emerged. A project would have a burst of logging, and then never log again. Also, that burst always seemed to last for around three seconds (see the screenshot below, which is all the entries for a particular project). 

![image](https://github.com/getsentry/sentry/assets/14812505/e6cec52f-1613-45d5-a746-9d454bb1d5a8)

I then remembered that while we read the secondary config from project settings, for the primary config we use the value [Relay pre-populates in the event](https://github.com/getsentry/sentry/pull/65116) and suddenly it made sense. [Matt was right](https://github.com/getsentry/sentry/pull/65116#discussion_r1500087757) - it is a caching issue.

More specifically, the way it happens is that Relay adds the current config (`A`) and sends the event to our ingest pipeline. While in the pipeline, an event's project has its grouping config updated to a newer one (`B`). Now the project's secondary config is `A` (which value we pull) and its current config is `B`. But we continue to use the Relay-populated value (`A`) for the primary config and voila, an event (and a metric) where both configs are `A`.

(We can confirm that this is the cause because we also [log](https://github.com/getsentry/sentry/blob/c1551141c72dbff7a27317b614dcf56150cd08c1/src/sentry/grouping/ingest.py#L261-L278) when the config value pre-populated by Relay doesn't match the value in project settings, and those logs always matched up 1-to-1 with the matching config logs, as can be seen in the screenshot below.)

![image](https://github.com/getsentry/sentry/assets/14812505/06e9894b-60cc-4f16-a245-efbc3fa6d070)

### Changes

To solve this problem, I made a few changes:

- I added a helper function, `_config_update_happened_recently`, which uses the transition period expiry to figure out when the project's config was updated, and returns `True` if that time is within a certain tolerance of the time the function is called, and I used that function to prevent logging if the config was just updated. Despite the 3-second pattern observed in the logs, when using it I gave it a tolerance of 30 seconds, just to be extra conservative.

- I stopped recording the hash comparison metric when the configs are equal.

- I made logging the config equality contingent on the config not having been recently updated.

- Given the link between the Relay/project settings logging and the hash comparison logging, I applied the same logic to the former, so that it also only fires when there's no recent update.