### PR TITLE
ref(autofix): make event_id optional

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -152,7 +152,15 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
         # This event_id is the event that the user is looking at when they click the "Fix" button
         event_id = data.get("event_id", None)
         if event_id is None:
-            raise ValueError("event_id is required")
+            event = group.get_recommended_event_for_environments()
+            if not event:
+                return Response(
+                    {
+                        "detail": "Could not find recommended event for issue, please try providing an event_id"
+                    },
+                    status=400,
+                )
+            event_id = event.event_id
 
         created_at = datetime.now().isoformat()
         metadata = group.data.get("metadata", {})


### PR DESCRIPTION
If someone doesn't pass in an `event_id` into autofix, don't raise a `ValueError` (this also returns a 500 which is not helpful for the user). Instead, try to find the recommended event for the group to get the `event_id`. If there's no recommended event, return a 400 response (cannot process the request).

Also refactors some of the tests to use the `@patch` decorator instead of `with` + indenting.