### PR TITLE
fix(replay): Do not assume sdk provided values exist on replayRecord

### DIFF
--- a/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
+++ b/static/app/utils/replays/hooks/useLogReplayDataLoaded.tsx
@@ -65,7 +65,7 @@ function useLogReplayDataLoaded({fetchError, fetching, projectSlug, replay}: Pro
       tags: {
         // This is a boolean to reduce cardinality -- technically this can
         // match 7.8.x, but replay wasn't released in that version, so this should be fine
-        recentSdkVersion: replayRecord.sdk.version.startsWith('7.8'),
+        recentSdkVersion: replayRecord.sdk.version?.startsWith('7.8') ?? false,
       },
     };
 

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -58,8 +58,8 @@ export type ReplayRecord = {
   project_id: string;
   releases: null | string[];
   sdk: {
-    name: string;
-    version: string;
+    name: null | string;
+    version: null | string;
   };
   /**
    * The **earliest** timestamp received as determined by the SDK.


### PR DESCRIPTION
`sdk.*` was typed as string, but its coming from the sdk so we can't trust that it'll be there. So we can fix the types, the only callsite that tsc complains about is some metrics logging, so fixing that is easy too.

Fixes https://github.com/getsentry/sentry/issues/66164