### PR TITLE
fix(trace): fix sibling groups

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1754,7 +1754,7 @@ function AutogroupedTraceBar(props: AutogroupedTraceBarProps) {
               key={i}
               className="TraceBar"
               style={{
-                left: `${left * 1000}%`,
+                left: `${left * 100}%`,
                 width: `${width * 100}%`,
                 backgroundColor: props.color,
               }}

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -906,8 +906,11 @@ export class VirtualizedViewManager {
     );
   }
 
-  computeRelativeLeftPositionFromOrigin(timestamp: number, node_space: [number, number]) {
-    return (timestamp - node_space[0]) / node_space[1];
+  computeRelativeLeftPositionFromOrigin(
+    timestamp: number,
+    entire_space: [number, number]
+  ) {
+    return (timestamp - entire_space[0]) / entire_space[1];
   }
 
   recomputeTimelineIntervals() {


### PR DESCRIPTION
That's a zero too many. I renamed the space arg to better show that we are speaking about the entire grouped space here