### PR TITLE
fix(perfscore): Temporary fix for `weighted_performance_score` returning incorrect values.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1915,6 +1915,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:starfish-browser-webvitals-use-backend-scores": False,
     # Enable INP in the browser starfish webvitals module
     "organizations:starfish-browser-webvitals-replace-fid-with-inp": False,
+    # Uses a computed total count to calculate the score in the browser starfish webvitals module, instead of measurements.score.total
+    "organizations:starfish-browser-webvitals-score-with-computed-total-count": False,
     # Enable mobile starfish app start module view
     "organizations:starfish-mobile-appstart": False,
     # Enable mobile starfish ui module view

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -239,6 +239,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:starfish-browser-webvitals", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:starfish-browser-webvitals-pageoverview-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:starfish-browser-webvitals-replace-fid-with-inp", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:starfish-browser-webvitals-score-with-computed-total-count", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:starfish-browser-webvitals-use-backend-scores", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:starfish-mobile-appstart", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:starfish-mobile-ui-module", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -1472,6 +1472,11 @@ class MetricsDatasetConfig(DatasetConfig):
             alias,
         )
 
+    # TODO: This function uses the sum of ttfb and inp score counts as the denominator because
+    # measurements.score.total was incorrectly double counting due to the issue described here:
+    # https://github.com/getsentry/relay/pull/3324
+    # Update this function to use measurements.score.total as the denominator once the issue is
+    # resolved and any historic data is out of retention.
     def _resolve_weighted_web_vital_score_function(
         self,
         args: Mapping[str, str | Column | SelectType | int | float],
@@ -1522,15 +1527,35 @@ class MetricsDatasetConfig(DatasetConfig):
                                             "greater",
                                             [
                                                 Function(
-                                                    "countIf",
+                                                    "plus",
                                                     [
-                                                        Column("value"),
                                                         Function(
-                                                            "equals",
+                                                            "countIf",
                                                             [
-                                                                Column("metric_id"),
-                                                                self.resolve_metric(
-                                                                    "measurements.score.total"
+                                                                Column("value"),
+                                                                Function(
+                                                                    "equals",
+                                                                    [
+                                                                        Column("metric_id"),
+                                                                        self.resolve_metric(
+                                                                            "measurements.score.ttfb"
+                                                                        ),
+                                                                    ],
+                                                                ),
+                                                            ],
+                                                        ),
+                                                        Function(
+                                                            "countIf",
+                                                            [
+                                                                Column("value"),
+                                                                Function(
+                                                                    "equals",
+                                                                    [
+                                                                        Column("metric_id"),
+                                                                        self.resolve_metric(
+                                                                            "measurements.score.inp"
+                                                                        ),
+                                                                    ],
                                                                 ),
                                                             ],
                                                         ),
@@ -1554,15 +1579,35 @@ class MetricsDatasetConfig(DatasetConfig):
                                             ],
                                         ),
                                         Function(
-                                            "countIf",
+                                            "plus",
                                             [
-                                                Column("value"),
                                                 Function(
-                                                    "equals",
+                                                    "countIf",
                                                     [
-                                                        Column("metric_id"),
-                                                        self.resolve_metric(
-                                                            "measurements.score.total"
+                                                        Column("value"),
+                                                        Function(
+                                                            "equals",
+                                                            [
+                                                                Column("metric_id"),
+                                                                self.resolve_metric(
+                                                                    "measurements.score.ttfb"
+                                                                ),
+                                                            ],
+                                                        ),
+                                                    ],
+                                                ),
+                                                Function(
+                                                    "countIf",
+                                                    [
+                                                        Column("value"),
+                                                        Function(
+                                                            "equals",
+                                                            [
+                                                                Column("metric_id"),
+                                                                self.resolve_metric(
+                                                                    "measurements.score.inp"
+                                                                ),
+                                                            ],
                                                         ),
                                                     ],
                                                 ),

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Mapping
 from django.utils.functional import cached_property
 from snuba_sdk import Column, Condition, Function, Op, OrderBy
 
+from sentry import features
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.search.events import builder, constants, fields
@@ -639,7 +640,12 @@ class MetricsDatasetConfig(DatasetConfig):
                         )
                     ],
                     calculated_args=[resolve_metric_id],
-                    snql_distribution=self._resolve_weighted_web_vital_score_function,
+                    snql_distribution=self._resolve_weighted_web_vital_score_with_computed_total_count_function
+                    if features.has(
+                        "organizations:starfish-browser-webvitals-score-with-computed-total-count",
+                        self.builder.params.organization,
+                    )
+                    else self._resolve_weighted_web_vital_score_function,
                     default_result_type="number",
                 ),
                 fields.MetricsFunction(
@@ -1472,12 +1478,121 @@ class MetricsDatasetConfig(DatasetConfig):
             alias,
         )
 
+    def _resolve_weighted_web_vital_score_function(
+        self,
+        args: Mapping[str, str | Column | SelectType | int | float],
+        alias: str,
+    ) -> SelectType:
+        column = args["column"]
+        metric_id = args["metric_id"]
+
+        if column not in [
+            "measurements.score.lcp",
+            "measurements.score.fcp",
+            "measurements.score.fid",
+            "measurements.score.inp",
+            "measurements.score.cls",
+            "measurements.score.ttfb",
+        ]:
+            raise InvalidSearchQuery("performance_score only supports measurements")
+
+        return Function(
+            "greatest",
+            [
+                Function(
+                    "least",
+                    [
+                        Function(
+                            "if",
+                            [
+                                Function(
+                                    "and",
+                                    [
+                                        Function(
+                                            "greater",
+                                            [
+                                                Function(
+                                                    "sumIf",
+                                                    [
+                                                        Column("value"),
+                                                        Function(
+                                                            "equals",
+                                                            [Column("metric_id"), metric_id],
+                                                        ),
+                                                    ],
+                                                ),
+                                                0,
+                                            ],
+                                        ),
+                                        Function(
+                                            "greater",
+                                            [
+                                                Function(
+                                                    "countIf",
+                                                    [
+                                                        Column("value"),
+                                                        Function(
+                                                            "equals",
+                                                            [
+                                                                Column("metric_id"),
+                                                                self.resolve_metric(
+                                                                    "measurements.score.total"
+                                                                ),
+                                                            ],
+                                                        ),
+                                                    ],
+                                                ),
+                                                0,
+                                            ],
+                                        ),
+                                    ],
+                                ),
+                                Function(
+                                    "divide",
+                                    [
+                                        Function(
+                                            "sumIf",
+                                            [
+                                                Column("value"),
+                                                Function(
+                                                    "equals", [Column("metric_id"), metric_id]
+                                                ),
+                                            ],
+                                        ),
+                                        Function(
+                                            "countIf",
+                                            [
+                                                Column("value"),
+                                                Function(
+                                                    "equals",
+                                                    [
+                                                        Column("metric_id"),
+                                                        self.resolve_metric(
+                                                            "measurements.score.total"
+                                                        ),
+                                                    ],
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                ),
+                                0.0,
+                            ],
+                        ),
+                        1.0,
+                    ],
+                ),
+                0.0,
+            ],
+            alias,
+        )
+
     # TODO: This function uses the sum of ttfb and inp score counts as the denominator because
     # measurements.score.total was incorrectly double counting due to the issue described here:
     # https://github.com/getsentry/relay/pull/3324
     # Update this function to use measurements.score.total as the denominator once the issue is
     # resolved and any historic data is out of retention.
-    def _resolve_weighted_web_vital_score_function(
+    def _resolve_weighted_web_vital_score_with_computed_total_count_function(
         self,
         args: Mapping[str, str | Column | SelectType | int | float],
         alias: str,

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2595,13 +2595,13 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
     def test_performance_score(self):
         self.store_transaction_metric(
             0.03,
-            metric="measurements.score.lcp",
+            metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.30,
-            metric="measurements.score.weight.lcp",
+            metric="measurements.score.weight.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
@@ -2626,18 +2626,18 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
 
         self.store_transaction_metric(
             1.00,
-            metric="measurements.score.lcp",
+            metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             1.00,
-            metric="measurements.score.weight.lcp",
+            metric="measurements.score.weight.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
-            0.00,
+            1.00,
             metric="measurements.score.fid",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
@@ -2650,7 +2650,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
-            1.00,
+            0.00,
             metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
@@ -2692,7 +2692,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": [
                     "transaction",
-                    "performance_score(measurements.score.lcp)",
                     "performance_score(measurements.score.fcp)",
                     "performance_score(measurements.score.fid)",
                     "performance_score(measurements.score.ttfb)",
@@ -2709,26 +2708,25 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         meta = response.data["meta"]
         field_meta = meta["fields"]
 
-        assert data[0]["performance_score(measurements.score.lcp)"] == 0.7923076923076923
         assert data[0]["performance_score(measurements.score.fcp)"] == 0.5
         assert data[0]["performance_score(measurements.score.fid)"] == 0
-        assert data[0]["performance_score(measurements.score.ttfb)"] == 0
+        assert data[0]["performance_score(measurements.score.ttfb)"] == 0.7923076923076923
         assert data[0]["performance_score(measurements.score.inp)"] == 0.8
 
         assert meta["isMetricsData"]
-        assert field_meta["performance_score(measurements.score.lcp)"] == "number"
+        assert field_meta["performance_score(measurements.score.ttfb)"] == "number"
 
     def test_performance_score_boundaries(self):
         # Scores shouldn't exceed 1 or go below 0, but we can test these boundaries anyways
         self.store_transaction_metric(
             0.65,
-            metric="measurements.score.lcp",
+            metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.30,
-            metric="measurements.score.weight.lcp",
+            metric="measurements.score.weight.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
@@ -2755,7 +2753,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": [
                     "transaction",
-                    "performance_score(measurements.score.lcp)",
+                    "performance_score(measurements.score.ttfb)",
                     "performance_score(measurements.score.fcp)",
                 ],
                 "query": "event.type:transaction",
@@ -2769,22 +2767,22 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         meta = response.data["meta"]
         field_meta = meta["fields"]
 
-        assert data[0]["performance_score(measurements.score.lcp)"] == 1.0
+        assert data[0]["performance_score(measurements.score.ttfb)"] == 1.0
         assert data[0]["performance_score(measurements.score.fcp)"] == 0.0
 
         assert meta["isMetricsData"]
-        assert field_meta["performance_score(measurements.score.lcp)"] == "number"
+        assert field_meta["performance_score(measurements.score.ttfb)"] == "number"
 
     def test_weighted_performance_score(self):
         self.store_transaction_metric(
             0.03,
-            metric="measurements.score.lcp",
+            metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.30,
-            metric="measurements.score.weight.lcp",
+            metric="measurements.score.weight.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
@@ -2797,13 +2795,13 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
 
         self.store_transaction_metric(
             1.00,
-            metric="measurements.score.lcp",
+            metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             1.00,
-            metric="measurements.score.weight.lcp",
+            metric="measurements.score.weight.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
@@ -2829,7 +2827,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
         self.store_transaction_metric(
             1.00,
-            metric="measurements.score.weight.lcp",
+            metric="measurements.score.weight.inp",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
@@ -2844,7 +2842,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": [
                     "transaction",
-                    "weighted_performance_score(measurements.score.lcp)",
+                    "weighted_performance_score(measurements.score.ttfb)",
                     "weighted_performance_score(measurements.score.inp)",
                 ],
                 "query": "event.type:transaction",
@@ -2858,10 +2856,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         meta = response.data["meta"]
         field_meta = meta["fields"]
 
-        assert data[0]["weighted_performance_score(measurements.score.lcp)"] == 0.2575
-        assert data[0]["weighted_performance_score(measurements.score.inp)"] == 0.2
+        assert data[0]["weighted_performance_score(measurements.score.ttfb)"] == 0.3433333333333333
+        assert data[0]["weighted_performance_score(measurements.score.inp)"] == 0.26666666666666666
         assert meta["isMetricsData"]
-        assert field_meta["weighted_performance_score(measurements.score.lcp)"] == "number"
+        assert field_meta["weighted_performance_score(measurements.score.ttfb)"] == "number"
 
     def test_invalid_performance_score_column(self):
         self.store_transaction_metric(
@@ -2908,7 +2906,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
     def test_no_weighted_performance_score_column(self):
         self.store_transaction_metric(
             0.0,
-            metric="measurements.score.lcp",
+            metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
@@ -2916,7 +2914,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": [
                     "transaction",
-                    "weighted_performance_score(measurements.score.lcp)",
+                    "weighted_performance_score(measurements.score.ttfb)",
                 ],
                 "query": "event.type:transaction",
                 "dataset": "metrics",
@@ -2930,20 +2928,20 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         meta = response.data["meta"]
         field_meta = meta["fields"]
 
-        assert data[0]["weighted_performance_score(measurements.score.lcp)"] == 0.0
+        assert data[0]["weighted_performance_score(measurements.score.ttfb)"] == 0.0
         assert meta["isMetricsData"]
-        assert field_meta["weighted_performance_score(measurements.score.lcp)"] == "number"
+        assert field_meta["weighted_performance_score(measurements.score.ttfb)"] == "number"
 
     def test_opportunity_score(self):
         self.store_transaction_metric(
             0.03,
-            metric="measurements.score.lcp",
+            metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             0.30,
-            metric="measurements.score.weight.lcp",
+            metric="measurements.score.weight.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
@@ -2968,13 +2966,13 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
 
         self.store_transaction_metric(
             1.0,
-            metric="measurements.score.lcp",
+            metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
         self.store_transaction_metric(
             1.0,
-            metric="measurements.score.weight.lcp",
+            metric="measurements.score.weight.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
@@ -3015,7 +3013,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {
                 "field": [
                     "transaction",
-                    "opportunity_score(measurements.score.lcp)",
+                    "opportunity_score(measurements.score.ttfb)",
                     "opportunity_score(measurements.score.inp)",
                     "opportunity_score(measurements.score.total)",
                 ],
@@ -3029,7 +3027,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         data = response.data["data"]
         meta = response.data["meta"]
 
-        assert data[0]["opportunity_score(measurements.score.lcp)"] == 0.27
+        assert data[0]["opportunity_score(measurements.score.ttfb)"] == 0.27
         # Should be 0.2. Precision issue?
         assert data[0]["opportunity_score(measurements.score.inp)"] == 0.19999999999999996
         assert data[0]["opportunity_score(measurements.score.total)"] == 1.77
@@ -3063,7 +3061,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         )
         self.store_transaction_metric(
             0.5,
-            metric="measurements.score.lcp",
+            metric="measurements.score.ttfb",
             tags={"transaction": "foo_transaction"},
             timestamp=self.min_ago,
         )
@@ -3079,7 +3077,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                 "field": [
                     "transaction",
                     "count_scores(measurements.score.total)",
-                    "count_scores(measurements.score.lcp)",
+                    "count_scores(measurements.score.ttfb)",
                     "count_scores(measurements.score.inp)",
                 ],
                 "query": "event.type:transaction",
@@ -3093,7 +3091,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         meta = response.data["meta"]
 
         assert data[0]["count_scores(measurements.score.total)"] == 4
-        assert data[0]["count_scores(measurements.score.lcp)"] == 1
+        assert data[0]["count_scores(measurements.score.ttfb)"] == 1
         assert data[0]["count_scores(measurements.score.inp)"] == 1
 
         assert meta["isMetricsData"]

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2838,18 +2838,21 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             timestamp=self.min_ago,
         )
 
-        response = self.do_request(
-            {
-                "field": [
-                    "transaction",
-                    "weighted_performance_score(measurements.score.ttfb)",
-                    "weighted_performance_score(measurements.score.inp)",
-                ],
-                "query": "event.type:transaction",
-                "dataset": "metrics",
-                "per_page": 50,
-            }
-        )
+        with self.feature(
+            {"organizations:starfish-browser-webvitals-score-with-computed-total-count": True}
+        ):
+            response = self.do_request(
+                {
+                    "field": [
+                        "transaction",
+                        "weighted_performance_score(measurements.score.ttfb)",
+                        "weighted_performance_score(measurements.score.inp)",
+                    ],
+                    "query": "event.type:transaction",
+                    "dataset": "metrics",
+                    "per_page": 50,
+                }
+            )
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         data = response.data["data"]


### PR DESCRIPTION
There was an issue with `measurements.score.total` double counting due to `pageloads` being scored twice (once as a transaction, and once as a span).

This caused `weighted_performance_score` to become inaccurate because it uses `measurements.score.total` as a denominator.

This is a temporary fix to update `weighted_performance_score` to use sum `measurements.score.ttfb` and `measurements.score.inp` counts as the denominator instead.
This works and does not involve any double counting because: 
- `measurements.score.ttfb` is required on all pageload profiles and only extracted on transactions.
- `measurements.score.inp` is required on all interaction profiles and only extracted on spans. 

We shouldn't rely on this going forward. We'll need to revert back to using `measurements.score.total` once historic data is no longer impacted.