### PR TITLE
fix(alert-rule): skip fetching rule snooze owner user if no owner_id

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -127,9 +127,10 @@ def fetch_alert_rule(request: Request, organization, alert_rule):
         if request.user.id == rule_snooze.owner_id:
             serialized_rule["snoozeCreatedBy"] = "You"
         else:
-            user = user_service.get_user(rule_snooze.owner_id)
-            if user:
-                serialized_rule["snoozeCreatedBy"] = user.get_display_name()
+            if rule_snooze.owner_id:
+                user = user_service.get_user(rule_snooze.owner_id)
+                if user:
+                    serialized_rule["snoozeCreatedBy"] = user.get_display_name()
         serialized_rule["snoozeForEveryone"] = rule_snooze.user_id is None
 
     return Response(serialized_rule)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -297,13 +297,23 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
     def test_with_snooze_rule(self):
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
-        self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, alert_rule=self.alert_rule)
+        rule_snooze = self.snooze_rule(
+            user_id=self.user.id, owner_id=self.user.id, alert_rule=self.alert_rule
+        )
 
         with self.feature("organizations:incidents"):
             response = self.get_success_response(self.organization.slug, self.alert_rule.id)
 
-        assert response.data["snooze"]
-        assert response.data["snoozeCreatedBy"] == "You"
+            assert response.data["snooze"]
+            assert response.data["snoozeCreatedBy"] == "You"
+
+            rule_snooze.owner_id = None
+            rule_snooze.save()
+
+            response = self.get_success_response(self.organization.slug, self.alert_rule.id)
+
+            assert response.data["snooze"]
+            assert "snoozeCreatedBy" not in response.data
 
     def test_with_snooze_rule_everyone(self):
         self.create_team(organization=self.organization, members=[self.user])


### PR DESCRIPTION
If a metric alert has been snoozed but has no `owner_id` for the associated `RuleSnooze` object, serializing the metric alert can fail because we are trying to fetch a user with id `None`. Add a check for the existence of an `owner_id` before fetching a user.