### PR TITLE
fix(api): Improve rate limit query

### DIFF
--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import Any
 
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 
 from sentry.api.serializers import SentryAppAlertRuleActionSerializer, Serializer, serialize
 from sentry.constants import SentryAppInstallationStatus, SentryAppStatus
@@ -203,7 +203,6 @@ class DatabaseBackedAppService(AppService):
                 # the installation by token id in SentryAppInstallation, we also search
                 # SentryAppInstallationToken by token id, then fetch  the linked installation.
                 # Internal Integrations follow this pattern because they can have multiple tokens.
-                from django.db.models import Q
 
                 # Decompose this query instead of using a subquery for performance.
                 install_token_list = SentryAppInstallationToken.objects.filter(
@@ -212,7 +211,7 @@ class DatabaseBackedAppService(AppService):
 
                 query = query.filter(
                     Q(api_token_id=filters["api_installation_token_id"])
-                    | Q(id__in=install_token_list)
+                    | Q(id__in=list(install_token_list))
                 )
 
             return query


### PR DESCRIPTION
The subquery that we use for fetching the sentry app installation is slow because we're joining `SentryAppInstallationToken` and `SentryAppInstallation`.

Instead, speed it up by fetching `SentryAppInstallationToken` independently first.

Real query info for the `SentryAppInstallationToken` query
```
Index Scan using sentry_sentryappinstallationtoken_api_token_id on sentry_sentryappinstallationtoken (cost=0.29..2.51 rows=1 width=8) (actual time=0.040..0.041 rows=1 loops=1)
	
Index Cond: (api_token_id = 408727)
	
Planning Time: 0.065 ms
	
Execution Time: 0.052 ms
```