### PR TITLE
Fix broken link to the Spring framework

### DIFF
--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -240,7 +240,7 @@ export const platforms: PlatformIntegration[] = [
     name: 'Spring',
     type: 'framework',
     language: 'java',
-    link: 'https://https://docs.sentry.io/platforms/java/guides/spring/',
+    link: 'https://docs.sentry.io/platforms/java/guides/spring/',
   },
   {
     id: 'java-spring-boot',


### PR DESCRIPTION
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
