### PR TITLE
ref: upgrade kombu to 5.3.6

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -87,7 +87,7 @@ jsonschema==4.20.0
 jsonschema-path==0.3.2
 jsonschema-spec==0.2.4
 jsonschema-specifications==2023.7.1
-kombu==5.3.4
+kombu==5.3.6
 lazy-object-proxy==1.10.0
 lxml==4.9.3
 lxml-stubs==0.4.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -67,7 +67,7 @@ isodate==0.6.1
 jmespath==0.10.0
 jsonschema==4.20.0
 jsonschema-specifications==2023.7.1
-kombu==5.3.4
+kombu==5.3.6
 lxml==4.9.3
 maxminddb==2.3.0
 milksnake==0.1.6


### PR DESCRIPTION
this fixes a warning in python 3.12 (datetime bug)

<!-- Describe your PR here. -->