### PR TITLE
ref(symbolication): Extend mixed stacktrace logic to JVM events

### DIFF
--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -12,6 +12,7 @@ from sentry.ingest.consumer.processors import CACHE_TIMEOUT
 from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.project import Project
+from sentry.stacktraces.processing import StacktraceInfo
 from sentry.utils import json
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.safe import get_path
@@ -149,7 +150,10 @@ def should_use_symbolicator_for_proguard(project_id: int) -> bool:
     return in_rollout_group(SYMBOLICATOR_PROGUARD_SAMPLE_RATE_OPTION, project_id)
 
 
-def is_jvm_event(data, stacktraces):
+def is_jvm_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:
+    """Returns whether `data` is a JVM event, based on its platform and
+    the supplied stacktraces."""
+
     if data.get("platform") == "java":
         return True
 

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -147,3 +147,14 @@ def should_use_symbolicator_for_proguard(project_id: int) -> bool:
         return True
 
     return in_rollout_group(SYMBOLICATOR_PROGUARD_SAMPLE_RATE_OPTION, project_id)
+
+
+def is_jvm_event(data, stacktraces):
+    if data.get("platform") == "java":
+        return True
+
+    for stacktrace in stacktraces:
+        if any(x == "java" for x in stacktrace.platforms):
+            return True
+
+    return False

--- a/src/sentry/lang/javascript/utils.py
+++ b/src/sentry/lang/javascript/utils.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import re
 from os.path import splitext
+from typing import Any
 from urllib.parse import urlsplit
+
+from sentry.stacktraces.processing import StacktraceInfo
 
 # number of surrounding lines (on each side) to fetch
 LINES_OF_CONTEXT = 5
@@ -120,7 +123,10 @@ def generate_module(src: str | None) -> str:
     return CLEAN_MODULE_RE.sub("", filename) or UNKNOWN_MODULE
 
 
-def is_js_event(data, stacktraces):
+def is_js_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:
+    """Returns whether `data` is a JS event, based on its platform and
+    the supplied stacktraces."""
+
     if data.get("platform") in ("javascript", "node"):
         return True
 

--- a/src/sentry/lang/javascript/utils.py
+++ b/src/sentry/lang/javascript/utils.py
@@ -118,3 +118,14 @@ def generate_module(src: str | None) -> str:
             return "/".join(tokens[idx + 1 :])
 
     return CLEAN_MODULE_RE.sub("", filename) or UNKNOWN_MODULE
+
+
+def is_js_event(data, stacktraces):
+    if data.get("platform") in ("javascript", "node"):
+        return True
+
+    for stacktrace in stacktraces:
+        if any(x in ("javascript", "node") for x in stacktrace.platforms):
+            return True
+
+    return False

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -455,12 +455,14 @@ def process_native_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     return data
 
 
-def get_native_symbolication_function(data) -> Callable[[Symbolicator, Any], Any] | None:
+def get_native_symbolication_function(
+    data, stacktraces
+) -> Callable[[Symbolicator, Any], Any] | None:
     if is_minidump_event(data):
         return process_minidump
     elif is_applecrashreport_event(data):
         return process_applecrashreport
-    elif is_native_event(data):
+    elif is_native_event(data, stacktraces):
         return process_native_stacktraces
     else:
         return None

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -456,8 +456,7 @@ def process_native_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
 
 def get_native_symbolication_function(
-    data: Any,
-    stacktraces: list[StacktraceInfo]
+    data: Any, stacktraces: list[StacktraceInfo]
 ) -> Callable[[Symbolicator, Any], Any] | None:
     """
     Returns the appropriate symbolication function (or `None`) that will process

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -456,8 +456,13 @@ def process_native_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
 
 def get_native_symbolication_function(
-    data, stacktraces
+    data: Any,
+    stacktraces: list[StacktraceInfo]
 ) -> Callable[[Symbolicator, Any], Any] | None:
+    """
+    Returns the appropriate symbolication function (or `None`) that will process
+    the event, based on the Event `data`, and the supplied `stacktraces`.
+    """
     if is_minidump_event(data):
         return process_minidump
     elif is_applecrashreport_event(data):

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -23,7 +23,7 @@ from sentry.lang.native.utils import (
 )
 from sentry.models.eventerror import EventError
 from sentry.stacktraces.functions import trim_function_name
-from sentry.stacktraces.processing import find_stacktraces_in_data
+from sentry.stacktraces.processing import StacktraceInfo, find_stacktraces_in_data
 from sentry.utils import metrics
 from sentry.utils.in_app import is_known_third_party, is_optional_package
 from sentry.utils.safe import get_path, set_path, setdefault_path, trim
@@ -456,8 +456,7 @@ def process_native_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
 
 def get_native_symbolication_function(
-    data: Any,
-    stacktraces: list[StacktraceInfo]
+    data: Any, stacktraces: list[StacktraceInfo]
 ) -> Callable[[Symbolicator, Any], Any] | None:
     """
     Returns the appropriate symbolication function (or `None`) that will process

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -1,7 +1,9 @@
 import logging
 import re
