### PR TITLE
fix(trace): fix error on autogrouped icon

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -2130,11 +2130,6 @@ const TraceStylingWrapper = styled('div')`
       > div {
         height: 100%;
       }
-
-      .TraceError {
-        top: -1px;
-        transform: translate(-50%, 0);
-      }
     }
 
     svg {


### PR DESCRIPTION
The transform rule was disabling the inverse span scaling rule