### PR TITLE
ref(code-mappings): Remove feature flag for php auto code mappings (post-GA)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1529,8 +1529,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:default-high-priority-alerts": False,
     # Enables automatically deriving of code mappings
     "organizations:derive-code-mappings": True,
-    # Enables automatically deriving of PHP code mappings
-    "organizations:derive-code-mappings-php": False,
     # Enable device.class as a selectable column
     "organizations:device-classification": False,
     # Enables synthesis of device.class in ingest

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -64,7 +64,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:default-high-priority-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:deprecate-fid-from-performance-score", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:derive-code-mappings", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    manager.add("organizations:derive-code-mappings-php", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:device-class-synthesis", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:device-classification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -102,12 +102,6 @@ def derive_code_mappings(
         logger.info("Event should not be processed.", extra=extra)
         return
 
-    # php automatic code mappings currently in LA
-    if data["platform"].startswith("php") and not features.has(
-        "organizations:derive-code-mappings-php", org
-    ):
-        return
-
     stacktrace_paths: list[str] = identify_stacktrace_paths(data)
     if not stacktrace_paths:
         logger.info("No stacktrace paths found.", extra=extra)

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -344,21 +344,6 @@ class TestPhpDeriveCodeMappings(BaseDeriveCodeMappings):
         )
 
     @responses.activate
-    @with_feature({"organizations:derive-code-mappings-php": False})
-    def test_missing_feature_flag(self):
-        repo_name = "php/place"
-        with patch(
-            "sentry.integrations.github.client.GitHubClientMixin.get_trees_for_org"
-        ) as mock_get_trees_for_org:
-            mock_get_trees_for_org.return_value = {
-                repo_name: RepoTree(Repo(repo_name, "master"), ["sentry/potato/kangaroo.php"])
-            }
-            derive_code_mappings(self.project.id, self.event_data)
-            # Check to make sure no code mappings were generated
-            assert not RepositoryProjectPathConfig.objects.exists()
-
-    @responses.activate
-    @with_feature({"organizations:derive-code-mappings-php": True})
     def test_derive_code_mappings_basic_php(self):
         repo_name = "php/place"
         with patch(
@@ -374,7 +359,6 @@ class TestPhpDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    @with_feature({"organizations:derive-code-mappings-php": True})
     def test_derive_code_mappings_different_roots_php(self):
         repo_name = "php/place"
         with patch(


### PR DESCRIPTION
Automatic code mapping support for PHP has been in GA for a week and has been stable. This removes the feature flag and any occurrences of it 

[Associated Sentry Options Automator PR](https://github.com/getsentry/sentry-options-automator/pull/979)
[Associated getsentry PR](https://github.com/getsentry/getsentry/pull/13440)