### PR TITLE
feat(crons): Add cross-hatch style for TIMEOUT checkin ticks

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
@@ -1,9 +1,10 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import DateTime from 'sentry/components/dateTime';
 import {Tooltip} from 'sentry/components/tooltip';
 import {CheckInStatus} from 'sentry/views/monitors/types';
-import {getColorsFromStatus} from 'sentry/views/monitors/utils';
+import {tickStyle} from 'sentry/views/monitors/utils';
 import {getAggregateStatus} from 'sentry/views/monitors/utils/getAggregateStatus';
 import {mergeBuckets} from 'sentry/views/monitors/utils/mergeBuckets';
 
@@ -125,17 +126,56 @@ const JobTick = styled('div')<{
 }>`
   position: absolute;
   top: calc(50% + 1px);
-  transform: translateY(-50%);
-  background: ${p => getColorsFromStatus(p.status, p.theme).tickColor};
-  opacity: 0.7;
   width: 4px;
   height: 14px;
+  transform: translateY(-50%);
+  opacity: 0.7;
+
+  ${p => {
+    const style = tickStyle[p.status];
+
+    if (style.hatchTick === undefined) {
+      return css`
+        background: ${p.theme[style.tickColor]};
+      `;
+    }
+
+    return css`
+      border: 1px solid ${p.theme[style.tickColor]};
+      ${!p.roundedLeft && 'border-left-width: 0'};
+      ${!p.roundedRight && 'border-right-width: 0'};
+
+      background-size: 3px 3px;
+      opacity: 0.5;
+      background-image: linear-gradient(
+          -45deg,
+          ${p.theme[style.hatchTick]} 25%,
+          transparent 25%,
+          transparent 50%,
+          ${p.theme[style.hatchTick]} 50%,
+          ${p.theme[style.hatchTick]} 75%,
+          transparent 75%,
+          transparent
+        ),
+        linear-gradient(
+          45deg,
+          ${p.theme[style.hatchTick]} 25%,
+          transparent 25%,
+          transparent 50%,
+          ${p.theme[style.hatchTick]} 50%,
+          ${p.theme[style.hatchTick]} 75%,
+          transparent 75%,
+          transparent
+        );
+    `;
+  }};
+
   ${p =>
     p.roundedLeft &&
     `
     border-top-left-radius: 2px;
     border-bottom-left-radius: 2px;
