### PR TITLE
fix: remove unused RbAttachmentCache

### DIFF
--- a/src/sentry/attachments/redis.py
+++ b/src/sentry/attachments/redis.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 
-from sentry.cache.redis import RbCache, RedisClusterCache
+from sentry.cache.redis import RedisClusterCache
 
 from .base import BaseAttachmentCache
 
@@ -15,11 +15,6 @@ class RedisClusterAttachmentCache(BaseAttachmentCache):
         if cluster_id is None:
             cluster_id = getattr(settings, "SENTRY_ATTACHMENTS_REDIS_CLUSTER", "rc-short")
         BaseAttachmentCache.__init__(self, inner=RedisClusterCache(cluster_id, **options))
-
-
-class RbAttachmentCache(BaseAttachmentCache):
-    def __init__(self, **options):
-        BaseAttachmentCache.__init__(self, inner=RbCache(**options))
 
 
 # Confusing legacy name for RediscClusterCache


### PR DESCRIPTION
It seems we don't use `RbAttachmentCache` in anywhere.