### PR TITLE
chore(staff): Switch to checking options instead of feature flag

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -23,12 +23,13 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from sentry_sdk import Scope
 
-from sentry import analytics, features, options, tsdb
+from sentry import analytics, options, tsdb
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.exceptions import StaffRequired, SuperuserRequired
 from sentry.apidocs.hooks import HTTP_METHOD_NAME
 from sentry.auth import access
+from sentry.auth.staff import has_staff_option
 from sentry.models.environment import Environment
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
 from sentry.silo import SiloLimit, SiloMode
@@ -256,9 +257,7 @@ class Endpoint(APIView):
         permissions = self.get_permissions()
         if request.user.is_authenticated and len(permissions) == 1:
             permission_cls = permissions[0]
-            enforce_staff_permission = features.has(
-                "auth:enterprise-staff-cookie", actor=request.user
-            )
+            enforce_staff_permission = has_staff_option(request.user)
 
             # TODO(schew2381): Remove SuperuserOrStaffFeatureFlaggedPermission
             # from isinstance checks once feature flag is removed.

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -4,7 +4,6 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
@@ -12,7 +11,7 @@ from sentry.api.bases.user import OrganizationUserPermission, UserEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.auth.authenticators.u2f import decode_credential_id
-from sentry.auth.staff import is_active_staff
+from sentry.auth.staff import has_staff_option, is_active_staff
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.authenticator import Authenticator
 from sentry.models.user import User
@@ -165,9 +164,9 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         # We should only be able to delete the last auth method through the
-        # _admin portal, which is indicated by staff. After the feature flag is
+        # _admin portal, which is indicated by staff. After the option is
         # removed, this will only check for is_active_staff.
-        if features.has("auth:enterprise-staff-cookie", actor=request.user):
+        if has_staff_option(request.user):
             check_remaining_auth = not is_active_staff(request)
         else:
             check_remaining_auth = not is_active_superuser(request)

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -15,7 +15,7 @@ from sentry.api.exceptions import (
     TwoFactorRequired,
 )
 from sentry.auth import access
-from sentry.auth.staff import is_active_staff
+from sentry.auth.staff import has_staff_option, is_active_staff
 from sentry.auth.superuser import SUPERUSER_ORG_ID, is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
@@ -118,13 +118,13 @@ class StaffPermissionMixin:
 
 # NOTE(schew2381): This is a temporary permission that does NOT perform an OR
 # between SuperuserPermission and StaffPermission. Instead, it uses StaffPermission
-# if the feature flag is enabled, and otherwise uses SuperuserPermission. We
+# if the option is enabled for the user, and otherwise checks SuperuserPermission. We
 # need this to handle the transition for endpoints that will only be accessible to
-# staff but not superuser, that currently use SuperuserPermission. Once the
-# feature is rolled out, we can delete this permission and use StaffPermission
+# staff but not superuser, that currently use SuperuserPermission. Once staff is
+# released to the everyone, we can delete this permission and use StaffPermission
 class SuperuserOrStaffFeatureFlaggedPermission(BasePermission):
     def has_permission(self, request: Request, view: object) -> bool:
-        enforce_staff_permission = features.has("auth:enterprise-staff-cookie", actor=request.user)
+        enforce_staff_permission = has_staff_option(request.user)
 
         if enforce_staff_permission:
             return StaffPermission().has_permission(request, view)

--- a/src/sentry/auth/elevated_mode.py
+++ b/src/sentry/auth/elevated_mode.py
@@ -3,8 +3,6 @@ from enum import Enum
 
 from rest_framework.request import Request
 
-from sentry import features
-
 
 class InactiveReason(str, Enum):
     INVALID_IP = "invalid-ip"
@@ -50,19 +48,17 @@ class ElevatedMode(ABC):
         pass
 
 
-# TODO(schew2381): Delete this method after the feature flag is removed
+# TODO(schew2381): Delete this method after the option is removed
 def has_elevated_mode(request: Request) -> bool:
     """
     This is a temporary helper method that checks if the user on the request has
-    the staff feature flag enabled. If so, it checks is_active_staff and
-    otherwise defaults to checking is_active_superuser.
+    the staff option enabled. If so, it checks is_active_staff and otherwise
+    defaults to checking is_active_superuser.
     """
-    from sentry.auth.staff import is_active_staff
+    from sentry.auth.staff import has_staff_option, is_active_staff
     from sentry.auth.superuser import is_active_superuser
 
