### PR TITLE
fix(msteams): use correct team id

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -264,18 +264,11 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
         We want the KeyError exception to be raised if the key does not exist.
         """
         channel_data = data["channelData"]
+
         new_team_info = channel_data["team"]
-
-        team_id = new_team_info.get("aadGroupId", None)
-        if team_id is None:
-            logger.info(
-                "sentry.integrations.msteams.webhooks: New team info data does not have aadGroupId",
-                extra={"data": data},
-            )
-            fallback_id = new_team_info["id"]
-            team_id = fallback_id
-
+        team_id = new_team_info["id"]
         team_name = new_team_info["name"]
+
         service_url = data["serviceUrl"]
         from_data = data["from"]
         user_id = from_data["id"]

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_endpoint.py
@@ -48,8 +48,8 @@ class TestGeTeamInstallationRequestData(TestCase):
             self._example_request_data
         )
         assert response == {
-            "conversation_id": "3d5d4c90-1ae9-41c7-9471-7ccd37ddb7d4",
-            "external_id": "3d5d4c90-1ae9-41c7-9471-7ccd37ddb7d4",
+            "conversation_id": "19:7c8cd8b4b4ad4e73a2957e6daad706ef@thread.tacv2",
+            "external_id": "19:7c8cd8b4b4ad4e73a2957e6daad706ef@thread.tacv2",
             "external_name": "Sales and Marketing",
             "installation_type": "team",
             "service_url": "https://smba.trafficmanager.net/amer/",


### PR DESCRIPTION
Use the correct id when leveraging the team id
https://learn.microsoft.com/en-us/microsoftteams/platform/resources/bot-v3/bots-notifications#schema-example-bot-added-to-team

https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events?tabs=dotnet#installation-update-event