### PR TITLE
ref(crons): Batch process by org for detecting broken monitors

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, options
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -491,9 +491,6 @@ class OrganizationMetricsSamplesEndpoint(OrganizationEventsV2EndpointBase):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     def get(self, request: Request, organization: Organization) -> Response:
-        if not features.has("organizations:metrics-samples-list", organization, actor=request.user):
-            return Response(status=404)
-
         try:
             snuba_params, params = self.get_snuba_dataclass(request, organization)
         except NoProjects:

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -46,6 +46,7 @@ from sentry.services.hybrid_cloud.organizationmember_mapping import (
     RpcOrganizationMemberMappingUpdate,
     organizationmember_mapping_service,
 )
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.signals import member_invited
 from sentry.utils.http import absolute_uri
@@ -53,7 +54,6 @@ from sentry.utils.http import absolute_uri
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
     from sentry.services.hybrid_cloud.integration import RpcIntegration
-    from sentry.services.hybrid_cloud.user import RpcUser
 
 _OrganizationMemberFlags = TypedDict(
     "_OrganizationMemberFlags",
@@ -389,32 +389,33 @@ class OrganizationMember(ReplicatedRegionModel):
         )
         msg.send_async([self.get_email()])
 
-    def send_sso_unlink_email(self, disabling_user: RpcUser, provider):
+    def send_sso_unlink_email(self, disabling_user: RpcUser | str, provider):
         from sentry.services.hybrid_cloud.lost_password_hash import lost_password_hash_service
         from sentry.utils.email import MessageBuilder
-
-        email = self.get_email()
-
-        recover_uri = "{path}?{query}".format(
-            path=reverse("sentry-account-recover"), query=urlencode({"email": email})
-        )
 
         # Nothing to send if this member isn't associated to a user
         if not self.user_id:
             return
 
+        email = self.get_email()
+        recover_uri = "{path}?{query}".format(
+            path=reverse("sentry-account-recover"), query=urlencode({"email": email})
+        )
         user = user_service.get_user(user_id=self.user_id)
         if not user:
             return
 
         has_password = user.has_usable_password()
+        actor_email = disabling_user
+        if isinstance(disabling_user, RpcUser):
+            actor_email = disabling_user.email
 
         context = {
             "email": email,
             "recover_url": absolute_uri(recover_uri),
             "has_password": has_password,
             "organization": self.organization,
-            "actor_email": disabling_user.email,
+            "actor_email": actor_email,
             "provider": provider,
         }
 

