### PR TITLE
ref(daily summary): Add org slug, format event count, add newline

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -44,7 +44,7 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
         attachment_text = self.get_attachment_text(group)
         if not attachment_text:
             return f"<{link}|*{escape_slack_text(title)}*>"
-        return f"<{link}|*{escape_slack_text(title)}*> {attachment_text}"
+        return f"<{link}|*{escape_slack_text(title)}*>\n{attachment_text}"
 
     def linkify_release(self, release, organization):
         path = f"/releases/{release.version}/"
@@ -99,11 +99,12 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
 
             fields = []
             event_count_text = "*Today’s Event Count*: "
+            formatted_total_today = f"{context.total_today:,}"
             if features.has("organizations:discover", project.organization):
                 discover_url = self.build_discover_url(project)
-                event_count_text += f"<{discover_url}|{context.total_today}>"
+                event_count_text += f"<{discover_url}|{formatted_total_today}>"
             else:
-                event_count_text += str(context.total_today)
+                event_count_text += formatted_total_today
             fields.append(self.make_field(event_count_text))
 
             # Calculate today's event count percentage against 14 day avg

--- a/src/sentry/notifications/notifications/daily_summary.py
+++ b/src/sentry/notifications/notifications/daily_summary.py
@@ -53,7 +53,9 @@ class DailySummaryNotification(BaseNotification):
         return ""
 
     def get_message_description(self, recipient: RpcActor, provider: ExternalProviders) -> Any:
-        return "Daily Summary for Your Projects (internal only!!!)"
+        return (
+            f"Daily Summary for Your {self.organization.slug.title()} Projects (internal only!!!)"
+        )
 
     def get_title_link(self, recipient: RpcActor, provider: ExternalProviders) -> str | None:
         return None

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -485,7 +485,10 @@ class DailySummaryTest(
             ).send()
         blocks, fallback_text = get_blocks_and_fallback_text()
         link_text = "http://testserver/organizations/baz/issues/{}/?referrer=slack"
-        assert fallback_text == "Daily Summary for Your Projects (internal only!!!)"
+        assert (
+            fallback_text
+            == f"Daily Summary for Your {self.organization.slug.title()} Projects (internal only!!!)"
+        )
         assert f":bell: *{fallback_text}*" in blocks[0]["text"]["text"]
         assert (
             "Your comprehensive overview for today - key issues, performance insights, and more."
@@ -503,7 +506,7 @@ class DailySummaryTest(
         # check error issues
         assert "*Today's Top 3 Error Issues" in blocks[5]["fields"][0]["text"]
         assert link_text.format(self.group1.id) in blocks[5]["fields"][0]["text"]
-        assert "Identity not found." in blocks[5]["fields"][0]["text"]
+        assert "\nIdentity not found." in blocks[5]["fields"][0]["text"]
         assert link_text.format(self.group2.id) in blocks[5]["fields"][0]["text"]
         assert link_text.format(self.group2.id) in blocks[5]["fields"][0]["text"]
         # check escalated or regressed issues
@@ -513,7 +516,7 @@ class DailySummaryTest(
         # check performance issues
         assert "*Today's Top 3 Performance Issues*" in blocks[6]["text"]["text"]
         assert link_text.format(self.perf_event.group.id) in blocks[6]["text"]["text"]
-        assert "db - SELECT `books_author`.`id`, `books_author`.`..." in blocks[6]["text"]["text"]
+        assert "\ndb - SELECT `books_author`.`id`, `books_author`.`..." in blocks[6]["text"]["text"]
         assert link_text.format(self.perf_event2.group.id) in blocks[6]["text"]["text"]
         # repeat above for second project
         assert self.project2.slug in blocks[8]["text"]["text"]
@@ -553,7 +556,10 @@ class DailySummaryTest(
             "yAxis": "count()",
         }
         query_string = urlencode(query_params, doseq=True)
-        assert fallback_text == "Daily Summary for Your Projects (internal only!!!)"
+        assert (
+            fallback_text
+            == f"Daily Summary for Your {self.organization.slug.title()} Projects (internal only!!!)"
+        )
         assert f":bell: *{fallback_text}*" in blocks[0]["text"]["text"]
         assert (
             "Your comprehensive overview for today - key issues, performance insights, and more."


### PR DESCRIPTION
Some more minor notification formatting changes - add the org slug to the title, format the event count to have commas, add a newline after the issue title.

Closes https://github.com/getsentry/team-core-product-foundations/issues/211