### PR TITLE
feat(trace): support roving with enter keys

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -43,10 +43,14 @@ import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
-import {rovingTabIndexReducer} from 'sentry/views/performance/newTraceDetails/rovingTabIndex';
+import {
+  rovingTabIndexReducer,
+  type RovingTabIndexState,
+} from 'sentry/views/performance/newTraceDetails/rovingTabIndex';
 import {
   searchInTraceTree,
   traceSearchReducer,
+  type TraceSearchState,
 } from 'sentry/views/performance/newTraceDetails/traceSearch';
 import {TraceSearchInput} from 'sentry/views/performance/newTraceDetails/traceSearchInput';
 import {
@@ -156,6 +160,7 @@ type TraceViewContentProps = {
 function TraceViewContent(props: TraceViewContentProps) {
   const api = useApi();
   const {projects} = useProjects();
+  const rootEvent = useRootEvent(props.trace);
 
   const [tracePreferences, setTracePreferences] = useLocalStorageState<{
     drawer: number;
@@ -167,8 +172,6 @@ function TraceViewContent(props: TraceViewContentProps) {
     drawer: 0,
   });
 
-  const rootEvent = useRootEvent(props.trace);
-
   const viewManager = useMemo(() => {
     return new VirtualizedViewManager({
       list: {width: tracePreferences.list_width},
@@ -177,6 +180,13 @@ function TraceViewContent(props: TraceViewContentProps) {
     // We only care about initial state when we initialize the view manager
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const previouslyFocusedNodeRef = useRef<TraceTreeNode<TraceTree.NodeValue> | null>(
+    null
+  );
+  const previouslyScrolledToNodeRef = useRef<TraceTreeNode<TraceTree.NodeValue> | null>(
+    null
+  );
 
   useEffect(() => {
     function onDividerResizeEnd(list_width: number) {
@@ -249,6 +259,9 @@ function TraceViewContent(props: TraceViewContentProps) {
     }
   );
 
+  const rovingTabIndexStateRef = useRef<RovingTabIndexState>(rovingTabIndexState);
+  rovingTabIndexStateRef.current = rovingTabIndexState;
+
   useLayoutEffect(() => {
     return rovingTabIndexDispatch({
       type: 'initialize',
@@ -271,12 +284,16 @@ function TraceViewContent(props: TraceViewContentProps) {
 
   const [searchState, searchDispatch] = useReducer(traceSearchReducer, {
     query: initialQuery,
-    resultIteratorIndex: undefined,
-    resultIndex: undefined,
-    results: undefined,
+    resultIteratorIndex: null,
+    resultIndex: null,
+    node: null,
+    results: null,
     status: undefined,
     resultsLookup: new Map(),
   });
+
+  const searchStateRef = useRef<TraceSearchState>(searchState);
+  searchStateRef.current = searchState;
 
   const [tabs, tabsDispatch] = useReducer(traceTabsReducer, {
     tabs: STATIC_DRAWER_TABS,
@@ -308,20 +325,61 @@ function TraceViewContent(props: TraceViewContentProps) {
 
   const searchingRaf = useRef<{id: number | null} | null>(null);
   const onTraceSearch = useCallback(
-    (query: string) => {
+    (
+      traceTree: TraceTree,
+      query: string,
+      previouslySelectedNode: TraceTreeNode<TraceTree.NodeValue> | null
+    ) => {
       if (searchingRaf.current?.id) {
         window.cancelAnimationFrame(searchingRaf.current.id);
       }
 
-      searchingRaf.current = searchInTraceTree(query, tree, results => {
-        searchDispatch({
-          type: 'set results',
-          results: results[0],
-          resultsLookup: results[1],
-        });
-      });
+      // @TODO: searchInTraceTree has to tell us if the current selected match is
+      // in the results set and where, so that we dont have to iterate over the results
+      // again to find it. If it is, we need to set the resultIndex to that index and the
+      // resultIteratorIndex to the index of the result in the results array
+      searchingRaf.current = searchInTraceTree(
+        traceTree,
+        query,
+        previouslySelectedNode,
+        ([matches, lookup, previousNodePosition]) => {
+          // If the user had focused a row, clear it and focus into the search result.
+          if (rovingTabIndexStateRef.current.index !== null) {
+            rovingTabIndexDispatch({type: 'clear index'});
+          }
+
+          const resultIteratorIndex: number | undefined =
+            typeof previousNodePosition?.resultIteratorIndex === 'number'
+              ? previousNodePosition.resultIteratorIndex
+              : matches.length > 0
+                ? 0
+                : undefined;
+
+          const resultIndex: number | undefined =
+            typeof previousNodePosition?.resultIndex === 'number'
+              ? previousNodePosition.resultIndex
+              : matches.length > 0
+                ? matches[0].index
+                : undefined;
+
+          const node: TraceTreeNode<TraceTree.NodeValue> | null = previousNodePosition
+            ? previouslySelectedNode
+            : matches.length > 0
+              ? matches[0].value
+              : null;
+
+          searchDispatch({
+            type: 'set results',
+            results: matches,
+            resultsLookup: lookup,
+            resultIteratorIndex: resultIteratorIndex,
+            resultIndex: resultIndex,
+            node,
+          });
+        }
+      );
     },
-    [tree]
+    []
   );
 
   const onSearchChange = useCallback(
@@ -331,10 +389,13 @@ function TraceViewContent(props: TraceViewContentProps) {
         return;
       }
 
-      onTraceSearch(event.currentTarget.value);
+      const previousNode =
+        rovingTabIndexStateRef.current.node ?? searchStateRef.current.node ?? null;
+
       searchDispatch({type: 'set query', query: event.currentTarget.value});
+      onTraceSearch(tree, event.currentTarget.value, previousNode);
     },
-    [onTraceSearch]
+    [onTraceSearch, tree]
   );
 
   const onSearchClear = useCallback(() => {
@@ -365,6 +426,35 @@ function TraceViewContent(props: TraceViewContentProps) {
   const onPreviousSearchClick = useCallback(() => {
     searchDispatch({type: 'go to previous match'});
   }, []);
+
+  useLayoutEffect(() => {
+    if (searchState.node && typeof searchStateRef.current.resultIndex === 'number') {
+      if (
+        previouslyFocusedNodeRef.current === searchState.node ||
+        previouslyScrolledToNodeRef.current === searchState.node
+      ) {
+        return;
+      }
+
+      viewManager.scrollToRow(searchStateRef.current.resultIndex);
+
+      const offset =
+        searchState.node.depth >= (previouslyScrolledToNodeRef.current?.depth ?? 0)
+          ? viewManager.trace_physical_space.width / 2
+          : 0;
+
+      previouslyScrolledToNodeRef.current = searchState.node;
+
+      if (viewManager.isOutsideOfViewOnKeyDown(searchState.node, offset)) {
+        viewManager.scrollRowIntoViewHorizontally(
+          searchState.node,
+          0,
+          offset,
+          'measured'
+        );
+      }
+    }
+  }, [searchState.node, viewManager]);
 
   const breadcrumbTransaction = useMemo(() => {
     return {
@@ -410,18 +500,18 @@ function TraceViewContent(props: TraceViewContentProps) {
   const traceContainerRef = useRef<HTMLElement | null>(null);
   useOnClickOutside(traceContainerRef, onOutsideClick);
 
-  const previouslyFocusedIndexRef = useRef<number | null>(null);
   const scrollToNode = useCallback(
     (
       node: TraceTreeNode<TraceTree.NodeValue>
     ): Promise<{index: number; node: TraceTreeNode<TraceTree.NodeValue>} | null> => {
-      previouslyFocusedIndexRef.current = null;
       return viewManager
         .scrollToPath(tree, [...node.path], () => void 0, {
           api,
           organization: props.organization,
         })
         .then(maybeNode => {
+          previouslyScrolledToNodeRef.current = maybeNode?.node ?? null;
+
           if (!maybeNode) {
             return null;
           }
@@ -434,7 +524,9 @@ function TraceViewContent(props: TraceViewContentProps) {
           });
 
           if (searchState.query) {
-            onTraceSearch(searchState.query);
+            const previousNode =
+              rovingTabIndexStateRef.current.node ?? searchStateRef.current.node ?? null;
+            onTraceSearch(tree, searchState.query, previousNode);
           }
 
           // Re-focus the row if in view as well
@@ -604,7 +696,7 @@ function TraceViewContent(props: TraceViewContentProps) {
             searchResultsIteratorIndex={searchState.resultIndex}
             searchResultsMap={searchState.resultsLookup}
             onTraceSearch={onTraceSearch}
-            previouslyFocusedIndexRef={previouslyFocusedIndexRef}
+            previouslyFocusedNodeRef={previouslyFocusedNodeRef}
             manager={viewManager}
           />
 

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -342,12 +342,19 @@ function TraceViewContent(props: TraceViewContentProps) {
   }, []);
 
   const onSearchKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'ArrowDown') {
-      searchDispatch({type: 'go to next match'});
-    } else {
-      if (event.key === 'ArrowUp') {
+    switch (event.key) {
+      case 'ArrowDown':
+        searchDispatch({type: 'go to next match'});
+        break;
+      case 'ArrowUp':
         searchDispatch({type: 'go to previous match'});
-      }
+        break;
+      case 'Enter':
+        searchDispatch({
+          type: event.shiftKey ? 'go to previous match' : 'go to next match',
+        });
+        break;
+      default:
     }
   }, []);
 

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -334,10 +334,6 @@ function TraceViewContent(props: TraceViewContentProps) {
         window.cancelAnimationFrame(searchingRaf.current.id);
       }
 
-      // @TODO: searchInTraceTree has to tell us if the current selected match is
-      // in the results set and where, so that we dont have to iterate over the results
-      // again to find it. If it is, we need to set the resultIndex to that index and the
-      // resultIteratorIndex to the index of the result in the results array
       searchingRaf.current = searchInTraceTree(
         traceTree,
         query,

--- a/static/app/views/performance/newTraceDetails/rovingTabIndex.tsx
+++ b/static/app/views/performance/newTraceDetails/rovingTabIndex.tsx
@@ -13,7 +13,8 @@ export type RovingTabIndexAction =
       node: TraceTreeNode<TraceTree.NodeValue> | null;
       type: 'initialize';
     }
-  | {index: number; node: TraceTreeNode<TraceTree.NodeValue>; type: 'set index'};
+  | {index: number; node: TraceTreeNode<TraceTree.NodeValue>; type: 'set index'}
+  | {type: 'clear index'};
 
 export type RovingTabIndexUserActions = 'next' | 'previous' | 'last' | 'first';
 
@@ -27,6 +28,8 @@ export function rovingTabIndexReducer(
     }
     case 'set index':
       return {...state, node: action.node, index: action.index};
+    case 'clear index':
+      return {...state, index: null, node: null};
     default:
       throw new Error('Invalid action');
   }

--- a/static/app/views/performance/newTraceDetails/traceSearch.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch.tsx
@@ -1,4 +1,5 @@
 import {
+  isAutogroupedNode,
   isSpanNode,
   isTraceErrorNode,
   isTransactionNode,
@@ -12,20 +13,31 @@ export type TraceSearchAction =
   | {query: string | undefined; type: 'set query'}
   | {type: 'go to next match'}
   | {type: 'go to previous match'}
-  | {resultIndex: number; resultIteratorIndex: number; type: 'set iterator index'}
+  | {
+      node: TraceTreeNode<TraceTree.NodeValue>;
+      resultIndex: number;
+      resultIteratorIndex: number;
+      type: 'set iterator index';
+    }
   | {type: 'clear iterator index'}
   | {type: 'clear query'}
   | {
+      node: TraceTreeNode<TraceTree.NodeValue> | null;
       results: ReadonlyArray<TraceResult>;
       resultsLookup: Map<TraceTreeNode<TraceTree.NodeValue>, number>;
       type: 'set results';
+      resultIndex?: number;
+      resultIteratorIndex?: number;
     };
 
 export type TraceSearchState = {
+  node: TraceTreeNode<TraceTree.NodeValue> | null;
   query: string | undefined;
-  resultIndex: number | undefined;
-  resultIteratorIndex: number | undefined;
-  results: ReadonlyArray<TraceResult> | undefined;
+  // Index in the list/tree
+  resultIndex: number | null;
+  // Index in the results array
+  resultIteratorIndex: number | null;
+  results: ReadonlyArray<TraceResult> | null;
   resultsLookup: Map<TraceTreeNode<TraceTree.NodeValue>, number>;
   status: [ts: number, 'loading' | 'success' | 'error'] | undefined;
 };
@@ -43,20 +55,26 @@ export function traceSearchReducer(
   switch (action.type) {
     case 'clear query': {
       return {
+        node: null,
         query: undefined,
-        resultIteratorIndex: undefined,
-        results: undefined,
-        resultIndex: undefined,
+        resultIteratorIndex: null,
+        results: null,
+        resultIndex: null,
         resultsLookup: new Map(),
         status: undefined,
       };
     }
     case 'go to next match': {
-      if (state.resultIteratorIndex === undefined) {
+      if (state.resultIteratorIndex === null) {
         if (!state.results || state.results.length === 0) {
           return state;
         }
-        return {...state, resultIteratorIndex: 0, resultIndex: state.results[0].index};
+        return {
+          ...state,
+          resultIteratorIndex: 0,
+          resultIndex: state.results[0].index,
+          node: state.results[0].value,
+        };
       }
       if (!state.results) return state;
 
@@ -70,10 +88,11 @@ export function traceSearchReducer(
         ...state,
         resultIteratorIndex: next,
         resultIndex: state.results[next].index,
+        node: state.results[next].value,
       };
     }
     case 'go to previous match': {
-      if (state.resultIteratorIndex === undefined) {
+      if (state.resultIteratorIndex === null) {
         if (!state.results || !state.results.length) {
           return state;
         }
@@ -81,6 +100,7 @@ export function traceSearchReducer(
           ...state,
           resultIteratorIndex: state.results.length - 1,
           resultIndex: state.results[state.results.length - 1].index,
+          node: state.results[state.results.length - 1].value,
         };
       }
       if (!state.results) return state;
@@ -95,6 +115,7 @@ export function traceSearchReducer(
         ...state,
         resultIteratorIndex: previous,
         resultIndex: state.results[previous].index,
+        node: state.results[previous].value,
       };
     }
     case 'set results': {
@@ -102,8 +123,9 @@ export function traceSearchReducer(
         ...state,
         status: [performance.now(), 'success'],
         results: action.results,
-        resultIteratorIndex: undefined,
-        resultIndex: undefined,
+        node: action.node,
+        resultIteratorIndex: action.resultIteratorIndex ?? null,
+        resultIndex: action.resultIndex ?? null,
         resultsLookup: action.resultsLookup,
       };
     }
@@ -112,8 +134,9 @@ export function traceSearchReducer(
         ...state,
         status: [performance.now(), 'loading'],
         query: action.query,
-        resultIteratorIndex: undefined,
-        resultIndex: undefined,
+        node: null,
+        resultIteratorIndex: null,
+        resultIndex: null,
         resultsLookup: new Map(),
       };
     }
@@ -123,11 +146,12 @@ export function traceSearchReducer(
         ...state,
         resultIteratorIndex: action.resultIteratorIndex,
         resultIndex: action.resultIndex,
+        node: action.node,
       };
     }
 
     case 'clear iterator index': {
-      return {...state, resultIteratorIndex: undefined, resultIndex: undefined};
+      return {...state, resultIteratorIndex: null, resultIndex: null, node: null};
     }
 
     default: {
@@ -142,13 +166,22 @@ type TraceResult = {
 };
 
 export function searchInTraceTree(
-  query: string,
   tree: TraceTree,
+  query: string,
+  previousNode: TraceTreeNode<TraceTree.NodeValue> | null,
   cb: (
-    results: [ReadonlyArray<TraceResult>, Map<TraceTreeNode<TraceTree.NodeValue>, number>]
+    results: [
+      ReadonlyArray<TraceResult>,
+      Map<TraceTreeNode<TraceTree.NodeValue>, number>,
+      {resultIndex: number | undefined; resultIteratorIndex: number | undefined} | null,
+    ]
   ) => void
 ): {id: number | null} {
   const raf: {id: number | null} = {id: 0};
+  let previousNodeResult: {
+    resultIndex: number | undefined;
+    resultIteratorIndex: number | undefined;
+  } | null = null;
   const results: Array<TraceResult> = [];
   const resultLookup = new Map();
 
@@ -161,9 +194,17 @@ export function searchInTraceTree(
 
     while (i < count && performance.now() - ts < 12) {
       const node = tree.list[i];
+
       if (searchInTraceSubset(query, node)) {
         results.push({index: i, value: node});
         resultLookup.set(node, matchCount);
+
+        if (previousNode === node) {
+          previousNodeResult = {
+            resultIndex: i,
+            resultIteratorIndex: matchCount,
+          };
+        }
         matchCount++;
       }
       i++;
@@ -174,7 +215,7 @@ export function searchInTraceTree(
     }
 
     if (i === count) {
-      cb([results, resultLookup]);
+      cb([results, resultLookup, previousNodeResult]);
       raf.id = null;
     }
   }
@@ -207,6 +248,15 @@ function searchInTraceSubset(
       return true;
     }
     if (node.value.event_id && node.value.event_id === query) {
+      return true;
+    }
+  }
+
+  if (isAutogroupedNode(node)) {
+    if (node.value.op?.includes(query)) {
+      return true;
+    }
+    if (node.value.description?.includes(query)) {
       return true;
     }
   }

--- a/static/app/views/performance/newTraceDetails/traceSearchInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearchInput.tsx
@@ -28,7 +28,6 @@ export function TraceSearchInput(props: TraceSearchInputProps) {
   const [status, setStatus] = useState<TraceSearchState['status']>();
 
   const timeoutRef = useRef<number | undefined>(undefined);
-
   const statusRef = useRef<TraceSearchState['status']>(status);
   statusRef.current = status;
 

--- a/static/app/views/performance/newTraceDetails/traceSearchInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearchInput.tsx
@@ -18,7 +18,7 @@ interface TraceSearchInputProps {
   onSearchClear: () => void;
   query: string | undefined;
   resultCount: number | undefined;
-  resultIteratorIndex: number | undefined;
+  resultIteratorIndex: number | null;
   status: TraceSearchState['status'];
 }
 
@@ -71,10 +71,10 @@ export function TraceSearchInput(props: TraceSearchInputProps) {
         )}
       </InputGroup.LeadingItems>
       <InputGroup.Input
+        size="xs"
         type="text"
         name="query"
         autoComplete="off"
-        size="xs"
         placeholder={t('Search in trace')}
         value={props.query}
         onChange={props.onChange}
@@ -85,7 +85,7 @@ export function TraceSearchInput(props: TraceSearchInputProps) {
           {`${
             props.query && !props.resultCount
               ? '0/0'
-              : (props.resultIteratorIndex !== undefined
+              : (props.resultIteratorIndex !== null
                   ? props.resultIteratorIndex + 1
                   : '-') + `/${props.resultCount ?? 0}`
           }`}


### PR DESCRIPTION
Implements roving with enter and shift+enter keys. Required a bit of a larger change as we want to track the nodes by values instead of their index in the list. The reason we cannot rely on the index is that as users manipulate the tree, that index might change - when that happens, persisting current user selection is a nicer UX and just losing state.