### PR TITLE
ref(replay): rename 'issue' breadcrumb filter to 'error'

### DIFF
--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -31,7 +31,7 @@ const TYPE_TO_LABEL: Record<string, string> = {
   start: 'Replay Start',
   feedback: 'User Feedback',
   replay: 'Replay',
-  issue: 'Issue',
+  issue: 'Error',
   console: 'Console',
   nav: 'Navigation',
   pageLoad: 'Page Load',


### PR DESCRIPTION
Match the breadcrumb filter to the breadcrumb title:

<img width="635" alt="SCR-20240325-npgy" src="https://github.com/getsentry/sentry/assets/56095982/64943470-84f5-4a4f-8779-672110b3e2b6">
