### PR TITLE
fix(perf): Improve `Chart` with `isBarChart` behaviour

### DIFF
--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -443,8 +443,24 @@ function Chart({
                     interval: 0, // Show _all_ axis labels
                   },
                 }}
+                yAxis={{
+                  minInterval: durationUnit ?? getDurationUnit(data),
+                  splitNumber: definedAxisTicks,
+                  max: dataMax,
+                  axisLabel: {
+                    color: theme.chartLabel,
+                    formatter(value: number) {
+                      return axisLabelFormatter(
+                        value,
+                        aggregateOutputFormat ?? aggregateOutputType(data[0].seriesName),
+                        undefined,
+                        durationUnit ?? getDurationUnit(data),
+                        rateUnit
+                      );
+                    },
+                  },
+                }}
                 additionalSeries={transformedThroughput}
-                yAxes={areaChartProps.yAxes}
                 tooltip={areaChartProps.tooltip}
                 colors={colors}
                 grid={grid}

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -461,7 +461,17 @@ function Chart({
                   },
                 }}
                 additionalSeries={transformedThroughput}
-                tooltip={areaChartProps.tooltip}
+                tooltip={{
+                  valueFormatter: (value, seriesName) => {
+                    return tooltipFormatter(
+                      value,
+                      aggregateOutputFormat ??
+                        aggregateOutputType(
+                          data?.length ? data[0].seriesName : seriesName
+                        )
+                    );
+                  },
+                }}
                 colors={colors}
                 grid={grid}
                 legend={showLegend ? {top: 0, right: 10} : undefined}

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -435,7 +435,14 @@ function Chart({
               <BarChart
                 height={height}
                 series={trimmedSeries}
-                xAxis={xAxis}
+                xAxis={{
+                  type: 'category',
+                  axisTick: {show: true},
+                  truncate: Infinity, // Show axis labels
+                  axisLabel: {
+                    interval: 0, // Show _all_ axis labels
+                  },
+                }}
                 additionalSeries={transformedThroughput}
                 yAxes={areaChartProps.yAxes}
                 tooltip={areaChartProps.tooltip}

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -460,7 +460,6 @@ function Chart({
                     },
                   },
                 }}
-                additionalSeries={transformedThroughput}
                 tooltip={{
                   valueFormatter: (value, seriesName) => {
                     return tooltipFormatter(


### PR DESCRIPTION
Passing `isBarChart` to the `Chart` component tries to render a bar chart, naturally. Right now, no UIs make use of `isBarChart` but I want to! I can't though, 'cause a bunch of things about it are a little broken. I think this code path was left in the dust while we improved the other chart types.

In short, I added some specific props to make the bar chart behave more sensibly. It needs different options from line and area charts.

- better X and Y axis labels and behaviour
- simpler tooltips
- removed properties that don't apply

Probably there's more work to be done, but this is a start.
