### PR TITLE
ref(tsc): Convert DebugImageDetails to FC and useApiQuery

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.tsx
@@ -6,9 +6,10 @@ import sortBy from 'lodash/sortBy';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {Button} from 'sentry/components/button';
+import {Button, LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization, Project} from 'sentry/types';
@@ -18,7 +19,10 @@ import type {Image, ImageStatus} from 'sentry/types/debugImage';
 import {CandidateDownloadStatus} from 'sentry/types/debugImage';
 import type {Event} from 'sentry/types/event';
 import {displayReprocessEventAction} from 'sentry/utils/displayReprocessEventAction';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import theme from 'sentry/utils/theme';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 import {getPrettyFileType} from 'sentry/views/settings/projectDebugFiles/utils';
 
 import {getFileName} from '../utils';
@@ -30,336 +34,313 @@ import {INTERNAL_SOURCE, INTERNAL_SOURCE_LOCATION} from './utils';
 
 type ImageCandidates = Image['candidates'];
 
-type Props = DeprecatedAsyncComponent['props'] &
-  ModalRenderProps & {
-    event: Event;
-    organization: Organization;
-    projSlug: Project['slug'];
-    image?: Image & {status: ImageStatus};
-    onReprocessEvent?: () => void;
-  };
-
-type State = DeprecatedAsyncComponent['state'] & {
-  debugFiles: Array<DebugFile> | null;
+type DebugImageDetailsProps = ModalRenderProps & {
+  event: Event;
+  organization: Organization;
+  projSlug: Project['slug'];
+  image?: Image & {status: ImageStatus};
+  onReprocessEvent?: () => void;
 };
 
-export class DebugImageDetails extends DeprecatedAsyncComponent<Props, State> {
-  getDefaultState(): State {
+function sortCandidates(
+  candidates: ImageCandidates,
+  unAppliedCandidates: ImageCandidates
+): ImageCandidates {
+  const [noPermissionCandidates, restNoPermissionCandidates] = partition(
+    candidates,
+    candidate => candidate.download.status === CandidateDownloadStatus.NO_PERMISSION
+  );
+
+  const [malFormedCandidates, restMalFormedCandidates] = partition(
+    restNoPermissionCandidates,
+    candidate => candidate.download.status === CandidateDownloadStatus.MALFORMED
+  );
+
+  const [errorCandidates, restErrorCandidates] = partition(
+    restMalFormedCandidates,
+    candidate => candidate.download.status === CandidateDownloadStatus.ERROR
+  );
+
+  const [okCandidates, restOKCandidates] = partition(
+    restErrorCandidates,
+    candidate => candidate.download.status === CandidateDownloadStatus.OK
+  );
+
+  const [deletedCandidates, notFoundCandidates] = partition(
+    restOKCandidates,
+    candidate => candidate.download.status === CandidateDownloadStatus.DELETED
+  );
+
+  return [
+    ...sortBy(noPermissionCandidates, ['source_name', 'location']),
+    ...sortBy(malFormedCandidates, ['source_name', 'location']),
+    ...sortBy(errorCandidates, ['source_name', 'location']),
+    ...sortBy(okCandidates, ['source_name', 'location']),
+    ...sortBy(deletedCandidates, ['source_name', 'location']),
+    ...sortBy(unAppliedCandidates, ['source_name', 'location']),
+    ...sortBy(notFoundCandidates, ['source_name', 'location']),
+  ];
+}
+
+function getCandidates({
+  debugFiles,
+  image,
+  isLoading,
+}: {
+  debugFiles: DebugFile[] | undefined;
+  image: DebugImageDetailsProps['image'];
+  isLoading: boolean;
+}) {
+  const {candidates = []} = image ?? {};
+
+  if (!debugFiles || isLoading) {
+    return candidates;
+  }
+
+  const debugFileCandidates = candidates.map(({location, ...candidate}) => ({
+    ...candidate,
+    location: location?.includes(INTERNAL_SOURCE_LOCATION)
+      ? location.split(INTERNAL_SOURCE_LOCATION)[1]
+      : location,
+  }));
+
+  const candidateLocations = new Set(
+    debugFileCandidates.map(({location}) => location).filter(location => !!location)
+  );
+
+  const [unAppliedDebugFiles, appliedDebugFiles] = partition(
+    debugFiles,
+    debugFile => !candidateLocations.has(debugFile.id)
+  );
+
+  const unAppliedCandidates = unAppliedDebugFiles.map(debugFile => {
+    const {
+      data,
+      symbolType,
+      objectName: filename,
+      id: location,
+      size,
+      dateCreated,
+      cpuName,
+    } = debugFile;
+
+    const features = data?.features ?? [];
+
     return {
-      ...super.getDefaultState(),
-      debugFiles: [],
-    };
-  }
-
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    if (!prevProps.image && !!this.props.image) {
-      this.remountComponent();
-    }
-
-    super.componentDidUpdate(prevProps, prevState);
-  }
-
-  getUploadedDebugFiles(candidates: ImageCandidates) {
-    return candidates.find(candidate => candidate.source === INTERNAL_SOURCE);
-  }
-
-  getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    const {organization, projSlug, image} = this.props;
-
-    if (!image) {
-      return [];
-    }
-
-    const {debug_id, candidates = []} = image;
-
-    const hasUploadedDebugFiles = this.getUploadedDebugFiles(candidates);
-    const endpoints: ReturnType<DeprecatedAsyncComponent['getEndpoints']> = [];
-
-    if (hasUploadedDebugFiles) {
-      endpoints.push([
-        'debugFiles',
-        `/projects/${organization.slug}/${projSlug}/files/dsyms/?debug_id=${debug_id}`,
-        {
-          query: {
-            // FIXME(swatinem): Ideally we should not filter here at all,
-            // though Symbolicator does not currently report `bcsymbolmap` and `il2cpp`
-            // candidates, and we would thus show bogus "unapplied" entries for those,
-            // which would probably confuse people more than not seeing successfully
-            // fetched candidates for those two types of files.
-            file_formats: [
-              'breakpad',
-              'macho',
-              'elf',
-              'pe',
-              'pdb',
-              'sourcebundle',
-              'wasm',
-              'portablepdb',
-            ],
-          },
+      download: {
+        status: CandidateDownloadStatus.UNAPPLIED,
+        features: {
+          has_sources: features.includes(DebugFileFeature.SOURCES),
+          has_debug_info: features.includes(DebugFileFeature.DEBUG),
+          has_unwind_info: features.includes(DebugFileFeature.UNWIND),
+          has_symbols: features.includes(DebugFileFeature.SYMTAB),
         },
-      ]);
-    }
+      },
+      cpuName,
+      location,
+      filename,
+      size,
+      dateCreated,
+      symbolType,
+      fileType: getPrettyFileType(debugFile),
+      source: INTERNAL_SOURCE,
+      source_name: t('Sentry'),
+    };
+  });
 
-    return endpoints;
-  }
+  const [debugFileInternalOkCandidates, debugFileOtherCandidates] = partition(
+    debugFileCandidates,
+    debugFileCandidate =>
+      debugFileCandidate.download.status === CandidateDownloadStatus.OK &&
+      debugFileCandidate.source === INTERNAL_SOURCE
+  );
 
-  sortCandidates(
-    candidates: ImageCandidates,
-    unAppliedCandidates: ImageCandidates
-  ): ImageCandidates {
-    const [noPermissionCandidates, restNoPermissionCandidates] = partition(
-      candidates,
-      candidate => candidate.download.status === CandidateDownloadStatus.NO_PERMISSION
-    );
+  const convertedDebugFileInternalOkCandidates = debugFileInternalOkCandidates.map(
+    debugFileOkCandidate => {
+      const internalDebugFileInfo = appliedDebugFiles.find(
+        appliedDebugFile => appliedDebugFile.id === debugFileOkCandidate.location
+      );
 
-    const [malFormedCandidates, restMalFormedCandidates] = partition(
-      restNoPermissionCandidates,
-      candidate => candidate.download.status === CandidateDownloadStatus.MALFORMED
-    );
+      if (!internalDebugFileInfo) {
+        return {
+          ...debugFileOkCandidate,
+          download: {
+            ...debugFileOkCandidate.download,
+            status: CandidateDownloadStatus.DELETED,
+          },
+        };
+      }
 
-    const [errorCandidates, restErrorCandidates] = partition(
-      restMalFormedCandidates,
-      candidate => candidate.download.status === CandidateDownloadStatus.ERROR
-    );
-
-    const [okCandidates, restOKCandidates] = partition(
-      restErrorCandidates,
-      candidate => candidate.download.status === CandidateDownloadStatus.OK
-    );
-
-    const [deletedCandidates, notFoundCandidates] = partition(
-      restOKCandidates,
-      candidate => candidate.download.status === CandidateDownloadStatus.DELETED
-    );
-
-    return [
-      ...sortBy(noPermissionCandidates, ['source_name', 'location']),
-      ...sortBy(malFormedCandidates, ['source_name', 'location']),
-      ...sortBy(errorCandidates, ['source_name', 'location']),
-      ...sortBy(okCandidates, ['source_name', 'location']),
-      ...sortBy(deletedCandidates, ['source_name', 'location']),
-      ...sortBy(unAppliedCandidates, ['source_name', 'location']),
-      ...sortBy(notFoundCandidates, ['source_name', 'location']),
-    ];
-  }
-
-  getCandidates() {
-    const {debugFiles, loading} = this.state;
-    const {image} = this.props;
-    const {candidates = []} = image ?? {};
-
-    if (!debugFiles || loading) {
-      return candidates;
-    }
-
-    const debugFileCandidates = candidates.map(({location, ...candidate}) => ({
-      ...candidate,
-      location: location?.includes(INTERNAL_SOURCE_LOCATION)
-        ? location.split(INTERNAL_SOURCE_LOCATION)[1]
-        : location,
-    }));
-
-    const candidateLocations = new Set(
-      debugFileCandidates.map(({location}) => location).filter(location => !!location)
-    );
-
-    const [unAppliedDebugFiles, appliedDebugFiles] = partition(
-      debugFiles,
-      debugFile => !candidateLocations.has(debugFile.id)
-    );
-
-    const unAppliedCandidates = unAppliedDebugFiles.map(debugFile => {
       const {
-        data,
         symbolType,
         objectName: filename,
         id: location,
         size,
         dateCreated,
-        cpuName,
-      } = debugFile;
-
-      const features = data?.features ?? [];
+      } = internalDebugFileInfo;
 
       return {
-        download: {
-          status: CandidateDownloadStatus.UNAPPLIED,
-          features: {
-            has_sources: features.includes(DebugFileFeature.SOURCES),
-            has_debug_info: features.includes(DebugFileFeature.DEBUG),
-            has_unwind_info: features.includes(DebugFileFeature.UNWIND),
-            has_symbols: features.includes(DebugFileFeature.SYMTAB),
-          },
-        },
-        cpuName,
+        ...debugFileOkCandidate,
         location,
         filename,
         size,
         dateCreated,
         symbolType,
-        fileType: getPrettyFileType(debugFile),
-        source: INTERNAL_SOURCE,
-        source_name: t('Sentry'),
+        prettyFileType: getPrettyFileType(internalDebugFileInfo),
       };
-    });
+    }
+  );
 
-    const [debugFileInternalOkCandidates, debugFileOtherCandidates] = partition(
-      debugFileCandidates,
-      debugFileCandidate =>
-        debugFileCandidate.download.status === CandidateDownloadStatus.OK &&
-        debugFileCandidate.source === INTERNAL_SOURCE
-    );
+  return sortCandidates(
+    [
+      ...convertedDebugFileInternalOkCandidates,
+      ...debugFileOtherCandidates,
+    ] as ImageCandidates,
+    unAppliedCandidates as ImageCandidates
+  );
+}
 
