### PR TITLE
ref(relocation): Add separate relocation-backend option

### DIFF
--- a/src/sentry/data/config/config.yml.default
+++ b/src/sentry/data/config/config.yml.default
@@ -83,7 +83,8 @@ redis.clusters:
 filestore.backend: 'filesystem'
 filestore.options:
   location: '/tmp/sentry-files'
-filestore.relocation:
+filestore.relocation-backend: 'filesystem'
+filestore.relocation-options:
   location: '/tmp/sentry-relocation-files'
 
 # NOTE: See docs/filestore for instructions on configuring the shell environment
@@ -91,7 +92,8 @@ filestore.relocation:
 # filestore.backend: 'gcs'
 # filestore.options:
 #   bucket_name: 'gcs-bucket-name'
-# filestore.relocation:
+# filestore.relocation-backend: 'gcs'
+# filestore.relocation-options:
 #   bucket_name: 'gcs-relocation-bucket-name'
 
 # filestore.backend: 's3'
@@ -99,7 +101,8 @@ filestore.relocation:
 #   access_key: 'AKIXXXXXX'
 #   secret_key: 'XXXXXXX'
 #   bucket_name: 's3-bucket-name'
-# filestore.relocation:
+# filestore.relocation-backend: 's3'
+# filestore.relocation-options:
 #   access_key: 'AKIXXXXXX'
 #   secret_key: 'XXXXXXX'
 #   bucket_name: 's3-relocation-bucket-name'

--- a/src/sentry/models/files/utils.py
+++ b/src/sentry/models/files/utils.py
@@ -88,14 +88,10 @@ def get_storage(config=None):
 
 
 def get_relocation_storage(config=None):
-    if config is not None:
-        backend = config["backend"]
-        relocation = config["relocation"]
-    else:
-        from sentry import options as options_store
+    from sentry import options as options_store
 
-        backend = options_store.get("filestore.backend")
-        relocation = options_store.get("filestore.relocation")
+    backend = options_store.get("filestore.relocation-backend")
+    relocation = options_store.get("filestore.relocation-options")
 
     try:
         backend = settings.SENTRY_FILESTORE_ALIASES[backend]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -312,8 +312,11 @@ register(
 # Filestore (default)
 register("filestore.backend", default="filesystem", flags=FLAG_NOSTORE)
 register("filestore.options", default={"location": "/tmp/sentry-files"}, flags=FLAG_NOSTORE)
+register("filestore.relocation-backend", default="filesystem", flags=FLAG_NOSTORE)
 register(
-    "filestore.relocation", default={"location": "/tmp/sentry-relocation-files"}, flags=FLAG_NOSTORE
+    "filestore.relocation-options",
+    default={"location": "/tmp/sentry-relocation-files"},
+    flags=FLAG_NOSTORE,
 )
 
 # Filestore for control silo

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -555,7 +555,8 @@ def apply_legacy_settings(settings: Any) -> None:
         ("MAILGUN_API_KEY", "mail.mailgun-api-key"),
         ("SENTRY_FILESTORE", "filestore.backend"),
         ("SENTRY_FILESTORE_OPTIONS", "filestore.options"),
-        ("SENTRY_FILESTORE_RELOCATION", "filestore.relocation"),
+        ("SENTRY_RELOCATION_FILESTORE", "filestore.relocation-backend"),
+        ("SENTRY_RELOCATION_FILESTORE_OPTIONS", "filestore.relocation-options"),
         ("GOOGLE_CLIENT_ID", "auth-google.client-id"),
         ("GOOGLE_CLIENT_SECRET", "auth-google.client-secret"),
     ):

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -214,6 +214,8 @@ def test_apply_legacy_settings(settings):
     settings.SENTRY_FILESTORE = "some-filestore"
     settings.SENTRY_FILESTORE_OPTIONS = {"filestore-foo": "filestore-bar"}
     settings.SENTRY_FILESTORE_RELOCATION = {"relocation-baz": "relocation-qux"}
+    settings.SENTRY_RELOCATION_FILESTORE = "some-other-filestore"
+    settings.SENTRY_RELOCATION_FILESTORE_OPTIONS = {"relocation-baz": "relocation-qux"}
     with pytest.warns(DeprecatedSettingWarning) as warninfo:
         apply_legacy_settings(settings)
     assert settings.CELERY_ALWAYS_EAGER is False
@@ -229,7 +231,8 @@ def test_apply_legacy_settings(settings):
         "mail.mailgun-api-key": "mailgun-api-key",
         "filestore.backend": "some-filestore",
         "filestore.options": {"filestore-foo": "filestore-bar"},
-        "filestore.relocation": {"relocation-baz": "relocation-qux"},
+        "filestore.relocation-backend": "some-other-filestore",
+        "filestore.relocation-options": {"relocation-baz": "relocation-qux"},
     }
     assert settings.DEFAULT_FROM_EMAIL == "mail-from"
     assert settings.ALLOWED_HOSTS == ["*"]
@@ -243,7 +246,11 @@ def test_apply_legacy_settings(settings):
             ("SENTRY_ENABLE_EMAIL_REPLIES", "SENTRY_OPTIONS['mail.enable-replies']"),
             ("SENTRY_FILESTORE", "SENTRY_OPTIONS['filestore.backend']"),
             ("SENTRY_FILESTORE_OPTIONS", "SENTRY_OPTIONS['filestore.options']"),
-            ("SENTRY_FILESTORE_RELOCATION", "SENTRY_OPTIONS['filestore.relocation']"),
+            ("SENTRY_RELOCATION_FILESTORE", "SENTRY_OPTIONS['filestore.relocation-backend']"),
+            (
+                "SENTRY_RELOCATION_FILESTORE_OPTIONS",
+                "SENTRY_OPTIONS['filestore.relocation-options']",
+            ),
             ("SENTRY_REDIS_OPTIONS", 'SENTRY_OPTIONS["redis.clusters"]'),
             ("SENTRY_SMTP_HOSTNAME", "SENTRY_OPTIONS['mail.reply-hostname']"),
             ("SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE", "SENTRY_OPTIONS['system.rate-limit']"),


### PR DESCRIPTION
Allows us to avoid the separate filestore service when on prod.