### PR TITLE
feat: mql test update for snuba change

### DIFF
--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -139,10 +139,10 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         # TODO: once snuba pr #5676 is merged, change expected_identity_series back to single entry
         #       the ones with [None, 0.0] should become None
         for aggregate, expected_identity_series, expected_identity_totals in (
-            ("count", [None], 0),
-            ("avg", [None], None),
-            ("sum", [None, 0.0], 0.0),
-            ("min", [None, 0.0], 0.0),
+            ("count", (None,), 0),
+            ("avg", (None,), None),
+            ("sum", (None, 0.0), 0.0),
+            ("min", (None, 0.0), 0.0),
         ):
             query_1 = self.mql(aggregate, TransactionMRI.DURATION.value, "transaction:/bar")
             plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
@@ -163,7 +163,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
 
             _, second, third = data[0][0]["series"]
             assert second in expected_identity_series
-            assert third in expected_identity_series
+            assert second == third
 
             assert data[0][0]["totals"] == expected_identity_totals
 

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -139,8 +139,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         for aggregate, expected_identity_series, expected_identity_totals in (
             ("count", None, 0),
             ("avg", None, None),
-            ("sum", 0.0, 0.0),
-            ("min", 0.0, 0.0),
+            ("sum", None, 0.0),
+            ("min", None, 0.0),
         ):
             query_1 = self.mql(aggregate, TransactionMRI.DURATION.value, "transaction:/bar")
             plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
