### PR TITLE
ref(replay): hide memory, a11y, trace tab for mobile replays

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -15,7 +15,13 @@ import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveRe
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
+function getReplayTabs({
+  organization,
+  isVideoReplay,
+}: {
+  isVideoReplay: boolean;
+  organization: Organization;
+}): Record<TabKey, ReactNode> {
   // The new trace table inside Breadcrumb items:
   const hasTraceTable = organization.features.includes('session-replay-trace-table');
 
@@ -24,9 +30,9 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
     [TabKey.CONSOLE]: t('Console'),
     [TabKey.NETWORK]: t('Network'),
     [TabKey.ERRORS]: t('Errors'),
-    [TabKey.TRACE]: hasTraceTable ? null : t('Trace'),
+    [TabKey.TRACE]: !hasTraceTable || isVideoReplay ? null : t('Trace'),
     [TabKey.PERF]: null,
-    [TabKey.A11Y]: (
+    [TabKey.A11Y]: isVideoReplay ? null : (
       <Fragment>
         <Tooltip
           isHoverable
@@ -49,16 +55,17 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
         />
       </Fragment>
     ),
-    [TabKey.MEMORY]: t('Memory'),
+    [TabKey.MEMORY]: isVideoReplay ? null : t('Memory'),
     [TabKey.TAGS]: t('Tags'),
   };
 }
 
 type Props = {
+  isVideoReplay: boolean;
   className?: string;
 };
 
-function FocusTabs({className}: Props) {
+function FocusTabs({className, isVideoReplay}: Props) {
   const organization = useOrganization();
   const {pathname, query} = useLocation();
   const {getActiveTab, setActiveTab} = useActiveReplayTab();
@@ -66,7 +73,7 @@ function FocusTabs({className}: Props) {
 
   return (
     <ScrollableTabs className={className} underlined>
-      {Object.entries(getReplayTabs(organization)).map(([tab, label]) =>
+      {Object.entries(getReplayTabs({organization, isVideoReplay})).map(([tab, label]) =>
         label ? (
           <ListLink
             data-test-id={`replay-details-${tab}-btn`}

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -30,7 +30,7 @@ function getReplayTabs({
     [TabKey.CONSOLE]: t('Console'),
     [TabKey.NETWORK]: t('Network'),
     [TabKey.ERRORS]: t('Errors'),
-    [TabKey.TRACE]: !hasTraceTable || isVideoReplay ? null : t('Trace'),
+    [TabKey.TRACE]: hasTraceTable || isVideoReplay ? null : t('Trace'),
     [TabKey.PERF]: null,
     [TabKey.A11Y]: isVideoReplay ? null : (
       <Fragment>

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -21,7 +21,7 @@ const MIN_CONTENT_HEIGHT = 180;
 
 const DIVIDER_SIZE = 16;
 
-function ReplayLayout({isVideoReplay}: {isVideoReplay?: boolean}) {
+function ReplayLayout({isVideoReplay = false}: {isVideoReplay?: boolean}) {
   const {getLayout} = useReplayLayout();
   const layout = getLayout() ?? LayoutKey.TOPBAR;
 
@@ -60,7 +60,7 @@ function ReplayLayout({isVideoReplay}: {isVideoReplay?: boolean}) {
   }
 
   const focusArea = (
-    <FluidPanel title={<SmallMarginFocusTabs />}>
+    <FluidPanel title={<SmallMarginFocusTabs isVideoReplay={isVideoReplay} />}>
       <ErrorBoundary mini>
         <FocusArea />
       </ErrorBoundary>


### PR DESCRIPTION
Normal web replays look the same:
<img width="1177" alt="SCR-20240325-oley" src="https://github.com/getsentry/sentry/assets/56095982/e27b03dd-d6a4-469d-abf1-06dd6d620c05">

Mobile replays don't have the a11y, memory, or trace tabs:
<img width="1053" alt="SCR-20240325-oldj" src="https://github.com/getsentry/sentry/assets/56095982/6c8afac3-113d-4d73-895d-dd4fa1c4bb4b">
