### PR TITLE
ref: instrument pickle unicode fallback with sentry

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2151,6 +2151,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# sample rate for pickle error collection
+register(
+    "pickle.send-error-to-sentry",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # killswitch for profiling ddm functions metrics.
 # Enable/Disable the ingestion of function metrics
 # in the generic metrics platform

--- a/tests/sentry/monkey/test_pickle.py
+++ b/tests/sentry/monkey/test_pickle.py
@@ -1,0 +1,35 @@
+import pickle
+
+import pytest
+
+from sentry.testutils.helpers.options import override_options
+
+
+@pytest.fixture(autouse=True)
+def assert_using_monkeypatched_pickle():
+    assert pickle.loads.__module__.startswith("sentry.")
+
+
+def _load_bad_pickle():
+    # a python 2 pickle of `u'\u2603'.encode('UTF-8')` with protocol 2
+    # results in mojibake
+    assert pickle.loads(b"\x80\x02U\x03\xe2\x98\x83q\x00.") == "â\x98\x83"
+
+
+@override_options({"pickle.send-error-to-sentry": 0})
+def test_pickle_loads_no_logging_to_sentry_when_disabled(caplog):
+    _load_bad_pickle()
+
+    # no sentry logging when we have disabled the option
+    assert not caplog.records
+
+
+@override_options({"pickle.send-error-to-sentry": 1})
+def test_pickle_loads_logging_to_sentry(caplog):
+    _load_bad_pickle()
+
+    (record,) = caplog.records
+    assert record.levelname == "ERROR"
+    assert record.exc_info == (None, None, None)
+    expected = "pickle.compat_pickle_loads.had_unicode_decode_error.UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)"
+    assert record.message == expected


### PR DESCRIPTION
we're still seeing some hits on the metrics for `loads` and `Unpickler.load`

unclear where they're coming from so I'm going to instrument this with sentry to figure it out

I've hidden this behaviour behind a feature flag so I can turn it on once rolled out (as I would expect these to be new sentry issues and would block canary / etc. if triggered)

here's what the resulting sentry errors will look like since I need to do some fudging around in `logging` to make them include a fulltrace and the original error message:

<img width="1427" alt="Screenshot 2024-03-19 at 4 21 37 PM" src="https://github.com/getsentry/sentry/assets/103459774/04011ff5-1d6a-4bf7-a42a-4107b93f79eb">
<img width="1089" alt="Screenshot 2024-03-19 at 4 22 25 PM" src="https://github.com/getsentry/sentry/assets/103459774/babcacf2-872d-4ea9-af0a-75b86e31e9a5">


<!-- Describe your PR here. -->