### PR TITLE
fix(slack): don't raise RuntimeError if unable to fetch property in slack request

### DIFF
--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -104,7 +104,7 @@ class SlackRequest:
         return self._integration
 
     @property
-    def channel_id(self) -> str:
+    def channel_id(self) -> str | None:
         return _get_field_id_option(self.data, "channel")
 
     @property
@@ -112,11 +112,11 @@ class SlackRequest:
         return self.data.get("response_url", "")
 
     @property
-    def team_id(self) -> str:
+    def team_id(self) -> str | None:
         return _get_field_id_option(self.data, "team")
 
     @property
-    def user_id(self) -> str:
+    def user_id(self) -> str | None:
         return _get_field_id_option(self.data, "user")
 
     @property

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -23,6 +23,17 @@ def _get_field_id_option(data: Mapping[str, Any], field_name: str) -> str | None
     return id_option
 
 
+def get_field_id(data: Mapping[str, Any], field_name: str) -> str:
+    """
+    TODO(mgaeta): Hack to convert optional strings to string. SlackRequest
+     should be refactored to deserialize `data` in the constructor.
+    """
+    id_option = _get_field_id_option(data, field_name)
+    if not id_option:
+        raise RuntimeError
+    return id_option
+
+
 @dataclasses.dataclass(frozen=True)
 class SlackRequestError(Exception):
     """
@@ -105,7 +116,7 @@ class SlackRequest:
 
     @property
     def channel_id(self) -> str | None:
-        return _get_field_id_option(self.data, "channel")
+        return get_field_id(self.data, "channel")
 
     @property
     def response_url(self) -> str:

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -23,17 +23,6 @@ def _get_field_id_option(data: Mapping[str, Any], field_name: str) -> str | None
     return id_option
 
 
-def get_field_id(data: Mapping[str, Any], field_name: str) -> str:
-    """
-    TODO(mgaeta): Hack to convert optional strings to string. SlackRequest
-     should be refactored to deserialize `data` in the constructor.
-    """
-    id_option = _get_field_id_option(data, field_name)
-    if not id_option:
-        raise RuntimeError
-    return id_option
-
-
 @dataclasses.dataclass(frozen=True)
 class SlackRequestError(Exception):
     """
@@ -116,7 +105,7 @@ class SlackRequest:
 
     @property
     def channel_id(self) -> str:
-        return get_field_id(self.data, "channel")
+        return _get_field_id_option(self.data, "channel")
 
     @property
     def response_url(self) -> str:
@@ -124,11 +113,11 @@ class SlackRequest:
 
     @property
     def team_id(self) -> str:
-        return get_field_id(self.data, "team")
+        return _get_field_id_option(self.data, "team")
 
     @property
     def user_id(self) -> str:
-        return get_field_id(self.data, "user")
+        return _get_field_id_option(self.data, "user")
 
     @property
     def data(self) -> Mapping[str, Any]:

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -118,6 +118,7 @@ class SlackRequestTest(TestCase):
         request.META = (options.get("slack.signing-secret"), self.request.body)
 
         slack_request = SlackRequest(request)
+        assert slack_request.team_id is None
         assert slack_request.logging_data == {
             "slack_channel_id": "1",
             "slack_user_id": "2",


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/67679

We are currently raising a `RuntimeError` if the `channel_id`, `team_id`, or `user_id` does not exist in an incoming Slack request. We use `team_id` and `user_id` here:
https://github.com/getsentry/sentry/blob/121726dc100a21249e177200f1054f8f5a30fbbb/src/sentry/integrations/slack/requests/base.py#L82-L92

And these values can be `None`, so we don't need to be raising a `RuntimeError`:
https://github.com/getsentry/sentry/blob/121726dc100a21249e177200f1054f8f5a30fbbb/src/sentry/services/hybrid_cloud/integration/impl.py#L457-L464

NOTE: Not yet sure if it's okay for `channel_id` to be `None`. We can remove that part if need be.

Replacing `get_field_id` which raises the error with `_get_field_id_option` which can return `None` should fix this.