### PR TITLE
feat(perf): Replace 2XX columns with 3XX columns in HTTP module

### DIFF
--- a/static/app/views/performance/http/domainTransactionsTable.tsx
+++ b/static/app/views/performance/http/domainTransactionsTable.tsx
@@ -27,7 +27,7 @@ type Row = Pick<
   | 'transaction'
   | 'transaction.method'
   | 'spm()'
-  | 'http_response_rate(2)'
+  | 'http_response_rate(3)'
   | 'http_response_rate(4)'
   | 'http_response_rate(5)'
   | 'avg(span.self_time)'
@@ -38,7 +38,7 @@ type Row = Pick<
 type Column = GridColumnHeader<
   | 'transaction'
   | 'spm()'
-  | 'http_response_rate(2)'
+  | 'http_response_rate(3)'
   | 'http_response_rate(4)'
   | 'http_response_rate(5)'
   | 'avg(span.self_time)'
@@ -57,8 +57,8 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: `http_response_rate(2)`,
-    name: t('2XXs'),
+    key: `http_response_rate(3)`,
+    name: t('3XXs'),
     width: 50,
   },
   {
@@ -86,7 +86,7 @@ const COLUMN_ORDER: Column[] = [
 const SORTABLE_FIELDS = [
   'avg(span.self_time)',
   'spm()',
-  'http_response_rate(2)',
+  'http_response_rate(3)',
   'http_response_rate(4)',
   'http_response_rate(5)',
   'time_spent_percentage()',

--- a/static/app/views/performance/http/domainsTable.tsx
+++ b/static/app/views/performance/http/domainsTable.tsx
@@ -25,7 +25,7 @@ type Row = Pick<
   | 'project.id'
   | 'span.domain'
   | 'spm()'
-  | 'http_response_rate(2)'
+  | 'http_response_rate(3)'
   | 'http_response_rate(4)'
   | 'http_response_rate(5)'
   | 'avg(span.self_time)'
@@ -36,7 +36,7 @@ type Row = Pick<
 type Column = GridColumnHeader<
   | 'span.domain'
   | 'spm()'
-  | 'http_response_rate(2)'
+  | 'http_response_rate(3)'
   | 'http_response_rate(4)'
   | 'http_response_rate(5)'
   | 'avg(span.self_time)'
@@ -55,8 +55,8 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: `http_response_rate(2)`,
-    name: t('2XXs'),
+    key: `http_response_rate(3)`,
+    name: t('3XXs'),
     width: 50,
   },
   {
@@ -84,7 +84,7 @@ const COLUMN_ORDER: Column[] = [
 const SORTABLE_FIELDS = [
   'avg(span.self_time)',
   'spm()',
-  'http_response_rate(2)',
+  'http_response_rate(3)',
   'http_response_rate(4)',
   'http_response_rate(5)',
   'time_spent_percentage()',

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -193,7 +193,7 @@ describe('HTTPSummaryPage', function () {
             'transaction',
             'transaction.method',
             'spm()',
-            'http_response_rate(2)',
+            'http_response_rate(3)',
             'http_response_rate(4)',
             'http_response_rate(5)',
             'avg(span.self_time)',
@@ -231,7 +231,7 @@ describe('HTTPSummaryPage', function () {
             transaction: '/api/users',
             'transaction.method': 'GET',
             'spm()': 17.88,
-            'http_response_rate(2)': 0.97,
+            'http_response_rate(3)': 0.97,
             'http_response_rate(4)': 0.025,
             'http_response_rate(5)': 0.005,
             'avg(span.self_time)': 204.5,
@@ -242,7 +242,7 @@ describe('HTTPSummaryPage', function () {
           fields: {
             'spm()': 'rate',
             'avg(span.self_time)': 'duration',
-            'http_response_rate(2)': 'percentage',
+            'http_response_rate(3)': 'percentage',
             'http_response_rate(4)': 'percentage',
             'http_response_rate(5)': 'percentage',
             'sum(span.self_time)': 'duration',
@@ -261,7 +261,7 @@ describe('HTTPSummaryPage', function () {
     expect(
       screen.getByRole('columnheader', {name: 'Requests Per Minute'})
     ).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: '2XXs'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: '3XXs'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: '4XXs'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: '5XXs'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Avg Duration'})).toBeInTheDocument();

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -118,7 +118,7 @@ export function HTTPDomainSummaryPage() {
       'transaction',
       'transaction.method',
       'spm()',
-      'http_response_rate(2)',
+      'http_response_rate(3)',
       'http_response_rate(4)',
       'http_response_rate(5)',
       'avg(span.self_time)',

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -177,7 +177,7 @@ describe('HTTPLandingPage', function () {
             'project.id',
             'span.domain',
             'spm()',
-            'http_response_rate(2)',
+            'http_response_rate(3)',
             'http_response_rate(4)',
             'http_response_rate(5)',
             'avg(span.self_time)',

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -85,7 +85,7 @@ export function HTTPLandingPage() {
       'project.id',
       'span.domain',
       'spm()',
-      'http_response_rate(2)',
+      'http_response_rate(3)',
       'http_response_rate(4)',
       'http_response_rate(5)',
       'avg(span.self_time)',

--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -120,7 +120,7 @@ describe('HTTPSamplesPanel', function () {
           fields: {
             'spm()': 'rate',
             'avg(span.self_time)': 'duration',
-            'http_response_rate(2)': 'percentage',
+            'http_response_rate(3)': 'percentage',
             'http_response_rate(4)': 'percentage',
             'http_response_rate(5)': 'percentage',
             'sum(span.self_time)': 'duration',


### PR DESCRIPTION
2XX is not very interesting. It's not good to make people do math to figure out the 3xx rate from the 2xx, 4xx, and 5xx. Instead, let's show the 3xx value everywhere it's relevant. If someone needs to calculate the 200 (which IMO will be rarer!) they can do so.

People want to see what's going wrong!
