### PR TITLE
refactor: replace memoize with django utils

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -9,6 +9,7 @@ from django.db import models, router, transaction
 from django.db.models.query_utils import DeferredAttribute
 from django.urls import reverse
 from django.utils import timezone as django_timezone
+from django.utils.functional import cached_property
 from rest_framework import serializers, status
 
 from bitfield.types import BitHandler
@@ -72,7 +73,6 @@ from sentry.services.organization.provisioning import (
     organization_provisioning_service,
 )
 from sentry.utils.audit import create_audit_entry
-from sentry.utils.cache import memoize
 
 ERR_DEFAULT_ORG = "You cannot remove the default organization."
 ERR_NO_USER = "This request requires an authenticated user."
@@ -231,7 +231,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     relayPiiConfig = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     apdexThreshold = serializers.IntegerField(min_value=1, required=False)
 
-    @memoize
+    @cached_property
     def _has_legacy_rate_limits(self):
         org = self.context["organization"]
         return OrganizationOption.objects.filter(

--- a/src/sentry/auth/system.py
+++ b/src/sentry/auth/system.py
@@ -9,9 +9,9 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http.request import HttpRequest
 from django.utils.crypto import constant_time_compare
+from django.utils.functional import cached_property
 
 from sentry import options
-from sentry.utils.cache import memoize
 
 INTERNAL_NETWORKS = [
     ipaddress.ip_network(str(net), strict=False) for net in settings.INTERNAL_SYSTEM_IPS
@@ -76,7 +76,7 @@ class SystemToken:
     def is_expired(self) -> bool:
         return False
 
-    @memoize
+    @cached_property
     def user(self) -> AnonymousUser:
         user = AnonymousUser()
         user.is_active = True

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -8,11 +8,11 @@ from typing import Any
 from uuid import uuid4
 
 from django.db.models.signals import post_delete
+from django.utils.functional import cached_property
 
 from sentry import nodestore
 from sentry.db.models.utils import Creator
 from sentry.utils import json
-from sentry.utils.cache import memoize
 from sentry.utils.canonical import CANONICAL_TYPES, CanonicalKeyDict
 from sentry.utils.strings import decompress
 
@@ -98,7 +98,7 @@ class NodeData(MutableMapping):
     def copy(self):
         return self.data.copy()
 
-    @memoize
+    @cached_property
     def data(self):
         """
         Get the current data object, fetching from nodestore if necessary.

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -13,6 +13,7 @@ import sentry_sdk
 from dateutil.parser import parse as parse_date
 from django.conf import settings
 from django.utils.encoding import force_str
+from django.utils.functional import cached_property
 
 from sentry import eventtypes
 from sentry.db.models import NodeData
@@ -24,7 +25,6 @@ from sentry.models.event import EventDict
 from sentry.snuba.events import Columns
 from sentry.spans.grouping.api import load_span_grouping_config
 from sentry.utils import json
-from sentry.utils.cache import memoize
 from sentry.utils.canonical import CanonicalKeyView
 from sentry.utils.safe import get_path, trim
 from sentry.utils.strings import truncatechars
@@ -292,7 +292,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
     def get_interfaces(self) -> Mapping[str, Interface]:
         return cast(Mapping[str, Interface], CanonicalKeyView(get_interfaces(self.data)))
 
-    @memoize
+    @cached_property
     def interfaces(self) -> Mapping[str, Interface]:
         return self.get_interfaces()
 
@@ -546,7 +546,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
 
         return data
 
-    @memoize
+    @cached_property
     def search_message(self) -> str:
         """
         The internal search_message attribute is only used for search purposes.
@@ -777,7 +777,7 @@ class GroupEvent(BaseEvent):
             return cast(str, self._snuba_data[column])
         return None
 
-    @memoize
+    @cached_property
     def search_message(self) -> str:
         message = super().search_message
         # Include values from the occurrence in our search message as well, so that occurrences work

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.utils.functional import cached_property
 from rest_framework import status
 
 from sentry.integrations.slack.requests.base import SlackRequest, SlackRequestError
 from sentry.models.group import Group
 from sentry.utils import json
-from sentry.utils.cache import memoize
 from sentry.utils.json import JSONData
 
 
@@ -24,7 +24,7 @@ class SlackActionRequest(SlackRequest):
     def type(self) -> str:
         return str(self.data.get("type"))
 
-    @memoize
+    @cached_property
     def callback_data(self) -> JSONData:
         """
         We store certain data in ``callback_id`` as JSON. It's a bit hacky, but

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -1,7 +1,8 @@
+from django.utils.functional import cached_property
+
 from sentry.interfaces.base import Interface
 from sentry.security import csp
 from sentry.utils import json
-from sentry.utils.cache import memoize
 from sentry.web.helpers import render_to_string
 
 __all__ = ("Csp", "Hpkp", "ExpectCT", "ExpectStaple")
@@ -179,11 +180,11 @@ class Csp(SecurityReport):
             "sentry/partial/interfaces/csp_email.html", {"data": self.get_api_context()}
         )
 
-    @memoize
+    @cached_property
     def normalized_blocked_uri(self):
         return csp.normalize_value(self.blocked_uri)
 
-    @memoize
+    @cached_property
     def local_script_violation_type(self):
         """
         If this is a locally-sourced script-src error, gives the type.

--- a/src/sentry/mediators/alert_rule_actions/creator.py
+++ b/src/sentry/mediators/alert_rule_actions/creator.py
@@ -1,4 +1,5 @@
 from django.db import router
+from django.utils.functional import cached_property
 
 from sentry.coreapi import APIError
 from sentry.mediators.external_requests.alert_rule_action_requester import (
@@ -9,7 +10,6 @@ from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
 from sentry.models.integrations.sentry_app_component import SentryAppComponent
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
-from sentry.utils.cache import memoize
 
 
 class AlertRuleActionCreator(Mediator):
@@ -39,6 +39,6 @@ class AlertRuleActionCreator(Mediator):
             fields=self.fields,
         )
 
-    @memoize
+    @cached_property
     def sentry_app(self):
         return self.install.sentry_app

--- a/src/sentry/mediators/external_issues/issue_link_creator.py
+++ b/src/sentry/mediators/external_issues/issue_link_creator.py
@@ -1,4 +1,5 @@
 from django.db import router
+from django.utils.functional import cached_property
 
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.external_issues.creator import Creator
@@ -9,7 +10,6 @@ from sentry.models.group import Group
 from sentry.models.platformexternalissue import PlatformExternalIssue
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation
 from sentry.services.hybrid_cloud.user import RpcUser
-from sentry.utils.cache import memoize
 
 
 class IssueLinkCreator(Mediator):
@@ -50,6 +50,6 @@ class IssueLinkCreator(Mediator):
             identifier=self.response["identifier"],
         )
 
-    @memoize
+    @cached_property
     def sentry_app(self):
         return self.install.sentry_app

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
 from django.db import router
+from django.utils.functional import cached_property
 from requests import RequestException
 from requests.models import Response
 
@@ -12,7 +13,6 @@ from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.utils import json
-from sentry.utils.cache import memoize
 
 logger = logging.getLogger("sentry.mediators.external-requests")
 
@@ -98,7 +98,7 @@ class AlertRuleActionRequester(Mediator):
             "Sentry-App-Signature": self.sentry_app.build_signature(self.body),
         }
 
