### PR TITLE
ref(ts): Remove legacy organization context from AccountSettingsLayout

### DIFF
--- a/static/app/views/settings/account/accountSettingsLayout.tsx
+++ b/static/app/views/settings/account/accountSettingsLayout.tsx
@@ -2,7 +2,6 @@ import {Component} from 'react';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organizations';
 import type {Client} from 'sentry/api';
-import {SentryPropTypeValidators} from 'sentry/sentryPropTypeValidators';
 import type {Organization} from 'sentry/types';
 import withApi from 'sentry/utils/withApi';
 import withLatestContext from 'sentry/utils/withLatestContext';
@@ -15,16 +14,6 @@ type Props = React.ComponentProps<typeof SettingsLayout> & {
 };
 
 class AccountSettingsLayout extends Component<Props> {
-  static childContextTypes = {
-    organization: SentryPropTypeValidators.isObject,
-  };
-
-  getChildContext() {
-    return {
-      organization: this.props.organization,
-    };
-  }
-
   componentDidUpdate(prevProps: Props) {
     const {api, organization} = this.props;
     if (prevProps.organization === organization) {


### PR DESCRIPTION
This was not being accessed