### PR TITLE
Revert: chore(staff): Add extra logs, include timestamp, remove finally

### DIFF
--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -1,11 +1,10 @@
 import logging
 from base64 import urlsafe_b64encode
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from functools import cached_property
 from time import time
 from urllib.parse import urlparse
 
-import sentry_sdk
 from cryptography.exceptions import InvalidKey, InvalidSignature
 from django.http.request import HttpRequest
 from django.urls import reverse
@@ -256,11 +255,10 @@ class U2fInterface(AuthenticatorInterface):
         # timestamp is valid here if it exists. The reason for this is we prefer
         # the failure to occur and present itself when tapping the U2F device,
         # not immediately upon generating the challenge/response.
-        timestamp = int(datetime.now(timezone.utc).timestamp())
         if request.session.get("staff_auth_flow"):
-            request.session["staff_webauthn_authentication_state"] = (state, timestamp)
+            request.session["staff_webauthn_authentication_state"] = state
         else:
-            request.session["webauthn_authentication_state"] = (state, timestamp)
+            request.session["webauthn_authentication_state"] = state
 
         logger.info(
             "U2F activate after setting state",
@@ -281,8 +279,6 @@ class U2fInterface(AuthenticatorInterface):
     def validate_response(self, request: HttpRequest, challenge, response):
         try:
             credentials = self.credentials()
-            staff_state = request.session.get("staff_webauthn_authentication_state")
-            default_state = request.session.get("webauthn_authentication_state")
             if hasattr(request, "user") and request.user.is_staff:
                 logger.info(
                     "Validating U2F for staff",
@@ -293,19 +289,15 @@ class U2fInterface(AuthenticatorInterface):
                             if "staff_auth_flow" in request.session
                             else "missing"
                         ),
-                        "state_timestamp": (
-                            datetime.fromtimestamp(default_state[1]) if default_state else 0
-                        ),
-                        "staff_timestamp": (
-                            datetime.fromtimestamp(staff_state[1]) if staff_state else 0
-                        ),
+                        "has_state": "webauthn_authentication_state" in request.session,
+                        "has_staff_state": "staff_webauthn_authentication_state" in request.session,
                         "active_silo": SiloMode.get_current_mode(),
                     },
                 )
             if _valid_staff_timestamp(request):
-                state, _ = request.session["staff_webauthn_authentication_state"]
+                state = request.session["staff_webauthn_authentication_state"]
             else:
-                state, _ = request.session["webauthn_authentication_state"]
+                state = request.session["webauthn_authentication_state"]
             if request.session.get("staff_webauthn_authentication_state") and request.session.get(
                 "webauthn_authentication_state"
             ):
@@ -323,8 +315,7 @@ class U2fInterface(AuthenticatorInterface):
                 auth_data=AuthenticatorData(websafe_decode(response["authenticatorData"])),
                 signature=websafe_decode(response["signatureData"]),
             )
-        except (InvalidSignature, InvalidKey, StopIteration) as err:
-            sentry_sdk.capture_exception(err)
+        except (InvalidSignature, InvalidKey, StopIteration):
             return False
         finally:
             # Cleanup the U2F state from the session

--- a/tests/sentry/auth/authenticators/test_u2f.py
+++ b/tests/sentry/auth/authenticators/test_u2f.py
@@ -77,8 +77,8 @@ class U2FInterfaceTest(TestCase):
         result = self.u2f.activate(self.request)
 
         assert isinstance(result, ActivationChallengeResult)
-        assert len(self.request.session["webauthn_authentication_state"][0]["challenge"]) == 43
-        assert self.request.session["webauthn_authentication_state"][0]["user_verification"] is None
+        assert len(self.request.session["webauthn_authentication_state"]["challenge"]) == 43
+        assert self.request.session["webauthn_authentication_state"]["user_verification"] is None
 
     @freeze_time(CURRENT_TIME)
     def test_activate_staff_webauthn_valid_timestamp(self):
