### PR TITLE
chore(perf): Use p95 for trends widgets on perf landing

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -253,7 +253,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
           sort: 'trend_percentage()',
           statsPeriod: '14d',
-          trendFunction: 'p50(transaction.duration)',
+          trendFunction: 'p95(transaction.duration)',
           trendType: 'improved',
         }),
       })
@@ -845,7 +845,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
           sort: 'trend_percentage()',
           statsPeriod: '7d',
-          trendFunction: 'p50(transaction.duration)',
+          trendFunction: 'p95(transaction.duration)',
           trendType: 'improved',
         }),
       })
@@ -1036,7 +1036,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
           sort: '-trend_percentage()',
           statsPeriod: '7d',
-          trendFunction: 'p50(transaction.duration)',
+          trendFunction: 'p95(transaction.duration)',
           trendType: 'regression',
         }),
       })

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -357,7 +357,7 @@ export const WIDGET_DEFINITIONS: ({
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.MOST_IMPROVED]: {
-    title: t('Most Improved'),
+    title: t('Most Improved (P95)'),
     titleTooltip: t(
       'This compares the baseline (%s) of the past with the present.',
       'improved'
@@ -366,7 +366,7 @@ export const WIDGET_DEFINITIONS: ({
     dataType: GenericPerformanceWidgetDataType.TRENDS,
   },
   [PerformanceWidgetSetting.MOST_REGRESSED]: {
-    title: t('Most Regressed'),
+    title: t('Most Regressed (P95)'),
     titleTooltip: t(
       'This compares the baseline (%s) of the past with the present.',
       'regressed'
@@ -375,7 +375,7 @@ export const WIDGET_DEFINITIONS: ({
     dataType: GenericPerformanceWidgetDataType.TRENDS,
   },
   [PerformanceWidgetSetting.MOST_CHANGED]: {
-    title: t('Most Changed'),
+    title: t('Most Changed (P95)'),
     titleTooltip: t(
       'This compares the baseline (%s) of the past with the present.',
       'changed'

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -69,7 +69,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
       ? TrendChangeType.IMPROVED
       : TrendChangeType.REGRESSION;
   const derivedTrendChangeType = withBreakpoint ? TrendChangeType.ANY : trendChangeType;
-  const trendFunctionField = TrendFunctionField.P50; // Setting p50 to match trends page
+  const trendFunctionField = TrendFunctionField.P95;
 
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
 

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -345,7 +345,7 @@ describe('Performance > Trends', function () {
 
     expect(summaryLink.closest('a')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/performance/summary/?display=trend&project=1&query=tpm%28%29%3A%3E0.01%20transaction.duration%3A%3E0%20transaction.duration%3A%3C15min%20count_percentage%28%29%3A%3E0.25%20count_percentage%28%29%3A%3C4%20trend_percentage%28%29%3A%3E0%25%20confidence%28%29%3A%3E6&referrer=performance-transaction-summary&statsPeriod=14d&transaction=%2Forganizations%2F%3AorgId%2Fperformance%2F&trendFunction=p50&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29'
+      '/organizations/org-slug/performance/summary/?display=trend&project=1&query=tpm%28%29%3A%3E0.01%20transaction.duration%3A%3E0%20transaction.duration%3A%3C15min%20count_percentage%28%29%3A%3E0.25%20count_percentage%28%29%3A%3C4%20trend_percentage%28%29%3A%3E0%25%20confidence%28%29%3A%3E6&referrer=performance-transaction-summary&statsPeriod=14d&transaction=%2Forganizations%2F%3AorgId%2Fperformance%2F&trendFunction=p95&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29'
     );
   });
 
@@ -543,7 +543,7 @@ describe('Performance > Trends', function () {
     );
 
     const trendDropdownButton = await getTrendDropdown();
-    expect(trendDropdownButton).toHaveTextContent('Percentilep50');
+    expect(trendDropdownButton).toHaveTextContent('Percentilep95');
   });
 
   it('sets duration as a default trend parameter for backend project if query does not specify trend parameter', async function () {

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -35,16 +35,10 @@ export const DEFAULT_MAX_DURATION = '15min';
 
 export const TRENDS_FUNCTIONS: TrendFunction[] = [
   {
-    label: 'p50',
-    field: TrendFunctionField.P50,
+    label: 'p99',
+    field: TrendFunctionField.P99,
     alias: 'percentile_range',
-    legendLabel: 'p50',
-  },
-  {
-    label: 'p75',
-    field: TrendFunctionField.P75,
-    alias: 'percentile_range',
-    legendLabel: 'p75',
+    legendLabel: 'p99',
   },
   {
     label: 'p95',
@@ -53,10 +47,16 @@ export const TRENDS_FUNCTIONS: TrendFunction[] = [
     legendLabel: 'p95',
   },
   {
-    label: 'p99',
-    field: TrendFunctionField.P99,
+    label: 'p75',
+    field: TrendFunctionField.P75,
     alias: 'percentile_range',
-    legendLabel: 'p99',
+    legendLabel: 'p75',
+  },
+  {
+    label: 'p50',
+    field: TrendFunctionField.P50,
+    alias: 'percentile_range',
+    legendLabel: 'p50',
   },
   {
     label: 'average',
@@ -156,7 +156,7 @@ export function getCurrentTrendFunction(
   const trendFunctionField =
     _trendFunctionField ?? decodeScalar(location?.query?.trendFunction);
   const trendFunction = TRENDS_FUNCTIONS.find(({field}) => field === trendFunctionField);
-  return trendFunction || TRENDS_FUNCTIONS[0];
+  return trendFunction || TRENDS_FUNCTIONS[1];
 }
 
 function getDefaultTrendParameter(


### PR DESCRIPTION
It's not clear what percentile the trends widgets were using and p50 as the default is not as useful as the p95.