--- a/src/sentry/models/organizationmembermapping.py
+++ b/src/sentry/models/organizationmembermapping.py
@@ -17,6 +17,9 @@ class OrganizationMemberMapping(Model):
     """
     This model resides exclusively in the control silo, and will
     - map a user or an email to a specific organization to indicate an organization membership
+
+    Note: If we ever expand this model to include flags we need to update the bulk updates
+    that are skipping outboxes because we assume flags are not replicated in a few place.
     """
 
     # This model is "autocreated" via an outbox write from the regional `Organization` it

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2138,12 +2138,6 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Rate to move from outbox based webhook delivery to webhookpayload.
-register(
-    "hybridcloud.webhookpayload.rollout",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 register(
     "metrics.sample-list.sample-rate",
     type=Float,

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -582,6 +582,38 @@ class DatabaseBackedOrganizationService(OrganizationService):
         for member in member_list:
             member.send_sso_link_email(sending_user_email, provider)
 
+    def send_sso_unlink_emails(
+        self, *, organization_id: int, sending_user_email: str, provider_key: str
+    ) -> None:
+        from sentry.auth import manager
+        from sentry.auth.exceptions import ProviderNotRegistered
+
+        try:
+            provider = manager.get(provider_key)
+        except ProviderNotRegistered as e:
+            logger.warning("Could not send SSO unlink emails: %s", e)
+            return
+
+        with unguarded_write(using=router.db_for_write(OrganizationMember)):
+            # Flags are not replicated -- these updates are safe to skip outboxes
+            OrganizationMember.objects.filter(organization_id=organization_id).update(
+                flags=F("flags")
+                .bitand(~OrganizationMember.flags["sso:linked"])
+                .bitand(~OrganizationMember.flags["sso:invalid"])
+            )
+
+        member_list = OrganizationMember.objects.filter(
+            organization_id=organization_id,
+        )
+        for member in member_list:
+            member.send_sso_unlink_email(sending_user_email, provider)
+
+    def count_members_without_sso(self, *, organization_id: int) -> int:
+        return OrganizationMember.objects.filter(
+            organization_id=organization_id,
+            flags=F("flags").bitand(~OrganizationMember.flags["sso:linked"]),
+        ).count()
+
     def delete_organization(
         self, *, organization_id: int, user: RpcUser
     ) -> RpcOrganizationDeleteResponse:

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -351,6 +351,18 @@ class OrganizationService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
+    def send_sso_unlink_emails(
+        self, *, organization_id: int, sending_user_email: str, provider_key: str
+    ) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def count_members_without_sso(self, *, organization_id: int) -> int:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
     def delete_organization(
         self, *, organization_id: int, user: RpcUser
     ) -> RpcOrganizationDeleteResponse:

--- a/src/sentry/services/hybrid_cloud/replica/impl.py
+++ b/src/sentry/services/hybrid_cloud/replica/impl.py
@@ -277,6 +277,10 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
             )
             org_slug_qs.delete()
 
+    def delete_replicated_auth_provider(self, *, auth_provider_id: int, region_name: str) -> None:
+        with enforce_constraints(transaction.atomic(router.db_for_write(AuthProviderReplica))):
+            AuthProviderReplica.objects.filter(auth_provider_id=auth_provider_id).delete()
+
 
 class DatabaseBackedControlReplicaService(ControlReplicaService):
     def upsert_external_actor_replica(self, *, external_actor: RpcExternalActor) -> None:

--- a/src/sentry/services/hybrid_cloud/replica/service.py
+++ b/src/sentry/services/hybrid_cloud/replica/service.py
@@ -97,6 +97,11 @@ class RegionReplicaService(RpcService):
     ) -> None:
         pass
 
+    @regional_rpc_method(resolve=ByRegionName())
+    @abc.abstractmethod
+    def delete_replicated_auth_provider(self, *, auth_provider_id: int, region_name: str) -> None:
+        pass
+
     @classmethod
     def get_local_implementation(cls) -> RpcService:
         from .impl import DatabaseBackedRegionReplicaService

--- a/src/sentry/spans/buffer/redis.py
+++ b/src/sentry/spans/buffer/redis.py
@@ -3,34 +3,92 @@ from __future__ import annotations
 from django.conf import settings
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
-from sentry.utils import redis
+from sentry.utils import json, redis
 
 SEGMENT_TTL = 5 * 60  # 5 min TTL in seconds
+TWO_MINUTES = 2 * 60  # 2 min delay in seconds
 
 
 def get_redis_client() -> RedisCluster | StrictRedis:
-    return redis.redis_clusters.get(settings.SENTRY_SPAN_BUFFER_CLUSTER)
+    return redis.redis_clusters.get(settings.SENTRY_SPAN_BUFFER_CLUSTER, decode_responses=False)
 
 
 def get_segment_key(project_id: str | int, segment_id: str) -> str:
     return f"segment:{segment_id}:{project_id}:process-segment"
 
 
+def get_last_processed_timestamp_key(partition_index: int) -> str:
+    return f"performance-issues:last-processed-timestamp:partition:{partition_index}"
+
+
+def get_unprocessed_segments_key(partition_index: int) -> str:
+    return f"performance-issues:unprocessed-segments:partition:{partition_index}"
+
+
 class RedisSpansBuffer:
     def __init__(self):
         self.client: RedisCluster | StrictRedis = get_redis_client()
 
-    def read_segment(self, project_id: str | int, segment_id: str) -> list[str | bytes]:
-        key = get_segment_key(project_id, segment_id)
+    def write_span_and_check_processing(
+        self,
+        project_id: str | int,
+        segment_id: str,
+        timestamp: int,
+        partition: int,
+        span: bytes,
+    ) -> bool:
+        segment_key = get_segment_key(project_id, segment_id)
+        timestamp_key = get_last_processed_timestamp_key(partition)
 
