### PR TITLE
chore(staff): Remove logs and separate u2f state in session

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -27,7 +27,6 @@ from sentry.utils.auth import DISABLE_SSO_CHECK_FOR_LOCAL_DEV, has_completed_sso
 from sentry.utils.settings import is_self_hosted
 
 logger: logging.Logger = logging.getLogger(__name__)
-getsentry_logger = logging.getLogger("getsentry.staff_auth_index")
 
 PREFILLED_SU_MODAL_KEY = "prefilled_su_modal"
 
@@ -80,14 +79,6 @@ class BaseAuthIndexEndpoint(Endpoint):
                 challenge = json.loads(validator.validated_data["challenge"])
                 response = json.loads(validator.validated_data["response"])
                 authenticated = interface.validate_response(request, challenge, response)
-                getsentry_logger.info(
-                    "verify.user.inputs",
-                    extra={
-                        "user": request.user.id,
-                        "authenticated": authenticated,
-                        "validator": validator.validated_data,
-                    },
-                )
                 if not authenticated:
                     logger.warning(
                         "u2f_authentication.verification_failed",
@@ -114,10 +105,6 @@ class BaseAuthIndexEndpoint(Endpoint):
             if authenticated:
                 metrics.incr("auth.password.success", sample_rate=1.0, skip_internal=False)
             return authenticated
-        getsentry_logger.info(
-            "verify.user.inputs.failed",
-            extra={"user": request.user.id, "validator": validator.validated_data},
-        )
         return False
 
 

--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -1,6 +1,4 @@
-import logging
 from base64 import urlsafe_b64encode
-from datetime import UTC, datetime, timedelta
 from functools import cached_property
 from time import time
 from urllib.parse import urlparse
@@ -19,18 +17,12 @@ from u2flib_server.model import DeviceRegistration
 
 from sentry import options
 from sentry.auth.authenticators.base import EnrollmentStatus
-from sentry.silo.base import SiloMode
 from sentry.utils import json
 from sentry.utils.dates import to_datetime
 from sentry.utils.decorators import classproperty
 from sentry.utils.http import absolute_uri
 
 from .base import ActivationChallengeResult, AuthenticatorInterface
-
-logger = logging.getLogger("sentry.auth.u2f")
-
-# The maximum time the staff auth flow flag can stay alive on the request session
-STAFF_AUTH_FLOW_MAX_AGE = timedelta(minutes=2)
 
 
 def decode_credential_id(device):
@@ -46,35 +38,6 @@ def create_credential_object(registeredKey):
 
 def _get_url_prefix() -> str:
     return options.get("system.url-prefix")
-
-
-def _valid_staff_timestamp(request, limit: timedelta = STAFF_AUTH_FLOW_MAX_AGE) -> bool:
-    """
-    Returns whether or not the staff timestamp exists and is valid within the
-    timedelta. If the timestamp is invalid, it is removed from the session.
-    """
-    timestamp = request.session.get("staff_auth_flow")
-    if not timestamp:
-        return False
-
-    flag_datetime = datetime.fromtimestamp(timestamp, UTC)
-    current_time = datetime.now(UTC)
-    time_difference = flag_datetime - current_time
-    logger.info(
-        "Validating staff timestamp",
-        extra={
-            "user": request.user.id,
-            "current_time": current_time,
-            "flag_datetime": flag_datetime,
-            "time_difference": flag_datetime - current_time,
-            "boolean_check": timedelta(0) < time_difference < limit,
-            "active_silo": SiloMode.get_current_mode(),
-        },
-    )
-
-    # For a valid timestamp, the time difference must be positive (timestamp is in the future)
-    # and less than the limit (timestamp is within the valid limit, e.g. within the last 2 minutes)
-    return timedelta(0) < time_difference < limit
 
 
 class U2fInterface(AuthenticatorInterface):
@@ -239,76 +202,14 @@ class U2fInterface(AuthenticatorInterface):
         challenge, state = self.webauthn_authentication_server.authenticate_begin(
             credentials=credentials
         )
-        logger.info(
-            "U2F activate",
-            extra={
-                "user": request.user.id,
-                "staff_flag": (
-                    datetime.fromtimestamp(request.session["staff_auth_flow"], UTC)
-                    if "staff_auth_flow" in request.session
-                    else "missing"
-                ),
-                "active_silo": SiloMode.get_current_mode(),
-            },
-        )
-        # It is an intentional decision to not check whether or not the staff
-        # timestamp is valid here if it exists. The reason for this is we prefer
-        # the failure to occur and present itself when tapping the U2F device,
-        # not immediately upon generating the challenge/response.
-        if request.session.get("staff_auth_flow"):
-            request.session["staff_webauthn_authentication_state"] = state
-        else:
-            request.session["webauthn_authentication_state"] = state
-
-        logger.info(
-            "U2F activate after setting state",
-            extra={
-                "user": request.user.id,
-                "staff_flag": (
-                    datetime.fromtimestamp(request.session["staff_auth_flow"], UTC)
-                    if "staff_auth_flow" in request.session
-                    else "missing"
-                ),
-                "has_state": "webauthn_authentication_state" in request.session,
-                "has_staff_state": "staff_webauthn_authentication_state" in request.session,
-                "active_silo": SiloMode.get_current_mode(),
-            },
-        )
+        request.session["webauthn_authentication_state"] = state
         return ActivationChallengeResult(challenge=cbor.encode(challenge["publicKey"]))
 
     def validate_response(self, request: HttpRequest, challenge, response):
         try:
             credentials = self.credentials()
-            if hasattr(request, "user") and request.user.is_staff:
-                logger.info(
-                    "Validating U2F for staff",
-                    extra={
-                        "user": request.user.id,
-                        "staff_flag": (
-                            datetime.fromtimestamp(request.session["staff_auth_flow"], UTC)
-                            if "staff_auth_flow" in request.session
-                            else "missing"
-                        ),
-                        "has_state": "webauthn_authentication_state" in request.session,
-                        "has_staff_state": "staff_webauthn_authentication_state" in request.session,
-                        "active_silo": SiloMode.get_current_mode(),
-                    },
-                )
-            if _valid_staff_timestamp(request):
-                state = request.session["staff_webauthn_authentication_state"]
-            else:
-                state = request.session["webauthn_authentication_state"]
-            if request.session.get("staff_webauthn_authentication_state") and request.session.get(
-                "webauthn_authentication_state"
-            ):
-                logger.info(
-                    "Both staff and non-staff U2F states are set",
-                    extra={
-                        "user": request.user.id,
-                    },
-                )
             self.webauthn_authentication_server.authenticate_complete(
-                state=state,
+                state=request.session.get("webauthn_authentication_state"),
                 credentials=credentials,
                 credential_id=websafe_decode(response["keyHandle"]),
                 client_data=ClientData(websafe_decode(response["clientData"])),
@@ -320,6 +221,4 @@ class U2fInterface(AuthenticatorInterface):
         finally:
             # Cleanup the U2F state from the session
             request.session.pop("webauthn_authentication_state", None)
-            request.session.pop("staff_webauthn_authentication_state", None)
-            request.session.pop("staff_auth_flow", None)
         return True

--- a/tests/sentry/auth/authenticators/test_u2f.py
+++ b/tests/sentry/auth/authenticators/test_u2f.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 from fido2 import cbor
@@ -10,17 +9,11 @@ from pytest import raises
 from sentry.auth.authenticators.base import ActivationChallengeResult
 from sentry.auth.authenticators.u2f import U2fInterface
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import control_silo_test
 
 
 @control_silo_test
 class U2FInterfaceTest(TestCase):
-    CURRENT_TIME = datetime(2024, 3, 11, 0, 0)
-    VALID_TIMESTAMP = (CURRENT_TIME + timedelta(minutes=1)).timestamp()
-    INVALID_EXPIRED_TIMESTAMP = (CURRENT_TIME - timedelta(minutes=3)).timestamp()
-    INVALID_FUTURE_TIMESTAMP = (CURRENT_TIME + timedelta(minutes=3)).timestamp()
-
     def setUp(self):
         self.u2f = U2fInterface()
         self.login_as(user=self.user)
@@ -80,37 +73,7 @@ class U2FInterfaceTest(TestCase):
         assert len(self.request.session["webauthn_authentication_state"]["challenge"]) == 43
         assert self.request.session["webauthn_authentication_state"]["user_verification"] is None
 
-    @freeze_time(CURRENT_TIME)
-    def test_activate_staff_webauthn_valid_timestamp(self):
-        self.test_try_enroll_webauthn()
-
-        self.request.session["staff_auth_flow"] = self.VALID_TIMESTAMP
-
-        result = self.u2f.activate(self.request)
-
-        assert isinstance(result, ActivationChallengeResult)
-        assert "webauthn_authentication_state" not in self.request.session
-        assert len(self.request.session["staff_webauthn_authentication_state"]["challenge"]) == 43
-        assert (
-            self.request.session["staff_webauthn_authentication_state"]["user_verification"] is None
-        )
-
-    @freeze_time(CURRENT_TIME)
-    def test_activate_staff_webauthn_invalid_timestamp(self):
-        self.test_try_enroll_webauthn()
-
-        self.request.session["staff_auth_flow"] = self.INVALID_EXPIRED_TIMESTAMP
-
-        result = self.u2f.activate(self.request)
-
-        assert isinstance(result, ActivationChallengeResult)
-        assert "webauthn_authentication_state" not in self.request.session
-        assert len(self.request.session["staff_webauthn_authentication_state"]["challenge"]) == 43
-        assert (
-            self.request.session["staff_webauthn_authentication_state"]["user_verification"] is None
-        )
-
-    def test_validate_response_normal_state(self):
+    def test_validate_response_state(self):
         self.test_try_enroll_webauthn()
         mock_state = Mock()
         self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
@@ -122,57 +85,15 @@ class U2FInterfaceTest(TestCase):
         assert kwargs.get("state") == "normal state"
         assert "webauthn_authentication_state" not in self.request.session
 
-    @freeze_time(CURRENT_TIME)
-    def test_validate_response_staff_state_valid_timestamp(self):
-        self.test_try_enroll_webauthn()
-        mock_state = Mock()
-        self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
-
-        self.request.session["staff_webauthn_authentication_state"] = "staff state"
-        self.request.session["staff_auth_flow"] = self.VALID_TIMESTAMP
-
-        assert self.u2f.validate_response(self.request, None, self.response)
-        _, kwargs = mock_state.call_args
-        assert kwargs.get("state") == "staff state"
-        assert "staff_webauthn_authentication_state" not in self.request.session
-
-    @freeze_time(CURRENT_TIME)
-    def test_validate_response_staff_state_invalid_timestamp(self):
-        self.test_try_enroll_webauthn()
-        mock_state = Mock()
-        self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
-
-        # Test expired timestamp
-        self.request.session["webauthn_authentication_state"] = "non-staff state"
-        self.request.session["staff_auth_flow"] = self.INVALID_EXPIRED_TIMESTAMP
-
-        assert self.u2f.validate_response(self.request, None, self.response)
-        _, kwargs = mock_state.call_args
-        assert kwargs.get("state") == "non-staff state"
-        assert "webauthn_authentication_state" not in self.request.session
-
-        # Test timestamp too far in the future
-        self.request.session["webauthn_authentication_state"] = "non-staff state"
-        self.request.session["staff_auth_flow"] = self.INVALID_FUTURE_TIMESTAMP
-        assert self.u2f.validate_response(self.request, None, self.response)
-        _, kwargs = mock_state.call_args
-        assert kwargs.get("state") == "non-staff state"
-        assert "webauthn_authentication_state" not in self.request.session
-
-    @freeze_time(CURRENT_TIME)
-    def test_validate_response_failing_still_clears_all_states(self):
+    def test_validate_response_failing_still_clears_state(self):
         self.test_try_enroll_webauthn()
         mock_state = Mock(side_effect=ValueError("test"))
         self.u2f.webauthn_authentication_server.authenticate_complete = mock_state
 
-        self.request.session["webauthn_authentication_state"] = "non-staff state"
-        self.request.session["staff_webauthn_authentication_state"] = "staff state"
-        self.request.session["staff_auth_flow"] = self.VALID_TIMESTAMP
+        self.request.session["webauthn_authentication_state"] = "state"
 
         with raises(ValueError):
             self.u2f.validate_response(self.request, None, self.response)
         _, kwargs = mock_state.call_args
-        assert kwargs.get("state") == "staff state"
+        assert kwargs.get("state") == "state"
         assert "webauthn_authentication_state" not in self.request.session
-        assert "staff_webauthn_authentication_state" not in self.request.session
-        assert "staff_auth_flow" not in self.request.session


### PR DESCRIPTION
Change back to storing U2F state in one key in the request session, instead of using a separate key for staff.

Requires https://github.com/getsentry/getsentry/pull/13361