-    enforce_staff_permission = features.has("auth:enterprise-staff-cookie", actor=request.user)
-
-    if enforce_staff_permission:
+    if has_staff_option(request.user):
         return is_active_staff(request)
 
     return is_active_superuser(request)

--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -52,7 +52,7 @@ def is_active_staff(request: HttpRequest | Request) -> bool:
     return staff.is_active
 
 
-# TODO(schew2381): Delete after staff is GA'd and the options are removed.
+# TODO(schew2381): Delete after staff is GA'd and the options are removed
 def has_staff_option(user) -> bool:
     """
     This checks two options, the first being whether or not staff has been GA'd.

--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -11,6 +11,7 @@ from django.utils import timezone as django_timezone
 from django.utils.crypto import constant_time_compare, get_random_string
 from rest_framework.request import Request
 
+from sentry import options
 from sentry.auth.elevated_mode import ElevatedMode, InactiveReason
 from sentry.auth.system import is_system_auth
 from sentry.utils.auth import has_completed_sso
@@ -49,6 +50,21 @@ def is_active_staff(request: HttpRequest | Request) -> bool:
         return True
     staff = getattr(request, "staff", None) or Staff(request)
     return staff.is_active
+
+
+# TODO(schew2381): Delete after staff is GA'd and the options are removed.
+def has_staff_option(user) -> bool:
+    """
+    This checks two options, the first being whether or not staff has been GA'd.
+    If not, it falls back to checking the second option which by email specifies which
+    users staff is enabled for.
+    """
+    if options.get("staff.ga-rollout"):
+        return True
+
+    if (email := getattr(user, "email", None)) is None:
+        return False
+    return email in options.get("staff.user-email-allowlist")
 
 
 class Staff(ElevatedMode):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -266,6 +266,12 @@ register(
 
 # Staff
 register(
+    "staff.ga-rollout",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "staff.user-email-allowlist",
     type=Sequence,
     default=[],

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -266,12 +266,6 @@ register(
 
 # Staff
 register(
-    "staff.ga-rollout",
-    type=Bool,
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "staff.user-email-allowlist",
     type=Sequence,
     default=[],

--- a/src/sentry/sentry_apps/apps.py
+++ b/src/sentry/sentry_apps/apps.py
@@ -14,8 +14,9 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from sentry_sdk.api import push_scope
 
-from sentry import analytics, audit_log, features
+from sentry import analytics, audit_log
 from sentry.api.helpers.slugs import sentry_slugify
+from sentry.auth.staff import has_staff_option
 from sentry.constants import SentryAppStatus
 from sentry.coreapi import APIError
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
@@ -69,16 +70,14 @@ def expand_events(rolled_up_events: list[str]) -> set[str]:
     )
 
 
-# TODO(schew2381): Delete this method after the feature flag is removed
+# TODO(schew2381): Delete this method after staff is GA'd and the options are removed
 def _is_elevated_user(user) -> bool:
     """
     This is a temporary helper method that checks if the user can become staff
