### PR TITLE
ref(crons): Return auto-mute broken monitors to 14 day period

### DIFF
--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -35,7 +35,7 @@ NUM_CONSECUTIVE_BROKEN_CHECKINS = 4
 NUM_DAYS_BROKEN_PERIOD = 14
 
 # The number of days until a monitor env is auto-muted AFTER user has been notified it was broken
-NUM_DAYS_MUTED_PERIOD = 1
+NUM_DAYS_MUTED_PERIOD = 14
 
 # Max number of environments to have in the broken monitor email link
 MAX_ENVIRONMENTS_IN_MONITOR_LINK = 10


### PR DESCRIPTION
Reverses the effects of https://github.com/getsentry/sentry/pull/67818, after we're done testing