### PR TITLE
feat(proguard): A/B test new Symbolicator implementation

### DIFF
--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -171,54 +171,10 @@ class JavaSourceLookupStacktraceProcessor(StacktraceProcessor):
             archive.close()
 
         # Symbolicator/Python A/B testing
-        if symbolicator_stacktraces := self.data.pop("symbolicator_stacktraces", None):
-            # This should always be set if symbolicator_stacktrace is, but better safe than sorry
-            symbolicator_exceptions = self.data.pop("symbolicator_exceptions", ())
-
-            def frames_differ(a, b):
-                return (
-                    a.get("lineno") != b.get("lineno")
-                    or a.get("abs_path") != b.get("abs_path")
-                    or a.get("function") != b.get("function")
-                    or a.get("filename") != b.get("filename")
-                    or a.get("module") != b.get("module")
-                    or a.get("in_app") != b.get("in_app")
-                    or a.get("context_line") != b.get("context_line")
-                )
-
-            def exceptions_differ(a, b):
-                return a.get("type") != b.get("type") or a.get("module") != b.get("module")
-
-            different_frames = []
-            for symbolicator_stacktrace, stacktrace_info in zip(
-                symbolicator_stacktraces, self.stacktrace_infos
-            ):
-                # NOTE: lets hope that `stacktrace_info` has the already processed frames
-                python_stacktrace = stacktrace_info.container.get("stacktrace")
-
-                for symbolicator_frame, python_frame in zip(
-                    symbolicator_stacktrace, python_stacktrace["frames"]
-                ):
-                    if frames_differ(symbolicator_frame, python_frame):
-                        different_frames.append((symbolicator_frame, python_frame))
-
-            different_exceptions = []
-            for symbolicator_exception, python_exception in zip(
-                symbolicator_exceptions,
-                get_path(self.data, "exception", "values", filter=True, default=()),
-            ):
-                if exceptions_differ(symbolicator_exception, python_exception):
-                    different_exceptions.append((symbolicator_exception, python_exception))
-
-            if different_frames or different_exceptions:
-                with sentry_sdk.push_scope() as scope:
-                    scope.set_extra("different_frames", different_frames)
-                    scope.set_extra("different_exceptions", different_exceptions)
-                    scope.set_extra("event_id", self.data.get("event_id"))
-                    scope.set_tag("project_id", self.project.id)
-                    sentry_sdk.capture_message(
-                        "JVM symbolication differences between symbolicator and python."
-                    )
+        try:
+            self.perform_ab_test()
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
 
     def handles_frame(self, frame, stacktrace_info):
         key = self._deep_freeze(frame)
@@ -332,6 +288,60 @@ class JavaSourceLookupStacktraceProcessor(StacktraceProcessor):
                     pass
 
         return new_frames, raw_frames, processing_errors
+
+    def perform_ab_test(self):
+        symbolicator_stacktraces = self.data.pop("symbolicator_stacktraces", None)
+
+        if symbolicator_stacktraces is None:
+            return
+
+        # This should always be set if symbolicator_stacktraces is, but better safe than sorry
+        symbolicator_exceptions = self.data.pop("symbolicator_exceptions", ())
+
+        def frames_differ(a, b):
+            return (
+                a.get("lineno") != b.get("lineno")
+                or a.get("abs_path") != b.get("abs_path")
+                or a.get("function") != b.get("function")
+                or a.get("filename") != b.get("filename")
+                or a.get("module") != b.get("module")
+                or a.get("in_app") != b.get("in_app")
+                or a.get("context_line") != b.get("context_line")
+            )
+
+        def exceptions_differ(a, b):
+            return a.get("type") != b.get("type") or a.get("module") != b.get("module")
+
+        different_frames = []
+        for symbolicator_stacktrace, stacktrace_info in zip(
+            symbolicator_stacktraces, self.stacktrace_infos
+        ):
+            # NOTE: lets hope that `stacktrace_info` has the already processed frames
+            python_stacktrace = stacktrace_info.container.get("stacktrace")
+
+            for symbolicator_frame, python_frame in zip(
+                symbolicator_stacktrace, python_stacktrace["frames"]
+            ):
+                if frames_differ(symbolicator_frame, python_frame):
+                    different_frames.append((symbolicator_frame, python_frame))
+
+        different_exceptions = []
+        for symbolicator_exception, python_exception in zip(
+            symbolicator_exceptions,
+            get_path(self.data, "exception", "values", filter=True, default=()),
+        ):
+            if exceptions_differ(symbolicator_exception, python_exception):
+                different_exceptions.append((symbolicator_exception, python_exception))
+
+        if different_frames or different_exceptions:
+            with sentry_sdk.push_scope() as scope:
+                scope.set_extra("different_frames", different_frames)
+                scope.set_extra("different_exceptions", different_exceptions)
+                scope.set_extra("event_id", self.data.get("event_id"))
+                scope.set_tag("project_id", self.project.id)
+                sentry_sdk.capture_message(
+                    "JVM symbolication differences between symbolicator and python."
+                )
 
 
 class JavaPlugin(Plugin2):

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -217,8 +217,8 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         return
 
     should_do_ab_test = do_proguard_processing_ab_test()
-    symbolicator_exceptions = []
-    symbolicator_stacktraces = []
+    symbolicator_exceptions: list[dict[str, Any]] = []
+    symbolicator_stacktraces: list[list[dict[str, Any]]] = []
 
     processing_errors = response.get("errors", [])
     if len(processing_errors) > 0 and not should_do_ab_test:

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -7,7 +7,7 @@ import sentry_sdk
 
 from sentry import options
 from sentry.attachments import CachedAttachment, attachment_cache
-from sentry.features.rollout import in_rollout_group
+from sentry.features.rollout import in_random_rollout, in_rollout_group
 from sentry.ingest.consumer.processors import CACHE_TIMEOUT
 from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.models.debugfile import ProjectDebugFile
@@ -141,6 +141,7 @@ def deobfuscate_view_hierarchy(data):
 
 SYMBOLICATOR_PROGUARD_PROJECTS_OPTION = "symbolicator.proguard-processing-projects"
 SYMBOLICATOR_PROGUARD_SAMPLE_RATE_OPTION = "symbolicator.proguard-processing-sample-rate"
+SYMBOLICATOR_PROGUARD_AB_TEST_OPTION = "symbolicator.proguard-processing-ab-test"
 
 
 def should_use_symbolicator_for_proguard(project_id: int) -> bool:
@@ -162,3 +163,7 @@ def is_jvm_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:
             return True
 
     return False
+
+
+def do_proguard_processing_ab_test() -> bool:
+    return in_random_rollout(SYMBOLICATOR_PROGUARD_AB_TEST_OPTION)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -591,6 +591,7 @@ register(
 register("symbolicator.proguard-processing-projects", type=Sequence, default=[])
 # Enable use of Symbolicator proguard processing for fraction of projects.
 register("symbolicator.proguard-processing-sample-rate", default=0.0)
+register("symbolicator.proguard-processing-ab-test", default=0.0)
 
 # Post Process Error Hook Sampling
 register(


### PR DESCRIPTION
Based upon #66764.

This adds a new rate option `"symbolicator.proguard-processing-ab-test"` that causes proguard events to be processed using Symbolicator in addition to the existing Python method and the results to be diffed.