### PR TITLE
feat(spans): Add regression score to spans indexed

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -90,6 +90,7 @@ class BaseQueryBuilder:
     organization_column: str = "organization.id"
     function_alias_prefix: str | None = None
     spans_metrics_builder = False
+    params: SnubaParams
 
     def get_middle(self):
         """Get the middle for comparison functions"""

--- a/tests/sentry/search/events/builder/test_spans_indexed.py
+++ b/tests/sentry/search/events/builder/test_spans_indexed.py
@@ -91,3 +91,17 @@ def test_span_duration_where(params, condition, op, value):
         selected_columns=["count"],
     )
     assert Condition(span_duration, op, value) in builder.where
+
+
+@django_db_all
+def test_foo(params):
+    mid = params["start"] + (params["end"] - params["start"]) / 2
+    builder = SpansIndexedQueryBuilder(
+        Dataset.SpansIndexed,
+        params,
+        query="transaction:/api/0/projects/",
+        selected_columns=[
+            f"regression_score(span.self_time, 0.95, {int(mid.timestamp())})",
+        ],
+    )
+    assert 0


### PR DESCRIPTION
To move off of the spans columns in the transactions dataset, this exposes the regression score function on the spans dataset to be used in regression issues.