### PR TITLE
fix(replays): preload future videos while video replay is playing

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -288,6 +288,11 @@ export class VideoReplayer {
     // Show the next video
     this.showVideo(nextVideo);
 
+    // Preload the next few videos
+    if (index < this._attachments.length) {
+      this.getOrCreateVideo(index + 1);
+    }
+
     // Set video to proper offset
     if (nextVideo) {
       this.setVideoTime(nextVideo, segmentOffsetMs);


### PR DESCRIPTION
following up from https://github.com/getsentry/sentry/pull/67657, when we're playing from the start of the replay, we only have segments `[0, 1, 2]`  loaded -- but by the time we get to `2`, we still haven't loaded `3` onwards yet, so there's a split second when the video glitches a bit as it loads 3 as soon as we hit that segment.

see video around 15-16 second mark:

https://github.com/getsentry/sentry/assets/56095982/3860863d-389d-4c0a-b4ec-ea94aa298505

fix: anytime a segment is playing, we should automatically load the next 3 (this number could be smaller)

no glitchiness at the same spot:

https://github.com/getsentry/sentry/assets/56095982/763f04cb-3dc2-4a87-b545-256e95ac41ef




the preloading optimization we made in https://github.com/getsentry/sentry/pull/67657 still applies if we skip to a different part of the replay further away -- those chunks in the middle don't get loaded eagerly. this just covers the case where we play the replay continuously