### PR TITLE
chore(trends): Remove unused trends widgets for testing

### DIFF
--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -3,7 +3,6 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
-import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/alert';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {CompactSelect} from 'sentry/components/compactSelect';
@@ -318,24 +317,6 @@ class TrendsContent extends Component<Props, State> {
                   )}
                 />
               </ListContainer>
-              <Feature features="organizations:performance-trendsv2-dev-only">
-                <ListContainer>
-                  <ChangedTransactions
-                    trendChangeType={TrendChangeType.IMPROVED}
-                    previousTrendFunction={previousTrendFunction}
-                    trendView={trendView}
-                    location={location}
-                    setError={this.setError}
-                  />
-                  <ChangedTransactions
-                    trendChangeType={TrendChangeType.REGRESSION}
-                    previousTrendFunction={previousTrendFunction}
-                    trendView={trendView}
-                    location={location}
-                    setError={this.setError}
-                  />
-                </ListContainer>
-              </Feature>
             </DefaultTrends>
           </Layout.Main>
         </Layout.Body>


### PR DESCRIPTION
Not sure what the original intent of these components are but it doesn't do anything the widgets above it already does.