### PR TITLE
Fix links to deprecated forum

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 ## Feedback, Advice, and General Help
 
 If you're looking to provide general feedback, or get help or advice, please
-utilize our [community forum](https://forum.sentry.io/) rather than GitHub Issues.
+utilize [GitHub Discussions](https://github.com/getsentry/sentry/discussions)
+rather than GitHub Issues.
 
 ## Contributing to Sentry
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Sentry is a developer-first error tracking and performance monitoring platform t
 # Resources
 
 - [Documentation](https://docs.sentry.io/)
-- [Community](https://forum.sentry.io/) (Bugs, feature requests,
+- [Discussions](https://github.com/getsentry/sentry/discussions) (Bugs, feature requests,
   general questions)
 - [Discord](https://discord.gg/PXa5Apfe7K)
 - [Contributing](https://docs.sentry.io/internal/contributing/)


### PR DESCRIPTION
Basically what the title says. I clicked the README link, and the forum immediately told me to go to GitHub discussions.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
