### PR TITLE
fix(replay): make user optional for replay events

### DIFF
--- a/src/sentry/replays/usecases/ingest/issue_creation.py
+++ b/src/sentry/replays/usecases/ingest/issue_creation.py
@@ -78,7 +78,7 @@ def report_rage_click_issue_with_replay_event(
             "contexts": _make_contexts(replay_id, replay_event),
             "level": RAGE_CLICK_LEVEL,
             "tags": _make_tags(replay_id, url, replay_event),
-            "user": replay_event["user"],
+            "user": replay_event.get("user"),
             "release": replay_event.get("release"),
             "sdk": replay_event.get("sdk"),
             "dist": replay_event.get("dist"),


### PR DESCRIPTION
Assuming this is an optional field -- it's used as an extra in issues reported by `report_rage_click_issue_with_replay_event`

Fixes [SENTRY-300X](https://sentry.sentry.io/issues/5065796955/)

Did a search on `event["user"]` to verify this isn't a problem for replay events elsewhere
