### PR TITLE
ref(crons): Rerun broken monitor env task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1038,8 +1038,8 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "monitors-detect-broken-monitor-envs": {
         "task": "sentry.monitors.tasks.detect_broken_monitor_envs",
-        # 05:00 PDT, 09:00 EDT, 12:00 UTC
-        "schedule": crontab(minute="0", hour="12"),
+        # 12:00 PDT, 15:00 EDT, 19:00 UTC
+        "schedule": crontab(minute="0", hour="19"),
         "options": {"expires": 15 * 60},
     },
     "clear-expired-snoozes": {


### PR DESCRIPTION
Run this task in a few hours, as we want to run it with the changes from https://github.com/getsentry/sentry/pull/67818