### PR TITLE
feat(use-case): Add visibility modifiers to use cases and use internal MRI parser

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -52,7 +52,7 @@ from sentry.search.events.types import (
     WhereType,
 )
 from sentry.sentry_metrics import indexer
-from sentry.sentry_metrics.use_case_id_registry import UseCaseID, extract_use_case_id
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import create_result_key
 from sentry.snuba.metrics.extraction import (
@@ -64,6 +64,7 @@ from sentry.snuba.metrics.extraction import (
     should_use_on_demand_metrics_for_querying,
 )
 from sentry.snuba.metrics.fields import histogram as metrics_histogram
+from sentry.snuba.metrics.naming_layer.mri import extract_use_case_id
 from sentry.snuba.metrics.query import (
     MetricField,
     MetricGroupByField,

--- a/src/sentry/sentry_metrics/aggregation_option_registry.py
+++ b/src/sentry/sentry_metrics/aggregation_option_registry.py
@@ -1,7 +1,8 @@
 from enum import Enum
 
 from sentry import options
-from sentry.sentry_metrics.use_case_id_registry import UseCaseID, extract_use_case_id
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+from sentry.snuba.metrics.naming_layer.mri import extract_use_case_id
 
 
 class AggregationOption(Enum):

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -27,7 +27,8 @@ from sentry.sentry_metrics.consumers.indexer.common import (
 from sentry.sentry_metrics.consumers.indexer.parsed_message import ParsedMessage
 from sentry.sentry_metrics.consumers.indexer.routing_producer import RoutingPayload
 from sentry.sentry_metrics.indexer.base import Metadata
-from sentry.sentry_metrics.use_case_id_registry import UseCaseID, extract_use_case_id
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+from sentry.snuba.metrics.naming_layer.mri import extract_use_case_id
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/sentry_metrics/use_case_id_registry.py
+++ b/src/sentry/sentry_metrics/use_case_id_registry.py
@@ -6,10 +6,12 @@ from enum import Enum
 from sentry.sentry_metrics.configuration import UseCaseKey
 
 
-class UseCaseIDVisibility(Enum):
-    # Available to users to query via public endpoints.
+class UseCaseIDAPIAccess(Enum):
+    """
+    Represents the access levels of a UseCaseID for sentry's APIs.
+    """
+
     PUBLIC = 0
-    # Available only internally.
     PRIVATE = 1
 
 
@@ -24,15 +26,15 @@ class UseCaseID(Enum):
     METRIC_STATS = "metric_stats"
 
 
-USE_CASE_ID_VISIBILITIES: Mapping[UseCaseID, UseCaseIDVisibility] = {
-    UseCaseID.SPANS: UseCaseIDVisibility.PUBLIC,
-    UseCaseID.TRANSACTIONS: UseCaseIDVisibility.PUBLIC,
-    UseCaseID.SESSIONS: UseCaseIDVisibility.PUBLIC,
-    UseCaseID.ESCALATING_ISSUES: UseCaseIDVisibility.PRIVATE,
-    UseCaseID.CUSTOM: UseCaseIDVisibility.PUBLIC,
-    UseCaseID.PROFILES: UseCaseIDVisibility.PRIVATE,
-    UseCaseID.BUNDLE_ANALYSIS: UseCaseIDVisibility.PRIVATE,
-    UseCaseID.METRIC_STATS: UseCaseIDVisibility.PRIVATE,
+USE_CASE_ID_API_ACCESSES: Mapping[UseCaseID, UseCaseIDAPIAccess] = {
+    UseCaseID.SPANS: UseCaseIDAPIAccess.PUBLIC,
+    UseCaseID.TRANSACTIONS: UseCaseIDAPIAccess.PUBLIC,
+    UseCaseID.SESSIONS: UseCaseIDAPIAccess.PUBLIC,
+    UseCaseID.ESCALATING_ISSUES: UseCaseIDAPIAccess.PRIVATE,
+    UseCaseID.CUSTOM: UseCaseIDAPIAccess.PUBLIC,
+    UseCaseID.PROFILES: UseCaseIDAPIAccess.PRIVATE,
+    UseCaseID.BUNDLE_ANALYSIS: UseCaseIDAPIAccess.PRIVATE,
+    UseCaseID.METRIC_STATS: UseCaseIDAPIAccess.PRIVATE,
 }
 
 # UseCaseKey will be renamed to MetricPathKey
@@ -71,11 +73,11 @@ USE_CASE_ID_WRITES_LIMIT_QUOTA_OPTIONS = {
 }
 
 
-def get_use_case_id_visibility(use_case_id: UseCaseID) -> UseCaseIDVisibility:
+def get_use_case_id_api_access(use_case_id: UseCaseID) -> UseCaseIDAPIAccess:
     """
-    Returns the visibility of a use case and defaults to private in case no visibility is provided.
+    Returns the api access visibility of a use case and defaults to private in case no api access is provided.
 
     The rationale for defaulting to private visibility is that we do not want to leak by mistake any internal metrics
     that users should not have access to.
     """
-    return USE_CASE_ID_VISIBILITIES.get(use_case_id, UseCaseIDVisibility.PRIVATE)
+    return USE_CASE_ID_API_ACCESSES.get(use_case_id, UseCaseIDAPIAccess.PRIVATE)

--- a/src/sentry/sentry_metrics/use_case_id_registry.py
+++ b/src/sentry/sentry_metrics/use_case_id_registry.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from enum import Enum
 
-from sentry_kafka_schemas.codecs import ValidationError
-
 from sentry.sentry_metrics.configuration import UseCaseKey
-from sentry.snuba.metrics import parse_mri
 
 
 class UseCaseIDVisibility(Enum):
@@ -82,17 +79,3 @@ def get_use_case_id_visibility(use_case_id: UseCaseID) -> UseCaseIDVisibility:
     that users should not have access to.
     """
     return USE_CASE_ID_VISIBILITIES.get(use_case_id, UseCaseIDVisibility.PRIVATE)
-
-
-def extract_use_case_id(mri: str) -> UseCaseID:
-    """
-    Returns the use case ID given the MRI, throws an error if MRI is invalid or the use case doesn't exist.
-    """
-    parsed_mri = parse_mri(mri)
-    if parsed_mri is not None:
-        if parsed_mri.namespace in {id.value for id in UseCaseID}:
-            return UseCaseID(parsed_mri.namespace)
-
-        raise ValidationError(f"The use case of the MRI {parsed_mri.namespace} does not exist")
-
-    raise ValidationError(f"The MRI {mri} is not valid")

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -39,6 +39,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import cast
 
+from sentry_kafka_schemas.codecs import ValidationError
+
 from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.dataset import EntityKey
@@ -369,6 +371,6 @@ def extract_use_case_id(mri: str) -> UseCaseID:
         if parsed_mri.namespace in {id.value for id in UseCaseID}:
             return UseCaseID(parsed_mri.namespace)
 
-        raise Exception(f"The use case of the MRI {parsed_mri.namespace} does not exist")
+        raise ValidationError(f"The use case of the MRI {parsed_mri.namespace} does not exist")
 
-    raise Exception(f"The MRI {mri} is not valid")
+    raise ValidationError(f"The MRI {mri} is not valid")

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -358,3 +358,17 @@ def get_available_operations(parsed_mri: ParsedMRI) -> Sequence[str]:
     else:
         entity_key = get_entity_key_from_entity_type(parsed_mri.entity, True).value
         return AVAILABLE_GENERIC_OPERATIONS[entity_key]
+
+
+def extract_use_case_id(mri: str) -> UseCaseID:
+    """
+    Returns the use case ID given the MRI, throws an error if MRI is invalid or the use case doesn't exist.
+    """
+    parsed_mri = parse_mri(mri)
+    if parsed_mri is not None:
+        if parsed_mri.namespace in {id.value for id in UseCaseID}:
+            return UseCaseID(parsed_mri.namespace)
+
+        raise Exception(f"The use case of the MRI {parsed_mri.namespace} does not exist")
+
+    raise Exception(f"The MRI {mri} is not valid")

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -79,43 +79,27 @@ class OrganizationMetricsPermissionTest(APITestCase):
             "post",
             "sentry-api-0-organization-metrics-query",
         ),
-        ("get", "sentry-api-0-organization-metrics-samples"),
     )
 
-    def setUp(self):
-        self.create_project(name="Bar", slug="bar", teams=[self.team], fire_project_created=True)
-
-    def send_request(self, organization, token, method, endpoint, *args):
-        url = reverse(endpoint, args=(organization.slug,) + args)
+    def send_request(self, token, method, endpoint, *args):
+        url = reverse(endpoint, args=(self.project.organization.slug,) + args)
         return getattr(self.client, method)(
             url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
         )
 
-    def test_access_with_wrong_permission_scopes(self):
+    def test_permissions(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=[])
 
         for method, endpoint, *rest in self.endpoints:
-            response = self.send_request(self.organization, token, method, endpoint, *rest)
+            response = self.send_request(token, method, endpoint, *rest)
             assert response.status_code == 403
 
-    def test_access_of_another_organization(self):
-        other_user = self.create_user("admin_2@localhost", is_superuser=True, is_staff=True)
-        self.create_organization(name="foo", slug="foo", owner=other_user)
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            token = ApiToken.objects.create(user=other_user, scope_list=["org:read"])
-
-        for method, endpoint, *rest in self.endpoints:
-            response = self.send_request(self.organization, token, method, endpoint, *rest)
-            assert response.status_code == 403
-
-    def test_access_with_permissions(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["org:read"])
 
         for method, endpoint, *rest in self.endpoints:
-            response = self.send_request(self.organization, token, method, endpoint, *rest)
+            response = self.send_request(token, method, endpoint, *rest)
             assert response.status_code in (200, 400, 404)
 
 

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -79,27 +79,43 @@ class OrganizationMetricsPermissionTest(APITestCase):
             "post",
             "sentry-api-0-organization-metrics-query",
         ),
+        ("get", "sentry-api-0-organization-metrics-samples"),
     )
 
-    def send_request(self, token, method, endpoint, *args):
-        url = reverse(endpoint, args=(self.project.organization.slug,) + args)
+    def setUp(self):
+        self.create_project(name="Bar", slug="bar", teams=[self.team], fire_project_created=True)
+
+    def send_request(self, organization, token, method, endpoint, *args):
+        url = reverse(endpoint, args=(organization.slug,) + args)
         return getattr(self.client, method)(
             url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
         )
 
-    def test_permissions(self):
+    def test_access_with_wrong_permission_scopes(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=[])
 
         for method, endpoint, *rest in self.endpoints:
-            response = self.send_request(token, method, endpoint, *rest)
+            response = self.send_request(self.organization, token, method, endpoint, *rest)
             assert response.status_code == 403
 
+    def test_access_of_another_organization(self):
+        other_user = self.create_user("admin_2@localhost", is_superuser=True, is_staff=True)
+        self.create_organization(name="foo", slug="foo", owner=other_user)
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=other_user, scope_list=["org:read"])
+
+        for method, endpoint, *rest in self.endpoints:
+            response = self.send_request(self.organization, token, method, endpoint, *rest)
+            assert response.status_code == 403
+
+    def test_access_with_permissions(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["org:read"])
 
         for method, endpoint, *rest in self.endpoints:
-            response = self.send_request(token, method, endpoint, *rest)
+            response = self.send_request(self.organization, token, method, endpoint, *rest)
             assert response.status_code in (200, 400, 404)
 
 

--- a/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
@@ -424,7 +424,7 @@ invalid_payloads = [
     ),
     (
         {
-            "name": "c:transactions/alert@none" * 21,
+            "name": "c:transactions/alert@" + ("none" * 50),
             "tags": {
                 "environment": "production",
                 "session.status": "errored",

--- a/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
@@ -368,7 +368,7 @@ invalid_payloads = [
     ),
     (
         {
-            "name": SessionMRI.RAW_ERROR.value * 21,
+            "name": "s:sessions/error@" + ("none" * 50),
             "tags": {
                 "environment": "production",
                 "session.status": "errored",


### PR DESCRIPTION
This PR adds the concept of visibility to use cases. The rationale behind this PR is that we are seeing an increase in the number of use cases added to the generic metrics platform and we want to differentiate between use cases that are meant to be surfaced directly in the product or just internally to power features of the product.

This PR also includes some minor improvements like moving into another module `extract_use_case_id` and cleanups of dead code.

Closes: https://github.com/getsentry/sentry/issues/67602