### PR TITLE
fix(migrations): Correct dependencies after deleting old migrations

### DIFF
--- a/src/sentry/migrations/0485_remove_scheduled_job.py
+++ b/src/sentry/migrations/0485_remove_scheduled_job.py
@@ -19,7 +19,7 @@ class Migration(CheckedMigration):
     is_dangerous = False
 
     dependencies = [
-        ("sentry", "0484_break_org_member_user_fk"),
+        ("sentry", "0001_squashed_0484_break_org_member_user_fk"),
     ]
 
     operations = [


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/67591 deleted old migrations but didn't update the dependency graph. Not sure how CI can pass here at all at the moment.