+from typing import Any
 
 from sentry.attachments import attachment_cache
+from sentry.stacktraces.processing import StacktraceInfo
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.safe import get_path
 
@@ -51,7 +53,10 @@ def native_images_from_data(data):
     return get_path(data, "debug_meta", "images", default=(), filter=is_native_image)
 
 
-def is_native_event(data, stacktraces):
+def is_native_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:
+    """Returns whether `data` is a native event, based on its platform and
+    the supplied stacktraces."""
+
     if is_native_platform(data.get("platform")):
         return True
 

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -2,7 +2,6 @@ import logging
 import re
 
 from sentry.attachments import attachment_cache
-from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.safe import get_path
 
@@ -52,11 +51,11 @@ def native_images_from_data(data):
     return get_path(data, "debug_meta", "images", default=(), filter=is_native_image)
 
 
-def is_native_event(data):
+def is_native_event(data, stacktraces):
     if is_native_platform(data.get("platform")):
         return True
 
-    for stacktrace in find_stacktraces_in_data(data):
+    for stacktrace in stacktraces:
         if any(is_native_platform(x) for x in stacktrace.platforms):
             return True
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -174,10 +174,10 @@ def _do_preprocess_event(
     # Possible values are `js`, `jvm`, and `native`.
     # The event will be submitted to Symbolicator for all returned platforms,
     # one after the other, so we handle mixed stacktraces.
-    platforms = get_symbolication_platforms(data)
-    should_symbolicate = len(platforms) > 0
-    if platforms:
-        first_platform = platforms.pop(0)
+    symbolicate_platforms = get_symbolication_platforms(data)
+    should_symbolicate = len(symbolicate_platforms) > 0
+    if symbolicate_platforms:
+        first_platform = symbolicate_platforms.pop(0)
         symbolication_function = get_symbolication_function_for_platform(first_platform, data)
         symbolication_function_name = getattr(symbolication_function, "__name__", "none")
 
@@ -204,7 +204,7 @@ def _do_preprocess_event(
                 event_id=event_id,
                 start_time=start_time,
                 has_attachments=has_attachments,
-                symbolicate_tasks=platforms,
+                symbolicate_platforms=symbolicate_platforms,
             )
             return
         # else: go directly to process, do not go through the symbolicate queue, do not collect 200

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -176,7 +176,7 @@ def _do_preprocess_event(
     # one after the other, so we handle mixed stacktraces.
     symbolicate_platforms = get_symbolication_platforms(data)
     should_symbolicate = len(symbolicate_platforms) > 0
-    if symbolicate_platforms:
+    if should_symbolicate:
         first_platform = symbolicate_platforms.pop(0)
         symbolication_function = get_symbolication_function_for_platform(first_platform, data)
         symbolication_function_name = getattr(symbolication_function, "__name__", "none")

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -214,19 +214,18 @@ def _do_symbolicate_event(
     def _continue_to_process_event(was_killswitched: bool = False) -> None:
         # Go through the remaining symbolication platforms
         # and submit the next one.
-        if not was_killswitched:
-            if symbolicate_platforms:
-                next_platform = symbolicate_platforms.pop(0)
+        if not was_killswitched and symbolicate_platforms:
+            next_platform = symbolicate_platforms.pop(0)
 
-                submit_symbolicate(
-                    task_kind=task_kind.with_platform(next_platform),
-                    cache_key=cache_key,
-                    event_id=event_id,
-                    start_time=start_time,
-                    has_attachments=has_attachments,
-                    symbolicate_platforms=symbolicate_platforms,
-                )
-                return
+            submit_symbolicate(
+                task_kind=task_kind.with_platform(next_platform),
+                cache_key=cache_key,
+                event_id=event_id,
+                start_time=start_time,
+                has_attachments=has_attachments,
+                symbolicate_platforms=symbolicate_platforms,
+            )
+            return
         # else:
         store.submit_process(
             from_reprocessing=task_kind.is_reprocessing,

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -159,7 +159,7 @@ def _do_symbolicate_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[str] | None = None,
 ) -> None:
     if data is None:
         data = processing.event_processing_store.get(cache_key)
@@ -174,9 +174,11 @@ def _do_symbolicate_event(
             task_kind.platform == SymbolicatorPlatform.js
             and get_native_symbolication_function(data, stacktraces) is not None
         ):
-            symbolicate_platforms = [SymbolicatorPlatform.native]
+            symbolicate_platforms = ["native"]
         else:
             symbolicate_platforms = []
+
+    symbolicate_platforms = [SymbolicatorPlatform(p) for p in symbolicate_platforms]
 
     if data is None:
         metrics.incr(
@@ -420,13 +422,15 @@ def submit_symbolicate(
     elif task_kind.is_low_priority:
         task = symbolicate_event_low_priority
 
+    # Pass symbolicate_platforms as strings—apparently we're not allowed to pickle
+    # custom classes.
     task.delay(
         cache_key=cache_key,
         start_time=start_time,
         event_id=event_id,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platforms,
+        symbolicate_platforms=[platform.value for platform in symbolicate_platforms],
     )
 
 
@@ -445,7 +449,7 @@ def symbolicate_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -482,7 +486,7 @@ def symbolicate_js_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -520,7 +524,7 @@ def symbolicate_jvm_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -557,7 +561,7 @@ def symbolicate_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -597,7 +601,7 @@ def symbolicate_js_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -638,7 +642,7 @@ def symbolicate_jvm_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -678,7 +682,7 @@ def symbolicate_event_from_reprocessing(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
     return _do_symbolicate_event(
@@ -708,7 +712,7 @@ def symbolicate_event_from_reprocessing_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
     return _do_symbolicate_event(

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -388,7 +388,7 @@ def submit_symbolicate(
     start_time: int | None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
 ) -> None:
     # oh how I miss a real `match` statement...
     task = symbolicate_event
@@ -435,7 +435,7 @@ def symbolicate_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -472,7 +472,7 @@ def symbolicate_js_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -510,7 +510,7 @@ def symbolicate_jvm_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -547,7 +547,7 @@ def symbolicate_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -587,7 +587,7 @@ def symbolicate_js_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -628,7 +628,7 @@ def symbolicate_jvm_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -668,7 +668,7 @@ def symbolicate_event_from_reprocessing(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     return _do_symbolicate_event(
@@ -698,7 +698,7 @@ def symbolicate_event_from_reprocessing_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     return _do_symbolicate_event(

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -388,7 +388,7 @@ def submit_symbolicate(
     start_time: int | None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] = [],
 ) -> None:
     # oh how I miss a real `match` statement...
     task = symbolicate_event
@@ -435,7 +435,7 @@ def symbolicate_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] = [],
     **kwargs: Any,
 ) -> None:
     """
@@ -472,7 +472,7 @@ def symbolicate_js_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] = [],
     **kwargs: Any,
 ) -> None:
     """
@@ -510,7 +510,7 @@ def symbolicate_jvm_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] = [],
     **kwargs: Any,
 ) -> None:
     """
@@ -547,7 +547,7 @@ def symbolicate_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] = [],
     **kwargs: Any,
 ) -> None:
     """
@@ -587,7 +587,7 @@ def symbolicate_js_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] = [],
     **kwargs: Any,
 ) -> None:
     """
@@ -628,7 +628,7 @@ def symbolicate_jvm_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] = [],
     **kwargs: Any,
 ) -> None:
     """
@@ -668,7 +668,7 @@ def symbolicate_event_from_reprocessing(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] = [],
     **kwargs: Any,
 ) -> None:
     return _do_symbolicate_event(
@@ -698,7 +698,7 @@ def symbolicate_event_from_reprocessing_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] = [],
     **kwargs: Any,
 ) -> None:
     return _do_symbolicate_event(

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -388,7 +388,7 @@ def submit_symbolicate(
     start_time: int | None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = [],
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
 ) -> None:
     # oh how I miss a real `match` statement...
     task = symbolicate_event
@@ -435,7 +435,7 @@ def symbolicate_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = [],
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -472,7 +472,7 @@ def symbolicate_js_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = [],
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -510,7 +510,7 @@ def symbolicate_jvm_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = [],
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -547,7 +547,7 @@ def symbolicate_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = [],
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -587,7 +587,7 @@ def symbolicate_js_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = [],
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -628,7 +628,7 @@ def symbolicate_jvm_event_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = [],
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -668,7 +668,7 @@ def symbolicate_event_from_reprocessing(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = [],
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     return _do_symbolicate_event(
@@ -698,7 +698,7 @@ def symbolicate_event_from_reprocessing_low_priority(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[SymbolicatorPlatform] = [],
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
     **kwargs: Any,
 ) -> None:
     return _do_symbolicate_event(

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -224,15 +224,10 @@ def _do_symbolicate_event(
             has_attachments=has_attachments,
         )
 
-    symbolication_function: Callable[[Symbolicator, Any], Any] | None = None
-    if task_kind.platform == SymbolicatorPlatform.js:
-        symbolication_function = process_js_stacktraces
-    elif task_kind.platform == SymbolicatorPlatform.jvm:
-        from sentry.lang.java.processing import process_jvm_stacktraces
-
-        symbolication_function = process_jvm_stacktraces
-    else:
-        symbolication_function = get_native_symbolication_function(data)
+    try:
+        symbolication_function = get_symbolication_function_for_platform(task_kind.platform, data)
+    except AssertionError:
+        symbolication_function = None
 
     symbolication_function_name = getattr(symbolication_function, "__name__", "none")
 

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -159,7 +159,7 @@ def _do_symbolicate_event(
     data: Event | None = None,
     queue_switches: int = 0,
     has_attachments: bool = False,
-    symbolicate_platforms: list[str] | None = None,
+    symbolicate_platforms: list[SymbolicatorPlatform] | None = None,
 ) -> None:
     if data is None:
         data = processing.event_processing_store.get(cache_key)
@@ -174,11 +174,9 @@ def _do_symbolicate_event(
             task_kind.platform == SymbolicatorPlatform.js
             and get_native_symbolication_function(data, stacktraces) is not None
         ):
-            symbolicate_platforms = ["native"]
+            symbolicate_platforms = [SymbolicatorPlatform.native]
         else:
             symbolicate_platforms = []
-
-    symbolicate_platforms = [SymbolicatorPlatform(p) for p in symbolicate_platforms]
 
     if data is None:
         metrics.incr(
@@ -424,13 +422,17 @@ def submit_symbolicate(
 
     # Pass symbolicate_platforms as strings—apparently we're not allowed to pickle
     # custom classes.
+    symbolicate_platform_names = (
+        None if symbolicate_platforms is None else [p.name for p in symbolicate_platforms]
+    )
+
     task.delay(
         cache_key=cache_key,
         start_time=start_time,
         event_id=event_id,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=[platform.value for platform in symbolicate_platforms],
+        symbolicate_platforms=symbolicate_platform_names,
     )
 
 
@@ -459,6 +461,12 @@ def symbolicate_event(
     :param int start_time: the timestamp when the event was ingested
     :param string event_id: the event identifier
     """
+
+    symbolicate_platform_values = (
+        None
+        if symbolicate_platforms is None
+        else [SymbolicatorPlatform(p) for p in symbolicate_platforms]
+    )
     return _do_symbolicate_event(
         cache_key=cache_key,
         start_time=start_time,
@@ -467,7 +475,7 @@ def symbolicate_event(
         data=data,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platforms,
+        symbolicate_platforms=symbolicate_platform_values,
     )
 
 
@@ -496,6 +504,12 @@ def symbolicate_js_event(
     :param int start_time: the timestamp when the event was ingested
     :param string event_id: the event identifier
     """
+
+    symbolicate_platform_values = (
+        None
+        if symbolicate_platforms is None
+        else [SymbolicatorPlatform(p) for p in symbolicate_platforms]
+    )
     return _do_symbolicate_event(
         cache_key=cache_key,
         start_time=start_time,
@@ -504,7 +518,7 @@ def symbolicate_js_event(
         data=data,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platforms,
+        symbolicate_platforms=symbolicate_platform_values,
     )
 
 
@@ -534,6 +548,12 @@ def symbolicate_jvm_event(
     :param int start_time: the timestamp when the event was ingested
     :param string event_id: the event identifier
     """
+
+    symbolicate_platform_values = (
+        None
+        if symbolicate_platforms is None
+        else [SymbolicatorPlatform(p) for p in symbolicate_platforms]
+    )
     return _do_symbolicate_event(
         cache_key=cache_key,
         start_time=start_time,
@@ -542,7 +562,7 @@ def symbolicate_jvm_event(
         data=data,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platforms,
+        symbolicate_platforms=symbolicate_platform_values,
     )
 
 
@@ -574,6 +594,12 @@ def symbolicate_event_low_priority(
     :param int start_time: the timestamp when the event was ingested
     :param string event_id: the event identifier
     """
+
+    symbolicate_platform_values = (
+        None
+        if symbolicate_platforms is None
+        else [SymbolicatorPlatform(p) for p in symbolicate_platforms]
+    )
     return _do_symbolicate_event(
         cache_key=cache_key,
         start_time=start_time,
@@ -582,7 +608,7 @@ def symbolicate_event_low_priority(
         data=data,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platforms,
+        symbolicate_platforms=symbolicate_platform_values,
     )
 
 
@@ -614,6 +640,12 @@ def symbolicate_js_event_low_priority(
     :param int start_time: the timestamp when the event was ingested
     :param string event_id: the event identifier
     """
+
+    symbolicate_platform_values = (
+        None
+        if symbolicate_platforms is None
+        else [SymbolicatorPlatform(p) for p in symbolicate_platforms]
+    )
     return _do_symbolicate_event(
         cache_key=cache_key,
         start_time=start_time,
@@ -622,7 +654,7 @@ def symbolicate_js_event_low_priority(
         data=data,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platforms,
+        symbolicate_platforms=symbolicate_platform_values,
     )
 
 
@@ -655,6 +687,12 @@ def symbolicate_jvm_event_low_priority(
     :param int start_time: the timestamp when the event was ingested
     :param string event_id: the event identifier
     """
+
+    symbolicate_platform_values = (
+        None
+        if symbolicate_platforms is None
+        else [SymbolicatorPlatform(p) for p in symbolicate_platforms]
+    )
     return _do_symbolicate_event(
         cache_key=cache_key,
         start_time=start_time,
@@ -663,7 +701,7 @@ def symbolicate_jvm_event_low_priority(
         data=data,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platforms,
+        symbolicate_platforms=symbolicate_platform_values,
     )
 
 
@@ -685,6 +723,12 @@ def symbolicate_event_from_reprocessing(
     symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
+
+    symbolicate_platform_values = (
+        None
+        if symbolicate_platforms is None
+        else [SymbolicatorPlatform(p) for p in symbolicate_platforms]
+    )
     return _do_symbolicate_event(
         cache_key=cache_key,
         start_time=start_time,
@@ -693,7 +737,7 @@ def symbolicate_event_from_reprocessing(
         data=data,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platforms,
+        symbolicate_platforms=symbolicate_platform_values,
     )
 
 
@@ -715,6 +759,12 @@ def symbolicate_event_from_reprocessing_low_priority(
     symbolicate_platforms: list[str] | None = None,
     **kwargs: Any,
 ) -> None:
+
+    symbolicate_platform_values = (
+        None
+        if symbolicate_platforms is None
+        else [SymbolicatorPlatform(p) for p in symbolicate_platforms]
+    )
     return _do_symbolicate_event(
         cache_key=cache_key,
         start_time=start_time,
@@ -723,5 +773,5 @@ def symbolicate_event_from_reprocessing_low_priority(
         data=data,
         queue_switches=queue_switches,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platforms,
+        symbolicate_platforms=symbolicate_platform_values,
     )


### PR DESCRIPTION
Based upon https://github.com/getsentry/sentry/pull/66764.

This extends the logic for mixed JS/native stacktraces to JVM stacktraces as well. Since with three platforms there are too many combinations to implement manually, we instead introduce a list of platforms for which symbolication must be performed. This list can contain any subset of `{js, jvm, native}`. Events are submitted to Symbolicator once for each platform in this list.