### PR TITLE
Fix Enhancement Rule Hints

### DIFF
--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T18:45:37.447995Z'
+created: '2024-03-22T11:57:23.290728+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           frame
             function (function name is not used if module or filename are available)
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function (function name is not used if module or filename are available)
               "__99+[Something else]_block_invoke_2"
           frame (non app frame)
@@ -35,7 +35,7 @@ system:
           frame
             function (function name is not used if module or filename are available)
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function (function name is not used if module or filename are available)
               "__99+[Something else]_block_invoke_2"
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-08-04T15:53:48.473074Z'
+created: '2024-03-22T11:57:51.104287+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -44,18 +44,18 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "_main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start_internal"
             package (ignored because function takes precedence)
               "std"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::panicking::try::do_call"
             package (ignored because function takes precedence)
@@ -70,7 +70,7 @@ system:
               "log_demo::main"
             package (ignored because function takes precedence)
               "log_demo"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "log::__private_api_log"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T18:46:11.097452Z'
+created: '2024-03-22T11:58:06.473567+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,10 +9,10 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame (non app frame)
@@ -32,10 +32,10 @@ system:
     system*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-13T15:30:44.361778Z'
+created: '2024-03-22T11:58:10.149231+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -33,7 +33,7 @@ app:
           frame (non app frame)
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*
@@ -92,7 +92,7 @@ system:
           frame*
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-12T10:57:04.515579Z'
+created: '2024-03-22T11:58:09.802091+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -39,25 +39,25 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "_main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start_internal"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::panicking::try::do_call"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*
             function*
               "log_demo::main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "log::__private_api_log"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T18:46:17.496488Z'
+created: '2024-03-22T11:58:14.369533+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,10 +9,10 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame (non app frame)
@@ -32,10 +32,10 @@ system:
     system*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-13T15:30:50.637947Z'
+created: '2024-03-22T11:58:18.262933+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -33,7 +33,7 @@ app:
           frame (non app frame)
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*
@@ -92,7 +92,7 @@ system:
           frame*
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-12T10:56:59.774229Z'
+created: '2024-03-22T11:58:17.906466+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -41,25 +41,25 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "_main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start_internal"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::panicking::try::do_call"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*
             function*
               "log_demo::main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "log::__private_api_log"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T18:45:42.493182Z'
+created: '2024-03-22T11:57:30.833871+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,10 +9,10 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame (non app frame)
@@ -32,10 +32,10 @@ system:
     system*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-13T15:30:12.623334Z'
+created: '2024-03-22T11:57:34.754351+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -33,7 +33,7 @@ app:
           frame (non app frame)
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*
@@ -92,7 +92,7 @@ system:
           frame*
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-12T10:57:16.548617Z'
+created: '2024-03-22T11:57:34.334708+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -41,25 +41,25 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "_main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start_internal"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::panicking::try::do_call"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*
             function*
               "log_demo::main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "log::__private_api_log"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T18:45:48.154315Z'
+created: '2024-03-22T11:57:39.089571+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,10 +9,10 @@ app:
     app*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame (non app frame)
@@ -32,10 +32,10 @@ system:
     system*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-13T15:30:20.019431Z'
+created: '2024-03-22T11:57:42.810060+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -33,7 +33,7 @@ app:
           frame (non app frame)
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*
@@ -92,7 +92,7 @@ system:
           frame*
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-12T10:57:08.694805Z'
+created: '2024-03-22T11:57:42.480291+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -41,25 +41,25 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "_main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start_internal"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::panicking::try::do_call"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start::{{closure}}"
           frame*
             function*
               "log_demo::main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "log::__private_api_log"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T18:43:32.477116Z'
+created: '2024-03-22T11:57:57.243126+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,10 +9,10 @@ app:
     app (threads of system take precedence)
       threads (ignored because hash matches system variant)
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame (non app frame)
@@ -32,10 +32,10 @@ system:
     system*
       threads*
         stacktrace*
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__99+[Something else]_block_invoke_2"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-13T15:30:38.097957Z'
+created: '2024-03-22T11:58:02.240343+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -33,7 +33,7 @@ app:
           frame (non app frame)
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*
@@ -92,7 +92,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__"
-          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+          frame* (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
             function*
               "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:07.460260Z'
+created: '2024-03-22T11:58:01.620488+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -41,16 +41,16 @@ system:
     system*
       exception*
         stacktrace*
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "_main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::rt::lang_start_internal"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "___rust_maybe_catch_panic"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "std::panicking::try::do_call"
           frame (ignored by stack trace rule (category:internals -group))
@@ -59,7 +59,7 @@ system:
           frame*
             function*
               "log_demo::main"
-          frame (ignored by stack trace rule (function:log_demo::* -group))
+          frame (ignored by stack trace rule (!function:log_demo::* -group))
             function*
               "log::__private_api_log"
         type*


### PR DESCRIPTION
While working towards matching the Python/Rust output, I noticed that the Python Rule hints were completely missing the negation marker (`!`), as well as lowercasing `PathLikeMatch`es in the hint output.

This fixes those two cases, and updates the snapshots accordingly. The grouping hints output should now more closely match what users were writing.