### PR TITLE
test(ui): Wait for results in widget card duration unit tests

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -663,12 +663,15 @@ describe('Dashboards > WidgetCard', function () {
     await waitFor(function () {
       expect(eventsStatsMock).toHaveBeenCalled();
     });
-    const {tooltip, yAxis} = spy.mock.calls.pop()?.[0] ?? {};
-    expect(tooltip).toBeDefined();
 
-    expect(yAxis).toBeDefined();
-    // @ts-expect-error
-    expect(yAxis.axisLabel.formatter(24, 'p95(measurements.custom)')).toEqual('24ms');
+    await waitFor(() => {
+      const mockCall = spy.mock.calls?.at(-1)?.[0];
+      expect(mockCall?.tooltip).toBeDefined();
+      // @ts-expect-error
+      expect(mockCall?.yAxis.axisLabel.formatter(24, 'p95(measurements.custom)')).toEqual(
+        '24ms'
+      );
+    });
   });
 
   it('renders label in seconds when there is a transition from seconds to minutes in the y axis', async function () {
@@ -758,12 +761,17 @@ describe('Dashboards > WidgetCard', function () {
     await waitFor(function () {
       expect(eventsStatsMock).toHaveBeenCalled();
     });
-    const {yAxis} = spy.mock.calls.pop()?.[0] ?? {};
-    expect(yAxis).toBeDefined();
+    await waitFor(() => {
+      const mockCall = spy.mock.calls?.at(-1)?.[0];
+      expect(mockCall?.yAxis).toBeDefined();
 
-    // @ts-expect-error
-    expect(yAxis.axisLabel.formatter(60000, 'p50(transaction.duration)')).toEqual('60s');
-    expect((yAxis as any).minInterval).toEqual(SECOND);
+      expect(
+        // @ts-expect-error
+        mockCall?.yAxis.axisLabel.formatter(60000, 'p50(transaction.duration)')
+      ).toEqual('60s');
+      // @ts-expect-error
+      expect(mockCall?.yAxis?.minInterval).toEqual(SECOND);
+    });
   });
 
   it('displays indexed badge in preview mode', async function () {


### PR DESCRIPTION
In react 18, the first render may not be the right one. Changes it to waitFor and to look at the most recent mock call instead of just the first one.

Part of https://github.com/getsentry/frontend-tsc/issues/22