-    if the feature flag is enabled. Otherwise, it defaults to checking that the
-    user can become a superuser.
+    if staff mode is enabled. Otherwise, it defaults to checking that the user
+    can become a superuser.
     """
-    return (
-        user.is_staff if features.has("auth:enterprise-staff-cookie", user) else user.is_superuser
-    )
+    return user.is_staff if has_staff_option(user) else user.is_superuser
 
 
 @dataclasses.dataclass

--- a/tests/sentry/api/endpoints/relocations/test_abort.py
+++ b/tests/sentry/api/endpoints/relocations/test_abort.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from sentry.api.endpoints.relocations.abort import ERR_NOT_ABORTABLE_STATUS
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.relocation import OrderedTask
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
@@ -34,7 +34,7 @@ class AbortRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_good_staff_abort_in_progress(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
@@ -53,7 +53,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_good_staff_abort_paused(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.PAUSE.value
@@ -72,7 +72,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data["status"] == Relocation.Status.FAILURE.name
         assert response.data["step"] == Relocation.Step.PREPROCESSING.name
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_already_succeeded(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.SUCCESS.value
@@ -91,7 +91,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_already_failed(self):
         self.login_as(user=self.staff_user, staff=True)
         self.relocation.status = Relocation.Status.FAILURE.value
@@ -110,7 +110,7 @@ class AbortRelocationTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_NOT_ABORTABLE_STATUS
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_not_found(self):
         self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex
@@ -121,8 +121,8 @@ class AbortRelocationTest(APITestCase):
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
-    @with_feature("auth:enterprise-staff-cookie")
-    def test_superuser_fails_with_flag(self):
+    @override_options({"staff.ga-rollout": True})
+    def test_superuser_fails_with_option(self):
         self.login_as(user=self.superuser, superuser=True)
         self.get_error_response(self.relocation.uuid, status_code=403)
 

--- a/tests/sentry/api/endpoints/relocations/test_cancel.py
+++ b/tests/sentry/api/endpoints/relocations/test_cancel.py
@@ -9,7 +9,7 @@ from sentry.api.endpoints.relocations.cancel import (
 )
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.relocation import OrderedTask
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
@@ -38,7 +38,7 @@ class CancelRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_good_staff_cancel_in_progress_at_next_step(self):
         staff_user = self.create_user(is_staff=True)
         self.login_as(user=staff_user, staff=True)

--- a/tests/sentry/api/endpoints/relocations/test_details.py
+++ b/tests/sentry/api/endpoints/relocations/test_details.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.relocation import OrderedTask
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
@@ -39,14 +39,14 @@ class GetRelocationDetailsTest(APITestCase):
         response = self.get_success_response(self.relocation.uuid, status_code=200)
         assert response.data["uuid"] == str(self.relocation.uuid)
 
-    @with_feature("auth:enterprise-staff-cookie")
-    def test_good_staff_found_with_flag(self):
+    @override_options({"staff.ga-rollout": True})
+    def test_good_staff_found_with_option(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)
         assert response.data["uuid"] == str(self.relocation.uuid)
 
-    @with_feature("auth:enterprise-staff-cookie")
-    def test_bad_superuser_fails_with_flag(self):
+    @override_options({"staff.ga-rollout": True})
+    def test_bad_superuser_fails_with_option(self):
         self.login_as(user=self.superuser, superuser=True)
         self.get_error_response(self.relocation.uuid, status_code=403)
 
@@ -55,7 +55,7 @@ class GetRelocationDetailsTest(APITestCase):
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=404)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_not_found(self):
         self.login_as(user=self.staff_user, staff=True)
         does_not_exist_uuid = uuid4().hex

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -22,7 +22,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import generate_rsa_key_pair
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 from sentry.utils.relocation import OrderedTask
@@ -104,7 +103,7 @@ class GetRelocationsTest(APITestCase):
 
         self.success_uuid = Relocation.objects.get(status=Relocation.Status.SUCCESS.value)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_good_staff_simple(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(status_code=200)
@@ -529,9 +528,10 @@ class PostRelocationsTest(APITestCase):
             sender=RelocationIndexEndpoint,
         )
 
-    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 1})
+    @override_options(
+        {"relocation.enabled": False, "relocation.daily-limit.small": 1, "staff.ga-rollout": True}
+    )
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    @with_feature("auth:enterprise-staff-cookie")
     def test_good_staff_when_feature_disabled(
         self,
         uploading_complete_mock: Mock,
@@ -948,8 +948,9 @@ class PostRelocationsTest(APITestCase):
 
         assert relocation_link_promo_code_signal_mock.call_count == 0
 
-    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options(
+        {"relocation.enabled": True, "relocation.daily-limit.small": 1, "staff.ga-rollout": True}
+    )
     def test_bad_staff_nonexistent_owner(
         self, relocation_link_promo_code_signal_mock: Mock, analytics_record_mock: Mock
     ):
@@ -1150,8 +1151,9 @@ class PostRelocationsTest(APITestCase):
             sender=RelocationIndexEndpoint,
         )
 
-    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 1})
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options(
+        {"relocation.enabled": True, "relocation.daily-limit.small": 1, "staff.ga-rollout": True}
+    )
     def test_good_no_throttle_for_staff(
         self, relocation_link_promo_code_signal_mock: Mock, analytics_record_mock: Mock
     ):

--- a/tests/sentry/api/endpoints/relocations/test_pause.py
+++ b/tests/sentry/api/endpoints/relocations/test_pause.py
@@ -11,7 +11,7 @@ from sentry.api.endpoints.relocations.pause import (
 )
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.relocation import OrderedTask
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
@@ -41,7 +41,7 @@ class PauseRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_good_staff_pause_asap(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(self.relocation.uuid, status_code=200)

--- a/tests/sentry/api/endpoints/relocations/test_retry.py
+++ b/tests/sentry/api/endpoints/relocations/test_retry.py
@@ -22,7 +22,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.backups import generate_rsa_key_pair
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json
@@ -130,9 +129,10 @@ class RetryRelocationTest(APITestCase):
             uuid=response.data["uuid"],
         )
 
-    @override_options({"relocation.enabled": False, "relocation.daily-limit.small": 2})
+    @override_options(
+        {"relocation.enabled": False, "relocation.daily-limit.small": 2, "staff.ga-rollout": True}
+    )
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    @with_feature("auth:enterprise-staff-cookie")
     def test_good_staff_when_feature_disabled(
         self, uploading_complete_mock: Mock, analytics_record_mock: Mock
     ):
@@ -295,9 +295,10 @@ class RetryRelocationTest(APITestCase):
         assert response.data.get("detail") == ERR_FILE_NO_LONGER_EXISTS
         assert uploading_complete_mock.call_count == 0
 
-    @override_options({"relocation.enabled": True, "relocation.daily-limit.small": 2})
+    @override_options(
+        {"relocation.enabled": True, "relocation.daily-limit.small": 2, "staff.ga-rollout": True}
+    )
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    @with_feature("auth:enterprise-staff-cookie")
     def test_bad_staff_owner_not_found(
         self, uploading_complete_mock: Mock, analytics_record_mock: Mock
     ):

--- a/tests/sentry/api/endpoints/relocations/test_unpause.py
+++ b/tests/sentry/api/endpoints/relocations/test_unpause.py
@@ -9,7 +9,7 @@ from sentry.api.endpoints.relocations import (
 from sentry.api.endpoints.relocations.unpause import ERR_NOT_UNPAUSABLE_STATUS
 from sentry.models.relocation import Relocation
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.relocation import OrderedTask
 
 TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
@@ -39,7 +39,7 @@ class UnpauseRelocationTest(APITestCase):
             latest_task_attempts=1,
         )
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     @patch("sentry.tasks.relocation.preprocessing_scan.delay")
     def test_good_staff_unpause_until_validating(self, async_task_scheduled: Mock):
         self.login_as(user=self.staff_user, staff=True)

--- a/tests/sentry/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/api/endpoints/test_doc_integrations.py
@@ -9,7 +9,7 @@ from sentry.api.serializers.base import serialize
 from sentry.models.integrations.doc_integration import DocIntegration
 from sentry.models.integrations.integration_feature import IntegrationFeature, IntegrationTypes
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.json import JSONData
 
@@ -38,7 +38,7 @@ class DocIntegrationsTest(APITestCase):
 class GetDocIntegrationsTest(DocIntegrationsTest):
     method = "GET"
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff_read_docs(self):
         """
         Tests that all DocIntegrations are returned for staff users,

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -12,6 +12,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
@@ -147,7 +148,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
 
         self._validate_updated_published_app(response)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff_update_published_app(self):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(
@@ -253,7 +254,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         )
         assert SentryApp.objects.get(id=app.id).popularity == popularity
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff_can_update_popularity(self):
         self.login_as(user=self.staff_user, staff=True)
         app = self.create_sentry_app(name="SampleApp", organization=self.organization)
