### PR TITLE
feat(sdk): Enable keep_alive

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3127,6 +3127,10 @@ SENTRY_SDK_CONFIG: ServerSdkConfig = {
     "send_default_pii": True,
     "auto_enabling_integrations": False,
     "enable_db_query_source": True,
+    # Keep alive is enabled to help avoid losing events due to network
+    # connectivity issues. We are specifically enabling this to help ensure
+    # cron monitor check-ins make it through.
+    "keep_alive": True,
 }
 
 SENTRY_DEV_DSN = os.environ.get("SENTRY_DEV_DSN")

--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -19,6 +19,7 @@ class SdkConfig(TypedDict):
     debug: bool
     send_default_pii: bool
     auto_enabling_integrations: bool
+    keep_alive: NotRequired[bool]
 
     send_client_reports: NotRequired[bool]
     traces_sampler: NotRequired[Callable[[dict[str, Any]], float]]


### PR DESCRIPTION
https://github.com/getsentry/sentry-python/issues/2617#issuecomment-2015313806

Hoping enabling this will help cron monitors have fewer time-outs