### PR TITLE
fix(event-details): Apply minmax to tags table values

### DIFF
--- a/static/app/components/keyValueTable.tsx
+++ b/static/app/components/keyValueTable.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const KeyValueTable = styled('dl')<{noMargin?: boolean}>`
   display: grid;
-  grid-template-columns: fit-content(50%) auto;
+  grid-template-columns: fit-content(50%) minmax(0, 1fr);
   ${p => (p.noMargin ? 'margin-bottom: 0;' : null)}
 `;
 


### PR DESCRIPTION
By default grid items will have auto min-width which defers to the content. By setting it to `minmax(0, 1fr)` we avoid grid items overflowing by assigning a min-width that does not depend on the content.

Fixes #67583