-    @memoize
+    @cached_property
     def body(self):
         return json.dumps(
             {
@@ -107,6 +107,6 @@ class AlertRuleActionRequester(Mediator):
             }
         )
 
-    @memoize
+    @cached_property
     def sentry_app(self):
         return self.install.sentry_app

--- a/src/sentry/mediators/external_requests/issue_link_requester.py
+++ b/src/sentry/mediators/external_requests/issue_link_requester.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from django.db import router
+from django.utils.functional import cached_property
 
 from sentry.coreapi import APIError
 from sentry.http import safe_urlread
@@ -16,7 +17,6 @@ from sentry.models.group import Group
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.utils import json
-from sentry.utils.cache import memoize
 
 logger = logging.getLogger("sentry.mediators.external-requests")
 
@@ -112,7 +112,7 @@ class IssueLinkRequester(Mediator):
             "Sentry-App-Signature": self.sentry_app.build_signature(self.body),
         }
 
-    @memoize
+    @cached_property
     def body(self):
         body: dict[str, Any] = {"fields": {}}
         for name, value in self.fields.items():
@@ -126,6 +126,6 @@ class IssueLinkRequester(Mediator):
         body["actor"] = {"type": "user", "id": self.user.id, "name": self.user.name}
         return json.dumps(body)
 
