### PR TITLE
chore(integrations): API docs for custom priorities for pagerduty and opsgenie

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -469,22 +469,26 @@ A list of actions that take place when all required conditions and filters for t
 **Send a PagerDuty notification**
 - `account` - The integration ID associated with the PagerDuty account.
 - `service` - The ID of the service to send the notification to.
+- `severity` - The severity of the Pagerduty alert. This is optional, the default is `critical` for fatal issues, `error` for error issues, `warning` for warning issues, and `info` for info and debug issues.
 ```json
 {
     "id": "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
     "account": 92385907,
-    "service": 9823924
+    "service": 9823924,
+    "severity": "critical"
 }
 ```
 
 **Send an Opsgenie notification**
 - `account` - The integration ID associated with the Opsgenie account.
 - `team` - The ID of the Opsgenie team to send the notification to.
+- `priority` - The priority of the Opsgenie alert. This is optional, the default is `P3`.
 ```json
 {
     "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
     "account": 8723897589,
-    "team": "9438930258-fairy"
+    "team": "9438930258-fairy",
+    "priority": "P1"
 }
 ```
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -260,6 +260,7 @@ Metric alert rule trigger actions follow the following structure:
 - `inputChannelId`: The ID of the Slack channel. This is only used for the Slack action, and can be used as an alternative to providing the `targetIdentifier`.
 - `integrationId`: The integration ID. This is required for every action type except `email` and `sentry_app.`
 - `sentryAppId`: The ID of the Sentry app. This is required when `type` is `sentry_app`.
+- `priority`: The severity of the Pagerduty alert or the priority of the Opsgenie alert (optional). Defaults for Pagerduty are `critical` for critical and `warning` for warning. Defaults for Opsgenie are `P1` for critical and `P2` for warning.
 """,
     )
     environment = serializers.CharField(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -341,6 +341,7 @@ Metric alert rule trigger actions follow the following structure:
 - `inputChannelId`: The ID of the Slack channel. This is only used for the Slack action, and can be used as an alternative to providing the `targetIdentifier`.
 - `integrationId`: The integration ID. This is required for every action type excluding `email` and `sentry_app.`
 - `sentryAppId`: The ID of the Sentry app. This is required when `type` is `sentry_app`.
+- `priority`: The severity of the Pagerduty alert or the priority of the Opsgenie alert (optional). Defaults for Pagerduty are `critical` for critical and `warning` for warning. Defaults for Opsgenie are `P1` for critical and `P2` for warning.
 """
     )
     environment = serializers.CharField(


### PR DESCRIPTION
Add docs explaining how to set up custom issue and metric alert priorities for Pagerduty and Opsgenie.

Issue alert
<img width="483" alt="Screenshot 2024-03-20 at 10 46 45" src="https://github.com/getsentry/sentry/assets/70817427/3a1631df-7839-4bb8-a788-41a001cad36d">

Metric alert (POST and PUT)
<img width="383" alt="Screenshot 2024-03-20 at 11 01 21" src="https://github.com/getsentry/sentry/assets/70817427/b8e7457d-21b5-4814-a08a-f5462bb478a0">