### PR TITLE
chore(billing): Update link to DataCategory definition in relay source code

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -644,7 +644,7 @@ GITHUB_COMMENT_BOT_DEFAULT = True
 EVENTS_MEMBER_ADMIN_DEFAULT = True
 ALERTS_MEMBER_WRITE_DEFAULT = True
 
-# Defined at https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
+# Defined at https://github.com/getsentry/relay/blob/master/py/sentry_relay/consts.py
 DataCategory = sentry_relay.consts.DataCategory
 
 CRASH_RATE_ALERT_SESSION_COUNT_ALIAS = "_total_count"


### PR DESCRIPTION
The link was outdated and was last updated 4 years ago. I'm updating it to make it easier to see the `DataCategory` enum values.