### PR TITLE
ref(ui): Allow keyValueTable value to expand more

### DIFF
--- a/static/app/components/keyValueTable.tsx
+++ b/static/app/components/keyValueTable.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const KeyValueTable = styled('dl')<{noMargin?: boolean}>`
   display: grid;
-  grid-template-columns: 50% 50%;
+  grid-template-columns: fit-content(50%) auto;
   ${p => (p.noMargin ? 'margin-bottom: 0;' : null)}
 `;
 


### PR DESCRIPTION
Instead of always being clamped at 50% the label will fit to it's max
column size like this:

<img alt="clipboard.png" width="375" src="https://i.imgur.com/XL4WYXN.png" />