### PR TITLE
fix(perf): Fix incorrect wrapping of queries in query table

### DIFF
--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -57,43 +57,39 @@ export function SpanDescriptionCell({
 
   if (moduleName === ModuleName.DB) {
     return (
-      <DescriptionWrapper>
-        <WiderHovercard
-          position="right"
-          body={
-            <FullSpanDescription
-              group={group}
-              shortDescription={rawDescription}
-              language="sql"
-            />
-          }
-        >
-          {descriptionLink}
-        </WiderHovercard>
-      </DescriptionWrapper>
+      <WiderHovercard
+        position="right"
+        body={
+          <FullSpanDescription
+            group={group}
+            shortDescription={rawDescription}
+            language="sql"
+          />
+        }
+      >
+        {descriptionLink}
+      </WiderHovercard>
     );
   }
 
   if (moduleName === ModuleName.HTTP) {
     return (
-      <DescriptionWrapper>
-        <WiderHovercard
-          position="right"
-          body={
-            <Fragment>
-              <TitleWrapper>{t('Example')}</TitleWrapper>
-              <FullSpanDescription
-                group={group}
-                shortDescription={rawDescription}
-                language="http"
-                filters={spanOp ? {[SPAN_OP]: spanOp} : undefined}
-              />
-            </Fragment>
-          }
-        >
-          {descriptionLink}
-        </WiderHovercard>
-      </DescriptionWrapper>
+      <WiderHovercard
+        position="right"
+        body={
+          <Fragment>
+            <TitleWrapper>{t('Example')}</TitleWrapper>
+            <FullSpanDescription
+              group={group}
+              shortDescription={rawDescription}
+              language="http"
+              filters={spanOp ? {[SPAN_OP]: spanOp} : undefined}
+            />
+          </Fragment>
+        }
+      >
+        {descriptionLink}
+      </WiderHovercard>
     );
   }
 
@@ -103,15 +99,10 @@ export function SpanDescriptionCell({
 const NULL_DESCRIPTION = <span>&lt;null&gt;</span>;
 
 export const WiderHovercard = styled(
-  ({
-    children,
-    className,
-    containerClassName,
-    ...props
-  }: React.ComponentProps<typeof Hovercard>) => (
+  ({children, className, ...props}: React.ComponentProps<typeof Hovercard>) => (
     <Hovercard
       className={(className ?? '') + ' wider'}
-      containerClassName={(containerClassName ?? '') + ' inline-flex'}
+      containerDisplayMode="inline-flex"
       {...props}
     >
       {children}
@@ -126,10 +117,4 @@ export const WiderHovercard = styled(
 
 const TitleWrapper = styled('div')`
   margin-bottom: ${space(1)};
-`;
-
-const DescriptionWrapper = styled('div')`
-  .inline-flex {
-    display: inline-flex;
-  }
 `;


### PR DESCRIPTION
**Before:**
<img width="688" alt="Screenshot 2024-03-25 at 10 01 56 AM" src="https://github.com/getsentry/sentry/assets/989898/033085c8-047d-4586-a1a5-b323409debad">

**After:**
<img width="812" alt="Screenshot 2024-03-25 at 10 14 24 AM" src="https://github.com/getsentry/sentry/assets/989898/7363438d-ab96-4b4c-a912-8a4115261c09">

## Explanation

This has been _slightly broken_ (correct truncation, but no ellipsis) for a few months, and _very broken_ (no truncation at all) since late last week, as of https://github.com/getsentry/sentry/pull/67494

For table cells that show hover cards (query descriptions, and resource URLs) the table cell contains a special `Hovercard` wrapper. When written, it used the `containerClassName` property to make sure it has `display: inline-flex` which allowed the children to truncate. This approach apparently stopped working at some point because `useHoverOverlay` manually sets `display: inline-block` _on the element_, which has a higher precedence in CSS.

The manual display property is configurable via the `contaienrDisplayMode` property. In this PR, I use that property instead of `containerClassName`, which fixes the wrapping behaviour. It also makes one level of wrapping elements unnecessary.

Unclear when this container behaviour broke, it's a very subtle bug. #67494 _added to it_ but changing the `GridEditable` behaviour. Something about setting table rows to a `subgrid` made the wrapping completely broken.
