### PR TITLE
chore(hybridcloud) Replace sha1 with sha256

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from hashlib import sha1
+from hashlib import sha256
 from typing import Any
 
 import sentry_sdk
@@ -110,7 +110,7 @@ def process_async_webhooks(
             "integration_proxy.control.process_async_webhooks",
             tags={"destination_region": region.name},
         ):
-            request_prefix_hash = sha1(
+            request_prefix_hash = sha256(
                 f"{shard_identifier}{object_identifier}".encode()
             ).hexdigest()
             logging_context["region"] = region.name

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ipaddress
 import socket
 from collections.abc import Iterable, Mapping
-from hashlib import sha1
+from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
@@ -254,7 +254,7 @@ class RegionSiloClient(BaseSiloClient):
         """
         hash = None
         if prefix_hash is not None:
-            hash = sha1(f"{prefix_hash}{self.region.name}{method}{path}".encode()).hexdigest()
+            hash = sha256(f"{prefix_hash}{self.region.name}{method}{path}".encode()).hexdigest()
 
         self.check_request_attempts(hash=hash, method=method, path=path)
         response = super().request(

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -1,4 +1,4 @@
-from hashlib import sha1
+from hashlib import sha256
 from unittest import mock
 from unittest.mock import patch
 
@@ -51,10 +51,10 @@ class ProcessControlOutboxTest(TestCase):
         outbox.save()
         outbox.refresh_from_db()
 
-        prefix_hash = sha1(
+        prefix_hash = sha256(
             f"{outbox.shard_identifier}{outbox.object_identifier}".encode()
         ).hexdigest()
-        hash = sha1(
+        hash = sha256(
             f"{prefix_hash}{_TEST_REGION.name}POST/extensions/github/webhook/".encode()
         ).hexdigest()
         cache_key = f"region_silo_client:request_attempts:{hash}"

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -1,5 +1,5 @@
 import ipaddress
-from hashlib import sha1
+from hashlib import sha256
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -123,7 +123,7 @@ class SiloClientTest(TestCase):
             )
 
             prefix_hash = "123"
-            hash = sha1(f"{prefix_hash}{self.region.name}POST{path}".encode()).hexdigest()
+            hash = sha256(f"{prefix_hash}{self.region.name}POST{path}".encode()).hexdigest()
             cache_key = f"region_silo_client:request_attempts:{hash}"
             num_of_request_attempts = 0
 
@@ -184,7 +184,7 @@ class SiloClientTest(TestCase):
             )
 
             prefix_hash = "123"
-            hash = sha1(f"{prefix_hash}{self.region.name}POST{path}".encode()).hexdigest()
+            hash = sha256(f"{prefix_hash}{self.region.name}POST{path}".encode()).hexdigest()
             cache_key = f"region_silo_client:request_attempts:{hash}"
             num_of_request_attempts = 0
 


### PR DESCRIPTION
This usage of sha1 can be conflated with a security relevant use case and was flagged by codeql. Swap out the cache key counter with a stronger hashing algorithm. We'll miss cache key hits after this deploys, but that's ok as the counters will begin again with the new key and eventually complete or discard the related payloads.

Refs https://github.com/getsentry/sentry/security/code-scanning/401