### PR TITLE
fix(replays): Fix canvas sizing in replays

### DIFF
--- a/static/app/components/replays/canvasReplayerPlugin.tsx
+++ b/static/app/components/replays/canvasReplayerPlugin.tsx
@@ -270,8 +270,8 @@ export function CanvasReplayerPlugin(events: eventWithTime[]): ReplayPlugin {
       const img = containers.get(e.data.id);
       if (img) {
         img.src = target.toDataURL();
-        img.style.width = '100%';
-        img.style.height = '100%';
+        img.style.maxWidth = '100%';
+        img.style.maxHeight = '100%';
       }
 
       prune(e);


### PR DESCRIPTION
`maxWidth` is needed instead of `width` for cases where the image snapshot size is smaller than the canvas size