### PR TITLE
test(ui): Fix two replay test flakes

### DIFF
--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -255,7 +255,7 @@ describe('EventReplay', function () {
         () => {
           expect(screen.getByText('Error: This Event')).toBeInTheDocument();
         },
-        {timeout: 3000, interval: 100}
+        {timeout: 5000, interval: 100}
       );
       expect(screen.getByText('JAVASCRIPT-101')).toBeInTheDocument();
 
@@ -268,6 +268,6 @@ describe('EventReplay', function () {
         'href',
         '/organizations/org-slug/issues/102/'
       );
-    });
+    }, 10000);
   });
 });

--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -255,7 +255,7 @@ describe('EventReplay', function () {
         () => {
           expect(screen.getByText('Error: This Event')).toBeInTheDocument();
         },
-        {timeout: 3000}
+        {timeout: 3000, interval: 100}
       );
       expect(screen.getByText('JAVASCRIPT-101')).toBeInTheDocument();
 

--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -6,7 +6,7 @@ import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
 import {ReplayErrorFixture} from 'sentry-fixture/replayError';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import EventReplay from 'sentry/components/events/eventReplay';
 import ConfigStore from 'sentry/stores/configStore';
@@ -251,7 +251,12 @@ describe('EventReplay', function () {
       );
 
       // Event that matches ID 1 should be shown as "This Event"
-      expect(await screen.findByText('Error: This Event')).toBeInTheDocument();
+      await waitFor(
+        () => {
+          expect(screen.getByText('Error: This Event')).toBeInTheDocument();
+        },
+        {timeout: 3000}
+      );
       expect(screen.getByText('JAVASCRIPT-101')).toBeInTheDocument();
 
       // Other events should link to the event and issue

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -407,7 +407,7 @@ describe('GroupReplays', () => {
       });
 
       await waitFor(() => {
-        expect(mockReplayCountApi).toHaveBeenCalledTimes(1);
+        expect(mockReplayCountApi).toHaveBeenCalled();
         expect(mockReplayApi).toHaveBeenCalledTimes(1);
       });
 


### PR DESCRIPTION
These two seem to flake in react 18, it seems the api is called twice and this component can sometimes take a while to finish rendering.

part of https://github.com/getsentry/frontend-tsc/issues/22