### PR TITLE
feat(issue-stream): Put merge and review actions inside overflow menu by default

### DIFF
--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -17,6 +17,7 @@ import type {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
+import {FOR_REVIEW_QUERIES} from 'sentry/views/issueList/utils';
 
 import ResolveActions from './resolveActions';
 import ReviewAction from './reviewAction';
@@ -102,16 +103,17 @@ function ActionSet({
     return '';
   };
 
-  // Determine whether to nest "Merge" and "Mark as Reviewed" buttons inside
-  // the dropdown menu based on the current screen size
   const nestMergeAndReviewViewport = useMedia(`(max-width: 1700px)`);
-  const nestMergeAndReview = nestMergeAndReviewViewport && !hasIssuePriority;
+  const nestReview = hasIssuePriority
+    ? !FOR_REVIEW_QUERIES.includes(query)
+    : nestMergeAndReviewViewport;
+  const nestMerge = hasIssuePriority ? true : nestMergeAndReviewViewport;
 
   const menuItems: MenuItemProps[] = [
     {
       key: 'merge',
       label: t('Merge'),
-      hidden: !nestMergeAndReview,
+      hidden: !nestMerge,
       disabled: mergeDisabled,
       details: makeMergeTooltip(),
       onAction: () => {
@@ -126,7 +128,7 @@ function ActionSet({
     {
       key: 'mark-reviewed',
       label: t('Mark Reviewed'),
-      hidden: !nestMergeAndReview,
+      hidden: !nestReview,
       disabled: !canMarkReviewed,
       onAction: () => onUpdate({inbox: false}),
     },
@@ -245,10 +247,8 @@ function ActionSet({
           })}
         />
       )}
-      {!nestMergeAndReview && (
-        <ReviewAction disabled={!canMarkReviewed} onUpdate={onUpdate} />
-      )}
-      {!nestMergeAndReview && (
+      {!nestReview && <ReviewAction disabled={!canMarkReviewed} onUpdate={onUpdate} />}
+      {!nestMerge && (
         <ActionLink
           aria-label={t('Merge Selected Issues')}
           type="button"

--- a/static/app/views/issueList/overview.actions.spec.tsx
+++ b/static/app/views/issueList/overview.actions.spec.tsx
@@ -302,7 +302,10 @@ describe('IssueListOverview (actions)', function () {
         headers: {Link: DEFAULT_LINKS_HEADER},
       });
 
-      await userEvent.click(await screen.findByRole('button', {name: 'Mark Reviewed'}));
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'More issue actions'})
+      );
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'Mark Reviewed'}));
 
       expect(updateIssueMock).toHaveBeenCalledWith(
         '/organizations/org-slug/issues/',


### PR DESCRIPTION
Old logic: Merge and review are shown as their own buttons on wide viewports, but nested when window size is smaller 
New logic: Merge is always nested within overflow menu, review is always nested _except_ when on the for review tab

Old logic is still used without the `issue-priority-ui` flag.

![CleanShot 2024-03-21 at 11 45 30](https://github.com/getsentry/sentry/assets/10888943/906edf06-1002-4ffb-955b-0ed8532f6d30)
