### PR TITLE
ref(replays): rm browser icon, rage/dead click in details for mobile replays

### DIFF
--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import {Link} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -17,9 +18,10 @@ import type {ReplayError, ReplayRecord} from 'sentry/views/replays/types';
 type Props = {
   replayErrors: ReplayError[];
   replayRecord: ReplayRecord | undefined;
+  isVideoReplay?: boolean;
 };
 
-function ReplayMetaData({replayErrors, replayRecord}: Props) {
+function ReplayMetaData({replayErrors, replayRecord, isVideoReplay}: Props) {
   const location = useLocation();
   const routes = useRoutes();
   const referrer = getRouteStringFromRoutes(routes);
@@ -53,33 +55,41 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
         )}
       </KeyMetricData>
 
-      <KeyMetricLabel>{t('Dead Clicks')}</KeyMetricLabel>
-      <KeyMetricData>
-        {replayRecord?.count_dead_clicks ? (
-          <Link to={breadcrumbTab}>
-            <ClickCount>
-              <IconCursorArrow size="sm" color="yellow300" />
-              {replayRecord.count_dead_clicks}
-            </ClickCount>
-          </Link>
-        ) : (
-          <Count>0</Count>
-        )}
-      </KeyMetricData>
+      {!isVideoReplay && (
+        <Fragment>
+          <KeyMetricLabel>{t('Dead Clicks')}</KeyMetricLabel>
+          <KeyMetricData>
+            {replayRecord?.count_dead_clicks ? (
+              <Link to={breadcrumbTab}>
+                <ClickCount>
+                  <IconCursorArrow size="sm" color="yellow300" />
+                  {replayRecord.count_dead_clicks}
+                </ClickCount>
+              </Link>
+            ) : (
+              <Count>0</Count>
+            )}
+          </KeyMetricData>
+        </Fragment>
+      )}
 
-      <KeyMetricLabel>{t('Rage Clicks')}</KeyMetricLabel>
-      <KeyMetricData>
-        {replayRecord?.count_rage_clicks ? (
-          <Link to={breadcrumbTab}>
-            <ClickCount>
-              <IconCursorArrow size="sm" color="red300" />
-              {replayRecord.count_rage_clicks}
-            </ClickCount>
-          </Link>
-        ) : (
-          <Count>0</Count>
-        )}
-      </KeyMetricData>
+      {!isVideoReplay && (
+        <Fragment>
+          <KeyMetricLabel>{t('Rage Clicks')}</KeyMetricLabel>
+          <KeyMetricData>
+            {replayRecord?.count_rage_clicks ? (
+              <Link to={breadcrumbTab}>
+                <ClickCount>
+                  <IconCursorArrow size="sm" color="red300" />
+                  {replayRecord.count_rage_clicks}
+                </ClickCount>
+              </Link>
+            ) : (
+              <Count>0</Count>
+            )}
+          </KeyMetricData>
+        </Fragment>
+      )}
 
       <KeyMetricLabel>{t('Errors')}</KeyMetricLabel>
       <KeyMetricData>

--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -18,10 +18,10 @@ import type {ReplayError, ReplayRecord} from 'sentry/views/replays/types';
 type Props = {
   replayErrors: ReplayError[];
   replayRecord: ReplayRecord | undefined;
-  isVideoReplay?: boolean;
+  showDeadRageClicks?: boolean;
 };
 
