### PR TITLE
feat(metrics): summary table total

### DIFF
--- a/static/app/utils/metrics/types.tsx
+++ b/static/app/utils/metrics/types.tsx
@@ -11,7 +11,7 @@ export type MetricTag = {
 };
 
 export type SortState = {
-  name: 'name' | 'avg' | 'min' | 'max' | 'sum' | undefined;
+  name: 'name' | 'avg' | 'min' | 'max' | 'sum' | 'total' | undefined;
   order: 'asc' | 'desc';
 };
 

--- a/static/app/views/ddm/chart/types.tsx
+++ b/static/app/views/ddm/chart/types.tsx
@@ -7,6 +7,7 @@ export type Series = {
   data: {name: number; value: number}[];
   id: string;
   seriesName: string;
+  total: number;
   unit: string;
   groupBy?: Record<string, string>;
   hidden?: boolean;

--- a/static/app/views/ddm/chart/useMetricChartSamples.tsx
+++ b/static/app/views/ddm/chart/useMetricChartSamples.tsx
@@ -178,6 +178,7 @@ export function useMetricChartSamples({
             xAxisIndex: newXAxisIndex,
             xValue,
             yValue,
+            total: yValue,
             tooltip: {
               axisPointer: {
                 type: 'none',

--- a/static/app/views/ddm/summaryTable.tsx
+++ b/static/app/views/ddm/summaryTable.tsx
@@ -172,6 +172,9 @@ export const SummaryTable = memo(function SummaryTable({
       <SortableHeaderCell onClick={changeSort} sortState={sort} name="sum" right>
         {t('Sum')}
       </SortableHeaderCell>
+      <SortableHeaderCell onClick={changeSort} sortState={sort} name="total" right>
+        {t('Total')}
+      </SortableHeaderCell>
       {hasActions && <HeaderCell disabled right />}
       <HeaderCell disabled />
       <TableBodyWrapper
@@ -196,6 +199,7 @@ export const SummaryTable = memo(function SummaryTable({
             min,
             max,
             sum,
+            total,
             isEquationSeries,
             queryIndex,
           }) => {
@@ -252,6 +256,7 @@ export const SummaryTable = memo(function SummaryTable({
                   <NumberCell>{formatMetricUsingUnit(min, unit)}</NumberCell>
                   <NumberCell>{formatMetricUsingUnit(max, unit)}</NumberCell>
                   <NumberCell>{formatMetricUsingUnit(sum, unit)}</NumberCell>
+                  <NumberCell>{formatMetricUsingUnit(total, unit)}</NumberCell>
 
                   {hasActions && (
                     <CenterCell>
@@ -409,9 +414,9 @@ function getValues(seriesData: Series['data']) {
 
 const SummaryTableWrapper = styled(`div`)<{hasActions: boolean}>`
   display: grid;
-  /* padding | color dot | name | avg | min | max | sum | actions | padding */
+  /* padding | color dot | name | avg | min | max | sum | total | actions | padding */
   grid-template-columns:
-    ${space(0.75)} ${space(3)} 8fr repeat(${p => (p.hasActions ? 5 : 4)}, max-content)
+    ${space(0.75)} ${space(3)} 8fr repeat(${p => (p.hasActions ? 6 : 5)}, max-content)
     ${space(0.75)};
 
   max-height: 200px;

--- a/static/app/views/ddm/utils/index.tsx
+++ b/static/app/views/ddm/utils/index.tsx
@@ -28,5 +28,9 @@ export function extendQueryWithGroupBys(
     return focusedSeriesQuery;
   }
 
+  if (query === focusedSeriesQuery) {
+    return query;
+  }
+
   return `(${query}) AND (${focusedSeriesQuery})`;
 }

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -370,9 +370,11 @@ const MetricWidgetBody = memo(
         }
 
         const newQuery = extendQueryWithGroupBys(queryToUpdate.query, [series.groupBy]);
-        onQueryChange?.(queryIndex, {query: newQuery});
+        const indexToUpdate = queries.length > 1 ? queryIndex : widgetIndex;
+
+        onQueryChange?.(indexToUpdate, {query: newQuery});
       },
-      [queries, onQueryChange]
+      [queries, onQueryChange, widgetIndex]
     );
 
     const isCumulativeSamplesOp =
@@ -538,6 +540,7 @@ export function getChartTimeseries(
       groupBy: entry.by,
       transaction: entry.by.transaction,
       release: entry.by.release,
+      total: entry.totals,
     }));
   });
 
@@ -560,6 +563,7 @@ export function getChartTimeseries(
     release: item.release as string | undefined,
     isEquationSeries: item.isEquationSeries,
     queryIndex: item.queryIndex,
+    total: item.total,
     emphasis: {
       focus: 'series',
     } as SeriesOption['emphasis'],


### PR DESCRIPTION
![image](https://github.com/getsentry/sentry/assets/86684834/78e294c8-1793-44b0-bab7-06ebcca0ca22)

Also fixes following 2 issues with "add to filter"
1. "Add to filter" is now idempotent so `foo:bar` will not get extended to `(foo:bar) AND foo:bar`
2. Indices are matching widgets in single query mode