### PR TITLE
fix(feedback): only track sidebar views if currentProject exists

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -82,14 +82,14 @@ function FeedbackOnboardingSidebar(props: CommonSidebarProps) {
   }, [allProjects]);
 
   useEffect(() => {
-    if (isActive) {
+    if (isActive && currentProject && hasProjectAccess) {
       // this tracks clicks from any source: feedback index, issue details feedback tab, banner callout, etc
       trackAnalytics('feedback.list-view-setup-sidebar', {
         organization,
         platform: currentProject?.platform ?? 'unknown',
       });
     }
-  }, [organization, currentProject, isActive]);
+  }, [organization, currentProject, isActive, hasProjectAccess]);
 
   if (!isActive || !hasProjectAccess || !currentProject) {
     return null;


### PR DESCRIPTION
We're getting a lot of `unknown` values in our amplitude analytics so let's be sure it's coming from projects without platforms, by doing an extra check for if the project actually exists.