### PR TITLE
fix(trends): Should add group by project id for trends timeseries

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -330,14 +330,6 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                     True,
                 ),
                 "stats": trending_transaction_names_stats,
-                # temporary change to see what stats data is returned
-                "raw_stats": trends_requests
-                if features.has(
-                    "organizations:performance-trendsv2-dev-only",
-                    organization,
-                    actor=request.user,
-                )
-                else {},
             }
 
         with handle_query_errors():

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -92,12 +92,6 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
 
         top_trending_transactions = {}
 
-        experiment_use_project_id = features.has(
-            "organizations:performance-trendsv2-dev-only",
-            organization,
-            actor=request.user,
-        )
-
         def get_top_events(user_query, params, event_limit, referrer):
             top_event_columns = cast(list[str], selected_columns[:])
             top_event_columns.append("count()")
@@ -154,28 +148,22 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 rollup=rollup,
                 zerofill_results=zerofill_results,
                 referrer=Referrer.API_TRENDS_GET_EVENT_STATS_V2_TIMESERIES.value,
-                groupby=Column("transaction"),
+                groupby=[Column("project_id"), Column("transaction")],
                 apply_formatting=False,
             )
 
             # Parse results
-            translated_groupby = ["transaction"]
+            translated_groupby = ["project_id", "transaction"]
             results = {}
             formatted_results = {}
             for index, item in enumerate(top_events["data"]):
                 result_key = create_result_key(item, translated_groupby, {})
-                if experiment_use_project_id:
-                    results[result_key] = {
-                        "order": index,
-                        "data": [],
-                        "project_id": item["project_id"],
-                    }
-                else:
-                    results[result_key] = {
-                        "order": index,
-                        "data": [],
-                        "project": item["project"],
-                    }
+                results[result_key] = {
+                    "order": index,
+                    "data": [],
+                    "project_id": item["project_id"],
+                }
+
             for row in result.get("data", []):  # type: ignore
                 result_key = create_result_key(row, translated_groupby, {})
                 if result_key in results:
@@ -190,11 +178,6 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                         },
                     )
             for key, item in results.items():
-                key = (
-                    f'{item["project_id"]},{key}'
-                    if experiment_use_project_id
-                    else f'{item["project"]},{key}'
-                )
                 formatted_results[key] = SnubaTSResult(
                     {
                         "data": zerofill(
@@ -206,9 +189,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                         )
                         if zerofill_results
                         else item["data"],
-                        "project": item["project_id"]
-                        if experiment_use_project_id
-                        else item["project"],
+                        "project": item["project_id"],
                         "isMetricsData": True,
                         "order": item["order"],
                     },

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1440,7 +1440,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         query: str | None = None,
         selected_columns: list[str] | None = None,
         limit: int | None = 10000,
-        groupby: Column | None = None,
+        groupby: Column | list[Column] | None = None,
         config: QueryBuilderConfig | None = None,
     ):
         self.interval = interval
@@ -1462,7 +1462,10 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
 
         # If additional groupby is provided it will be used first before time
         if groupby is not None:
-            self.groupby.insert(0, groupby)
+            if isinstance(groupby, list):
+                self.groupby = groupby + self.groupby
+            else:
+                self.groupby.insert(0, groupby)
 
     def resolve_granularity(self) -> Granularity:
         """Find the largest granularity that is smaller than the interval"""

--- a/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
+++ b/tests/sentry/api/endpoints/test_organization_events_trends_v2.py
@@ -268,46 +268,6 @@ class OrganizationEventsTrendsStatsV2EndpointTest(MetricsAPIBaseTestCase):
         assert len(result_stats.get(f"{self.project.id},foo", [])) > 0
 
     @mock.patch("sentry.api.endpoints.organization_events_trends_v2.detect_breakpoints")
-    def test_simple_with_trends_p95_with_project_id(self, mock_detect_breakpoints):
-        # TODO: can we delete this?
-        mock_trends_result = [
-            {
-                "project": self.project.id,
-                "transaction": "foo",
-                "change": "regression",
-                "trend_difference": -15,
-                "trend_percentage": 0.88,
-            }
-        ]
-        mock_detect_breakpoints.return_value = {"data": mock_trends_result}
-
-        with self.feature({**self.features, "organizations:performance-trendsv2-dev-only": True}):
-            response = self.client.get(
-                self.url,
-                format="json",
-                data={
-                    "end": iso_format(self.now),
-                    "start": iso_format(self.now - timedelta(days=1)),
-                    "interval": "1h",
-                    "field": ["project", "transaction"],
-                    "query": "event.type:transaction",
-                    "project": self.project.id,
-                    "trendFunction": "p95(transaction.duration)",
-                },
-            )
-
-        assert response.status_code == 200, response.content
-
-        events = response.data["events"]
-        result_stats = response.data["stats"]
-
-        assert len(events["data"]) == 1
-        assert events["data"] == mock_trends_result
-
-        assert len(result_stats) > 0
-        assert len(result_stats.get(f"{self.project.id},foo", [])) > 0
-
-    @mock.patch("sentry.api.endpoints.organization_events_trends_v2.detect_breakpoints")
     def test_simple_with_top_events(self, mock_detect_breakpoints):
         # store second metric but with lower count
         self.store_performance_metric(


### PR DESCRIPTION
This was not grouping the timeseries query by project so if 2 projects have the same transaction name which is not impossible, they end up getting grouped into a single timeseries.