### PR TITLE
feat(issues): Remove trace timeline whitespace placeholder

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -308,6 +308,10 @@ const StyledDataSection = styled(DataSection)`
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     padding: ${space(1)} ${space(4)};
   }
+
+  &:empty {
+    display: none;
+  }
 `;
 
 export default GroupEventDetailsContent;

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.spec.tsx
@@ -2,7 +2,7 @@ import {EventFixture} from 'sentry-fixture/event';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -93,11 +93,13 @@ describe('TraceTimeline', () => {
       body: discoverBody,
       match: [MockApiClient.matchQuery({dataset: 'discover'})],
     });
-    render(<TraceTimeline event={event} />, {organization});
-    expect(await screen.findByTestId('trace-timeline-empty')).toBeInTheDocument();
-    expect(useRouteAnalyticsParams).toHaveBeenCalledWith({
-      trace_timeline_status: 'empty',
-    });
+    const {container} = render(<TraceTimeline event={event} />, {organization});
+    await waitFor(() =>
+      expect(useRouteAnalyticsParams).toHaveBeenCalledWith({
+        trace_timeline_status: 'empty',
+      })
+    );
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('displays nothing if there are no events', async () => {
@@ -111,11 +113,13 @@ describe('TraceTimeline', () => {
       body: emptyBody,
       match: [MockApiClient.matchQuery({dataset: 'discover'})],
     });
-    render(<TraceTimeline event={event} />, {organization});
-    expect(await screen.findByTestId('trace-timeline-empty')).toBeInTheDocument();
-    expect(useRouteAnalyticsParams).toHaveBeenCalledWith({
-      trace_timeline_status: 'empty',
-    });
+    const {container} = render(<TraceTimeline event={event} />, {organization});
+    await waitFor(() =>
+      expect(useRouteAnalyticsParams).toHaveBeenCalledWith({
+        trace_timeline_status: 'empty',
+      })
+    );
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('shows seconds for very short timelines', async () => {

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -2,7 +2,6 @@ import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -43,27 +42,20 @@ export function TraceTimeline({event}: TraceTimelineProps) {
     !isLoading &&
     traceEvents.length > 0 &&
     traceEvents.every(item => item.id === event.id);
-  if (isError || noEvents || onlySelfEvent) {
+  if (isError || noEvents || onlySelfEvent || isLoading) {
     // display empty placeholder to reduce layout shift
-    return <div style={{height: 36}} data-test-id="trace-timeline-empty" />;
+    return null;
   }
 
   return (
     <ErrorBoundary mini>
       <TimelineWrapper>
         <div ref={timelineRef}>
-          {isLoading ? (
-            <LoadingSkeleton>
-              <Placeholder height="14px" />
-              <Placeholder height="8px" />
-            </LoadingSkeleton>
-          ) : (
-            <TimelineEventsContainer>
-              <TimelineOutline />
-              {/* Sets a min width of 200 for testing */}
-              <TraceTimelineEvents event={event} width={Math.max(width, 200)} />
-            </TimelineEventsContainer>
-          )}
+          <TimelineEventsContainer>
+            <TimelineOutline />
+            {/* Sets a min width of 200 for testing */}
+            <TraceTimelineEvents event={event} width={Math.max(width, 200)} />
+          </TimelineEventsContainer>
         </div>
         <QuestionTooltipWrapper>
           <QuestionTooltip
@@ -109,12 +101,4 @@ const TimelineEventsContainer = styled('div')`
   position: relative;
   height: 34px;
   padding-top: 10px;
-`;
-
-const LoadingSkeleton = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(0.25)};
-  padding: ${space(0.5)} 0 ${space(1)};
-  height: 34px;
 `;


### PR DESCRIPTION
Trace timeline currently holds the space no matter what if the event has a trace id to reduce layout shift.  This removes the loading state and placeholder in favor of some layout shift for the less common state of displaying the trace timeline.

Fixes a bug with suspect commit container being empty and still displaying padding
