### PR TITLE
fix(msteams): Allow bot being added to msteams

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Callable, Mapping
+from enum import Enum
 from typing import Any
 
 from django.http import HttpRequest, HttpResponse
@@ -158,6 +159,19 @@ class MsTeamsWebhookMixin:
             return None
         return integration_service.get_integration(provider=self.provider, external_id=team_id)
 
+    def get_integration_for_tenant(self, data: Mapping[str, Any]) -> RpcIntegration | None:
+        try:
+            channel_data = data["channelData"]
+            tenant_id = channel_data["tenant"]["id"]
+            return integration_service.get_integration(
+                provider=self.provider, external_id=tenant_id
+            )
+        except Exception as err:
+            logger.info(
+                "failed to get tenant id from request data", exc_info=err, extra={"data": data}
+            )
+        return None
+
     @classmethod
     def infer_integration_id_from_card_action(cls, data: Mapping[str, Any]) -> int | None:
         # The bot builds and sends Adaptive Cards to the channel, and in it will include card actions and context.
@@ -187,6 +201,20 @@ class MsTeamsWebhookMixin:
         )
 
 
+class MsTeamsEvents(Enum):
+    INSTALLATION_UPDATE = "installationUpdate"
+    MESSAGE = "message"
+    CONVERSATION_UPDATE = "conversationUpdate"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def get_from_value(cls, value: str) -> MsTeamsEvents:
+        try:
+            return MsTeamsEvents(value)
+        except Exception:
+            return MsTeamsEvents.UNKNOWN
+
+
 @all_silo_endpoint
 class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
     owner = ApiOwner.INTEGRATIONS
@@ -197,9 +225,124 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
     permission_classes = ()
     provider = "msteams"
 
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._event_handlers: dict[MsTeamsEvents, Callable[[HttpRequest], HttpResponse]] = {
+            MsTeamsEvents.MESSAGE: self.handle_message_event,
+            MsTeamsEvents.CONVERSATION_UPDATE: self.handle_conversation_update_event,
+            MsTeamsEvents.UNKNOWN: self.handle_unknown_event,
+        }
+
     @csrf_exempt
     def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         return super().dispatch(request, *args, **kwargs)
