### PR TITLE
chore(ingest): Remove unused `retry_process_event`

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -278,32 +278,6 @@ def preprocess_event_from_reprocessing(
     )
 
 
-@instrumented_task(
-    name="sentry.tasks.store.retry_process_event",
-    queue="sleep",
-    time_limit=(60 * 5) + 5,
-    soft_time_limit=60 * 5,
-    silo_mode=SiloMode.REGION,
-)
-def retry_process_event(process_task_name: str, task_kwargs: dict[str, Any], **kwargs: Any) -> None:
-    """
-    The only purpose of this task is be enqueued with some ETA set. This is
-    essentially an implementation of ETAs on top of Celery's existing ETAs, but
-    with the intent of having separate workers wait for those ETAs.
-    """
-    tasks = {
-        "process_event": process_event,
-        "process_event_proguard": process_event_proguard,
-        "process_event_from_reprocessing": process_event_from_reprocessing,
-    }
-
-    process_task = tasks.get(process_task_name)
-    if not process_task:
-        raise ValueError(f"Invalid argument for process_task_name: {process_task_name}")
-
-    process_task.delay(**task_kwargs)
-
-
 def is_process_disabled(project_id: int, event_id: str, platform: str) -> bool:
     if killswitch_matches_context(
         "store.load-shed-process-event-projects",


### PR DESCRIPTION
While digging around in the `store` tasks I discovered that we have a task, `retry_process_event`, which isn't used anywhere. It turns out the only reference to it was removed 4 years ago in https://github.com/getsentry/sentry/pull/18546. This therefore removes it as well. (I think this change was just missed when removing old code in that PR.)