### PR TITLE
ref(replays): add back breadcrumbs and errors tab for video replay

### DIFF
--- a/static/app/views/replays/detail/layout/focusArea.tsx
+++ b/static/app/views/replays/detail/layout/focusArea.tsx
@@ -13,7 +13,16 @@ export default function FocusArea({isVideoReplay}: {isVideoReplay?: boolean}) {
   const {getActiveTab} = useActiveReplayTab({isVideoReplay});
 
   if (isVideoReplay) {
-    return <TagPanel />;
+    switch (getActiveTab()) {
+      case TabKey.ERRORS:
+        return <ErrorList />;
+      case TabKey.BREADCRUMBS:
+        return <Breadcrumbs />;
+      case TabKey.TAGS:
+      default: {
+        return <TagPanel />;
+      }
+    }
   }
 
   switch (getActiveTab()) {

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -70,7 +70,7 @@ function FocusTabs({className, isVideoReplay}: Props) {
   const {pathname, query} = useLocation();
   const {getActiveTab, setActiveTab} = useActiveReplayTab({isVideoReplay});
   const activeTab = getActiveTab();
-  const supportedVideoTabs = [TabKey.TAGS];
+  const supportedVideoTabs = [TabKey.TAGS, TabKey.ERRORS, TabKey.BREADCRUMBS];
 
   const unsupportedVideoTab = tab => {
     return isVideoReplay && !supportedVideoTabs.includes(tab);


### PR DESCRIPTION
looks like we have error breadcrumbs now, so adding them back in:
![Screenshot 2024-03-27 at 23 30 09](https://github.com/getsentry/sentry/assets/56095982/455c0e51-77b7-4100-a650-0ae0f5e64133)

https://github.com/getsentry/sentry/assets/56095982/8b4be082-0b91-4d6e-933a-5c24456e4f92

