### PR TITLE
feat(crons): Send email to orgs with broken monitors

### DIFF
--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import timedelta
+from typing import Any
 from urllib.parse import urlencode, urlparse, urlunparse
 
 from django.urls import reverse
@@ -86,7 +87,7 @@ def detect_broken_monitor_envs():
             continue
 
         # Map user email to a dictionary of monitors and their earliest incident start date amongst its broken environments
-        user_broken_envs = defaultdict(
+        user_broken_envs: dict[str, dict[str, Any]] = defaultdict(
             lambda: defaultdict(
                 lambda: {"environment_names": [], "earliest_start": django_timezone.now()}
             )

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import timedelta
+from unittest.mock import call, patch
 
 from django.utils import timezone
 
@@ -18,6 +19,7 @@ from sentry.monitors.models import (
 )
 from sentry.monitors.tasks.detect_broken_monitor_envs import detect_broken_monitor_envs
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 
 
@@ -77,21 +79,27 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 status=CheckInStatus.ERROR,
                 date_added=timezone.now() - timedelta(days=i),
             )
-
         return incident
 
     @with_feature("organizations:crons-broken-monitor-detection")
-    def test_creates_broken_detection_no_duplicates(self):
+    @patch("sentry.monitors.tasks.detect_broken_monitor_envs.MessageBuilder")
+    @patch("django.utils.timezone.now")
+    def test_creates_broken_detection_no_duplicates(self, mock_now, builder):
+        now = before_now()
+        mock_now.return_value = now
         monitor, monitor_environment = self.create_monitor_and_env()
-
         incident = self.create_incident_for_monitor_env(monitor, monitor_environment)
 
         detect_broken_monitor_envs()
-        assert len(MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)) == 1
+        broken_detections = MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)
+        assert len(broken_detections) == 1
+        assert broken_detections.first().user_notified_timestamp == now
+        assert builder.call_count == 1
 
-        # running the task again shouldn't create duplicates
+        # running the task again shouldn't create duplicates or send additional emails
         detect_broken_monitor_envs()
         assert len(MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)) == 1
+        assert builder.call_count == 1
 
     @with_feature("organizations:crons-broken-monitor-detection")
     def test_does_not_create_broken_detection_insufficient_duration(self):
@@ -157,7 +165,6 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
 
     def test_does_not_create_broken_detection_no_feature(self):
         monitor, monitor_environment = self.create_monitor_and_env()
-
         incident = self.create_incident_for_monitor_env(monitor, monitor_environment)
 
         detect_broken_monitor_envs()
@@ -173,3 +180,83 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
 
         detect_broken_monitor_envs()
         assert len(MonitorEnvBrokenDetection.objects.filter(monitor_incident=incident)) == 0
+
+    @with_feature("organizations:crons-broken-monitor-detection")
+    @patch("sentry.monitors.tasks.detect_broken_monitor_envs.MessageBuilder")
+    @patch("django.utils.timezone.now")
+    def test_sends_emails_to_all_users_across_orgs(self, mock_now, builder):
+        now = before_now()
+        mock_now.return_value = now
+        monitor, monitor_environment = self.create_monitor_and_env()
+
+        second_user = self.create_user("second_user@example.com")
+        second_org = self.create_organization(owner=second_user)
+        self.create_member(user=self.user, organization=second_org)
+        second_team = self.create_team(organization=second_org, members=[second_user, self.user])
+        second_project = self.create_project(organization=second_org, teams=[second_team])
+        second_env = self.create_environment(second_project, name="production")
+
+        second_monitor, second_monitor_environment = self.create_monitor_and_env(
+            name="second monitor",
+            organization_id=second_org.id,
+            project_id=second_project.id,
+            environment_id=second_env.id,
+        )
+
+        self.create_incident_for_monitor_env(monitor, monitor_environment)
+        self.create_incident_for_monitor_env(second_monitor, second_monitor_environment)
+
+        detect_broken_monitor_envs()
+        broken_detections = MonitorEnvBrokenDetection.objects.all()
+        assert len(broken_detections) == 2
+        assert broken_detections[0].user_notified_timestamp == now
+        assert broken_detections[1].user_notified_timestamp == now
+        # should build 3 emails, 2 for self.user from the 2 orgs, and 1 for second_user
+        expected_contexts = [
+            {
+                "broken_monitors": [
+                    (
+                        monitor.slug,
+                        f"http://testserver/organizations/{self.organization.slug}/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
+                        timezone.now() - timedelta(days=14),
+                    )
+                ],
+                "view_monitors_link": f"http://testserver/organizations/{self.organization.slug}/crons/",
+            },
+            {
+                "broken_monitors": [
+                    (
+                        second_monitor.slug,
+                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        timezone.now() - timedelta(days=14),
+                    )
+                ],
+                "view_monitors_link": f"http://testserver/organizations/{second_org.slug}/crons/",
+            },
+            {
+                "broken_monitors": [
+                    (
+                        second_monitor.slug,
+                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        timezone.now() - timedelta(days=14),
+                    )
+                ],
+                "view_monitors_link": f"http://testserver/organizations/{second_org.slug}/crons/",
+            },
+        ]
+
+        builder.assert_has_calls(
+            [
+                call(
+                    **{
+                        "subject": "Your monitors are broken!",
+                        "template": "sentry/emails/crons/broken-monitors.txt",
+                        "html_template": "sentry/emails/crons/broken-monitors.html",
+                        "type": "crons.broken_monitors",
+                        "context": context,
+                    }
+                )
+                for context in expected_contexts[:1]
+            ],
+            any_order=True,
+        )


### PR DESCRIPTION
Modifies the logic in our detect broken monitors task to batch process by open incidents by org, determining if they qualify as broken and then emailing the relevant users.

- Uses project.member_set to get all OrganizationMembers that should be emailed
- Consolidates multiple broken entries in the same monitor (but different environments) into a single line entry for the email

For initial deploy I also plan on resetting our crons-broken-monitor-detection flag to LA orgs, so if there is any problem with the emails we don't spam all of our customers

Relies on: https://github.com/getsentry/sentry/pull/66927

Closes: https://github.com/getsentry/team-crons/issues/133