### PR TITLE
feat(replays): Implement retry policy for replay GCS uploads

### DIFF
--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -186,7 +186,7 @@ class GoogleCloudFile(File):
                 )
                 if "r" in self._mode:
                     self._is_dirty = False
-                    self.storage.try_get(_try_download)
+                    self._storage.try_get(_try_download)
         return self._file
 
     @file.setter

--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import mimetypes
 import os
 import posixpath
+from collections.abc import Callable
 from tempfile import SpooledTemporaryFile
 
 from django.conf import settings
@@ -22,6 +23,7 @@ from requests.exceptions import RequestException
 
 from sentry.net.http import TimeoutAdapter
 from sentry.utils import metrics
+from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 
 # how many times do we want to try if stuff goes wrong
 GCS_RETRIES = 5
@@ -184,7 +186,7 @@ class GoogleCloudFile(File):
                 )
                 if "r" in self._mode:
                     self._is_dirty = False
-                    try_repeated(_try_download)
+                    self.storage.try_get(_try_download)
         return self._file
 
     @file.setter
@@ -213,7 +215,7 @@ class GoogleCloudFile(File):
 
         if self._file is not None:
             if self._is_dirty:
-                try_repeated(_try_upload)
+                self._storage.try_set(_try_upload)
             self._file.close()
             self._file = None
 
@@ -278,7 +280,7 @@ class GoogleCloudStorage(Storage):
             content.name = cleaned_name
             encoded_name = self._encode_name(name)
             file = GoogleCloudFile(encoded_name, "w", self)
-            try_repeated(_try_upload)
+            self.try_set(_try_upload)
         return cleaned_name
 
     def delete(self, name):
@@ -287,7 +289,7 @@ class GoogleCloudStorage(Storage):
             self.bucket.delete_blob(self._encode_name(normalized_name))
 
         try:
-            try_repeated(_try_delete)
+            self.try_del(_try_delete)
         except NotFound:
             pass
 
@@ -361,3 +363,43 @@ class GoogleCloudStorage(Storage):
             name = clean_name(name)
             return name
         return super().get_available_name(name, max_length)
+
+    def try_del(self, callable: Callable[[], None]) -> None:
+        self._try(callable)
+
+    def try_get(self, callable: Callable[[], None]) -> None:
+        self._try(callable)
+
+    def try_set(self, callable: Callable[[], None]) -> None:
+        self._try(callable)
+
+    def _try(self, callable: Callable[[], None]) -> None:
+        # The default policy since 2018 has been to retry five times in a loop with no backoff
+        # for gets, sets, and deletes. This behavior has been preserved here.
+        #
+        # To implement a custom retry policy see `src/sentry/utils/retries.py` and the
+        # `GoogleCloudStorageReplayUploadPolicy` class.
+        try_repeated(callable)
+
+
+class GoogleCloudStorageReplayUploadPolicy(GoogleCloudStorage):
+    """Replay upload-policy blob-storage class."""
+
+    # "try_del" and "try_get" inherit the default behavior. We don't want to exponentially
+    # wait in those contexts. We're maintaining the status-quo for now but in the future we
+    # can add policies for these methods or use no policy at all and implement retries at a
+    # higher, more contextual level.
+    #
+    # def try_del(self, callable: Callable[[], None]) -> None:
+    # def try_get(self, callable: Callable[[], None]) -> None:
+
+    def try_set(self, callable: Callable[[], None]) -> None:
+        """Upload a blob with exponential delay for a maximum of five attempts."""
+
+        def should_retry(attempt: int, e: Exception) -> bool:
+            """Retry gateway timeout exceptions up to the limit."""
+            return attempt <= GCS_RETRIES and isinstance(e, GatewayTimeout)
+
+        # Retry cadence: 0.25, 0.5, 1, 2, 4, 8
+        policy = ConditionalRetryPolicy(should_retry, exponential_delay(0.5))
+        policy(callable)

--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -381,12 +381,12 @@ class GoogleCloudStorage(Storage):
         # for gets, sets, and deletes. This behavior has been preserved here.
         #
         # To implement a custom retry policy see `src/sentry/utils/retries.py` and the
-        # `GoogleCloudStorageReplayUploadPolicy` class.
+        # `GoogleCloudStorageWithReplayUploadPolicy` class.
         try_repeated(callable)
 
 
-class GoogleCloudStorageReplayUploadPolicy(GoogleCloudStorage):
-    """Replay upload-policy blob-storage class."""
+class GoogleCloudStorageWithReplayUploadPolicy(GoogleCloudStorage):
+    """Google cloud storage class with replay upload policy."""
 
     # "try_del" and "try_get" inherit the default behavior. We don't want to exponentially
     # wait in those contexts. We're maintaining the status-quo for now but in the future we


### PR DESCRIPTION
The replay consumer occasionally receives GatewayTimeout errors.  Currently we retry in a loop with no delay.  Instead we'd like to retry with exponential delay. This will give GCS some time to recover.  This will (hopefully) be better for the consumer's health and limit the number of times we have to reprocess events after a crash.