### PR TITLE
ref(crons): Rerun broken monitor env task attempt #2

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1038,8 +1038,8 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "monitors-detect-broken-monitor-envs": {
         "task": "sentry.monitors.tasks.detect_broken_monitor_envs",
-        # 12:00 PDT, 15:00 EDT, 19:00 UTC
-        "schedule": crontab(minute="0", hour="19"),
+        # 17:00 PDT, 20:00 EDT, 0:00 UTC
+        "schedule": crontab(minute="0", hour="0"),
         "options": {"expires": 15 * 60},
     },
     "clear-expired-snoozes": {


### PR DESCRIPTION
Unfortunately the last attempt to rerun this task https://github.com/getsentry/sentry/pull/67870 was not successful as the time it took for CI to pass -> merge -> deployment already exceeded the scheduled time of the task. Pushing this task to a comfortable 5 hours into the future to give enough for CI + deploy.