### PR TITLE
chore(metrics): Rename query type

### DIFF
--- a/static/app/components/modals/metricWidgetViewerModal.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal.tsx
@@ -15,7 +15,7 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types';
 import {getMetricsUrl} from 'sentry/utils/metrics';
 import {toDisplayType} from 'sentry/utils/metrics/dashboard';
-import {MetricQueryType} from 'sentry/utils/metrics/types';
+import {MetricExpressionType} from 'sentry/utils/metrics/types';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {
   DashboardMetricsEquation,
@@ -169,7 +169,7 @@ function MetricWidgetViewerModal({
           formula: '',
           name: '',
           id: generateEquationId(),
-          type: MetricQueryType.FORMULA,
+          type: MetricExpressionType.EQUATION,
           isHidden: false,
         },
       ];

--- a/static/app/components/modals/metricWidgetViewerModal/queries.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal/queries.tsx
@@ -17,7 +17,7 @@ import {
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {isCustomMetric} from 'sentry/utils/metrics';
-import {MetricQueryType} from 'sentry/utils/metrics/types';
+import {MetricExpressionType} from 'sentry/utils/metrics/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
@@ -92,7 +92,7 @@ export function Queries({
               disabled={!query.isHidden && visibleExpressions.length === 1}
               isSelected={false}
               queryId={query.id}
-              type={MetricQueryType.QUERY}
+              type={MetricExpressionType.QUERY}
             />
           )}
           <QueryBuilder
@@ -118,7 +118,7 @@ export function Queries({
               disabled={!equation.isHidden && visibleExpressions.length === 1}
               isSelected={false}
               queryId={equation.id}
-              type={MetricQueryType.FORMULA}
+              type={MetricExpressionType.EQUATION}
             />
           )}
           <FormulaInput
@@ -257,7 +257,7 @@ interface QueryToggleProps {
   isSelected: boolean;
   onChange: (isHidden: boolean) => void;
   queryId: number;
-  type: MetricQueryType;
+  type: MetricExpressionType;
 }
 
 function QueryToggle({
@@ -275,7 +275,7 @@ function QueryToggle({
 
   return (
     <Tooltip title={tooltipTitle} delay={500}>
-      {type === MetricQueryType.QUERY ? (
+      {type === MetricExpressionType.QUERY ? (
         <StyledQuerySymbol
           isHidden={isHidden}
           queryId={queryId}

--- a/static/app/utils/metrics/constants.tsx
+++ b/static/app/utils/metrics/constants.tsx
@@ -5,7 +5,7 @@ import type {
   MetricQueryWidgetParams,
   SortState,
 } from 'sentry/utils/metrics/types';
-import {MetricDisplayType, MetricQueryType} from 'sentry/utils/metrics/types';
+import {MetricDisplayType, MetricExpressionType} from 'sentry/utils/metrics/types';
 
 export const METRICS_DOCS_URL = 'https://docs.sentry.io/product/metrics/';
 
@@ -32,7 +32,7 @@ export const DEFAULT_SORT_STATE: SortState = {
 export const NO_QUERY_ID = -1;
 
 export const emptyMetricsQueryWidget: MetricQueryWidgetParams = {
-  type: MetricQueryType.QUERY,
+  type: MetricExpressionType.QUERY,
   id: NO_QUERY_ID,
   mri: 'd:transactions/duration@millisecond' satisfies MRI,
   op: 'avg',
@@ -44,7 +44,7 @@ export const emptyMetricsQueryWidget: MetricQueryWidgetParams = {
 };
 
 export const emptyMetricsFormulaWidget: MetricFormulaWidgetParams = {
-  type: MetricQueryType.FORMULA,
+  type: MetricExpressionType.EQUATION,
   id: NO_QUERY_ID,
   formula: '',
   sort: DEFAULT_SORT_STATE,

--- a/static/app/utils/metrics/types.tsx
+++ b/static/app/utils/metrics/types.tsx
@@ -27,28 +27,28 @@ export interface MetricsQuery {
   query?: string;
 }
 
-export enum MetricQueryType {
+export enum MetricExpressionType {
   QUERY = 1,
-  FORMULA = 2,
+  EQUATION = 2,
 }
 
 export interface BaseWidgetParams {
   displayType: MetricDisplayType;
   id: number;
   isHidden: boolean;
-  type: MetricQueryType;
+  type: MetricExpressionType;
   focusedSeries?: FocusedMetricsSeries[];
   sort?: SortState;
 }
 
 export interface MetricQueryWidgetParams extends BaseWidgetParams, MetricsQuery {
-  type: MetricQueryType.QUERY;
+  type: MetricExpressionType.QUERY;
   powerUserMode?: boolean;
 }
 
 export interface MetricFormulaWidgetParams extends BaseWidgetParams {
   formula: string;
-  type: MetricQueryType.FORMULA;
+  type: MetricExpressionType.EQUATION;
 }
 
 export type MetricWidgetQueryParams = MetricQueryWidgetParams | MetricFormulaWidgetParams;

--- a/static/app/views/dashboards/metrics/types.tsx
+++ b/static/app/views/dashboards/metrics/types.tsx
@@ -1,5 +1,5 @@
 import type {MRI} from 'sentry/types/metrics';
-import type {MetricQueryType} from 'sentry/utils/metrics/types';
+import type {MetricExpressionType} from 'sentry/utils/metrics/types';
 
 export type Order = 'asc' | 'desc' | undefined;
 
@@ -9,7 +9,7 @@ export interface DashboardMetricsQuery {
   mri: MRI;
   op: string;
   orderBy: Order;
-  type: MetricQueryType.QUERY;
+  type: MetricExpressionType.QUERY;
   groupBy?: string[];
   isQueryOnly?: boolean;
   limit?: number;
@@ -20,7 +20,7 @@ export interface DashboardMetricsEquation {
   formula: string;
   id: number;
   isHidden: boolean;
-  type: MetricQueryType.FORMULA;
+  type: MetricExpressionType.EQUATION;
 }
 
 export type DashboardMetricsExpression = DashboardMetricsQuery | DashboardMetricsEquation;

--- a/static/app/views/dashboards/metrics/utils.spec.tsx
+++ b/static/app/views/dashboards/metrics/utils.spec.tsx
@@ -1,4 +1,4 @@
-import {MetricDisplayType, MetricQueryType} from 'sentry/utils/metrics/types';
+import {MetricDisplayType, MetricExpressionType} from 'sentry/utils/metrics/types';
 import type {DashboardMetricsExpression} from 'sentry/views/dashboards/metrics/types';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -27,7 +27,7 @@ describe('getMetricExpressions function', () => {
         mri: 'd:transactions/duration@milisecond',
         op: 'avg',
         query: 'foo:bar',
-        type: MetricQueryType.QUERY,
+        type: MetricExpressionType.QUERY,
         orderBy: 'asc',
         isHidden: false,
       } satisfies DashboardMetricsExpression,
@@ -51,7 +51,7 @@ describe('getMetricExpressions function', () => {
       {
         id: 0,
         formula: '$a + $b',
-        type: MetricQueryType.FORMULA,
+        type: MetricExpressionType.EQUATION,
         isHidden: false,
       } satisfies DashboardMetricsExpression,
     ]);
@@ -86,7 +86,7 @@ describe('getMetricExpressions function', () => {
         mri: 'd:transactions/duration@milisecond',
         op: 'avg',
         query: 'foo:bar release:1.0',
-        type: MetricQueryType.QUERY,
+        type: MetricExpressionType.QUERY,
         orderBy: 'desc',
         isHidden: false,
       } satisfies DashboardMetricsExpression,
@@ -96,7 +96,7 @@ describe('getMetricExpressions function', () => {
         mri: 'd:transactions/duration@milisecond',
         op: 'avg',
         query: 'foo:baz release:1.0',
-        type: MetricQueryType.QUERY,
+        type: MetricExpressionType.QUERY,
         orderBy: undefined,
         isHidden: false,
       } satisfies DashboardMetricsExpression,
@@ -124,7 +124,7 @@ describe('getMetricExpressions function', () => {
         mri: 'd:transactions/duration@milisecond',
         op: 'avg',
         query: 'release:[1.0,2.0]',
-        type: MetricQueryType.QUERY,
+        type: MetricExpressionType.QUERY,
         orderBy: undefined,
         isHidden: false,
       } satisfies DashboardMetricsExpression,
@@ -157,7 +157,7 @@ describe('expressionsToWidget', () => {
         mri: 'd:transactions/duration@milisecond',
         op: 'avg',
         query: 'foo:bar',
-        type: MetricQueryType.QUERY,
+        type: MetricExpressionType.QUERY,
         orderBy: 'asc',
         isHidden: true,
       } satisfies DashboardMetricsExpression,
@@ -190,7 +190,7 @@ describe('expressionsToWidget', () => {
       {
         id: 1,
         formula: '$a + $b',
-        type: MetricQueryType.FORMULA,
+        type: MetricExpressionType.EQUATION,
         isHidden: false,
       } satisfies DashboardMetricsExpression,
     ];
@@ -225,14 +225,14 @@ describe('expressionsToWidget', () => {
         mri: 'd:transactions/duration@milisecond',
         op: 'avg',
         query: 'foo:bar',
-        type: MetricQueryType.QUERY,
+        type: MetricExpressionType.QUERY,
         orderBy: 'asc',
         isHidden: true,
       } satisfies DashboardMetricsExpression,
       {
         id: 1,
         formula: '$a + $b',
-        type: MetricQueryType.FORMULA,
+        type: MetricExpressionType.EQUATION,
         isHidden: false,
       } satisfies DashboardMetricsExpression,
     ];

--- a/static/app/views/dashboards/metrics/utils.tsx
+++ b/static/app/views/dashboards/metrics/utils.tsx
@@ -4,7 +4,7 @@ import type {MRI} from 'sentry/types';
 import {unescapeMetricsFormula} from 'sentry/utils/metrics';
 import {NO_QUERY_ID} from 'sentry/utils/metrics/constants';
 import {formatMRIField, MRIToField, parseField} from 'sentry/utils/metrics/mri';
-import {MetricDisplayType, MetricQueryType} from 'sentry/utils/metrics/types';
+import {MetricDisplayType, MetricExpressionType} from 'sentry/utils/metrics/types';
 import type {MetricsQueryApiQueryParams} from 'sentry/utils/metrics/useMetricsQuery';
 import type {
   DashboardMetricsEquation,
@@ -49,7 +49,7 @@ function getReleaseQuery(dashboardFilters: DashboardFilters) {
 export function isMetricsFormula(
   query: DashboardMetricsExpression
 ): query is DashboardMetricsEquation {
-  return query.type === MetricQueryType.FORMULA;
+  return query.type === MetricExpressionType.EQUATION;
 }
 
 function getExpressionIdFromWidgetQuery(query: WidgetQuery): number {
@@ -102,7 +102,7 @@ export function getMetricQueries(
     const orderBy = query.orderby ? query.orderby : undefined;
     return {
       id: id,
-      type: MetricQueryType.QUERY,
+      type: MetricExpressionType.QUERY,
       mri: parsed.mri,
       op: parsed.op,
       query: extendQuery(query.conditions, dashboardFilters),
@@ -136,7 +136,7 @@ export function getMetricEquations(widget: Widget): DashboardMetricsEquation[] {
 
       return {
         id: id,
-        type: MetricQueryType.FORMULA,
+        type: MetricExpressionType.EQUATION,
         formula: query.aggregates[0].slice(9),
         isHidden: !!query.isHidden,
       } satisfies DashboardMetricsEquation;
@@ -166,7 +166,7 @@ export function expressionsToApiQueries(
   expressions: DashboardMetricsExpression[]
 ): MetricsQueryApiQueryParams[] {
   return expressions
-    .filter(e => !(e.type === MetricQueryType.FORMULA && e.isHidden))
+    .filter(e => !(e.type === MetricExpressionType.EQUATION && e.isHidden))
     .map(e =>
       isMetricsFormula(e)
         ? {
@@ -247,7 +247,7 @@ export function defaultMetricWidget(): Widget {
     [
       {
         id: 0,
-        type: MetricQueryType.QUERY,
+        type: MetricExpressionType.QUERY,
         mri: 'd:transactions/duration@millisecond',
         op: 'avg',
         query: '',

--- a/static/app/views/metrics/context.tsx
+++ b/static/app/views/metrics/context.tsx
@@ -16,7 +16,10 @@ import {
   emptyMetricsQueryWidget,
   NO_QUERY_ID,
 } from 'sentry/utils/metrics/constants';
-import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
+import {
+  MetricExpressionType,
+  type MetricWidgetQueryParams,
+} from 'sentry/utils/metrics/types';
 import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import {decodeInteger, decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
@@ -36,7 +39,7 @@ export type FocusAreaProps = {
 };
 
 interface MetricsContextValue {
-  addWidget: (type?: MetricQueryType) => void;
+  addWidget: (type?: MetricExpressionType) => void;
   duplicateWidget: (index: number) => void;
   focusArea: FocusAreaProps;
   hasMetrics: boolean;
@@ -143,7 +146,7 @@ export function useMetricWidgets() {
   );
 
   const addWidget = useCallback(
-    (type: MetricQueryType = MetricQueryType.QUERY) => {
+    (type: MetricExpressionType = MetricExpressionType.QUERY) => {
       const lastIndexOfSameType = currentWidgetsRef.current.findLastIndex(
         w => w.type === type
       );
@@ -152,7 +155,7 @@ export function useMetricWidgets() {
       } else {
         setWidgets(currentWidgets => [
           ...currentWidgets,
-          type === MetricQueryType.QUERY
+          type === MetricExpressionType.QUERY
             ? emptyMetricsQueryWidget
             : emptyMetricsFormulaWidget,
         ]);
@@ -297,7 +300,7 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
   }, [focusAreaSelection, handleAddFocusArea, handleRemoveFocusArea]);
 
   const handleAddWidget = useCallback(
-    (type?: MetricQueryType) => {
+    (type?: MetricExpressionType) => {
       addWidget(type);
       handleSetSelectedWidgetIndex(widgets.length);
     },

--- a/static/app/views/metrics/metricQueryContextMenu.tsx
+++ b/static/app/views/metrics/metricQueryContextMenu.tsx
@@ -28,7 +28,7 @@ import {
 import {hasCustomMetrics} from 'sentry/utils/metrics/features';
 import {
   type MetricDisplayType,
-  MetricQueryType,
+  MetricExpressionType,
   type MetricsQuery,
 } from 'sentry/utils/metrics/types';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -65,7 +65,7 @@ export function MetricQueryContextMenu({
 
   // At least one query must remain
   const canDelete =
-    widgets.filter(widget => widget.type === MetricQueryType.QUERY).length > 1;
+    widgets.filter(widget => widget.type === MetricExpressionType.QUERY).length > 1;
 
   const items = useMemo<MenuItemProps[]>(
     () => [

--- a/static/app/views/metrics/pageHeaderActions.tsx
+++ b/static/app/views/metrics/pageHeaderActions.tsx
@@ -18,7 +18,10 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isCustomMeasurement} from 'sentry/utils/metrics';
 import {MRIToField} from 'sentry/utils/metrics/mri';
-import {MetricQueryType, type MetricQueryWidgetParams} from 'sentry/utils/metrics/types';
+import {
+  MetricExpressionType,
+  type MetricQueryWidgetParams,
+} from 'sentry/utils/metrics/types';
 import {middleEllipsis} from 'sentry/utils/middleEllipsis';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
@@ -111,7 +114,7 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
       widgets
         .filter(
           (query): query is MetricQueryWidgetParams =>
-            query.type === MetricQueryType.QUERY
+            query.type === MetricExpressionType.QUERY
         )
         .map((widget, index) => {
           const createAlert = getCreateAlert(organization, {

--- a/static/app/views/metrics/queries.tsx
+++ b/static/app/views/metrics/queries.tsx
@@ -10,8 +10,8 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
+  MetricExpressionType,
   type MetricFormulaWidgetParams,
-  MetricQueryType,
   type MetricQueryWidgetParams,
   type MetricsQuery,
   type MetricWidgetQueryParams,
@@ -58,10 +58,10 @@ export function Queries() {
   );
 
   const handleAddWidget = useCallback(
-    (type: MetricQueryType) => {
+    (type: MetricExpressionType) => {
       trackAnalytics('ddm.widget.add', {
         organization,
-        type: type === MetricQueryType.QUERY ? 'query' : 'equation',
+        type: type === MetricExpressionType.QUERY ? 'query' : 'equation',
       });
       addWidget(type);
     },
@@ -72,7 +72,7 @@ export function Queries() {
     const querySymbolSet = new Set<string>();
     for (const widget of widgets) {
       const symbol = getQuerySymbol(widget.id);
-      if (widget.type === MetricQueryType.QUERY) {
+      if (widget.type === MetricExpressionType.QUERY) {
         querySymbolSet.add(symbol);
       }
     }
@@ -89,7 +89,7 @@ export function Queries() {
             key={`${widget.type}_${widget.id}`}
             onFocusCapture={() => setSelectedWidgetIndex(index)}
           >
-            {widget.type === MetricQueryType.QUERY ? (
+            {widget.type === MetricExpressionType.QUERY ? (
               <Query
                 widget={widget}
                 onChange={handleChange}
@@ -120,14 +120,14 @@ export function Queries() {
         <Button
           size="sm"
           icon={<IconAdd isCircled />}
-          onClick={() => handleAddWidget(MetricQueryType.QUERY)}
+          onClick={() => handleAddWidget(MetricExpressionType.QUERY)}
         >
           {t('Add query')}
         </Button>
         <Button
           size="sm"
           icon={<IconAdd isCircled />}
-          onClick={() => handleAddWidget(MetricQueryType.FORMULA)}
+          onClick={() => handleAddWidget(MetricExpressionType.EQUATION)}
         >
           {t('Add equation')}
         </Button>
@@ -200,7 +200,7 @@ function Query({
           isSelected={isSelected}
           queryId={widget.id}
           onChange={handleToggle}
-          type={MetricQueryType.QUERY}
+          type={MetricExpressionType.QUERY}
         />
       )}
       <QueryBuilder
@@ -267,7 +267,7 @@ function Formula({
           isSelected={isSelected}
           queryId={widget.id}
           onChange={handleToggle}
-          type={MetricQueryType.FORMULA}
+          type={MetricExpressionType.EQUATION}
         />
       )}
       <FormulaInput
@@ -290,7 +290,7 @@ interface QueryToggleProps {
   isSelected: boolean;
   onChange: (isHidden: boolean) => void;
   queryId: number;
-  type: MetricQueryType;
+  type: MetricExpressionType;
 }
 
 function QueryToggle({
@@ -308,7 +308,7 @@ function QueryToggle({
 
   return (
     <Tooltip title={tooltipTitle} delay={500}>
-      {type === MetricQueryType.QUERY ? (
+      {type === MetricExpressionType.QUERY ? (
         <StyledQuerySymbol
           isHidden={isHidden}
           queryId={queryId}

--- a/static/app/views/metrics/scratchpad.tsx
+++ b/static/app/views/metrics/scratchpad.tsx
@@ -7,7 +7,10 @@ import type {Field} from 'sentry/components/metrics/metricSamplesTable';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getMetricsCorrelationSpanUrl} from 'sentry/utils/metrics';
-import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
+import {
+  MetricExpressionType,
+  type MetricWidgetQueryParams,
+} from 'sentry/utils/metrics/types';
 import type {MetricsQueryApiQueryParams} from 'sentry/utils/metrics/useMetricsQuery';
 import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -82,7 +85,8 @@ export function MetricScratchpad() {
   const filteredWidgets = useMemo(() => {
     return widgets.filter(
       w =>
-        w.type !== MetricQueryType.FORMULA || formulaDependencies[w.id]?.isError === false
+        w.type !== MetricExpressionType.EQUATION ||
+        formulaDependencies[w.id]?.isError === false
     );
   }, [formulaDependencies, widgets]);
 
@@ -132,7 +136,7 @@ export function MetricScratchpad() {
           focusedSeries={firstWidget.focusedSeries}
           tableSort={firstWidget.sort}
           queries={filteredWidgets
-            .filter(w => !(w.type === MetricQueryType.FORMULA && w.isHidden))
+            .filter(w => !(w.type === MetricExpressionType.EQUATION && w.isHidden))
             .map(w => widgetToQuery(w))}
           isSelected
           hasSiblings={false}
@@ -162,7 +166,7 @@ function MultiChartWidgetQueries({
   const queries = useMemo(() => {
     return [
       widgetToQuery(widget),
-      ...(widget.type === MetricQueryType.FORMULA
+      ...(widget.type === MetricExpressionType.EQUATION
         ? formulaDependencies[widget.id]?.dependencies?.map(dependency =>
             widgetToQuery(dependency, true)
           )

--- a/static/app/views/metrics/useCreateDashboard.tsx
+++ b/static/app/views/metrics/useCreateDashboard.tsx
@@ -2,7 +2,10 @@ import {useMemo} from 'react';
 
 import {openCreateDashboardFromScratchpad} from 'sentry/actionCreators/modal';
 import {convertToDashboardWidget} from 'sentry/utils/metrics/dashboard';
-import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
+import {
+  MetricExpressionType,
+  type MetricWidgetQueryParams,
+} from 'sentry/utils/metrics/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
@@ -23,7 +26,7 @@ export function useCreateDashboard(
       const queryIdsInArray = new Set<number>();
       const widgetsWithDependencies = widgets.reduce<MetricWidgetQueryParams[]>(
         (acc, widget) => {
-          if (widget.type === MetricQueryType.FORMULA) {
+          if (widget.type === MetricExpressionType.EQUATION) {
             const {dependencies, isError} = formulaDependencies[widget.id];
             if (isError) {
               return acc;
@@ -53,7 +56,7 @@ export function useCreateDashboard(
 
     return widgets
       .map(widget => {
-        if (widget.type !== MetricQueryType.FORMULA) {
+        if (widget.type !== MetricExpressionType.EQUATION) {
           return convertToDashboardWidget([widget], widget.displayType);
         }
 

--- a/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.spec.tsx
+++ b/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.spec.tsx
@@ -1,7 +1,7 @@
 import {emptyMetricsQueryWidget} from 'sentry/utils/metrics/constants';
 import {
   MetricDisplayType,
-  MetricQueryType,
+  MetricExpressionType,
   type MetricWidgetQueryParams,
 } from 'sentry/utils/metrics/types';
 import {parseMetricWidgetsQueryParam} from 'sentry/views/metrics/utils/parseMetricWidgetsQueryParam';
@@ -30,7 +30,7 @@ describe('parseMetricWidgetQueryParam', () => {
         // INPUT
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'sum',
           query: 'test:query',
@@ -46,7 +46,7 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'sum',
           query: 'test:query',
@@ -67,7 +67,7 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'sum',
           query: 'test:query',
@@ -80,7 +80,7 @@ describe('parseMetricWidgetQueryParam', () => {
         },
         {
           id: 0,
-          type: MetricQueryType.FORMULA,
+          type: MetricExpressionType.EQUATION,
           formula: 'a + b',
           displayType: 'line',
           sort: {name: 'avg', order: 'desc'},
@@ -89,7 +89,7 @@ describe('parseMetricWidgetQueryParam', () => {
         },
         {
           id: 1,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:custom/sentry.event_manager.save@second',
           op: 'avg',
           query: '',
@@ -105,7 +105,7 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'sum',
           query: 'test:query',
@@ -118,7 +118,7 @@ describe('parseMetricWidgetQueryParam', () => {
         },
         {
           id: 1,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:custom/sentry.event_manager.save@second',
           op: 'avg',
           query: '',
@@ -132,7 +132,7 @@ describe('parseMetricWidgetQueryParam', () => {
         // Formulas should always be at the end
         {
           id: 0,
-          type: MetricQueryType.FORMULA,
+          type: MetricExpressionType.EQUATION,
           formula: 'a + b',
           displayType: MetricDisplayType.LINE,
           sort: {name: 'avg', order: 'desc'},
@@ -150,11 +150,11 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
         },
         {
-          type: MetricQueryType.FORMULA,
+          type: MetricExpressionType.EQUATION,
           formula: 'a * 2',
         },
       ],
@@ -162,7 +162,7 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'avg',
           query: '',
@@ -175,7 +175,7 @@ describe('parseMetricWidgetQueryParam', () => {
         },
         {
           id: 0,
-          type: MetricQueryType.FORMULA,
+          type: MetricExpressionType.EQUATION,
           formula: 'a * 2',
           displayType: MetricDisplayType.LINE,
           focusedSeries: [],
@@ -207,7 +207,7 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'avg',
           query: '',
@@ -244,14 +244,14 @@ describe('parseMetricWidgetQueryParam', () => {
         },
         {
           // Missing formula
-          type: MetricQueryType.FORMULA,
+          type: MetricExpressionType.EQUATION,
         },
       ],
       // RESULT
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'avg',
           query: '',
@@ -275,7 +275,7 @@ describe('parseMetricWidgetQueryParam', () => {
         },
         {
           // Missing formula
-          type: MetricQueryType.FORMULA,
+          type: MetricExpressionType.EQUATION,
         },
       ],
       // RESULT
@@ -289,7 +289,7 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'sum',
           query: 'test:query',
@@ -305,7 +305,7 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'sum',
           query: 'test:query',
@@ -324,7 +324,7 @@ describe('parseMetricWidgetQueryParam', () => {
     function widgetWithId<T extends number | undefined>(id: T) {
       return {
         id,
-        type: MetricQueryType.QUERY as const,
+        type: MetricExpressionType.QUERY as const,
         mri: 'd:transactions/duration@millisecond' as const,
         op: 'sum' as const,
         query: 'test:query',
@@ -366,7 +366,7 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 5,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'sum',
           query: 'test:query',
@@ -382,7 +382,7 @@ describe('parseMetricWidgetQueryParam', () => {
       [
         {
           id: 0,
-          type: MetricQueryType.QUERY,
+          type: MetricExpressionType.QUERY,
           mri: 'd:transactions/duration@millisecond',
           op: 'sum',
           query: 'test:query',

--- a/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.tsx
+++ b/static/app/views/metrics/utils/parseMetricWidgetsQueryParam.tsx
@@ -9,8 +9,8 @@ import {
   type BaseWidgetParams,
   type FocusedMetricsSeries,
   MetricDisplayType,
+  MetricExpressionType,
   type MetricFormulaWidgetParams,
-  MetricQueryType,
   type MetricQueryWidgetParams,
   type MetricWidgetQueryParams,
   type SortState,
@@ -120,9 +120,9 @@ function isValidId(n: number | undefined): n is number {
 function parseQueryType(
   widget: Record<string, unknown>,
   key: string
-): MetricQueryType | undefined {
+): MetricExpressionType | undefined {
   const value = widget[key];
-  return typeof value === 'number' && Object.values(MetricQueryType).includes(value)
+  return typeof value === 'number' && Object.values(MetricExpressionType).includes(value)
     ? value
     : undefined;
 }
@@ -146,7 +146,7 @@ function parseQueryWidget(
     ),
     powerUserMode: parseBooleanParam(widget, 'powerUserMode') ?? false,
     ...baseWidgetParams,
-    type: MetricQueryType.QUERY,
+    type: MetricExpressionType.QUERY,
   };
 }
 
@@ -163,7 +163,7 @@ function parseFormulaWidget(
   return {
     formula,
     ...baseWidgetParams,
-    type: MetricQueryType.FORMULA,
+    type: MetricExpressionType.EQUATION,
   };
 }
 
@@ -219,15 +219,17 @@ export function parseMetricWidgetsQueryParam(
       return;
     }
 
-    const type = parseQueryType(widget, 'type') ?? MetricQueryType.QUERY;
+    const type = parseQueryType(widget, 'type') ?? MetricExpressionType.QUERY;
 
     const id = parseQueryId(widget, 'id');
-    if (type === MetricQueryType.QUERY ? usedQueryIds.has(id) : usedFormulaIds.has(id)) {
+    if (
+      type === MetricExpressionType.QUERY ? usedQueryIds.has(id) : usedFormulaIds.has(id)
+    ) {
       // We drop widgets with duplicate ids
       return;
     }
     if (id !== NO_QUERY_ID) {
-      if (type === MetricQueryType.QUERY) {
+      if (type === MetricExpressionType.QUERY) {
         usedQueryIds.add(id);
       } else {
         usedFormulaIds.add(id);
@@ -248,7 +250,7 @@ export function parseMetricWidgetsQueryParam(
     };
 
     switch (type) {
-      case MetricQueryType.QUERY: {
+      case MetricExpressionType.QUERY: {
         const query = parseQueryWidget(widget, baseWidgetParams);
         if (!query) {
           break;
@@ -259,7 +261,7 @@ export function parseMetricWidgetsQueryParam(
         }
         break;
       }
-      case MetricQueryType.FORMULA: {
+      case MetricExpressionType.EQUATION: {
         const formula = parseFormulaWidget(widget, baseWidgetParams);
         if (!formula) {
           break;

--- a/static/app/views/metrics/utils/useFormulaDependencies.tsx
+++ b/static/app/views/metrics/utils/useFormulaDependencies.tsx
@@ -1,7 +1,10 @@
 import {useCallback, useMemo} from 'react';
 
 import {unescapeMetricsFormula} from 'sentry/utils/metrics';
-import {MetricQueryType, type MetricQueryWidgetParams} from 'sentry/utils/metrics/types';
+import {
+  MetricExpressionType,
+  type MetricQueryWidgetParams,
+} from 'sentry/utils/metrics/types';
 import {useMetricsContext} from 'sentry/views/metrics/context';
 import {parseFormula} from 'sentry/views/metrics/formulaParser/parser';
 import {type TokenList, TokenType} from 'sentry/views/metrics/formulaParser/types';
@@ -17,7 +20,7 @@ export function useFormulaDependencies() {
   const queriesLookup = useMemo(() => {
     const lookup = new Map<string, MetricQueryWidgetParams>();
     widgets.forEach(widget => {
-      if (widget.type === MetricQueryType.QUERY) {
+      if (widget.type === MetricExpressionType.QUERY) {
         lookup.set(getQuerySymbol(widget.id), widget);
       }
     });
@@ -56,7 +59,7 @@ export function useFormulaDependencies() {
 
   const formulaDependencies = useMemo(() => {
     return widgets.reduce((acc: Record<number, FormulaDependencies>, widget) => {
-      if (widget.type === MetricQueryType.FORMULA) {
+      if (widget.type === MetricExpressionType.EQUATION) {
         acc[widget.id] = getFormulaQueryDependencies(widget.formula);
       }
       return acc;

--- a/static/app/views/metrics/utils/useMetricsIntervalParam.tsx
+++ b/static/app/views/metrics/utils/useMetricsIntervalParam.tsx
@@ -16,7 +16,7 @@ import type {PageFilters} from 'sentry/types';
 import {parsePeriodToHours} from 'sentry/utils/dates';
 import {useUpdateQuery} from 'sentry/utils/metrics';
 import {parseMRI} from 'sentry/utils/metrics/mri';
-import {MetricQueryType} from 'sentry/utils/metrics/types';
+import {MetricExpressionType} from 'sentry/utils/metrics/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -87,7 +87,7 @@ export function useMetricsIntervalParam() {
   const isCustomMetricsOnly = useMemo(() => {
     return widgets.every(
       widget =>
-        widget.type === MetricQueryType.FORMULA ||
+        widget.type === MetricExpressionType.EQUATION ||
         parseMRI(widget.mri)?.useCase === 'custom'
     );
   }, [widgets]);

--- a/static/app/views/metrics/utils/widgetToQuery.tsx
+++ b/static/app/views/metrics/utils/widgetToQuery.tsx
@@ -1,4 +1,7 @@
-import {MetricQueryType, type MetricWidgetQueryParams} from 'sentry/utils/metrics/types';
+import {
+  MetricExpressionType,
+  type MetricWidgetQueryParams,
+} from 'sentry/utils/metrics/types';
 import type {MetricsQueryApiQueryParams} from 'sentry/utils/metrics/useMetricsQuery';
 import {getEquationSymbol} from 'sentry/views/metrics/equationSymbol copy';
 import {getQuerySymbol} from 'sentry/views/metrics/querySymbol';
@@ -7,7 +10,7 @@ export function widgetToQuery(
   widget: MetricWidgetQueryParams,
   isQueryOnly = false
 ): MetricsQueryApiQueryParams {
-  return widget.type === MetricQueryType.FORMULA
+  return widget.type === MetricExpressionType.EQUATION
     ? {
         name: getEquationSymbol(widget.id),
         formula: widget.formula,

--- a/static/app/views/metrics/widgetDetails.tsx
+++ b/static/app/views/metrics/widgetDetails.tsx
@@ -19,7 +19,7 @@ import type {
   MetricQueryWidgetParams,
   MetricWidgetQueryParams,
 } from 'sentry/utils/metrics/types';
-import {MetricQueryType} from 'sentry/utils/metrics/types';
+import {MetricExpressionType} from 'sentry/utils/metrics/types';
 import type {MetricsSamplesResults} from 'sentry/utils/metrics/useMetricsSamples';
 import useOrganization from 'sentry/utils/useOrganization';
 import {CodeLocations} from 'sentry/views/metrics/codeLocations';
@@ -53,7 +53,7 @@ export function WidgetDetails() {
   );
 
   // TODO(aknaus): better fallback
-  if (selectedWidget?.type === MetricQueryType.FORMULA) {
+  if (selectedWidget?.type === MetricExpressionType.EQUATION) {
     <MetricDetails onRowHover={handleSampleRowHover} focusArea={focusArea} />;
   }
 


### PR DESCRIPTION
Rename `MetricQueryType` to `MetricExpressionType`.
Rename `MetricQueryType.FORMULA` to `MetricExpressionType.EQUATION`