### PR TITLE
Remove Redis references from Sentry

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2329,7 +2329,6 @@ SENTRY_METRICS_INDEXER_CARDINALITY_LIMITER_OPTIONS_PERFORMANCE: dict[str, Any] =
     "num_shards": 1,
     "num_physical_shards": 1,
 }
-
 SENTRY_METRICS_INDEXER_ENABLE_SLICED_PRODUCER = False
 
 # Release Health

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2317,6 +2317,19 @@ SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE = (
 # dropped due to rate limits.
 SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 0.01
 
+# Cardinality limits during metric bucket ingestion.
+# Which cluster to use. Example: {"cluster": "default"}
+SENTRY_METRICS_INDEXER_CARDINALITY_LIMITER_OPTIONS: dict[str, Any] = {
+    "cluster": "default",
+    "num_shards": 1,
+    "num_physical_shards": 1,
+}
+SENTRY_METRICS_INDEXER_CARDINALITY_LIMITER_OPTIONS_PERFORMANCE: dict[str, Any] = {
+    "cluster": "default",
+    "num_shards": 1,
+    "num_physical_shards": 1,
+}
+
 SENTRY_METRICS_INDEXER_ENABLE_SLICED_PRODUCER = False
 
 # Release Health

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2317,18 +2317,6 @@ SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE = (
 # dropped due to rate limits.
 SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 0.01
 
-# Cardinality limits during metric bucket ingestion.
-# Which cluster to use. Example: {"cluster": "default"}
-SENTRY_METRICS_INDEXER_CARDINALITY_LIMITER_OPTIONS: dict[str, Any] = {
-    "cluster": "default",
-    "num_shards": 1,
-    "num_physical_shards": 1,
-}
-SENTRY_METRICS_INDEXER_CARDINALITY_LIMITER_OPTIONS_PERFORMANCE: dict[str, Any] = {
-    "cluster": "default",
-    "num_shards": 1,
-    "num_physical_shards": 1,
-}
 SENTRY_METRICS_INDEXER_ENABLE_SLICED_PRODUCER = False
 
 # Release Health

--- a/src/sentry/sentry_metrics/configuration.py
+++ b/src/sentry/sentry_metrics/configuration.py
@@ -52,8 +52,6 @@ class MetricsIngestConfiguration:
     internal_metrics_tag: str | None
     writes_limiter_cluster_options: Mapping[str, Any]
     writes_limiter_namespace: str
-    cardinality_limiter_cluster_options: Mapping[str, Any]
-    cardinality_limiter_namespace: str
 
     should_index_tag_values: bool
     schema_validation_rule_option_name: str | None = None
@@ -84,8 +82,6 @@ def get_ingest_config(
                 internal_metrics_tag="release-health",
                 writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS,
                 writes_limiter_namespace=RELEASE_HEALTH_PG_NAMESPACE,
-                cardinality_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_CARDINALITY_LIMITER_OPTIONS,
-                cardinality_limiter_namespace=RELEASE_HEALTH_PG_NAMESPACE,
                 should_index_tag_values=True,
                 schema_validation_rule_option_name=RELEASE_HEALTH_SCHEMA_VALIDATION_RULES_OPTION_NAME,
             )
@@ -100,8 +96,6 @@ def get_ingest_config(
                 internal_metrics_tag="perf",
                 writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE,
                 writes_limiter_namespace=PERFORMANCE_PG_NAMESPACE,
-                cardinality_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_CARDINALITY_LIMITER_OPTIONS_PERFORMANCE,
-                cardinality_limiter_namespace=PERFORMANCE_PG_NAMESPACE,
                 is_output_sliced=settings.SENTRY_METRICS_INDEXER_ENABLE_SLICED_PRODUCER,
                 should_index_tag_values=False,
                 schema_validation_rule_option_name=GENERIC_METRICS_SCHEMA_VALIDATION_RULES_OPTION_NAME,
@@ -118,8 +112,6 @@ def get_ingest_config(
                 internal_metrics_tag="release-health",
                 writes_limiter_cluster_options={},
                 writes_limiter_namespace="test-namespace-rh",
-                cardinality_limiter_cluster_options={},
-                cardinality_limiter_namespace=RELEASE_HEALTH_PG_NAMESPACE,
                 should_index_tag_values=True,
                 schema_validation_rule_option_name=RELEASE_HEALTH_SCHEMA_VALIDATION_RULES_OPTION_NAME,
             )
@@ -135,8 +127,6 @@ def get_ingest_config(
                 internal_metrics_tag="perf",
                 writes_limiter_cluster_options={},
                 writes_limiter_namespace="test-namespace-perf",
-                cardinality_limiter_cluster_options={},
-                cardinality_limiter_namespace=PERFORMANCE_PG_NAMESPACE,
                 should_index_tag_values=False,
                 schema_validation_rule_option_name=GENERIC_METRICS_SCHEMA_VALIDATION_RULES_OPTION_NAME,
             )


### PR DESCRIPTION
<!-- Describe your PR here. -->
As part of [deprecating unused rate limiters from the indexer](https://github.com/getsentry/getsentry/issues/13425), we want to remove references to the Redis VMS that were previously used by the indexer's cardinality rate limiting

Requires https://github.com/getsentry/getsentry/pull/13450
<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
