### PR TITLE
feat(code-mappings): EA automatic code mapping derivation for Go projects 

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -91,7 +91,7 @@ class ProjectRepoPathParsingEndpointLoosePermission(ProjectPermission):
 @region_silo_endpoint
 class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,  # This shouldn't be a post request? We are only fetching data on our end
     }
     permission_classes = (ProjectRepoPathParsingEndpointLoosePermission,)
     """

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -91,7 +91,7 @@ class ProjectRepoPathParsingEndpointLoosePermission(ProjectPermission):
 @region_silo_endpoint
 class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,  # This shouldn't be a post request? We are only fetching data on our end
+        "POST": ApiPublishStatus.UNKNOWN,
     }
     permission_classes = (ProjectRepoPathParsingEndpointLoosePermission,)
     """

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1531,6 +1531,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:derive-code-mappings": True,
     # Enables automatically deriving of PHP code mappings
     "organizations:derive-code-mappings-php": False,
+    # Enables automatically deriving of Go code mappings
+    "organizations:derive-code-mappings-go": False,
     # Enable device.class as a selectable column
     "organizations:device-classification": False,
     # Enables synthesis of device.class in ingest

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -65,6 +65,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:deprecate-fid-from-performance-score", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:derive-code-mappings", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:derive-code-mappings-php", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+    manager.add("organizations:derive-code-mappings-go", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:device-class-synthesis", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:device-classification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -540,12 +540,12 @@ def find_roots(stack_frame_path: FrameFilename, source_path: str) -> tuple[str, 
 
             if stack_root:  # append trailing slash
                 stack_root = f"{stack_root}{stack_path_delim}"
+                if stack_frame_path.leading_slash:
+                    stack_root = f"/{stack_root}"
             if stack_frame_path.frame_type() == "packaged":
                 next_dir = overlap_to_check[0]
                 stack_root = f"{stack_root}{next_dir}/"
                 source_root = f"{source_root}{next_dir}/"
-            if stack_frame_path.leading_slash:
-                stack_root = f"/{stack_root}"
 
             return (stack_root, source_root)
 

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import NamedTuple
 
-from sentry.api.endpoints.project_repo_path_parsing import find_roots
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.project import Project
@@ -139,7 +138,9 @@ def convert_stacktrace_frame_path_to_source_path(
 # XXX: Look at sentry.interfaces.stacktrace and maybe use that
 class FrameFilename:
     def __init__(self, frame_file_path: str) -> None:
+        self.leading_slash = False
         if frame_file_path[0] == "/":
+            self.leading_slash = True
             frame_file_path = frame_file_path.replace("/", "", 1)
 
         # Using regexes would be better but this is easier to understand
@@ -300,35 +301,17 @@ class CodeMappingTreesHelper:
             ]
 
             for file in matches:
+                stacktrace_root, source_path = find_roots(frame_filename, file)
                 file_matches.append(
                     {
                         "filename": file,
                         "repo_name": repo_tree.repo.name,
                         "repo_branch": repo_tree.repo.branch,
-                        "stacktrace_root": f"{frame_filename.root}/",
-                        "source_path": _get_code_mapping_source_path(file, frame_filename),
+                        "stacktrace_root": stacktrace_root,
+                        "source_path": source_path,
                     }
                 )
         return file_matches
-
-    def _normalized_stack_and_source_roots(
-        self, stacktrace_root: str, source_path: str
-    ) -> tuple[str, str]:
-        # We have a one to one code mapping (e.g. "app/" & "app/")
-        if source_path == stacktrace_root:
-            stacktrace_root = ""
-            source_path = ""
-        # stacktrace_root starts with a FILE_PATH_PREFIX_REGEX
-        elif (without := remove_straight_path_prefix(stacktrace_root)) != stacktrace_root:
-            start_index = get_straight_path_prefix_end_index(stacktrace_root)
-            starts_with = stacktrace_root[:start_index]
-            if source_path == without:
-                stacktrace_root = starts_with
-                source_path = ""
-            elif source_path.rfind(f"/{without}"):
-                stacktrace_root = starts_with
-                source_path = source_path.replace(f"/{without}", "/")
-        return (stacktrace_root, source_path)
 
     def _generate_code_mapping_from_tree(
         self,
@@ -342,18 +325,9 @@ class CodeMappingTreesHelper:
         ]
         if len(matched_files) != 1:
             return []
-        # this will not work for
-        # if frame_filename.extension == "go":
-        if frame_filename.frame_type() != "packaged":
-            stacktrace_root, source_path = find_roots(frame_filename.full_path, matched_files[0])
-        else:
-            stacktrace_root = f"{frame_filename.root}/"
-            source_path = _get_code_mapping_source_path(matched_files[0], frame_filename)
 
-        if frame_filename.frame_type() != "packaged":
-            stacktrace_root, source_path = self._normalized_stack_and_source_roots(
-                stacktrace_root, source_path
-            )
+        stacktrace_root, source_path = find_roots(frame_filename, matched_files[0])
+
         # It is too risky generating code mappings when there's more
         # than one file potentially matching
         return [
@@ -405,12 +379,25 @@ class CodeMappingTreesHelper:
     def _potential_match_no_transformation(
         self, src_file: str, frame_filename: FrameFilename
     ) -> bool:
+        """
+        This function determines if a file's source path in a github repo (src_path)
+        matches a stack trace's file path (frame_filename.file_and_dir_path).
+
+        Typically, we can just check if any trailing substring of the source path contains
+        the stack trace's file path.
+
+        However, if the stack trace's file path is longer than the source paths
+        (which can occur if the project platform uses absolute paths in the stack trace)
+        then we check to see if the tail of the stack trace (as opposed to the entire
+        stack trace) matches any trailing substring of the source path.
+        """
         # src_file: static/app/utils/handleXhrErrorResponse.tsx
         # full_name: ./app/utils/handleXhrErrorResponse.tsx
         # file_and_dir_path: app/utils/handleXhrErrorResponse.tsx
         src_file_items = src_file.split("/")
         file_and_dir_path_items = frame_filename.file_and_dir_path.split("/")
         if len(file_and_dir_path_items) > len(src_file_items):
+
             num_relevant_items = max(1, len(src_file_items) - 1)
             relevant_items = file_and_dir_path_items[
                 (len(file_and_dir_path_items) - num_relevant_items) :
@@ -444,6 +431,9 @@ def create_code_mapping(
     project: Project,
     code_mapping: CodeMapping,
 ) -> RepositoryProjectPathConfig:
+    """
+    This function creates and saves a code mapping for a given project
+    """
     repository, _ = Repository.objects.get_or_create(
         name=code_mapping.repo.name,
         organization_id=organization_integration.organization_id,
@@ -534,39 +524,12 @@ def get_sorted_code_mapping_configs(project: Project) -> list[RepositoryProjectP
     return sorted_configs
 
 
-# Why is this called get source path? It gets the source ROOT, not the source path.
-def _get_code_mapping_source_path(src_file: str, frame_filename: FrameFilename) -> str:
-    """Generate the source code root for a code mapping. It always includes a trailing slash"""
-    source_code_root = ""
-    if frame_filename.frame_type() == "packaged":
-        if frame_filename.dir_path != "":
-            # src/sentry/identity/oauth2.py (sentry/identity/oauth2.py) -> src/sentry/
-            source_path = src_file.rsplit(frame_filename.dir_path)[0].rstrip("/")
-            source_code_root = f"{source_path}/"
-        elif frame_filename.root != "":
-            # src/sentry/wsgi.py (sentry/wsgi.py) -> src/sentry/
-            source_code_root = src_file.rsplit(frame_filename.file_name)[0]
-        else:
-            # ssl.py -> raise NotImplementedError
-            raise NotImplementedError("We do not support top level files.")
-    else:
-        # static/app/foo.tsx (./app/foo.tsx) -> static/app/
-        # static/app/foo.tsx (app/foo.tsx) -> static/app/
-
-        # if frame_filename.extension == "go":
-        #     _, source_code_root = find_roots(f"{frame_filename.file_and_dir_path}", src_file)
-        # else:
-        source_code_root = f"{src_file.replace(frame_filename.file_and_dir_path, remove_straight_path_prefix(frame_filename.root))}/"
-    if source_code_root:
-        assert source_code_root.endswith("/")
-    return source_code_root
-
-
-def find_roots(stack_path: str, source_path: str) -> tuple[str, str]:
+def find_roots(stack_frame_path: FrameFilename, source_path: str) -> tuple[str, str]:
     """
     Returns a tuple containing the stack_root, and the source_root.
     If there is no overlap, raise an exception since this should not happen
     """
+    stack_path = stack_frame_path.full_path
     stack_path_delim = SLASH if SLASH in stack_path else BACKSLASH
     overlap_to_check = stack_path.split(stack_path_delim)
     stack_root_items: list[str] = []
@@ -577,6 +540,12 @@ def find_roots(stack_path: str, source_path: str) -> tuple[str, str]:
 
             if stack_root:  # append trailing slash
                 stack_root = f"{stack_root}{stack_path_delim}"
+            if stack_frame_path.frame_type() == "packaged":
+                next_dir = overlap_to_check[0]
+                stack_root = f"{stack_root}{next_dir}/"
+                source_root = f"{source_root}{next_dir}/"
+            if stack_frame_path.leading_slash:
+                stack_root = f"/{stack_root}"
 
             return (stack_root, source_root)
 

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -22,7 +22,7 @@ from sentry.utils.json import JSONData
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.safe import get_path
 
-SUPPORTED_LANGUAGES = ["javascript", "python", "node", "ruby", "php"]
+SUPPORTED_LANGUAGES = ["javascript", "python", "node", "ruby", "php", "go"]
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +107,11 @@ def derive_code_mappings(
         "organizations:derive-code-mappings-php", org
     ):
         return
+
+    # if data["platform"].startswith("go") and not features.has(
+    #     "organizations:derive-code-mappings-go", org
+    # ):
+    #     return
 
     stacktrace_paths: list[str] = identify_stacktrace_paths(data)
     if not stacktrace_paths:

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -108,10 +108,10 @@ def derive_code_mappings(
     ):
         return
 
-    # if data["platform"].startswith("go") and not features.has(
-    #     "organizations:derive-code-mappings-go", org
-    # ):
-    #     return
+    if data["platform"].startswith("go") and not features.has(
+        "organizations:derive-code-mappings-go", org
+    ):
+        return
 
     stacktrace_paths: list[str] = identify_stacktrace_paths(data)
     if not stacktrace_paths:

--- a/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
@@ -5,11 +5,7 @@ from django.db import router
 from django.urls import reverse
 from rest_framework import status
 
-from sentry.integrations.utils.code_mapping import (
-    FrameFilename,
-    UnsupportedFrameFilename,
-    _get_code_mapping_source_path,
-)
+from sentry.integrations.utils.code_mapping import FrameFilename, UnsupportedFrameFilename
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
@@ -67,15 +63,14 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
     @patch("sentry.integrations.github.GitHubIntegration.get_trees_for_org")
     def test_get_start_with_backslash(self, mock_get_trees_for_org):
         file = "stack/root/file.py"
-        frame_info = FrameFilename(f"/{file}")
         config_data = {"stacktraceFilename": f"/{file}"}
         expected_matches = [
             {
                 "filename": file,
                 "repo_name": "getsentry/codemap",
                 "repo_branch": "master",
-                "stacktrace_root": f"{frame_info.root}",
-                "source_path": _get_code_mapping_source_path(file, frame_info),
+                "stacktrace_root": "",
+                "source_path": "",
             }
         ]
         with patch(
@@ -228,7 +223,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
 
     # - This test case is a FALSE POSITIVE (it does NOT achieve the desired behavior, but has been made to artificially pass the test case)
     # - References GitHub issue #66852 (Top-level files are not supported in code mapping even though they should be)
-    # - Remove the patch and uncomment the rest of the test case to see expected, non-erroneous behvaior
+    # - Uncomment the commented code and remove the with pytest.raises block for the actual expected behavior
     @patch("sentry.integrations.github.GitHubIntegration.get_trees_for_org")
     def test_get_top_level_file(self, mock_get_trees_for_org):
         file = "index.php"
@@ -243,8 +238,8 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
         #         "filename": file,
         #         "repo_name": "getsentry/codemap",
         #         "repo_branch": "master",
-        #         "stacktrace_root": f"{frame_info.root}",
-        #         "source_path": _get_code_mapping_source_path(file, frame_info),
+        #         "stacktrace_root": "",
+        #         "source_path": "",
         #     }
         # ]
         # with patch(

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -271,64 +271,6 @@ class TestDerivedCodeMappings(TestCase):
         ]
         assert matches == expected_matches
 
-    def test_normalized_stack_and_source_roots_starts_with_period_slash(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "./app/", "static/app/"
-        )
-        assert stacktrace_root == "./"
-        assert source_path == "static/"
-
-    def test_normalized_stack_and_source_roots_starts_with_period_slash_no_containing_directory(
-        self,
-    ):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "./app/", "app/"
-        )
-        assert stacktrace_root == "./"
-        assert source_path == ""
-
-    def test_normalized_stack_and_source_not_matching(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "sentry/", "src/sentry/"
-        )
-        assert stacktrace_root == "sentry/"
-        assert source_path == "src/sentry/"
-
-    def test_normalized_stack_and_source_roots_equal(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "source/", "source/"
-        )
-        assert stacktrace_root == ""
-        assert source_path == ""
-
-    def test_normalized_stack_and_source_roots_starts_with_period_slash_two_levels(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "./app/", "app/foo/app/"
-        )
-        assert stacktrace_root == "./"
-        assert source_path == "app/foo/"
-
-    def test_normalized_stack_and_source_roots_starts_with_app(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "app:///utils/", "utils/"
-        )
-        assert stacktrace_root == "app:///"
-        assert source_path == ""
-
-    def test_normalized_stack_and_source_roots_starts_with_multiple_dot_dot_slash(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "../../../../../../packages/", "packages/"
-        )
-        assert stacktrace_root == "../../../../../../"
-        assert source_path == ""
-
-    def test_normalized_stack_and_source_roots_starts_with_app_dot_dot_slash(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "app:///../services/", "services/"
-        )
-        assert stacktrace_root == "app:///../"
-        assert source_path == ""
-
 
 class TestConvertStacktraceFramePathToSourcePath(TestCase):
     def setUp(self):

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -429,8 +429,8 @@ class TestPhpDeriveCodeMappings(BaseDeriveCodeMappings):
             }
             derive_code_mappings(self.project.id, self.event_data)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
-            assert code_mapping.stack_root == "sentry/"
-            assert code_mapping.source_root == "src/sentry/"
+            assert code_mapping.stack_root == ""
+            assert code_mapping.source_root == "src/"
             assert code_mapping.repository.name == repo_name
 
 

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -338,10 +338,16 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
                     "in_app": True,
                     "filename": "/Users/JohnDoe/Documents/code/sentry/kangaroo.go",
                 },
+                {
+                    "in_app": True,
+                    "filename": "/src/cmd/vroom/profile.go",
+                },
             ],
             self.platform,
         )
 
