### PR TITLE
fix(audit-log): Update `member.add` Audit Log Renderer

### DIFF
--- a/src/sentry/audit_log/events.py
+++ b/src/sentry/audit_log/events.py
@@ -12,7 +12,9 @@ class MemberAddAuditLogEvent(AuditLogEvent):
     def render(self, audit_log_entry: AuditLogEntry):
         if audit_log_entry.target_user == audit_log_entry.actor:
             return "joined the organization"
-        return f"add member {audit_log_entry.target_user.get_display_name()}"
+
+        member = audit_log_entry.data.get("email") or audit_log_entry.target_user.get_display_name()
+        return f"add member {member}"
 
 
 class MemberEditAuditLogEvent(AuditLogEvent):


### PR DESCRIPTION
For `member.add`, if the `target_user` doesn't exist, the row doesn't render, so I get the email or the display name, similar to the other events

![image](https://github.com/getsentry/sentry/assets/33237075/ca41d1d5-841d-4f75-9051-e2979c5aa32e)
