### PR TITLE
feat(new-trace): Preventing duplication of issues.

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -274,7 +274,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
   function renderSpanErrorMessage() {
     const {span, organization, node} = props;
 
-    const hasErrors = node.errors.length > 0 || node.performance_issues.length > 0;
+    const hasErrors = node.errors.size > 0 || node.performance_issues.size > 0;
 
     if (!hasErrors || isGapSpan(span)) {
       return null;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
@@ -36,6 +36,10 @@ export function ErrorNodeDetails({
   organization: Organization;
   scrollToNode: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
 }) {
+  const issues = useMemo(() => {
+    return [...node.errors];
+  }, [node.errors]);
+
   const {isLoading, data} = useApiQuery<EventError>(
     [
       `/organizations/${organization.slug}/events/${node.value.project_slug}:${node.value.event_id}/`,
@@ -89,7 +93,7 @@ export function ErrorNodeDetails({
         </TraceDrawerComponents.Actions>
       </TraceDrawerComponents.HeaderContainer>
 
-      <IssueList issues={node.errors} node={node} organization={organization} />
+      <IssueList issues={issues} node={node} organization={organization} />
 
       <TraceDrawerComponents.Table className="table key-value">
         <tbody>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -177,7 +177,7 @@ function IssueListHeader({node}: {node: TraceTreeNode<TraceTree.NodeValue>}) {
   return (
     <StyledPanelHeader disablePadding>
       <IssueHeading>
-        {errors.length + performance_issues.length > MAX_DISPLAYED_ISSUES_COUNT
+        {errors.size + performance_issues.size > MAX_DISPLAYED_ISSUES_COUNT
           ? tct(`[count]+  issues, [link]`, {
               count: MAX_DISPLAYED_ISSUES_COUNT,
               link: (
@@ -196,30 +196,30 @@ function IssueListHeader({node}: {node: TraceTreeNode<TraceTree.NodeValue>}) {
                 </StyledLink>
               ),
             })
-          : errors.length > 0 && performance_issues.length === 0
+          : errors.size > 0 && performance_issues.size === 0
             ? tct('[count] [text]', {
-                count: errors.length,
-                text: tn('Error', 'Errors', errors.length),
+                count: errors.size,
+                text: tn('Error', 'Errors', errors.size),
               })
-            : performance_issues.length > 0 && errors.length === 0
+            : performance_issues.size > 0 && errors.size === 0
               ? tct('[count] [text]', {
-                  count: performance_issues.length,
+                  count: performance_issues.size,
                   text: tn(
                     'Performance issue',
                     'Performance Issues',
-                    performance_issues.length
+                    performance_issues.size
                   ),
                 })
               : tct(
                   '[errors] [errorsText] and [performance_issues] [performanceIssuesText]',
                   {
-                    errors: errors.length,
-                    performance_issues: performance_issues.length,
-                    errorsText: tn('Error', 'Errors', errors.length),
+                    errors: errors.size,
+                    performance_issues: performance_issues.size,
+                    errorsText: tn('Error', 'Errors', errors.size),
                     performanceIssuesText: tn(
                       'performance issue',
                       'performance issues',
-                      performance_issues.length
+                      performance_issues.size
                     ),
                   }
                 )}

--- a/static/app/views/performance/newTraceDetails/traceHeader.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader.tsx
@@ -97,9 +97,9 @@ export default function TraceHeader({
     throw new Error('Expected a trace node');
   }
 
-  const errors = traceNode.errors.length || metaResults.data?.errors || 0;
+  const errors = traceNode.errors.size || metaResults.data?.errors || 0;
   const performanceIssues =
-    traceNode.performance_issues.length || metaResults.data?.performance_issues || 0;
+    traceNode.performance_issues.size || metaResults.data?.performance_issues || 0;
   const errorsAndIssuesCount = errors + performanceIssues;
 
   const replay_id = rootEventResults?.data?.contexts.replay?.replay_id;

--- a/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
@@ -1842,8 +1842,8 @@ describe('TraceTree', () => {
           project_slug: '',
           event_id: '',
         });
-        node.errors = [makeTraceError()];
-        node.performance_issues = [makeTracePerformanceIssue()];
+        node.errors.add(makeTraceError());
+        node.performance_issues.add(makeTracePerformanceIssue());
         root.children.push(node);
       }
 
@@ -1855,8 +1855,8 @@ describe('TraceTree', () => {
       const autogroupedNode = root.children[0];
       assertSiblingAutogroupedNode(autogroupedNode);
       expect(autogroupedNode.has_errors).toBe(true);
-      expect(autogroupedNode.errors).toHaveLength(5);
-      expect(autogroupedNode.performance_issues).toHaveLength(5);
+      expect(autogroupedNode.errors.size).toBe(5);
+      expect(autogroupedNode.performance_issues.size).toBe(5);
     });
 
     it('adds autogrouped siblings as children under autogrouped node', () => {
@@ -1997,8 +1997,8 @@ describe('TraceTree', () => {
             event_id: '',
           }
         );
-        node.errors = [makeTraceError()];
-        node.performance_issues = [makeTracePerformanceIssue()];
+        node.errors.add(makeTraceError());
+        node.performance_issues.add(makeTracePerformanceIssue());
         last.children.push(node);
         last = node;
       }
@@ -2016,8 +2016,8 @@ describe('TraceTree', () => {
 
       assertAutogroupedNode(root.children[0]);
       expect(root.children[0].has_errors).toBe(true);
-      expect(root.children[0].errors).toHaveLength(3);
-      expect(root.children[0].performance_issues).toHaveLength(3);
+      expect(root.children[0].errors.size).toBe(3);
+      expect(root.children[0].performance_issues.size).toBe(3);
     });
 
     it('autogrouping direct children skips rendering intermediary nodes', () => {

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -1082,18 +1082,13 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     }
 
     if (isTransactionNode(this)) {
-      for (const error of this.value.errors) {
-        this.errors.add(error);
-      }
-
-      for (const issue of this.value.performance_issues) {
-        this.performance_issues.add(issue);
-      }
+      this.errors = new Set(this.value.errors);
+      this.performance_issues = new Set(this.value.performance_issues);
     }
 
     // For error nodes, its value is the only associated issue.
     if (isTraceErrorNode(this)) {
-      this.errors.add(this.value);
+      this.errors = new Set([this.value]);
     }
   }
 

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -313,8 +313,13 @@ export class TraceTree {
       tree.eventsCount += 1;
 
       if (isTraceTransaction(value)) {
-        traceNode.addErrorsFromArray(value.errors);
-        traceNode.addPerformanceIssuesFromArray(value.performance_issues);
+        for (const error of value.errors) {
+          traceNode.errors.add(error);
+        }
+
+        for (const performanceIssue of value.performance_issues) {
+          traceNode.performance_issues.add(performanceIssue);
+        }
       } else {
         traceNode.errors.add(value);
       }
@@ -507,10 +512,16 @@ export class TraceTree {
         project_slug: undefined,
       });
 
-      node.addErrorsFromArray(getRelatedSpanErrorsFromTransaction(span, parent));
-      node.addPerformanceIssuesFromArray(
-        getRelatedPerformanceIssuesFromTransaction(span, parent)
-      );
+      for (const error of getRelatedSpanErrorsFromTransaction(span, parent)) {
+        node.errors.add(error);
+      }
+
+      for (const performanceIssue of getRelatedPerformanceIssuesFromTransaction(
+        span,
+        parent
+      )) {
+        node.performance_issues.add(performanceIssue);
+      }
 
       // This is the case where the current span is the parent of a txn at the
       // trace level. When zooming into the parent of the txn, we want to place a copy
@@ -641,8 +652,15 @@ export class TraceTree {
       }
 
       autoGroupedNode.groupCount = groupMatchCount + 1;
-      autoGroupedNode.addErrorsFromArray(errors);
-      autoGroupedNode.addPerformanceIssuesFromArray(performance_issues);
+
+      for (const error of errors) {
+        autoGroupedNode.errors.add(error);
+      }
+
+      for (const performanceIssue of performance_issues) {
+        autoGroupedNode.performance_issues.add(performanceIssue);
+      }
+
       autoGroupedNode.space = [
         start * autoGroupedNode.multiplier,
         (end - start) * autoGroupedNode.multiplier,
@@ -741,10 +759,13 @@ export class TraceTree {
             }
 
             if (child.has_errors) {
-              autoGroupedNode.addErrorsFromArray([...child.errors]);
-              autoGroupedNode.addPerformanceIssuesFromArray([
-                ...child.performance_issues,
-              ]);
+              for (const error of child.errors) {
+                autoGroupedNode.errors.add(error);
+              }
+
+              for (const performanceIssue of child.performance_issues) {
+                autoGroupedNode.performance_issues.add(performanceIssue);
+              }
             }
 
             autoGroupedNode.children.push(node.children[j]);
@@ -1061,8 +1082,13 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     }
 
     if (isTransactionNode(this)) {
-      this.addErrorsFromArray(this.value.errors);
-      this.addPerformanceIssuesFromArray(this.value.performance_issues);
+      for (const error of this.value.errors) {
+        this.errors.add(error);
+      }
+
+      for (const issue of this.value.performance_issues) {
+        this.performance_issues.add(issue);
+      }
     }
 
     // For error nodes, its value is the only associated issue.
@@ -1126,18 +1152,6 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     }
 
     return node;
-  }
-
-  addErrorsFromArray(errors: TraceErrorType[]) {
-    for (const error of errors) {
-      this.errors.add(error);
-    }
-  }
-
-  addPerformanceIssuesFromArray(performanceIssues: TracePerformanceIssue[]) {
-    for (const issue of performanceIssues) {
-      this.performance_issues.add(issue);
-    }
   }
 
   get isOrphaned() {

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -313,10 +313,10 @@ export class TraceTree {
       tree.eventsCount += 1;
 
       if (isTraceTransaction(value)) {
-        traceNode.errors.push(...value.errors);
-        traceNode.performance_issues.push(...value.performance_issues);
+        traceNode.addErrorsFromArray(value.errors);
+        traceNode.addPerformanceIssuesFromArray(value.performance_issues);
       } else {
-        traceNode.errors.push(value);
+        traceNode.errors.add(value);
       }
 
       if (parent) {
@@ -507,8 +507,10 @@ export class TraceTree {
         project_slug: undefined,
       });
 
-      node.errors = getRelatedSpanErrorsFromTransaction(span, parent);
-      node.performance_issues = getRelatedPerformanceIssuesFromTransaction(span, parent);
+      node.addErrorsFromArray(getRelatedSpanErrorsFromTransaction(span, parent));
+      node.addPerformanceIssuesFromArray(
+        getRelatedPerformanceIssuesFromTransaction(span, parent)
+      );
 
       // This is the case where the current span is the parent of a txn at the
       // trace level. When zooming into the parent of the txn, we want to place a copy
@@ -580,10 +582,10 @@ export class TraceTree {
         isSpanNode(tail.children[0]) &&
         tail.children[0].value.op === head.value.op
       ) {
-        if ((tail?.errors?.length ?? 0) > 0) {
+        if ((tail?.errors?.size ?? 0) > 0) {
           errors.push(...tail?.errors);
         }
-        if ((tail?.performance_issues?.length ?? 0) > 0) {
+        if ((tail?.performance_issues?.size ?? 0) > 0) {
           performance_issues.push(...tail.performance_issues);
         }
 
@@ -602,10 +604,10 @@ export class TraceTree {
 
       // Checking the tail node for errors as it is not included in the grouping
       // while loop, but is hidden when the autogrouped node is collapsed
-      if ((tail?.errors?.length ?? 0) > 0) {
+      if ((tail?.errors?.size ?? 0) > 0) {
         errors.push(...tail?.errors);
       }
-      if ((tail?.performance_issues?.length ?? 0) > 0) {
+      if ((tail?.performance_issues?.size ?? 0) > 0) {
         performance_issues.push(...tail.performance_issues);
       }
 
@@ -639,8 +641,8 @@ export class TraceTree {
       }
 
       autoGroupedNode.groupCount = groupMatchCount + 1;
-      autoGroupedNode.errors = errors;
-      autoGroupedNode.performance_issues = performance_issues;
+      autoGroupedNode.addErrorsFromArray(errors);
+      autoGroupedNode.addPerformanceIssuesFromArray(performance_issues);
       autoGroupedNode.space = [
         start * autoGroupedNode.multiplier,
         (end - start) * autoGroupedNode.multiplier,
@@ -739,20 +741,10 @@ export class TraceTree {
             }
 
             if (child.has_errors) {
-              if (
-                child.value &&
-                'errors' in child.value &&
-                Array.isArray(child.value.errors)
-              ) {
-                autoGroupedNode.errors.push(...child.errors);
-              }
-              if (
-                child.value &&
-                'performance_issues' in child.value &&
-                Array.isArray(child.performance_issues)
-              ) {
-                autoGroupedNode.performance_issues.push(...child.performance_issues);
-              }
+              autoGroupedNode.addErrorsFromArray([...child.errors]);
+              autoGroupedNode.addPerformanceIssuesFromArray([
+                ...child.performance_issues,
+              ]);
             }
 
             autoGroupedNode.children.push(node.children[j]);
@@ -1009,8 +1001,8 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     project_slug: undefined,
     event_id: undefined,
   };
-  errors: TraceErrorType[] = [];
-  performance_issues: TracePerformanceIssue[] = [];
+  errors: Set<TraceErrorType> = new Set<TraceErrorType>();
+  performance_issues: Set<TracePerformanceIssue> = new Set<TracePerformanceIssue>();
 
   multiplier: number;
   space: [number, number] | null = null;
@@ -1069,13 +1061,13 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     }
 
     if (isTransactionNode(this)) {
-      this.errors = this.value.errors;
-      this.performance_issues = this.value.performance_issues;
+      this.addErrorsFromArray(this.value.errors);
+      this.addPerformanceIssuesFromArray(this.value.performance_issues);
     }
 
     // For error nodes, its value is the only associated issue.
     if (isTraceErrorNode(this)) {
-      this.errors = [this.value];
+      this.errors.add(this.value);
     }
   }
 
@@ -1136,6 +1128,18 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     return node;
   }
 
+  addErrorsFromArray(errors: TraceErrorType[]) {
+    for (const error of errors) {
+      this.errors.add(error);
+    }
+  }
+
+  addPerformanceIssuesFromArray(performanceIssues: TracePerformanceIssue[]) {
+    for (const issue of performanceIssues) {
+      this.performance_issues.add(issue);
+    }
+  }
+
   get isOrphaned() {
     return this.parent?.value && 'orphan_errors' in this.parent.value;
   }
@@ -1174,7 +1178,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
   }
 
   get has_errors(): boolean {
-    return this.errors.length > 0 || this.performance_issues.length > 0;
+    return this.errors.size > 0 || this.performance_issues.size > 0;
   }
 
   get parent_transaction(): TraceTreeNode<TraceTree.Transaction> | null {
@@ -1488,7 +1492,7 @@ export class ParentAutogroupNode extends TraceTreeNode<TraceTree.ChildrenAutogro
   }
 
   get has_errors(): boolean {
-    return this.errors.length > 0 || this.performance_issues.length > 0;
+    return this.errors.size > 0 || this.performance_issues.size > 0;
   }
 
   get autogroupedSegments(): [number, number][] {
@@ -1527,7 +1531,7 @@ export class SiblingAutogroupNode extends TraceTreeNode<TraceTree.SiblingAutogro
   }
 
   get has_errors(): boolean {
-    return this.errors.length > 0 || this.performance_issues.length > 0;
+    return this.errors.size > 0 || this.performance_issues.size > 0;
   }
 
   get autogroupedSegments(): [number, number][] {

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -6,10 +6,6 @@ import type {Client} from 'sentry/api';
 import type {Organization} from 'sentry/types';
 import {getDuration} from 'sentry/utils/formatters';
 import clamp from 'sentry/utils/number/clamp';
-import type {
-  TraceError,
-  TracePerformanceIssue,
-} from 'sentry/utils/performance/quickTrace/types';
 import {requestAnimationTimeout} from 'sentry/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils';
 import {lightTheme as theme} from 'sentry/utils/theme';
 import {
@@ -19,6 +15,7 @@ import {
   isSiblingAutogroupedNode,
   isSpanNode,
   isTraceErrorNode,
+  isTraceNode,
   isTransactionNode,
 } from 'sentry/views/performance/newTraceDetails/guards';
 import {
@@ -1926,15 +1923,15 @@ function hasEventWithEventId(
   node: TraceTreeNode<TraceTree.NodeValue>,
   eventId: string
 ): boolean {
-  // Search in errors
-  const errors: TraceError[] = isAutogroupedNode(node)
-    ? node.errors
-    : node.value && 'errors' in node.value && Array.isArray(node.value.errors)
-      ? node.value.errors
-      : [];
+  // Skip trace nodes since they accumulate all errors and performance issues
+  // in the trace and is not an event.
+  if (isTraceNode(node)) {
+    return false;
+  }
 
-  if (errors.length > 0) {
-    for (const e of errors) {
+  // Search in errors
+  if (node.errors.size > 0) {
+    for (const e of node.errors) {
       if (e.event_id === eventId) {
         return true;
       }
@@ -1942,16 +1939,8 @@ function hasEventWithEventId(
   }
 
   // Search in performance issues
-  const performance_issues: TracePerformanceIssue[] = isAutogroupedNode(node)
-    ? node.performance_issues
-    : node.value &&
-        'performance_issues' in node.value &&
-        Array.isArray(node.value.performance_issues)
-      ? node.value.performance_issues
-      : [];
-
-  if (performance_issues.length > 0) {
-    for (const p of performance_issues) {
+  if (node.performance_issues.size > 0) {
+    for (const p of node.performance_issues) {
       if (p.event_id === eventId) {
         return true;
       }


### PR DESCRIPTION
For example: if an autogrouped node groups spans part of a N+1 query issue, we should just display one issue in it's trace drawer issue list and not N issues. 