### PR TITLE
chore(grouping): Log when landing in optimized transition logic branch

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1326,6 +1326,8 @@ def get_culprit(data: Mapping[str, Any]) -> str:
 
 def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> GroupInfo | None:
     if job["optimized_grouping"]:
+        # TODO: This logging can come out as soon as it's clear we're successfully landing in this branch in prod
+        logger.info("_save_aggregate_new.called", extra=metric_tags)
         group_info = _save_aggregate_new(
             event=event,
             job=job,


### PR DESCRIPTION
This adds a log which fires when we land in the branch using the new transition logic, purely as a sanity check. In theory, the `sentry` org should be opted in to using the new logic, and that fact should show up in tags on the metrics, but the only `using_transition_optimization` value which is coming through is `false`:

![image](https://github.com/getsentry/sentry/assets/14812505/443c114f-24b0-4c7e-9c9d-b0ca35269be1)

So I'd like to know if we actually _are_ using the new logic or not. Once this problem is debugged, I'll pull the log back out.
