### PR TITLE
fix(hc): Updates chunk-uplod region URL surfacing to apply to CLI versions >= 2.30

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -69,11 +69,26 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         # User-Agent: sentry-cli/1.70.1
         user_agent = request.headers.get("User-Agent", "")
         sentrycli_version = SENTRYCLI_SEMVER_RE.search(user_agent)
-        supports_relative_url = (sentrycli_version is not None) and (
-            int(sentrycli_version.group("major")),
-            int(sentrycli_version.group("minor")),
-            int(sentrycli_version.group("patch")),
-        ) >= (1, 70, 1)
+        sentrycli_version_split = None
+        if sentrycli_version is not None:
+            sentrycli_version_split = (
+                int(sentrycli_version.group("major")),
+                int(sentrycli_version.group("minor")),
+                int(sentrycli_version.group("patch")),
+            )
+
+        region_upload_urls_enabled = options.get("hybrid_cloud.use_region_specific_upload_url")
+        requires_region_url = (
+            region_upload_urls_enabled
+            and sentrycli_version_split
+            and sentrycli_version_split >= (2, 30, 0)
+        )
+
+        supports_relative_url = (
+            not requires_region_url
+            and sentrycli_version_split
+            and sentrycli_version_split >= (1, 70, 1)
+        )
 
         # If user do not overwritten upload url prefix
         if len(endpoint) == 0:
@@ -85,7 +100,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 # We need to generate region specific upload URLs when possible to avoid hitting the API proxy
                 # which tends to cause timeouts and performance issues for uploads.
                 base_url = None
-                if options.get("hybrid_cloud.use_region_specific_upload_url"):
+                if region_upload_urls_enabled:
                     base_url = generate_region_url()
                 url = absolute_uri(relative_url, base_url)
         else:


### PR DESCRIPTION
Our previous attempted fix to expose full region URLs failed due to the client CLI version check we have in the endpoint. This change pins 2.30.0 as the minimum CLI version required to support absolute region URLs during chunk upload, but can be back-versioned to an earlier CLI client version if needed.
