### PR TITLE
ref(crons): Match subject to broken email header

### DIFF
--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -164,7 +164,7 @@ def detect_broken_monitor_envs():
                 "view_monitors_link": generate_monitor_overview_url(organization),
             }
             message = MessageBuilder(
-                subject="Your monitors are broken!",
+                subject="Your Cron Monitors Aren't Working",
                 template="sentry/emails/crons/broken-monitors.txt",
                 html_template="sentry/emails/crons/broken-monitors.html",
                 type="crons.broken_monitors",

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -249,7 +249,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
             [
                 call(
                     **{
-                        "subject": "Your monitors are broken!",
+                        "subject": "Your Cron Monitors Aren't Working",
                         "template": "sentry/emails/crons/broken-monitors.txt",
                         "html_template": "sentry/emails/crons/broken-monitors.html",
                         "type": "crons.broken_monitors",


### PR DESCRIPTION
Matches the subject here to the heading that exists in the email 