+
+    @classmethod
+    def _get_team_installation_request_data(cls, data: dict[str, Any]) -> dict:
+        """
+        Helper method that will construct the installation request for a MsTeams team channel.
+        We want the KeyError exception to be raised if the key does not exist.
+        """
+        channel_data = data["channelData"]
+        new_team_info = channel_data["team"]
+
+        team_id = new_team_info.get("aadGroupId", None)
+        if team_id is None:
+            logger.info(
+                "sentry.integrations.msteams.webhooks: New team info data does not have aadGroupId",
+                extra={"data": data},
+            )
+            fallback_id = new_team_info["id"]
+            team_id = fallback_id
+
+        team_name = new_team_info["name"]
+        service_url = data["serviceUrl"]
+        from_data = data["from"]
+        user_id = from_data["id"]
+
+        tenant_info = channel_data["tenant"]
+        tenant_id = tenant_info["id"]
+        params = {
+            "service_url": service_url,
+            "user_id": user_id,
+            "tenant_id": tenant_id,
+            "conversation_id": team_id,
+            "external_id": team_id,
+            "external_name": team_name,
+            "installation_type": "team",
+        }
+        return params
+
+    def handle_installation_update_event(self, request: HttpRequest) -> HttpResponse:
+        data = request.data
+        action = data.get("action", None)
+        if action is None or action != "add":
+            logger.info(
+                "sentry.integrations.msteams.webhooks: Action not supported",
+                extra={"request_data": data},
+            )
+            return self.respond(status=204)
+
+        try:
+            installation_params = self._get_team_installation_request_data(data=data)
+        except Exception as err:
+            logger.info(
+                "sentry.integrations.msteams.webhooks: Installation param error",
+                exc_info=err,
+                extra={"request_data": data},
+            )
+            return self.respond(status=400)
+
+        # sign the params so this can't be forged
+        signed_params = sign(**installation_params)
+
+        # send welcome message to the team
+        preinstall_client = get_preinstall_client(installation_params["service_url"])
+        card = build_team_installation_message(signed_params)
+        preinstall_client.send_card(installation_params["conversation_id"], card)
+
+        return self.respond(status=201)
+
+    def handle_message_event(self, request: HttpRequest) -> HttpResponse:
+        data = request.data
+        conversation = data.get("conversation", {})
+        conversation_type = conversation.get("conversationType")
+
+        # the only message events we care about are those which
+        # are from a user submitting an option on a card, which
+        # will always contain an "payload.actionType" in the data.
+        if data.get("value", {}).get("payload", {}).get("actionType"):
+            # Processing card actions can only occur in the Region silo.
+            if SiloMode.get_current_mode() == SiloMode.CONTROL:
+                return self.respond(status=400)
+            return self.handle_action_submitted(request)
+        elif conversation_type == "channel":
+            return self.handle_channel_message(request)
+
+        return self.handle_personal_message(request)
+
+    def handle_conversation_update_event(self, request: HttpRequest) -> HttpResponse:
+        data = request.data
+        conversation = data.get("conversation", {})
+        conversation_type = conversation.get("conversationType")
+        channel_data = data["channelData"]
+        event = channel_data.get("eventType")
+
+        if event == "teamMemberAdded":
+            return self.handle_team_member_added(request)
+        elif event == "teamMemberRemoved":
+            if SiloMode.get_current_mode() == SiloMode.CONTROL:
+                return self.respond(status=400)
+            return self.handle_team_member_removed(request)
+        elif (
+            data.get("membersAdded") and conversation_type == "personal"
+        ):  # no explicit event for user adding app unfortunately
+            return self.handle_personal_member_add(request)
+
+        return self.respond(status=204)
+
+    def handle_unknown_event(self, request: HttpRequest) -> HttpResponse:
+        return self.respond(status=204)
 
     def post(self, request: HttpRequest) -> HttpResponse:
         """
@@ -211,52 +354,13 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
         self.verify_webhook_request(request)
 
         data = request.data
-        conversation = data.get("conversation", {})
-        conversation_type = conversation.get("conversationType")
-        event_type = data["type"]
+        raw_event_type = data["type"]
+        event_type = MsTeamsEvents.get_from_value(value=raw_event_type)
 
-        log_params = {
-            "conversation": conversation,
-            "conversation_type": conversation_type,
-            "event_type": event_type,
-        }
+        event_handler_func = self._event_handlers[event_type]
+        response = event_handler_func(request)
 
-        response = None
-        # only care about conversationUpdate and message
-        if event_type == "message":
-            # the only message events we care about are those which
-            # are from a user submitting an option on a card, which
-            # will always contain an "payload.actionType" in the data.
-            if data.get("value", {}).get("payload", {}).get("actionType"):
-                # Processing card actions can only occur in the Region silo.
-                if SiloMode.get_current_mode() == SiloMode.CONTROL:
-                    response = self.respond(status=400)
-                else:
-                    response = self.handle_action_submitted(request)
-            elif conversation_type == "channel":
-                response = self.handle_channel_message(request)
-            else:
-                response = self.handle_personal_message(request)
-        elif event_type == "conversationUpdate":
-            channel_data = data["channelData"]
-            event = channel_data.get("eventType")
-
-            log_params["channel_data"] = channel_data
-            log_params["event"] = event
-            # TODO: Handle other events
-            if event == "teamMemberAdded":
-                response = self.handle_team_member_added(request)
-            elif event == "teamMemberRemoved":
-                if SiloMode.get_current_mode() == SiloMode.CONTROL:
-                    response = self.respond(status=400)
-                else:
-                    response = self.handle_team_member_removed(request)
-            elif (
-                data.get("membersAdded") and conversation_type == "personal"
-            ):  # no explicit event for user adding app unfortunately
-                response = self.handle_personal_member_add(request)
-
-        logger.info("sentry.integrations.msteams.webhook", extra=log_params)
+        logger.info("sentry.integrations.msteams.webhook", extra={"request_data": data})
         return response if response else self.respond(status=204)
 
     def verify_webhook_request(self, request: HttpRequest) -> bool:

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -40,6 +40,8 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
         integration = self.get_integration_from_card_action(data=self.request_data)
         if integration is None:
             integration = self.get_integration_from_channel_data(data=self.request_data)
+        if integration is None:
+            integration = self.get_integration_for_tenant(data=self.request_data)
         if integration:
             return Integration.objects.filter(id=integration.id).first()
         return None

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_events.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_events.py
@@ -1,0 +1,26 @@
+from uuid import uuid4
+
+from sentry.integrations.msteams import MsTeamsEvents
+
+
+class TestGetFromValue:
+    def test_handle_unsupported(self) -> None:
+        unsupported_value = str(uuid4())
+        response = MsTeamsEvents.get_from_value(unsupported_value)
+        assert response == MsTeamsEvents.UNKNOWN
+
+    def test_message(self) -> None:
+        response = MsTeamsEvents.get_from_value("message")
+        assert response == MsTeamsEvents.MESSAGE
+
+    def test_installation_update(self) -> None:
+        response = MsTeamsEvents.get_from_value("installationUpdate")
+        assert response == MsTeamsEvents.INSTALLATION_UPDATE
+
+    def test_conversation_update(self) -> None:
+        response = MsTeamsEvents.get_from_value("conversationUpdate")
+        assert response == MsTeamsEvents.CONVERSATION_UPDATE
+
+    def test_unknown(self) -> None:
+        response = MsTeamsEvents.get_from_value("unknown")
+        assert response == MsTeamsEvents.UNKNOWN

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
@@ -57,6 +57,6 @@ class TestGeTeamInstallationRequestData(TestCase):
 
     def test_raises_error_with_missing_data(self) -> None:
         bad_request_data = self._example_request_data.copy()
-        del bad_request_data["channelData"]["tenant"]
+        bad_request_data["channelData"].pop("tenant", None)  # Remove "tenant" key
         with pytest.raises(KeyError):
             MsTeamsWebhookEndpoint._get_team_installation_request_data(bad_request_data)

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from sentry.integrations.msteams import MsTeamsWebhookEndpoint
@@ -56,7 +58,7 @@ class TestGeTeamInstallationRequestData(TestCase):
         }
 
     def test_raises_error_with_missing_data(self) -> None:
-        bad_request_data = self._example_request_data.copy()
+        bad_request_data: dict[str, Any] = self._example_request_data.copy()
         bad_request_data["channelData"].pop("tenant", None)  # Remove "tenant" key
         with pytest.raises(KeyError):
             MsTeamsWebhookEndpoint._get_team_installation_request_data(bad_request_data)

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
@@ -1,0 +1,62 @@
+import pytest
+
+from sentry.integrations.msteams import MsTeamsWebhookEndpoint
+from sentry.testutils.cases import TestCase
+
+
+class TestGeTeamInstallationRequestData(TestCase):
+    def setUp(self) -> None:
+        self._example_request_data = {
+            "entities": [{"type": "clientInfo", "locale": "en-US"}],
+            "timestamp": "2024-03-21T18:41:30.088Z",
+            "action": "add",
+            "recipient": {"name": "Sentry", "id": "28:8922afe2-d747-4ae9-9bce-fa2e6f4631f6"},
+            "locale": "en-US",
+            "channelId": "msteams",
+            "from": {
+                "aadObjectId": "8a9a85f5-748b-4d75-baa5-b8d2f6bfe209",
+                "id": "29:1OG0nX1xCYfjz1_OSjsk4d5Ix51njAv7AMuc3fq18b0URfOSHBQs58aGFgsVJm4f--gX-EQSV8o_pbHXc-gZ9dA",
+            },
+            "type": "installationUpdate",
+            "conversation": {
+                "tenantId": "ce067f64-338d-44a0-89fb-7fc8973e254f",
+                "isGroup": "True",
+                "id": "19:7c8cd8b4b4ad4e73a2957e6daad706ef@thread.tacv2",
+                "conversationType": "channel",
+            },
+            "channelData": {
+                "channel": {"id": "19:7c8cd8b4b4ad4e73a2957e6daad706ef@thread.tacv2"},
+                "team": {
+                    "name": "Sales and Marketing",
+                    "aadGroupId": "3d5d4c90-1ae9-41c7-9471-7ccd37ddb7d4",
+                    "id": "19:7c8cd8b4b4ad4e73a2957e6daad706ef@thread.tacv2",
+                },
+                "settings": {
+                    "selectedChannel": {"id": "19:7c8cd8b4b4ad4e73a2957e6daad706ef@thread.tacv2"}
+                },
+                "source": {"name": "message"},
+                "tenant": {"id": "ce067f64-338d-44a0-89fb-7fc8973e254f"},
+            },
+            "serviceUrl": "https://smba.trafficmanager.net/amer/",
+            "id": "f:1af81a4d-ed72-647d-c803-1681b91a7fa4",
+        }
+
+    def test_with_example_request(self) -> None:
+        response = MsTeamsWebhookEndpoint._get_team_installation_request_data(
+            self._example_request_data
+        )
+        assert response == {
+            "conversation_id": "3d5d4c90-1ae9-41c7-9471-7ccd37ddb7d4",
+            "external_id": "3d5d4c90-1ae9-41c7-9471-7ccd37ddb7d4",
+            "external_name": "Sales and Marketing",
+            "installation_type": "team",
+            "service_url": "https://smba.trafficmanager.net/amer/",
+            "tenant_id": "ce067f64-338d-44a0-89fb-7fc8973e254f",
+            "user_id": "29:1OG0nX1xCYfjz1_OSjsk4d5Ix51njAv7AMuc3fq18b0URfOSHBQs58aGFgsVJm4f--gX-EQSV8o_pbHXc-gZ9dA",
+        }
+
+    def test_raises_error_with_missing_data(self) -> None:
+        bad_request_data = self._example_request_data.copy()
+        del bad_request_data["channelData"]["tenant"]
+        with pytest.raises(KeyError):
+            MsTeamsWebhookEndpoint._get_team_installation_request_data(bad_request_data)

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from sentry.integrations.msteams import MsTeamsWebhookEndpoint
+from sentry.integrations.msteams import MsTeamsEvents, MsTeamsWebhookEndpoint
 from sentry.testutils.cases import TestCase
 
 
@@ -62,3 +62,13 @@ class TestGeTeamInstallationRequestData(TestCase):
         bad_request_data["channelData"].pop("tenant", None)  # Remove "tenant" key
         with pytest.raises(KeyError):
             MsTeamsWebhookEndpoint._get_team_installation_request_data(bad_request_data)
+
+
+class TestEventHandler(TestCase):
+    def test_has_all_handlers(self) -> None:
+        instance = MsTeamsWebhookEndpoint()
+        assert len(instance._event_handlers) == 4
+        assert MsTeamsEvents.INSTALLATION_UPDATE in instance._event_handlers
+        assert MsTeamsEvents.UNKNOWN in instance._event_handlers
+        assert MsTeamsEvents.MESSAGE in instance._event_handlers
+        assert MsTeamsEvents.CONVERSATION_UPDATE in instance._event_handlers


### PR DESCRIPTION
Currently when the MSTeams bot is added to a team/channel, we block the request from being processed because we try to check for an existing integration by id, when instead we should check if it already exists with a tenant, and allow it to be installed in a new team/channel. 

Some code is also refactored with more logging for easier extensibility and reading.
