### PR TITLE
redirect on org select for external app installations

### DIFF
--- a/static/app/views/sentryAppExternalInstallation/index.spec.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.spec.tsx
@@ -20,6 +20,7 @@ describe('SentryAppExternalInstallation', () => {
     getOrgMock: ReturnType<typeof MockApiClient.addMockResponse>,
     getAppMock: ReturnType<typeof MockApiClient.addMockResponse>,
     getInstallationsMock: ReturnType<typeof MockApiClient.addMockResponse>,
+    getFeaturesMock: ReturnType<typeof MockApiClient.addMockResponse>,
     org1: TOrganization,
     org1Lite: Pick<TOrganization, 'slug' | 'name' | 'id'>,
     org2: TOrganization,
@@ -235,19 +236,9 @@ describe('SentryAppExternalInstallation', () => {
         />
       );
 
-      // await selectEvent.select(screen.getByTestId('org-select'), 'org2');
       await selectEvent.select(screen.getByRole('textbox'), 'org2');
       expect(window.location.assign).toHaveBeenCalledWith(generateOrgSlugUrl('org2'));
-
-      // expect(getOrgMock).toHaveBeenCalledTimes(2);
-      // expect(getOrgMock).toHaveBeenLastCalledWith(
-      //   '/organizations/org2/',
-      //   expect.anything()
-      // );
-      // expect(getInstallationsMock).toHaveBeenCalled();
-      // expect(getFeaturesMock).toHaveBeenCalled();
-
-      // await waitFor(() => expect(screen.getByTestId('install')).toBeEnabled());
+      expect(getFeaturesMock).toHaveBeenCalled();
     });
   });
 });

--- a/static/app/views/sentryAppExternalInstallation/index.spec.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.spec.tsx
@@ -1,13 +1,17 @@
 import pick from 'lodash/pick';
+import {ConfigFixture} from 'sentry-fixture/config';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
+import ConfigStore from 'sentry/stores/configStore';
 import type {Organization as TOrganization} from 'sentry/types';
