### PR TITLE
feat(integration): Save and reply in thread replies

### DIFF
--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -65,7 +65,7 @@ class NewIssueAlertNotificationMessage(BaseNewNotificationMessage):
                 return RuleFireHistoryAndRuleActionUuidActionValidationError()
 
         # We can create a NotificationMessage if it has both, or neither, of rule fire history and action.
-        # The following is an XNOR check for incident and trigger
+        # The following is an XNOR check for rule fire history and action
         if (self.rule_fire_history_id is not None) != (self.rule_action_uuid is not None):
             return RuleFireHistoryAndRuleActionUuidActionValidationError()
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -16,7 +16,6 @@ from sentry.integrations.slack.message_builder.notifications.rule_save_edit impo
 from sentry.integrations.slack.utils import get_channel_id
 from sentry.models.integrations.integration import Integration
 from sentry.models.rule import Rule
-from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
 from sentry.rules import EventState
 from sentry.rules.actions import IntegrationEventAction
@@ -35,7 +34,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     integration_key = "workspace"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        rule_fire_history = kwargs.pop("rule_fire_history", None)
         super().__init__(*args, **kwargs)
         # XXX(CEO): when removing the feature flag, put `label` back up as a class var
         self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"  # type: ignore[misc]
@@ -59,7 +57,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         self._repository: IssueAlertNotificationMessageRepository = (
             get_default_issue_alert_repository()
         )
