### PR TITLE
ref(daily summary): Filter to only regressed/escalated issues today

### DIFF
--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -207,8 +207,8 @@ def build_summary_data(
             regressed_or_escalated_groups_today = Activity.objects.filter(
                 group__in=([group for group in regressed_or_escalated_groups]),
                 type__in=(ActivityType.SET_REGRESSION.value, ActivityType.SET_ESCALATING.value),
+                datetime__gte=ctx.start,
             )
-
             deduped_groups_by_activity_type: DefaultDict[ActivityType, set] = defaultdict(set)
 
             for activity in regressed_or_escalated_groups_today:

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -387,6 +387,54 @@ class DailySummaryTest(
         assert project_context_map.escalated_today == [self.group2, self.group3]
         assert project_context_map.regressed_today == []
 
+    def test_build_summary_data_group_regressed_escalated_in_the_past(self):
+        """
+        Test that if a group has regressed or escalated some time in the past over 24 hours ago, it does not show up.
+        """
+        for _ in range(2):
+            regressed_past_group = self.store_event_and_outcomes(
+                self.project.id,
+                self.three_days_ago,
+                fingerprint="group-12",
+                category=DataCategory.ERROR,
+                resolve=False,
+            )
+        for _ in range(2):
+            escalated_past_group = self.store_event_and_outcomes(
+                self.project.id,
+                self.three_days_ago,
+                fingerprint="group-13",
+                category=DataCategory.ERROR,
+                resolve=False,
+            )
+        with freeze_time(self.two_days_ago):
+            Activity.objects.create_group_activity(
+                regressed_past_group,
+                ActivityType.SET_REGRESSION,
+                data={
+                    "event_id": regressed_past_group.get_latest_event().event_id,
+                },
+            )
+            Activity.objects.create_group_activity(
+                escalated_past_group,
+                ActivityType.SET_ESCALATING,
+                data={
+                    "event_id": escalated_past_group.get_latest_event().event_id,
+                },
+            )
+        summary = build_summary_data(
+            timestamp=self.now.timestamp(),
+            duration=ONE_DAY,
+            organization=self.organization,
+            daily=True,
+        )
+        project_id = self.project.id
+        project_context_map = cast(
+            DailySummaryProjectContext, summary.projects_context_map[project_id]
+        )
+        assert regressed_past_group not in project_context_map.regressed_today
+        assert escalated_past_group not in project_context_map.escalated_today
+
     @mock.patch("sentry.tasks.summaries.daily_summary.deliver_summary")
     def test_prepare_summary_data(self, mock_deliver_summary):
         """Test that if the summary has data in it, we pass it along to be sent"""


### PR DESCRIPTION
Issues that have events from the last 24 hours could have activity rows that were in the past, and were showing up as "escalated today" or "regressed today" even if the substatus change was over 24 hours old. This PR filters the activity query to the desired time period. 