### PR TITLE
ref(crons): Shorten auto-mute broken monitors for testing

### DIFF
--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -34,8 +34,8 @@ NUM_CONSECUTIVE_BROKEN_CHECKINS = 4
 # The number of days a monitor env has to be failing to qualify as broken
 NUM_DAYS_BROKEN_PERIOD = 14
 
-# The number of days until a monitor env is auto-muted AFTER it has been marked broken
-NUM_DAYS_MUTED_PERIOD = 14
+# The number of days until a monitor env is auto-muted AFTER user has been notified it was broken
+NUM_DAYS_MUTED_PERIOD = 1
 
 # Max number of environments to have in the broken monitor email link
 MAX_ENVIRONMENTS_IN_MONITOR_LINK = 10

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -392,8 +392,8 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
         # This broken detection shouldn't be automatically disabled, because it's not long enough
         broken_detection = MonitorEnvBrokenDetection.objects.create(
             monitor_incident=incident,
-            detection_timestamp=now - timedelta(days=10),
-            user_notified_timestamp=now - timedelta(days=10),
+            detection_timestamp=now - timedelta(days=0),
+            user_notified_timestamp=now - timedelta(days=0),
         )
         second_broken_detection = MonitorEnvBrokenDetection.objects.create(
             monitor_incident=second_incident,


### PR DESCRIPTION
Shortens the period we wait before marking monitors as broken, to be used for testing of the internal orgs that we have this task enabled to run on. 

Also clarifies the comment for this constant

Will return it to normal: https://github.com/getsentry/sentry/pull/67819