### PR TITLE
feat(tracing): Allow multiple average columns

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -349,6 +349,7 @@ class Referrer(Enum):
     )
     API_PERFORMANCE_VITAL_DETAIL = "api.performance.vital-detail"
     API_PERFORMANCE_VITALS_CARDS = "api.performance.vitals-cards"
+    API_PERFORMANCE_ORG_EVENT_AVERAGE_SPAN = "ape.performance.org-event-average-span"
     API_PROFILING_LANDING_CHART = "api.profiling.landing-chart"
     API_PROFILING_LANDING_TABLE = "api.profiling.landing-table"
     API_PROFILING_LANDING_FUNCTIONS_CARD = "api.profiling.landing-functions-card"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -349,7 +349,7 @@ class Referrer(Enum):
     )
     API_PERFORMANCE_VITAL_DETAIL = "api.performance.vital-detail"
     API_PERFORMANCE_VITALS_CARDS = "api.performance.vitals-cards"
-    API_PERFORMANCE_ORG_EVENT_AVERAGE_SPAN = "ape.performance.org-event-average-span"
+    API_PERFORMANCE_ORG_EVENT_AVERAGE_SPAN = "api.performance.org-event-average-span"
     API_PROFILING_LANDING_CHART = "api.profiling.landing-chart"
     API_PROFILING_LANDING_TABLE = "api.profiling.landing-table"
     API_PROFILING_LANDING_FUNCTIONS_CARD = "api.profiling.landing-functions-card"

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -366,7 +366,7 @@ class EventComparisonTest(MetricsEnhancedPerformanceTestCase):
                         assert self.RESULT_COLUMN not in span
 
     def test_invalid_column(self):
-        # If there's nothing stored for a metric, span.duration in this case the query returns nan
+        # If any columns are invalid, ignore average field in results completely
         response = self.client.get(
             self.url, {"averageColumn": ["span.self_time", "span.everything"]}
         )


### PR DESCRIPTION
- This updates the averageColumn param to be a list so multiple columns can be passed, so that the frontend can load both span.self_time and span.duration