@@ -507,7 +507,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0][1]["totals"] == self.to_reference_unit(12.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_group_by_on_null_tag(self) -> None:
         for value, transaction, time in (
             (1, "/hello", self.now()),
@@ -553,7 +553,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(1.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_parenthesized_filter(self) -> None:
         query_1 = self.mql("sum", TransactionMRI.DURATION.value, "(transaction:/hello)", "platform")
         plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
@@ -578,7 +578,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             self.to_reference_unit(1.0),
             self.to_reference_unit(2.0),
         ]
-        assert first_query[0]["totals"] == 3.0
+        assert first_query[0]["totals"] == self.to_reference_unit(3.0)
         assert first_query[1]["by"] == {"platform": "ios"}
         assert first_query[1]["series"] == [
             None,
@@ -588,7 +588,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_and_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:ios AND transaction:/hello", "platform"
@@ -618,7 +618,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[0]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_or_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:ios OR platform:android", "platform"
@@ -655,7 +655,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_negated_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "!platform:ios transaction:/hello", "platform"
@@ -685,7 +685,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[0]["totals"] == self.to_reference_unit(3.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_in_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:[android, ios]", "platform"
@@ -722,7 +722,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_not_in_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, '!platform:["android", "ios"]', "platform"
@@ -1391,9 +1391,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0][1]["by"] == {"platform": "android", "transaction": "/hello"}
         assert data[0][1]["series"] == [None, 1.0, 1.0]
         assert data[0][1]["totals"] == 2.0
-        assert data[0][2]["by"] == {"platform": "windows", "transaction": "/world"}
-        assert data[0][2]["series"] == [None, 0.0, 0.0]
-        assert data[0][2]["totals"] == 0.0
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     def test_query_with_basic_formula_and_coercible_units(self):

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -136,7 +136,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     def test_query_with_empty_results(self) -> None:
         # TODO: the identities returned here to not make much sense, we need to figure out the right semantics.
-        # TODO: once kyles optimizer is published, change expected_identity series back to single entry
+        # TODO: once snuba pr #5662 is merged, change expected_identity_series back to single entry
+        #       the ones with [None, 0.0] should become None
         for aggregate, expected_identity_series, expected_identity_totals in (
             ("count", [None], 0),
             ("avg", [None], None),
@@ -1400,6 +1401,13 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0][1]["by"] == {"platform": "android", "transaction": "/hello"}
         assert data[0][1]["series"] == [None, 1.0, 1.0]
         assert data[0][1]["totals"] == 2.0
+
+        # TODO: after snuba pr #5662 is merged, change to assert len(data[0]) == 2
+        assert len(data[0]) in {2, 3}
+        if len(data[0]) == 3:
+            assert data[0][2]["by"] == {"platform": "windows", "transaction": "/world"}
+            assert data[0][2]["series"] == [None, 0.0, 0.0]
+            assert data[0][2]["totals"] == 0.0
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     def test_query_with_basic_formula_and_coercible_units(self):

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -507,7 +507,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0][1]["totals"] == self.to_reference_unit(12.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_group_by_on_null_tag(self) -> None:
         for value, transaction, time in (
             (1, "/hello", self.now()),
@@ -553,7 +553,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(1.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_parenthesized_filter(self) -> None:
         query_1 = self.mql("sum", TransactionMRI.DURATION.value, "(transaction:/hello)", "platform")
         plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
@@ -588,7 +588,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_and_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:ios AND transaction:/hello", "platform"
@@ -618,7 +618,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[0]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_or_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:ios OR platform:android", "platform"
@@ -655,7 +655,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_negated_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "!platform:ios transaction:/hello", "platform"
@@ -685,7 +685,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[0]["totals"] == self.to_reference_unit(3.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_in_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:[android, ios]", "platform"
@@ -722,7 +722,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_not_in_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, '!platform:["android", "ios"]', "platform"
@@ -929,7 +929,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert second_meta[0]["order"] == "DESC"
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     @patch("sentry.sentry_metrics.querying.data_v2.execution.SNUBA_QUERY_LIMIT", 3)
     def test_query_with_multiple_aggregations_and_single_group_by_and_dynamic_limit(
         self,

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -136,7 +136,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     def test_query_with_empty_results(self) -> None:
         # TODO: the identities returned here to not make much sense, we need to figure out the right semantics.
-        # TODO: once snuba pr #5662 is merged, change expected_identity_series back to single entry
+        # TODO: once snuba pr #5676 is merged, change expected_identity_series back to single entry
         #       the ones with [None, 0.0] should become None
         for aggregate, expected_identity_series, expected_identity_totals in (
             ("count", [None], 0),
@@ -1402,7 +1402,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0][1]["series"] == [None, 1.0, 1.0]
         assert data[0][1]["totals"] == 2.0
 
-        # TODO: after snuba pr #5662 is merged, change to assert len(data[0]) == 2
+        # TODO: after snuba pr #5676 is merged, change to assert len(data[0]) == 2
         assert len(data[0]) in {2, 3}
         if len(data[0]) == 3:
             assert data[0][2]["by"] == {"platform": "windows", "transaction": "/world"}

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -507,7 +507,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0][1]["totals"] == self.to_reference_unit(12.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_group_by_on_null_tag(self) -> None:
         for value, transaction, time in (
             (1, "/hello", self.now()),
@@ -553,7 +553,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(1.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_parenthesized_filter(self) -> None:
         query_1 = self.mql("sum", TransactionMRI.DURATION.value, "(transaction:/hello)", "platform")
         plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
@@ -588,7 +588,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_and_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:ios AND transaction:/hello", "platform"
@@ -618,7 +618,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[0]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_or_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:ios OR platform:android", "platform"
@@ -655,7 +655,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_negated_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "!platform:ios transaction:/hello", "platform"
@@ -685,7 +685,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[0]["totals"] == self.to_reference_unit(3.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_in_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:[android, ios]", "platform"
@@ -722,7 +722,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    # @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.skip("Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_not_in_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, '!platform:["android", "ios"]', "platform"

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -159,13 +159,11 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             data = results["data"]
             assert len(data) == 1
             assert data[0][0]["by"] == {}
-
             assert data[0][0]["series"] == [
                 None,
                 expected_identity_series,
                 expected_identity_series,
             ]
-
             assert data[0][0]["totals"] == expected_identity_totals
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -161,18 +161,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             assert len(data) == 1
             assert data[0][0]["by"] == {}
 
-            matches_one = False
-            assert isinstance(expected_identity_series, list)  # mypy
-            for e in expected_identity_series:
-                if data[0][0]["series"] == [
-                    None,
-                    e,
-                    e,
-                ]:
-                    matches_one = True
-                    break
-            assert matches_one
-
             _, second, third = data[0][0]["series"]
             assert second in expected_identity_series
             assert third in expected_identity_series
@@ -521,7 +509,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0][1]["totals"] == self.to_reference_unit(12.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    # @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_group_by_on_null_tag(self) -> None:
         for value, transaction, time in (
             (1, "/hello", self.now()),


### PR DESCRIPTION
These are test changes in preparation for https://github.com/getsentry/snuba/pull/5676

* changed all skipped tests to xfail
* changed a couple passing tests to xfail, and modified them to pass for with the new optimizer
* pretty much all xfail should pass once optimizer is deployed