### PR TITLE
ref(daily summary): More formatting updates

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -152,24 +152,28 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
                     linked_title = self.linkify_error_title(error[0])
                     top_errors_text += f"• {linked_title}\n"
                 error_issue_fields.append(self.make_field(top_errors_text))
-
-            # Add escalated/regressed issues
-            if context.escalated_today or context.regressed_today:
-                issue_state_text = "*Issues that escalated or regressed today*\n"
-                if context.escalated_today:
-                    for escalated_issue in context.escalated_today:
-                        linked_title = self.linkify_error_title(escalated_issue)
-                        issue_state_text += f"• :point_up: {linked_title}\n"
-
-                if context.regressed_today:
-                    if not context.escalated_today:
-                        issue_state_text = "*Issues that escalated or regressed today*\n"
-                    for regressed_issue in context.regressed_today:
-                        linked_title = self.linkify_error_title(regressed_issue)
-                        issue_state_text += f"• :recycle: {linked_title}\n"
-
-                error_issue_fields.append(self.make_field(issue_state_text))
             blocks.append(self.get_section_fields_block(error_issue_fields))
+
+            # Add regressed and escalated issues
+            regressed_escalated_fields = []
+
+            if context.escalated_today:
+                escalated_issue_text = "*Issues that escalated today*\n"
+                for escalated_issue in context.escalated_today:
+                    linked_title = self.linkify_error_title(escalated_issue)
+                    escalated_issue_text += f"• :point_up: {linked_title}\n"
+                regressed_escalated_fields.append(self.make_field(escalated_issue_text))
+
+            if context.regressed_today:
+                regressed_issue_text = "*Issues that regressed today*\n"
+                for regressed_issue in context.regressed_today:
+                    linked_title = self.linkify_error_title(regressed_issue)
+                    regressed_issue_text += f"• :recycle: {linked_title}\n"
+
+                regressed_escalated_fields.append(self.make_field(regressed_issue_text))
+
+            if regressed_escalated_fields:
+                blocks.append(self.get_section_fields_block(regressed_escalated_fields))
 
             # Add performance data
             if context.key_performance_issues:

--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -46,8 +46,8 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
         if not attachment_text:
             return f"<{link}|*{escape_slack_text(formatted_title)}*>"
 
