### PR TITLE
Do not use deprecated Sentry SDK features

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -134,7 +134,7 @@ class AuthIdentityHandler:
     @staticmethod
     def warn_about_ambiguous_email(email: str, users: Collection[User], chosen_user: User) -> None:
         with sentry_sdk.push_scope() as scope:
-            scope.level = "warning"
+            scope.set_level("warning")
             scope.set_tag("email", email)
             scope.set_extra("user_ids", [user.id for user in users])
             scope.set_extra("chosen_user", chosen_user.id)

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -77,7 +77,7 @@ def assemble_download(
         with sentry_sdk.configure_scope() as scope:
             if data_export.user_id:
                 user = dict(id=data_export.user_id)
-                scope.user = user
+                scope.set_user(user)
             scope.set_tag("organization.slug", data_export.organization.slug)
             scope.set_tag("export.type", ExportQueryType.as_str(data_export.query_type))
             scope.set_extra("export.query", data_export.query_info)
@@ -309,7 +309,7 @@ def merge_export_blobs(data_export_id, **kwargs):
         with sentry_sdk.configure_scope() as scope:
             if data_export.user_id:
                 user = dict(id=data_export.user_id)
-                scope.user = user
+                scope.set_user(user)
             scope.set_tag("organization.slug", data_export.organization.slug)
             scope.set_tag("export.type", ExportQueryType.as_str(data_export.query_type))
             scope.set_extra("export.query", data_export.query_info)

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -158,7 +158,7 @@ class CompositeRuleStore:
                     },
                 )
                 sentry_sdk.set_tag("namespace", self._namespace.value.name)
-                sentry_sdk.capture_message("Clusterer discarded rules", level="warn")
+                sentry_sdk.capture_message("Clusterer discarded rules", level="warning")
             sorted_rules = sorted_rules[: self.MERGE_MAX_RULES]
 
         return {rule: last_seen for rule, last_seen in sorted_rules}

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -219,7 +219,7 @@ def before_send_transaction(event, _):
 def before_send(event, _):
     if event.get("tags"):
         if settings.SILO_MODE:
-            event["tags"]["silo_mode"] = settings.SILO_MODE
+            event["tags"]["silo_mode"] = str(settings.SILO_MODE)
         if settings.SENTRY_REGION:
             event["tags"]["sentry_region"] = settings.SENTRY_REGION
     return event
@@ -612,9 +612,10 @@ def bind_organization_context(organization: Organization | RpcOrganization) -> N
     helper = settings.SENTRY_ORGANIZATION_CONTEXT_HELPER
 
     # XXX(dcramer): this is duplicated in organizationContext.jsx on the frontend
-    with configure_scope() as scope, sentry_sdk.start_span(
-        op="other", description="bind_organization_context"
-    ):
+    # fmt: off
+    with configure_scope() as scope, \
+         sentry_sdk.start_span(op="other", description="bind_organization_context"):
+        # fmt: on
         # This can be used to find errors that may have been mistagged
         check_tag_for_scope_bleed("organization.slug", organization.slug)
 


### PR DESCRIPTION
Makes some tiny changed to not use deprecated Sentry SDK features and thus making the code more future proof.