### PR TITLE
fix: set scope_id property for project scoped abuse quota

### DIFF
--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -66,7 +66,11 @@ class RedisQuota(Quota):
         if key:
             key.project = project
 
-        results = [*self.get_abuse_quotas(project.organization)]
+        results = []
+        for quota in self.get_abuse_quotas(project.organization):
+            if quota.scope == QuotaScope.PROJECT:
+                quota.scope_id = project.id
+            results.append(quota)
 
         # If the organization belongs to the disabled list, we want to stop ingesting custom metrics.
         if project.organization.id in (options.get("custom-metrics-ingestion-disabled-orgs") or ()):


### PR DESCRIPTION
The  get_usage() function in RedisQuota doesn't return the AbuseQuota usage for project because QuotaConfig lack the scope_id properties 

This result in incorrect generation of the quota redis_key

Current generated redis key:
 ```quota:pae{1}:xxxxxxxx```
Should be like: 
```quota:pae{1}2:xxxxxxxx```

This PR set the scope_id in QuotaConfig for project scoped abuse quota with the current project id when getting it's quotas

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