-        attachment_text = attachment_text.replace("\n", " ").replace("`", "")
-        return f"<{link}|*{escape_slack_text(title)}*>\n`{attachment_text}`"
+        formatted_attachment_text = attachment_text.replace("\n", " ").replace("`", "")
+        return f"<{link}|*{escape_slack_text(formatted_title)}*>\n`{self.truncate_text(formatted_attachment_text)}`"
 
     def linkify_release(self, release, organization):
         path = f"/releases/{release.version}/"

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -665,18 +665,19 @@ class DailySummaryTest(
         # check error issues
         assert "*Today's Top 3 Error Issues" in blocks[5]["fields"][0]["text"]
         assert link_text.format(self.group1.id) in blocks[5]["fields"][0]["text"]
-        assert "\nIdentity not found." in blocks[5]["fields"][0]["text"]
+        assert "\n`Identity not found.`" in blocks[5]["fields"][0]["text"]
         assert link_text.format(self.group2.id) in blocks[5]["fields"][0]["text"]
         assert link_text.format(self.group2.id) in blocks[5]["fields"][0]["text"]
-        # check escalated or regressed issues
-        assert "*Issues that escalated or regressed today*" in blocks[5]["fields"][1]["text"]
-        assert link_text.format(self.group2.id) in blocks[5]["fields"][1]["text"]
-        assert link_text.format(self.group3.id) in blocks[5]["fields"][1]["text"]
         # check performance issues
-        assert "*Today's Top 3 Performance Issues*" in blocks[6]["text"]["text"]
-        assert link_text.format(self.perf_event.group.id) in blocks[6]["text"]["text"]
-        assert "\ndb - SELECT `books_author`.`id`, `b..." in blocks[6]["text"]["text"]
-        assert link_text.format(self.perf_event2.group.id) in blocks[6]["text"]["text"]
+        assert "*Today's Top 3 Performance Issues*" in blocks[5]["fields"][1]["text"]
+        assert link_text.format(self.perf_event.group.id) in blocks[5]["fields"][1]["text"]
+        assert "\n`db - SELECT books_author.id, b...`" in blocks[5]["fields"][1]["text"]
+        assert link_text.format(self.perf_event2.group.id) in blocks[5]["fields"][1]["text"]
+        # check escalated or regressed issues
+        assert "*Issues that escalated today*" in blocks[6]["fields"][0]["text"]
+        assert link_text.format(self.group3.id) in blocks[6]["fields"][0]["text"]
+        assert "*Issues that regressed today*" in blocks[6]["fields"][1]["text"]
+        assert link_text.format(self.group2.id) in blocks[6]["fields"][1]["text"]
         # repeat above for second project
         assert self.project2.slug in blocks[8]["text"]["text"]
         assert "*Today’s Event Count*" in blocks[3]["fields"][0]["text"]
@@ -987,16 +988,17 @@ class DailySummaryTest(
         assert link_text.format(self.group2.id) in blocks[5]["fields"][0]["text"]
         assert link_text.format(self.group2.id) in blocks[5]["fields"][0]["text"]
         # check escalated or regressed issues
-        assert "*Issues that escalated or regressed today*" in blocks[5]["fields"][1]["text"]
-        assert link_text.format(self.group2.id) in blocks[5]["fields"][1]["text"]
-        assert link_text.format(self.group3.id) in blocks[5]["fields"][1]["text"]
+        assert "*Issues that escalated today*" in blocks[6]["fields"][0]["text"]
+        assert link_text.format(self.group3.id) in blocks[6]["fields"][0]["text"]
+        assert "*Issues that regressed today*" in blocks[6]["fields"][1]["text"]
+        assert link_text.format(self.group2.id) in blocks[6]["fields"][1]["text"]
         # repeat above for second project, skipping where performance issue info would be
-        assert self.project2.slug in blocks[7]["text"]["text"]
-        assert "*Today’s Event Count*" in blocks[8]["fields"][0]["text"]
-        assert "*Today's Top 3 Error Issues" in blocks[9]["fields"][0]["text"]
-        assert link_text.format(self.group4.id) in blocks[9]["fields"][0]["text"]
+        assert self.project2.slug in blocks[8]["text"]["text"]
+        assert "*Today’s Event Count*" in blocks[9]["fields"][0]["text"]
+        assert "*Today's Top 3 Error Issues" in blocks[10]["fields"][0]["text"]
+        assert link_text.format(self.group4.id) in blocks[10]["fields"][0]["text"]
         # check footer
-        assert "Getting this at a funky time?" in blocks[11]["elements"][0]["text"]
+        assert "Getting this at a funky time?" in blocks[12]["elements"][0]["text"]
 
     @responses.activate
     @with_feature("organizations:slack-block-kit")
@@ -1036,13 +1038,13 @@ class DailySummaryTest(
         assert link_text.format(self.group2.id) in blocks[5]["fields"][0]["text"]
         assert link_text.format(self.group2.id) in blocks[5]["fields"][0]["text"]
         # check performance issues - skipped past escalated or regressed issues
-        assert "*Today's Top 3 Performance Issues*" in blocks[6]["text"]["text"]
-        assert link_text.format(self.perf_event.group.id) in blocks[6]["text"]["text"]
-        assert link_text.format(self.perf_event2.group.id) in blocks[6]["text"]["text"]
+        assert "*Today's Top 3 Performance Issues*" in blocks[5]["fields"][1]["text"]
+        assert link_text.format(self.perf_event.group.id) in blocks[5]["fields"][1]["text"]
+        assert link_text.format(self.perf_event2.group.id) in blocks[5]["fields"][1]["text"]
         # repeat above for second project
-        assert self.project2.slug in blocks[8]["text"]["text"]
-        assert "*Today’s Event Count*" in blocks[9]["fields"][0]["text"]
-        assert "*Today's Top 3 Error Issues" in blocks[10]["fields"][0]["text"]
-        assert link_text.format(self.group4.id) in blocks[10]["fields"][0]["text"]
+        assert self.project2.slug in blocks[7]["text"]["text"]
+        assert "*Today’s Event Count*" in blocks[8]["fields"][0]["text"]
+        assert "*Today's Top 3 Error Issues" in blocks[9]["fields"][0]["text"]
+        assert link_text.format(self.group4.id) in blocks[9]["fields"][0]["text"]
         # check footer
-        assert "Getting this at a funky time?" in blocks[12]["elements"][0]["text"]
+        assert "Getting this at a funky time?" in blocks[11]["elements"][0]["text"]


### PR DESCRIPTION
Update the daily summary format again to split regressed and escalated issues into their own columns, move performance data up to be in a column next to error data, and code format the issue details text. 

Addresses [this piece of feedback](https://www.notion.so/sentry/Split-Top-Regressed-and-Escalating-Issues-into-2-blocks-3dc6bbc5a32a46fe913e93340b30d81a?pvs=4) as well as feedback from a Slack conversation.


<img width="683" alt="Screenshot 2024-03-26 at 6 09 55 PM" src="https://github.com/getsentry/sentry/assets/29959063/155f1f48-219e-43d1-b73e-5581b126ae04">
