### PR TITLE
ref(perf): Replace boolean type props of `Chart` with a `type` prop

### DIFF
--- a/static/app/views/performance/browser/interactionSummary/interactionBreakdownChart.tsx
+++ b/static/app/views/performance/browser/interactionSummary/interactionBreakdownChart.tsx
@@ -4,7 +4,7 @@ import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {space} from 'sentry/styles/space';
 import {getDurationUnit} from 'sentry/utils/discover/charts';
 import {useInteractionBreakdownTimeseriesQuery} from 'sentry/views/performance/browser/interactionSummary/useInteractionBreakdownTimeseriesQuery';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 
 type Props = {
   element: string;
@@ -28,6 +28,7 @@ export function InteractionBreakdownChart({operation, element, page}: Props) {
         chartColors={[CHART_PALETTE[0][0]]}
         durationUnit={getDurationUnit(data)}
         aggregateOutputFormat="duration"
+        type={ChartType.AREA}
         grid={{
           left: 20,
           right: 50,

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -7,7 +7,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {RESOURCE_THROUGHPUT_UNIT} from 'sentry/views/performance/browser/resources';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {AVG_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
@@ -69,7 +69,7 @@ function ResourceSummaryCharts(props: {groupId: string}) {
             height={160}
             data={[spanMetricsSeriesData?.[`spm()`]]}
             loading={areSpanMetricsSeriesLoading}
-            isLineChart
+            type={ChartType.LINE}
             definedAxisTicks={4}
             aggregateOutputFormat="rate"
             rateUnit={RESOURCE_THROUGHPUT_UNIT}
@@ -89,7 +89,7 @@ function ResourceSummaryCharts(props: {groupId: string}) {
             data={[spanMetricsSeriesData?.[`avg(${SPAN_SELF_TIME})`]]}
             loading={areSpanMetricsSeriesLoading}
             chartColors={[AVG_COLOR]}
-            isLineChart
+            type={ChartType.LINE}
             definedAxisTicks={4}
           />
         </ChartPanel>
@@ -106,7 +106,7 @@ function ResourceSummaryCharts(props: {groupId: string}) {
             ]}
             loading={areSpanMetricsSeriesLoading}
             chartColors={[AVG_COLOR]}
-            isLineChart
+            type={ChartType.LINE}
             definedAxisTicks={4}
             tooltipFormatterOptions={{
               valueFormatter: bytes =>

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
@@ -23,7 +23,7 @@ import type {UnweightedWebVitalsScoreBreakdown} from 'sentry/views/performance/b
 import {useProjectWebVitalsTimeseriesQuery} from 'sentry/views/performance/browser/webVitals/utils/queries/useProjectWebVitalsTimeseriesQuery';
 import {useReplaceFidWithInpSetting} from 'sentry/views/performance/browser/webVitals/utils/useReplaceFidWithInpSetting';
 import {useStoredScoresSetting} from 'sentry/views/performance/browser/webVitals/utils/useStoredScoresSetting';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 
 export const SCORE_MIGRATION_TIMESTAMP = 1702771200000;
 export const FID_DEPRECATION_DATE = 1710259200000;
@@ -233,6 +233,7 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
           (isRawScoreTimeseriesDataLoading && scoreMigrationTimestampAfterStart) ||
           (shouldUseStoredScores && isProjectScoresLoading)
         }
+        type={ChartType.AREA}
         grid={{
           left: 5,
           right: 5,

--- a/static/app/views/performance/database/durationChart.tsx
+++ b/static/app/views/performance/database/durationChart.tsx
@@ -2,7 +2,7 @@ import type {Series} from 'sentry/types/echarts';
 import {DurationAggregateSelector} from 'sentry/views/performance/database/durationAggregateSelector';
 import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
 import {AVG_COLOR} from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 
 interface Props {
@@ -26,7 +26,7 @@ export function DurationChart({series, isLoading, error}: Props) {
         loading={isLoading}
         error={error}
         chartColors={[AVG_COLOR]}
-        isLineChart
+        type={ChartType.LINE}
       />
     </ChartPanel>
   );

--- a/static/app/views/performance/database/throughputChart.tsx
+++ b/static/app/views/performance/database/throughputChart.tsx
@@ -3,7 +3,7 @@ import {RateUnit} from 'sentry/utils/discover/fields';
 import {formatRate} from 'sentry/utils/formatters';
 import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
 import {THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {getThroughputChartTitle} from 'sentry/views/starfish/views/spans/types';
 
@@ -27,7 +27,7 @@ export function ThroughputChart({series, isLoading}: Props) {
         data={[series]}
         loading={isLoading}
         chartColors={[THROUGHPUT_COLOR]}
-        isLineChart
+        type={ChartType.LINE}
         aggregateOutputFormat="rate"
         rateUnit={RateUnit.PER_MINUTE}
         tooltipFormatterOptions={{

--- a/static/app/views/performance/http/durationChart.tsx
+++ b/static/app/views/performance/http/durationChart.tsx
@@ -1,7 +1,7 @@
 import type {Series} from 'sentry/types/echarts';
 import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
 import {AVG_COLOR} from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {getDurationChartTitle} from 'sentry/views/starfish/views/spans/types';
 
@@ -26,7 +26,7 @@ export function DurationChart({series, isLoading, error}: Props) {
         loading={isLoading}
         error={error}
         chartColors={[AVG_COLOR]}
-        isLineChart
+        type={ChartType.LINE}
       />
     </ChartPanel>
   );

--- a/static/app/views/performance/http/responseRateChart.tsx
+++ b/static/app/views/performance/http/responseRateChart.tsx
@@ -6,7 +6,7 @@ import {
   HTTP_RESPONSE_4XX_COLOR,
   HTTP_RESPONSE_5XX_COLOR,
 } from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 
@@ -35,7 +35,7 @@ export function ResponseRateChart({series, isLoading, error}: Props) {
           HTTP_RESPONSE_4XX_COLOR,
           HTTP_RESPONSE_5XX_COLOR,
         ]}
-        isLineChart
+        type={ChartType.LINE}
         aggregateOutputFormat="percentage"
         dataMax={getAxisMaxForPercentageSeries(series)}
         tooltipFormatterOptions={{

--- a/static/app/views/performance/http/throughputChart.tsx
+++ b/static/app/views/performance/http/throughputChart.tsx
@@ -3,7 +3,7 @@ import {RateUnit} from 'sentry/utils/discover/fields';
 import {formatRate} from 'sentry/utils/formatters';
 import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
 import {THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {getThroughputChartTitle} from 'sentry/views/starfish/views/spans/types';
 
@@ -28,7 +28,7 @@ export function ThroughputChart({series, isLoading, error}: Props) {
         loading={isLoading}
         error={error}
         chartColors={[THROUGHPUT_COLOR]}
-        isLineChart
+        type={ChartType.LINE}
         aggregateOutputFormat="rate"
         rateUnit={RateUnit.PER_MINUTE}
         tooltipFormatterOptions={{

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -31,7 +31,7 @@ import {useTransactionWebVitalsQuery} from 'sentry/views/performance/browser/web
 import type {RowWithScoreAndOpportunity} from 'sentry/views/performance/browser/webVitals/utils/types';
 import {useReplaceFidWithInpSetting} from 'sentry/views/performance/browser/webVitals/utils/useReplaceFidWithInpSetting';
 import {useStoredScoresSetting} from 'sentry/views/performance/browser/webVitals/utils/useStoredScoresSetting';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {
@@ -92,6 +92,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
             !shouldUseStoredScores,
             order
           )}
+          type={ChartType.AREA}
           disableXAxis
           loading={false}
           grid={{

--- a/static/app/views/performance/landing/widgets/widgets/slowScreens.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/slowScreens.tsx
@@ -50,7 +50,7 @@ import {
 } from 'sentry/views/performance/landing/widgets/utils';
 import {Subtitle} from 'sentry/views/profiling/landing/styles';
 import {RightAlignedCell} from 'sentry/views/replays/deadRageClick/deadRageSelectorCards';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
@@ -300,7 +300,7 @@ function SlowScreensByTTID(props: PerformanceWidgetProps) {
             top: '8px',
             bottom: '0',
           }}
-          isLineChart
+          type={ChartType.LINE}
           aggregateOutputFormat={OUTPUT_TYPE[YAxis.TTID]}
           tooltipFormatterOptions={{
             valueFormatter: value =>

--- a/static/app/views/starfish/components/chart.spec.tsx
+++ b/static/app/views/starfish/components/chart.spec.tsx
@@ -1,12 +1,14 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 
 describe('Chart', function () {
   test('it shows an error panel if an error prop is supplied', function () {
     const parsingError = new Error('Could not parse chart data');
 
-    render(<Chart error={parsingError} data={[]} loading={false} />);
+    render(
+      <Chart error={parsingError} data={[]} loading={false} type={ChartType.LINE} />
+    );
 
     expect(screen.getByTestId('chart-error-panel')).toBeInTheDocument();
   });

--- a/static/app/views/starfish/views/appStartup/countChart.tsx
+++ b/static/app/views/starfish/views/appStartup/countChart.tsx
@@ -16,7 +16,7 @@ import {
   PRIMARY_RELEASE_COLOR,
   SECONDARY_RELEASE_COLOR,
 } from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
@@ -141,7 +141,7 @@ export function CountChart({chartHeight}: Props) {
         }}
         showLegend
         definedAxisTicks={2}
-        isLineChart
+        type={ChartType.LINE}
         aggregateOutputFormat={OUTPUT_TYPE[YAxis.COUNT]}
         tooltipFormatterOptions={{
           valueFormatter: value =>

--- a/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/startDurationWidget.tsx
@@ -16,7 +16,7 @@ import {
   PRIMARY_RELEASE_COLOR,
   SECONDARY_RELEASE_COLOR,
 } from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
@@ -143,7 +143,7 @@ function StartDurationWidget({additionalFilters, chartHeight}: Props) {
         }}
         showLegend
         definedAxisTicks={2}
-        isLineChart
+        type={ChartType.LINE}
         aggregateOutputFormat="duration"
         tooltipFormatterOptions={{
           valueFormatter: value =>

--- a/static/app/views/starfish/views/mobileServiceView/index.tsx
+++ b/static/app/views/starfish/views/mobileServiceView/index.tsx
@@ -15,7 +15,10 @@ import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
+import Chart, {
+  ChartType,
+  useSynchronizeCharts,
+} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
@@ -179,7 +182,7 @@ export function MobileStarfishView() {
               }}
               showLegend
               definedAxisTicks={2}
-              isLineChart
+              type={ChartType.LINE}
               aggregateOutputFormat="duration"
               tooltipFormatterOptions={{
                 valueFormatter: value =>
@@ -207,7 +210,7 @@ export function MobileStarfishView() {
               aggregateOutputFormat="duration"
               definedAxisTicks={2}
               stacked
-              isLineChart
+              type={ChartType.LINE}
               tooltipFormatterOptions={{
                 valueFormatter: value =>
                   tooltipFormatterUsingAggregateOutputType(value, 'duration'),
@@ -233,7 +236,7 @@ export function MobileStarfishView() {
               }}
               showLegend
               definedAxisTicks={2}
-              isLineChart
+              type={ChartType.LINE}
               aggregateOutputFormat="duration"
               tooltipFormatterOptions={{
                 valueFormatter: value =>
@@ -260,7 +263,7 @@ export function MobileStarfishView() {
               aggregateOutputFormat="duration"
               definedAxisTicks={2}
               stacked
-              isLineChart
+              type={ChartType.LINE}
               tooltipFormatterOptions={{
                 valueFormatter: value =>
                   tooltipFormatterUsingAggregateOutputType(value, 'duration'),
@@ -286,7 +289,7 @@ export function MobileStarfishView() {
               }}
               showLegend
               definedAxisTicks={2}
-              isLineChart
+              type={ChartType.LINE}
               aggregateOutputFormat="percentage"
               tooltipFormatterOptions={{
                 valueFormatter: value =>
@@ -313,7 +316,7 @@ export function MobileStarfishView() {
               aggregateOutputFormat="percentage"
               definedAxisTicks={2}
               stacked
-              isLineChart
+              type={ChartType.LINE}
               tooltipFormatterOptions={{
                 valueFormatter: value =>
                   tooltipFormatterUsingAggregateOutputType(value, 'percentage'),

--- a/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
@@ -21,7 +21,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
@@ -269,7 +269,7 @@ export function ScreenCharts({yAxes, additionalFilters, project}: Props) {
                     }}
                     showLegend
                     definedAxisTicks={2}
-                    isLineChart
+                    type={ChartType.LINE}
                     aggregateOutputFormat={OUTPUT_TYPE[YAxis.TTID]}
                     tooltipFormatterOptions={{
                       valueFormatter: value =>
@@ -337,7 +337,7 @@ export function ScreenCharts({yAxes, additionalFilters, project}: Props) {
                     }}
                     showLegend
                     definedAxisTicks={2}
-                    isLineChart
+                    type={ChartType.LINE}
                     aggregateOutputFormat={OUTPUT_TYPE[YAxis.TTFD]}
                     tooltipFormatterOptions={{
                       valueFormatter: value =>
@@ -379,7 +379,7 @@ export function ScreenCharts({yAxes, additionalFilters, project}: Props) {
                 }}
                 showLegend
                 definedAxisTicks={2}
-                isLineChart
+                type={ChartType.LINE}
                 aggregateOutputFormat={OUTPUT_TYPE[YAxis.COUNT]}
                 tooltipFormatterOptions={{
                   valueFormatter: value =>

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -11,7 +11,7 @@ import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {AVG_COLOR} from 'sentry/views/starfish/colours';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {isNearAverage} from 'sentry/views/starfish/components/samplesTable/common';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
@@ -243,7 +243,7 @@ function DurationChart({
               : sampledSpanDataSeries
           }
           chartColors={[AVG_COLOR, 'black']}
-          isLineChart
+          type={ChartType.LINE}
           definedAxisTicks={4}
         />
       </div>

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -9,7 +9,10 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import {AVG_COLOR, ERRORS_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
-import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
+import Chart, {
+  ChartType,
+  useSynchronizeCharts,
+} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
@@ -170,7 +173,7 @@ export function SpanSummaryView({groupId}: Props) {
               data={[spanMetricsThroughputSeries]}
               loading={areSpanMetricsSeriesLoading}
               chartColors={[THROUGHPUT_COLOR]}
-              isLineChart
+              type={ChartType.LINE}
               definedAxisTicks={4}
               aggregateOutputFormat="rate"
               rateUnit={RateUnit.PER_MINUTE}
@@ -188,7 +191,7 @@ export function SpanSummaryView({groupId}: Props) {
               data={[spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
               loading={areSpanMetricsSeriesLoading}
               chartColors={[AVG_COLOR]}
-              isLineChart
+              type={ChartType.LINE}
               definedAxisTicks={4}
             />
           </ChartPanel>
@@ -202,7 +205,7 @@ export function SpanSummaryView({groupId}: Props) {
                 data={[spanMetricsSeriesData?.[`http_error_count()`]]}
                 loading={areSpanMetricsSeriesLoading}
                 chartColors={[ERRORS_COLOR]}
-                isLineChart
+                type={ChartType.LINE}
                 definedAxisTicks={4}
               />
             </ChartPanel>

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -12,7 +12,10 @@ import {EMPTY_OPTION_VALUE} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {AVG_COLOR, ERRORS_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
-import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
+import Chart, {
+  ChartType,
+  useSynchronizeCharts,
+} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
@@ -174,7 +177,7 @@ function ThroughputChart({
       aggregateOutputFormat="rate"
       rateUnit={throughputUnit}
       stacked
-      isLineChart
+      type={ChartType.LINE}
       chartColors={[THROUGHPUT_COLOR]}
       tooltipFormatterOptions={{
         valueFormatter: value => formatRate(value, throughputUnit),
@@ -230,7 +233,7 @@ function DurationChart({moduleName, filters, extraQuery}: ChartProps): JSX.Eleme
       }}
       definedAxisTicks={4}
       stacked
-      isLineChart
+      type={ChartType.LINE}
       chartColors={[AVG_COLOR]}
     />
   );
@@ -263,7 +266,7 @@ function ErrorChart({moduleName, filters}: ChartProps): JSX.Element {
       }}
       definedAxisTicks={4}
       stacked
-      isLineChart
+      type={ChartType.LINE}
       chartColors={[ERRORS_COLOR]}
     />
   );
@@ -325,6 +328,7 @@ function BundleSizeChart(props: ChartProps) {
   return (
     <Chart
       stacked
+      type={ChartType.AREA}
       loading={isLoading}
       data={data}
       aggregateOutputFormat="size"

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -34,6 +34,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
 import {AVG_COLOR, ERRORS_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
 import Chart, {
+  ChartType,
   computeAxisMax,
   useSynchronizeCharts,
 } from 'sentry/views/starfish/components/chart';
@@ -211,7 +212,7 @@ export default function EndpointOverview() {
             }}
             disableXAxis
             definedAxisTicks={2}
-            isLineChart
+            type={ChartType.LINE}
             chartColors={[AVG_COLOR]}
             scatterPlot={sampleData}
             tooltipFormatterOptions={{
@@ -241,7 +242,7 @@ export default function EndpointOverview() {
             height={80}
             data={[throughputResults, tpsLine]}
             loading={loading}
-            isLineChart
+            type={ChartType.LINE}
             definedAxisTicks={2}
             disableXAxis
             chartColors={[THROUGHPUT_COLOR]}
@@ -290,7 +291,7 @@ export default function EndpointOverview() {
               bottom: '0',
             }}
             definedAxisTicks={2}
-            isLineChart
+            type={ChartType.LINE}
             chartColors={[ERRORS_COLOR]}
           />
           <SidebarSpacer />

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -13,7 +13,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {tooltipFormatterUsingAggregateOutputType} from 'sentry/utils/discover/charts';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import useOrganization from 'sentry/utils/useOrganization';
-import Chart from 'sentry/views/starfish/components/chart';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {useRoutingContext} from 'sentry/views/starfish/utils/routingContext';
 import type {DataRow} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
@@ -148,7 +148,11 @@ export function SpanGroupBreakdown({
               bottom: '0',
             }}
             definedAxisTicks={6}
-            isLineChart={dataDisplayType !== DataDisplayType.PERCENTAGE}
+            type={
+              dataDisplayType === DataDisplayType.PERCENTAGE
+                ? ChartType.AREA
+                : ChartType.LINE
+            }
             stacked={dataDisplayType === DataDisplayType.PERCENTAGE}
             aggregateOutputFormat={
               dataDisplayType === DataDisplayType.PERCENTAGE ? 'percentage' : 'duration'

--- a/static/app/views/starfish/views/webServiceView/starfishView.tsx
+++ b/static/app/views/starfish/views/webServiceView/starfishView.tsx
@@ -16,7 +16,10 @@ import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
-import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
+import Chart, {
+  ChartType,
+  useSynchronizeCharts,
+} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {useEventsStatsQuery} from 'sentry/views/starfish/utils/useEventsStatsQuery';
@@ -152,7 +155,7 @@ export function StarfishView(props: BaseStarfishViewProps) {
               }}
               aggregateOutputFormat="duration"
               definedAxisTicks={2}
-              isLineChart
+              type={ChartType.LINE}
               tooltipFormatterOptions={{
                 valueFormatter: value =>
                   tooltipFormatterUsingAggregateOutputType(value, 'duration'),
@@ -176,7 +179,7 @@ export function StarfishView(props: BaseStarfishViewProps) {
               rateUnit={RateUnit.PER_SECOND}
               definedAxisTicks={2}
               stacked
-              isLineChart
+              type={ChartType.LINE}
               chartColors={[THROUGHPUT_COLOR]}
               tooltipFormatterOptions={{
                 valueFormatter: value => formatRate(value, RateUnit.PER_SECOND),
@@ -198,7 +201,7 @@ export function StarfishView(props: BaseStarfishViewProps) {
                 bottom: '0',
               }}
               definedAxisTicks={2}
-              isLineChart
+              type={ChartType.LINE}
               chartColors={[CHART_PALETTE[5][3]]}
             />
           </MiniChartPanel>


### PR DESCRIPTION
Follow-up to #67363


Instead of `isLineChart` and `isBarChart` use a `type` enum, which clearly specifies the type. Remove the default value (area) and require that type is always supplied.

- anything that used to say `isLineChart` gets `type={ChartType.LINE}`
- anything that didn't specify `isLineChart` gets `type={ChartType.AREA}` which is the default
- anything conditional gets a clearer condition
