### PR TITLE
Propagate Rust `Enhancements` parse errors

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -63,7 +63,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.5
 sentry-kafka-schemas>=0.1.64
-sentry-ophio==0.2.5
+sentry-ophio==0.2.6
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.55
 sentry-sdk>=1.43.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -178,7 +178,7 @@ sentry-devenv==1.2.3
 sentry-forked-django-stubs==4.2.7.post3
 sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.64
-sentry-ophio==0.2.5
+sentry-ophio==0.2.6
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.55
 sentry-sdk==1.43.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -120,7 +120,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.5
 sentry-kafka-schemas==0.1.64
-sentry-ophio==0.2.5
+sentry-ophio==0.2.6
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.55
 sentry-sdk==1.43.0

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -179,7 +179,7 @@ def get_default_enhancements(config_id=None) -> str:
     base: str | None = DEFAULT_GROUPING_ENHANCEMENTS_BASE
     if config_id is not None:
         base = CONFIGURATIONS[config_id].enhancements_base
-    return Enhancements(rules=[], bases=[base]).dumps()
+    return Enhancements.from_config_string("", bases=[base]).dumps()
 
 
 def get_projects_default_fingerprinting_bases(

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -285,7 +285,7 @@ class StrategyConfiguration:
 
     def __init__(self, enhancements: str | None = None, **extra: Any):
         if enhancements is None:
-            enhancements_instance = Enhancements([])
+            enhancements_instance = Enhancements.from_config_string("")
         else:
             enhancements_instance = Enhancements.loads(enhancements)
         self.enhancements = enhancements_instance

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -58,6 +58,14 @@ family:native                                   max-frames=3
     assert isinstance(dumped, str)
 
 
+def test_parse_empty_with_base():
+    enhancement = Enhancements.from_config_string(
+        "",
+        bases=["newstyle:2023-01-11"],
+    )
+    assert enhancement
+
+
 def test_parsing_errors():
     with pytest.raises(InvalidEnhancerConfig):
         Enhancements.from_config_string("invalid.message:foo -> bar")


### PR DESCRIPTION
The Rust `Enhancements` now have prettier Parse Errors. It makes sense to surface those up to users.

This also means that parsing `RustEnhancements` is now infallible, so this updates all the typings and related code.

---

The Rust code also silently ignores a bunch of errors for compatibility reasons, as the Python code does the same. It should be possible with some effort to also introduce a `strict` parsing mode to raise those errors, but that is something for the future.