### PR TITLE
chore(login): update the login banners

### DIFF
--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -78,9 +78,9 @@
   <div class="alert-banner">
     <div class="alert-message">
       {% if banner_choice == 0 %}
-      Sentry Launch Week is back. Tune in starting March 18th at 9AM for a full week of new features and products. &nbsp<a target="_blank" href="https://sentry.io/events/launch-week/?utm_source=pendo&utm_medium=site&utm_campaign=general-fy25q1-launchweek&utm_content=workshop-loginbanner1q24launchweek-learnmore">Learn more.</a>
+      Protect user privacy and debug errors faster with Session Replay. Join us April 3rd at 10AM PT to learn more. &nbsp<a target="_blank" href="https://sentry.io/resources/session-replay-privacy-workshop/?utm_source=pendo&utm_medium=site&utm_campaign=replay-fy25q1-srworkshop&utm_content=workshop-aprilreplayworkshop-register">Register now.</a>
       {% elif banner_choice == 1 %}
-      Sentry Launch Week is back. Tune in starting March 18th at 9AM for a full week of new features and products. &nbsp<a target="_blank" href="https://sentry.io/events/launch-week/?utm_source=pendo&utm_medium=site&utm_campaign=general-fy25q1-launchweek&utm_content=workshop-loginbanner1q24launchweek-learnmore">Learn more.</a>
+      AI-powered Autofix will generate code to fix your issues. Tune in April 25th at 10AM PT to learn more. &nbsp<a target="_blank" href="https://sentry.io/resources/autofix-workshop/?utm_source=pendo&utm_medium=site&utm_campaign=ai-fy25q1-Initiative&utm_content=workshop-aprilautofixworkshop-register">Register now.</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Updated the login banners to promote Replay and Autofix workshops. 

**PLEASE NOTE**: I am not able to preview the changes locally. Please preview before approving.