### PR TITLE
fix(email) Fix errors when inbound replies have no body_plain

### DIFF
--- a/src/sentry/web/frontend/mailgun_inbound_webhook.py
+++ b/src/sentry/web/frontend/mailgun_inbound_webhook.py
@@ -63,7 +63,7 @@ class MailgunInboundWebhookView(View):
             logger.info("mailgun.invalid-email", extra={"email": to_email})
             return HttpResponse(status=200)
 
-        payload = EmailReplyParser.parse_reply(request.POST["body-plain"]).strip()
+        payload = EmailReplyParser.parse_reply(request.POST.get("body-plain", "").strip())
         if not payload:
             # If there's no body, we don't need to go any further
             return HttpResponse(status=200)

--- a/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
+++ b/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
@@ -53,6 +53,25 @@ class TestMailgunInboundWebhookView(TestCase):
         qs = ControlOutbox.objects.filter(category=OutboxCategory.ISSUE_COMMENT_UPDATE)
         assert qs.exists() is False
 
+    def test_missing_body_plain(self):
+        token = "a" * 50
+        timestamp = "1422513193"
+        signature = "e018afea61a8eeb2f309972385b123e376079462895ebd1ede5391fb7680b6db"
+        with self.options({"mail.mailgun-api-key": token}):
+            resp = self.client.post(
+                reverse("sentry-mailgun-inbound-hook"),
+                {
+                    "recipient": self.mailto,
+                    "sender": self.user.email,
+                    "signature": signature,
+                    "token": token,
+                    "timestamp": timestamp,
+                },
+            )
+        assert resp.status_code == 200
+        qs = ControlOutbox.objects.filter(category=OutboxCategory.ISSUE_COMMENT_UPDATE)
+        assert qs.exists() is False
+
     def test_success(self):
         token = "a" * 50
         timestamp = "1422513193"


### PR DESCRIPTION
This has happened a few times in production and while harmless I don't want more alerts firing.

Fixes SENTRY-32Q7
