### PR TITLE
ref(api): make webhook APIs private

### DIFF
--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -113,7 +113,7 @@ class PushEventWebhook(Webhook):
 class BitbucketWebhookEndpoint(Endpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = ()
     _handlers = {"repo:push": PushEventWebhook}

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -564,7 +564,7 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
 
     owner = ApiOwner.ECOSYSTEM
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
     _handlers = {

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -181,7 +181,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
 class GitHubEnterpriseWebhookEndpoint(GitHubEnterpriseWebhookBase):
     owner = ApiOwner.ECOSYSTEM
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     _handlers = {
         "push": GitHubEnterprisePushEventWebhook,

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -241,7 +241,7 @@ class GitlabWebhookMixin:
 class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = ()
     permission_classes = ()

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -219,7 +219,7 @@ class MsTeamsEvents(Enum):
 class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = ()
     permission_classes = ()

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -131,8 +131,8 @@ def get_payload_and_token(
 class VercelWebhookEndpoint(Endpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = ()
     permission_classes = ()


### PR DESCRIPTION
These webhook APIs are what third parties like Github, Bitbucket, etc are calling when Sentry orgs have an integration with these third parties and they set up webhooks inside the third party integration. These endpoints “listen” to events from our integrations like when a Github user creates a new pull request, commits something, etc.

This differs from the Sentry webhook platform in which customers can set up things on their end to “listen” to events coming in from sentry, like new errors, etc. but in this case we are hitting APIs that they specify. We have documentation for this [here](https://docs.sentry.io/product/integrations/integration-platform/webhooks/)