### PR TITLE
perf(metrics-extraction): Cache should_use_on_demand decision

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2021,6 +2021,12 @@ register(
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Use to rollout using a cache for should_use_on_demand function, which resolves queries
+register(
+    "on_demand_metrics.cache_should_use_on_demand",
+    default=0.0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Relocation: whether or not the self-serve API for the feature is enabled. When set on a region
 # silo, this flag controls whether or not that region's API will serve relocation requests to

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2025,7 +2025,7 @@ register(
 register(
     "on_demand_metrics.cache_should_use_on_demand",
     default=0.0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_AUTOMATOR_MODIFIABLE | FLAG_MODIFIABLE_RATE,
 )
 
 # Relocation: whether or not the self-serve API for the feature is enabled. When set on a region


### PR DESCRIPTION
### Summary
Checking whether a query should use on-demand requires us to parse the query and use the event_search_grammar every time. This isn't that costly when doing an api call (in the 10ms to 100ms range) but when doing thousands of checks it adds up to a significant amount of time. This caches the decision of using on-demand solely based on the properties for up to an hour.

Behind an option so we can check the impact of this and roll it off quickly if required.