### PR TITLE
fix(replays): fix display of selector widgets if no proj selected

### DIFF
--- a/static/app/views/replays/detail/useAllMobileProj.tsx
+++ b/static/app/views/replays/detail/useAllMobileProj.tsx
@@ -11,9 +11,13 @@ export default function useAllMobileProj() {
 
   const {projects} = useProjects();
   const projectsSelected = projects.filter(p => projectIds.map(String).includes(p.id));
+
+  // if no projects selected, look through all projects
+  const proj = projectsSelected.length ? projectsSelected : projects;
+
   const allMobileProj =
     organization.features.includes('session-replay-mobile-player') &&
-    projectsSelected.every(p => mobile.includes(p.platform ?? 'other'));
+    proj.every(p => mobile.includes(p.platform ?? 'other'));
 
   return {allMobileProj};
 }


### PR DESCRIPTION
Fixing a small bug that was hiding the selector widgets if all/no projects were selected:

https://github.com/getsentry/sentry/assets/56095982/16c7de04-fe14-40ec-959e-a7354bc2bf47

