### PR TITLE
chore(enterprise): Remove rolled out feature flags

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -208,7 +208,6 @@ describe('IntegrationDetailedView', function () {
   });
 
   it('cannot enable PR bot without GitHub integration', async function () {
-    org.features.push('integrations-open-pr-comment');
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/config/integrations/?provider_key=github`,
       body: {
@@ -241,8 +240,6 @@ describe('IntegrationDetailedView', function () {
   });
 
   it('can enable github features', async function () {
-    org.features.push('integrations-open-pr-comment');
-
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/config/integrations/?provider_key=github`,
       body: {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -242,7 +242,6 @@ describe('IntegrationDetailedView', function () {
 
   it('can enable github features', async function () {
     org.features.push('integrations-open-pr-comment');
-    org.features.push('integrations-gh-invite');
 
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/config/integrations/?provider_key=github`,

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -36,9 +36,8 @@ describe('inviteBanner', function () {
     });
   });
 
-  it('render banners with feature flag', async function () {
+  it('render banners', async function () {
     const org = OrganizationFixture({
-      features: ['integrations-gh-invite'],
       githubNudgeInvite: true,
     });
 
@@ -60,27 +59,8 @@ describe('inviteBanner', function () {
     expect(screen.getByText('See all 5 missing members')).toBeInTheDocument();
   });
 
-  it('does not render banner if no feature flag', function () {
-    const org = OrganizationFixture({
-      features: [],
-    });
-
-    const {container} = render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
-    );
-
-    expect(container).toBeEmptyDOMElement();
-  });
-
   it('does not render banner if no option', function () {
-    const org = OrganizationFixture({
-      features: ['integrations-gh-invite'],
-    });
+    const org = OrganizationFixture({});
 
     const {container} = render(
       <InviteBanner
@@ -96,7 +76,6 @@ describe('inviteBanner', function () {
 
   it('does not render banner if no missing members', async function () {
     const org = OrganizationFixture({
-      features: ['integrations-gh-invite'],
       githubNudgeInvite: true,
     });
 
@@ -121,7 +100,6 @@ describe('inviteBanner', function () {
 
   it('does not render banner if no integration', async function () {
     const org = OrganizationFixture({
-      features: ['integrations-gh-invite'],
       githubNudgeInvite: true,
     });
 
@@ -146,7 +124,6 @@ describe('inviteBanner', function () {
 
   it('does not render banner if lacking org:write', function () {
     const org = OrganizationFixture({
-      features: ['integrations-gh-invite'],
       access: [],
       githubNudgeInvite: true,
     });
@@ -165,7 +142,6 @@ describe('inviteBanner', function () {
 
   it('renders banner if snoozed_ts days is longer than threshold', async function () {
     const org = OrganizationFixture({
-      features: ['integrations-gh-invite'],
       githubNudgeInvite: true,
     });
     const promptResponse = {
@@ -199,7 +175,6 @@ describe('inviteBanner', function () {
 
   it('does not render banner if snoozed_ts days is shorter than threshold', async function () {
     const org = OrganizationFixture({
-      features: ['integrations-gh-invite'],
       githubNudgeInvite: true,
     });
     const promptResponse = {
@@ -262,7 +237,6 @@ describe('inviteBanner', function () {
     });
 
     const org = OrganizationFixture({
-      features: ['integrations-gh-invite'],
       githubNudgeInvite: true,
     });
 

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -41,9 +41,7 @@ export function InviteBanner({
   onModalClose,
 }: Props) {
   const isEligibleForBanner =
-    organization.features.includes('integrations-gh-invite') &&
-    organization.access.includes('org:write') &&
-    organization.githubNudgeInvite;
+    organization.access.includes('org:write') && organization.githubNudgeInvite;
   const [sendingInvite, setSendingInvite] = useState<boolean>(false);
   const [showBanner, setShowBanner] = useState<boolean>(false);
   const [missingMembers, setMissingMembers] = useState<MissingMember[]>(


### PR DESCRIPTION
Found some flags that could be removed as they are GA'd in flagr. This will enable them in self-hosted as well:

- `integrations-gh-invite`
- `integrations-open-pr-comment`
- `integrations-open-pr-comment-js`

After this is merged I will remove the above from flagr. Found them while working on

Found while working on https://github.com/getsentry/sentry/pull/67706