### PR TITLE
feat: tie activated condition type to the activated alert rule creation

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from django.db import router, transaction
@@ -46,7 +46,6 @@ from sentry.incidents.models.incident import (
     IncidentTrigger,
     TriggerStatus,
 )
-from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.actor import Actor
 from sentry.models.notificationaction import ActionService, ActionTarget
 from sentry.models.project import Project
@@ -84,6 +83,10 @@ from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry_from_user
 from sentry.utils.snuba import is_measurement
+
+if TYPE_CHECKING:
+    from sentry.incidents.utils.types import AlertRuleActivationConditionType
+
 
 # We can return an incident as "windowed" which returns a range of points around the start of the incident
 # It attempts to center the start of the incident, only showing earlier data if there isn't enough time
@@ -485,6 +488,7 @@ def create_alert_rule(
     event_types=None,
     comparison_delta: int | None = None,
     monitor_type: AlertRuleMonitorType = AlertRuleMonitorType.CONTINUOUS,
+    activation_condition: AlertRuleActivationConditionType | None = None,
     **kwargs,
 ):
     """
@@ -517,6 +521,9 @@ def create_alert_rule(
 
     :return: The created `AlertRule`
     """
+    if monitor_type == AlertRuleMonitorType.ACTIVATED and not activation_condition:
+        raise ValidationError("Activation condition required for activated alert rule")
+
     resolution = DEFAULT_ALERT_RULE_RESOLUTION
     if comparison_delta is not None:
         # Since comparison alerts make twice as many queries, run the queries less frequently.
@@ -583,10 +590,17 @@ def create_alert_rule(
             ]
             AlertRuleExcludedProjects.objects.bulk_create(exclusions)
         elif monitor_type == AlertRuleMonitorType.ACTIVATED and projects:
+            # initialize projects join table for activated alert rules
             arps = [
                 AlertRuleProjects(alert_rule=alert_rule, project=project) for project in projects
             ]
             AlertRuleProjects.objects.bulk_create(arps)
+
+        if monitor_type == AlertRuleMonitorType.ACTIVATED and activation_condition:
+            # NOTE: if monitor_type is activated, activation_condition is required
+            AlertRuleActivationCondition.objects.create(
+                alert_rule=alert_rule, condition_type=activation_condition.value
+            )
 
         # NOTE: This constructs the query in snuba
         # NOTE: Will only subscribe if AlertRule.monitor_type === 'CONTINUOUS'
@@ -923,29 +937,6 @@ class AlertRuleActivationConditionLabelAlreadyUsedError(Exception):
 class ProjectsNotAssociatedWithAlertRuleError(Exception):
     def __init__(self, project_slugs):
         self.project_slugs = project_slugs
-
-
-def create_alert_rule_activation_condition(
-    alert_rule: AlertRule,
-    label: str,
-    condition_type: AlertRuleActivationConditionType,
-):
-    """
-    Creates a new AlertRuleActivationCondition
-    :param alert_rule: The alert rule to create the condition for
-    :param label: A description of the condition
-    :param condition_type: The type of condition being created (so far, only deploy/release creation)
-    :return: The created AlertRuleActivationCondition
-    """
-    if AlertRuleActivationCondition.objects.filter(alert_rule=alert_rule, label=label).exists():
-        raise AlertRuleActivationConditionLabelAlreadyUsedError()
-
-    with transaction.atomic(router.db_for_write(AlertRuleActivationCondition)):
-        condition = AlertRuleActivationCondition.objects.create(
-            alert_rule=alert_rule, label=label, condition_type=condition_type.value
-        )
-
-    return condition
 
 
 def create_alert_rule_activation(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -32,7 +32,6 @@ from sentry.hybridcloud.models.webhookpayload import WebhookPayload
 from sentry.incidents.logic import (
     create_alert_rule,
     create_alert_rule_activation,
-    create_alert_rule_activation_condition,
     create_alert_rule_trigger,
     create_alert_rule_trigger_action,
     query_datasets_to_type,
@@ -1489,6 +1488,7 @@ class Factories:
         event_types=None,
         comparison_delta=None,
         monitor_type=AlertRuleMonitorType.CONTINUOUS,
+        activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
     ):
         if not name:
             name = petname.generate(2, " ", letters=10).title()
@@ -1516,24 +1516,13 @@ class Factories:
             event_types=event_types,
             comparison_delta=comparison_delta,
             monitor_type=monitor_type,
+            activation_condition=activation_condition,
         )
 
         if date_added is not None:
             alert_rule.update(date_added=date_added)
 
         return alert_rule
-
-    @staticmethod
-    @assume_test_silo_mode(SiloMode.REGION)
-    def create_alert_rule_activation_condition(
-        alert_rule,
-        label=None,
-        condition_type=AlertRuleActivationConditionType.RELEASE_CREATION,
-    ):
-        if not label:
-            label = petname.generate(2, " ", letters=10).title()
-
-        return create_alert_rule_activation_condition(alert_rule, label, condition_type)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -391,15 +391,6 @@ class Fixtures:
             projects = [self.project]
         return Factories.create_alert_rule(organization, projects, *args, **kwargs)
 
