### PR TITLE
ref(performance): Remove Apdex and User Misery charts on landing page

### DIFF
--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -1,6 +1,7 @@
 import {canUseMetricsData} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {PerformanceDisplayProvider} from 'sentry/utils/performance/contexts/performanceDisplayContext';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import Table from '../../table';
 import {ProjectPerformanceType} from '../../utils';
@@ -12,6 +13,33 @@ import type {BasePerformanceViewProps} from './types';
 export function AllTransactionsView(props: BasePerformanceViewProps) {
   const {setPageError} = usePageAlert();
   const doubleChartRowCharts: PerformanceWidgetSetting[] = [];
+  const organization = useOrganization();
+
+  let allowedCharts = [
+    PerformanceWidgetSetting.USER_MISERY_AREA,
+    PerformanceWidgetSetting.TPM_AREA,
+    PerformanceWidgetSetting.FAILURE_RATE_AREA,
+    PerformanceWidgetSetting.APDEX_AREA,
+    PerformanceWidgetSetting.P50_DURATION_AREA,
+    PerformanceWidgetSetting.P75_DURATION_AREA,
+    PerformanceWidgetSetting.P95_DURATION_AREA,
+    PerformanceWidgetSetting.P99_DURATION_AREA,
+  ];
+
+  const hasTransactionSummaryCleanupFlag = organization.features.includes(
+    'performance-transaction-summary-cleanup'
+  );
+
+  if (hasTransactionSummaryCleanupFlag) {
+    allowedCharts = [
+      PerformanceWidgetSetting.TPM_AREA,
+      PerformanceWidgetSetting.FAILURE_RATE_AREA,
+      PerformanceWidgetSetting.P50_DURATION_AREA,
+      PerformanceWidgetSetting.P75_DURATION_AREA,
+      PerformanceWidgetSetting.P95_DURATION_AREA,
+      PerformanceWidgetSetting.P99_DURATION_AREA,
+    ];
+  }
 
   if (
     props.organization.features.includes('performance-new-trends') &&
@@ -40,19 +68,7 @@ export function AllTransactionsView(props: BasePerformanceViewProps) {
     <PerformanceDisplayProvider value={{performanceType: ProjectPerformanceType.ANY}}>
       <div data-test-id="all-transactions-view">
         <DoubleChartRow {...props} allowedCharts={doubleChartRowCharts} />
-        <TripleChartRow
-          {...props}
-          allowedCharts={[
-            PerformanceWidgetSetting.USER_MISERY_AREA,
-            PerformanceWidgetSetting.TPM_AREA,
-            PerformanceWidgetSetting.FAILURE_RATE_AREA,
-            PerformanceWidgetSetting.APDEX_AREA,
-            PerformanceWidgetSetting.P50_DURATION_AREA,
-            PerformanceWidgetSetting.P75_DURATION_AREA,
-            PerformanceWidgetSetting.P95_DURATION_AREA,
-            PerformanceWidgetSetting.P99_DURATION_AREA,
-          ]}
-        />
+        <TripleChartRow {...props} allowedCharts={allowedCharts} />
         <Table {...props} setError={setPageError} />
       </div>
     </PerformanceDisplayProvider>


### PR DESCRIPTION
As we move to a spans-only architecture, these charts will no longer be supported. For now, we're hiding them behind a feature flag as we transition away from them.

The charts in question, on the performance landing page:

![image](https://github.com/getsentry/sentry/assets/16740047/6f86527f-35ec-4c8c-b255-a3157e8e43a0)
