### PR TITLE
feat(search): adds useGroupSnubaDataset query param

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -137,6 +137,7 @@ interface EndpointParams extends Partial<PageFilters['datetime']> {
   query?: string;
   sort?: string;
   statsPeriod?: string | null;
+  useGroupSnubaDataset?: boolean;
 }
 
 type CountsEndpointParams = Omit<EndpointParams, 'cursor' | 'page' | 'query'> & {
@@ -430,6 +431,10 @@ class IssueListOverview extends Component<Props, State> {
     const groupStatsPeriod = this.getGroupStatsPeriod();
     if (groupStatsPeriod !== DEFAULT_GRAPH_STATS_PERIOD) {
       params.groupStatsPeriod = groupStatsPeriod;
+    }
+
+    if (this.props.location.query.useGroupSnubaDataset) {
+      params.useGroupSnubaDataset = true;
     }
 
     // only include defined values.


### PR DESCRIPTION
Paired with https://github.com/getsentry/sentry/pull/67273. Will pass the query param `useGroupSnubaDataset` to search if it's in the URL.