-    def create_alert_rule_activation_condition(self, alert_rule=None, *args, **kwargs):
-        if not alert_rule:
-            alert_rule = self.create_alert_rule(
-                monitor_type=AlertRuleMonitorType.ACTIVATED,
-            )
-        return Factories.create_alert_rule_activation_condition(
-            alert_rule=alert_rule, *args, **kwargs
-        )
-
     def create_alert_rule_activation(self, alert_rule=None, *args, **kwargs):
         if not alert_rule:
             alert_rule = self.create_alert_rule(

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -51,6 +51,7 @@ from sentry.incidents.models.incident import (
     PendingIncidentSnapshot,
     TimeSeriesSnapshot,
 )
+from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.models.apiauthorization import ApiAuthorization
 from sentry.models.apigrant import ApiGrant
 from sentry.models.apikey import ApiKey
@@ -463,8 +464,8 @@ class BackupTestCase(TransactionTestCase):
             organization=org,
             projects=[project],
             monitor_type=AlertRuleMonitorType.ACTIVATED,
+            activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
         )
-        self.create_alert_rule_activation_condition(alert_rule=activated_alert)
         self.create_alert_rule_activation(alert_rule=activated_alert, metric_value=100)
         activated_trigger = self.create_alert_rule_trigger(alert_rule=activated_alert)
         self.create_alert_rule_trigger_action(alert_rule_trigger=activated_trigger)

--- a/tests/sentry/incidents/models/test_alert_rule.py
+++ b/tests/sentry/incidents/models/test_alert_rule.py
@@ -160,12 +160,10 @@ class AlertRuleTest(TestCase):
     def test_conditionally_subscribe_project_to_alert_rules(self):
         query_extra = "foo:bar"
         project = self.create_project(name="foo")
-        alert_rule = self.create_alert_rule(
-            projects=[project], monitor_type=AlertRuleMonitorType.ACTIVATED
-        )
-        self.create_alert_rule_activation_condition(
-            alert_rule=alert_rule,
-            condition_type=AlertRuleActivationConditionType.DEPLOY_CREATION,
+        self.create_alert_rule(
+            projects=[project],
+            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            activation_condition=AlertRuleActivationConditionType.DEPLOY_CREATION,
         )
         with self.tasks():
             created_subscriptions = (

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 import responses
 from django.core import mail
+from django.forms import ValidationError
 from django.test import override_settings
 from django.utils import timezone
 
@@ -443,6 +444,7 @@ class GetIncidentSubscribersTest(TestCase, BaseIncidentsTest):
 class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
     def test_create_alert_rule(self):
         # pytest parametrize does not work in TestCase subclasses, so hack around this
+        # TODO: backfill projects so all monitor_types include 'projects' fk
         for monitor_type, expected_projects in [
             (None, 0),
             (AlertRuleMonitorType.CONTINUOUS, 0),
@@ -494,6 +496,32 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             assert alert_rule.resolve_threshold == resolve_threshold
             assert alert_rule.threshold_period == threshold_period
             assert alert_rule.projects.all().count() == expected_projects
+
+    def test_create_activated_alert_rule_errors_without_condition(self):
+        name = "hello"
+        query = "level:error"
+        aggregate = "count(*)"
+        time_window = 10
+        threshold_type = AlertRuleThresholdType.ABOVE
+        resolve_threshold = 10
+        threshold_period = 1
+        event_types = [SnubaQueryEventType.EventType.ERROR]
+        kwargs = {"monitor_type": AlertRuleMonitorType.ACTIVATED}
+
+        with pytest.raises(ValidationError):
+            create_alert_rule(
+                self.organization,
+                [self.project],
+                name,
+                query,
+                aggregate,
+                time_window,
+                threshold_type,
+                threshold_period,
+                resolve_threshold=resolve_threshold,
+                event_types=event_types,
+                **kwargs,
+            )
 
     def test_ignore(self):
         name = "hello"

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -71,6 +71,7 @@ from sentry.incidents.models.incident import (
     IncidentType,
     TriggerStatus,
 )
+from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.integrations.discord.utils.channel import ChannelType
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.actor import ActorTuple, get_actor_for_user, get_actor_id_for_user
@@ -455,7 +456,14 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             resolve_threshold = 10
             threshold_period = 1
             event_types = [SnubaQueryEventType.EventType.ERROR]
-            kwargs = {"monitor_type": monitor_type} if monitor_type else {}
+            kwargs = (
+                {
+                    "monitor_type": monitor_type,
+                    "activation_condition": AlertRuleActivationConditionType.RELEASE_CREATION,
+                }
+                if monitor_type
+                else {}
+            )
             alert_rule = create_alert_rule(
                 self.organization,
                 [self.project],

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -119,10 +119,11 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
         # Let the logic flow through to snuba and see whether we properly construct the snuba query
         project = self.create_project(name="foo")
         release = Release.objects.create(organization_id=project.organization_id, version="42")
-        alert_rule = self.create_alert_rule(
-            projects=[project], monitor_type=AlertRuleMonitorType.ACTIVATED
+        self.create_alert_rule(
+            projects=[project],
+            monitor_type=AlertRuleMonitorType.ACTIVATED,
+            activation_condition=AlertRuleActivationConditionType.RELEASE_CREATION,
         )
-        self.create_alert_rule_activation_condition(alert_rule=alert_rule)
 
         subscribe_project = AlertRule.objects.conditionally_subscribe_project_to_alert_rules
         with patch(


### PR DESCRIPTION
Activated Alert Rules require an activation_condition to determine when the rule should be activated.

Previously i had the condition_type creation separate from the alert rule creation itself, but here i'm now tieing this into the `create_alert_rule` helper and added a validation to require it as well

Addresses https://github.com/getsentry/team-core-product-foundations/issues/214