### PR TITLE
chore(nodestore): Remove traces to allow measuring set_subkeys

### DIFF
--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -278,7 +278,6 @@ class NodeStorage(local, Service):
             return self.cache.get_many(id_list)
         return {}
 
-    @sentry_sdk.tracing.trace
     def _set_cache_item(self, item_id: str, data: Any) -> None:
         if self.cache and data:
             self.cache.set(item_id, data)

--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -69,7 +69,6 @@ class BigtableNodeStorage(NodeStorage):
         rv.update(self.store.get_many(id_list))
         return rv
 
-    @sentry_sdk.tracing.trace
     def _set_bytes(self, id: str, data: Any, ttl: timedelta | None = None) -> None:
         self.store.set(id, data, ttl)
 


### PR DESCRIPTION
I tried using "View Similar Spans" for nodestore's `set_subkeys`, however, Sentry only lets you see the time of the span itself without the children. This means that if the children's spans take 99% of the time, it will look like `set_subkeys` takes a very short time even though its children make its total span duration a lot longer.

This removes the two children spans to help us see the true impact of `set_subkeys`.


[Sample event:](https://sentry.sentry.io/discover/sentry:b524d254c34e459cb02ef2a13021bc6c/?field=title&field=transaction.duration&homepage=true&id=25491&name=&project=1&query=transaction%3Asentry.tasks.store.save_event%2A+event.type%3Atransaction+title%3Asentry.tasks.store.save_event&sort=-transaction.duration&statsPeriod=24h&topEvents=5&yAxis=count%28%29)
<img width="1342" alt="image" src="https://github.com/getsentry/sentry/assets/44410/9b5d7566-9553-414a-a037-05c418e53c72">

[Span summary:](https://sentry.sentry.io/performance/summary/spans/nodestore:5b93b7e1d4f9bdcd/?project=1&query=transaction%3Asentry.tasks.store.save_event%2A+event.type%3Atransaction+title%3Asentry.tasks.store.save_event&statsPeriod=24h&transaction=sentry.tasks.store.save_event)
<img width="709" alt="image" src="https://github.com/getsentry/sentry/assets/44410/222280f1-44f1-40a3-a22b-59fb57a34bf5">

[Specific event:](https://sentry.sentry.io/performance/sentry:40b1ae4e95cc40f78ab00f8c0a5fe51e/?project=1&query=transaction%3Asentry.tasks.store.save_event%2A+event.type%3Atransaction+title%3Asentry.tasks.store.save_event&statsPeriod=24h&transaction=sentry.tasks.store.save_event#span-8cb5def0b7799569)
Notice that it says 47ms but the trace navigator shows that the total span time (including its children) is 338ms.
<img width="677" alt="image" src="https://github.com/getsentry/sentry/assets/44410/f7a4f7ee-9987-429c-915b-eb4b572fdd0b">
<img width="937" alt="image" src="https://github.com/getsentry/sentry/assets/44410/4d97dc67-8f81-415a-8227-39d2b0d9d1ce">
