### PR TITLE
feat(trace): add no data message

### DIFF
--- a/static/app/views/performance/newTraceDetails/guards.tsx
+++ b/static/app/views/performance/newTraceDetails/guards.tsx
@@ -67,7 +67,9 @@ export function isTraceNode(
   );
 }
 
-export function isNoDataNode(node: TraceTreeNode<TraceTree.NodeValue>): boolean {
+export function isNoDataNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): node is NoDataNode {
   return node instanceof NoDataNode;
 }
 

--- a/static/app/views/performance/newTraceDetails/guards.tsx
+++ b/static/app/views/performance/newTraceDetails/guards.tsx
@@ -1,5 +1,6 @@
 import {
   MissingInstrumentationNode,
+  NoDataNode,
   ParentAutogroupNode,
   SiblingAutogroupNode,
   type TraceTree,
@@ -54,7 +55,7 @@ export function isTraceErrorNode(
 export function isRootNode(
   node: TraceTreeNode<TraceTree.NodeValue>
 ): node is TraceTreeNode<null> {
-  return node.value === null;
+  return node.value === null && !(node instanceof NoDataNode);
 }
 
 export function isTraceNode(
@@ -64,6 +65,10 @@ export function isTraceNode(
     node.value &&
     ('orphan_errors' in node.value || 'transactions' in node.value)
   );
+}
+
+export function isNoDataNode(node: TraceTreeNode<TraceTree.NodeValue>): boolean {
+  return node instanceof NoDataNode;
 }
 
 export function shouldAddMissingInstrumentationSpan(sdk: string | undefined): boolean {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/noData.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/noData.tsx
@@ -1,0 +1,73 @@
+import {useRef} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {Button} from 'sentry/components/button';
+import useFeedbackWidget from 'sentry/components/feedback/widget/useFeedbackWidget';
+import {IconGroup} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import type {Organization} from 'sentry/types';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import {
+  makeTraceNodeBarColor,
+  type NoDataNode,
+  type TraceTree,
+  type TraceTreeNode,
+} from 'sentry/views/performance/newTraceDetails/traceTree';
+import {Row} from 'sentry/views/performance/traceDetails/styles';
+
+interface NoDataDetailsProps {
+  node: NoDataNode;
+  onParentClick: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
+  organization: Organization;
+  scrollToNode: (node: TraceTreeNode<TraceTree.NodeValue>) => void;
+}
+
+export function NoDataDetails(props: NoDataDetailsProps) {
+  const theme = useTheme();
+
+  return (
+    <TraceDrawerComponents.DetailContainer>
+      <TraceDrawerComponents.HeaderContainer>
+        <TraceDrawerComponents.IconTitleWrapper>
+          <TraceDrawerComponents.IconBorder
+            backgroundColor={makeTraceNodeBarColor(theme, props.node)}
+          >
+            <IconGroup />
+          </TraceDrawerComponents.IconBorder>
+          <div style={{fontWeight: 'bold'}}>{t('Empty')}</div>
+        </TraceDrawerComponents.IconTitleWrapper>
+
+        <TraceDrawerComponents.Actions>
+          <Button size="xs" onClick={_e => props.scrollToNode(props.node)}>
+            {t('Show in view')}
+          </Button>
+        </TraceDrawerComponents.Actions>
+      </TraceDrawerComponents.HeaderContainer>
+
+      <TraceDrawerComponents.Table className="table key-value">
+        <tbody>
+          <Row title={t('Data quality')}>
+            {tct(
+              'The cause of missing data could be misconfiguration or lack of instrumentation. Send us [feedback] if you are having trouble figuring this out.',
+              {feedback: <InlineFeedbackLink />}
+            )}
+          </Row>
+        </tbody>
+      </TraceDrawerComponents.Table>
+    </TraceDrawerComponents.DetailContainer>
+  );
+}
+
+function InlineFeedbackLink() {
+  const linkref = useRef<HTMLAnchorElement>(null);
+  const feedback = useFeedbackWidget({buttonRef: linkref});
+  return feedback ? (
+    <a href="#" ref={linkref}>
+      {t('feedback')}
+    </a>
+  ) : (
+    <a href="mailto:support@sentry.io?subject=Trace%20does%20not%20contain%20data">
+      {t('feedback')}
+    </a>
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/details.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/details.tsx
@@ -5,6 +5,7 @@ import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDeta
 
 import {
   isMissingInstrumentationNode,
+  isNoDataNode,
   isParentAutogroupedNode,
   isSiblingAutogroupedNode,
   isSpanNode,
@@ -14,6 +15,7 @@ import {
 import type {TraceTree, TraceTreeNode} from '../../traceTree';
 import {ErrorNodeDetails} from '../details/error';
 import {MissingInstrumentationNodeDetails} from '../details/missingInstrumentation';
+import {NoDataDetails} from '../details/noData';
 import {ParentAutogroupNodeDetails} from '../details/parentAutogroup';
 import {SiblingAutogroupNodeDetails} from '../details/siblingAutogroup';
 import {SpanNodeDetails} from '../details/span';
@@ -93,6 +95,17 @@ export default function NodeDetail({
   if (isMissingInstrumentationNode(node)) {
     return (
       <MissingInstrumentationNodeDetails node={node} onParentClick={onParentClick} />
+    );
+  }
+
+  if (isNoDataNode(node)) {
+    return (
+      <NoDataDetails
+        node={node}
+        onParentClick={onParentClick}
+        organization={organization}
+        scrollToNode={scrollToNode}
+      />
     );
   }
 

--- a/static/app/views/performance/newTraceDetails/traceTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabs.tsx
@@ -9,6 +9,7 @@ import type {
 import {
   isAutogroupedNode,
   isMissingInstrumentationNode,
+  isNoDataNode,
   isSpanNode,
   isTraceErrorNode,
   isTraceNode,
@@ -41,6 +42,10 @@ export function getTraceTabTitle(node: TraceTreeNode<TraceTree.NodeValue>) {
 
   if (isTraceNode(node)) {
     return t('Trace');
+  }
+
+  if (isNoDataNode(node)) {
+    return t('Empty');
   }
 
   Sentry.captureMessage('Unknown node type in trace drawer');

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -241,6 +241,9 @@ export function makeTraceNodeBarColor(
   if (isTraceErrorNode(node)) {
     return theme.red300;
   }
+  if (isNoDataNode(node)) {
+    return theme.yellow300;
+  }
   return pickBarColor('default');
 }
 
@@ -512,7 +515,7 @@ export class TraceTree {
     }
 
     // If we have no spans, insert an empty node to indicate that there is no data
-    if (!spans.length) {
+    if (!spans.length && !parent.children.length) {
       parent.zoomedIn = true;
       parent.spanChildren.push(new NoDataNode(parent));
       return parent;

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -1127,8 +1127,12 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
     }
   }
 
-  cloneDeep(): TraceTreeNode<T> | ParentAutogroupNode | SiblingAutogroupNode {
-    let node: TraceTreeNode<T> | ParentAutogroupNode | SiblingAutogroupNode;
+  cloneDeep():
+    | TraceTreeNode<T>
+    | ParentAutogroupNode
+    | SiblingAutogroupNode
+    | NoDataNode {
+    let node: TraceTreeNode<T> | ParentAutogroupNode | SiblingAutogroupNode | NoDataNode;
 
     if (isParentAutogroupedNode(this)) {
       node = new ParentAutogroupNode(
@@ -1139,6 +1143,8 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
         this.tail
       );
       node.groupCount = this.groupCount;
+    } else if (isNoDataNode(this)) {
+      node = new NoDataNode(this.parent);
     } else {
       node = new TraceTreeNode(this.parent, this.value, this.metadata);
     }

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -1152,7 +1152,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue> {
       clone = new SiblingAutogroupNode(this.parent, this.value, this.metadata);
       clone.groupCount = this.groupCount;
     } else if (isNoDataNode(this)) {
-      node = new NoDataNode(this.parent);
+      clone = new NoDataNode(this.parent);
     } else {
       clone = new TraceTreeNode(this.parent, this.value, this.metadata);
     }

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.spec.tsx
@@ -430,6 +430,42 @@ describe('VirtualizedViewManger', () => {
       expect(manager.list.scrollToRow).toHaveBeenCalledWith(2);
     });
 
+    it('scrolls to empty data node of expanded transaction', async () => {
+      manager.list = makeList();
+
+      const tree = TraceTree.FromTrace(
+        makeTrace({
+          transactions: [
+            makeTransaction({
+              event_id: 'event_id',
+              project_slug: 'project',
+              children: [],
+            }),
+          ],
+        })
+      );
+
+      MockApiClient.addMockResponse({
+        url: EVENT_REQUEST_URL,
+        method: 'GET',
+        body: makeEvent(undefined, []),
+      });
+
+      const result = await manager.scrollToPath(
+        tree,
+        ['empty:node', 'txn:event_id'],
+        () => void 0,
+        {
+          api: api,
+          organization,
+        }
+      );
+
+      expect(tree.list[1].zoomedIn).toBe(true);
+      expect(result?.node).toBe(tree.list[2]);
+      expect(manager.list.scrollToRow).toHaveBeenCalledWith(2);
+    });
+
     it('scrolls to span -> transaction -> span -> transaction', async () => {
       manager.list = makeList();
 

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -11,6 +11,7 @@ import {lightTheme as theme} from 'sentry/utils/theme';
 import {
   isAutogroupedNode,
   isMissingInstrumentationNode,
+  isNoDataNode,
   isParentAutogroupedNode,
   isSiblingAutogroupedNode,
   isSpanNode,
@@ -1068,6 +1069,7 @@ export class VirtualizedViewManager {
         const nextSegment = segments[segments.length - 1];
         if (
           nextSegment?.startsWith('span:') ||
+          nextSegment?.startsWith('empty:') ||
           nextSegment?.startsWith('ag:') ||
           nextSegment?.startsWith('ms:')
         ) {
@@ -2031,6 +2033,10 @@ function findInTreeFromSegment(
 
     if (type === 'error' && isTraceErrorNode(node)) {
       return node.value.event_id === id;
+    }
+
+    if (type === 'empty' && isNoDataNode(node)) {
+      return true;
     }
 
     return false;


### PR DESCRIPTION
Sometimes we try to fetch data from traces that have no children (we dont know aot). When the data fetched is empty, we previously just didnt show anything, so it looked like the UI never updated. With this, we will now show an empty data row and explain the cause. The new row is linkable, just like everything else so users can share direct links to this nodes as well.

![CleanShot 2024-03-28 at 16 50 07@2x](https://github.com/getsentry/sentry/assets/9317857/c3c558c4-f81c-47ca-9ca4-119c1abcf9d0)
