### PR TITLE
feat(relocation): Allow staff to always see public keys

### DIFF
--- a/tests/sentry/api/endpoints/relocations/test_public_key.py
+++ b/tests/sentry/api/endpoints/relocations/test_public_key.py
@@ -6,6 +6,7 @@ from google.api_core.exceptions import GoogleAPIError
 from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.backups import FakeKeyManagementServiceClient, generate_rsa_key_pair
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 
 
@@ -37,6 +38,43 @@ class GetRelocationPublicKeyTest(APITestCase):
     ):
         superuser = self.create_user("superuser", is_superuser=True, is_active=True)
         self.login_as(user=superuser, superuser=True)
+        self.mock_kms_client(fake_kms_client)
+        response = self.get_success_response(status_code=200)
+
+        assert response.status_code == 200
+        assert bytes(response.data["public_key"], "utf-8") == self.pub_key_pem
+        assert fake_kms_client.get_public_key.call_count == 1
+
+    def test_good_superuser_when_feature_disabled(
+        self, fake_kms_client: FakeKeyManagementServiceClient
+    ):
+        superuser = self.create_user("superuser", is_superuser=True, is_active=True)
+        self.login_as(user=superuser, superuser=True)
+        self.mock_kms_client(fake_kms_client)
+        response = self.get_success_response(status_code=200)
+
+        assert response.status_code == 200
+        assert bytes(response.data["public_key"], "utf-8") == self.pub_key_pem
+        assert fake_kms_client.get_public_key.call_count == 1
+
+    @override_options({"relocation.enabled": True})
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_good_staff_when_feature_enabled(self, fake_kms_client: FakeKeyManagementServiceClient):
+        staff = self.create_user("staff", is_staff=True, is_active=True)
+        self.login_as(user=staff, staff=True)
+        self.mock_kms_client(fake_kms_client)
+        response = self.get_success_response(status_code=200)
+
+        assert response.status_code == 200
+        assert bytes(response.data["public_key"], "utf-8") == self.pub_key_pem
+        assert fake_kms_client.get_public_key.call_count == 1
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_good_staff_when_feature_disabled(
+        self, fake_kms_client: FakeKeyManagementServiceClient
+    ):
+        staff = self.create_user("staff", is_staff=True, is_active=True)
+        self.login_as(user=staff, staff=True)
         self.mock_kms_client(fake_kms_client)
         response = self.get_success_response(status_code=200)
 
@@ -81,5 +119,26 @@ class GetRelocationPublicKeyTest(APITestCase):
     def test_bad_no_auth(self, fake_kms_client: FakeKeyManagementServiceClient):
         self.mock_kms_client(fake_kms_client)
         self.get_error_response(status_code=401)
+
+        assert fake_kms_client.get_public_key.call_count == 0
+
+    def test_bad_superuser_missing_cookie_when_feature_disabled(
+        self, fake_kms_client: FakeKeyManagementServiceClient
+    ):
+        superuser = self.create_user("superuser", is_superuser=True, is_active=True)
+        self.login_as(user=superuser, staff=False)
+        self.mock_kms_client(fake_kms_client)
+        self.get_error_response(status_code=400)
+
+        assert fake_kms_client.get_public_key.call_count == 0
+
+    @with_feature("auth:enterprise-staff-cookie")
+    def test_bad_staff_missing_cookie_when_feature_disabled(
+        self, fake_kms_client: FakeKeyManagementServiceClient
+    ):
+        staff = self.create_user("staff", is_staff=True, is_active=True)
+        self.login_as(user=staff, staff=False)
+        self.mock_kms_client(fake_kms_client)
+        self.get_error_response(status_code=400)
 
         assert fake_kms_client.get_public_key.call_count == 0

--- a/tests/sentry/api/endpoints/relocations/test_public_key.py
+++ b/tests/sentry/api/endpoints/relocations/test_public_key.py
@@ -6,7 +6,6 @@ from google.api_core.exceptions import GoogleAPIError
 from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.backups import FakeKeyManagementServiceClient, generate_rsa_key_pair
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 
 
@@ -57,8 +56,7 @@ class GetRelocationPublicKeyTest(APITestCase):
         assert bytes(response.data["public_key"], "utf-8") == self.pub_key_pem
         assert fake_kms_client.get_public_key.call_count == 1
 
-    @override_options({"relocation.enabled": True})
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"relocation.enabled": True, "staff.ga-rollout": True})
     def test_good_staff_when_feature_enabled(self, fake_kms_client: FakeKeyManagementServiceClient):
         staff = self.create_user("staff", is_staff=True, is_active=True)
         self.login_as(user=staff, staff=True)
@@ -69,7 +67,7 @@ class GetRelocationPublicKeyTest(APITestCase):
         assert bytes(response.data["public_key"], "utf-8") == self.pub_key_pem
         assert fake_kms_client.get_public_key.call_count == 1
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_good_staff_when_feature_disabled(
         self, fake_kms_client: FakeKeyManagementServiceClient
     ):
@@ -132,7 +130,7 @@ class GetRelocationPublicKeyTest(APITestCase):
 
         assert fake_kms_client.get_public_key.call_count == 0
 
-    @with_feature("auth:enterprise-staff-cookie")
+    @override_options({"staff.ga-rollout": True})
     def test_bad_staff_missing_cookie_when_feature_disabled(
         self, fake_kms_client: FakeKeyManagementServiceClient
     ):


### PR DESCRIPTION
Most other `GET` endpoints associated with this feature ignore the `relocation.enabled` option if the user making the request is staff and/or a superuser. The `GET /publickeys/relocations/` did not. By making this change, we make the behavior more consistent across the entire set of APIs.