-    @memoize
+    @cached_property
     def sentry_app(self):
         return self.install.sentry_app

--- a/src/sentry/mediators/external_requests/select_requester.py
+++ b/src/sentry/mediators/external_requests/select_requester.py
@@ -2,6 +2,8 @@ import logging
 from urllib.parse import urlencode, urlparse, urlunparse
 from uuid import uuid4
 
+from django.utils.functional import cached_property
+
 from sentry.coreapi import APIError
 from sentry.http import safe_urlread
 from sentry.mediators.external_requests.util import send_and_save_sentry_app_request, validate
@@ -9,7 +11,6 @@ from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation
 from sentry.utils import json
-from sentry.utils.cache import memoize
 
 logger = logging.getLogger("sentry.mediators.external-requests")
 
@@ -112,6 +113,6 @@ class SelectRequester(Mediator):
             "Sentry-App-Signature": self.sentry_app.build_signature(""),
         }
 
-    @memoize
+    @cached_property
     def sentry_app(self):
         return self.install.sentry_app

--- a/src/sentry/mediators/mediator.py
+++ b/src/sentry/mediators/mediator.py
@@ -5,9 +5,9 @@ import logging
 from contextlib import contextmanager
 
 from django.db import transaction
+from django.utils.functional import cached_property
 
 import sentry
-from sentry.utils.cache import memoize
 from sentry.utils.functional import compact
 
 from .param import Param
@@ -215,7 +215,7 @@ class Mediator:
         # that it matches the name we'll be invoking on the Mediator instance.
         return {k[1:]: v for k, v in self.__class__.__dict__.items() if isinstance(v, Param)}
 
-    @memoize
+    @cached_property
     def _logging_name(self):
         return ".".join([self.__class__.__module__, self.__class__.__name__])
 

--- a/src/sentry/mediators/plugins/migrator.py
+++ b/src/sentry/mediators/plugins/migrator.py
@@ -1,3 +1,5 @@
+from django.utils.functional import cached_property
+
 from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
 from sentry.plugins.base import plugins
@@ -5,7 +7,6 @@ from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.organization.model import RpcOrganization
 from sentry.services.hybrid_cloud.repository import repository_service
 from sentry.services.hybrid_cloud.repository.model import RpcRepository
-from sentry.utils.cache import memoize
 
 
 class Migrator(Mediator):
@@ -43,7 +44,7 @@ class Migrator(Mediator):
     def repositories(self) -> list[RpcRepository]:
         return repository_service.get_repositories(organization_id=self.organization.id)
 
-    @memoize
+    @cached_property
     def projects(self):
         return list(self.organization.projects)
 

--- a/src/sentry/mediators/sentry_app_installations/installation_notifier.py
+++ b/src/sentry/mediators/sentry_app_installations/installation_notifier.py
@@ -1,4 +1,5 @@
 from django.db import router
+from django.utils.functional import cached_property
 
 from sentry.api.serializers import AppPlatformEvent, SentryAppInstallationSerializer, serialize
 from sentry.coreapi import APIUnauthorized
