### PR TITLE
fix(trace): select node when moving with cursor

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -307,7 +307,7 @@ function Trace({
 
   const handleZoomIn = useCallback(
     (
-      event: React.MouseEvent,
+      event: React.MouseEvent<Element> | React.KeyboardEvent<Element>,
       node: TraceTreeNode<TraceTree.NodeValue>,
       value: boolean
     ) => {
@@ -342,7 +342,7 @@ function Trace({
 
   const handleExpandNode = useCallback(
     (
-      event: React.MouseEvent<Element>,
+      event: React.MouseEvent<Element> | React.KeyboardEvent<Element>,
       node: TraceTreeNode<TraceTree.NodeValue>,
       value: boolean
     ) => {
@@ -439,8 +439,23 @@ function Trace({
           search_dispatch({type: 'clear iterator index'});
         }
       }
+      if (event.key === 'ArrowLeft') {
+        if (node.zoomedIn) handleZoomIn(event, node, false);
+        if (node.expanded) handleExpandNode(event, node, false);
+      }
+      if (event.key === 'ArrowRight') {
+        if (!node.zoomedIn && node.canFetch) handleZoomIn(event, node, true);
+        if (!node.expanded) handleExpandNode(event, node, true);
+      }
     },
-    [manager, roving_dispatch, search_dispatch, trace.list]
+    [
+      manager,
+      roving_dispatch,
+      search_dispatch,
+      handleExpandNode,
+      handleZoomIn,
+      trace.list,
+    ]
   );
 
   // @TODO this is the implementation of infinite scroll. Once the user

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -235,8 +235,8 @@ function Trace({
     loadedRef.current = true;
 
     if (!scrollQueueRef.current) {
-      if (search_state.query) {
-        onTraceSearch(treeRef.current, search_state.query, null);
+      if (searchStateRef.current.query) {
+        onTraceSearch(treeRef.current, searchStateRef.current.query, null);
       }
       return;
     }
@@ -289,8 +289,8 @@ function Trace({
       manager.list?.scrollToRow(maybeNode.index, 'top');
       manager.scrollRowIntoViewHorizontally(maybeNode.node, 0, 12, 'exact');
 
-      if (search_state.query) {
-        onTraceSearch(treeRef.current, search_state.query, maybeNode.node);
+      if (searchStateRef.current.query) {
+        onTraceSearch(treeRef.current, searchStateRef.current.query, maybeNode.node);
       }
     });
   }, [
@@ -300,7 +300,6 @@ function Trace({
     trace,
     trace_id,
     manager,
-    search_state.query,
     onTraceSearch,
     onRowClick,
     roving_dispatch,
@@ -327,10 +326,10 @@ function Trace({
         .then(() => {
           setRender(a => (a + 1) % 2);
 
-          if (search_state.query) {
+          if (searchStateRef.current.query) {
             const previousNode =
               rovingTabIndexStateRef.current.node || searchStateRef.current.node;
-            onTraceSearch(treeRef.current, search_state.query, previousNode);
+            onTraceSearch(treeRef.current, searchStateRef.current.query, previousNode);
           }
           treePromiseStatusRef.current!.set(node, 'success');
         })
@@ -338,7 +337,7 @@ function Trace({
           treePromiseStatusRef.current!.set(node, 'error');
         });
     },
-    [api, organization, search_state, onTraceSearch]
+    [api, organization, onTraceSearch]
   );
 
   const handleExpandNode = useCallback(
@@ -352,13 +351,13 @@ function Trace({
       treeRef.current.expand(node, value);
       setRender(a => (a + 1) % 2);
 
-      if (search_state.query) {
+      if (searchStateRef.current.query) {
         const previousNode =
           rovingTabIndexStateRef.current.node || searchStateRef.current.node;
-        onTraceSearch(treeRef.current, search_state.query, previousNode);
+        onTraceSearch(treeRef.current, searchStateRef.current.query, previousNode);
       }
     },
-    [search_state, onTraceSearch]
+    [onTraceSearch]
   );
 
   const onVirtulizedRowClick = useCallback(
@@ -379,8 +378,8 @@ function Trace({
       onRowClick(node, event);
       roving_dispatch({type: 'set index', index, node});
 
-      if (search_state.resultsLookup.has(node)) {
-        const idx = search_state.resultsLookup.get(node)!;
+      if (searchStateRef.current.resultsLookup.has(node)) {
+        const idx = searchStateRef.current.resultsLookup.get(node)!;
 
         search_dispatch({
           type: 'set iterator index',
@@ -392,7 +391,7 @@ function Trace({
         search_dispatch({type: 'clear iterator index'});
       }
     },
-    [roving_dispatch, onRowClick, search_state, search_dispatch, previouslyFocusedNodeRef]
+    [roving_dispatch, onRowClick, search_dispatch, previouslyFocusedNodeRef]
   );
 
   const onRowKeyDown = useCallback(
@@ -413,7 +412,11 @@ function Trace({
           treeRef.current.list.length - 1
         );
         manager.scrollToRow(nextIndex);
-        roving_dispatch({type: 'set index', index: nextIndex, node});
+        roving_dispatch({
+          type: 'set index',
+          index: nextIndex,
+          node: treeRef.current.list[nextIndex],
+        });
 
         const nextNode = treeRef.current.list[nextIndex];
         const offset =
@@ -423,8 +426,8 @@ function Trace({
           manager.scrollRowIntoViewHorizontally(trace.list[nextIndex], 0, offset);
         }
 
-        if (search_state.resultsLookup.has(trace.list[nextIndex])) {
-          const idx = search_state.resultsLookup.get(trace.list[nextIndex])!;
+        if (searchStateRef.current.resultsLookup.has(trace.list[nextIndex])) {
+          const idx = searchStateRef.current.resultsLookup.get(trace.list[nextIndex])!;
 
           search_dispatch({
             type: 'set iterator index',
@@ -437,7 +440,7 @@ function Trace({
         }
       }
     },
-    [manager, roving_dispatch, search_state, search_dispatch, trace.list]
+    [manager, roving_dispatch, search_dispatch, trace.list]
   );
 
   // @TODO this is the implementation of infinite scroll. Once the user

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/error.tsx
@@ -1,7 +1,6 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
 import {Button} from 'sentry/components/button';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
@@ -15,6 +14,7 @@ import {IconFire} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {EventError, Organization} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
 import {getTraceTabTitle} from 'sentry/views/performance/newTraceDetails/traceTabs';
 import {Row, Tags} from 'sentry/views/performance/traceDetails/styles';
 
@@ -26,16 +26,15 @@ import {TraceDrawerComponents} from './styles';
 export function ErrorNodeDetails({
   node,
   organization,
-  location,
   scrollToNode,
   onParentClick,
 }: {
-  location: Location;
   node: TraceTreeNode<TraceTree.TraceError>;
   onParentClick: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
   organization: Organization;
   scrollToNode: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
 }) {
+  const location = useLocation();
   const issues = useMemo(() => {
     return [...node.errors];
   }, [node.errors]);

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction.tsx
@@ -1,6 +1,5 @@
 import {createRef, Fragment, useLayoutEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 import omit from 'lodash/omit';
 
 import {Button} from 'sentry/components/button';
@@ -51,6 +50,7 @@ import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
+import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
 import {isCustomMeasurement} from 'sentry/views/dashboards/utils';
 import {CustomMetricsEventData} from 'sentry/views/ddm/customMetricsEventData';
@@ -201,7 +201,6 @@ function ReplaySection({
 }
 
 type TransactionDetailProps = {
-  location: Location;
   manager: VirtualizedViewManager;
   node: TraceTreeNode<TraceTree.Transaction>;
   onParentClick: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
@@ -212,10 +211,10 @@ type TransactionDetailProps = {
 export function TransactionNodeDetails({
   node,
   organization,
-  location,
   scrollToNode,
   onParentClick,
 }: TransactionDetailProps) {
+  const location = useLocation();
   const {projects} = useProjects();
   const issues = useMemo(() => {
     return [...node.errors, ...node.performance_issues];

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/details.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/details.tsx
@@ -1,5 +1,3 @@
-import type {Location} from 'history';
-
 import type {Organization} from 'sentry/types';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/virtualizedViewManager';
 
@@ -22,12 +20,10 @@ import {TransactionNodeDetails} from '../details/transaction';
 export default function NodeDetail({
   node,
   organization,
-  location,
   manager,
   scrollToNode,
   onParentClick,
 }: {
-  location: Location;
   manager: VirtualizedViewManager;
   node: TraceTreeNode<TraceTree.NodeValue>;
   onParentClick: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
@@ -40,7 +36,6 @@ export default function NodeDetail({
         node={node}
         organization={organization}
         onParentClick={onParentClick}
-        location={location}
         manager={manager}
         scrollToNode={scrollToNode}
       />
@@ -64,7 +59,6 @@ export default function NodeDetail({
         node={node}
         organization={organization}
         onParentClick={onParentClick}
-        location={location}
         scrollToNode={scrollToNode}
       />
     );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
 import EventVitals from 'sentry/components/events/eventVitals';
@@ -19,6 +18,7 @@ import type {
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import {useLocation} from 'sentry/utils/useLocation';
 import Tags from 'sentry/views/discover/tags';
 
 import {isTraceNode} from '../../guards';
@@ -34,7 +34,6 @@ const WEB_VITALS = [
 ];
 
 type TraceFooterProps = {
-  location: Location;
   node: TraceTreeNode<TraceTree.NodeValue> | null;
   organization: Organization;
   rootEventResults: UseApiQueryResult<EventTransaction, RequestError>;
@@ -88,6 +87,7 @@ function TraceDataLoading() {
 }
 
 export function TraceLevelDetails(props: TraceFooterProps) {
+  const location = useLocation();
   const issues = useMemo(() => {
     if (!props.node) {
       return [];
@@ -141,7 +141,7 @@ export function TraceLevelDetails(props: TraceFooterProps) {
               totalValues={props.tree.eventsCount}
               eventView={props.traceEventView}
               organization={props.organization}
-              location={props.location}
+              location={location}
             />
           </div>
         </WebVitalsAndTags>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useMemo, useRef} from 'react';
 import {type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import type {Location} from 'history';
 
 import {Button} from 'sentry/components/button';
 import {IconPanel, IconPin} from 'sentry/icons';
@@ -36,7 +35,6 @@ const MIN_TRACE_DRAWER_DIMENSTIONS: [number, number] = [480, 30];
 type TraceDrawerProps = {
   drawerSize: number;
   layout: 'drawer bottom' | 'drawer left' | 'drawer right';
-  location: Location;
   manager: VirtualizedViewManager;
   onDrawerResize: (size: number) => void;
   onLayoutChange: (layout: 'drawer bottom' | 'drawer left' | 'drawer right') => void;
@@ -199,7 +197,6 @@ function TraceDrawer(props: TraceDrawerProps) {
                 tree={props.trace}
                 rootEventResults={props.rootEventResults}
                 organization={props.organization}
-                location={props.location}
                 traces={props.traces}
                 traceEventView={props.traceEventView}
               />
@@ -207,7 +204,6 @@ function TraceDrawer(props: TraceDrawerProps) {
               <NodeDetail
                 node={props.tabs.current.node}
                 organization={props.organization}
-                location={props.location}
                 manager={props.manager}
                 scrollToNode={props.scrollToNode}
                 onParentClick={onParentClick}


### PR DESCRIPTION
When navigating with arrow keys or search, we were not updating the details inside the drawer. Also add left and right arrow keys to collapse/expand nodes when using the roving index (we cannot do that inside the searchbar as left/right keys) can be used to navigate the editing position inside the text input and it would be weird if the UI jumped around as the cursor moved.