### PR TITLE
chore(crons): Add metrics for when we succeed in creating or updating a checkin via the consumer

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -327,6 +327,10 @@ def update_existing_check_in(
         updated_status,
         start_time,
     )
+    metrics.incr(
+        "monitors.checkin.result",
+        tags={**metric_kwargs, "status": "updated_existing_checkin"},
+    )
 
     # IN_PROGRESS heartbeats bump the date_updated
     if updated_status == CheckInStatus.IN_PROGRESS:
@@ -729,6 +733,10 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span):
                 else:
                     txn.set_tag("outcome", "create_new_checkin")
                     signal_first_checkin(project, monitor)
+                    metrics.incr(
+                        "monitors.checkin.result",
+                        tags={**metric_kwargs, "status": "created_new_checkin"},
+                    )
 
             track_outcome(
                 org_id=project.organization_id,


### PR DESCRIPTION
We want to have a slo to measure that we process all checkins that make it through relay. We already log results for when we drop checkins, adding in results for when we succeed as well