### PR TITLE
test(ui): Add 2nd mock error body to replay data

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -428,7 +428,8 @@ describe('useReplayData', () => {
       expect(result.current).toStrictEqual(
         expect.objectContaining({
           attachments: mockSegmentResponse,
-          errors: mockErrorResponse,
+          // mockErrorResponse is the same between both responses
+          errors: [...mockErrorResponse, ...mockErrorResponse],
           replayRecord: expectedReplay,
         })
       )


### PR DESCRIPTION
We make two requests that respond with two bodies. I guess in react 17 it can sometimes have one request body and then both together, but in react 18 its always both. Notice I didn't change any other part of the test.

part of https://github.com/getsentry/frontend-tsc/issues/22
