### PR TITLE
chore(sdk): Bump sentry-sdk to 1.44.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -66,7 +66,7 @@ sentry-kafka-schemas>=0.1.64
 sentry-ophio==0.2.6
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.55
-sentry-sdk>=1.43.0
+sentry-sdk>=1.44.0
 snuba-sdk>=2.0.31
 simplejson>=3.17.6
 sqlparse>=0.4.4

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -180,7 +180,7 @@ sentry-kafka-schemas==0.1.64
 sentry-ophio==0.2.6
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.55
-sentry-sdk==1.43.0
+sentry-sdk==1.44.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -122,7 +122,7 @@ sentry-kafka-schemas==0.1.64
 sentry-ophio==0.2.6
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.55
-sentry-sdk==1.43.0
+sentry-sdk==1.44.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Literal, NotRequired, TypedDict
 
-# This shouild be imported from sentry_sdk, but it is currenntly not avalable
-# due to the way it's being exported
-#
-# see: https://github.com/getsentry/sentry-python/issues/2909
-# see: https://github.com/getsentry/sentry-python/issues/2910
-_Event = Any
+from sentry_sdk.types import Event
 
 
 class SdkConfig(TypedDict):
@@ -23,8 +18,8 @@ class SdkConfig(TypedDict):
 
     send_client_reports: NotRequired[bool]
     traces_sampler: NotRequired[Callable[[dict[str, Any]], float]]
-    before_send: NotRequired[Callable[[_Event, dict[str, Any]], _Event | None]]
-    before_send_transaction: NotRequired[Callable[[_Event, dict[str, Any]], _Event | None]]
+    before_send: NotRequired[Callable[[Event, dict[str, Any]], Event | None]]
+    before_send_transaction: NotRequired[Callable[[Event, dict[str, Any]], Event | None]]
     profiles_sample_rate: NotRequired[float]
     profiler_mode: NotRequired[Literal["sleep", "thread", "gevent", "unknown"]]
     enable_db_query_source: NotRequired[bool]


### PR DESCRIPTION
Bumps the SDK to 1.44.0. Also, now imports the `Event` type from the SDK, since the issues that previously prevented this import have been resolved.