-        return self.client.lrange(key, 0, -1) or []
+        with self.client.pipeline() as p:
+            p.rpush(segment_key, span)
+            p.get(timestamp_key)
+            p.set(timestamp_key, timestamp)
+            results = p.execute()
 
-    def write_span(self, project_id: str | int, segment_id: str, span: bytes) -> bool:
-        key = get_segment_key(project_id, segment_id)
-        length = self.client.rpush(key, span)
-        new_key = length == 1
+        new_key = results[0] == 1
+        last_processed_timestamp: bytes | None = results[1]
 
         if new_key:
-            self.client.expire(key, SEGMENT_TTL)
+            bucket = get_unprocessed_segments_key(partition)
+            with self.client.pipeline() as p:
+                p.expire(segment_key, SEGMENT_TTL)
+                p.rpush(bucket, json.dumps([timestamp, segment_key]))
+                p.execute()
 
-        return new_key
+        if last_processed_timestamp is None:
+            return False
+
+        return timestamp > int(last_processed_timestamp)
+
+    def read_and_expire_many_segments(self, keys: list[str]) -> list[tuple[str, list[str | bytes]]]:
+        values = []
+        with self.client.pipeline() as p:
+            for key in keys:
+                p.lrange(key, 0, -1)
+
+            p.delete(*keys)
+            response = p.execute()
+
+        for value in response[:-1]:
+            values.append(value)
+
+        return values
+
+    def get_unprocessed_segments_and_prune_bucket(self, now: int, partition: int) -> list[str]:
+        key = get_unprocessed_segments_key(partition)
+        results = self.client.lrange(key, 0, -1) or []
+
+        ltrim_index = 0
+        segment_keys = []
+        for result in results:
+            segment_timestamp, segment_key = json.loads(result)
+            if now - segment_timestamp < TWO_MINUTES:
+                break
+
+            ltrim_index += 1
+            segment_keys.append(segment_key)
+
+        self.client.ltrim(key, ltrim_index, -1)
+
+        return segment_keys

--- a/src/sentry/spans/consumers/detect_performance_issues/message.py
+++ b/src/sentry/spans/consumers/detect_performance_issues/message.py
@@ -4,9 +4,6 @@ from copy import deepcopy
 from typing import Any
 
 import sentry_sdk
