### PR TITLE
feat(api-idorslug): Created IdOrSlug Lookup

### DIFF
--- a/src/sentry/db/models/fields/slug.py
+++ b/src/sentry/db/models/fields/slug.py
@@ -1,4 +1,5 @@
 from django.db.models import SlugField
+from django.db.models.lookups import Lookup
 
 from sentry.slug.validators import no_numeric_validator, org_slug_validator
 
@@ -9,3 +10,22 @@ class SentrySlugField(SlugField):
 
 class SentryOrgSlugField(SlugField):
     default_validators = [*SlugField.default_validators, org_slug_validator]
+
+
+class IdOrSlugLookup(Lookup):
+    lookup_name = "id_or_slug"
+
+    def as_sql(self, compiler, connection):
+        # We can ignore the lhs because we know that the lhs will
+        # query either 'slug' or 'id'
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+
+        if rhs_params and rhs_params[0].isnumeric():
+            # If numeric, use the 'id' field for comparison
+            return f"id = {rhs}", rhs_params
+        else:
+            # If not numeric, use the 'slug' field for comparison
+            return f"slug = {rhs}", rhs_params
+
+
+SentrySlugField.register_lookup(IdOrSlugLookup)

--- a/src/sentry/db/models/fields/slug.py
+++ b/src/sentry/db/models/fields/slug.py
@@ -20,7 +20,7 @@ class IdOrSlugLookup(Lookup):
         # query either 'slug' or 'id'
         rhs, rhs_params = self.process_rhs(compiler, connection)
 
-        if rhs_params and rhs_params[0].isnumeric():
+        if rhs_params and str(rhs_params[0]).isnumeric():
             # If numeric, use the 'id' field for comparison
             return f"id = {rhs}", rhs_params
         else:

--- a/tests/sentry/db/models/fields/test_slug.py
+++ b/tests/sentry/db/models/fields/test_slug.py
@@ -78,7 +78,7 @@ class IdOrSlugLookupTests(TestCase):
         self.assertEqual(params, ["123slug"])
 
     @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_rhs")
-    def test_as_sql_with_alphaetic_rhs(self, mock_process_rhs) -> None:
+    def test_as_sql_with_alphabetic_rhs(self, mock_process_rhs) -> None:
         mock_process_rhs.return_value = ("%s", ["slug"])
 
         lookup = IdOrSlugLookup("slug__id_or_slug", "slug")

--- a/tests/sentry/db/models/fields/test_slug.py
+++ b/tests/sentry/db/models/fields/test_slug.py
@@ -1,7 +1,9 @@
+from unittest.mock import Mock, patch
+
 import pytest
 from django.core.exceptions import ValidationError
 
-from sentry.db.models.fields.slug import SentryOrgSlugField, SentrySlugField
+from sentry.db.models.fields.slug import IdOrSlugLookup, SentryOrgSlugField, SentrySlugField
 from sentry.testutils.cases import TestCase
 
 
@@ -47,3 +49,41 @@ class TestSentryOrgSlugField(TestCase):
     def test_with_underscore(self) -> None:
         with pytest.raises(ValidationError):
             self.field.run_validators("dfj49_29dFJ")
+
+
+class IdOrSlugLookupTests(TestCase):
+    def setUp(self) -> None:
+        self.compiler = Mock()
+        self.connection = Mock()
+
+    @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_rhs")
+    def test_as_sql_with_numeric_rhs(self, mock_process_rhs) -> None:
+        mock_process_rhs.return_value = ("%s", ["123"])
+
+        lookup = IdOrSlugLookup("id__id_or_slug", "123")
+        sql, params = lookup.as_sql(self.compiler, self.connection)
+
+        self.assertEqual(sql, "id = %s")
+        self.assertEqual(params, ["123"])
+
+    @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_rhs")
+    def test_as_sql_with_non_numeric_rhs(self, mock_process_rhs) -> None:
+        mock_process_rhs.return_value = ("%s", ["123slug"])
+
+        lookup = IdOrSlugLookup("slug__id_or_slug", "123slug")
+
+        sql, params = lookup.as_sql(self.compiler, self.connection)
+
+        self.assertEqual(sql, "slug = %s")
+        self.assertEqual(params, ["123slug"])
+
+    @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_rhs")
+    def test_as_sql_with_alphaetic_rhs(self, mock_process_rhs) -> None:
+        mock_process_rhs.return_value = ("%s", ["slug"])
+
+        lookup = IdOrSlugLookup("slug__id_or_slug", "slug")
+
+        sql, params = lookup.as_sql(self.compiler, self.connection)
+
+        self.assertEqual(sql, "slug = %s")
+        self.assertEqual(params, ["slug"])


### PR DESCRIPTION
The lookup will be used in `convert_args` functions to handle resource id as well as slugs in our apis
Something like:
```
doc_integration = DocIntegration.objects.get(slug__id_or_slug=doc_integration_slug)
```

For: https://github.com/getsentry/team-core-product-foundations/issues/194