### PR TITLE
fix(tests) Fix silo mode request errors from relay

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3992,6 +3992,8 @@ REGION_PINNED_URL_NAMES = {
     "sentry-chartcuterie-config",
     "sentry-robots-txt",
 }
+# Used in tests to skip forwarding relay paths to a region silo that does not exist.
+APIGATEWAY_PROXY_SKIP_RELAY = False
 
 # Shared resource ids for accounting
 EVENT_PROCESSING_STORE = "rc_processing_redis"

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -159,9 +159,7 @@ def proxy_region_request(
     metric_tags = {"region": region.name, "url_name": url_name}
 
     # XXX: See sentry.testutils.pytest.sentry for more information
-    if getattr(settings, "APIGATEWAY_PROXY_SKIP_RELAY") and request.path.startswith(
-        "/api/0/relays/"
-    ):
+    if settings.APIGATEWAY_PROXY_SKIP_RELAY and request.path.startswith("/api/0/relays/"):
         return StreamingHttpResponse(streaming_content="relay proxy skipped", status=404)
 
     try:

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -157,6 +157,13 @@ def proxy_region_request(
 
     timeout = ENDPOINT_TIMEOUT_OVERRIDE.get(url_name, settings.GATEWAY_PROXY_TIMEOUT)
     metric_tags = {"region": region.name, "url_name": url_name}
+
+    # XXX: See sentry.testutils.pytest.sentry for more information
+    if getattr(settings, "APIGATEWAY_PROXY_SKIP_RELAY") and request.path.startswith(
+        "/api/0/relays/"
+    ):
+        return StreamingHttpResponse(streaming_content="relay proxy skipped", status=404)
+
     try:
         with metrics.timer("apigateway.proxy_request.duration", tags=metric_tags):
             resp = external_request(

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -80,6 +80,13 @@ def _configure_test_env_regions() -> None:
     settings.SENTRY_SUBNET_SECRET = "secret"
     settings.SENTRY_CONTROL_ADDRESS = "http://controlserver/"
 
+    # Relay integration tests spin up a relay instance in a container
+    # this container then sends requests to the threaded server running
+    # in the pytest process. Without this the requests from relay arrive
+    # in the threaded server with a non-deterministic silo mode causing
+    # flaky test failures.
+    settings.APIGATEWAY_PROXY_SKIP_RELAY = True
+
     monkey_patch_single_process_silo_mode_state()
 
 

--- a/src/sentry/testutils/relay.py
+++ b/src/sentry/testutils/relay.py
@@ -166,7 +166,6 @@ class RelayStoreHelper(RequiredBaseclass):
     def relay_setup_fixtures(
         self,
         settings,
-        live_server,
         get_relay_store_url,
         get_relay_minidump_url,
         get_relay_unreal_url,


### PR DESCRIPTION
Several of our tests use the `live_server` pytest fixture which starts a webserver in a thread. Other tests will start a relay instance, and this relay instance sends requests to the threaded server. When the threaded server receives these requests it can be in a non-deterministic silo mode which causes the requests to fail.

By skipping the api proxy for relay requests during tests we can sidestep this issue.