### PR TITLE
feat(hybridcloud) Add additional RPC methods for SSO setup/disable 

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -46,6 +46,7 @@ from sentry.services.hybrid_cloud.organizationmember_mapping import (
     RpcOrganizationMemberMappingUpdate,
     organizationmember_mapping_service,
 )
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.signals import member_invited
 from sentry.utils.http import absolute_uri
@@ -53,7 +54,6 @@ from sentry.utils.http import absolute_uri
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
     from sentry.services.hybrid_cloud.integration import RpcIntegration
-    from sentry.services.hybrid_cloud.user import RpcUser
 
 _OrganizationMemberFlags = TypedDict(
     "_OrganizationMemberFlags",
@@ -389,32 +389,33 @@ class OrganizationMember(ReplicatedRegionModel):
         )
         msg.send_async([self.get_email()])
 
-    def send_sso_unlink_email(self, disabling_user: RpcUser, provider):
+    def send_sso_unlink_email(self, disabling_user: RpcUser | str, provider):
         from sentry.services.hybrid_cloud.lost_password_hash import lost_password_hash_service
         from sentry.utils.email import MessageBuilder
-
-        email = self.get_email()
-
-        recover_uri = "{path}?{query}".format(
-            path=reverse("sentry-account-recover"), query=urlencode({"email": email})
-        )
 
         # Nothing to send if this member isn't associated to a user
         if not self.user_id:
             return
 
+        email = self.get_email()
+        recover_uri = "{path}?{query}".format(
+            path=reverse("sentry-account-recover"), query=urlencode({"email": email})
+        )
         user = user_service.get_user(user_id=self.user_id)
         if not user:
             return
 
         has_password = user.has_usable_password()
+        actor_email = disabling_user
+        if isinstance(disabling_user, RpcUser):
+            actor_email = disabling_user.email
 
         context = {
             "email": email,
             "recover_url": absolute_uri(recover_uri),
             "has_password": has_password,
             "organization": self.organization,
-            "actor_email": disabling_user.email,
+            "actor_email": actor_email,
             "provider": provider,
         }
 

--- a/src/sentry/models/organizationmembermapping.py
+++ b/src/sentry/models/organizationmembermapping.py
@@ -17,6 +17,9 @@ class OrganizationMemberMapping(Model):
     """
     This model resides exclusively in the control silo, and will
     - map a user or an email to a specific organization to indicate an organization membership
+
+    Note: If we ever expand this model to include flags we need to update the bulk updates
+    that are skipping outboxes because we assume flags are not replicated in a few place.
     """
 
     # This model is "autocreated" via an outbox write from the regional `Organization` it

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -582,6 +582,38 @@ class DatabaseBackedOrganizationService(OrganizationService):
         for member in member_list:
             member.send_sso_link_email(sending_user_email, provider)
 
+    def send_sso_unlink_emails(
+        self, *, organization_id: int, sending_user_email: str, provider_key: str
+    ) -> None:
+        from sentry.auth import manager
+        from sentry.auth.exceptions import ProviderNotRegistered
+
+        try:
+            provider = manager.get(provider_key)
+        except ProviderNotRegistered as e:
+            logger.warning("Could not send SSO unlink emails: %s", e)
+            return
+
+        member_list = OrganizationMember.objects.filter(
+            organization_id=organization_id,
+        )
+        for member in member_list:
+            # Update all members regardless of whether or not
+            # the invitation was accepted. We don't use a bulk update
+            # because of outboxes
+            member.update(
+                flags=F("flags")
+                .bitand(~OrganizationMember.flags["sso:linked"])
+                .bitand(~OrganizationMember.flags["sso:invalid"])
+            )
+            member.send_sso_unlink_email(sending_user_email, provider)
+
+    def count_members_without_sso(self, *, organization_id: int) -> int:
+        return OrganizationMember.objects.filter(
+            organization_id=organization_id,
+            flags=F("flags").bitand(~OrganizationMember.flags["sso:linked"]),
+        ).count()
+
     def delete_organization(
         self, *, organization_id: int, user: RpcUser
     ) -> RpcOrganizationDeleteResponse:

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -596,7 +596,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
         with unguarded_write(using=router.db_for_write(OrganizationMember)):
             # Flags are not replicated -- these updates are safe to skip outboxes
