### PR TITLE
feat(perf): Add HTTP module release status badges

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -51,6 +51,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import MetricsOnboardingSidebar from 'sentry/views/ddm/ddmOnboarding/sidebar';
+import {releaseLevelAsBadgeProps as HTTPModuleBadgeProps} from 'sentry/views/performance/http/settings';
 
 import {ProfilingOnboardingSidebar} from '../profiling/ProfilingOnboarding/profilingOnboardingSidebar';
 
@@ -271,6 +272,7 @@ function Sidebar() {
                   to={`/organizations/${organization.slug}/performance/http/`}
                   id="performance-http"
                   icon={<SubitemDot collapsed />}
+                  {...HTTPModuleBadgeProps}
                 />
               </Feature>
               <Feature features="starfish-browser-webvitals" organization={organization}>

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import FeatureBadge from 'sentry/components/featureBadge';
 import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
@@ -23,6 +24,7 @@ import {
 import {DurationChart} from 'sentry/views/performance/http/durationChart';
 import {HTTPSamplesPanel} from 'sentry/views/performance/http/httpSamplesPanel';
 import {ResponseRateChart} from 'sentry/views/performance/http/responseRateChart';
+import {RELEASE_LEVEL} from 'sentry/views/performance/http/settings';
 import {ThroughputChart} from 'sentry/views/performance/http/throughputChart';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
@@ -154,7 +156,10 @@ export function HTTPDomainSummaryPage() {
               },
             ]}
           />
-          <Layout.Title>{domain}</Layout.Title>
+          <Layout.Title>
+            {domain}
+            <FeatureBadge type={RELEASE_LEVEL} />
+          </Layout.Title>
         </Layout.HeaderContent>
       </Layout.Header>
 

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -1,6 +1,7 @@
 import React, {Fragment} from 'react';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import FeatureBadge from 'sentry/components/featureBadge';
 import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
@@ -18,6 +19,7 @@ import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/u
 import {DomainsTable, isAValidSort} from 'sentry/views/performance/http/domainsTable';
 import {DurationChart} from 'sentry/views/performance/http/durationChart';
 import {ResponseRateChart} from 'sentry/views/performance/http/responseRateChart';
+import {RELEASE_LEVEL} from 'sentry/views/performance/http/settings';
 import {ThroughputChart} from 'sentry/views/performance/http/throughputChart';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
@@ -117,7 +119,10 @@ export function HTTPLandingPage() {
             ]}
           />
 
-          <Layout.Title>{t('HTTP')}</Layout.Title>
+          <Layout.Title>
+            {t('HTTP')}
+            <FeatureBadge type={RELEASE_LEVEL} />
+          </Layout.Title>
         </Layout.HeaderContent>
       </Layout.Header>
 

--- a/static/app/views/performance/http/settings.ts
+++ b/static/app/views/performance/http/settings.ts
@@ -1,0 +1,10 @@
+import type {BadgeType} from 'sentry/components/featureBadge';
+
+export const RELEASE_LEVEL: BadgeType = 'alpha';
+
+// NOTE: Awkward typing, but without it `RELEASE_LEVEL` is narrowed and the comparison is not allowed
+export const releaseLevelAsBadgeProps = {
+  isAlpha: (RELEASE_LEVEL as BadgeType) === 'alpha',
+  isBeta: (RELEASE_LEVEL as BadgeType) === 'beta',
+  isNew: (RELEASE_LEVEL as BadgeType) === 'new',
+};


### PR DESCRIPTION
- sidebar link badge
- landing page title badge
- domain page title badge

**e.g.,**
![Screenshot 2024-03-21 at 4 17 59 PM](https://github.com/getsentry/sentry/assets/989898/fcde41ac-dcaf-4937-923a-c4c3fa62ba1b)
