### PR TITLE
test(ui): Fix act warning in group replays for react 18

### DIFF
--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -597,7 +597,9 @@ describe('GroupReplays', () => {
       });
 
       const mockReplace = jest.mocked(browserHistory.replace);
-      const replayPlayPlause = screen.getAllByTestId('replay-table-play-button')[0];
+      const replayPlayPlause = (
+        await screen.findAllByTestId('replay-table-play-button')
+      )[0];
       await userEvent.click(replayPlayPlause);
 
       await waitFor(() =>


### PR DESCRIPTION
Waiting for the mock api to be called is not quite enough, needs to wait for the play button as well to avoid act warnings.

part of https://github.com/getsentry/frontend-tsc/issues/22
