### PR TITLE
feat(react): Capture access to legacy organizationContext

### DIFF
--- a/static/app/views/organizationContext.spec.tsx
+++ b/static/app/views/organizationContext.spec.tsx
@@ -1,5 +1,6 @@
 import {Component} from 'react';
 import type {RouteContextInterface} from 'react-router';
+import * as Sentry from '@sentry/react';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -98,7 +99,7 @@ describe('OrganizationContext', function () {
    */
   class OrganizationNameLegacyConsumer extends Component {
     static contextTypes = {
-      organization: SentryPropTypeValidators.isOrganization,
+      organization: SentryPropTypeValidators.isObject,
     };
     declare context: {organization: Organization | undefined};
 
@@ -130,6 +131,8 @@ describe('OrganizationContext', function () {
     );
 
     expect(await screen.findByText(organization.slug)).toBeInTheDocument();
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith('Legacy organization accessed!');
   });
 
   it('does not fetch if organization is already set', async function () {

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useRef,
 } from 'react';
+import {captureMessage} from '@sentry/react';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
 import {switchOrganization} from 'sentry/actionCreators/organizations';
@@ -37,6 +38,17 @@ interface Props {
   children: React.ReactNode;
 }
 
+const proxyHandler: ProxyHandler<Organization> = {
+  get(organization, prop) {
+    // XXX(epurkhiser): Record a sentry message when we've accessed the
+    // organiztion. Once we stop getting these we can remove the
+    // LegacyOrganizationContextProvider
+    captureMessage('Legacy organization accessed!');
+
+    return organization[prop];
+  },
+};
+
 /**
  * There are still a number of places where we consume the legacy organization
  * context. So for now we still need a component that provides this.
@@ -46,11 +58,19 @@ class LegacyOrganizationContextProvider extends Component<{
   children?: React.ReactNode;
 }> {
   static childContextTypes = {
-    organization: SentryPropTypeValidators.isOrganization,
+    organization: SentryPropTypeValidators.isObject,
   };
 
   getChildContext() {
-    return {organization: this.props.value};
+    if (!this.props.value) {
+      return {organization: null};
+    }
+
+    // XXX(epurkhiser): Proxying the legacy context organization object to
+    // figure out where we're actually accessing this (if at all) anymore.
+    const organization = new Proxy(this.props.value, proxyHandler);
+
+    return {organization};
   }
 
   render() {

--- a/static/app/views/settings/account/accountSettingsLayout.tsx
+++ b/static/app/views/settings/account/accountSettingsLayout.tsx
@@ -16,7 +16,7 @@ type Props = React.ComponentProps<typeof SettingsLayout> & {
 
 class AccountSettingsLayout extends Component<Props> {
   static childContextTypes = {
-    organization: SentryPropTypeValidators.isOrganization,
+    organization: SentryPropTypeValidators.isObject,
   };
 
   getChildContext() {


### PR DESCRIPTION
This will allow us to determine if this is still in use anywhere

I've removed the isOrganization propType validators since those were accessing the organization object.