### PR TITLE
fix(generic-metrics): Remove sets and dists from internal metrics Kafka backend

### DIFF
--- a/src/sentry/sentry_metrics/client/kafka.py
+++ b/src/sentry/sentry_metrics/client/kafka.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
@@ -89,67 +88,6 @@ class KafkaMetricsBackend(GenericMetricsBackend):
         }
 
         self.__produce(counter_metric, use_case_id)
-
-    def set(
-        self,
-        use_case_id: UseCaseID,
-        org_id: int,
-        project_id: int,
-        metric_name: str,
-        value: Sequence[int],
-        tags: dict[str, str],
-        unit: str | None,
-    ) -> None:
-
-        """
-        Emit a set metric for internal use cases only. Can support
-        a sequence of values. Note that, as of now, this function
-        will return immediately even if the metric message has not been
-        produced to the broker yet.
-        """
-
-        set_metric = {
-            "org_id": org_id,
-            "project_id": project_id,
-            "name": build_mri(metric_name, "s", use_case_id, unit),
-            "value": value,
-            "timestamp": int(datetime.now().timestamp()),
-            "tags": tags,
-            "retention_days": get_retention_from_org_id(org_id),
-            "type": "s",
-        }
-
-        self.__produce(set_metric, use_case_id)
-
-    def distribution(
-        self,
-        use_case_id: UseCaseID,
-        org_id: int,
-        project_id: int,
-        metric_name: str,
-        value: Sequence[int | float],
-        tags: dict[str, str],
-        unit: str | None,
-    ) -> None:
-
-        """
-        Emit a distribution metric for internal use cases only. Can
-        support a sequence of values. Note that, as of now, this function
-        will return immediately even if the metric message has not been
-        produced to the broker yet.
-        """
-        dist_metric = {
-            "org_id": org_id,
-            "project_id": project_id,
-            "name": build_mri(metric_name, "d", use_case_id, unit),
-            "value": value,
-            "timestamp": int(datetime.now().timestamp()),
-            "tags": tags,
-            "retention_days": get_retention_from_org_id(org_id),
-            "type": "d",
-        }
-
-        self.__produce(dist_metric, use_case_id)
 
     def __produce(self, metric: dict[str, Any], use_case_id: UseCaseID):
         ingest_codec.validate(metric)

--- a/tests/sentry/sentry_metrics/test_kafka.py
+++ b/tests/sentry/sentry_metrics/test_kafka.py
@@ -33,36 +33,6 @@ class KafkaMetricsInterfaceTest(GenericMetricsTestMixIn, TestCase):
         generic_metrics_backend.producer = LocalProducer(broker)
         generic_metrics_backend.kafka_topic = my_topic
 
-        # produce a set metric onto the first offset
-        generic_metrics_backend.set(
-            self.use_case_id,
-            self.org_id,
-            self.project_id,
-            self.metric_name,
-            self.set_values,
-            self.metrics_tags,
-            self.unit,
-        )
-
-        set_metric = {
-            "org_id": self.org_id,
-            "project_id": self.project_id,
-            "name": self.get_mri(self.metric_name, "s", self.use_case_id, self.unit),
-            "value": self.set_values,
-            "timestamp": int(datetime.now().timestamp()),
-            "tags": self.metrics_tags,
-            "retention_days": self.retention_days,
-            "type": "s",
-        }
-
-        set_value = json.dumps(set_metric).encode("utf-8")
-
-        produced_message = broker_storage.consume(Partition(my_topic, 0), 0)
-        assert produced_message is not None
-        assert produced_message.payload.value == set_value
-        # check that there's no other remaining message in the topic
-        assert broker_storage.consume(Partition(my_topic, 0), 1) is None
-
         # produce a counter metric onto the second offset
         generic_metrics_backend.counter(
             self.use_case_id,
@@ -92,33 +62,3 @@ class KafkaMetricsInterfaceTest(GenericMetricsTestMixIn, TestCase):
         assert produced_message.payload.value == counter_value
         # check that there's no other remaining message in the topic
         assert broker_storage.consume(Partition(my_topic, 0), 2) is None
-
-        # produce a distribution metric onto the third offset
-        generic_metrics_backend.distribution(
-            self.use_case_id,
-            self.org_id,
-            self.project_id,
-            self.metric_name,
-            self.dist_values,
-            self.metrics_tags,
-            self.unit,
-        )
-
-        distribution_metric = {
-            "org_id": self.org_id,
-            "project_id": self.project_id,
-            "name": self.get_mri(self.metric_name, "d", self.use_case_id, self.unit),
-            "value": self.dist_values,
-            "timestamp": int(datetime.now().timestamp()),
-            "tags": self.metrics_tags,
-            "retention_days": self.retention_days,
-            "type": "d",
-        }
-
-        distribution_value = json.dumps(distribution_metric).encode("utf-8")
-
-        produced_message = broker_storage.consume(Partition(my_topic, 0), 2)
-        assert produced_message is not None
-        assert produced_message.payload.value == distribution_value
-        # check that there's no other remaining message in the topic
-        assert broker_storage.consume(Partition(my_topic, 0), 3) is None

--- a/tests/sentry/sentry_metrics/test_kafka.py
+++ b/tests/sentry/sentry_metrics/test_kafka.py
@@ -57,8 +57,8 @@ class KafkaMetricsInterfaceTest(GenericMetricsTestMixIn, TestCase):
 
         counter_value = json.dumps(counter_metric).encode("utf-8")
 
-        produced_message = broker_storage.consume(Partition(my_topic, 0), 1)
+        produced_message = broker_storage.consume(Partition(my_topic, 0), 0)
         assert produced_message is not None
         assert produced_message.payload.value == counter_value
         # check that there's no other remaining message in the topic
-        assert broker_storage.consume(Partition(my_topic, 0), 2) is None
+        assert broker_storage.consume(Partition(my_topic, 0), 1) is None


### PR DESCRIPTION
As the schema for sets and distributions changes, we want to make sure there is no way to produce metrics with incorrect schemas. As a result, we should delete the entrypoints for creating sets and distributions as long as we're confident no one is using these APIs. 

(There _is_ schema validation in this producer so this PR mainly is to clean up the interface.)