-  `}
+  `};
   ${p =>
     p.roundedRight &&
     `

--- a/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.tsx
@@ -12,7 +12,7 @@ import type {
   TimeWindowOptions,
 } from 'sentry/views/monitors/components/overviewTimeline/types';
 import type {CheckInStatus} from 'sentry/views/monitors/types';
-import {getColorsFromStatus, statusToText} from 'sentry/views/monitors/utils';
+import {statusToText,tickStyle} from 'sentry/views/monitors/utils';
 
 interface Props extends Omit<TooltipProps, 'title'> {
   jobTick: JobTickData;
@@ -96,7 +96,7 @@ const HiddenHeader = styled('thead')`
 `;
 
 const StatusLabel = styled('td')<{status: CheckInStatus}>`
-  color: ${p => getColorsFromStatus(p.status, p.theme).labelColor};
+  color: ${p => p.theme[tickStyle[p.status].labelColor]};
   text-align: left;
 `;
 

--- a/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.tsx
@@ -12,7 +12,7 @@ import type {
   TimeWindowOptions,
 } from 'sentry/views/monitors/components/overviewTimeline/types';
 import type {CheckInStatus} from 'sentry/views/monitors/types';
-import {statusToText,tickStyle} from 'sentry/views/monitors/utils';
+import {statusToText, tickStyle} from 'sentry/views/monitors/utils';
 
 interface Props extends Omit<TooltipProps, 'title'> {
   jobTick: JobTickData;

--- a/static/app/views/monitors/utils.tsx
+++ b/static/app/views/monitors/utils.tsx
@@ -4,7 +4,7 @@ import {t, tn} from 'sentry/locale';
 import type {Organization, SelectValue} from 'sentry/types';
 import {shouldUse24Hours} from 'sentry/utils/dates';
 import type {MonitorConfig} from 'sentry/views/monitors/types';
-import {ColorOrAlias} from 'sentry/utils/theme';
+import type {ColorOrAlias} from 'sentry/utils/theme';
 import {CheckInStatus, ScheduleType} from 'sentry/views/monitors/types';
 
 export function makeMonitorListQueryKey(

--- a/static/app/views/monitors/utils.tsx
+++ b/static/app/views/monitors/utils.tsx
@@ -1,10 +1,10 @@
-import type {Theme} from '@emotion/react';
 import cronstrue from 'cronstrue';
 
 import {t, tn} from 'sentry/locale';
 import type {Organization, SelectValue} from 'sentry/types';
 import {shouldUse24Hours} from 'sentry/utils/dates';
 import type {MonitorConfig} from 'sentry/views/monitors/types';
+import {ColorOrAlias} from 'sentry/utils/theme';
 import {CheckInStatus, ScheduleType} from 'sentry/views/monitors/types';
 
 export function makeMonitorListQueryKey(
@@ -106,16 +106,45 @@ export const statusToText: Record<CheckInStatus, string> = {
   [CheckInStatus.TIMEOUT]: t('Timed Out'),
 };
 
-export function getColorsFromStatus(status: CheckInStatus, theme: Theme) {
-  const statusToColor: Record<CheckInStatus, {labelColor: string; tickColor: string}> = {
-    [CheckInStatus.ERROR]: {tickColor: theme.red300, labelColor: theme.red400},
-    [CheckInStatus.TIMEOUT]: {tickColor: theme.red300, labelColor: theme.red400},
-    [CheckInStatus.OK]: {tickColor: theme.green300, labelColor: theme.green400},
-    [CheckInStatus.MISSED]: {tickColor: theme.yellow300, labelColor: theme.yellow400},
-    [CheckInStatus.IN_PROGRESS]: {tickColor: theme.disabled, labelColor: theme.disabled},
-  };
-  return statusToColor[status];
+interface TickStyle {
+  /**
+   * The color of the tooltip label
+   */
+  labelColor: ColorOrAlias;
+  /**
+   * The color of the tick
+   */
+  tickColor: ColorOrAlias;
+  /**
+   * Use a cross hatch fill for the tick instead of a solid color. The tick
+   * color will be used as the border color
+   */
+  hatchTick?: ColorOrAlias;
 }
+
+export const tickStyle: Record<CheckInStatus, TickStyle> = {
+  [CheckInStatus.ERROR]: {
+    labelColor: 'red400',
+    tickColor: 'red300',
+  },
+  [CheckInStatus.TIMEOUT]: {
+    labelColor: 'red400',
+    tickColor: 'red300',
+    hatchTick: 'red200',
+  },
+  [CheckInStatus.OK]: {
+    labelColor: 'green400',
+    tickColor: 'green300',
+  },
+  [CheckInStatus.MISSED]: {
+    labelColor: 'yellow400',
+    tickColor: 'yellow300',
+  },
+  [CheckInStatus.IN_PROGRESS]: {
+    labelColor: 'disabled',
+    tickColor: 'disabled',
+  },
+};
 
 export const getScheduleIntervals = (n: number): SelectValue<string>[] => [
   {value: 'minute', label: tn('minute', 'minutes', n)},

--- a/static/app/views/monitors/utils.tsx
+++ b/static/app/views/monitors/utils.tsx
@@ -3,8 +3,8 @@ import cronstrue from 'cronstrue';
 import {t, tn} from 'sentry/locale';
 import type {Organization, SelectValue} from 'sentry/types';
 import {shouldUse24Hours} from 'sentry/utils/dates';
-import type {MonitorConfig} from 'sentry/views/monitors/types';
 import type {ColorOrAlias} from 'sentry/utils/theme';
+import type {MonitorConfig} from 'sentry/views/monitors/types';
 import {CheckInStatus, ScheduleType} from 'sentry/views/monitors/types';
 
 export function makeMonitorListQueryKey(


### PR DESCRIPTION
Looks like this

<img alt="clipboard.png" width="587" src="https://i.imgur.com/VvRxYrE.png" />

<img alt="clipboard.png" width="618" src="https://i.imgur.com/G2UnYkC.png" />

Should make it easier to differentiate between error and timeout
check-ins