### PR TITLE
fix(trends): Cross query pollution in trends endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -115,7 +115,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 (event["project_id"], re.sub(r'"', '\\"', event["transaction"])) for event in events
             ]
             conditions = [
-                f"(project_id:{project_id} transaction:{transaction})"
+                f'(project_id:{project_id} transaction:"{transaction}")'
                 for project_id, transaction in pairs
             ]
             return " OR ".join(conditions)


### PR DESCRIPTION
When there are 2 projects that share a transaction name and the 2 transactions are split into 2 different parallel queries, we have an issue where the query returns more data is expected and pollutes the results with duplicate results once the 2 queries are merged. This results in a validation error in Seer.