@@ -293,7 +294,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert app.status == SentryAppStatus.PUBLISHED
         assert app.date_published
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff_can_publish_apps(self):
         self.login_as(user=self.staff_user, staff=True)
         app = self.create_sentry_app(name="SampleApp", organization=self.organization)

--- a/tests/sentry/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps_stats.py
@@ -1,6 +1,6 @@
 from sentry.api.serializers.base import serialize
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 
@@ -48,7 +48,7 @@ class SentryAppsStatsTest(APITestCase):
         response = self.get_success_response(status_code=200)
         self._check_response(response)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff_has_access(self):
         staff_user = self.create_user(is_staff=True)
         self.login_as(user=staff_user, staff=True)

--- a/tests/sentry/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_details.py
@@ -15,7 +15,6 @@ from sentry.models.authenticator import Authenticator
 from sentry.models.organization import Organization
 from sentry.models.user import User
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
@@ -389,7 +388,7 @@ class UserAuthenticatorDetailsTest(UserAuthenticatorDetailsTestBase):
 
             assert not Authenticator.objects.filter(id=auth.id).exists()
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_require_2fa__can_delete_last_auth_staff(self):
         self._require_2fa_for_organization()
 

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -13,6 +13,7 @@ from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -57,7 +58,7 @@ class UserDetailsGetTest(UserDetailsTest):
         assert "identities" in resp.data
         assert len(resp.data["identities"]) == 0
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff_simple(self):
         self.login_as(user=self.staff_user, staff=True)
 
