### PR TITLE
ref(daily summary): Truncate issue data

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -21,7 +21,7 @@ from sentry.utils.http import absolute_uri
 
 from .base import SlackNotificationsMessageBuilder
 
-MAX_CHARS_ONE_LINE = 38
+MAX_CHARS_ONE_LINE = 35
 
 
 class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
@@ -40,12 +40,13 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
         link = group.get_absolute_url(
             params={"referrer": self.notification.get_referrer(ExternalProviders.SLACK)}
         )
-        title = build_attachment_title(group)[:MAX_CHARS_ONE_LINE]
+        title = build_attachment_title(group)
+        formatted_title = self.truncate_text(title)
         attachment_text = self.get_attachment_text(group)
         if not attachment_text:
-            return f"<{link}|*{escape_slack_text(title)}*>"
-        attachment_text = attachment_text.replace("\n", " ")[:MAX_CHARS_ONE_LINE]
-        return f"<{link}|*{escape_slack_text(title)}*>\n{attachment_text}"
+            return f"<{link}|*{escape_slack_text(formatted_title)}*>"
+        formatted_attachment_text = attachment_text.replace("\n", " ")
+        return f"<{link}|*{escape_slack_text(formatted_title)}*>\n{self.truncate_text(formatted_attachment_text)}"
 
     def linkify_release(self, release, organization):
         path = f"/releases/{release.version}/"
@@ -53,11 +54,14 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
         release_description = parse_release(release.version).get("description")
         return f":rocket: *<{url}|Release {release_description}>*\n"
 
+    def truncate_text(self, text):
+        if text and len(text) > MAX_CHARS_ONE_LINE:
+            text = text[:MAX_CHARS_ONE_LINE] + "..."
+        return text
+
     def get_attachment_text(self, group):
         attachment_text = build_attachment_text(group)
-        if attachment_text and len(attachment_text) > 50:
-            attachment_text = attachment_text[0:49] + "..."
-        return attachment_text
+        return self.truncate_text(attachment_text)
 
     def build_discover_url(self, project):
         query_params = {

--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -21,6 +21,8 @@ from sentry.utils.http import absolute_uri
 
 from .base import SlackNotificationsMessageBuilder
 
+MAX_CHARS_ONE_LINE = 38
+
 
 class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
     def __init__(
@@ -38,11 +40,11 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
         link = group.get_absolute_url(
             params={"referrer": self.notification.get_referrer(ExternalProviders.SLACK)}
         )
-        title = build_attachment_title(group)
+        title = build_attachment_title(group)[:MAX_CHARS_ONE_LINE]
         attachment_text = self.get_attachment_text(group)
         if not attachment_text:
             return f"<{link}|*{escape_slack_text(title)}*>"
-        attachment_text = attachment_text.replace("\n", " ")
+        attachment_text = attachment_text.replace("\n", " ")[:MAX_CHARS_ONE_LINE]
         return f"<{link}|*{escape_slack_text(title)}*>\n{attachment_text}"
 
     def linkify_release(self, release, organization):

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -843,6 +843,57 @@ class DailySummaryTest(
 
     @responses.activate
     @with_feature("organizations:slack-block-kit")
+    def test_slack_notification_contents_truncate_text(self):
+        data = {
+            "timestamp": iso_format(self.now),
+            "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+            "fingerprint": ["group-5"],
+            "exception": {
+                "values": [
+                    {
+                        "type": "OperationalErrorThatIsVeryLongForSomeReasonOhMy",
+                        "value": "QueryCanceled('canceling statement due to user request\n')",
+                    }
+                ]
+            },
+        }
+        self.store_event(
+            data=data,
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "project_id": self.project.id,
+                "outcome": Outcome.ACCEPTED,
+                "category": DataCategory.ERROR,
+                "timestamp": self.now,
+                "key_id": 1,
+            },
+            num_times=1,
+        )
+
+        ctx = build_summary_data(
+            timestamp=self.now.timestamp(),
+            duration=ONE_DAY,
+            organization=self.organization,
+            daily=True,
+        )
+        top_projects_context_map = build_top_projects_map(ctx, self.user.id)
+        with self.tasks():
+            DailySummaryNotification(
+                organization=ctx.organization,
+                recipient=self.user,
+                provider=ExternalProviders.SLACK,
+                project_context=top_projects_context_map,
+            ).send()
+        blocks, fallback_text = get_blocks_and_fallback_text()
+        assert "OperationalErrorThatIsVeryLongForSomeR" in blocks[4]["fields"][0]["text"]
+        assert "QueryCanceled('canceling statement due" in blocks[4]["fields"][0]["text"]
+
+    @responses.activate
+    @with_feature("organizations:slack-block-kit")
     def test_limit_to_two_projects(self):
         """Test that if we have data for more than 2 projects that we only show data for the top 2"""
         self.populate_event_data()

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -675,7 +675,7 @@ class DailySummaryTest(
         # check performance issues
         assert "*Today's Top 3 Performance Issues*" in blocks[6]["text"]["text"]
         assert link_text.format(self.perf_event.group.id) in blocks[6]["text"]["text"]
-        assert "\ndb - SELECT `books_author`.`id`, `books_author`.`..." in blocks[6]["text"]["text"]
+        assert "\ndb - SELECT `books_author`.`id`, `b..." in blocks[6]["text"]["text"]
         assert link_text.format(self.perf_event2.group.id) in blocks[6]["text"]["text"]
         # repeat above for second project
         assert self.project2.slug in blocks[8]["text"]["text"]
@@ -786,10 +786,7 @@ class DailySummaryTest(
                 project_context=top_projects_context_map,
             ).send()
         blocks, fallback_text = get_blocks_and_fallback_text()
-        assert (
-            '""" Traceback (most recent call last): File /\'/us...'
-            in blocks[4]["fields"][0]["text"]
-        )
+        assert '""" Traceback (most recent call las...' in blocks[4]["fields"][0]["text"]
 
     @responses.activate
     @with_feature("organizations:slack-block-kit")
@@ -889,8 +886,8 @@ class DailySummaryTest(
                 project_context=top_projects_context_map,
             ).send()
         blocks, fallback_text = get_blocks_and_fallback_text()
-        assert "OperationalErrorThatIsVeryLongForSomeR" in blocks[4]["fields"][0]["text"]
-        assert "QueryCanceled('canceling statement due" in blocks[4]["fields"][0]["text"]
+        assert "OperationalErrorThatIsVeryLongForSo..." in blocks[4]["fields"][0]["text"]
+        assert "QueryCanceled('canceling statement ..." in blocks[4]["fields"][0]["text"]
 
     @responses.activate
     @with_feature("organizations:slack-block-kit")


### PR DESCRIPTION
Truncate the issue title and details to 38 characters long so it fits on one line (in text split across 2 columns). I futzed around with a few numbers and some different long error titles / content to settle on this, but we can further refine if still needed after seeing it for "real". 

A long one before:
<img width="656" alt="Screenshot 2024-03-26 at 4 15 23 PM" src="https://github.com/getsentry/sentry/assets/29959063/fa5074db-d79a-488f-a4e1-e536fca3a54f">


A truncated one now:
<img width="647" alt="Screenshot 2024-03-26 at 4 15 09 PM" src="https://github.com/getsentry/sentry/assets/29959063/b0511b57-f4ec-4c41-93b7-521ad486de8e">
