### PR TITLE
feat(trace): fix scrollbar offset bug rendering indicator in the wrong position

### DIFF
--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -1616,12 +1616,12 @@ function maybeToggleScrollbar(
   if (scrollHeight > containerHeight) {
     container.style.overflowY = 'scroll';
     container.style.scrollbarGutter = 'stable';
+    manager.onScrollbarWidthChange(container.offsetWidth - container.clientWidth);
   } else {
     container.style.overflowY = 'auto';
     container.style.scrollbarGutter = 'auto';
+    manager.onScrollbarWidthChange(0);
   }
-
-  manager.onScrollbarWidthChange(container.offsetWidth - container.clientWidth);
 }
 
 interface UseVirtualizedListProps {


### PR DESCRIPTION
Workaround the scrollbar width causing the indicator to be rendered in the wrong position. We now force the scrollbar whenever we know the content will scroll and disable it when it doesnt. This adds a bit of layout thrashing, though we optimize it to only be done when the bit is actually flipped as opposed to on each resize event