### PR TITLE
fix(event-tags): Highlights section still appears empty

### DIFF
--- a/static/app/components/events/contextSummary/index.tsx
+++ b/static/app/components/events/contextSummary/index.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -51,6 +53,7 @@ type Props = {
 };
 
 function ContextSummary({event}: Props) {
+  const hasNewTagsUI = useHasNewTagsUI();
   if (objectIsEmpty(event.contexts)) {
     return null;
   }
@@ -113,6 +116,19 @@ function ContextSummary({event}: Props) {
 
     return <Component key={key} {...props} />;
   });
+
+  if (hasNewTagsUI) {
+    // TODO(Leander): When a design is confirmed, move this to HighlightsDataSection
+    return (
+      <EventDataSection
+        title={t('Highlighted Event Data')}
+        data-test-id="highlighted-event-data"
+        type="highlighted-event-data"
+      >
+        <Wrapper>{contexts}</Wrapper>
+      </EventDataSection>
+    );
+  }
 
   return <Wrapper>{contexts}</Wrapper>;
 }

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -1,9 +1,6 @@
 import ContextSummary from 'sentry/components/events/contextSummary';
-import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
-import {t} from 'sentry/locale';
 import type {Event, Group, Project} from 'sentry/types';
-import {objectIsEmpty} from 'sentry/utils';
 
 interface HighlightsSectionProps {
   event: Event;
@@ -13,17 +10,9 @@ interface HighlightsSectionProps {
 
 export default function HighlightsDataSection({event}: HighlightsSectionProps) {
   const hasNewTagsUI = useHasNewTagsUI();
-  if (!hasNewTagsUI || objectIsEmpty(event.contexts)) {
+  if (!hasNewTagsUI) {
     return null;
   }
-
-  return (
-    <EventDataSection
-      title={t('Highlighted Event Data')}
-      data-test-id="highlighted-event-data"
-      type="highlighted-event-data"
-    >
-      <ContextSummary event={event} />
-    </EventDataSection>
-  );
+  // TODO(Leander): When a design is confirmed, remove this usage of ContextSummary
+  return <ContextSummary event={event} />;
 }


### PR DESCRIPTION
Fixes event tags showing up empty
- The reason was because I tried to short circuit the rendering by only checking `objectIsEmpty(event.contexts)` but it appears there are two more conditions which could cause `ContextSummary` to render empty. 
- Instead of trying to match those to some parent we'll conditionally show, for now, I will just render the component with the header if it does end up getting painted (by modifying `contextSummary.tsx`
- Once designs are finalized, this component will not be used any more, and the internal logic of rendering a minimum amount of contexts, etc. will go away cleanly.