@@ -544,7 +545,7 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
         assert response.data["detail"] == "Missing required permission to hard delete account."
         assert User.objects.filter(id=user2.id).exists()
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff_hard_delete_account_without_permission(self):
         self.login_as(user=self.staff_user, staff=True)
         user2 = self.create_user(email="user2@example.com")
@@ -567,7 +568,7 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
         self.get_success_response(user2.id, hardDelete=True, organizations=[], status_code=204)
         assert not User.objects.filter(id=user2.id).exists()
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff_hard_delete_account_with_permission(self):
         self.login_as(user=self.staff_user, staff=True)
         user2 = self.create_user(email="user2@example.com")
@@ -578,8 +579,8 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
         self.get_success_response(user2.id, hardDelete=True, organizations=[], status_code=204)
         assert not User.objects.filter(id=user2.id).exists()
 
-    @with_feature("auth:enterprise-staff-cookie")
-    def test_superuser_cannot_hard_delete_with_active_feature_flag(self):
+    @override_options({"staff.ga-rollout": True})
+    def test_superuser_cannot_hard_delete_with_active_option(self):
         self.login_as(user=self.superuser, superuser=True)
         user2 = self.create_user(email="user2@example.com")
 

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -11,7 +11,6 @@ from sentry.models.userrole import UserRole
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
@@ -314,8 +313,8 @@ class UserDetailsStaffUpdateTest(UserDetailsTest):
     method = "put"
 
     @fixture(autouse=True)
-    def use_staff_feature_flag(self):
-        with Feature("auth:enterprise-staff-cookie"):
+    def _activate_staff_mode(self):
+        with override_options({"staff.ga-rollout": True}):
             yield
 
     def test_staff_can_change_is_active(self):

--- a/tests/sentry/api/endpoints/test_user_index.py
+++ b/tests/sentry/api/endpoints/test_user_index.py
@@ -1,6 +1,6 @@
 from sentry.models.userpermission import UserPermission
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -19,7 +19,7 @@ class UserListTest(APITestCase):
         self.login_as(self.normal_user)
         self.get_error_response(status_code=403)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff_simple(self):
         self.staff_user = self.create_user(is_staff=True)
         self.login_as(self.staff_user, staff=True)

--- a/tests/sentry/api/endpoints/test_user_permission_details.py
+++ b/tests/sentry/api/endpoints/test_user_permission_details.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from sentry.api.permissions import StaffPermission
 from sentry.models.userpermission import UserPermission
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -50,7 +50,7 @@ class UserPermissionDetailsGetTest(UserDetailsTest):
         self.login_as(self.superuser, superuser=True)
         self.get_error_response("me", "broadcasts.admin", status_code=404)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_with_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -60,7 +60,7 @@ class UserPermissionDetailsGetTest(UserDetailsTest):
         # ensure we fail the scope check and call is_active_staff
         assert mock_has_permission.call_count == 1
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_without_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -91,7 +91,7 @@ class UserPermissionDetailsPostTest(UserDetailsTest):
             user=self.superuser, permission="broadcasts.admin"
         ).exists()
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_with_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -103,7 +103,7 @@ class UserPermissionDetailsPostTest(UserDetailsTest):
         # ensure we fail the scope check and call is_active_staff
         assert mock_has_permission.call_count == 1
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_duplicate_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -138,7 +138,7 @@ class UserPermissionDetailsDeleteTest(UserDetailsTest):
             user=self.superuser, permission="broadcasts.admin"
         ).exists()
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_with_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)
@@ -151,7 +151,7 @@ class UserPermissionDetailsDeleteTest(UserDetailsTest):
         # ensure we fail the scope check and call is_active_staff
         assert mock_has_permission.call_count == 1
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_without_permission(self, mock_has_permission):
         self.login_as(self.staff_user, staff=True)

--- a/tests/sentry/api/endpoints/test_user_permissions.py
+++ b/tests/sentry/api/endpoints/test_user_permissions.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from sentry.api.permissions import StaffPermission
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -26,7 +26,7 @@ class UserPermissionsGetTest(UserPermissionsTest):
         assert "broadcasts.admin" in response.data
         assert "users.admin" in response.data
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_lookup_self(self, mock_has_permission):
         staff_user = self.create_user(is_staff=True)

