### PR TITLE
fix(alerts): Refetch configs when changing the alert project

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -204,6 +204,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
     }
 
     this.fetchEnvironments();
+    this.refetchConfigs();
   }
 
   isRuleStateChange(prevState: State): boolean {
@@ -399,6 +400,20 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       })
       .then(response => this.setState({environments: response}))
       .catch(_err => addErrorMessage(t('Unable to fetch environments')));
+  }
+
+  refetchConfigs() {
+    const {organization} = this.props;
+    const {project} = this.state;
+
+    this.api
+      .requestPromise(
+        `/projects/${organization.slug}/${project.slug}/rules/configuration/`
+      )
+      .then(response => this.setState({configs: response}))
+      .catch(() => {
+        // No need to alert user if this fails, can use existing data
+      });
   }
 
   fetchStatus() {


### PR DESCRIPTION
Alerts can return different sets of actions/conditions/rules depending on the selected project. One example is the priority alert condition which is enabled in certain projects with a feature flag. However, currently the UI doesn't refetch the new config data after the project has changed.

This is a quick fix for that which refetches the configuration in the background. It already does this for environments, so I added this in a similar fashion.