### PR TITLE
fix(hybridcloud) Fix delivery of audits with deleted users

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -91,21 +91,15 @@ class AuditLogEntry(Model):
                 # Fetch user by RPC service as
                 # Audit logs are often created in regions.
                 user = user_service.get_user(self.actor_id)
-                self.actor_label = user.username
+                if user:
+                    self.actor_label = user.username
             elif self.actor_key:
                 # TODO(hybridcloud) This requires an RPC service.
                 self.actor_label = self.actor_key.key
-            else:
-                logger.error(
-                    "Expected a user or actor key for audit log",
-                    extra={
-                        "event": self.event,
-                        "organization_id": self.organization_id,
-                        "event_data": self.data,
-                    },
-                )
-                # Fallback to IP address if user or actor label not available
-                self.actor_label = self.ip_address
+
+        # Fallback to IP address if user or actor label not available
+        if not self.actor_label:
+            self.actor_label = self.ip_address or ""
 
     def as_event(self) -> AuditLogEvent:
         """

--- a/src/sentry/services/hybrid_cloud/log/impl.py
+++ b/src/sentry/services/hybrid_cloud/log/impl.py
@@ -24,7 +24,10 @@ class DatabaseBackedLogService(LogService):
             if '"auth_user"' in error_message:
                 # It is possible that a user existed at the time of serialization but was deleted by the time of consumption
                 # in which case we follow the database's SET NULL on delete handling.
-                event.actor_user_id = None
+                if event.actor_user_id:
+                    event.actor_user_id = None
+                if event.target_user_id:
+                    event.target_user_id = None
                 return self.record_audit_log(event=event)
             else:
                 raise


### PR DESCRIPTION
In looking into SENTRY-2S0H, I noticed that all the audit messages had ip_address which is a reasonable fallback for audit log authors. Thanks to the additional logging I added to investigate this issue I found another issue with audit logs. If a member delete audit (or any audit log) references a deleted user when the message is processed we would fail to save the audit log as the invalid relation was not nulled out (like it would have been if the user was removed after the audit was created).

By nulling out `target_user_id` we can persist these audit logs and continue to make progress on audit logs for an org.
