### PR TITLE
ref(daily summary): Add referrer to link

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -7,11 +7,7 @@ from urllib.parse import urlencode
 from sentry_relay.processing import parse_release
 
 from sentry import features
-from sentry.integrations.message_builder import (
-    build_attachment_text,
-    build_attachment_title,
-    get_title_link,
-)
+from sentry.integrations.message_builder import build_attachment_text, build_attachment_title
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.models.project import Project
@@ -39,7 +35,9 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
         self.recipient = recipient
 
     def linkify_error_title(self, group):
-        link = get_title_link(group, None, False, False, self.notification, ExternalProviders.SLACK)
+        link = group.get_absolute_url(
+            params={"referrer": self.notification.get_referrer(ExternalProviders.SLACK)}
+        )
         title = build_attachment_title(group)
         attachment_text = self.get_attachment_text(group)
         if not attachment_text:

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -769,7 +769,7 @@ class DailySummaryTest(
                 project_context=top_projects_context_map,
             ).send()
         blocks, fallback_text = get_blocks_and_fallback_text()
-        link_text = "http://testserver/organizations/baz/issues/{}/?referrer=slack"
+        link_text = "http://testserver/organizations/baz/issues/{}/?referrer=daily_summary-slack"
         # check the today's event count section
         assert "*Today’s Event Count*" in blocks[3]["fields"][0]["text"]
         assert "higher than last 14d avg" in blocks[3]["fields"][1]["text"]
@@ -817,7 +817,7 @@ class DailySummaryTest(
                 project_context=top_projects_context_map,
             ).send()
         blocks, fallback_text = get_blocks_and_fallback_text()
-        link_text = "http://testserver/organizations/baz/issues/{}/?referrer=slack"
+        link_text = "http://testserver/organizations/baz/issues/{}/?referrer=daily_summary-slack"
         assert f"*{self.project.slug}*" in blocks[2]["text"]["text"]
         # check the today's event count section
         assert "*Today’s Event Count*" in blocks[3]["fields"][0]["text"]

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -592,7 +592,7 @@ class DailySummaryTest(
                 project_context=top_projects_context_map,
             ).send()
         blocks, fallback_text = get_blocks_and_fallback_text()
-        link_text = "http://testserver/organizations/baz/issues/{}/?referrer=slack"
+        link_text = "http://testserver/organizations/baz/issues/{}/?referrer=daily_summary-slack"
         assert (
             fallback_text
             == f"Daily Summary for Your {self.organization.slug.title()} Projects (internal only!!!)"


### PR DESCRIPTION
Add referrer to the issue links so we can tell the clicks are coming from the daily summary. I didn't make a GH issue but this is from the [feedback tracker](https://www.notion.so/sentry/Add-notification-specific-referrer-to-links-eef70f97dfb442cd80e57e3656fc885c?pvs=4).