### PR TITLE
feat(ddm): Add slugs to the capture message when a new custom metric is received

### DIFF
--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -176,7 +176,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
 
             project = Project.objects.get_from_cache(id=project_id)
             if not project.flags.has_custom_metrics:
-                organization = Organization.objects.get_from_cache(organization_id=org_id)
+                organization = Organization.objects.get_from_cache(id=org_id)
                 with sentry_sdk.push_scope() as scope:
                     scope.set_tag("organization_id", org_id)
                     scope.set_tag("organization_slug", organization.slug)

--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -16,6 +16,7 @@ from django.db.models import F
 from sentry_kafka_schemas.schema_types.snuba_generic_metrics_v1 import GenericMetric
 
 from sentry.constants import DataCategory
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.indexer.strings import (
     SHARED_TAG_STRINGS,
@@ -175,11 +176,14 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
 
             project = Project.objects.get_from_cache(id=project_id)
             if not project.flags.has_custom_metrics:
+                organization = Organization.objects.get_from_cache(organization_id=org_id)
                 with sentry_sdk.push_scope() as scope:
                     scope.set_tag("organization_id", org_id)
+                    scope.set_tag("organization_slug", organization.slug)
                     scope.set_tag("project_id", project_id)
+                    scope.set_tag("project_slug", project.slug)
                     sentry_sdk.capture_message(
-                        f"Project {project_id} of organization {org_id} has sent the first custom metric",
+                        "A new project has sent the first custom metric",
                         fingerprint=["new-first-custom-metric"],
                     )
 


### PR DESCRIPTION
This PR adds the organization and project slug when new projects are sending their first custom metric.