### PR TITLE
feat(fingeprint_rules): Support release as a matcher

### DIFF
--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -283,6 +283,7 @@ MATCHERS = {
     "family": "family",
     "app": "app",
     "sdk": "sdk",
+    "release": "release",
 }
 
 

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -130,6 +130,7 @@ error.type:DatabaseUnavailable                        -> DatabaseUnavailable
 stack.function:assertion_failed stack.module:foo      -> AssertionFailed, foo
 app:true                                        -> aha
 app:true                                        -> {{ default }}
+release:foo                                     -> {{ default }}
 """
     )
     assert rules._to_config_structure() == {
@@ -146,6 +147,7 @@ app:true                                        -> {{ default }}
             },
             {"matchers": [["app", "true"]], "fingerprint": ["aha"], "attributes": {}},
             {"matchers": [["app", "true"]], "fingerprint": ["{{ default }}"], "attributes": {}},
+            {"matchers": [["release", "foo"]], "fingerprint": ["{{ default }}"], "attributes": {}},
         ],
         "version": 1,
     }


### PR DESCRIPTION
If a customer tried to use `release` in Fingerprint rules it would show an `Unknown matcher` message.

This fixes #67836
<img width="872" alt="image" src="https://github.com/getsentry/sentry/assets/44410/92adc93b-5334-46da-9fcc-94fb4fb91813">

