### PR TITLE
feat(issue-priority): Add a timeout to Seer requests

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -760,6 +760,13 @@ register(
 )
 
 register(
+    "issues.severity.seer-timout",
+    type=Float,
+    default=0.2,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "issues.severity.default-high-priority-alerts-orgs-allowlist",
     type=Sequence,
     default=[],

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -70,6 +70,7 @@ class TestGetEventSeverity(TestCase):
             "/v0/issues/severity-score",
             body=json.dumps(payload),
             headers={"content-type": "application/json;charset=utf-8"},
+            timeout=0.2,
         )
         mock_logger_info.assert_called_with(
             "Got severity score of %s for event %s",
@@ -116,6 +117,7 @@ class TestGetEventSeverity(TestCase):
                 "/v0/issues/severity-score",
                 body=json.dumps(payload),
                 headers={"content-type": "application/json;charset=utf-8"},
+                timeout=0.2,
             )
             mock_logger_info.assert_called_with(
                 "Got severity score of %s for event %s",


### PR DESCRIPTION
Add a configurable timeout of 200ms to Seer requests, 2 * P99 of 100ms for the `severity_endpoint`.
