### PR TITLE
chore(registry): Add option to exclude rule from registry after being added

### DIFF
--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -109,10 +109,11 @@ class RuleBase(abc.ABC):
     ) -> bool:
         raise NotImplementedError
 
+    @classmethod
     @property
-    def include_rule(self) -> bool:
-        if self.should_show_rule:
-            return self.should_show_rule()
+    def include_rule(cls) -> bool:
+        if cls.should_show_rule:
+            return cls.should_show_rule()
         return True
 
 

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -53,8 +53,8 @@ CallbackFuture = namedtuple("CallbackFuture", ["callback", "kwargs", "key"])
 
 class RuleBase(abc.ABC):
     form_cls: type[forms.Form] = None  # type: ignore[assignment]
-
     logger = logging.getLogger("sentry.rules")
+    should_show_rule: Callable[[], bool] | None = None
 
     def __init__(
         self,
@@ -108,6 +108,12 @@ class RuleBase(abc.ABC):
         self, condition_activity: ConditionActivity, event_map: dict[str, Any]
     ) -> bool:
         raise NotImplementedError
+
+    @property
+    def include_rule(self) -> bool:
+        if self.should_show_rule:
+            return self.should_show_rule()
+        return True
 
 
 class EventState:

--- a/src/sentry/rules/registry.py
+++ b/src/sentry/rules/registry.py
@@ -12,11 +12,14 @@ class RuleRegistry:
         self._map: dict[str, type[RuleBase]] = {}
 
     def __contains__(self, rule_id: int) -> bool:
-        return rule_id in self._map
+        rule = self._map.get(rule_id)
+        return rule and rule.include_rule
 
     def __iter__(self) -> Generator[tuple[str, type[RuleBase]], None, None]:
         for rule_type, rule_list in self._rules.items():
             for rule in rule_list:
+                if not rule.include_rule:
+                    continue
                 yield rule_type, rule
 
     def add(self, rule: type[RuleBase]) -> None:
@@ -25,6 +28,6 @@ class RuleRegistry:
 
     def get(self, rule_id: str, type: str | None = None) -> type[RuleBase] | None:
         cls = self._map.get(rule_id)
-        if type is not None and cls not in self._rules[type]:
+        if (type is not None and cls not in self._rules[type]) or not cls.include_rule:
             return None
         return cls

--- a/tests/sentry/rules/test_registry.py
+++ b/tests/sentry/rules/test_registry.py
@@ -1,0 +1,38 @@
+from sentry.rules import rules
+from sentry.rules.base import RuleBase
+from sentry.testutils.cases import TestCase
+
+
+class DummyExcludedRule(RuleBase):
+    id = "dummy.exclude"
+    rule_type = "dummy"
+    should_show_rule = lambda: False  # noqa: E731
+
+
+class DummyIncludedRule(RuleBase):
+    id = "dummy.include"
+    rule_type = "dummy"
+    should_show_rule = lambda: True  # noqa: E731
+
+
+class RegistryTest(TestCase):
+    def test_included_rule(self):
+        rules.add(DummyIncludedRule)
+
+        # Test __iter__
+        assert (DummyIncludedRule.rule_type, DummyIncludedRule) in list(rules)
+        # Test get
+        assert rules.get(DummyIncludedRule.id) is DummyIncludedRule
+        # Test __contains__
+        assert DummyIncludedRule.id in rules
+
+    def test_excluded_rule(self):
+        rules.add(DummyExcludedRule)
+
+        # Test __iter__
+        for rule in rules:
+            assert rule is not DummyExcludedRule
+        # Test get
+        assert rules.get(DummyExcludedRule.id) is None
+        # Test __contains__
+        assert DummyExcludedRule.id not in rules


### PR DESCRIPTION
Closed b/c overcomplicated for a small change

Add the option to exclude a rule from a registry after being added.

This will be used in https://github.com/getsentry/sentry/pull/59315 to exclude the rule according to an option