### PR TITLE
Further post Rust cleanup of `Enhancements`

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -15,10 +15,8 @@ from sentry_ophio.enhancers import Component as RustComponent
 from sentry_ophio.enhancers import Enhancements as RustEnhancements
 
 from sentry import projectoptions
-from sentry.features.rollout import in_random_rollout
 from sentry.grouping.component import GroupingComponent
 from sentry.stacktraces.functions import set_in_app
-from sentry.utils import metrics
 from sentry.utils.safe import get_path, set_path
 
 from .exceptions import InvalidEnhancerConfig
@@ -34,31 +32,6 @@ RUST_CACHE = RustCache(1_000)
 
 VERSIONS = [2]
 LATEST_VERSION = VERSIONS[-1]
-
-
-class StacktraceState:
-    def __init__(self):
-        self.vars = {"max-frames": 0, "min-frames": 0, "invert-stacktrace": False}
-        self.setters = {}
-
-    def set(self, var, value, rule=None):
-        self.vars[var] = value
-        if rule is not None:
-            self.setters[var] = rule
-
-    def get(self, var):
-        return self.vars.get(var)
-
-    def describe_var_rule(self, var):
-        rule = self.setters.get(var)
-        if rule is not None:
-            return rule.matcher_description
-
-    def add_to_hint(self, hint, var):
-        description = self.describe_var_rule(var)
-        if description is None:
-            return hint
-        return f"{hint} by stack trace rule ({description})"
 
 
 def merge_rust_enhancements(
@@ -96,8 +69,6 @@ def parse_rust_enhancements(
         raise InvalidEnhancerConfig(str(e))
 
 
-RustAssembleResult = tuple[bool | None, str | None, bool, list[RustComponent]]
-RustEnhancedFrames = list[tuple[str | None, bool | None]]
 RustExceptionData = dict[str, bytes | None]
 
 
@@ -117,114 +88,12 @@ def make_rust_exception_data(
     return e
 
 
-def assemble_rust_components(
-    rust_enhancements: RustEnhancements | None,
-    match_frames: list[dict[str, bytes]],
-    exception_data: dict[str, Any],
-    components: list[GroupingComponent],
-) -> RustAssembleResult | None:
-    """
-    If `RustEnhancements` were successfully parsed and usage is enabled,
-    this will update all the frame `components` contributions.
-
-    This primarily means updating the `contributes`, `hint` as well as other attributes
-    of each frames `GroupingComponent`.
-    Instead of modifying the input `components` directly, the results are returned
-    as a list of `RustComponent`.
-    """
-    if not rust_enhancements:
-        return None
-
-    try:
-        rust_components = [
-            RustComponent(
-                is_prefix_frame=c.is_prefix_frame or False,
-                is_sentinel_frame=c.is_sentinel_frame or False,
-                contributes=c.contributes,
-            )
-            for c in components
-        ]
-
-        rust_results = rust_enhancements.assemble_stacktrace_component(
-            match_frames, make_rust_exception_data(exception_data), rust_components
-        )
-        metrics.incr("rust_enhancements.assembling_run")
-
-        return (
-            rust_results.contributes,
-            rust_results.hint,
-            rust_results.invert_stacktrace,
-            rust_components,
-        )
-    except Exception:
-        logger.exception("failed running Rust Enhancements component contributions")
-        return None
-
-
-def compare_rust_components(
-    component: GroupingComponent,
-    invert_stacktrace: bool,
-    rust_results: RustAssembleResult | None,
-    frames: Sequence[dict[str, Any]],
-):
-    """
-    Compares the results of `rust_results` with the component modifications
-    applied by Python code directly to `components`.
-
-    This will log an internal error on every mismatch.
-    """
-    if not rust_results:
-        return
-
-    contributes, hint, invert, rust_components_ = rust_results
-
-    python_components = [
-        (c.contributes, c.hint, c.is_prefix_frame, c.is_sentinel_frame) for c in component.values
-    ]
-    rust_components = [
-        (c.contributes, c.hint, c.is_prefix_frame, c.is_sentinel_frame) for c in rust_components_
-    ]
-
-    python_res = (component.contributes, component.hint, invert_stacktrace, python_components)
-    rust_res = (contributes, hint, invert, rust_components)
-
-    if python_res != rust_res:
-        with sentry_sdk.push_scope() as scope:
-            scope.set_extra("python_res", python_res)
-            scope.set_extra("rust_res", rust_res)
-            scope.set_extra("frames", frames)
-
-            sentry_sdk.capture_message("Rust Enhancements mismatch")
-
-
-def fully_assemble_rust_component(
-    rust_results: RustAssembleResult,
-    components: list[GroupingComponent],
-):
-    contributes, hint, invert, rust_components = rust_results
-
-    for py_component, rust_component in zip(components, rust_components):
-        py_component.update(
-            contributes=rust_component.contributes,
-            hint=rust_component.hint,
-            is_prefix_frame=rust_component.is_prefix_frame,
-            is_sentinel_frame=rust_component.is_sentinel_frame,
-        )
-
-    component = GroupingComponent(
-        id="stacktrace", values=components, hint=hint, contributes=contributes
-    )
-
-    return component, invert
-
-
 class Enhancements:
     # NOTE: You must add a version to ``VERSIONS`` any time attributes are added
     # to this class, s.t. no enhancements lacking these attributes are loaded
     # from cache.
     # See ``GroupingConfigLoader._get_enhancements`` in src/sentry/grouping/api.py.
 
-    @sentry_sdk.tracing.trace
     def __init__(
         self, rules, rust_enhancements: RustEnhancements, version=None, bases=None, id=None
     ):
@@ -239,23 +108,15 @@ class Enhancements:
 
         self.rust_enhancements = merge_rust_enhancements(bases, rust_enhancements)
 
-        self._modifier_rules: list[Rule] = []
-        self._updater_rules: list[Rule] = []
-        for rule in self.iter_rules():
-            if modifier_rule := rule._as_modifier_rule():
-                self._modifier_rules.append(modifier_rule)
-            if updater_rule := rule._as_updater_rule():
-                self._updater_rules.append(updater_rule)
-
     def apply_modifications_to_frame(
         self,
         frames: Sequence[dict[str, Any]],
         platform: str,
         exception_data: dict[str, Any],
     ) -> None:
-        """This applies the frame modifications to the frames itself. This does not affect grouping."""
-
-        # Matching frames are used for matching rules
+        """
+        This applies the frame modifications to the frames itself. This does not affect grouping.
+        """
         match_frames = [create_match_frame(frame, platform) for frame in frames]
 
         rust_enhanced_frames = self.rust_enhancements.apply_modifications_to_frames(
@@ -268,88 +129,44 @@ class Enhancements:
             if category is not None:
                 set_path(frame, "data", "category", value=category)
 
-    def update_frame_components_contributions(
-        self, components, frames, match_frames, platform, exception_data
-    ):
-        stacktrace_state = StacktraceState()
-        in_memory_cache: dict[str, str] = {}
-        # Apply direct frame actions and update the stack state alongside
-        for rule in self._updater_rules:
-            for idx, action in rule.get_matching_frame_actions(
-                match_frames, exception_data, in_memory_cache
-            ):
-                action.update_frame_components_contributions(components, frames, idx, rule=rule)
-                action.modify_stacktrace_state(stacktrace_state, rule)
-
-        # Use the stack state to update frame contributions again to trim
-        # down to max-frames.  min-frames is handled on the other hand for
-        # the entire stacktrace later.
-        max_frames = stacktrace_state.get("max-frames")
-
-        if max_frames > 0:
-            ignored = 0
-            for component in reversed(components):
-                if not component.contributes:
-                    continue
-                ignored += 1
-                if ignored <= max_frames:
-                    continue
-                hint = "ignored because only %d %s considered" % (
-                    max_frames,
-                    "frames are" if max_frames != 1 else "frame is",
-                )
-                hint = stacktrace_state.add_to_hint(hint, var="max-frames")
-                component.update(hint=hint, contributes=False)
-
-        return stacktrace_state
-
     def assemble_stacktrace_component(self, components, frames, platform, exception_data=None):
         """
         This assembles a `stacktrace` grouping component out of the given
         `frame` components and source frames.
 
-        Internally this invokes the `update_frame_components_contributions` method
-        but also handles cases where the entire stacktrace should be discarded.
+        This also handles cases where the entire stacktrace should be discarded.
         """
         match_frames = [create_match_frame(frame, platform) for frame in frames]
 
-        rust_results = None
-        if in_random_rollout("grouping.rust_enhancers.compare_components"):
-            rust_results = assemble_rust_components(
-                self.rust_enhancements, match_frames, exception_data, components
+        rust_components = [
+            RustComponent(
+                is_prefix_frame=c.is_prefix_frame or False,
+                is_sentinel_frame=c.is_sentinel_frame or False,
+                contributes=c.contributes,
+            )
+            for c in components
+        ]
+
+        rust_results = self.rust_enhancements.assemble_stacktrace_component(
+            match_frames, make_rust_exception_data(exception_data), rust_components
+        )
+
+        for py_component, rust_component in zip(components, rust_components):
+            py_component.update(
+                contributes=rust_component.contributes,
+                hint=rust_component.hint,
+                is_prefix_frame=rust_component.is_prefix_frame,
+                is_sentinel_frame=rust_component.is_sentinel_frame,
             )
 
-        if rust_results is not None and in_random_rollout(
-            "grouping.rust_enhancers.prefer_rust_components"
-        ):
-            return fully_assemble_rust_component(rust_results, components)
-
-        hint = None
-        contributes = None
-        stacktrace_state = self.update_frame_components_contributions(
-            components, frames, match_frames, platform, exception_data
-        )
-
-        min_frames = stacktrace_state.get("min-frames")
-        if min_frames > 0:
-            total_contributes = sum(x.contributes for x in components)
-            if 0 < total_contributes < min_frames:
-                hint = (
-                    "discarded because stack trace only contains %d "
-                    "frame%s which is under the configured threshold"
-                    % (total_contributes, "s" if total_contributes != 1 else "")
-                )
-                hint = stacktrace_state.add_to_hint(hint, var="min-frames")
-                contributes = False
-
-        invert_stacktrace = stacktrace_state.get("invert-stacktrace")
         component = GroupingComponent(
-            id="stacktrace", values=components, hint=hint, contributes=contributes
+            id="stacktrace",
+            values=components,
+            hint=rust_results.hint,
+            contributes=rust_results.contributes,
         )
 
-        compare_rust_components(component, invert_stacktrace, rust_results, frames)
-
-        return component, invert_stacktrace
+        return component, rust_results.invert_stacktrace
 
     def as_dict(self, with_rules=False):
         rv = {
@@ -363,13 +180,6 @@ class Enhancements:
         if with_rules:
             rv["rules"] = [x.as_dict() for x in self.rules]
         return rv
-
-    def iter_rules(self):
-        for base in self.bases:
-            base = ENHANCEMENT_BASES.get(base)
-            if base:
-                yield from base.iter_rules()
-        yield from self.rules
 
     def _to_config_structure(self):
         return [
@@ -440,8 +250,6 @@ def _load_configs() -> dict[str, Enhancements]:
                 # We cannot use `:` in filenames on Windows but we already have ids with
                 # `:` in their names hence this trickery.
                 fn = fn.replace("@", ":")
-                # NOTE: we want to force parsing the `RustEnhancements` here, as the base rules
-                # are required for inheritance, and because they are well tested.
                 enhancements = Enhancements.from_config_string(f.read(), id=fn[:-4])
                 rv[fn[:-4]] = enhancements
     return rv

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -8,8 +8,6 @@ from sentry.grouping.component import GroupingComponent
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.enhancer.matchers import create_match_frame
-from sentry.testutils.helpers.options import override_options
-from sentry.testutils.pytest.fixtures import django_db_all
 
 
 def dump_obj(obj):
@@ -471,13 +469,6 @@ def test_range_matching_direct():
 
 @pytest.mark.parametrize("action", ["+", "-"])
 @pytest.mark.parametrize("type", ["prefix", "sentinel"])
-@django_db_all  # because of `options` usage
-@override_options(
-    {
-        "grouping.rust_enhancers.compare_components": 1.0,
-        "grouping.rust_enhancers.prefer_rust_components": 1.0,
-    }
-)
 def test_sentinel_and_prefix(action, type):
     enhancements = Enhancements.from_config_string(f"function:foo {action}{type}")
 

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -10,8 +10,6 @@ from sentry.grouping.api import (
 )
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
-from sentry.testutils.helpers.options import override_options
-from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
 from tests.sentry.grouping import with_grouping_input
 
@@ -61,8 +59,6 @@ def dump_variant(variant, lines=None, indent=0):
 
 @with_grouping_input("grouping_input")
 @pytest.mark.parametrize("config_name", CONFIGURATIONS.keys(), ids=lambda x: x.replace("-", "_"))
-@django_db_all  # because of `options` usage
-@override_options({"grouping.rust_enhancers.compare_components": 1.0})
 def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
     grouping_config = get_default_grouping_config_dict(config_name)
     loaded_config = load_grouping_config(grouping_config)
@@ -89,26 +85,3 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
     assert evt.get_grouping_config() == grouping_config
 
     insta_snapshot(output)
-
-    with override_options(
-        {
-            "grouping.rust_enhancers.prefer_rust_components": 1.0,
-        }
-    ):
-        evt = grouping_input.create_event(grouping_config)
-        evt.project = None
-        detect_synthetic_exception(evt.data, loaded_config)
-
-        rust_hashes = evt.get_hashes()
-        assert rust_hashes.hashes == hashes.hashes
-
-        rv = []
-        for key, value in sorted(evt.get_grouping_variants().items()):
-            if rv:
-                rv.append("-" * 74)
-            rv.append("%s:" % key)
-            dump_variant(value, rv, 1)
-        rust_output = "\n".join(rv)
-
-        # FIXME: the `hint` output does not (yet) fully match what Python produces
-        assert rust_output == output


### PR DESCRIPTION
Now that we have fully rolled out usage of Rust `Enhancements`, its time to clean up the random rollout code, comparison code, as well as legacy Python code that is not needed anymore.