### PR TITLE
test(ui): Add missing await to waitFors

### DIFF
--- a/static/app/components/discover/transactionsList.spec.tsx
+++ b/static/app/components/discover/transactionsList.spec.tsx
@@ -349,16 +349,14 @@ describe('TransactionsList', function () {
         'Failing Transactions',
       ]);
 
-      await userEvent.click(menuOptions[1]); // Failing transactions is 'count' as per the test options
+      // Failing transactions is 'count' as per the test options
+      await userEvent.click(screen.getByRole('option', {name: 'Failing Transactions'}));
 
-      waitFor(() => {
+      await waitFor(() => {
         // now the sort is descending by count
-        expect(screen.getAllByTestId('grid-cell').map(e => e.textContent)).toEqual([
-          '/a',
-          '100',
-          '/b',
-          '1000',
-        ]);
+        expect(
+          screen.getAllByTestId('grid-cell').map(e => e.textContent?.trim())
+        ).toEqual(['/b', '1000', '/a', '100']);
       });
     });
 

--- a/static/app/views/monitors/components/overviewTimeline/timelineCursor.spec.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineCursor.spec.tsx
@@ -52,10 +52,10 @@ describe('TimelineCursor', function () {
     expect(cursor).toBeInTheDocument();
 
     // Cursor is 10px into the container
-    waitFor(() => {
+    await waitFor(() => {
       expect(container.style.getPropertyValue('--cursorOffset')).toBe('10px');
-      expect(container.style.getPropertyValue('--cursorMax')).toBe('100px');
     });
+    expect(container.style.getPropertyValue('--cursorMax')).toBe('100px');
 
     // move cursor outside it is not visible
     fireEvent.mouseMove(body, {clientX: 120, clientY: 20});


### PR DESCRIPTION
These tests were not waiting for the `waitFor()` to finish

part of https://github.com/getsentry/frontend-tsc/issues/22