### PR TITLE
fix(devenv): make apply-migrations

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -155,7 +155,7 @@ def main(context: dict[str, str]) -> int:
         (
             (
                 "python migrations",
-                (f"{venv_dir}/bin/{repo}", "upgrade", "--noinput"),
+                ("make", "apply-migrations"),
             ),
         ),
     ):

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -186,6 +186,7 @@ create-db() {
 }
 
 apply-migrations() {
+    create-db
     echo "--> Applying migrations"
     sentry upgrade --noinput
 }
@@ -211,7 +212,6 @@ bootstrap() {
     develop
     init-config
     run-dependent-services
-    create-db
     apply-migrations
     create-superuser
     # Load mocks requires a superuser
@@ -243,7 +243,6 @@ drop-db() {
 
 reset-db() {
     drop-db
-    create-db
     apply-migrations
     create-superuser
     echo 'Finished resetting database. To load mock data, run `./bin/load-mocks`'


### PR DESCRIPTION
this fixes getsentry when bootstrapping (or, blow away colima state then devenv sync in getsentry) because getsentry's make apply-migrations ensures dbs exist beforehand - made sentry do the same thing here

reproduced as part of getting getsentry bootstrap integration coverage here: https://github.com/getsentry/getsentry/pull/13411, successful run: https://github.com/getsentry/getsentry/actions/runs/8440468769/job/23117397465
