### PR TITLE
feat(metric-stats): Register 'cardinality.window' tag

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -197,6 +197,7 @@ SHARED_TAG_STRINGS = {
     "mri.namespace": PREFIX + 275,
     "outcome.id": PREFIX + 276,
     "outcome.reason": PREFIX + 277,
+    "cardinality.window": PREFIX + 278,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }


### PR DESCRIPTION
String does not exist in `sentry_perfstringindexer` and `sentry_stringindexer` tables.