-function ReplayMetaData({replayErrors, replayRecord, isVideoReplay}: Props) {
+function ReplayMetaData({replayErrors, replayRecord, showDeadRageClicks = true}: Props) {
   const location = useLocation();
   const routes = useRoutes();
   const referrer = getRouteStringFromRoutes(routes);
@@ -55,7 +55,7 @@ function ReplayMetaData({replayErrors, replayRecord, isVideoReplay}: Props) {
         )}
       </KeyMetricData>
 
-      {!isVideoReplay && (
+      {showDeadRageClicks && (
         <Fragment>
           <KeyMetricLabel>{t('Dead Clicks')}</KeyMetricLabel>
           <KeyMetricData>
@@ -73,7 +73,7 @@ function ReplayMetaData({replayErrors, replayRecord, isVideoReplay}: Props) {
         </Fragment>
       )}
 
-      {!isVideoReplay && (
+      {showDeadRageClicks && (
         <Fragment>
           <KeyMetricLabel>{t('Rage Clicks')}</KeyMetricLabel>
           <KeyMetricData>

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -23,6 +23,7 @@ function ReplayView({toggleFullscreen}: Props) {
   const isFullscreen = useIsFullscreen();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const {isFetching, replay} = useReplayContext();
+  const isVideoReplay = replay?.isVideoReplay();
 
   return (
     <Fragment>
@@ -30,7 +31,7 @@ function ReplayView({toggleFullscreen}: Props) {
         <PlayerContainer>
           <ContextContainer>
             <ReplayCurrentUrl />
-            <BrowserOSIcons />
+            <BrowserOSIcons showBrowser={!isVideoReplay} />
             {isFullscreen ? (
               <ReplaySidebarToggleButton
                 isOpen={isSidebarOpen}

--- a/static/app/views/replays/detail/browserOSIcons.tsx
+++ b/static/app/views/replays/detail/browserOSIcons.tsx
@@ -4,7 +4,7 @@ import ContextIcon from 'sentry/components/replays/contextIcon';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {Tooltip} from 'sentry/components/tooltip';
 
-export default function BrowserOSIcons() {
+export default function BrowserOSIcons({showBrowser = true}: {showBrowser?: boolean}) {
   const {replay} = useReplayContext();
   const replayRecord = replay?.getReplay();
 
@@ -17,17 +17,19 @@ export default function BrowserOSIcons() {
           showVersion
         />
       </Tooltip>
-      <Tooltip
-        title={`${replayRecord?.browser.name ?? ''} ${
-          replayRecord?.browser.version ?? ''
-        }`}
-      >
-        <ContextIcon
-          name={replayRecord?.browser.name ?? ''}
-          version={replayRecord?.browser.version ?? undefined}
-          showVersion
-        />
-      </Tooltip>
+      {showBrowser && (
+        <Tooltip
+          title={`${replayRecord?.browser.name ?? ''} ${
+            replayRecord?.browser.version ?? ''
+          }`}
+        >
+          <ContextIcon
+            name={replayRecord?.browser.name ?? ''}
+            version={replayRecord?.browser.version ?? undefined}
+            showVersion
+          />
+        </Tooltip>
+      )}
     </Fragment>
   );
 }

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -116,7 +116,7 @@ export default function Page({
       <ReplayMetaData
         replayRecord={replayRecord}
         replayErrors={replayErrors}
-        isVideoReplay={isVideoReplay}
+        showDeadRageClicks={!isVideoReplay}
       />
     </Header>
   );

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -113,7 +113,11 @@ export default function Page({
         <HeaderPlaceholder width="100%" height="58px" />
       )}
 
-      <ReplayMetaData replayRecord={replayRecord} replayErrors={replayErrors} />
+      <ReplayMetaData
+        replayRecord={replayRecord}
+        replayErrors={replayErrors}
+        isVideoReplay={isVideoReplay}
+      />
     </Header>
   );
 


### PR DESCRIPTION
For mobile replays, remove the
- browser icon next to URL
- rage/dead click counts at the top

<img width="1248" alt="SCR-20240320-jlss" src="https://github.com/getsentry/sentry/assets/56095982/5dc69f00-6f04-450e-bac8-b238758a3d08">

web replays still look the same:
<img width="1186" alt="SCR-20240320-jnkt" src="https://github.com/getsentry/sentry/assets/56095982/612c0fb1-5b03-4efa-bc99-6a0befdd7ecd">
