### PR TITLE
chore(staff): Create staff email allowlist option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -264,6 +264,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_REQUIRED,
 )
 
+# Staff
+register(
+    "staff.user-email-allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # API
 # Killswitch for apis to work with id or slug as path parameters
 register(


### PR DESCRIPTION
In preparation to replace with `auth:enterprise-staff-cookie` feature flag with this option so I can easily modify who has access to staff mode with the options automator, rather than having to pass CI with the feature flag handler