### PR TITLE
ref(ownership): Update ownership data after mutation

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -116,13 +116,6 @@ type CreateOwnershipRuleModalOptions = {
   eventData?: Event;
 };
 
-export type EditOwnershipRulesModalOptions = {
-  onSave: (ownership: IssueOwnership) => void;
-  organization: Organization;
-  ownership: IssueOwnership;
-  project: Project;
-};
-
 /**
  * Open the edit ownership modal within issue details
  */
@@ -134,6 +127,13 @@ export async function openIssueOwnershipRuleModal(
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
+
+export type EditOwnershipRulesModalOptions = {
+  onSave: (ownership: IssueOwnership) => void;
+  organization: Organization;
+  ownership: IssueOwnership;
+  project: Project;
+};
 
 export async function openEditOwnershipRules(options: EditOwnershipRulesModalOptions) {
   const mod = await import('sentry/components/modals/editOwnershipRulesModal');

--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -117,7 +117,7 @@ type CreateOwnershipRuleModalOptions = {
 };
 
 export type EditOwnershipRulesModalOptions = {
-  onSave: (text: string | null) => void;
+  onSave: (ownership: IssueOwnership) => void;
   organization: Organization;
   ownership: IssueOwnership;
   project: Project;

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import type {RouteComponentProps} from 'react-router';
 
-import {openEditOwnershipRules, openModal} from 'sentry/actionCreators/modal';
+import {closeModal, openEditOwnershipRules, openModal} from 'sentry/actionCreators/modal';
 import Access, {hasEveryAccess} from 'sentry/components/acl/access';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -76,17 +76,12 @@ url:http://example.com/settings/* #product
 tags.sku_class:enterprise #enterprise`;
   }
 
-  handleOwnershipSave = (text: string | null) => {
+  handleOwnershipSave = (ownership: IssueOwnership) => {
     this.setState(prevState => ({
-      ...(prevState.ownership
-        ? {
-            ownership: {
-              ...prevState.ownership,
-              raw: text || '',
-            },
-          }
-        : {}),
+      ...prevState,
+      ownership,
     }));
+    closeModal();
   };
 
   handleCodeOwnerAdded = (data: CodeOwner) => {

--- a/static/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -13,7 +13,7 @@ import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import MemberListStore from 'sentry/stores/memberListStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import type {Organization, Project, Team} from 'sentry/types';
+import type {IssueOwnership, Organization, Project, Team} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 
@@ -33,7 +33,7 @@ type Props = {
    */
   page: 'issue_details' | 'project_settings';
   project: Project;
-  onSave?: (text: string | null) => void;
+  onSave?: (ownership: IssueOwnership) => void;
 } & typeof defaultProps;
 
 type State = {
@@ -82,14 +82,14 @@ class OwnerInput extends Component<Props, State> {
     );
 
     request
-      .then(() => {
+      .then(ownership => {
         addSuccessMessage(t('Updated issue ownership rules'));
         this.setState(
           {
             hasChanges: false,
             text,
           },
-          () => onSave?.(text)
+          () => onSave?.(ownership)
         );
         trackIntegrationAnalytics('project_ownership.saved', {
           page,


### PR DESCRIPTION
Closes the modal and updates the cache when saving ownership rules.

**before**

https://github.com/getsentry/sentry/assets/35509934/f79db9c0-e120-4c95-bd3e-c58f2c1b8fd9


**after**

https://github.com/getsentry/sentry/assets/35509934/243cfbb4-3f33-4ea9-8431-0773eaa0c412



