### PR TITLE
fix(trace): render web vitals measurements

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -674,7 +674,7 @@ type EventContexts = {
   unity?: UnityContext;
 };
 
-export type Measurement = {value: number; unit?: string};
+export type Measurement = {value: number; type?: string; unit?: string};
 
 export type EventTag = {key: string; value: string};
 

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -211,7 +211,7 @@ function TraceViewContent(props: TraceViewContentProps) {
       return TraceTree.Empty();
     }
 
-    if (props.status === 'loading' || rootEvent.status === 'loading') {
+    if (props.status === 'loading') {
       const loadingTrace =
         loadingTraceRef.current ??
         TraceTree.Loading(
@@ -226,19 +226,12 @@ function TraceViewContent(props: TraceViewContentProps) {
       return loadingTrace;
     }
 
-    if (props.trace && rootEvent.status === 'success') {
-      return TraceTree.FromTrace(props.trace, rootEvent.data);
+    if (props.trace) {
+      return TraceTree.FromTrace(props.trace);
     }
 
     throw new Error('Invalid trace state');
-  }, [
-    props.traceSlug,
-    props.trace,
-    props.status,
-    projects,
-    rootEvent.data,
-    rootEvent.status,
-  ]);
+  }, [props.traceSlug, props.trace, props.status, projects]);
 
   const [rovingTabIndexState, rovingTabIndexDispatch] = useReducer(
     rovingTabIndexReducer,

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1912,7 +1912,7 @@ const TraceStylingWrapper = styled('div')`
       min-width: 34px;
       text-align: center;
       position: absolute;
-      font-size: ${p => p.theme.fontSizeExtraSmall};
+      font-size: 10px;
       font-weight: bold;
       color: ${p => p.theme.textColor};
       background-color: ${p => p.theme.background};

--- a/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
-import {EntryType, type Event, type EventTransaction} from 'sentry/types';
+import {EntryType, type Event} from 'sentry/types';
 import type {
   TraceFullDetailed,
   TracePerformanceIssue,
@@ -242,12 +242,10 @@ describe('TreeNode', () => {
             makeTransaction({
               start_timestamp: 0,
               timestamp: 1,
+              measurements: {ttfb: {value: 0, unit: 'millisecond'}},
             }),
           ],
-        }),
-        {
-          measurements: {ttfb: {value: 0, unit: 'millisecond'}},
-        } as unknown as EventTransaction
+        })
       );
 
       expect(tree.indicators.length).toBe(1);
@@ -261,16 +259,14 @@ describe('TreeNode', () => {
             makeTransaction({
               start_timestamp: 0,
               timestamp: 1,
+              measurements: {
+                ttfb: {value: 500, unit: 'millisecond'},
+                fcp: {value: 0.5, unit: 'second'},
+                lcp: {value: 500_000_000, unit: 'nanosecond'},
+              },
             }),
           ],
-        }),
-        {
-          measurements: {
-            ttfb: {value: 500, unit: 'millisecond'},
-            fcp: {value: 0.5, unit: 'second'},
-            lcp: {value: 500_000_000, unit: 'nanosecond'},
-          },
-        } as unknown as EventTransaction
+        })
       );
 
       expect(tree.indicators[0].start).toBe(500);
@@ -285,14 +281,12 @@ describe('TreeNode', () => {
             makeTransaction({
               start_timestamp: 0,
               timestamp: 1,
+              measurements: {
+                ttfb: {value: 2, unit: 'second'},
+              },
             }),
           ],
-        }),
-        {
-          measurements: {
-            ttfb: {value: 2, unit: 'second'},
-          },
-        } as unknown as EventTransaction
+        })
       );
 
       expect(tree.root.space).toEqual([0, 2000]);
@@ -305,14 +299,12 @@ describe('TreeNode', () => {
             makeTransaction({
               start_timestamp: 0,
               timestamp: 1,
+              measurements: {
+                ttfb: {value: 2000, unit: 'millisecond'},
+              },
             }),
           ],
-        }),
-        {
-          measurements: {
-            ttfb: {value: 2000, unit: 'millisecond'},
-          },
-        } as unknown as EventTransaction
+        })
       );
 
       expect(tree.root.space).toEqual([0, 2000]);
@@ -326,15 +318,13 @@ describe('TreeNode', () => {
             makeTransaction({
               start_timestamp: 0,
               timestamp: 1,
+              measurements: {
+                ttfb: {value: 2000, unit: 'millisecond'},
+                lcp: {value: 1000, unit: 'millisecond'},
+              },
             }),
           ],
-        }),
-        {
-          measurements: {
-            ttfb: {value: 2000, unit: 'millisecond'},
-            lcp: {value: 1000, unit: 'millisecond'},
-          },
-        } as unknown as EventTransaction
+        })
       );
 
       expect(tree.indicators[0].start).toBe(1000);

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -5,6 +5,7 @@ import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types'
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import type {Organization} from 'sentry/types';
 import type {Event, EventTransaction, Measurement} from 'sentry/types/event';
+import {MobileVital, WebVital} from 'sentry/utils/fields';
 import type {
   TraceError as TraceErrorType,
   TraceFullDetailed,
@@ -252,7 +253,20 @@ function shouldCollapseNodeByDefault(node: TraceTreeNode<TraceTree.NodeValue>) {
 }
 
 // cls is not included as it is a cumulative layout shift and not a single point in time
-const RENDERABLE_MEASUREMENTS = ['fcp', 'fp', 'lcp', 'ttfb'];
+const RENDERABLE_MEASUREMENTS = [
+  WebVital.TTFB,
+  WebVital.FP,
+  WebVital.FCP,
+  WebVital.LCP,
+  MobileVital.TIME_TO_FULL_DISPLAY,
+  MobileVital.TIME_TO_INITIAL_DISPLAY,
+].map(n => n.replace('measurements.', ''));
+
+const MEASUREMENT_ACRONYM_MAPPING = {
+  [MobileVital.TIME_TO_FULL_DISPLAY.replace('measurements.', '')]: 'TTFD',
+  [MobileVital.TIME_TO_INITIAL_DISPLAY.replace('measurements.', '')]: 'TTID',
+};
+
 export class TraceTree {
   type: 'loading' | 'empty' | 'error' | 'trace' = 'trace';
   root: TraceTreeNode<null> = TraceTreeNode.Root();
@@ -802,7 +816,7 @@ export class TraceTree {
         duration: 0,
         measurement: value,
         type: measurement as TraceTree.Indicator['type'],
-        label: measurement.toUpperCase(),
+        label: (MEASUREMENT_ACRONYM_MAPPING[measurement] ?? measurement).toUpperCase(),
       });
     }
   }


### PR DESCRIPTION
These were now added back to the response, we just werent collecting them from all entries