### PR TITLE
fix(replays): don't load segment 0

### DIFF
--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -86,7 +86,8 @@ describe('VideoReplayer - no starting gap', () => {
       onLoaded: jest.fn(),
     });
     // @ts-expect-error private
-    expect(inst._currentIndex).toEqual(0);
+    // currentIndex is undefined before we ever press play
+    expect(inst._currentIndex).toEqual(undefined);
 
     const playPromise = inst.play(6500);
     jest.advanceTimersByTime(10000);

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -78,7 +78,6 @@ export class VideoReplayer {
     this.preloadVideos({low: 0, high: PRELOAD_BUFFER});
 
     this._trackList = this._attachments.map(({timestamp}, i) => [timestamp, i]);
-    this.loadSegment(0);
   }
 
   private createVideo(segmentData: VideoEvent, index: number) {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/67847

Calling `loadSegment(0)` in the constructor works under the assumption that we'll always play the replay from the beginning; however, there's a case where the user might seek to a later part of the video before pressing play first. This was resulting in a bug where the first video was always playing even though that wasn't the right part of the video. We don't actually need to the `loadSegment(0)` call at all for the replay to play normally from the beginning (see last video):

## BEFORE: Replay was playing first clip erroneously after seeking to later part of the video

https://github.com/getsentry/sentry/assets/56095982/4fc77cff-ab30-4026-8e14-28764c1dda50


## AFTER: Replay plays correctly if we seek to later part of the video

https://github.com/getsentry/sentry/assets/56095982/ae8e77f8-f918-45bd-a577-300a9bf96254


## Replay plays normally from beginning

https://github.com/getsentry/sentry/assets/56095982/e76b3694-f33a-4aa5-9681-ab820e439eb9

