### PR TITLE
feat(crons): Mute severely broken environments and email users

### DIFF
--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -260,3 +260,196 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             ],
             any_order=True,
         )
+
+    @with_feature("organizations:crons-broken-monitor-detection")
+    @patch("sentry.monitors.tasks.detect_broken_monitor_envs.MessageBuilder")
+    @patch("django.utils.timezone.now")
+    def test_disables_environments_and_sends_email(self, mock_now, builder):
+        now = before_now()
+        mock_now.return_value = now
+        monitor, monitor_environment = self.create_monitor_and_env()
+
+        second_user = self.create_user("second_user@example.com")
+        second_org = self.create_organization(owner=second_user)
+        self.create_member(user=self.user, organization=second_org)
+        second_team = self.create_team(organization=second_org, members=[second_user, self.user])
+        second_project = self.create_project(organization=second_org, teams=[second_team])
+        second_env = self.create_environment(second_project, name="production")
+
+        second_monitor, second_monitor_environment = self.create_monitor_and_env(
+            name="second monitor",
+            organization_id=second_org.id,
+            project_id=second_project.id,
+            environment_id=second_env.id,
+        )
+
+        incident = self.create_incident_for_monitor_env(monitor, monitor_environment)
+        second_incident = self.create_incident_for_monitor_env(
+            second_monitor, second_monitor_environment
+        )
+
+        broken_detection = MonitorEnvBrokenDetection.objects.create(
+            monitor_incident=incident,
+            detection_timestamp=now - timedelta(days=14),
+            user_notified_timestamp=now - timedelta(days=14),
+        )
+        second_broken_detection = MonitorEnvBrokenDetection.objects.create(
+            monitor_incident=second_incident,
+            detection_timestamp=now - timedelta(days=14),
+            user_notified_timestamp=now - timedelta(days=14),
+        )
+
+        detect_broken_monitor_envs()
+
+        # should have the two monitor environments as muted
+        monitor_environment.refresh_from_db()
+        second_monitor_environment.refresh_from_db()
+        assert monitor_environment.is_muted
+        assert second_monitor_environment.is_muted
+
+        broken_detection.refresh_from_db()
+        second_broken_detection.refresh_from_db()
+        assert broken_detection.env_muted_timestamp == now
+        assert second_broken_detection.env_muted_timestamp == now
+
+        # should build 3 emails, 2 for self.user from the 2 orgs, and 1 for second_user
+        expected_contexts = [
+            {
+                "muted_monitors": [
+                    (
+                        monitor.slug,
+                        f"http://testserver/organizations/{self.organization.slug}/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
+                        timezone.now() - timedelta(days=14),
+                    )
+                ],
+                "view_monitors_link": f"http://testserver/organizations/{self.organization.slug}/crons/",
+            },
+            {
+                "muted_monitors": [
+                    (
+                        second_monitor.slug,
+                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        timezone.now() - timedelta(days=14),
+                    )
+                ],
+                "view_monitors_link": f"http://testserver/organizations/{second_org.slug}/crons/",
+            },
+            {
+                "muted_monitors": [
+                    (
+                        second_monitor.slug,
+                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        timezone.now() - timedelta(days=14),
+                    )
+                ],
+                "view_monitors_link": f"http://testserver/organizations/{second_org.slug}/crons/",
+            },
+        ]
+
+        builder.assert_has_calls(
+            [
+                call(
+                    **{
+                        "subject": "Your Cron Monitors have been muted",
+                        "template": "sentry/emails/crons/muted-monitors.txt",
+                        "html_template": "sentry/emails/crons/muted-monitors.html",
+                        "type": "crons.muted_monitors",
+                        "context": context,
+                    }
+                )
+                for context in expected_contexts
+            ],
+            any_order=True,
+        )
+
+    @with_feature("organizations:crons-broken-monitor-detection")
+    @patch("sentry.monitors.tasks.detect_broken_monitor_envs.MessageBuilder")
+    @patch("django.utils.timezone.now")
+    def test_disables_corrects_environments_and_sends_email(self, mock_now, builder):
+        now = before_now()
+        mock_now.return_value = now
+        monitor, monitor_environment = self.create_monitor_and_env()
+
+        second_user = self.create_user("second_user@example.com")
+        second_org = self.create_organization(owner=second_user)
+        self.create_member(user=self.user, organization=second_org)
+        second_team = self.create_team(organization=second_org, members=[second_user, self.user])
+        second_project = self.create_project(organization=second_org, teams=[second_team])
+        second_env = self.create_environment(second_project, name="production")
+
+        second_monitor, second_monitor_environment = self.create_monitor_and_env(
+            name="second monitor",
+            organization_id=second_org.id,
+            project_id=second_project.id,
+            environment_id=second_env.id,
+        )
+
+        incident = self.create_incident_for_monitor_env(monitor, monitor_environment)
+        second_incident = self.create_incident_for_monitor_env(
+            second_monitor, second_monitor_environment
+        )
+
+        # This broken detection shouldn't be automatically disabled, because it's not long enough
+        broken_detection = MonitorEnvBrokenDetection.objects.create(
+            monitor_incident=incident,
+            detection_timestamp=now - timedelta(days=10),
+            user_notified_timestamp=now - timedelta(days=10),
+        )
+        second_broken_detection = MonitorEnvBrokenDetection.objects.create(
+            monitor_incident=second_incident,
+            detection_timestamp=now - timedelta(days=14),
+            user_notified_timestamp=now - timedelta(days=14),
+        )
+
+        detect_broken_monitor_envs()
+
+        # should have the one monitor environment as muted
+        monitor_environment.refresh_from_db()
+        second_monitor_environment.refresh_from_db()
+        assert not monitor_environment.is_muted
+        assert second_monitor_environment.is_muted
+
+        broken_detection.refresh_from_db()
+        second_broken_detection.refresh_from_db()
+        assert broken_detection.env_muted_timestamp is None
+        assert second_broken_detection.env_muted_timestamp == now
+
+        # should build 3 emails, 2 for self.user from the 2 orgs, and 1 for second_user
+        expected_contexts = [
+            {
+                "muted_monitors": [
+                    (
+                        second_monitor.slug,
+                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        timezone.now() - timedelta(days=14),
+                    )
+                ],
+                "view_monitors_link": f"http://testserver/organizations/{second_org.slug}/crons/",
+            },
+            {
+                "muted_monitors": [
+                    (
+                        second_monitor.slug,
+                        f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
+                        timezone.now() - timedelta(days=14),
+                    )
+                ],
+                "view_monitors_link": f"http://testserver/organizations/{second_org.slug}/crons/",
+            },
+        ]
+
+        builder.assert_has_calls(
+            [
+                call(
+                    **{
+                        "subject": "Your Cron Monitors have been muted",
+                        "template": "sentry/emails/crons/muted-monitors.txt",
+                        "html_template": "sentry/emails/crons/muted-monitors.html",
+                        "type": "crons.muted_monitors",
+                        "context": context,
+                    }
+                )
+                for context in expected_contexts
+            ],
+            any_order=True,
+        )


### PR DESCRIPTION
After a 14 day period of us notifying a customer that their monitor environment is broken and they have not taken action to restore it, we choose to automatically mute the monitor

Relies on: https://github.com/getsentry/sentry/pull/67553, https://github.com/getsentry/sentry/pull/67611

Closes: https://github.com/getsentry/team-crons/issues/138, https://github.com/getsentry/team-crons/issues/144