### PR TITLE
Assert grouping hints generated by Rust match

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -63,7 +63,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.2
 sentry-kafka-schemas>=0.1.64
-sentry-ophio==0.2.3
+sentry-ophio==0.2.5
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.52
 sentry-sdk>=1.40.6

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -178,7 +178,7 @@ sentry-devenv==1.2.3
 sentry-forked-django-stubs==4.2.7.post3
 sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.64
-sentry-ophio==0.2.3
+sentry-ophio==0.2.5
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.52
 sentry-sdk==1.40.6

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -120,7 +120,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.2
 sentry-kafka-schemas==0.1.64
-sentry-ophio==0.2.3
+sentry-ophio==0.2.5
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.52
 sentry-sdk==1.40.6

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -299,10 +299,10 @@ def compare_rust_components(
     contributes, hint, invert, rust_components_ = rust_results
 
     python_components = [
-        (c.contributes, c.is_prefix_frame, c.is_sentinel_frame) for c in component.values
+        (c.contributes, c.hint, c.is_prefix_frame, c.is_sentinel_frame) for c in component.values
     ]
     rust_components = [
-        (c.contributes, c.is_prefix_frame, c.is_sentinel_frame) for c in rust_components_
+        (c.contributes, c.hint, c.is_prefix_frame, c.is_sentinel_frame) for c in rust_components_
     ]
 
     python_res = (component.contributes, component.hint, invert_stacktrace, python_components)

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -65,6 +65,7 @@ def dump_variant(variant, lines=None, indent=0):
 @override_options({"grouping.rust_enhancers.compare_components": 1.0})
 def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
     grouping_config = get_default_grouping_config_dict(config_name)
+    loaded_config = load_grouping_config(grouping_config)
     evt = grouping_input.create_event(grouping_config)
 
     # Make sure we don't need to touch the DB here because this would
@@ -72,7 +73,7 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
     evt.project = None
 
     # Set the synthetic marker if detected
-    detect_synthetic_exception(evt.data, load_grouping_config(grouping_config))
+    detect_synthetic_exception(evt.data, loaded_config)
 
     rv: list[str] = []
     for key, value in sorted(evt.get_grouping_variants().items()):
@@ -96,17 +97,18 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
     ):
         evt = grouping_input.create_event(grouping_config)
         evt.project = None
+        detect_synthetic_exception(evt.data, loaded_config)
 
         rust_hashes = evt.get_hashes()
         assert rust_hashes.hashes == hashes.hashes
 
-        # rv = []
-        # for key, value in sorted(evt.get_grouping_variants().items()):
-        #     if rv:
-        #         rv.append("-" * 74)
-        #     rv.append("%s:" % key)
-        #     dump_variant(value, rv, 1)
-        # rust_output = "\n".join(rv)
+        rv = []
+        for key, value in sorted(evt.get_grouping_variants().items()):
+            if rv:
+                rv.append("-" * 74)
+            rv.append("%s:" % key)
+            dump_variant(value, rv, 1)
+        rust_output = "\n".join(rv)
 
         # FIXME: the `hint` output does not (yet) fully match what Python produces
-        # assert rust_output == output
+        assert rust_output == output


### PR DESCRIPTION
Once https://github.com/getsentry/sentry/pull/67506 lands on the Sentry side,
and with https://github.com/getsentry/ophio/pull/49 merged and released on the Rust side,
the output of the snapshot tests is identical across Python and Rust.