### PR TITLE
ref(code-mappings): Unify code-mapping logic

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
@@ -4,7 +4,6 @@ from django.db import router
 from django.urls import reverse
 from rest_framework import status
 
-from sentry.integrations.utils.code_mapping import FrameFilename, _get_code_mapping_source_path
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
@@ -62,15 +61,14 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
     @patch("sentry.integrations.github.GitHubIntegration.get_trees_for_org")
     def test_get_start_with_backslash(self, mock_get_trees_for_org):
         file = "stack/root/file.py"
-        frame_info = FrameFilename(f"/{file}")
         config_data = {"stacktraceFilename": f"/{file}"}
         expected_matches = [
             {
                 "filename": file,
                 "repo_name": "getsentry/codemap",
                 "repo_branch": "master",
-                "stacktrace_root": f"{frame_info.root}",
-                "source_path": _get_code_mapping_source_path(file, frame_info),
+                "stacktrace_root": "",
+                "source_path": "",
             }
         ]
         with patch(
@@ -117,8 +115,9 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
             "projectId": self.project.id,
             "stacktraceFilename": "stack/root/file.py",
         }
-        with assume_test_silo_mode(SiloMode.CONTROL), unguarded_write(
-            using=router.db_for_write(Integration)
+        with (
+            assume_test_silo_mode(SiloMode.CONTROL),
+            unguarded_write(using=router.db_for_write(Integration)),
         ):
             Integration.objects.all().delete()
         response = self.client.get(self.url, data=config_data, format="json")
@@ -185,8 +184,9 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
             "defaultBranch": "master",
             "repoName": "name",
         }
-        with assume_test_silo_mode(SiloMode.CONTROL), unguarded_write(
-            using=router.db_for_write(Integration)
+        with (
+            assume_test_silo_mode(SiloMode.CONTROL),
+            unguarded_write(using=router.db_for_write(Integration)),
         ):
             Integration.objects.all().delete()
         response = self.client.post(self.url, data=config_data, format="json")

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -197,8 +197,8 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
             "integrationId": self.integration.id,
             "repositoryId": self.repo.id,
             "provider": "github",
-            "stackRoot": "",
-            "sourceRoot": "src/",
+            "stackRoot": "sentry/",
+            "sourceRoot": "src/sentry/",
             "defaultBranch": "master",
         }
 
@@ -225,8 +225,8 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
             "integrationId": self.integration.id,
             "repositoryId": self.repo.id,
             "provider": "github",
-            "stackRoot": "stuff/hey/here/",
-            "sourceRoot": "src/",
+            "stackRoot": "stuff/hey/here/sentry/",
+            "sourceRoot": "src/sentry/",
             "defaultBranch": "master",
         }
 
@@ -261,8 +261,8 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
             "integrationId": self.integration.id,
             "repositoryId": self.repo.id,
             "provider": "github",
-            "stackRoot": "C:\\potatos\\and\\prs\\",
-            "sourceRoot": "src/",
+            "stackRoot": "C:\\potatos\\and\\prs\\sentry\\",
+            "sourceRoot": "src/sentry/",
             "defaultBranch": "main",
         }
 
@@ -300,8 +300,8 @@ class ProjectStacktraceLinkGitlabTest(BaseStacktraceLinkTest):
             "integrationId": self.integration.id,
             "repositoryId": self.repo.id,
             "provider": "gitlab",
-            "stackRoot": "",
-            "sourceRoot": "src/",
+            "stackRoot": "sentry/",
+            "sourceRoot": "src/sentry/",
             "defaultBranch": "master",
         }
 

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -271,64 +271,6 @@ class TestDerivedCodeMappings(TestCase):
         ]
         assert matches == expected_matches
 
-    def test_normalized_stack_and_source_roots_starts_with_period_slash(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "./app/", "static/app/"
-        )
-        assert stacktrace_root == "./"
-        assert source_path == "static/"
-
-    def test_normalized_stack_and_source_roots_starts_with_period_slash_no_containing_directory(
-        self,
-    ):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "./app/", "app/"
-        )
-        assert stacktrace_root == "./"
-        assert source_path == ""
-
-    def test_normalized_stack_and_source_not_matching(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "sentry/", "src/sentry/"
-        )
-        assert stacktrace_root == "sentry/"
-        assert source_path == "src/sentry/"
-
-    def test_normalized_stack_and_source_roots_equal(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "source/", "source/"
-        )
-        assert stacktrace_root == ""
-        assert source_path == ""
-
-    def test_normalized_stack_and_source_roots_starts_with_period_slash_two_levels(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "./app/", "app/foo/app/"
-        )
-        assert stacktrace_root == "./"
-        assert source_path == "app/foo/"
-
-    def test_normalized_stack_and_source_roots_starts_with_app(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "app:///utils/", "utils/"
-        )
-        assert stacktrace_root == "app:///"
-        assert source_path == ""
-
-    def test_normalized_stack_and_source_roots_starts_with_multiple_dot_dot_slash(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "../../../../../../packages/", "packages/"
-        )
-        assert stacktrace_root == "../../../../../../"
-        assert source_path == ""
-
-    def test_normalized_stack_and_source_roots_starts_with_app_dot_dot_slash(self):
-        stacktrace_root, source_path = self.code_mapping_helper._normalized_stack_and_source_roots(
-            "app:///../services/", "services/"
-        )
-        assert stacktrace_root == "app:///../"
-        assert source_path == ""
-
 
 class TestConvertStacktraceFramePathToSourcePath(TestCase):
     def setUp(self):

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -385,8 +385,8 @@ class TestPhpDeriveCodeMappings(BaseDeriveCodeMappings):
             }
             derive_code_mappings(self.project.id, self.event_data)
             code_mapping = RepositoryProjectPathConfig.objects.all()[0]
-            assert code_mapping.stack_root == "sentry/"
-            assert code_mapping.source_root == "src/sentry/"
+            assert code_mapping.stack_root == ""
+            assert code_mapping.source_root == "src/"
             assert code_mapping.repository.name == repo_name
 
 
@@ -563,7 +563,7 @@ class TestPythonDeriveCodeMappings(BaseDeriveCodeMappings):
             }
             derive_code_mappings(self.project.id, self.test_data)
             code_mapping = RepositoryProjectPathConfig.objects.all().first()
-            # sentry/models/release.py -> models/release.py -> sentry/models/release.py
-            # If the normalization code was used these would be the empty stack root
+
+            # This works, but ideally it should be "" and ""
             assert code_mapping.stack_root == "sentry/"
             assert code_mapping.source_root == "sentry/"


### PR DESCRIPTION
The goal of this PR is to unify all logic to derive the stack trace root and source code root, since this logic has been materially different across automatic and manual code-mapping derivations. 

This PR makes `find_roots` the single source of truth for deriving these roots across the manual and automatic derivations. As an added benefit, `find_roots` is more refactorable and resilient to future platforms that made be added, and it reduces the footprint and complexity of code-mappings in general. 