### PR TITLE
ref: remove unused pickle.send-error-to-sentry option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2214,13 +2214,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# sample rate for pickle error collection
-register(
-    "pickle.send-error-to-sentry",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # killswitch for profiling ddm functions metrics.
 # Enable/Disable the ingestion of function metrics
 # in the generic metrics platform


### PR DESCRIPTION
blocks https://github.com/getsentry/sentry-options-automator/pull/987

<!-- Describe your PR here. -->