-    const convertedDebugFileInternalOkCandidates = debugFileInternalOkCandidates.map(
-      debugFileOkCandidate => {
-        const internalDebugFileInfo = appliedDebugFiles.find(
-          appliedDebugFile => appliedDebugFile.id === debugFileOkCandidate.location
-        );
+export function DebugImageDetails({
+  image,
+  projSlug,
+  Header,
+  Body,
+  Footer,
+  event,
+  onReprocessEvent,
+}: DebugImageDetailsProps) {
+  const organization = useOrganization();
+  const api = useApi();
+  const hasUploadedDebugFiles =
+    image?.candidates.some(candidate => candidate.source === INTERNAL_SOURCE) ?? false;
 
-        if (!internalDebugFileInfo) {
-          return {
-            ...debugFileOkCandidate,
-            download: {
-              ...debugFileOkCandidate.download,
-              status: CandidateDownloadStatus.DELETED,
-            },
-          };
-        }
+  const {
+    data: debugFiles,
+    isLoading,
+    isError,
+    refetch,
+  } = useApiQuery<DebugFile[]>(
+    [
+      `/projects/${organization.slug}/${projSlug}/files/dsyms/?debug_id=${image?.debug_id}`,
+      {
+        query: {
+          // FIXME(swatinem): Ideally we should not filter here at all,
+          // though Symbolicator does not currently report `bcsymbolmap` and `il2cpp`
+          // candidates, and we would thus show bogus "unapplied" entries for those,
+          // which would probably confuse people more than not seeing successfully
+          // fetched candidates for those two types of files.
+          file_formats: [
+            'breakpad',
+            'macho',
+            'elf',
+            'pe',
+            'pdb',
+            'sourcebundle',
+            'wasm',
+            'portablepdb',
+          ],
+        },
+      },
+    ],
+    {
+      enabled: hasUploadedDebugFiles,
+      staleTime: 0,
+    }
+  );
 
-        const {
-          symbolType,
-          objectName: filename,
-          id: location,
-          size,
-          dateCreated,
-        } = internalDebugFileInfo;
+  const {code_file, status} = image ?? {};
+  const candidates = getCandidates({debugFiles, image, isLoading});
+  const baseUrl = api.baseUrl;
+  const fileName = getFileName(code_file);
+  const haveCandidatesUnappliedDebugFile = candidates.some(
+    candidate => candidate.download.status === CandidateDownloadStatus.UNAPPLIED
+  );
+  const hasReprocessWarning =
+    haveCandidatesUnappliedDebugFile &&
+    displayReprocessEventAction(organization.features, event) &&
+    !!onReprocessEvent;
 
-        return {
-          ...debugFileOkCandidate,
-          location,
-          filename,
-          size,
-          dateCreated,
-          symbolType,
-          prettyFileType: getPrettyFileType(internalDebugFileInfo),
-        };
-      }
-    );
-
-    return this.sortCandidates(
-      [
-        ...convertedDebugFileInternalOkCandidates,
-        ...debugFileOtherCandidates,
-      ] as ImageCandidates,
-      unAppliedCandidates as ImageCandidates
-    );
+  if (isLoading) {
+    return <LoadingIndicator />;
   }
 
-  handleDelete = async (debugId: string) => {
-    const {organization, projSlug} = this.props;
+  if (isError) {
+    return <LoadingError />;
+  }
 
-    this.setState({loading: true});
-
+  const handleDelete = async (debugId: string) => {
     try {
-      await this.api.requestPromise(
+      await api.requestPromise(
         `/projects/${organization.slug}/${projSlug}/files/dsyms/?id=${debugId}`,
         {method: 'DELETE'}
       );
-      this.fetchData();
+      refetch();
     } catch {
       addErrorMessage(t('An error occurred while deleting the debug file.'));
-      this.setState({loading: false});
     }
   };
 
-  getDebugFilesSettingsLink() {
-    const {organization, projSlug, image} = this.props;
-    const orgSlug = organization.slug;
-    const debugId = image?.debug_id;
+  const debugFilesSettingsLink =
+    projSlug && image?.debug_id
+      ? `/settings/${organization.slug}/projects/${projSlug}/debug-symbols/?query=${image?.debug_id}`
+      : undefined;
 
-    if (!orgSlug || !projSlug || !debugId) {
-      return undefined;
-    }
-
-    return `/settings/${orgSlug}/projects/${projSlug}/debug-symbols/?query=${debugId}`;
-  }
-
-  renderBody() {
-    const {Header, Body, Footer, image, organization, projSlug, event, onReprocessEvent} =
-      this.props;
-    const {loading} = this.state;
-
-    const {code_file, status} = image ?? {};
-    const debugFilesSettingsLink = this.getDebugFilesSettingsLink();
-    const candidates = this.getCandidates();
-    const baseUrl = this.api.baseUrl;
-    const fileName = getFileName(code_file);
-    const haveCandidatesUnappliedDebugFile = candidates.some(
-      candidate => candidate.download.status === CandidateDownloadStatus.UNAPPLIED
-    );
-    const hasReprocessWarning =
-      haveCandidatesUnappliedDebugFile &&
-      displayReprocessEventAction(organization.features, event) &&
-      !!onReprocessEvent;
-
-    return (
-      <Fragment>
-        <Header closeButton>
-          <Title>
-            {t('Image')}
-            <FileName>{fileName ?? t('Unknown')}</FileName>
-          </Title>
-        </Header>
-        <Body>
-          <Content>
-            <GeneralInfo image={image} />
-            {hasReprocessWarning && (
-              <ReprocessAlert
-                api={this.api}
-                orgSlug={organization.slug}
-                projSlug={projSlug}
-                eventId={event.id}
-                onReprocessEvent={onReprocessEvent}
-              />
-            )}
-            <Candidates
-              imageStatus={status}
-              candidates={candidates}
-              organization={organization}
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Title>
+          {t('Image')}
+          <FileName>{fileName ?? t('Unknown')}</FileName>
+        </Title>
+      </Header>
+      <Body>
+        <Content>
+          <GeneralInfo image={image} />
+          {hasReprocessWarning && (
+            <ReprocessAlert
+              api={api}
+              orgSlug={organization.slug}
               projSlug={projSlug}
-              baseUrl={baseUrl}
-              isLoading={loading}
-              eventDateReceived={event.dateReceived}
-              onDelete={this.handleDelete}
-              hasReprocessWarning={hasReprocessWarning}
+              eventId={event.id}
+              onReprocessEvent={onReprocessEvent}
             />
-          </Content>
-        </Body>
-        <Footer>
-          <StyledButtonBar gap={1}>
-            <Button
-              href="https://docs.sentry.io/platforms/native/data-management/debug-files/"
-              external
+          )}
+          <Candidates
+            imageStatus={status}
+            candidates={candidates}
+            organization={organization}
+            projSlug={projSlug}
+            baseUrl={baseUrl}
+            isLoading={isLoading}
+            eventDateReceived={event.dateReceived}
+            onDelete={handleDelete}
+            hasReprocessWarning={hasReprocessWarning}
+          />
+        </Content>
+      </Body>
+      <Footer>
+        <StyledButtonBar gap={1}>
+          <Button
+            href="https://docs.sentry.io/platforms/native/data-management/debug-files/"
+            external
+          >
+            {t('Read the docs')}
+          </Button>
+          {debugFilesSettingsLink && (
+            <LinkButton
+              title={t(
+                'Search for this debug file in all images for the %s project',
+                projSlug
+              )}
+              to={debugFilesSettingsLink}
             >
-              {t('Read the docs')}
-            </Button>
-            {debugFilesSettingsLink && (
-              <Button
-                title={t(
-                  'Search for this debug file in all images for the %s project',
-                  projSlug
-                )}
-                to={debugFilesSettingsLink}
-              >
-                {t('Open in Settings')}
-              </Button>
-            )}
-          </StyledButtonBar>
-        </Footer>
-      </Fragment>
-    );
-  }
+              {t('Open in Settings')}
+            </LinkButton>
+          )}
+        </StyledButtonBar>
+      </Footer>
+    </Fragment>
+  );
 }
 
 const Content = styled('div')`


### PR DESCRIPTION
This is the modal that displays when you open up and event's "Images Loaded" section and click "View" on one of the images. This only displays for certain platforms. [Here's an example](https://sentry-sdks.dev.getsentry.net:7999/issues/5083459556/#images-loaded) 

I also verified that deleting one of the candidates still works as expected:

https://github.com/getsentry/sentry/assets/10888943/10653f66-c98e-4cdc-9295-79314f5f5f51

