### PR TITLE
fix(profiles): Default duration to zero when the key doesn't exist

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -965,7 +965,7 @@ def _calculate_duration_for_sample_format_v1(profile: Profile) -> int:
     return min(
         int(
             (
-                int(profile["transaction"]["relative_end_ns"])
+                int(profile["transaction"].get("relative_end_ns", 0))
                 - int(profile["transaction"].get("relative_start_ns", 0))
             )
             * 1e-6

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -966,7 +966,7 @@ def _calculate_duration_for_sample_format_v1(profile: Profile) -> int:
         int(
             (
                 int(profile["transaction"]["relative_end_ns"])
-                - int(profile["transaction"]["relative_start_ns"])
+                - int(profile["transaction"].get("relative_start_ns", 0))
             )
             * 1e-6
         ),


### PR DESCRIPTION
Relay would omit this field when the value is `0` https://github.com/getsentry/relay/blob/master/relay-profiling/src/transaction_metadata.rs#L20.