### PR TITLE
fix(trace): dont autogroup on autogrouped nodes

### DIFF
--- a/static/app/views/performance/newTraceDetails/guards.tsx
+++ b/static/app/views/performance/newTraceDetails/guards.tsx
@@ -42,7 +42,7 @@ export function isSiblingAutogroupedNode(
 export function isAutogroupedNode(
   node: TraceTreeNode<TraceTree.NodeValue>
 ): node is ParentAutogroupNode | SiblingAutogroupNode {
-  return !!(node.value && 'autogrouped_by' in node.value);
+  return node instanceof ParentAutogroupNode || node instanceof SiblingAutogroupNode;
 }
 
 export function isTraceErrorNode(


### PR DESCRIPTION
Fixes autogrouped reassignment of tree nodes when tree is mutated at some parent level which was causing NaN value and incorrect hierarchy when we had a chain of autogrouped nodes