-            OrganizationMember.objects.filter(organization_id=organization_id,).update(
+            OrganizationMember.objects.filter(organization_id=organization_id).update(
                 flags=F("flags")
                 .bitand(~OrganizationMember.flags["sso:linked"])
                 .bitand(~OrganizationMember.flags["sso:invalid"])

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -351,6 +351,18 @@ class OrganizationService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
+    def send_sso_unlink_emails(
+        self, *, organization_id: int, sending_user_email: str, provider_key: str
+    ) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def count_members_without_sso(self, *, organization_id: int) -> int:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
     def delete_organization(
         self, *, organization_id: int, user: RpcUser
     ) -> RpcOrganizationDeleteResponse:

--- a/src/sentry/services/hybrid_cloud/replica/impl.py
+++ b/src/sentry/services/hybrid_cloud/replica/impl.py
@@ -277,6 +277,10 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
             )
             org_slug_qs.delete()
 
+    def delete_replicated_auth_provider(self, *, auth_provider_id: int, region_name: str) -> None:
+        with enforce_constraints(transaction.atomic(router.db_for_write(AuthProviderReplica))):
+            AuthProviderReplica.objects.filter(auth_provider_id=auth_provider_id).delete()
+
 
 class DatabaseBackedControlReplicaService(ControlReplicaService):
     def upsert_external_actor_replica(self, *, external_actor: RpcExternalActor) -> None:

--- a/src/sentry/services/hybrid_cloud/replica/service.py
+++ b/src/sentry/services/hybrid_cloud/replica/service.py
@@ -97,6 +97,11 @@ class RegionReplicaService(RpcService):
     ) -> None:
         pass
 
+    @regional_rpc_method(resolve=ByRegionName())
+    @abc.abstractmethod
+    def delete_replicated_auth_provider(self, *, auth_provider_id: int, region_name: str) -> None:
+        pass
+
     @classmethod
     def get_local_implementation(cls) -> RpcService:
         from .impl import DatabaseBackedRegionReplicaService

--- a/tests/sentry/hybridcloud/test_organization.py
+++ b/tests/sentry/hybridcloud/test_organization.py
@@ -3,6 +3,8 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
+from django.core import mail
+from django.db.models import F
 
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
@@ -22,6 +24,7 @@ from sentry.services.hybrid_cloud.project import RpcProject
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
+from sentry.testutils.helpers.task_runner import TaskRunner
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, region_silo_test
 
@@ -247,7 +250,7 @@ class RpcOrganizationMemberTest(TestCase):
 
 @django_db_all(transaction=True)
 @region_silo_test
-def test_org_member():
+def test_update_organization_member():
     org = Factories.create_organization()
     user = Factories.create_user(email="test@sentry.io")
     rpc_member = organization_service.add_organization_member(
@@ -267,3 +270,65 @@ def test_org_member():
     member_query = OrganizationMember.objects.all()
     assert member_query.count() == 1
     assert member_query[0].role == "manager"
+
+
+@django_db_all(transaction=True)
+@all_silo_test
+def test_count_members_without_sso():
+    org = Factories.create_organization()
+    user = Factories.create_user(email="test@sentry.io")
+    user_two = Factories.create_user(email="has.sso@sentry.io")
+    Factories.create_member(organization=org, user=user)
+    Factories.create_member(organization=org, email="invite@sentry.io")
+    # has sso setup, not included in result
+    Factories.create_member(
+        organization=org,
+        user=user_two,
+        flags=OrganizationMember.flags["sso:linked"],
+    )
+    result = organization_service.count_members_without_sso(organization_id=org.id)
+    assert result == 2
+
+
+@django_db_all(transaction=True)
+@all_silo_test
+def test_send_sso_unlink_emails():
+    org = Factories.create_organization()
+    user = Factories.create_user(email="test@sentry.io")
+    user_two = Factories.create_user(email="two@sentry.io")
+    Factories.create_member(
+        organization=org, user=user, flags=OrganizationMember.flags["sso:linked"]
+    )
+    Factories.create_member(
+        organization=org, user=user_two, flags=OrganizationMember.flags["sso:linked"]
+    )
+    Factories.create_member(
+        organization=org, email="invite@sentry.io", flags=OrganizationMember.flags["sso:invalid"]
+    )
+    with TaskRunner():
+        result = organization_service.send_sso_unlink_emails(
+            organization_id=org.id,
+            sending_user_email="owner@sentry.io",
+            provider_key="google",
+        )
+        assert result is None
+
+    with assume_test_silo_mode(SiloMode.REGION):
+        # No members should be linked or invalid now
+        assert (
+            OrganizationMember.objects.filter(
+                flags=F("flags").bitor(OrganizationMember.flags["sso:linked"])
+            ).count()
+            == 0
+        )
+        assert (
+            OrganizationMember.objects.filter(
+                flags=F("flags").bitor(OrganizationMember.flags["sso:invalid"])
+            ).count()
+            == 0
+        )
+
+    # Only real members should get emails
+    assert len(mail.outbox) == 2
+    assert "Action Required" in mail.outbox[0].subject
+    assert "Single Sign-On" in mail.outbox[0].body


### PR DESCRIPTION
Add the required RPC methods that we'll need to move SSO setup/teardown to control silo.

Part one of https://github.com/getsentry/sentry/pull/67451