### PR TITLE
fix(msteams): Allow new install event to pass

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -200,6 +200,22 @@ class MsTeamsWebhookMixin:
             or self.infer_team_id_from_channel_data(data=data) is not None
         )
 
+    @classmethod
+    def is_new_integration_installation_event(cls, data: Mapping[str, Any]) -> bool:
+        try:
+            raw_event_type = data["type"]
+            event_type = MsTeamsEvents.get_from_value(value=raw_event_type)
+            if event_type != MsTeamsEvents.INSTALLATION_UPDATE:
+                return False
+
+            action = data.get("action", None)
+            if action is None or action != "add":
+                return False
+
+            return True
+        except Exception:
+            return False
+
 
 class MsTeamsEvents(Enum):
     INSTALLATION_UPDATE = "installationUpdate"

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -68,14 +68,21 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
     def get_response(self) -> HttpResponseBase:
         if self.view_class not in self.region_view_classes:
             logger.info(
-                "View class not in region",
+                "View class not in region, sending to webhook handler",
                 extra={"request_data": self.request_data},
             )
             return self.get_response_from_control_silo()
 
         if not self.can_infer_integration(data=self.request_data):
             logger.info(
-                "Could not infer integration",
+                "Could not infer integration, sending to webhook handler",
+                extra={"request_data": self.request_data},
+            )
+            return self.get_response_from_control_silo()
+
+        if self.is_new_integration_installation_event(data=self.request_data):
+            logger.info(
+                "New installation event detected, sending to webhook handler",
                 extra={"request_data": self.request_data},
             )
             return self.get_response_from_control_silo()
@@ -116,7 +123,7 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
 
         if self._check_if_event_should_be_sync(data=self.request_data):
             logger.info(
-                "MSTeams event should be handled synchronously",
+                "MSTeams event should be handled synchronously, sending to webhook handler",
                 extra={"request_data": self.request_data},
             )
             return self.get_response_from_control_silo()

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_mixin.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_mixin.py
@@ -1,43 +1,45 @@
+from typing import Any
+
 from sentry.integrations.msteams import MsTeamsWebhookMixin
 
 
 class TestIsNewIntegrationInstallationEvent:
-    def test_valid_new_installation_event(self):
-        data = {"type": "installationUpdate", "action": "add"}
+    def test_valid_new_installation_event(self) -> None:
+        data: dict[str, Any] = {"type": "installationUpdate", "action": "add"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is True
 
-    def test_valid_non_installation_event(self):
-        data = {"type": "message", "action": "add"}
+    def test_valid_non_installation_event(self) -> None:
+        data: dict[str, Any] = {"type": "message", "action": "add"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
 
-    def test_invalid_missing_type_field(self):
-        data = {"action": "add"}
+    def test_invalid_missing_type_field(self) -> None:
+        data: dict[str, Any] = {"action": "add"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
 
-    def test_empty_input(self):
-        data = {}
+    def test_empty_input(self) -> None:
+        data: dict[str, Any] = {}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
 
-    def test_only_required_fields(self):
-        data = {"type": "installationUpdate"}
+    def test_only_required_fields(self) -> None:
+        data: dict[str, Any] = {"type": "installationUpdate"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
 
-    def test_additional_fields(self):
-        data = {"type": "installationUpdate", "action": "add", "extra": "field"}
+    def test_additional_fields(self) -> None:
+        data: dict[str, Any] = {"type": "installationUpdate", "action": "add", "extra": "field"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is True
 
-    def test_minimum_input(self):
-        data = {"type": "installationUpdate", "action": "add"}
+    def test_minimum_input(self) -> None:
+        data: dict[str, Any] = {"type": "installationUpdate", "action": "add"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is True
 
-    def test_invalid_event_type(self):
-        data = {"type": "invalidType", "action": "add"}
+    def test_invalid_event_type(self) -> None:
+        data: dict[str, Any] = {"type": "invalidType", "action": "add"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
 
-    def test_invalid_action(self):
-        data = {"type": "installationUpdate", "action": "remove"}
+    def test_invalid_action(self) -> None:
+        data: dict[str, Any] = {"type": "installationUpdate", "action": "remove"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
 
-    def test_different_event_type(self):
-        data = {"type": "message", "action": "add"}
+    def test_different_event_type(self) -> None:
+        data: dict[str, Any] = {"type": "message", "action": "add"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_mixin.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_mixin.py
@@ -1,0 +1,43 @@
+from sentry.integrations.msteams import MsTeamsWebhookMixin
+
+
+class TestIsNewIntegrationInstallationEvent:
+    def test_valid_new_installation_event(self):
+        data = {"type": "installationUpdate", "action": "add"}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is True
+
+    def test_valid_non_installation_event(self):
+        data = {"type": "message", "action": "add"}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
+
+    def test_invalid_missing_type_field(self):
+        data = {"action": "add"}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
+
+    def test_empty_input(self):
+        data = {}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
+
+    def test_only_required_fields(self):
+        data = {"type": "installationUpdate"}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
+
+    def test_additional_fields(self):
+        data = {"type": "installationUpdate", "action": "add", "extra": "field"}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is True
+
+    def test_minimum_input(self):
+        data = {"type": "installationUpdate", "action": "add"}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is True
+
+    def test_invalid_event_type(self):
+        data = {"type": "invalidType", "action": "add"}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
+
+    def test_invalid_action(self):
+        data = {"type": "installationUpdate", "action": "remove"}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
+
+    def test_different_event_type(self):
+        data = {"type": "message", "action": "add"}
+        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_mixin.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_mixin.py
@@ -16,10 +16,6 @@ class TestIsNewIntegrationInstallationEvent:
         data: dict[str, Any] = {"action": "add"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
 
-    def test_empty_input(self) -> None:
-        data: dict[str, Any] = {}
-        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
-
     def test_only_required_fields(self) -> None:
         data: dict[str, Any] = {"type": "installationUpdate"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
@@ -38,8 +34,4 @@ class TestIsNewIntegrationInstallationEvent:
 
     def test_invalid_action(self) -> None:
         data: dict[str, Any] = {"type": "installationUpdate", "action": "remove"}
-        assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False
-
-    def test_different_event_type(self) -> None:
-        data: dict[str, Any] = {"type": "message", "action": "add"}
         assert MsTeamsWebhookMixin.is_new_integration_installation_event(data) is False


### PR DESCRIPTION
When a new installation event comes in from the MSTeams bot, we need to allow that to go through to the Webhook event handler, instead of doing other checks and trying to get the integration or regions, as the integration does not exist yet. We were erroring because while we can technically infer an integration, it is new, and not existing.

![Screenshot 2024-03-28 at 5 26 45 PM](https://github.com/getsentry/sentry/assets/5581484/22f5caed-d61e-40ec-adf7-0d21a350b9b1)

The greater fix resolves around updating this entire middleware and changing the logic.

Resolves: https://github.com/getsentry/sentry/issues/66678