### PR TITLE
fix(perf): Allow querying for indexed `http.client` spans status code

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -143,6 +143,7 @@ SPAN_COLUMN_MAP = {
     "environment": "sentry_tags[environment]",
     "device.class": "sentry_tags[device.class]",
     "category": "sentry_tags[category]",
+    "span.status_code": "sentry_tags[status_code]",
     "resource.render_blocking_status": "sentry_tags[resource.render_blocking_status]",
     "http.response_content_length": "sentry_tags[http.response_content_length]",
     "http.decoded_response_content_length": "sentry_tags[http.decoded_response_content_length]",

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -119,6 +119,45 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
         assert data[0]["device.class"] == "Unknown"
         assert meta["dataset"] == "spansIndexed"
 
+    def test_network_span(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "sentry_tags": {
+                            "action": "GET",
+                            "category": "http",
+                            "description": "GET https://*.resource.com",
+                            "domain": "*.resource.com",
+                            "op": "http.client",
+                            "status_code": "200",
+                            "transaction": "/api/0/data/",
+                            "transaction.method": "GET",
+                            "transaction.op": "http.server",
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ]
+        )
+
+        response = self.do_request(
+            {
+                "field": ["span.op", "span.status_code"],
+                "query": "span.status_code:200",
+                "project": self.project.id,
+                "dataset": "spansIndexed",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["span.op"] == "http.client"
+        assert data[0]["span.status_code"] == "200"
+        assert meta["dataset"] == "spansIndexed"
+
     def test_inp_span(self):
         self.store_spans(
             [


### PR DESCRIPTION
Without this mapping, the query tries to match against `tags` instead of `sentry.tags` which is not where that data lives!
