### PR TITLE
ref(crons): Add named route for monitor details

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1002,6 +1002,11 @@ urlpatterns += [
                     name="sentry-organization-replay-rage-clicks",
                 ),
                 re_path(
+                    r"^(?P<organization_slug>[\w_-]+)/crons/(?P<project_slug>[\w_-]+)/(?P<monitor_slug>[\w_-]+)/$",
+                    react_page_view,
+                    name="sentry-organization-cron-monitor-details",
+                ),
+                re_path(
                     r"^(?P<organization_slug>[\w_-]+)/restore/$",
                     generic_react_page_view,
                     name="sentry-restore-organization",


### PR DESCRIPTION
Adds named route here which will be used to generate URLs for the emails we send alerting users of broken monitors