### PR TITLE
ref(weekly report): Fix flaky test

### DIFF
--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -326,10 +326,8 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
         # without the flag, resolved issues are not filtered out
         key_errors = project_key_errors(ctx, self.project, Referrer.REPORTS_KEY_ERRORS.value)
-        assert key_errors == [
-            {"group_id": event1.group.id, "count()": 1},
-            {"group_id": group2.id, "count()": 1},
-        ]
+        assert {"group_id": event1.group.id, "count()": 1} in key_errors
+        assert {"group_id": group2.id, "count()": 1} in key_errors
 
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -326,6 +326,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
         # without the flag, resolved issues are not filtered out
         key_errors = project_key_errors(ctx, self.project, Referrer.REPORTS_KEY_ERRORS.value)
+        assert key_errors
         assert {"group_id": event1.group.id, "count()": 1} in key_errors
         assert {"group_id": group2.id, "count()": 1} in key_errors
 


### PR DESCRIPTION
Assert separately so the order doesn't matter. Fixes https://sentry.sentry.io/issues/5084595643/