### PR TITLE
chore(snuba): Add missing cross_org_query tag to dynamic sampling query

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -195,7 +195,7 @@ def fetch_projects_with_total_root_transaction_count_and_rates(
                 dataset=Dataset.PerformanceMetrics.value,
                 app_id="dynamic_sampling",
                 query=query,
-                tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value},
+                tenant_ids={"use_case_id": UseCaseID.TRANSACTIONS.value, "cross_org_query": 1},
             )
             data = raw_snql_query(
                 request,


### PR DESCRIPTION
This queries `GenericOrgMetricsCounters` in snuba. The tenant_ids in the request should contain `"cross_org_query": 1` to help bypass certain allocation policy restrictions. 