### PR TITLE
fix(superuser): use union of superuser scopes and existing scopes

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -927,11 +927,13 @@ def from_request_org_and_scopes(
         )
 
         superuser_scopes = get_superuser_scopes(auth_state, request.user)
+        if scopes:
+            superuser_scopes = superuser_scopes.union(set(scopes))
 
         return ApiBackedOrganizationGlobalAccess(
             rpc_user_organization_context=rpc_user_org_context,
             auth_state=auth_state,
-            scopes=scopes if scopes is not None else superuser_scopes,
+            scopes=superuser_scopes,
         )
 
     if hasattr(request, "auth") and not request.user.is_authenticated:
@@ -1029,11 +1031,13 @@ def from_request(
         sso_state = auth_state.sso_state
 
         superuser_scopes = get_superuser_scopes(auth_state, request.user)
+        if scopes:
+            superuser_scopes = superuser_scopes.union(set(scopes))
 
         return OrganizationGlobalAccess(
             organization=organization,
             _member=member,
-            scopes=scopes if scopes is not None else superuser_scopes,
+            scopes=superuser_scopes,
             sso_is_valid=sso_state.is_valid,
             requires_sso=sso_state.is_required,
             permissions=access_service.get_permissions_for_user(request.user.id),

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -77,7 +77,7 @@ SUPERUSER_SCOPES = settings.SENTRY_SCOPES.union({"org:superuser"})
 SUPERUSER_READONLY_SCOPES = settings.SENTRY_READONLY_SCOPES.union({"org:superuser"})
 
 
-def get_superuser_scopes(auth_state: RpcAuthState, user: Any):
+def get_superuser_scopes(auth_state: RpcAuthState, user: Any) -> set[str]:
     superuser_scopes = SUPERUSER_SCOPES
     if (
         not is_self_hosted()


### PR DESCRIPTION
If scopes are passed in to `from_request_org_and_scopes` or `from_request` and the user making the request is active superuser, we always overwrite any scopes with the appropriate superuser scopes (read-only or write -- currently feature flagged). However, this means that if somebody is the owner of their own org and has superuser read-only, their scopes will be overwritten to be read-only rather than all permissions an owner has.

If we do the union of the scopes, this will ensure that:
1. Write scopes are never removed if the user originally has them
2. The `org:superuser` scope is also attached to the scope list so we can show the red sidebar