@@ -90,12 +90,9 @@ class U2FInterfaceTest(TestCase):
 
         assert isinstance(result, ActivationChallengeResult)
         assert "webauthn_authentication_state" not in self.request.session
+        assert len(self.request.session["staff_webauthn_authentication_state"]["challenge"]) == 43
         assert (
-            len(self.request.session["staff_webauthn_authentication_state"][0]["challenge"]) == 43
-        )
-        assert (
-            self.request.session["staff_webauthn_authentication_state"][0]["user_verification"]
-            is None
+            self.request.session["staff_webauthn_authentication_state"]["user_verification"] is None
         )
 
     @freeze_time(CURRENT_TIME)
@@ -108,12 +105,9 @@ class U2FInterfaceTest(TestCase):
 
         assert isinstance(result, ActivationChallengeResult)
         assert "webauthn_authentication_state" not in self.request.session
+        assert len(self.request.session["staff_webauthn_authentication_state"]["challenge"]) == 43
         assert (
-            len(self.request.session["staff_webauthn_authentication_state"][0]["challenge"]) == 43
-        )
-        assert (
-            self.request.session["staff_webauthn_authentication_state"][0]["user_verification"]
-            is None
+            self.request.session["staff_webauthn_authentication_state"]["user_verification"] is None
         )
 
     def test_validate_response_normal_state(self):
@@ -121,7 +115,7 @@ class U2FInterfaceTest(TestCase):
         mock_state = Mock()
         self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
 
-        self.request.session["webauthn_authentication_state"] = ("normal state", 5)
+        self.request.session["webauthn_authentication_state"] = "normal state"
 
         assert self.u2f.validate_response(self.request, None, self.response)
         _, kwargs = mock_state.call_args
@@ -134,7 +128,7 @@ class U2FInterfaceTest(TestCase):
         mock_state = Mock()
         self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
 
-        self.request.session["staff_webauthn_authentication_state"] = ("staff state", 5)
+        self.request.session["staff_webauthn_authentication_state"] = "staff state"
         self.request.session["staff_auth_flow"] = self.VALID_TIMESTAMP
 
         assert self.u2f.validate_response(self.request, None, self.response)
@@ -149,7 +143,7 @@ class U2FInterfaceTest(TestCase):
         self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
 
         # Test expired timestamp
-        self.request.session["webauthn_authentication_state"] = ("non-staff state", 5)
+        self.request.session["webauthn_authentication_state"] = "non-staff state"
         self.request.session["staff_auth_flow"] = self.INVALID_EXPIRED_TIMESTAMP
 
         assert self.u2f.validate_response(self.request, None, self.response)
@@ -158,7 +152,7 @@ class U2FInterfaceTest(TestCase):
         assert "webauthn_authentication_state" not in self.request.session
 
         # Test timestamp too far in the future
-        self.request.session["webauthn_authentication_state"] = ("non-staff state", 5)
+        self.request.session["webauthn_authentication_state"] = "non-staff state"
         self.request.session["staff_auth_flow"] = self.INVALID_FUTURE_TIMESTAMP
         assert self.u2f.validate_response(self.request, None, self.response)
         _, kwargs = mock_state.call_args
@@ -171,8 +165,8 @@ class U2FInterfaceTest(TestCase):
         mock_state = Mock(side_effect=ValueError("test"))
         self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
 
-        self.request.session["webauthn_authentication_state"] = ("non-staff state", 5)
-        self.request.session["staff_webauthn_authentication_state"] = ("staff state", 5)
+        self.request.session["webauthn_authentication_state"] = "non-staff state"
+        self.request.session["staff_webauthn_authentication_state"] = "staff state"
         self.request.session["staff_auth_flow"] = self.VALID_TIMESTAMP
 
         with raises(ValueError):


### PR DESCRIPTION
Reverting b/c popping the session keys are not working anymore after adding the timestamp. Hopefully putting this back fixes it.

Reverts https://github.com/getsentry/sentry/pull/67183

Closed b/c I reverted it with a trigger instead 🤦‍♂️