### PR TITLE
feat(ddm): Add support for more use case ids in the metrics meta endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -57,11 +57,14 @@ from sentry.utils import metrics
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.dates import get_rollup_from_request, parse_stats_period
 
+# These are the use case ids that are queried by default in case no use case is supplied.
 DEFAULT_USE_CASE_IDS = [
     UseCaseID.TRANSACTIONS,
     UseCaseID.SESSIONS,
     UseCaseID.SPANS,
     UseCaseID.CUSTOM,
+    UseCaseID.PROFILES,
+    UseCaseID.METRIC_STATS,
 ]
 
 

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -395,7 +395,7 @@ def get_stored_metrics_of_projects(
     use_case_id_to_index = defaultdict(list)
     for use_case_id in use_case_ids:
         entity_keys = get_entity_keys_of_use_case_id(use_case_id=use_case_id)
-        for entity_key in entity_keys:
+        for entity_key in entity_keys or ():
             requests.append(
                 _get_metrics_by_project_for_entity_query(
                     entity_key=entity_key,


### PR DESCRIPTION
This PR adds the profiles and metric stats use cases in the meta endpoint as defaults.

Connected to: https://github.com/getsentry/sentry/pull/67596
