### PR TITLE
fix(perf): Allow querying for `span.module` in indexed spans

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -143,6 +143,7 @@ SPAN_COLUMN_MAP = {
     "environment": "sentry_tags[environment]",
     "device.class": "sentry_tags[device.class]",
     "category": "sentry_tags[category]",
+    "span.category": "sentry_tags[category]",
     "span.status_code": "sentry_tags[status_code]",
     "resource.render_blocking_status": "sentry_tags[resource.render_blocking_status]",
     "http.response_content_length": "sentry_tags[http.response_content_length]",

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -144,7 +144,7 @@ class OrganizationEventsSpanIndexedEndpointTest(OrganizationEventsEndpointTestBa
         response = self.do_request(
             {
                 "field": ["span.op", "span.status_code"],
-                "query": "span.status_code:200",
+                "query": "span.module:http span.status_code:200",
                 "project": self.project.id,
                 "dataset": "spansIndexed",
             }


### PR DESCRIPTION
`resolve_span_module` [delegates `span.module` to `span.category`](https://github.com/getsentry/sentry/blob/7a44b756da14e601f0389418f69bd6cae25d0587/src/sentry/search/events/datasets/field_aliases.py#L108) but there's [no column mapping from `span.category` to `sentry_tags[category]`](https://github.com/getsentry/sentry/blob/7a44b756da14e601f0389418f69bd6cae25d0587/src/sentry/utils/snuba.py#L109-L155)! So, as a result searching indexed spans for `span.module:http` doesn't work, but `category:http` _does_ work because it delegates directly to `sentry_tags[category]`

Adding a mapping from `spans.category` to `sentry_tags[category]` which both allows `span.module` to resolve correctly, _and_ allows querying by `span.category` which is more intuitive than `category`.