-from sentry_kafka_schemas import get_codec
-from sentry_kafka_schemas.codecs import Codec
-from sentry_kafka_schemas.schema_types.snuba_spans_v1 import SpanEvent
 
 from sentry.event_manager import (
     Job,
@@ -20,13 +17,7 @@ from sentry.models.project import Project
 from sentry.utils import metrics
 from sentry.utils.canonical import CanonicalKeyDict
 
-SPAN_SCHEMA: Codec[SpanEvent] = get_codec("snuba-spans")
-
 logger = logging.getLogger(__name__)
-
-
-def _deserialize_span(value: bytes) -> Mapping[str, Any]:
-    return SPAN_SCHEMA.decode(value)
 
 
 def build_tree(spans):

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -13,11 +13,13 @@ from sentry_kafka_schemas.schema_types.snuba_spans_v1 import SpanEvent
 
 from sentry import options
 from sentry.spans.buffer.redis import RedisSpansBuffer
+from sentry.spans.produce_segment import produce_segment_to_kafka
 
 logger = logging.getLogger(__name__)
 SPAN_SCHEMA: Codec[SpanEvent] = get_codec("snuba-spans")
 
 PROCESS_SEGMENT_DELAY = 2 * 60  # 2 minutes
+BATCH_SIZE = 100
 
 
 def _deserialize_span(value: bytes) -> Mapping[str, Any]:
@@ -40,8 +42,24 @@ def process_message(message: Message[KafkaPayload]):
     if project_id not in options.get("standalone-spans.process-spans-consumer.project-allowlist"):
         return
 
+    timestamp = int(message.value.timestamp.timestamp())
+    partition = message.value.partition.index
+
     client = RedisSpansBuffer()
-    client.write_span(project_id, segment_id, message.payload.value)
+
+    should_process_segments = client.write_span_and_check_processing(
+        project_id, segment_id, timestamp, partition, message.payload.value
+    )
+
+    if should_process_segments:
+        keys = client.get_unprocessed_segments_and_prune_bucket(timestamp, partition)
+        # With pipelining, redis server is forced to queue replies using
+        # up memory, so batching the keys we fetch.
+        for i in range(0, len(keys), BATCH_SIZE):
+            segments = client.read_and_expire_many_segments(keys[i : i + BATCH_SIZE])
+
+            for segment in segments:
+                produce_segment_to_kafka(segment)
 
 
 class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/src/sentry/spans/produce_segment.py
+++ b/src/sentry/spans/produce_segment.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+
+from arroyo import Topic as ArroyoTopic
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.types import Message, Value
+from confluent_kafka import KafkaException
+from django.conf import settings
+
+from sentry.conf.types.kafka_definition import Topic
+from sentry.spans.consumers.detect_performance_issues.factory import process_message
+from sentry.utils.arroyo_producer import SingletonProducer
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+
+logger = logging.getLogger(__name__)
+
+
+def _get_producer() -> KafkaProducer:
+    cluster_name = get_topic_definition(Topic.BUFFERED_SEGMENTS)["cluster"]
+    producer_config = get_kafka_producer_cluster_options(cluster_name)
+    producer_config.pop("compression.type", None)
+    producer_config.pop("message.max.bytes", None)
+    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+
+_segments_producer = SingletonProducer(_get_producer)
+
+
+def prepare_message(segments) -> bytes:
+    segment_str = b",".join(segments)
+    return b'{"spans": [' + segment_str + b"]}"
+
+
+def produce_segment_to_kafka(segments) -> None:
+    if segments is None or len(segments) == 0:
+        return
+
+    payload_data = prepare_message(segments)
+    payload = KafkaPayload(None, payload_data, [])
+    if settings.SENTRY_EVENTSTREAM != "sentry.eventstream.kafka.KafkaEventStream":
+        # If we're not running Kafka then we're just in dev.
+        # Skip producing to Kafka and just process the message directly
+        process_message(Message(Value(payload=payload, committable={})))
+        return
+
+    try:
+        topic = get_topic_definition(Topic.BUFFERED_SEGMENTS)["real_topic_name"]
+        _segments_producer.produce(ArroyoTopic(topic), payload)
+    except KafkaException:
+        logger.exception("Failed to produce segment to Kafka")

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1177,7 +1177,7 @@ urlpatterns += [
         GenericReactPageView.as_view(auth_required=False),
         name="sentry-join-request",
     ),
-    # Keep named URL for for things using reverse
+    # Keep named URL for things using reverse
     re_path(
         r"^(?P<organization_slug>[\w_-]+)/issues/(?P<short_id>[\w_-]+)/$",
         react_page_view,

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -428,7 +428,8 @@ describe('useReplayData', () => {
       expect(result.current).toStrictEqual(
         expect.objectContaining({
           attachments: mockSegmentResponse,
-          errors: mockErrorResponse,
+          // mockErrorResponse is the same between both responses
+          errors: [...mockErrorResponse, ...mockErrorResponse],
           replayRecord: expectedReplay,
         })
       )

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -107,35 +107,18 @@ class OrganizationMetricsPermissionTest(APITestCase):
 @region_silo_test
 class OrganizationMetricsSamplesEndpointTest(BaseSpansTestCase, APITestCase):
     view = "sentry-api-0-organization-metrics-samples"
-    default_features = ["organizations:metrics-samples-list"]
 
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
 
-    def do_request(self, query, features=None, **kwargs):
-        if features is None:
-            features = self.default_features
-        with self.feature(features):
-            return self.client.get(
-                reverse(self.view, kwargs={"organization_slug": self.organization.slug}),
-                query,
-                format="json",
-                **kwargs,
-            )
-
-    def test_feature_flag(self):
-        query = {
-            "mri": "d:spans/exclusive_time@millisecond",
-            "field": ["id"],
-            "project": [self.project.id],
-        }
-
-        response = self.do_request(query, features=[])
-        assert response.status_code == 404, response.data
-
-        response = self.do_request(query, features=["organizations:metrics-samples-list"])
-        assert response.status_code == 200, response.data
+    def do_request(self, query, **kwargs):
+        return self.client.get(
+            reverse(self.view, kwargs={"organization_slug": self.organization.slug}),
+            query,
+            format="json",
+            **kwargs,
+        )
 
     def test_no_project(self):
         query = {

--- a/tests/sentry/hybridcloud/test_organization.py
+++ b/tests/sentry/hybridcloud/test_organization.py
@@ -3,6 +3,8 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
+from django.core import mail
+from django.db.models import F
 
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
@@ -22,6 +24,7 @@ from sentry.services.hybrid_cloud.project import RpcProject
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
+from sentry.testutils.helpers.task_runner import TaskRunner
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, region_silo_test
 
@@ -247,7 +250,7 @@ class RpcOrganizationMemberTest(TestCase):
 
 @django_db_all(transaction=True)
 @region_silo_test
-def test_org_member():
+def test_update_organization_member():
     org = Factories.create_organization()
     user = Factories.create_user(email="test@sentry.io")
     rpc_member = organization_service.add_organization_member(
@@ -267,3 +270,65 @@ def test_org_member():
     member_query = OrganizationMember.objects.all()
     assert member_query.count() == 1
     assert member_query[0].role == "manager"
+
+
+@django_db_all(transaction=True)
+@all_silo_test
+def test_count_members_without_sso():
+    org = Factories.create_organization()
+    user = Factories.create_user(email="test@sentry.io")
+    user_two = Factories.create_user(email="has.sso@sentry.io")
+    Factories.create_member(organization=org, user=user)
+    Factories.create_member(organization=org, email="invite@sentry.io")
+    # has sso setup, not included in result
+    Factories.create_member(
+        organization=org,
+        user=user_two,
+        flags=OrganizationMember.flags["sso:linked"],
+    )
+    result = organization_service.count_members_without_sso(organization_id=org.id)
+    assert result == 2
+
+
+@django_db_all(transaction=True)
+@all_silo_test
+def test_send_sso_unlink_emails():
+    org = Factories.create_organization()
+    user = Factories.create_user(email="test@sentry.io")
+    user_two = Factories.create_user(email="two@sentry.io")
+    Factories.create_member(
+        organization=org, user=user, flags=OrganizationMember.flags["sso:linked"]
+    )
+    Factories.create_member(
+        organization=org, user=user_two, flags=OrganizationMember.flags["sso:linked"]
+    )
+    Factories.create_member(
+        organization=org, email="invite@sentry.io", flags=OrganizationMember.flags["sso:invalid"]
+    )
+    with TaskRunner():
+        result = organization_service.send_sso_unlink_emails(
+            organization_id=org.id,
+            sending_user_email="owner@sentry.io",
+            provider_key="google",
+        )
+        assert result is None
+
+    with assume_test_silo_mode(SiloMode.REGION):
+        # No members should be linked or invalid now
+        assert (
+            OrganizationMember.objects.filter(
+                flags=F("flags").bitor(OrganizationMember.flags["sso:linked"])
+            ).count()
+            == 0
+        )
+        assert (
+            OrganizationMember.objects.filter(
+                flags=F("flags").bitor(OrganizationMember.flags["sso:invalid"])
+            ).count()
+            == 0
+        )
+
+    # Only real members should get emails
+    assert len(mail.outbox) == 2
+    assert "Action Required" in mail.outbox[0].subject
+    assert "Single Sign-On" in mail.outbox[0].body

--- a/tests/sentry/spans/buffer/test_redis.py
+++ b/tests/sentry/spans/buffer/test_redis.py
@@ -1,22 +1,44 @@
-from unittest import mock
-
-from sentry.spans.buffer.redis import RedisSpansBuffer, get_redis_client
+from sentry.spans.buffer.redis import RedisSpansBuffer
 
 
 class TestRedisSpansBuffer:
     def test_first_span_in_segment_calls_expire(self):
         buffer = RedisSpansBuffer()
-        with mock.patch.object(buffer, "client", new=get_redis_client()) as mock_client:
-            mock_client.expire = mock.Mock()
+        buffer.write_span_and_check_processing("segment_1", "foo", 1710280889, 0, b"span data")
+        buffer.write_span_and_check_processing("segment_2", "foo", 1710280889, 0, b"span data")
+        assert buffer.client.ttl("segment:foo:segment_1:process-segment") == 300
+        assert buffer.client.lrange(
+            "performance-issues:unprocessed-segments:partition:0", 0, -1
+        ) == [
+            b'[1710280889,"segment:foo:segment_1:process-segment"]',
+            b'[1710280889,"segment:foo:segment_2:process-segment"]',
+        ]
 
-            buffer.write_span("bar", "foo", b"span data")
-            mock_client.expire.assert_called_once_with("segment:foo:bar:process-segment", 300)
+        assert buffer.read_and_expire_many_segments(
+            ["segment:foo:segment_1:process-segment", "segment:foo:segment_2:process-segment"]
+        ) == [[b"span data"], [b"span data"]]
 
-    def test_ttl_not_set_repeatedly(self):
+    def test_segment_not_pushed_repeatedly_to_process_bucket(self):
         buffer = RedisSpansBuffer()
-        buffer.write_span("bar", "foo", b"span data")
-        with mock.patch.object(buffer, "client", new=get_redis_client()) as mock_client:
-            mock_client.expire = mock.Mock()
-            buffer.write_span("bar", "foo", b"other span data")
+        buffer.write_span_and_check_processing("bar", "foo", 1710280889, 0, b"span data")
+        buffer.write_span_and_check_processing("bar", "foo", 1710280890, 0, b"other span data")
+        assert buffer.client.lrange(
+            "performance-issues:unprocessed-segments:partition:0", 0, -1
+        ) == [b'[1710280889,"segment:foo:bar:process-segment"]']
 
-            mock_client.expire.assert_not_called
+    def test_processing_intervals(self):
+        buffer = RedisSpansBuffer()
+        should_process = buffer.write_span_and_check_processing(
+            "bar", "foo", 1710280889, 0, b"span data"
+        )
+        assert should_process is False
+
+        should_process = buffer.write_span_and_check_processing(
+            "bar", "foo", 1710280889, 0, b"span data 2"
+        )
+        assert should_process is False
+
+        should_process = buffer.write_span_and_check_processing(
+            "bar", "foo", 1710280890, 0, b"other span data"
+        )
+        assert should_process is True

--- a/tests/sentry/spans/consumers/detect_performance_issues/test_factory.py
+++ b/tests/sentry/spans/consumers/detect_performance_issues/test_factory.py
@@ -23,8 +23,7 @@ def build_mock_message(data, topic=None):
 
 
 @mock.patch("sentry.spans.consumers.detect_performance_issues.factory.process_segment")
-def test_consumer_processes_segment(mock_process_segment):
-
+def test_segment_deserialized_correctly(mock_process_segment):
     topic = ArroyoTopic(get_topic_definition(Topic.BUFFERED_SEGMENTS)["real_topic_name"])
     partition = Partition(topic, 0)
     strategy = DetectPerformanceIssuesStrategyFactory().create_with_partitions(
@@ -32,7 +31,7 @@ def test_consumer_processes_segment(mock_process_segment):
         partitions={},
     )
 
-    span_data = build_mock_span(project_id=1)
+    span_data = build_mock_span(project_id=1, is_segment=True)
     segment_data = {"spans": [span_data]}
     message = build_mock_message(segment_data, topic)
 

--- a/tests/sentry/spans/consumers/process/test_factory.py
+++ b/tests/sentry/spans/consumers/process/test_factory.py
@@ -1,15 +1,18 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest import mock
 
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition
 from arroyo.types import Topic as ArroyoTopic
+from django.test import override_settings
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.spans.buffer.redis import get_redis_client
+from sentry.spans.consumers.detect_performance_issues.factory import BUFFERED_SEGMENT_SCHEMA
 from sentry.spans.consumers.process.factory import ProcessSpansStrategyFactory
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
+from sentry.utils.arroyo_producer import SingletonProducer
 from sentry.utils.kafka_config import get_topic_definition
 
 
@@ -69,13 +72,13 @@ def test_consumer_pushes_to_redis():
         partitions={},
     )
 
-    span_data = build_mock_span(project_id=1)
-    message = build_mock_message(span_data, topic)
+    span_data = build_mock_span(project_id=1, is_segment=True)
+    message1 = build_mock_message(span_data, topic)
 
     strategy.submit(
         Message(
             BrokerValue(
-                KafkaPayload(b"key", message.value().encode("utf-8"), []),
+                KafkaPayload(b"key", message1.value().encode("utf-8"), []),
                 partition,
                 1,
                 datetime.now(),
@@ -83,10 +86,13 @@ def test_consumer_pushes_to_redis():
         )
     )
 
+    span_data = build_mock_span(project_id=1)
+    message2 = build_mock_message(span_data, topic)
+
     strategy.submit(
         Message(
             BrokerValue(
-                KafkaPayload(b"key", message.value().encode("utf-8"), []),
+                KafkaPayload(b"key", message2.value().encode("utf-8"), []),
                 partition,
                 1,
                 datetime.now(),
@@ -97,10 +103,60 @@ def test_consumer_pushes_to_redis():
     strategy.poll()
     strategy.join(1)
     strategy.terminate()
+
     assert redis_client.lrange("segment:a49b42af9fb69da0:1:process-segment", 0, -1) == [
-        message.value(),
-        message.value(),
+        message1.value().encode("utf-8"),
+        message2.value().encode("utf-8"),
     ]
+
+
+@override_options(
+    {
+        "standalone-spans.process-spans-consumer.enable": True,
+        "standalone-spans.process-spans-consumer.project-allowlist": [1],
+    }
+)
+@override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
+@mock.patch.object(SingletonProducer, "produce")
+def test_produces_valid_segment_to_kafka(mock_produce):
+    topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_SPANS)["real_topic_name"])
+    partition = Partition(topic, 0)
+    strategy = ProcessSpansStrategyFactory().create_with_partitions(
+        commit=mock.Mock(),
+        partitions={},
+    )
+
+    span_data = build_mock_span(project_id=1, is_segment=True)
+    message1 = build_mock_message(span_data, topic)
+
+    strategy.submit(
+        Message(
+            BrokerValue(
+                KafkaPayload(b"key", message1.value().encode("utf-8"), []),
+                partition,
+                1,
+                datetime.now() - timedelta(minutes=3),
+            )
+        )
+    )
+
+    span_data = build_mock_span(project_id=1)
+    message2 = build_mock_message(span_data, topic)
+
+    strategy.submit(
+        Message(
+            BrokerValue(
+                KafkaPayload(b"key", message2.value().encode("utf-8"), []),
+                partition,
+                1,
+                datetime.now(),
+            )
+        )
+    )
+
+    mock_produce.assert_called_once()
+    BUFFERED_SEGMENT_SCHEMA.decode(mock_produce.call_args.args[1].value)
+    assert mock_produce.call_args.args[0] == ArroyoTopic("buffered-segments")
 
 
 @override_options(

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -317,7 +317,7 @@ class EventComparisonTest(MetricsEnhancedPerformanceTestCase):
             1,
             internal_metric=constants.SELF_TIME_LIGHT,
             timestamp=self.ten_mins_ago,
-            tags={"group": "26b881987e4bad99"},
+            tags={"span.group": "26b881987e4bad99"},
         )
 
     def test_get(self):


### PR DESCRIPTION
Split out from the original https://github.com/getsentry/sentry/pull/67297.

Changes the logic inside of this detection task to 
- Fetch all organization ids with open incidents longer than 14 days
- Iterates through all those organization ids and grabs all relevant incidents
  - Verifies that the incidents should be marked as broken (4 most recent check-ins are also failing)
- Creates BrokenMonitorEnvDetections to match each incident that qualifies as broken