### PR TITLE
feat(priority-alerts): Add a ratelimit to severity service calls

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2173,8 +2173,10 @@ def _get_severity_metadata_for_group(
     """
     from sentry.receivers.rules import PLATFORMS_WITH_PRIORITY_ALERTS
 
-    is_supported_platform = any(
-        event.platform.startswith(platform) for platform in PLATFORMS_WITH_PRIORITY_ALERTS
+    is_supported_platform = (
+        any(event.platform.startswith(platform) for platform in PLATFORMS_WITH_PRIORITY_ALERTS)
+        if event.platform
+        else False
     )
     is_error_group = group_type == ErrorGroupType.type_id if group_type else True
     feature_enabled = features.has("projects:first-event-severity-calculation", event.project)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2183,9 +2183,10 @@ def _get_severity_metadata_for_group(
     if should_calculate_severity:
         from sentry import ratelimits as ratelimiter
 
+        limit = options.get("issues.severity.first-event-severity-calculation-rate-limit", 5)
         if ratelimiter.backend.is_limited(
             f"seer:severity-calculation:{project_id}",
-            limit=5,
+            limit=limit,
             window=1,  # starting this out 5 requests per second
         ):
             logger.warning(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -100,7 +100,6 @@ from sentry.models.userreport import UserReport
 from sentry.net.http import connection_from_url
 from sentry.plugins.base import plugins
 from sentry.quotas.base import index_data_category
-from sentry.receivers.rules import PLATFORMS_WITH_PRIORITY_ALERTS
 from sentry.reprocessing2 import is_reprocessed_event
 from sentry.signals import (
     first_event_received,
@@ -2172,10 +2171,12 @@ def _get_severity_metadata_for_group(
 
     Returns {} if conditions aren't met or on exception.
     """
+    from sentry.receivers.rules import PLATFORMS_WITH_PRIORITY_ALERTS
+
     is_supported_platform = any(
         event.platform.startswith(platform) for platform in PLATFORMS_WITH_PRIORITY_ALERTS
     )
-    is_error_group = group_type is not None and group_type == ErrorGroupType.type_id
+    is_error_group = group_type == ErrorGroupType.type_id if group_type else True
     feature_enabled = features.has("projects:first-event-severity-calculation", event.project)
 
     should_calculate_severity = feature_enabled and is_supported_platform and is_error_group

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -719,6 +719,13 @@ register(
 )
 
 register(
+    "issues.severity.first-event-severity-calculation-rate-limit",
+    type=Int,
+    default=5,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "issues.severity.default-high-priority-alerts-orgs-allowlist",
     type=Sequence,
     default=[],

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -719,9 +719,16 @@ register(
 )
 
 register(
-    "issues.severity.first-event-severity-calculation-rate-limit",
+    "issues.severity.seer-project-rate-limit",
     type=Int,
     default=5,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "issues.severity.seer-global-rate-limit",
+    type=Int,
+    default=25,
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -37,7 +37,7 @@ DEFAULT_RULE_DATA_NEW = {
 }
 
 
-PLATFORMS_WITH_NEW_DEFAULT = ["python", "javascript"]
+PLATFORMS_WITH_PRIORITY_ALERTS = ["python", "javascript"]
 
 
 def has_high_priority_issue_alerts(project: Project) -> bool:
@@ -48,7 +48,7 @@ def has_high_priority_issue_alerts(project: Project) -> bool:
         and project.platform is not None
         and any(
             project.platform.startswith(base_platform)
-            for base_platform in PLATFORMS_WITH_NEW_DEFAULT
+            for base_platform in PLATFORMS_WITH_PRIORITY_ALERTS
         )
     )
 

--- a/tests/sentry/event_manager/test_priority.py
+++ b/tests/sentry/event_manager/test_priority.py
@@ -20,7 +20,7 @@ class TestEventManagerPriority(TestCase):
     @with_feature("projects:issue-priority")
     @with_feature("projects:first-event-severity-calculation")
     def test_flag_on(self, mock_get_severity_score: MagicMock):
-        manager = EventManager(make_event(level=logging.FATAL))
+        manager = EventManager(make_event(level=logging.FATAL, platform="python"))
         event = manager.save(self.project.id)
 
         mock_get_severity_score.assert_called()
@@ -32,7 +32,7 @@ class TestEventManagerPriority(TestCase):
     @patch("sentry.event_manager._get_severity_score", return_value=(0.1121, "ml"))
     @with_feature("projects:first-event-severity-calculation")
     def test_flag_off(self, mock_get_severity_score: MagicMock):
-        manager = EventManager(make_event(level=logging.FATAL))
+        manager = EventManager(make_event(level=logging.FATAL, platform="python"))
         event = manager.save(self.project.id)
 
         mock_get_severity_score.assert_called()
@@ -48,10 +48,12 @@ class TestEventManagerPriority(TestCase):
     def test_get_priority_for_group_not_called_on_second_event(
         self, mock_get_priority_for_group: MagicMock, mock_get_severity_score: MagicMock
     ):
-        event = EventManager(make_event(level=logging.FATAL)).save(self.project.id)
+        event = EventManager(make_event(level=logging.FATAL, platform="python")).save(
+            self.project.id
+        )
         assert mock_get_priority_for_group.call_count == 1
 
-        event2 = EventManager(make_event()).save(self.project.id)
+        event2 = EventManager(make_event(platform="python")).save(self.project.id)
 
         # Same group, but no extra `_get_priority_for_group` call
         assert event2.group_id == event.group_id
@@ -66,7 +68,7 @@ class TestEventManagerPriority(TestCase):
             (logging.ERROR, PriorityLevel.HIGH),
             (logging.FATAL, PriorityLevel.HIGH),
         ):
-            manager = EventManager(make_event(level=level, fingerprint=[level]))
+            manager = EventManager(make_event(level=level, fingerprint=[level], platform="python"))
             event = manager.save(self.project.id)
 
             assert event.group
@@ -85,7 +87,7 @@ class TestEventManagerPriority(TestCase):
             (logging.ERROR, PriorityLevel.MEDIUM),
             (logging.FATAL, PriorityLevel.HIGH),
         ):