@@ -6,7 +7,6 @@ from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.services.hybrid_cloud.user.model import RpcUser
-from sentry.utils.cache import memoize
 from sentry.utils.sentry_apps import send_and_save_webhook_request
 
 
@@ -41,10 +41,10 @@ class InstallationNotifier(Mediator):
             actor=self.user,
         )
 
-    @memoize
+    @cached_property
     def sentry_app(self):
         return self.install.sentry_app
 
-    @memoize
+    @cached_property
     def api_grant(self):
         return self.install.api_grant_id and self.install.api_grant

--- a/src/sentry/mediators/token_exchange/grant_exchanger.py
+++ b/src/sentry/mediators/token_exchange/grant_exchanger.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 from django.db import router
+from django.utils.functional import cached_property
 
 from sentry import analytics
 from sentry.coreapi import APIUnauthorized
@@ -16,7 +17,6 @@ from sentry.models.integrations.sentry_app_installation import SentryAppInstalla
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation
 from sentry.silo import unguarded_write
-from sentry.utils.cache import memoize
 
 
 class GrantExchanger(Mediator):
@@ -82,7 +82,7 @@ class GrantExchanger(Mediator):
         except SentryAppInstallation.DoesNotExist:
             pass
 
-    @memoize
+    @cached_property
     def grant(self):
         try:
             return (

--- a/src/sentry/mediators/token_exchange/refresher.py
+++ b/src/sentry/mediators/token_exchange/refresher.py
@@ -1,4 +1,5 @@
 from django.db import router
+from django.utils.functional import cached_property
 
 from sentry import analytics
 from sentry.coreapi import APIUnauthorized
@@ -12,7 +13,6 @@ from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation
-from sentry.utils.cache import memoize
 
 
 class Refresher(Mediator):
@@ -63,14 +63,14 @@ class Refresher(Mediator):
             pass
         return token
 
-    @memoize
+    @cached_property
     def token(self):
         try:
             return ApiToken.objects.get(refresh_token=self.refresh_token)
         except ApiToken.DoesNotExist:
             raise APIUnauthorized
 
-    @memoize
+    @cached_property
     def application(self):
         try:
             return ApiApplication.objects.get(client_id=self.client_id)

--- a/src/sentry/mediators/token_exchange/validator.py
+++ b/src/sentry/mediators/token_exchange/validator.py
@@ -1,4 +1,5 @@
 from django.db import router
+from django.utils.functional import cached_property
 
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.mediator import Mediator
@@ -7,7 +8,6 @@ from sentry.models.apiapplication import ApiApplication
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation
-from sentry.utils.cache import memoize
 
 
 class Validator(Mediator):
@@ -38,14 +38,14 @@ class Validator(Mediator):
         if self.install.sentry_app.id != self.sentry_app.id:
             raise APIUnauthorized
 
-    @memoize
+    @cached_property
     def sentry_app(self):
         try:
             return self.application.sentry_app
         except SentryApp.DoesNotExist:
             raise APIUnauthorized
 
-    @memoize
+    @cached_property
     def application(self):
         try:
             return ApiApplication.objects.get(client_id=self.client_id)

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -5,8 +5,7 @@ from typing import Any
 from datadog import initialize
 from datadog.threadstats.base import ThreadStats
 from datadog.util.hostname import get_hostname
-
-from sentry.utils.cache import memoize
+from django.utils.functional import cached_property
 
 from .base import MetricsBackend, Tags
 
@@ -29,7 +28,7 @@ class DatadogMetricsBackend(MetricsBackend):
             # TypeError: 'NoneType' object is not callable
             pass
 
-    @memoize
+    @cached_property
     def stats(self) -> ThreadStats:
         instance = ThreadStats()
         instance.start()

--- a/src/sentry/models/commit.py
+++ b/src/sentry/models/commit.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, ClassVar
 from django.db import models
 from django.db.models.query import QuerySet
 from django.utils import timezone
+from django.utils.functional import cached_property
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
@@ -16,7 +17,6 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
-from sentry.utils.cache import memoize
 from sentry.utils.groupreference import find_referenced_groups
 
 if TYPE_CHECKING:
@@ -59,13 +59,13 @@ class Commit(Model):
 
     __repr__ = sane_repr("organization_id", "repository_id", "key")
 
-    @memoize
+    @cached_property
     def title(self):
         if not self.message:
             return ""
         return self.message.splitlines()[0]
 
-    @memoize
+    @cached_property
     def short_id(self):
         if len(self.key) == 40:
             return self.key[:7]

--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -6,9 +6,9 @@ from typing import Any
 
 import sentry_sdk
 from django.core.cache import BaseCache, InvalidCacheBackendError, caches
+from django.utils.functional import cached_property
 
 from sentry.utils import json
-from sentry.utils.cache import memoize
 from sentry.utils.services import Service
 
 # Cache an instance of the encoder we want to use
@@ -294,7 +294,7 @@ class NodeStorage(local, Service):
         if self.cache:
             self.cache.delete_many([item_id for item_id in id_list])
 
-    @memoize
+    @cached_property
     def cache(self) -> BaseCache | None:
         try:
             return caches["nodedata"]

--- a/src/sentry/utils/cache.py
+++ b/src/sentry/utils/cache.py
@@ -1,43 +1,13 @@
-from collections.abc import Callable, Mapping
-from typing import Any, Generic, TypeVar
+from collections.abc import Mapping
+from typing import Any, TypeVar
 
 from django.core.cache import cache
 
-__all__ = ["cache", "memoize", "default_cache", "cache_key_for_event"]
+__all__ = ["cache", "default_cache", "cache_key_for_event"]
 
 default_cache = cache
 
 T = TypeVar("T")
-
-
-class memoize(Generic[T]):
-    """
-    Memoize the result of a property call.
-
-    >>> class A(object):
-    >>>     @memoize
-    >>>     def func(self):
-    >>>         return 'foo'
-    """
-
-    def __init__(self, func: Callable[[Any], T]) -> None:
-        if isinstance(func, classmethod) or isinstance(func, staticmethod):
-            func = func.__func__  # type: ignore[unreachable]
-
-        self.__name__ = func.__name__
-        self.__module__ = func.__module__
-        self.__doc__ = func.__doc__
-        self.func = func
-
-    def __get__(self, obj: Any, type: Any = None) -> T:
-        if obj is None:
-            return self  # type: ignore[return-value]
-        d, n = vars(obj), self.__name__
-        if n not in d:
-            value = self.func(obj)
-            d[n] = value
-        value = d[n]
-        return value
 
 
 def cache_key_for_event(data: Mapping[str, Any]) -> str:

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -2,6 +2,7 @@ from unittest import mock
 from urllib.parse import urlencode
 
 import pytest
+from django.utils.functional import cached_property
 
 from sentry import options
 from sentry.integrations.slack.requests.action import SlackActionRequest
@@ -12,7 +13,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import control_silo_test, region_silo_test
 from sentry.utils import json
-from sentry.utils.cache import memoize
 
 
 @control_silo_test
@@ -33,7 +33,7 @@ class SlackRequestTest(TestCase):
             options.get("slack.signing-secret"), self.request.body
         )
 
-    @memoize
+    @cached_property
     def slack_request(self):
         return SlackRequest(self.request)
 
@@ -152,7 +152,7 @@ class SlackEventRequestTest(TestCase):
             options.get("slack.signing-secret"), self.request.body
         )
 
-    @memoize
+    @cached_property
     def slack_request(self):
         return SlackEventRequest(self.request)
 
@@ -238,7 +238,7 @@ class SlackActionRequestTest(TestCase):
             options.get("slack.signing-secret"), self.request.body
         )
 
-    @memoize
+    @cached_property
     def slack_request(self):
         return SlackActionRequest(self.request)
 


### PR DESCRIPTION
Let's remove internal implementation in favor of `functools`

Ref: https://github.com/getsentry/team-ingest/issues/400