### PR TITLE
feat(autofix): Add endpoint for tracking proper setup

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.group import GroupEndpoint
+from sentry.api.endpoints.event_ai_suggested_fix import get_openai_policy
+from sentry.constants import ObjectStatus
+from sentry.models.group import Group
+from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.models.organization import Organization
+from sentry.services.hybrid_cloud.integration import integration_service
+
+logger = logging.getLogger(__name__)
+
+from rest_framework.request import Request
+
+
+def get_autofix_integration_setup_problems(organization: Organization) -> str | None:
+    """
+    Runs through the checks to see if we can use the GitHub integration for Autofix.
+
+    If there are no issues, returns None.
+    If there is an issue, returns the reason.
+    """
+    integrations = integration_service.get_organization_integrations(
+        organization_id=organization.id, providers=["github"], limit=1
+    )
+
+    integration = integrations[0] if integrations else None
+
+    if not integration:
+        return "integration_missing"
+
+    if integration.status != ObjectStatus.ACTIVE:
+        return "integration_inactive"
+
+    if not RepositoryProjectPathConfig.objects.filter(
+        organization_integration_id=integration.id
+    ).exists():
+        return "integration_no_code_mappings"
+
+    return None
+
+
+@region_silo_endpoint
+class GroupAutofixSetupCheck(GroupEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    private = True
+
+    def get(self, request: Request, group: Group) -> Response:
+        """
+        Checks if we are able to run Autofix on the given group.
+        """
+        if not features.has("projects:ai-autofix", group.project):
+            return Response({"detail": "Feature not enabled for project"}, status=403)
+
+        policy = get_openai_policy(
+            request.organization,
+            request.user,
+            pii_certified=True,
+        )
+
+        requires_subprocessor_consent = policy == "subprocessor"
+
+        org: Organization = request.organization
+        has_gen_ai_consent = org.get_option("sentry:gen_ai_consent", False)
+
+        integration_check = get_autofix_integration_setup_problems(organization=org)
+
+        return Response(
+            {
+                "subprocessorConsent": {
+                    "ok": not requires_subprocessor_consent,
+                    "reason": None,
+                },
+                "genAIConsent": {
+                    "ok": has_gen_ai_consent,
+                    "reason": None,
+                },
+                "integration": {
+                    "ok": integration_check is None,
+                    "reason": integration_check,
+                },
+            }
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls import include
 from django.urls import URLPattern, URLResolver, re_path
 
 from sentry.api.endpoints.bundle_analysis import BundleAnalysisEndpoint
+from sentry.api.endpoints.group_autofix_setup_check import GroupAutofixSetupCheck
 from sentry.api.endpoints.group_event_details import GroupEventDetailsEndpoint
 from sentry.api.endpoints.group_similar_issues_embeddings import (
     GroupSimilarIssuesEmbeddingsEndpoint,
@@ -765,6 +766,11 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
             r"^(?P<issue_id>[^\/]+)/ai-autofix/$",
             GroupAiAutofixEndpoint.as_view(),
             name=f"{name_prefix}-group-ai-autofix",
+        ),
+        re_path(
+            r"^(?P<issue_id>[^\/]+)/autofix/setup/$",
+            GroupAutofixSetupCheck.as_view(),
+            name=f"{name_prefix}-group-autofix-setup",
         ),
         # Load plugin group urls
         re_path(

--- a/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_setup_check.py
@@ -1,0 +1,138 @@
+from unittest.mock import patch
+
+from sentry.constants import ObjectStatus
+from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.models.repository import Repository
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
+from sentry.testutils.silo import assume_test_silo_mode
+
+
+@apply_feature_flag_on_cls("projects:ai-autofix")
+class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+
+        integration = self.create_integration(organization=self.organization, external_id="1")
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.org_integration = integration.add_organization(self.organization, self.user)
+
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="example",
+            integration_id=integration.id,
+        )
+        self.code_mapping = self.create_code_mapping(
+            repo=self.repo,
+            project=self.project,
+            stack_root="sentry/",
+            source_root="sentry/",
+        )
+        self.organization.update_option("sentry:gen_ai_consent", True)
+
+    def test_successful_setup(self):
+        """
+        Everything is set up correctly, should respond with OKs.
+        """
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data == {
+            "subprocessorConsent": {
+                "ok": True,
+                "reason": None,
+            },
+            "genAIConsent": {
+                "ok": True,
+                "reason": None,
+            },
+            "integration": {
+                "ok": True,
+                "reason": None,
+            },
+        }
+
+
+@apply_feature_flag_on_cls("projects:ai-autofix")
+class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
+    def test_no_gen_ai_consent(self):
+        self.organization.update_option("sentry:gen_ai_consent", False)
+
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["genAIConsent"] == {
+            "ok": False,
+            "reason": None,
+        }
+
+    @patch(
+        "sentry.api.endpoints.group_autofix_setup_check.get_openai_policy",
+        return_value="subprocessor",
+    )
+    def test_needs_subprocessor_consent(self, mock):
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/issues/{group.id}/autofix/setup/"
+
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["subprocessorConsent"] == {
+            "ok": False,
+            "reason": None,
+        }
+
+    def test_no_code_mappings(self):
+        RepositoryProjectPathConfig.objects.filter(
+            organization_integration_id=self.organization_integration.id
+        ).delete()
+
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["integration"] == {
+            "ok": False,
+            "reason": "integration_no_code_mappings",
+        }
+
+    def test_disabled_integration(self):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.organization_integration.update(status=ObjectStatus.DISABLED)
+
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["integration"] == {
+            "ok": False,
+            "reason": "integration_inactive",
+        }
+
+    def test_missing_integration(self):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.organization_integration.delete()
+
+        group = self.create_group()
+        self.login_as(user=self.user)
+        url = f"/api/0/issues/{group.id}/autofix/setup/"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["integration"] == {
+            "ok": False,
+            "reason": "integration_missing",
+        }


### PR DESCRIPTION
Adds the endpoint `GET /issues/<issue_id>/autofix/setup/`

This checks whether we are able to run Autofix on the given issue. It checks for:

- Whether the organization needs to consent to a subprocessor in order to participate
- Whether the organization needs to consent to our generative AI agreement
- Proper GitHub integration setup

This will be used in onboarding materials to make Autofix simpler to get started.