### PR TITLE
chore(slack): add logger to beginning of slack action POST

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -764,6 +764,10 @@ class SlackActionEndpoint(Endpoint):
         ]
 
     def post(self, request: Request) -> Response:
+        logger.info(
+            "slack.action.post",
+            extra=request.data,
+        )
         try:
             slack_request = self.slack_request_class(request)
             slack_request.validate()

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -766,7 +766,7 @@ class SlackActionEndpoint(Endpoint):
     def post(self, request: Request) -> Response:
         logger.info(
             "slack.action.post",
-            extra=request.data,
+            extra={**request.data, **request.META},
         )
         try:
             slack_request = self.slack_request_class(request)

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -766,7 +766,7 @@ class SlackActionEndpoint(Endpoint):
     def post(self, request: Request) -> Response:
         logger.info(
             "slack.action.post",
-            extra={**request.data, **request.META},
+            extra={**request.data, **request._request.META},
         )
         try:
             slack_request = self.slack_request_class(request)


### PR DESCRIPTION
The time between the `slack.action.request` logger and the `slack.action.response-error` logger is < 0.3 seconds. If the time between the new logger here and the `slack.action.request` logger is > 3 seconds then we would have our culprit for why we are getting `expired_trigger_id` errors.

However, we are also getting `exchanged_trigger_id` errors which are coming from us receiving multiple requests with the same trigger id, which would not be addressed by this logger.