### PR TITLE
feat(ui): Put react 18 concurrent renderer behind a flag

### DIFF
--- a/static/app/bootstrap/renderDom.tsx
+++ b/static/app/bootstrap/renderDom.tsx
@@ -1,3 +1,4 @@
+import {render} from 'react-dom';
 import {createRoot} from 'react-dom/client';
 
 export function renderDom(
@@ -13,6 +14,17 @@ export function renderDom(
     return;
   }
 
-  const root = createRoot(rootEl);
-  root.render(<Component {...props} />);
+  // Types are for ConfigStore, the window object is from json and features is not a Set
+  if (
+    (window.__initialData.features as unknown as string[]).includes(
+      'organizations:react-concurrent-renderer-enabled'
+    )
+  ) {
+    // Enable concurrent rendering
+    const root = createRoot(rootEl);
+    root.render(<Component {...props} />);
+  } else {
+    // Legacy rendering
+    render(<Component {...props} />, rootEl);
+  }
 }

--- a/static/app/bootstrap/renderPipelineView.tsx
+++ b/static/app/bootstrap/renderPipelineView.tsx
@@ -1,3 +1,4 @@
+import {render} from 'react-dom';
 import {createRoot} from 'react-dom/client';
 
 import {ROOT_ELEMENT} from 'sentry/constants';
@@ -6,8 +7,20 @@ import PipelineView from 'sentry/views/integrationPipeline/pipelineView';
 
 function renderDom(pipelineName: string, props: PipelineInitialData['props']) {
   const rootEl = document.getElementById(ROOT_ELEMENT)!;
-  const root = createRoot(rootEl);
-  root.render(<PipelineView pipelineName={pipelineName} {...props} />);
+
+  // Types are for ConfigStore, the window object is from json and features is not a Set
+  if (
+    (window.__initialData.features as unknown as string[]).includes(
+      'organizations:react-concurrent-renderer-enabled'
+    )
+  ) {
+    // Enable concurrent rendering
+    const root = createRoot(rootEl);
+    root.render(<PipelineView pipelineName={pipelineName} {...props} />);
+  } else {
+    // Legacy rendering
+    render(<PipelineView pipelineName={pipelineName} {...props} />, rootEl);
+  }
 }
 
 export function renderPipelineView() {


### PR DESCRIPTION
Uses the legacy renderer until we enable the option which was added in https://github.com/getsentry/sentry/pull/67441 This allows us to more safely merge react 18 without the need for rollbacks. We also have identified 2 bugs we might try to fix before turning it on

part of https://github.com/getsentry/frontend-tsc/issues/22