### PR TITLE
ref(replay): only preload mobile replay videos when needed

### DIFF
--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -178,18 +178,20 @@ describe('VideoReplayer - no starting gap', () => {
     expect(inst._currentIndex).toEqual(7);
 
     // videos loaded should be [0, 1, 2, 4, 5, 6, 7]
+    // since we have [0, 1, 2] preloaded initially
+    // and only [4, 5, 6, 7] loaded when segment 7 is requested
+
     // @ts-expect-error private
-    expect(Object.keys(inst._videos).length).toEqual(7);
+    const videos = inst._videos;
     // @ts-expect-error private
-    expect(inst._videos[0]).toEqual(inst.getVideo(0));
-    // @ts-expect-error private
-    expect(inst._videos[2]).toEqual(inst.getVideo(2));
-    // @ts-expect-error private
-    expect(inst._videos[3]).toEqual(undefined);
-    // @ts-expect-error private
-    expect(inst._videos[4]).toEqual(inst.getVideo(4));
-    // @ts-expect-error private
-    expect(inst._videos[7]).toEqual(inst.getVideo(7));
+    const getVideo = index => inst.getVideo(index);
+
+    expect(Object.keys(videos).length).toEqual(7);
+    expect(videos[0]).toEqual(getVideo(0));
+    expect(videos[2]).toEqual(getVideo(2));
+    expect(videos[3]).toEqual(undefined);
+    expect(videos[4]).toEqual(getVideo(4));
+    expect(videos[7]).toEqual(getVideo(7));
   });
 
   it('should work correctly if we have missing segments', async () => {
@@ -208,19 +210,18 @@ describe('VideoReplayer - no starting gap', () => {
     // @ts-expect-error private
     expect(inst._currentIndex).toEqual(6);
 
+    // @ts-expect-error private
+    const videos = inst._videos;
+    // @ts-expect-error private
+    const getVideo = index => inst.getVideo(index);
+
     // videos loaded should be [0, 1, 2, 3, 4, 5, 7, 8]
-    // @ts-expect-error private
-    expect(Object.keys(inst._videos).length).toEqual(8);
-    // @ts-expect-error private
-    expect(inst._videos[0]).toEqual(inst.getVideo(0));
-    // @ts-expect-error private
-    expect(inst._videos[2]).toEqual(inst.getVideo(2));
-    // @ts-expect-error private
-    expect(inst._videos[5]).toEqual(inst.getVideo(5));
-    // @ts-expect-error private
-    expect(inst._videos[6]).toEqual(inst.getVideo(6));
-    // @ts-expect-error private
-    expect(inst._videos[7]).toEqual(inst.getVideo(7));
+    expect(Object.keys(videos).length).toEqual(8);
+    expect(videos[0]).toEqual(getVideo(0));
+    expect(videos[2]).toEqual(getVideo(2));
+    expect(videos[5]).toEqual(getVideo(5));
+    expect(videos[6]).toEqual(getVideo(6));
+    expect(videos[7]).toEqual(getVideo(7));
   });
 });
 

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -150,7 +150,7 @@ export class VideoReplayer {
   }
 
   protected getSegment(index?: number | undefined): VideoEvent | undefined {
-    if (typeof index === 'undefined') {
+    if (index === undefined) {
       return undefined;
     }
 
@@ -162,7 +162,7 @@ export class VideoReplayer {
    * Loads the segment at the requested index.
    */
   protected fetchVideo(index: number | undefined): HTMLVideoElement | undefined {
-    if (typeof index === 'undefined') {
+    if (index === undefined || index < 0 || index >= this._attachments.length) {
       return undefined;
     }
 
@@ -194,7 +194,7 @@ export class VideoReplayer {
    * Returns the video in the dictionary at the requested index.
    */
   protected getVideo(index: number | undefined): HTMLVideoElement | undefined {
-    if (typeof index === 'undefined') {
+    if (index === undefined) {
       return undefined;
     }
 

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -43,7 +43,7 @@ export class VideoReplayer {
   private _timer = new Timer();
   private _trackList: [ts: number, index: number][];
   /**
-   * _videos is a dict that maps segmentId to the video element.
+   * _videos is a dict that maps attachment index to the video element.
    * Video elements in this dict are preloaded and ready to be played.
    */
   private _videos: Record<number, HTMLVideoElement>;
@@ -183,8 +183,7 @@ export class VideoReplayer {
   }
 
   /**
-   * Fetches videos from attachments and adds them to the _videos dictionary.
-   * Loads the segment at the requested index.
+   * Fetches the video if it exists, otherwise creates the video and adds to the _videos dictionary.
    */
   protected getOrCreateVideo(index: number | undefined): HTMLVideoElement | undefined {
     const video = this.getVideo(index);


### PR DESCRIPTION
- Optimize loading of videos for mobile replays
- This PR modifies the `_videos` array by converting it into a dictionary that maps segment index to the video element. This makes it easier to only load videos when requested, rather than preloading them all at once.
- Also fixes a bug where `currentIndex` was consistently undefined in the `createVideo` function, but it looks like it's working as expected now
- Closes https://github.com/getsentry/sentry/issues/67430