-        self._rule_fire_history: RuleFireHistory | None = rule_fire_history
 
     def after(
         self, event: GroupEvent, state: EventState, notification_uuid: str | None = None

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -16,6 +16,7 @@ from sentry.integrations.slack.message_builder.notifications.rule_save_edit impo
 from sentry.integrations.slack.utils import get_channel_id
 from sentry.models.integrations.integration import Integration
 from sentry.models.rule import Rule
+from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
 from sentry.rules import EventState
 from sentry.rules.actions import IntegrationEventAction
@@ -34,6 +35,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     integration_key = "workspace"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        rule_fire_history = kwargs.pop("rule_fire_history", None)
         super().__init__(*args, **kwargs)
         # XXX(CEO): when removing the feature flag, put `label` back up as a class var
         self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"  # type: ignore[misc]
@@ -57,6 +59,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         self._repository: IssueAlertNotificationMessageRepository = (
             get_default_issue_alert_repository()
         )
+        self._rule_fire_history: RuleFireHistory | None = rule_fire_history
 
     def after(
         self, event: GroupEvent, state: EventState, notification_uuid: str | None = None

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Sequence
+from logging import Logger, getLogger
 from typing import Any
 
 from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.repository import get_default_issue_alert_repository
-from sentry.integrations.repository.issue_alert import IssueAlertNotificationMessageRepository
+from sentry.integrations.repository.base import NotificationMessageValidationError
+from sentry.integrations.repository.issue_alert import (
+    IssueAlertNotificationMessageRepository,
+    NewIssueAlertNotificationMessage,
+)
 from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
@@ -23,8 +28,11 @@ from sentry.rules.actions import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
 from sentry.services.hybrid_cloud.integration import RpcIntegration
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.response import BaseApiResponse, MappingApiResponse
 from sentry.types.rules import RuleFuture
 from sentry.utils import json, metrics
+
+_default_logger: Logger = getLogger(__name__)
 
 
 class SlackNotifyServiceAction(IntegrationEventAction):
@@ -80,6 +88,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             additional_attachment = get_additional_attachment(
                 integration, self.project.organization
             )
+            payload = {}
             if features.has("organizations:slack-block-kit", event.group.project.organization):
                 blocks = SlackIssuesMessageBuilder(
                     group=event.group,
@@ -120,12 +129,71 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     "attachments": json.dumps(attachments),
                 }
 
+            rule = rules[0] if rules else None
+            rule_to_use = self.rule if self.rule else rule
+            rule_id = rule_to_use.id if rule_to_use else None
+            rule_action_uuid = self.data.get("action_uuid", None)
+            if not rule_action_uuid:
+                # We are logging because this should never happen, all actions should have an uuid
+                # We can monitor for this, and create an alert if this ever appears
+                _default_logger.info(
+                    "integration.slack.actions: No action uuid",
+                    extra={
+                        "rule_id": rule_id,
+                        "notification_uuid": notification_uuid,
+                    },
+                )
+
+            new_notification_message_object = NewIssueAlertNotificationMessage(
+                rule_fire_history_id=self._rule_fire_history.id, rule_action_uuid=rule_action_uuid
+            )
+
+            # Only try to get the parent notification message if the organization is in the FF
+            # We need to search by rule action uuid and rule id, so only search if they exist
+            if (
+                features.has(
+                    "organizations:slack-thread-issue-alert", event.group.project.organization
+                )
+                and rule_action_uuid
+                and rule_id
+            ):
+                parent_notification_message = None
+                try:
+                    parent_notification_message = self._repository.get_parent_notification_message(
+                        rule_id=rule_id,
+                        group_id=event.group.id,
+                        rule_action_uuid=rule_action_uuid,
+                    )
+                except Exception:
+                    # if there's an error trying to grab a parent notification, don't let that error block this flow
+                    # we already log at the repository layer, no need to log again here
+                    pass
+
+                if parent_notification_message:
+                    # If a parent notification exists for this rule and action, then we can reply in a thread
+                    # Make sure we track that this reply will be in relation to the parent row
+                    new_notification_message_object.parent_notification_message_id = (
+                        parent_notification_message.id
+                    )
+                    # To reply to a thread, use the specific key in the payload as referenced by the docs
+                    # https://api.slack.com/methods/chat.postMessage#arg_thread_ts
+                    payload["thread_ts"] = parent_notification_message.message_identifier
+
             client = SlackClient(integration_id=integration.id)
             try:
-                client.post(
+                response = client.post(
                     "/chat.postMessage", data=payload, timeout=5, log_response_with_error=True
                 )
             except ApiError as e:
+                # Record the error code and details from the exception
+                new_notification_message_object.error_code = e.code
+                new_notification_message_object.error_details = {
+                    "url": e.url,
+                    "host": e.host,
+                    "path": e.path,
+                    "data": e.json if e.json else e.text,
+                }
+
                 log_params = {
                     "error": str(e),
                     "project_id": event.project_id,
@@ -140,7 +208,51 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     "rule.fail.slack_post",
                     extra=log_params,
                 )
-            rule = rules[0] if rules else None
+            else:
+                # Slack will always send back a ts identifier https://api.slack.com/methods/chat.postMessage#examples
+                # on a successful message
+                ts = None
+                # This is a workaround for typing, and the dynamic nature of the return value
+                if isinstance(response, BaseApiResponse):
+                    ts = response.json.get("ts")
+                elif isinstance(response, MappingApiResponse):
+                    ts = response.get("ts")
+                else:
+                    _default_logger.info(
+                        "failed to get ts from slack response",
+                        extra={
+                            "response_type": type(response).__name__,
+                        },
+                    )
+                new_notification_message_object.message_identifier = (
+                    str(ts) if ts is not None else None
+                )
+
+            if (
+                features.has(
+                    "organizations:slack-thread-issue-alert", event.group.project.organization
+                )
+                and rule_action_uuid
+                and rule_id
+            ):
+                try:
+                    self._repository.create_notification_message(
+                        data=new_notification_message_object
+                    )
+                except NotificationMessageValidationError as err:
+                    extra = (
+                        new_notification_message_object.__dict__
+                        if new_notification_message_object
+                        else None
+                    )
+                    _default_logger.info(
+                        "integration.slack.actions: Validation error", exc_info=err, extra=extra
+                    )
+                except Exception:
+                    # if there's an error trying to save a notification message, don't let that error block this flow
+                    # we already log at the repository layer, no need to log again here
+                    pass
+
             self.record_notification_sent(event, channel, rule, notification_uuid)
 
         key = f"slack:{integration.id}:{channel}"

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -142,7 +142,8 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 )
 
             new_notification_message_object = NewIssueAlertNotificationMessage(
-                rule_fire_history_id=self.rule_fire_history.id, rule_action_uuid=rule_action_uuid
+                rule_fire_history_id=self.rule_fire_history.id if self.rule_fire_history else None,
+                rule_action_uuid=rule_action_uuid,
             )
 
             # Only try to get the parent notification message if the organization is in the FF

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -15,7 +15,7 @@ from sentry.models.project import Project
 from sentry.models.user import User
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import issue_ignored, issue_unignored, issue_unresolved
-from sentry.tasks.integrations import kick_off_status_syncs
+from sentry.tasks.integrations.kick_off_status_syncs import kick_off_status_syncs
 from sentry.types.activity import ActivityType
 from sentry.utils import json
 

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -15,7 +15,7 @@ from sentry.models.project import Project
 from sentry.models.user import User
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import issue_ignored, issue_unignored, issue_unresolved
-from sentry.tasks.integrations.kick_off_status_syncs import kick_off_status_syncs
+from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.types.activity import ActivityType
 from sentry.utils import json
 


### PR DESCRIPTION
Depends on: https://github.com/getsentry/sentry/pull/67214

Save the notification message, and try to reply in a thread is applicable.

Will save the record of the notification message, both success and failure. For success, that will let us do thread replies in subsequent requests and through workflow notifications. For failures, that will help us bring failing notification actions to the user.
