### PR TITLE
fix(metric-alerts): add entity to timestamp condition

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -12,7 +12,7 @@ from django.db import router, transaction
 from django.db.models.signals import post_save
 from django.forms import ValidationError
 from django.utils import timezone as django_timezone
-from snuba_sdk import Column, Condition, Entity, Limit, Op
+from snuba_sdk import Column, Condition, Limit, Op
 
 from sentry import analytics, audit_log, features, quotas
 from sentry.auth.access import SystemAccess
@@ -65,6 +65,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
     EntitySubscription,
+    get_entity_from_query_builder,
     get_entity_key_from_query_builder,
     get_entity_subscription_from_snuba_query,
 )
@@ -356,7 +357,7 @@ def build_incident_query_builder(
             query_builder.columns[i] = replace(column, alias="count")
     entity_key = get_entity_key_from_query_builder(query_builder)
     time_col = ENTITY_TIME_COLUMNS[entity_key]
-    entity = Entity(entity_key.value, alias=entity_key.value)
+    entity = get_entity_from_query_builder(query_builder)
     query_builder.add_conditions(
         [
             Condition(Column(time_col, entity=entity), Op.GTE, start),

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -672,7 +672,7 @@ def get_entity_from_query_builder(query_builder: QueryBuilder) -> Entity | None:
     if isinstance(match, Join):
         # need to specify Entity for Join queries
         match = match.relationships[0].lhs
-        return Entity(match.name)
+        return Entity(name=match.name, alias=match.name)
     return None
 
 

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict, Union
 
-from snuba_sdk import Column, Condition, Join, Op, Request
+from snuba_sdk import Column, Condition, Entity, Join, Op, Request
 
 from sentry import features
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, CRASH_RATE_ALERT_SESSION_COUNT_ALIAS
@@ -664,6 +664,16 @@ def get_entity_key_from_request(request: Request) -> EntityKey:
         # XXX: Is there a better way to handle this
         match = match.relationships[0].lhs
     return EntityKey(match.name)
+
+
+def get_entity_from_query_builder(query_builder: QueryBuilder) -> Entity | None:
+    request = query_builder.get_snql_query()
+    match = request.query.match
+    if isinstance(match, Join):
+        # need to specify Entity for Join queries
+        match = match.relationships[0].lhs
+        return Entity(match.name)
+    return None
 
 
 def get_entity_key_from_query_builder(query_builder: QueryBuilder) -> EntityKey:

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -88,7 +88,7 @@ from sentry.testutils.cases import BaseIncidentsTest, BaseMetricsTestCase, Snuba
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
-from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
 from sentry.utils import json
 
 pytestmark = [pytest.mark.sentry_metrics]


### PR DESCRIPTION
Fixes SENTRY-2J26
Fixes SENTRY-2WPW
Fixes SENTRY-2XXH
Fixes SENTRY-2ZSY

The timestamp column needs to have a qualifying entity when the Snuba query includes a JOIN. We get the name of the time-related column by getting the `EntityKey`, and we can initialize an `Entity` object with this information.