### PR TITLE
fix(trace): fix comparison

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -726,7 +726,7 @@ export class TraceTree {
               child.value &&
               'start_timestamp' in child.value &&
               typeof child.value.start_timestamp === 'number' &&
-              child.value.start_timestamp > start_timestamp
+              child.value.start_timestamp < start_timestamp
             ) {
               start_timestamp = child.value.start_timestamp;
             }


### PR DESCRIPTION
Wrong comparison meant the start timestamp was always max int