### PR TITLE
Revert "feat(feedback): add ff for ingest feedback topic"

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1953,8 +1953,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:use-metrics-layer-in-alerts": False,
     # Enable User Feedback v2 ingest
     "organizations:user-feedback-ingest": False,
-    # Enable User Feedback v2 ingest topic (ingest-feedback-events)
-    "organizations:user-feedback-ingest-topic": False,
     # Use ReplayClipPreview inside the User Feedback Details panel
     "organizations:user-feedback-replay-clip": False,
     # Enable User Feedback spam auto filtering feature UI

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -257,7 +257,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:use-metrics-layer-in-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:user-feedback-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    manager.add("organizations:user-feedback-ingest-topic", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:user-feedback-replay-clip", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:user-feedback-spam-filter-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:user-feedback-spam-filter-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -65,7 +65,6 @@ EXPOSABLE_FEATURES = [
     "organizations:session-replay",
     "organizations:session-replay-combined-envelope-items",
     "organizations:user-feedback-ingest",
-    "organizations:user-feedback-ingest-topic",
     "organizations:session-replay-recording-scrubbing",
     "organizations:device-class-synthesis",
     "organizations:custom-metrics",


### PR DESCRIPTION
Reverts getsentry/sentry#67747

Found out from an ingest team member that this is not the right usecase for a feature flag. `store.rs`, where we produce to kafka, is too late in the pipeline to have the project state as context. Which is where Relay keeps its feature flags. Instead we should use a regular option.