### PR TITLE
fix(metrics): Delay focus area position update

### DIFF
--- a/static/app/views/ddm/chart/useFocusArea.tsx
+++ b/static/app/views/ddm/chart/useFocusArea.tsx
@@ -299,7 +299,10 @@ function FocusAreaOverlay({
   }, [chartRef, rect, useFullYAxis, position]);
 
   useEffect(() => {
-    updatePosition();
+    // In some cases echarts is not yet done with updating the chart
+    // and the sample axes are not yet available to read the position from
+    // so we need to delay the update until the next microtask
+    queueMicrotask(updatePosition);
   }, [rect, updatePosition]);
 
   if (!position) {


### PR DESCRIPTION
Fix focus area not rendering after back navigation from a different page.

closes #67421