+import {generateOrgSlugUrl} from 'sentry/utils';
 import SentryAppExternalInstallation from 'sentry/views/sentryAppExternalInstallation';
 
 describe('SentryAppExternalInstallation', () => {
@@ -16,7 +20,6 @@ describe('SentryAppExternalInstallation', () => {
     getOrgMock: ReturnType<typeof MockApiClient.addMockResponse>,
     getAppMock: ReturnType<typeof MockApiClient.addMockResponse>,
     getInstallationsMock: ReturnType<typeof MockApiClient.addMockResponse>,
-    getFeaturesMock: ReturnType<typeof MockApiClient.addMockResponse>,
     org1: TOrganization,
     org1Lite: Pick<TOrganization, 'slug' | 'name' | 'id'>,
     org2: TOrganization,
@@ -77,6 +80,19 @@ describe('SentryAppExternalInstallation', () => {
         url: `/organizations/${org1.slug}/sentry-app-installations/`,
         body: [],
       });
+
+      window.__initialData = ConfigFixture({
+        customerDomain: {
+          subdomain: 'org1',
+          organizationUrl: 'https://org1.sentry.io',
+          sentryUrl: 'https://sentry.io',
+        },
+        links: {
+          ...(window.__initialData?.links ?? {}),
+          sentryUrl: 'https://sentry.io',
+        },
+      });
+      ConfigStore.loadInitialData(window.__initialData);
     });
 
     it('sets the org automatically', async () => {
@@ -120,7 +136,7 @@ describe('SentryAppExternalInstallation', () => {
         />
       );
 
-      await userEvent.click(await screen.findByTestId('install'));
+      await userEvent.click(await screen.findByTestId('install')); // failing currently
 
       expect(installMock).toHaveBeenCalledWith(
         installUrl,
@@ -145,9 +161,32 @@ describe('SentryAppExternalInstallation', () => {
         url: '/organizations/',
         body: [org1Lite, org2Lite],
       });
+
+      getOrgMock = MockApiClient.addMockResponse({
+        url: `/organizations/${org1.slug}/`,
+        body: org1,
+      });
+
+      getInstallationsMock = MockApiClient.addMockResponse({
+        url: `/organizations/${org1.slug}/sentry-app-installations/`,
+        body: [],
+      });
+
+      window.__initialData = ConfigFixture({
+        customerDomain: {
+          subdomain: 'org1',
+          organizationUrl: 'https://org1.sentry.io',
+          sentryUrl: 'https://sentry.io',
+        },
+        links: {
+          ...(window.__initialData?.links ?? {}),
+          sentryUrl: 'https://sentry.io',
+        },
+      });
+      ConfigStore.loadInitialData(window.__initialData);
     });
 
-    it('renders org dropdown', () => {
+    it('sets the org automatically', async () => {
       render(
         <SentryAppExternalInstallation
           {...RouteComponentPropsFixture()}
@@ -157,38 +196,58 @@ describe('SentryAppExternalInstallation', () => {
 
       expect(getAppMock).toHaveBeenCalled();
       expect(getOrgsMock).toHaveBeenCalled();
-      expect(screen.getByText('Select an organization')).toBeInTheDocument();
+      expect(getOrgMock).toHaveBeenCalled();
+      expect(getInstallationsMock).toHaveBeenCalled();
+      expect(screen.queryByText('Select an organization')).not.toBeInTheDocument();
+      await waitFor(() => expect(screen.getByTestId('install')).toBeEnabled());
     });
 
-    it('selecting org from dropdown loads the org through the API', async () => {
-      getOrgMock = MockApiClient.addMockResponse({
-        url: `/organizations/${org2.slug}/`,
-        body: org2,
-      });
+    it('selecting org changes the url', async () => {
+      const preselectedOrg = OrganizationFixture();
+      const {routerProps} = initializeOrg({organization: preselectedOrg});
 
+      window.__initialData = ConfigFixture({
+        customerDomain: {
+          subdomain: 'org1',
+          organizationUrl: 'https://org1.sentry.io',
+          sentryUrl: 'https://sentry.io',
+        },
+        links: {
+          ...(window.__initialData?.links ?? {}),
+          sentryUrl: 'https://sentry.io',
+        },
+      });
+      ConfigStore.loadInitialData(window.__initialData);
+
+      getOrgMock = MockApiClient.addMockResponse({
+        url: `/organizations/org1/`,
+        body: preselectedOrg,
+      });
       getInstallationsMock = MockApiClient.addMockResponse({
-        url: `/organizations/${org2.slug}/sentry-app-installations/`,
+        url: `/organizations/${org1.slug}/sentry-app-installations/`,
         body: [],
       });
 
       render(
         <SentryAppExternalInstallation
-          {...RouteComponentPropsFixture()}
+          {...routerProps}
           params={{sentryAppSlug: sentryApp.slug}}
         />
       );
 
-      await selectEvent.select(screen.getByText('Select an organization'), 'org2');
+      // await selectEvent.select(screen.getByTestId('org-select'), 'org2');
+      await selectEvent.select(screen.getByRole('textbox'), 'org2');
+      expect(window.location.assign).toHaveBeenCalledWith(generateOrgSlugUrl('org2'));
 
-      expect(getOrgMock).toHaveBeenCalledTimes(1);
-      expect(getOrgMock).toHaveBeenLastCalledWith(
-        '/organizations/org2/',
-        expect.anything()
-      );
-      expect(getInstallationsMock).toHaveBeenCalled();
-      expect(getFeaturesMock).toHaveBeenCalled();
+      // expect(getOrgMock).toHaveBeenCalledTimes(2);
+      // expect(getOrgMock).toHaveBeenLastCalledWith(
+      //   '/organizations/org2/',
+      //   expect.anything()
+      // );
+      // expect(getInstallationsMock).toHaveBeenCalled();
+      // expect(getFeaturesMock).toHaveBeenCalled();
 
-      await waitFor(() => expect(screen.getByTestId('install')).toBeEnabled());
+      // await waitFor(() => expect(screen.getByTestId('install')).toBeEnabled());
     });
   });
 });

--- a/static/app/views/sentryAppExternalInstallation/index.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.tsx
@@ -37,10 +37,9 @@ export default class SentryAppExternalInstallation extends DeprecatedAsyncView<
 
   getDefaultState() {
     const state = super.getDefaultState();
-    const customerDomain = ConfigStore.get('customerDomain');
     return {
       ...state,
-      selectedOrgSlug: customerDomain?.subdomain,
+      selectedOrgSlug: null,
       organization: null,
       organizations: [],
       reloading: false,
@@ -52,6 +51,20 @@ export default class SentryAppExternalInstallation extends DeprecatedAsyncView<
       ['organizations', '/organizations/'],
       ['sentryApp', `/sentry-apps/${this.sentryAppSlug}/`],
     ];
+  }
+
+  onLoadAllEndpointsSuccess() {
+    // auto select the org if there is only one
+    const {organizations} = this.state;
+    if (organizations.length === 1) {
+      this.onSelectOrg(organizations[0].slug);
+    }
+
+    // now check the subomdain and use that org slug if it exists
+    const customerDomain = ConfigStore.get('customerDomain');
+    if (customerDomain?.subdomain) {
+      this.onSelectOrg(customerDomain.subdomain);
+    }
   }
 
   getTitle() {
@@ -260,6 +273,7 @@ export default class SentryAppExternalInstallation extends DeprecatedAsyncView<
               value={selectedOrgSlug}
               placeholder={t('Select an organization')}
               options={this.getOptions()}
+              data-test-id="org-select"
             />
           )}
         </FieldGroup>


### PR DESCRIPTION
per https://getsentry.atlassian.net/browse/API-2929
resolves https://github.com/getsentry/team-core-product-foundations/issues/105

OnSelectOrg customer domain redirect copied from `integrationOrganizationLink`
getDefaultState() modified to default to the customer domain as well