### PR TITLE
fix(replays): remove extra styles from replay index table

### DIFF
--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -112,6 +112,7 @@ function ReplaysListTable({
   return (
     <Fragment>
       <ReplayTable
+        referrerLocation={'replay'}
         fetchError={fetchError}
         isFetching={isFetching}
         replays={replays}

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -39,6 +39,7 @@ type Props = {
   emptyMessage?: ReactNode;
   gridRows?: string;
   onClickPlay?: (index: number) => void;
+  referrerLocation?: string;
   showDropdownFilters?: boolean;
 };
 
@@ -54,6 +55,7 @@ const ReplayTable = memo(
     gridRows,
     showDropdownFilters,
     onClickPlay,
+    referrerLocation,
   }: Props) => {
     const routes = useRoutes();
     const location = useLocation();
@@ -109,7 +111,10 @@ const ReplayTable = memo(
         {replays?.map(
           (replay: ReplayListRecord | ReplayListRecordWithTx, index: number) => {
             return (
-              <Row key={replay.id} isPlaying={index === selectedReplayIndex}>
+              <Row
+                key={replay.id}
+                isPlaying={index === selectedReplayIndex && referrerLocation !== 'replay'}
+              >
                 {visibleColumns.map(column => {
                   switch (column) {
                     case ReplayColumn.ACTIVITY:


### PR DESCRIPTION
- fixes https://github.com/getsentry/sentry/issues/67274
- remove this extra style that was coming from the replay tab of issues

before:
<img width="1156" alt="SCR-20240319-nawc" src="https://github.com/getsentry/sentry/assets/56095982/36d7c787-6b1c-4656-b187-8b4cf4ca9c67">

after:
<img width="1158" alt="SCR-20240319-natk" src="https://github.com/getsentry/sentry/assets/56095982/f734b938-299e-478a-85f7-b7eda87098dd">

