### PR TITLE
ref(suspect commits): Handle None in event frames

### DIFF
--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -255,7 +255,7 @@ def get_event_file_committers(
     munged = munged_filename_and_frames(event_platform, frames, "munged_filename", sdk_name)
     if munged:
         frames = munged[1]
-    app_frames = [frame for frame in frames if frame.get("in_app")][-frame_limit:]
+    app_frames = [frame for frame in frames if frame and frame.get("in_app")][-frame_limit:]
     if not app_frames:
         app_frames = [frame for frame in frames][-frame_limit:]
 

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import timedelta
+from typing import Any
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
@@ -741,7 +742,7 @@ class GetEventFileCommitters(CommitTestCase):
     @patch("sentry.utils.committers.get_frame_paths")
     def test_none_frame(self, mock_get_frame_paths):
         """Test that if a frame is None, we skip over it"""
-        frames = [
+        frames: list[Any] = [
             {
                 "function": "handle_set_commits",
                 "abs_path": "/usr/src/sentry/src/sentry/tasks.py",


### PR DESCRIPTION
I'm not sure how this happens, but sometimes `None` was in the `event_frames` list - this checks if the frame exists before doing `.get()` on it. 

Fixes https://sentry.sentry.io/issues/5088663511/