### PR TITLE
ref(rules): Combine added/removed data

### DIFF
--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -31,8 +31,8 @@ def check_value_changed(
 
 
 def generate_diff_labels(
-    present_state: dict[str, Any],
-    prior_state: dict[str, Any],
+    present_state: list[dict[str, Any]],
+    prior_state: list[dict[str, Any]],
     rule: Rule,
     key: str,
 ) -> DefaultDict[str, list[str]]:

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -50,15 +50,13 @@ def generate_diff_labels(
     # Check if the id is in both but the data has changed
     for item in added_items:
         if changed_data.get(item):
-            for data in prior_state:
-                for present_data in present_state:
-                    if data["id"] == item and present_data["id"] == item:
-                        if present_data != data:
-                            old_label = generate_rule_label(rule.project, rule, data)
-                            new_label = generate_rule_label(rule.project, rule, present_data)
-                            changed_data[item] = [
-                                (f"Changed {key} from *{old_label}* to *{new_label}*")
-                            ]
+            prior_item = [data for data in prior_state if data["id"] == item]
+            present_item = [data for data in present_state if data["id"] == item]
+            if prior_item and present_item:
+                if prior_item[0] != present_item[0]:
+                    old_label = generate_rule_label(rule.project, rule, prior_item[0])
+                    new_label = generate_rule_label(rule.project, rule, present_item[0])
+                    changed_data[item] = [(f"Changed {key} from *{old_label}* to *{new_label}*")]
 
     # Removed items
     for data in present_state:

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -49,14 +49,12 @@ def generate_diff_labels(
 
     # Check if the id is in both but the data has changed
     for item in added_items:
-        if changed_data.get(item):
-            prior_item = [data for data in prior_state if data["id"] == item]
-            present_item = [data for data in present_state if data["id"] == item]
-            if prior_item and present_item:
-                if prior_item[0] != present_item[0]:
-                    old_label = generate_rule_label(rule.project, rule, prior_item[0])
-                    new_label = generate_rule_label(rule.project, rule, present_item[0])
-                    changed_data[item] = [(f"Changed {key} from *{old_label}* to *{new_label}*")]
+        prior_item = [data for data in prior_state if data["id"] == item]
+        present_item = [data for data in present_state if data["id"] == item]
+        if prior_item and present_item and prior_item[0] != present_item[0]:
+            old_label = generate_rule_label(rule.project, rule, prior_item[0])
+            new_label = generate_rule_label(rule.project, rule, present_item[0])
+            changed_data[item] = [(f"Changed {key} from *{old_label}* to *{new_label}*")]
 
     # Removed items
     for data in present_state:

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -31,8 +31,8 @@ def check_value_changed(
 
 
 def generate_diff_labels(
-    prior_state: list[dict[str, Any]],
-    present_state: list[dict[str, Any]],
+    prior_state: DefaultDict[str, dict[str, str | int]],
+    present_state: DefaultDict[str, dict[str, str | int]],
     rule: Rule,
     key: str,
 ) -> DefaultDict[str, list[str]]:
@@ -44,21 +44,21 @@ def generate_diff_labels(
     present_ids = set(present_state.keys())
 
     # Added items that are not seen in the prior rule data
-    for item in present_ids.difference(prior_ids):
-        label = generate_rule_label(rule.project, rule, present_state.get(item)[0])
-        changed_data[item].append(added_statement.format(key, label))
+    for id in present_ids.difference(prior_ids):
+        label = generate_rule_label(rule.project, rule, present_state.get(id))
+        changed_data[id].append(added_statement.format(key, label))
 
     # Check if the id is in both but the data has changed
-    for item in set(prior_ids & present_ids):
-        if prior_state.get(item)[0] != present_state.get(item)[0]:
-            old_label = generate_rule_label(rule.project, rule, prior_state.get(item)[0])
-            new_label = generate_rule_label(rule.project, rule, present_state.get(item)[0])
-            changed_data[item] = [(f"Changed {key} from *{old_label}* to *{new_label}*")]
+    for id in set(prior_ids & present_ids):
+        if prior_state.get(id) != present_state.get(id):
+            old_label = generate_rule_label(rule.project, rule, prior_state.get(id))
+            new_label = generate_rule_label(rule.project, rule, present_state.get(id))
+            changed_data[id] = [(f"Changed {key} from *{old_label}* to *{new_label}*")]
 
     # Removed items
-    for item in prior_ids.difference(present_ids):
-        label = generate_rule_label(rule.project, rule, prior_state.get(item)[0])
-        changed_data[item].append(removed_statement.format(key, label))
+    for id in prior_ids.difference(present_ids):
+        label = generate_rule_label(rule.project, rule, prior_state.get(id))
+        changed_data[id].append(removed_statement.format(key, label))
 
     return changed_data
 
@@ -79,15 +79,10 @@ def get_frequency_label(value_str: str | None) -> str | None:
     return None
 
 
-def convert_data(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    converted_data = defaultdict(list)
+def convert_data(data: list[dict[str, Any]]) -> DefaultDict[str, dict[str, str | int]]:
+    converted_data: DefaultDict[str, dict[str, str | int]] = defaultdict(dict)
     for datum in data:
-        id = datum["id"]
-        values = {}
-        for d in datum:
-            values[d] = datum[d]
-        converted_data[id].append(values)
-
+        converted_data[datum["id"]] = {k: v for k, v in datum.items()}
     return converted_data
 
 

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -44,21 +44,21 @@ def generate_diff_labels(
     present_ids = set(present_state.keys())
 
     # Added items that are not seen in the prior rule data
-    for id in present_ids.difference(prior_ids):
-        label = generate_rule_label(rule.project, rule, present_state.get(id))
-        changed_data[id].append(added_statement.format(key, label))
+    for added_id in present_ids.difference(prior_ids):
+        label = generate_rule_label(rule.project, rule, present_state.get(added_id))
+        changed_data[added_id].append(added_statement.format(key, label))
 
     # Check if the id is in both but the data has changed
-    for id in set(prior_ids & present_ids):
-        if prior_state.get(id) != present_state.get(id):
-            old_label = generate_rule_label(rule.project, rule, prior_state.get(id))
-            new_label = generate_rule_label(rule.project, rule, present_state.get(id))
-            changed_data[id] = [(f"Changed {key} from *{old_label}* to *{new_label}*")]
+    for changed_id in set(prior_ids & present_ids):
+        if prior_state.get(changed_id) != present_state.get(changed_id):
+            old_label = generate_rule_label(rule.project, rule, prior_state.get(changed_id))
+            new_label = generate_rule_label(rule.project, rule, present_state.get(changed_id))
+            changed_data[changed_id] = [(f"Changed {key} from *{old_label}* to *{new_label}*")]
 
     # Removed items
-    for id in prior_ids.difference(present_ids):
-        label = generate_rule_label(rule.project, rule, prior_state.get(id))
-        changed_data[id].append(removed_statement.format(key, label))
+    for removed_id in prior_ids.difference(present_ids):
+        label = generate_rule_label(rule.project, rule, prior_state.get(removed_id))
+        changed_data[removed_id].append(removed_statement.format(key, label))
 
     return changed_data
 

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -31,8 +31,8 @@ def check_value_changed(
 
 
 def generate_diff_labels(
-    prior_state: DefaultDict[str, dict[str, str | int]],
-    present_state: DefaultDict[str, dict[str, str | int]],
+    prior_state: dict[str, dict[str, str | int]],
+    present_state: dict[str, dict[str, str | int]],
     rule: Rule,
     key: str,
 ) -> DefaultDict[str, list[str]]:
@@ -79,10 +79,10 @@ def get_frequency_label(value_str: str | None) -> str | None:
     return None
 
 
-def convert_data(data: list[dict[str, Any]]) -> DefaultDict[str, dict[str, str | int]]:
-    converted_data: DefaultDict[str, dict[str, str | int]] = defaultdict(dict)
+def convert_data(data: list[dict[str, str | int]]) -> dict[str, dict[str, str | int]]:
+    converted_data: dict[str, dict] = {}
     for datum in data:
-        converted_data[datum.get("id")] = datum
+        converted_data[str(datum.get("id"))] = datum
 
     return converted_data
 

--- a/src/sentry/rules/actions/utils.py
+++ b/src/sentry/rules/actions/utils.py
@@ -82,7 +82,8 @@ def get_frequency_label(value_str: str | None) -> str | None:
 def convert_data(data: list[dict[str, Any]]) -> DefaultDict[str, dict[str, str | int]]:
     converted_data: DefaultDict[str, dict[str, str | int]] = defaultdict(dict)
     for datum in data:
-        converted_data[datum["id"]] = {k: v for k, v in datum.items()}
+        converted_data[datum.get("id")] = datum
+
     return converted_data
 
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1091,7 +1091,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert rendered_blocks[0]["text"]["text"] == message
         changes = "*Changes*\n"
         changes += "• Added condition 'The issue's category is equal to Performance'\n"
-        changes += "• Changed action from *Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification* to *Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification*\n"
+        changes += "• Changed action from *Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification* to *Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification*\n"
         changes += "• Changed frequency from *5 minutes* to *3 hours*\n"
         changes += f"• Added *{staging_env.name}* environment\n"
         changes += "• Changed rule name from *my rule* to *new rule*\n"

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1091,8 +1091,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert rendered_blocks[0]["text"]["text"] == message
         changes = "*Changes*\n"
         changes += "• Added condition 'The issue's category is equal to Performance'\n"
-        changes += "• Added action 'Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification'\n"
-        changes += "• Removed action 'Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification'\n"
+        changes += "• Changed action from *Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification* to *Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification*\n"
         changes += "• Changed frequency from *5 minutes* to *3 hours*\n"
         changes += f"• Added *{staging_env.name}* environment\n"
         changes += "• Changed rule name from *my rule* to *new rule*\n"


### PR DESCRIPTION
If an alert rule is edited such that a condition or action is updated (rather than completely removed or added new), this PR combines the text to one line like "Changed condition from The issue is seen by more than 3 users in 1h to The issue is seen by more than 2 users in 1h" where before it was 2 separate lines of being added and removed.

<img width="680" alt="Screenshot 2024-03-27 at 12 32 02 PM" src="https://github.com/getsentry/sentry/assets/29959063/2e66f003-9024-4590-bd35-88e50d856765">

Closes [#171](https://github.com/getsentry/team-core-product-foundations/issues/171)