### PR TITLE
feat(perf): Add duration samples table to HTTP module sample panel

### DIFF
--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -11,9 +11,10 @@ jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useOrganization');
 
-describe('HTTPSamplesPanel', function () {
+describe('HTTPSamplesPanel', () => {
   const organization = OrganizationFixture();
-  let eventsRequestMock;
+
+  let ribbonRequestMock;
 
   jest.mocked(usePageFilters).mockReturnValue({
     isReady: true,
@@ -50,73 +51,10 @@ describe('HTTPSamplesPanel', function () {
 
   jest.mocked(useOrganization).mockReturnValue(organization);
 
-  beforeEach(function () {
-    eventsRequestMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {
-        data: [],
-      },
-    });
-  });
+  beforeEach(() => {
+    jest.clearAllMocks();
 
-  afterAll(function () {
-    jest.resetAllMocks();
-  });
-
-  it('fetches panel data', async function () {
-    render(<HTTPSamplesPanel />);
-
-    expect(eventsRequestMock).toHaveBeenNthCalledWith(
-      1,
-      `/organizations/${organization.slug}/events/`,
-      expect.objectContaining({
-        method: 'GET',
-        query: {
-          dataset: 'spansMetrics',
-          environment: [],
-          field: [
-            'spm()',
-            'avg(span.self_time)',
-            'sum(span.self_time)',
-            'http_response_rate(3)',
-            'http_response_rate(4)',
-            'http_response_rate(5)',
-            'time_spent_percentage()',
-          ],
-          per_page: 50,
-          project: [],
-          query: 'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
-          referrer: 'api.starfish.http-module-samples-panel-metrics-ribbon',
-          statsPeriod: '10d',
-        },
-      })
-    );
-
-    expect(eventsRequestMock).toHaveBeenNthCalledWith(
-      2,
-      `/organizations/${organization.slug}/events/`,
-      expect.objectContaining({
-        method: 'GET',
-        query: {
-          dataset: 'spansMetrics',
-          environment: [],
-          field: ['span.status_code', 'count()'],
-          per_page: 50,
-          sort: 'span.status_code',
-          project: [],
-          query: 'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
-          referrer: 'api.starfish.http-module-samples-panel-response-bar-chart',
-          statsPeriod: '10d',
-        },
-      })
-    );
-
-    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
-  });
-
-  it('show basic transaction info', async function () {
-    MockApiClient.addMockResponse({
+    ribbonRequestMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
 
@@ -149,29 +87,260 @@ describe('HTTPSamplesPanel', function () {
         },
       },
     });
+  });
 
-    render(<HTTPSamplesPanel />);
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
 
-    // Panel heading
-    expect(screen.getByRole('heading', {name: 'GET /api/0/users'})).toBeInTheDocument();
+  describe('status panel', () => {
+    let chartRequestMock;
 
-    // Metrics ribbon
-    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+    beforeEach(() => {
+      jest.mocked(useLocation).mockReturnValue({
+        pathname: '',
+        search: '',
+        query: {
+          domain: '*.sentry.dev',
+          statsPeriod: '10d',
+          transaction: '/api/0/users',
+          transactionMethod: 'GET',
+          panel: 'status',
+        },
+        hash: '',
+        state: undefined,
+        action: 'PUSH',
+        key: '',
+      });
 
-    expect(
-      screen.getByRole('heading', {name: 'Requests Per Minute'})
-    ).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Avg Duration'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: '3XXs'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: '4XXs'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: '5XXs'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Time Spent'})).toBeInTheDocument();
+      chartRequestMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events/`,
+        method: 'GET',
 
-    expect(screen.getByText('22.2/min')).toBeInTheDocument();
-    expect(screen.getByText('140.20ms')).toBeInTheDocument();
-    expect(screen.getByText('1%')).toBeInTheDocument();
-    expect(screen.getByText('2.5%')).toBeInTheDocument();
-    expect(screen.getByText('1.5%')).toBeInTheDocument();
-    expect(screen.getByText('45.15min')).toBeInTheDocument();
+        match: [
+          MockApiClient.matchQuery({
+            referrer: 'api.starfish.http-module-samples-panel-response-bar-chart',
+          }),
+        ],
+        body: {},
+      });
+    });
+
+    it('fetches panel data', async () => {
+      render(<HTTPSamplesPanel />);
+
+      expect(ribbonRequestMock).toHaveBeenNthCalledWith(
+        1,
+        `/organizations/${organization.slug}/events/`,
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            dataset: 'spansMetrics',
+            environment: [],
+            field: [
+              'spm()',
+              'avg(span.self_time)',
+              'sum(span.self_time)',
+              'http_response_rate(3)',
+              'http_response_rate(4)',
+              'http_response_rate(5)',
+              'time_spent_percentage()',
+            ],
+            per_page: 50,
+            project: [],
+            query:
+              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
+            referrer: 'api.starfish.http-module-samples-panel-metrics-ribbon',
+            statsPeriod: '10d',
+          },
+        })
+      );
+
+      expect(chartRequestMock).toHaveBeenNthCalledWith(
+        1,
+        `/organizations/${organization.slug}/events/`,
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            dataset: 'spansMetrics',
+            environment: [],
+            field: ['span.status_code', 'count()'],
+            per_page: 50,
+            sort: 'span.status_code',
+            project: [],
+            query:
+              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
+            referrer: 'api.starfish.http-module-samples-panel-response-bar-chart',
+            statsPeriod: '10d',
+          },
+        })
+      );
+
+      await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+    });
+
+    it('shows basic transaction info', async () => {
+      render(<HTTPSamplesPanel />);
+
+      // Panel heading
+      expect(screen.getByRole('heading', {name: 'GET /api/0/users'})).toBeInTheDocument();
+
+      // Metrics ribbon
+      await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+
+      expect(
+        screen.getByRole('heading', {name: 'Requests Per Minute'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Avg Duration'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: '3XXs'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: '4XXs'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: '5XXs'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Time Spent'})).toBeInTheDocument();
+
+      expect(screen.getByText('22.2/min')).toBeInTheDocument();
+      expect(screen.getByText('140.20ms')).toBeInTheDocument();
+      expect(screen.getByText('1%')).toBeInTheDocument();
+      expect(screen.getByText('2.5%')).toBeInTheDocument();
+      expect(screen.getByText('1.5%')).toBeInTheDocument();
+      expect(screen.getByText('45.15min')).toBeInTheDocument();
+    });
+  });
+
+  describe('Duration panel', () => {
+    let chartRequestMock, samplesRequestMock;
+
+    beforeEach(() => {
+      jest.mocked(useLocation).mockReturnValue({
+        pathname: '',
+        search: '',
+        query: {
+          domain: '*.sentry.dev',
+          statsPeriod: '10d',
+          transaction: '/api/0/users',
+          transactionMethod: 'GET',
+          panel: 'duration',
+        },
+        hash: '',
+        state: undefined,
+        action: 'PUSH',
+        key: '',
+      });
+
+      chartRequestMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-stats/`,
+        method: 'GET',
+        match: [
+          MockApiClient.matchQuery({
+            referrer: 'api.starfish.http-module-samples-panel-duration-chart',
+          }),
+        ],
+        body: {data: [[1711393200, [{count: 900}]]]},
+      });
+
+      samplesRequestMock = MockApiClient.addMockResponse({
+        url: `/api/0/organizations/${organization.slug}/spans-samples/`,
+        method: 'GET',
+        body: {
+          data: [
+            {
+              span_id: 'b1bf1acde131623a',
+              'span.description':
+                'GET https://sentry.io/api/0/organizations/sentry/info/?projectId=1',
+              project: 'javascript',
+              timestamp: '2024-03-25T20:31:36+00:00',
+              'span.status_code': '200',
+              'transaction.id': '11c910c9c10b3ec4ecf8f209b8c6ce48',
+              'span.self_time': 320.300102,
+            },
+          ],
+        },
+      });
+    });
+
+    it('fetches panel data', async () => {
+      render(<HTTPSamplesPanel />);
+
+      await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+
+      expect(chartRequestMock).toHaveBeenNthCalledWith(
+        1,
+        `/organizations/${organization.slug}/events-stats/`,
+        expect.objectContaining({
+          method: 'GET',
+          query: expect.objectContaining({
+            dataset: 'spansMetrics',
+            environment: [],
+            interval: '30m',
+            per_page: 50,
+            project: [],
+            query:
+              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
+            referrer: 'api.starfish.http-module-samples-panel-duration-chart',
+            statsPeriod: '10d',
+            yAxis: 'avg(span.self_time)',
+          }),
+        })
+      );
+
+      expect(samplesRequestMock).toHaveBeenNthCalledWith(
+        1,
+        `/api/0/organizations/${organization.slug}/spans-samples/`,
+        expect.objectContaining({
+          method: 'GET',
+          query: expect.objectContaining({
+            query:
+              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
+            project: [],
+            additionalFields: ['transaction.id', 'span.description', 'span.status_code'],
+            lowerBound: 0,
+            firstBound: expect.closeTo(333.3333),
+            secondBound: expect.closeTo(666.6666),
+            upperBound: 1000,
+            referrer: 'api.starfish.http-module-samples-panel-samples',
+            statsPeriod: '10d',
+          }),
+        })
+      );
+    });
+
+    it('show basic transaction info', async () => {
+      render(<HTTPSamplesPanel />);
+
+      // Panel heading
+      expect(screen.getByRole('heading', {name: 'GET /api/0/users'})).toBeInTheDocument();
+
+      // Metrics ribbon
+      await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+
+      expect(
+        screen.getByRole('heading', {name: 'Requests Per Minute'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Avg Duration'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: '3XXs'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: '4XXs'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: '5XXs'})).toBeInTheDocument();
+      expect(screen.getByRole('heading', {name: 'Time Spent'})).toBeInTheDocument();
+
+      expect(screen.getByText('22.2/min')).toBeInTheDocument();
+      expect(screen.getByText('140.20ms')).toBeInTheDocument();
+      expect(screen.getByText('1%')).toBeInTheDocument();
+      expect(screen.getByText('2.5%')).toBeInTheDocument();
+      expect(screen.getByText('1.5%')).toBeInTheDocument();
+      expect(screen.getByText('45.15min')).toBeInTheDocument();
+
+      // Samples table
+      expect(screen.getByRole('table', {name: 'Span Samples'})).toBeInTheDocument();
+
+      expect(screen.getByRole('columnheader', {name: 'Event ID'})).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'Status'})).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', {name: 'URL'})).toBeInTheDocument();
+
+      expect(screen.getByRole('cell', {name: '11c910c9'})).toBeInTheDocument();
+      expect(screen.getByRole('link', {name: '11c910c9'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/javascript:11c910c9c10b3ec4ecf8f209b8c6ce48#span-b1bf1acde131623a'
+      );
+      expect(screen.getByRole('cell', {name: '200'})).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -291,7 +291,7 @@ export function HTTPSamplesPanel() {
               <ModuleLayout.Full>
                 <SpanSamplesTable
                   data={samplesData}
-                  isLoading={isSamplesDataFetching}
+                  isLoading={isDurationDataFetching || isSamplesDataFetching}
                   error={samplesDataError}
                 />
               </ModuleLayout.Full>

--- a/static/app/views/performance/http/spanSamplesTable.tsx
+++ b/static/app/views/performance/http/spanSamplesTable.tsx
@@ -1,0 +1,108 @@
+import type {Location} from 'history';
+
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  type GridColumnHeader,
+} from 'sentry/components/gridEditable';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types';
+import type {EventsMetaType} from 'sentry/utils/discover/eventView';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
+import {TransactionIdCell} from 'sentry/views/starfish/components/tableCells/transactionIdCell';
+import type {IndexedResponse} from 'sentry/views/starfish/types';
+import {SpanIndexedField} from 'sentry/views/starfish/types';
+
+type ColumnKeys =
+  | SpanIndexedField.PROJECT
+  | SpanIndexedField.TRANSACTION_ID
+  | SpanIndexedField.SPAN_DESCRIPTION
+  | SpanIndexedField.RESPONSE_CODE;
+
+type Row = Pick<IndexedResponse, ColumnKeys>;
+
+type Column = GridColumnHeader<ColumnKeys>;
+
+const COLUMN_ORDER: Column[] = [
+  {
+    key: SpanIndexedField.TRANSACTION_ID,
+    name: t('Event ID'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: SpanIndexedField.RESPONSE_CODE,
+    name: t('Status'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: SpanIndexedField.SPAN_DESCRIPTION,
+    name: t('URL'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+];
+
+interface Props {
+  data: Row[];
+  isLoading: boolean;
+  error?: Error | null;
+  meta?: EventsMetaType;
+}
+
+export function SpanSamplesTable({data, isLoading, error, meta}: Props) {
+  const location = useLocation();
+  const organization = useOrganization();
+
+  return (
+    <GridEditable
+      aria-label={t('Span Samples')}
+      isLoading={isLoading}
+      error={error}
+      data={data}
+      columnOrder={COLUMN_ORDER}
+      columnSortBy={[]}
+      grid={{
+        renderHeadCell: col =>
+          renderHeadCell({
+            column: col,
+            location,
+          }),
+        renderBodyCell: (column, row) =>
+          renderBodyCell(column, row, meta, location, organization),
+      }}
+      location={location}
+    />
+  );
+}
+
+function renderBodyCell(
+  column: Column,
+  row: Row,
+  meta: EventsMetaType | undefined,
+  location: Location,
+  organization: Organization
+) {
+  if (column.key === SpanIndexedField.TRANSACTION_ID) {
+    return (
+      <TransactionIdCell
+        orgSlug={organization.slug}
+        projectSlug={row.project}
+        transactionId={row[SpanIndexedField.TRANSACTION_ID]}
+        spanId={row[SpanIndexedField.ID]}
+      />
+    );
+  }
+
+  if (!meta?.fields) {
+    return row[column.key];
+  }
+
+  const renderer = getFieldRenderer(column.key, meta.fields, false);
+
+  return renderer(row, {
+    location,
+    organization,
+    unit: meta.units?.[column.key],
+  });
+}

--- a/static/app/views/performance/http/spanSamplesTable.tsx
+++ b/static/app/views/performance/http/spanSamplesTable.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import GridEditable, {
@@ -94,6 +95,10 @@ function renderBodyCell(
     );
   }
 
+  if (column.key === SpanIndexedField.SPAN_DESCRIPTION) {
+    return <SpanDescriptionCell>{row[column.key]}</SpanDescriptionCell>;
+  }
+
   if (!meta?.fields) {
     return row[column.key];
   }
@@ -106,3 +111,7 @@ function renderBodyCell(
     unit: meta.units?.[column.key],
   });
 }
+
+const SpanDescriptionCell = styled('span')`
+  word-break: break-word;
+`;

--- a/static/app/views/starfish/components/tableCells/transactionIdCell.tsx
+++ b/static/app/views/starfish/components/tableCells/transactionIdCell.tsx
@@ -1,0 +1,21 @@
+import Link from 'sentry/components/links/link';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+
+interface Props {
+  orgSlug: string;
+  projectSlug: string;
+  transactionId: string;
+  spanId?: string;
+}
+
+export function TransactionIdCell({projectSlug, orgSlug, transactionId, spanId}: Props) {
+  let url = normalizeUrl(
+    `/organizations/${orgSlug}/performance/${projectSlug}:${transactionId}`
+  );
+
+  if (spanId) {
+    url += `#span-${spanId}`;
+  }
+
+  return <Link to={url}>{transactionId.slice(0, 8)}</Link>;
+}


### PR DESCRIPTION
Basic sample panel to show a few random samples based on duration. Interactions and sync with chart coming later!

**e.g.,**
![Screenshot 2024-03-26 at 3 54 04 PM](https://github.com/getsentry/sentry/assets/989898/6b12ed12-b415-426b-921f-efa93f415dac)
