### PR TITLE
fix(replays): change autostart logic

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -256,7 +256,7 @@ function ProviderNonMemo({
   const replayerRef = useRef<Replayer>(null);
   const [dimensions, setDimensions] = useState<Dimensions>({height: 0, width: 0});
   const [currentHoverTime, setCurrentHoverTime] = useState<undefined | number>();
-  const [isPlaying, setIsPlaying] = useState(!!autoStart);
+  const [isPlaying, setIsPlaying] = useState(false);
   const [finishedAtMS, setFinishedAtMS] = useState<number>(-1);
   const [isSkippingInactive, setIsSkippingInactive] = useState(
     savedReplayConfigRef.current.isSkippingInactive
@@ -460,6 +460,9 @@ function ProviderNonMemo({
       replayerRef.current = inst;
 
       applyInitialOffset();
+      if (autoStart) {
+        inst.play(startTimeOffsetMs);
+      }
     },
     [
       applyInitialOffset,
@@ -475,6 +478,8 @@ function ProviderNonMemo({
       setReplayFinished,
       startTimestampMs,
       theme.purple200,
+      startTimeOffsetMs,
+      autoStart,
     ]
   );
 


### PR DESCRIPTION
This PR fixes a bug where sometimes the video doesn't start even though `isPlaying` is set to true. That happens because we set the state too early before the replay player is mounted.