-            manager = EventManager(make_event(level=level, fingerprint=[level]))
+            manager = EventManager(make_event(level=level, fingerprint=[level], platform="python"))
             event = manager.save(self.project.id)
 
             assert event.group
@@ -104,7 +106,7 @@ class TestEventManagerPriority(TestCase):
             (logging.ERROR, PriorityLevel.HIGH),
             (logging.FATAL, PriorityLevel.HIGH),
         ):
-            manager = EventManager(make_event(level=level, fingerprint=[level]))
+            manager = EventManager(make_event(level=level, fingerprint=[level], platform="python"))
             event = manager.save(self.project.id)
 
             assert event.group

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -53,7 +53,8 @@ class TestGetEventSeverity(TestCase):
                             "mechanism": {"type": "generic", "handled": True},
                         }
                     ]
-                }
+                },
+                platform="python",
             )
         )
         event = manager.save(self.project.id)
@@ -142,6 +143,7 @@ class TestGetEventSeverity(TestCase):
         manager = EventManager(
             make_event(
                 exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},
+                platform="python",
             )
         )
         event = manager.save(self.project.id)
@@ -176,6 +178,7 @@ class TestGetEventSeverity(TestCase):
                 make_event(
                     exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},
                     level=level,
+                    platform="python",
                 )
             )
             event = manager.save(self.project.id)
@@ -195,7 +198,7 @@ class TestGetEventSeverity(TestCase):
         mock_urlopen: MagicMock,
     ) -> None:
         for title in NON_TITLE_EVENT_TITLES:
-            manager = EventManager(make_event(exception={"values": []}))
+            manager = EventManager(make_event(exception={"values": []}, platform="python"))
             event = manager.save(self.project.id)
             # `title` is a property with no setter, but it pulls from `metadata`, so it's equivalent
             # to set it there. (We have to ignore mypy because `metadata` isn't supposed to be mutable.)
@@ -240,7 +243,8 @@ class TestGetEventSeverity(TestCase):
                             "mechanism": {"type": "generic", "handled": True},
                         }
                     ]
-                }
+                },
+                platform="python",
             )
         )
         event = manager.save(self.project.id)
@@ -286,6 +290,7 @@ class TestGetEventSeverity(TestCase):
                         }
                     ],
                 },
+                platform="python",
             )
         )
         event = manager.save(self.project.id)
@@ -316,7 +321,8 @@ class TestEventManagerSeverity(TestCase):
         with self.feature({"projects:first-event-severity-calculation": True}):
             manager = EventManager(
                 make_event(
-                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]}
+                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},
+                    platform="python",
                 )
             )
             event = manager.save(self.project.id)
@@ -333,7 +339,8 @@ class TestEventManagerSeverity(TestCase):
         with self.feature({"projects:first-event-severity-calculation": False}):
             manager = EventManager(
                 make_event(
-                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]}
+                    exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},
+                    platform="python",
                 )
             )
             event = manager.save(self.project.id)
@@ -354,6 +361,7 @@ class TestEventManagerSeverity(TestCase):
                 make_event(
                     exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},
                     fingerprint=["dogs_are_great"],
+                    platform="python",
                 )
             ).save(self.project.id)
 
@@ -363,6 +371,7 @@ class TestEventManagerSeverity(TestCase):
                 make_event(
                     exception={"values": [{"type": "BrokenStuffError", "value": "It broke"}]},
                     fingerprint=["dogs_are_great"],
+                    platform="python",
                 )
             ).save(self.project.id)
 
@@ -378,6 +387,7 @@ class TestEventManagerSeverity(TestCase):
                     make_event(
                         exception={"values": [{"type": "NopeError", "value": "Nopey McNopeface"}]},
                         fingerprint=["dogs_are_great"],
+                        platform="python",
                     )
                 ).save(self.project.id)
 
@@ -392,6 +402,7 @@ class TestEventManagerSeverity(TestCase):
                     make_event(
                         exception={"values": [{"type": "BrokenStuffError", "value": "It broke"}]},
                         fingerprint=["dogs_are_great"],
+                        platform="python",
                     )
                 ).save(self.project.id)
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -185,7 +185,8 @@ class IssueOccurrenceProcessMessageTest(IssueOccurrenceTestBase):
         assert group.priority == PriorityLevel.LOW
 
     @with_feature("projects:issue-priority")
-    @mock.patch("sentry.event_manager._get_severity_metadata_for_group")
+    @with_feature("projects:first-event-severity-calculation")
+    @mock.patch("sentry.event_manager._get_severity_score")
     def test_issue_platform_override_priority(self, mock_get_severity_score):
         # test explicitly set priority of HIGH
         message = get_test_message(self.project.id)


### PR DESCRIPTION
Adding a ratelimit of 5 requests per second to the Seer severity service. We can adjust this if we see the ratelimit kick in as we're rolling out the service. 

Refactored a bit to only call the service for python/js projects and check the conditions before checking the ratelimit.