### PR TITLE
fix(severity): Calculate severity only for errors

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1832,7 +1832,7 @@ def _create_group(project: Project, event: Event, **group_creation_kwargs: Any) 
     # Add severity to metadata for alert filtering for errors events.
     # We can skip this if the group type is explicitly NOT an error.
     group_type = group_creation_kwargs.get("type", None)
-    severity = {}
+    severity: Mapping[str, Any] = {}
     if not group_type or group_type == ErrorGroupType.type_id:
         severity = _get_severity_metadata_for_group(event)
         group_data["metadata"].update(severity)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -71,7 +71,7 @@ from sentry.grouping.ingest import (
 )
 from sentry.grouping.result import CalculatedHashes
 from sentry.ingest.inbound_filters import FilterStatKeys
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import ErrorGroupType, GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.killswitches import killswitch_matches_context
@@ -1829,11 +1829,15 @@ def _create_group(project: Project, event: Event, **group_creation_kwargs: Any) 
     # add sdk tag to metadata
     group_data.setdefault("metadata", {}).update(sdk_metadata_from_event(event))
 
-    # add severity to metadata for alert filtering
-    severity = _get_severity_metadata_for_group(event)
-    group_data["metadata"].update(severity)
+    # Add severity to metadata for alert filtering for errors events.
+    # We can skip this if the group type is explicitly NOT an error.
+    group_type = group_creation_kwargs.get("type", None)
+    if not group_type or group_type == ErrorGroupType.type_id:
+        severity = _get_severity_metadata_for_group(event)
+        group_data["metadata"].update(severity)
 
     if features.has("projects:issue-priority", project, actor=None):
+        # the kwargs only include priority for non-error issue platform events, which takes precedence.
         priority = group_creation_kwargs.get("priority", None)
         if priority is None:
             priority = _get_priority_for_group(severity, group_creation_kwargs)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1832,6 +1832,7 @@ def _create_group(project: Project, event: Event, **group_creation_kwargs: Any) 
     # Add severity to metadata for alert filtering for errors events.
     # We can skip this if the group type is explicitly NOT an error.
     group_type = group_creation_kwargs.get("type", None)
+    severity = {}
     if not group_type or group_type == ErrorGroupType.type_id:
         severity = _get_severity_metadata_for_group(event)
         group_data["metadata"].update(severity)

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -185,7 +185,10 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
         assert group.priority == PriorityLevel.LOW
 
     @with_feature("projects:issue-priority")
-    def test_issue_platform_override_priority(self):
+    @mock.patch(
+        "sentry.event_manager._get_severity_metadata_for_group", return_value=(0.1121, "ml")
+    )
+    def test_issue_platform_override_priority(self, mock_get_severity_score):
         # test explicitly set priority of HIGH
         message = get_test_message(self.project.id)
         message["initial_issue_priority"] = PriorityLevel.HIGH.value
@@ -194,6 +197,7 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
         assert result is not None
         occurrence = result[0]
         assert occurrence is not None
+        assert mock_get_severity_score.call_count == 0
         group = Group.objects.filter(grouphash__hash=occurrence.fingerprint[0]).first()
         assert group.priority == PriorityLevel.HIGH
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -185,9 +185,7 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
         assert group.priority == PriorityLevel.LOW
 
     @with_feature("projects:issue-priority")
-    @mock.patch(
-        "sentry.event_manager._get_severity_metadata_for_group", return_value=(0.1121, "ml")
-    )
+    @mock.patch("sentry.event_manager._get_severity_metadata_for_group")
     def test_issue_platform_override_priority(self, mock_get_severity_score):
         # test explicitly set priority of HIGH
         message = get_test_message(self.project.id)
@@ -200,6 +198,7 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
         assert mock_get_severity_score.call_count == 0
         group = Group.objects.filter(grouphash__hash=occurrence.fingerprint[0]).first()
         assert group.priority == PriorityLevel.HIGH
+        assert "severity" not in group.data["metadata"]
 
 
 class IssueOccurrenceLookupEventIdTest(IssueOccurrenceTestBase):


### PR DESCRIPTION
We shouldn't be attempting to calculate severity for non-errors. Priority for these issues is set using the default or the value provided in the kwargs instead. 