### PR TITLE
chore(github): remove all `reinstall_id` logic

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -342,9 +342,6 @@ class GitHubIntegrationProvider(IntegrationProvider):
         if state.get("sender"):
             integration["metadata"]["sender"] = state["sender"]
 
-        if state.get("reinstall_id"):
-            integration["reinstall_id"] = state["reinstall_id"]
-
         return integration
 
     def setup(self) -> None:
@@ -361,9 +358,6 @@ class GitHubInstallation(PipelineView):
         return f"https://github.com/apps/{slugify(name)}"
 
     def dispatch(self, request: Request, pipeline: Pipeline) -> HttpResponse:
-        if "reinstall_id" in request.GET:
-            pipeline.bind_state("reinstall_id", request.GET["reinstall_id"])
-
         if "installation_id" not in request.GET:
             return self.redirect(self.get_app_url())
 

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -419,9 +419,6 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
             "idp_config": state["oauth_config_information"],
         }
 
-        if state.get("reinstall_id"):
-            integration["reinstall_id"] = state["reinstall_id"]
-
         return integration
 
     def setup(self):
@@ -442,8 +439,6 @@ class GitHubEnterpriseInstallationRedirect(PipelineView):
 
     def dispatch(self, request: Request, pipeline) -> HttpResponse:
         installation_data = pipeline.fetch_state(key="installation_data")
-        if "reinstall_id" in request.GET:
-            pipeline.bind_state("reinstall_id", request.GET["reinstall_id"])
 
         if "installation_id" in request.GET:
             pipeline.bind_state("installation_id", request.GET["installation_id"])

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -124,13 +124,7 @@ class IntegrationPipeline(Pipeline):
         return response
 
     def _finish_pipeline(self, data):
-        if "reinstall_id" in data:
-            self.integration = Integration.objects.get(
-                provider=self.provider.integration_key, id=data["reinstall_id"]
-            )
-            self.integration.update(external_id=data["external_id"], status=ObjectStatus.ACTIVE)
-            self.integration.get_installation(self.organization.id).reinstall()
-        elif "expect_exists" in data:
+        if "expect_exists" in data:
             self.integration = Integration.objects.get(
                 provider=self.provider.integration_key, external_id=data["external_id"]
             )

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -350,44 +350,6 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert b"The GitHub installation could not be found." in resp.content
 
     @responses.activate
-    def test_reinstall_flow(self):
-        self._stub_github()
-        self.assert_setup_flow()
-
-        integration = Integration.objects.get(provider=self.provider.key)
-        integration.update(status=ObjectStatus.DISABLED)
-        assert integration.status == ObjectStatus.DISABLED
-        assert integration.external_id == self.installation_id
-
-        resp = self.client.get(
-            "{}?{}".format(self.init_path, urlencode({"reinstall_id": integration.id}))
-        )
-
-        assert resp.status_code == 302
-        redirect = urlparse(resp["Location"])
-        assert redirect.scheme == "https"
-        assert redirect.netloc == "github.com"
-        assert redirect.path == "/apps/sentry-test-app"
-
-        # New Installation
-        self.installation_id = "install_2"
-
-        self._stub_github()
-
-        resp = self.client.get(
-            "{}?{}".format(self.setup_path, urlencode({"installation_id": self.installation_id}))
-        )
-
-        assert resp.status_code == 200
-
-        auth_header = responses.calls[0].request.headers["Authorization"]
-        assert auth_header == "Bearer jwt_token_1"
-
-        integration = Integration.objects.get(provider=self.provider.key)
-        assert integration.status == ObjectStatus.ACTIVE
-        assert integration.external_id == self.installation_id
-
-    @responses.activate
     def test_disable_plugin_when_fully_migrated(self):
         self._stub_github()
 


### PR DESCRIPTION
The last mention of `reinstall_id` in query parameters was removed in
https://github.com/getsentry/sentry/pull/18740/files#diff-2400e6ada8288507a26e3a20012883a30eb2687a6803a4b9c1b182b6c953a9a4L90