### PR TITLE
fix(issue-stream): Invalidate cached data modifying issues from stream

### DIFF
--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -19,6 +19,7 @@ import {space} from 'sentry/styles/space';
 import type {Group, PageFilters} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {uniq} from 'sentry/utils/array/uniq';
+import {useQueryClient} from 'sentry/utils/queryClient';
 import theme from 'sentry/utils/theme';
 import useApi from 'sentry/utils/useApi';
 import useMedia from 'sentry/utils/useMedia';
@@ -157,6 +158,7 @@ function IssueListActions({
   statsPeriod,
 }: IssueListActionsProps) {
   const api = useApi();
+  const queryClient = useQueryClient();
   const organization = useOrganization();
   const {
     pageSelected,
@@ -296,6 +298,15 @@ function IssueListActions({
           success: () => {
             clearIndicators();
             onActionTaken?.(itemIds ?? [], data);
+
+            // Prevents stale data on issue details
+            queryClient.invalidateQueries({
+              predicate: apiQuery =>
+                typeof apiQuery.queryKey[0] === 'string' &&
+                apiQuery.queryKey[0].startsWith(
+                  `/organizations/${organization.slug}/issues/`
+                ),
+            });
           },
           error: () => {
             clearIndicators();

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -300,13 +300,23 @@ function IssueListActions({
             onActionTaken?.(itemIds ?? [], data);
 
             // Prevents stale data on issue details
-            queryClient.invalidateQueries({
-              predicate: apiQuery =>
-                typeof apiQuery.queryKey[0] === 'string' &&
-                apiQuery.queryKey[0].startsWith(
-                  `/organizations/${organization.slug}/issues/`
-                ),
-            });
+            if (itemIds?.length) {
+              for (const itemId of itemIds) {
+                queryClient.invalidateQueries({
+                  queryKey: [`/organizations/${organization.slug}/issues/${itemId}/`],
+                  exact: false,
+                });
+              }
+            } else {
+              // If we're doing a full query update we invalidate all issue queries to be safe
+              queryClient.invalidateQueries({
+                predicate: apiQuery =>
+                  typeof apiQuery.queryKey[0] === 'string' &&
+                  apiQuery.queryKey[0].startsWith(
+                    `/organizations/${organization.slug}/issues/`
+                  ),
+              });
+            }
           },
           error: () => {
             clearIndicators();


### PR DESCRIPTION
This fixes the following problem with stale issue details data:

1. Hover over an issue in the stream, which loads it into the cache
2. Change priority or resolve/archive that issue from the stream
3. Click into that issue and see that it still shows the old state