### PR TITLE
Remove `Enhancements` version 1

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -92,7 +92,7 @@ _        = space*
 )
 
 
-VERSIONS = [1, 2]
+VERSIONS = [2]
 LATEST_VERSION = VERSIONS[-1]
 
 
@@ -342,7 +342,7 @@ class Enhancements:
     # NOTE: You must add a version to ``VERSIONS`` any time attributes are added
     # to this class, s.t. no enhancements lacking these attributes are loaded
     # from cache.
-    # See ``_get_project_enhancements_config`` in src/sentry/grouping/api.py.
+    # See ``GroupingConfigLoader._get_enhancements`` in src/sentry/grouping/api.py.
 
     @sentry_sdk.tracing.trace
     def __init__(self, rules, version=None, bases=None, id=None, rust_enhancements=None):

--- a/src/sentry/grouping/enhancer/actions.py
+++ b/src/sentry/grouping/enhancer/actions.py
@@ -9,12 +9,8 @@ from sentry.utils.safe import get_path, set_path
 from .exceptions import InvalidEnhancerConfig
 
 ACTIONS = ["group", "app", "prefix", "sentinel"]
-ACTION_BITSIZE = {
-    # version -> bit-size
-    1: 4,
-    2: 8,
-}
-assert len(ACTIONS) < 1 << max(ACTION_BITSIZE.values())
+ACTION_BITSIZE = 8
+assert len(ACTIONS) < 1 << ACTION_BITSIZE
 ACTION_FLAGS = {
     (True, None): 0,
     (True, "up"): 1,
@@ -61,7 +57,7 @@ class Action:
     def _from_config_structure(cls, val, version: int):
         if isinstance(val, list):
             return VarAction(val[0], val[1])
-        flag, range = REVERSE_ACTION_FLAGS[val >> ACTION_BITSIZE[version]]
+        flag, range = REVERSE_ACTION_FLAGS[val >> ACTION_BITSIZE]
         return FlagAction(ACTIONS[val & 0xF], flag, range)
 
 
@@ -81,9 +77,7 @@ class FlagAction(Action):
         )
 
     def _to_config_structure(self, version: int):
-        return ACTIONS.index(self.key) | (
-            ACTION_FLAGS[self.flag, self.range] << ACTION_BITSIZE[version]
-        )
+        return ACTIONS.index(self.key) | (ACTION_FLAGS[self.flag, self.range] << ACTION_BITSIZE)
 
     def _slice_to_range(self, seq, idx):
         if self.range is None:

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -30,7 +30,7 @@ def dump_obj(obj):
     return rv
 
 
-@pytest.mark.parametrize("version", [1, 2])
+@pytest.mark.parametrize("version", [2])
 def test_basic_parsing(insta_snapshot, version):
     enhancement = Enhancements.from_config_string(
         """


### PR DESCRIPTION
These are used for caches and inside of long expired event payloads. We can remove parsing support for these.