--- a/tests/sentry/api/endpoints/test_user_permissions_config.py
+++ b/tests/sentry/api/endpoints/test_user_permissions_config.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from sentry.api.permissions import StaffPermission
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -26,7 +26,7 @@ class UserPermissionsConfigGetTest(UserPermissionsConfigTest):
         assert "users.admin" in response.data
         assert "options.admin" in response.data
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     @patch.object(StaffPermission, "has_permission", wraps=StaffPermission().has_permission)
     def test_staff_lookup_self(self, mock_has_permission):
         self.staff_user = self.create_user(is_staff=True)

--- a/tests/sentry/api/test_permissions.py
+++ b/tests/sentry/api/test_permissions.py
@@ -4,7 +4,7 @@ from sentry.api.permissions import (
     SuperuserPermission,
 )
 from sentry.testutils.cases import DRFPermissionTestCase
-from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 
 
 class PermissionsTest(DRFPermissionTestCase):
@@ -18,8 +18,8 @@ class PermissionsTest(DRFPermissionTestCase):
     def test_staff_permission(self):
         assert self.staff_permission.has_permission(self.staff_request, None)
 
-    @with_feature("auth:enterprise-staff-cookie")
-    def test_superuser_or_staff_feature_flagged_permission_active_flag(self):
+    @override_options({"staff.ga-rollout": True})
+    def test_superuser_or_staff_feature_flagged_permission_active_option(self):
         # With active superuser
         assert not self.superuser_staff_flagged_permission.has_permission(
             self.superuser_request, None
@@ -28,7 +28,7 @@ class PermissionsTest(DRFPermissionTestCase):
         # With active staff
         assert self.superuser_staff_flagged_permission.has_permission(self.staff_request, None)
 
-    def test_superuser_or_staff_feature_flagged_permission_inactive_flag(self):
+    def test_superuser_or_staff_feature_flagged_permission_inactive_option(self):
         # With active staff
         assert not self.superuser_staff_flagged_permission.has_permission(self.staff_request, None)
 

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -5,7 +5,7 @@ from django.urls import URLResolver, get_resolver, reverse
 
 from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -266,8 +266,9 @@ class ReactPageViewTest(TestCase):
         other_org = self.create_organization()
 
         self.login_as(self.user)
-        with override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True), self.feature(
-            {"organizations:customer-domains": [other_org.slug]}
+        with (
+            override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True),
+            self.feature({"organizations:customer-domains": [other_org.slug]}),
         ):
             # Should not be able to induce activeorg
             assert "activeorg" not in self.client.session
@@ -286,8 +287,9 @@ class ReactPageViewTest(TestCase):
         other_org = self.create_organization()
 
         self.login_as(user, superuser=is_superuser, staff=is_staff)
-        with override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True), self.feature(
-            {"organizations:customer-domains": [other_org.slug]}
+        with (
+            override_settings(SENTRY_USE_CUSTOMER_DOMAINS=True),
+            self.feature({"organizations:customer-domains": [other_org.slug]}),
         ):
             # Induce activeorg
             assert "activeorg" not in self.client.session
@@ -319,11 +321,11 @@ class ReactPageViewTest(TestCase):
     def test_customer_domain_non_member_org_superuser(self):
         self._run_customer_domain_elevated_privileges(is_superuser=True, is_staff=False)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_customer_domain_non_member_org_staff(self):
         self._run_customer_domain_elevated_privileges(is_superuser=False, is_staff=True)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_customer_domain_non_member_org_superuser_and_staff(self):
         self._run_customer_domain_elevated_privileges(is_superuser=True, is_staff=True)
 

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -15,7 +15,7 @@ from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.scheduled import run_deletion
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, create_test_regions, region_silo_test
 from sentry.utils import json
 
@@ -272,11 +272,11 @@ class ClientConfigViewTest(TestCase):
     def test_superuser(self):
         self._run_test_with_privileges(is_superuser=True, is_staff=False)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_staff(self):
         self._run_test_with_privileges(is_superuser=False, is_staff=True)
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_superuser_and_staff(self):
         self._run_test_with_privileges(is_superuser=True, is_staff=True)
 


### PR DESCRIPTION
Note: this is the second step described in https://github.com/getsentry/getsentry/pull/13463

---
### Summary
Switch from feature flag to using staff option.

There are two options:
1. [User Email Option](https://github.com/getsentry/sentry/pull/67742) - this is set in the [options automator](https://github.com/getsentry/sentry-options-automator/pull/974) to limit staff to specific users
2. [GA Option](https://github.com/getsentry/sentry/pull/67851) - this will be used to turn staff on for all sentry employees (has not been set in options automator yet)

To easily switch the tests to over from the feature flag, we override the GA option when testing, which doesn't require us to know the user's email (simplifies testing process quite a bit)