### PR TITLE
fix(hc): Add replacements for RPC methods that return tuples

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/model.py
+++ b/src/sentry/services/hybrid_cloud/integration/model.py
@@ -69,6 +69,11 @@ class RpcOrganizationIntegration(RpcModel):
         return "disabled"
 
 
+class RpcOrganizationIntegrationContextResult(RpcModel):
+    integration: RpcIntegration | None
+    installs: list[RpcOrganizationIntegration]
+
+
 class RpcIntegrationExternalProject(RpcModel):
     id: int
     organization_integration_id: int

--- a/src/sentry/services/hybrid_cloud/notifications/model.py
+++ b/src/sentry/services/hybrid_cloud/notifications/model.py
@@ -20,3 +20,9 @@ class RpcExternalActor(RpcModel):
     external_name: str = ""
     # The unique identifier i.e user ID, channel ID.
     external_id: str | None = None
+
+
+class RpcGroupSubscriptionStatus(RpcModel):
+    is_disabled: bool
+    is_active: bool
+    has_only_inactive_subscriptions: bool

--- a/src/sentry/services/hybrid_cloud/notifications/serial.py
+++ b/src/sentry/services/hybrid_cloud/notifications/serial.py
@@ -1,5 +1,6 @@
 from sentry.models.integrations.external_actor import ExternalActor
-from sentry.services.hybrid_cloud.notifications import RpcExternalActor
+from sentry.notifications.types import GroupSubscriptionStatus
+from sentry.services.hybrid_cloud.notifications import RpcExternalActor, RpcGroupSubscriptionStatus
 
 
 def serialize_external_actor(actor: ExternalActor) -> RpcExternalActor:
@@ -12,4 +13,24 @@ def serialize_external_actor(actor: ExternalActor) -> RpcExternalActor:
         provider=actor.provider,
         external_name=actor.external_name,
         external_id=actor.external_id,
+    )
+
+
+def serialize_group_subscription_status(
+    status: GroupSubscriptionStatus,
+) -> RpcGroupSubscriptionStatus:
+    return RpcGroupSubscriptionStatus(
+        is_disabled=status.is_disabled,
+        is_active=status.is_active,
+        has_only_inactive_subscriptions=status.has_only_inactive_subscriptions,
+    )
+
+
+def deserialize_group_subscription_status(
+    status: RpcGroupSubscriptionStatus,
+) -> GroupSubscriptionStatus:
+    return GroupSubscriptionStatus(
+        is_disabled=status.is_disabled,
+        is_active=status.is_active,
+        has_only_inactive_subscriptions=status.has_only_inactive_subscriptions,
     )

--- a/src/sentry/services/hybrid_cloud/notifications/service.py
+++ b/src/sentry/services/hybrid_cloud/notifications/service.py
@@ -11,6 +11,7 @@ from sentry.notifications.types import (
     NotificationSettingsOptionEnum,
 )
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
+from sentry.services.hybrid_cloud.notifications import RpcGroupSubscriptionStatus
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.silo import SiloMode
 from sentry.types.integrations import ExternalProviderEnum, ExternalProviders
@@ -79,6 +80,17 @@ class NotificationsService(RpcService):
         project_ids: list[int],
         type: NotificationSettingEnum,
     ) -> Mapping[int, tuple[bool, bool, bool]]:
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def get_subscriptions_for_projects__tmp(
+        self,
+        *,
+        user_id: int,
+        project_ids: list[int],
+        type: NotificationSettingEnum,
+    ) -> Mapping[int, RpcGroupSubscriptionStatus]:
         pass
 
     @rpc_method

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -37,7 +37,11 @@ from sentry.services.hybrid_cloud.user import (
     UserSerializeType,
     UserUpdateArgs,
 )
-from sentry.services.hybrid_cloud.user.model import RpcVerifyUserEmail, UserIdEmailArgs
+from sentry.services.hybrid_cloud.user.model import (
+    RpcUserCreationResult,
+    RpcVerifyUserEmail,
+    UserIdEmailArgs,
+)
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user, serialize_user_avatar
 from sentry.services.hybrid_cloud.user.service import UserService
 from sentry.signals import user_signup
@@ -194,10 +198,16 @@ class DatabaseBackedUserService(UserService):
     def get_or_create_user_by_email(
         self, *, email: str, ident: str | None = None, referrer: str | None = None
     ) -> tuple[RpcUser, bool]:
+        result = self.get_or_create_user_by_email__tmp(email=email, ident=ident, referrer=referrer)
+        return result.user, result.was_newly_created
+
+    def get_or_create_user_by_email__tmp(
+        self, *, email: str, ident: str | None = None, referrer: str | None = None
+    ) -> RpcUserCreationResult:
         with transaction.atomic(router.db_for_write(User)):
             rpc_user = self.get_user_by_email(email=email, ident=ident)
             if rpc_user:
-                return (rpc_user, False)
+                return RpcUserCreationResult(user=rpc_user, was_newly_created=False)
 
             # Create User if it doesn't exist
             user = User.objects.create(
@@ -209,7 +219,7 @@ class DatabaseBackedUserService(UserService):
                 sender=self, user=user, source="api", referrer=referrer or "unknown"
             )
             user.update(flags=F("flags").bitor(User.flags.newsletter_consent_prompt))
-            return (serialize_rpc_user(user), True)
+            return RpcUserCreationResult(user=serialize_rpc_user(user), was_newly_created=True)
 
     def get_user_by_email(
         self,

--- a/src/sentry/services/hybrid_cloud/user/model.py
+++ b/src/sentry/services/hybrid_cloud/user/model.py
@@ -150,3 +150,8 @@ class UserIdEmailArgs(TypedDict):
 class RpcVerifyUserEmail(RpcModel):
     exists: bool = False
     email: str = ""
+
+
+class RpcUserCreationResult(RpcModel):
+    user: RpcUser
+    was_newly_created: bool

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -17,7 +17,12 @@ from sentry.services.hybrid_cloud.user import (
     UserSerializeType,
     UserUpdateArgs,
 )
-from sentry.services.hybrid_cloud.user.model import RpcAvatar, RpcVerifyUserEmail, UserIdEmailArgs
+from sentry.services.hybrid_cloud.user.model import (
+    RpcAvatar,
+    RpcUserCreationResult,
+    RpcVerifyUserEmail,
+    UserIdEmailArgs,
+)
 from sentry.silo import SiloMode
 
 
@@ -147,6 +152,17 @@ class UserService(RpcService):
         ident: str | None = None,
         referrer: str | None = None,
     ) -> tuple[RpcUser, bool]:
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def get_or_create_user_by_email__tmp(
+        self,
+        *,
+        email: str,
+        ident: str | None = None,
+        referrer: str | None = None,
+    ) -> RpcUserCreationResult:
         pass
 
     @rpc_method


### PR DESCRIPTION
This is a step in the process to replace all RPC methods that have a fixed-length tuple as a return type, for the purpose of representing them in OpenAPI.

See https://github.com/getsentry/sentry/pull/67320