### PR TITLE
ref(login): added navigation links to welcome and help center

### DIFF
--- a/src/sentry/templates/sentry/account/recover/index.html
+++ b/src/sentry/templates/sentry/account/recover/index.html
@@ -22,5 +22,4 @@
       <button type="submit" class="btn btn-primary">{% trans "Send Email" %}</button>
     </fieldset>
   </form>
-  <p>{% blocktrans %}Need help with your account?  <a href="https://help.sentry.io/"> Click here to check out our help center.</a>{% endblocktrans %}</p>
 {% endblock %}

--- a/src/sentry/templates/sentry/account/recover/index.html
+++ b/src/sentry/templates/sentry/account/recover/index.html
@@ -22,4 +22,5 @@
       <button type="submit" class="btn btn-primary">{% trans "Send Email" %}</button>
     </fieldset>
   </form>
+  <p>{% blocktrans %}Need help with your account?  <a href="https://help.sentry.io/"> Click here to check out our help center.</a>{% endblocktrans %}</p>
 {% endblock %}

--- a/src/sentry/templates/sentry/bases/auth.html
+++ b/src/sentry/templates/sentry/bases/auth.html
@@ -18,6 +18,11 @@
     {% block auth_container %}
       <div class="auth-container p-y-2">
         {% block auth_main %}{% endblock %}
+        <p>
+          {% blocktrans %}
+            Need help with your account?  Click <a class="help-center-link" href="https://help.sentry.io/">here</a> to check out our help center.
+          {% endblocktrans %}
+        </p>
       </div>
     {% endblock %}
   </section>

--- a/src/sentry/templates/sentry/bases/auth.html
+++ b/src/sentry/templates/sentry/bases/auth.html
@@ -10,7 +10,7 @@
 
 <div class="box">
   <div class="auth-sidebar">
-    <a href="/">
+    <a href="https://sentry.io/welcome/">
       <span class="icon-sentry-logo"></span>
     </a>
   </div>

--- a/static/less/layout.less
+++ b/static/less/layout.less
@@ -169,7 +169,7 @@ body.auth {
       }
     }
 
-    a {
+    .help-center-link {
       color: #6c5fc7;
     }
   }

--- a/static/less/layout.less
+++ b/static/less/layout.less
@@ -168,6 +168,10 @@ body.auth {
         margin-bottom: 0;
       }
     }
+
+    a {
+      color: #6c5fc7;
+    }
   }
 
   .tab-content .auth-container {


### PR DESCRIPTION
Refactored auth page logo icon link to navigate to welcome page: https://sentry.io/welcome. 

Also added text, link and anchor styling on recover page for navigation to external help center:

<img width="750" alt="Screenshot 2024-03-22 at 3 11 55 PM" src="https://github.com/getsentry/sentry/assets/8451987/cb5c594a-89b8-4b0c-8e7d-984dd8242076">

