### PR TITLE
feat(runner): add ingest-feedback-events topic to devserver

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -327,6 +327,7 @@ def devserver(
             kafka_consumers.add("ingest-attachments")
             kafka_consumers.add("ingest-transactions")
             kafka_consumers.add("ingest-monitors")
+            kafka_consumers.add("ingest-feedback-events")
 
             if settings.SENTRY_USE_PROFILING:
                 kafka_consumers.add("ingest-profiles")


### PR DESCRIPTION
Adding a new topic to sentry local devservers. This is yet to be tested in prod, currently feedbacks are still ingested through ingest-events. See https://github.com/getsentry/sentry/pull/66484
