### PR TITLE
fix(issue-stream): Ensure that bulk action checkboxes are all hidden at the same time

### DIFF
--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -99,7 +99,7 @@ function GroupList({
   const topIssue = groupIds[0];
   const canSelect = !useMedia(
     `(max-width: ${
-      isSavedSearchesOpen ? theme.breakpoints.large : theme.breakpoints.small
+      isSavedSearchesOpen ? theme.breakpoints.xlarge : theme.breakpoints.medium
     })`
   );
 


### PR DESCRIPTION
This fixes the problem where, at certain viewport widths, it would still render checkboxes for issues but not in the header:

![CleanShot 2024-03-19 at 15 58 45](https://github.com/getsentry/sentry/assets/10888943/dca80a2a-6ad4-46e9-9ee2-6f7b256a4517)
