### PR TITLE
style(replays): adjust user badge style on replay details

### DIFF
--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -173,6 +173,7 @@ const Title = styled('h1')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   color: ${p => p.theme.headingColor};
   margin: 0;
+  line-height: 1.4;
 `;
 
 const TimeContainer = styled('div')`
@@ -180,11 +181,11 @@ const TimeContainer = styled('div')`
   gap: ${space(1)};
   align-items: center;
   color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeLarge};
+  font-size: ${p => p.theme.fontSizeMedium};
+  line-height: 1.4;
 `;
 
 const DisplayHeader = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${space(0.5)};
 `;


### PR DESCRIPTION

- Both the `h1` and time element (date created row) have a line-height of `1.4`
- the time element has its `font-size` reduced to `14px`
- the `4px` gap between the`h1` and the time element is removed

<img width="706" alt="SCR-20240321-jcrt" src="https://github.com/getsentry/sentry/assets/56095982/efba0bdf-30f6-48a4-995d-a3015c23ea76">
<img width="1183" alt="SCR-20240321-jcps" src="https://github.com/getsentry/sentry/assets/56095982/9f8e54cf-359d-43c0-9de9-2d0919aef686">
