### PR TITLE
fix(replay): Correctly mock getReplay() method when a replay is deleted

### DIFF
--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -143,8 +143,8 @@ export default class ReplayReader {
       this._replayRecord = replayRecord;
       const archivedReader = new Proxy(this, {
         get(_target, prop, _receiver) {
-          if (prop === '_replayRecord') {
-            return replayRecord;
+          if (prop === 'getReplay') {
+            return () => replayRecord;
           }
           return () => {};
         },


### PR DESCRIPTION
Instead of mocking the protected member, lets mock the actual public function

Fixes JAVASCRIPT-2RC8
Fixes JAVASCRIPT-2S3J