### PR TITLE
feat(trace-explorer): Add boiler plate for trace explorer

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -319,7 +319,7 @@ function Sidebar() {
               <Feature features="performance-trace-explorer">
                 <SidebarItem
                   {...sidebarItemProps}
-                  label={<GuideAnchor target="starfish">{t('Traces')}</GuideAnchor>}
+                  label={<GuideAnchor target="traces">{t('Traces')}</GuideAnchor>}
                   to={`/organizations/${organization.slug}/performance/traces`}
                   id="performance-trace-explorer"
                   icon={<SubitemDot collapsed />}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -316,6 +316,15 @@ function Sidebar() {
                   icon={<SubitemDot collapsed />}
                 />
               </Feature>
+              <Feature features="performance-trace-explorer">
+                <SidebarItem
+                  {...sidebarItemProps}
+                  label={<GuideAnchor target="starfish">{t('Traces')}</GuideAnchor>}
+                  to={`/organizations/${organization.slug}/performance/traces`}
+                  id="performance-trace-explorer"
+                  icon={<SubitemDot collapsed />}
+                />
+              </Feature>
             </SidebarAccordion>
           );
         }

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1598,6 +1598,9 @@ function buildRoutes() {
           />
         </Route>
       </Route>
+      <Route path="traces/">
+        <IndexRoute component={make(() => import('sentry/views/performance/traces'))} />
+      </Route>
       <Route path="summary/">
         <IndexRoute
           component={make(

--- a/static/app/views/performance/traces/index.tsx
+++ b/static/app/views/performance/traces/index.tsx
@@ -1,0 +1,76 @@
+import {Fragment} from 'react';
+
+import Feature from 'sentry/components/acl/feature';
+import {Alert} from 'sentry/components/alert';
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import * as Layout from 'sentry/components/layouts/thirds';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+
+function TraceExplorerLandingPage() {
+  const organization = useOrganization();
+
+  return (
+    <Fragment>
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Breadcrumbs
+            crumbs={[
+              {
+                label: 'Performance',
+                to: normalizeUrl(`/organizations/${organization.slug}/performance/`),
+                preservePageFilters: true,
+              },
+              {
+                label: 'Traces',
+              },
+            ]}
+          />
+          <Layout.Title>{t('Traces')}</Layout.Title>
+        </Layout.HeaderContent>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main>
+          <Fragment />
+        </Layout.Main>
+      </Layout.Body>
+    </Fragment>
+  );
+}
+
+function NoAccess() {
+  return (
+    <Layout.Page withPadding>
+      <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+    </Layout.Page>
+  );
+}
+
+const DEFAULT_STATS_PERIOD = '24h';
+
+export default function TracesPage() {
+  const organization = useOrganization();
+
+  return (
+    <SentryDocumentTitle title={t('Traces')} orgSlug={organization.slug}>
+      <PageFiltersContainer
+        defaultSelection={{
+          datetime: {start: null, end: null, utc: null, period: DEFAULT_STATS_PERIOD},
+        }}
+      >
+        <Layout.Page>
+          <Feature
+            features={['performance-trace-explorer']}
+            organization={organization}
+            renderDisabled={NoAccess}
+          >
+            <TraceExplorerLandingPage />
+          </Feature>
+        </Layout.Page>
+      </PageFiltersContainer>
+    </SentryDocumentTitle>
+  );
+}


### PR DESCRIPTION
Laying out the boiler plate to start a new page for the trace explorer. Guarded behind the `performance-trace-explorer` feature flag currently.