+    @responses.activate
+    @with_feature({"organizations:derive-code-mappings-go": True})
     def test_derive_code_mappings_go_abs_filename(self):
         repo_name = "go_repo"
         with patch(
@@ -356,6 +362,8 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.source_root == ""
             assert code_mapping.repository.name == repo_name
 
+    @responses.activate
+    @with_feature({"organizations:derive-code-mappings-go": True})
     def test_derive_code_mappings_go_long_abs_filename(self):
         repo_name = "go_repo"
         with patch(
@@ -367,6 +375,22 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
             derive_code_mappings(self.project.id, self.event_data)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
             assert code_mapping.stack_root == "/Users/JohnDoe/Documents/code/"
+            assert code_mapping.source_root == ""
+            assert code_mapping.repository.name == repo_name
+
+    @responses.activate
+    @with_feature({"organizations:derive-code-mappings-go": True})
+    def test_derive_code_mappings_go_normal(self):
+        repo_name = "go_repo"
+        with patch(
+            "sentry.integrations.github.client.GitHubClientMixin.get_trees_for_org"
+        ) as mock_get_trees_for_org:
+            mock_get_trees_for_org.return_value = {
+                repo_name: RepoTree(Repo(repo_name, "master"), ["cmd/vroom/profile.go"])
+            }
+            derive_code_mappings(self.project.id, self.event_data)
+            code_mapping = RepositoryProjectPathConfig.objects.all()[0]
+            assert code_mapping.stack_root == "/src/"
             assert code_mapping.source_root == ""
             assert code_mapping.repository.name == repo_name
 


### PR DESCRIPTION
Changes contained in this PR:

- **Adds support for Go automatic code mappings**
- **Refactor how source code and stack trace roots are derived. This also unifies the root derivation logic between derive_code_mappings and the repo_path_parsing endpoint**
- Adds a false positive test case for #66852 for visibility 