### PR TITLE
nit(ui): Specify account type in error message

### DIFF
--- a/static/app/constants/superuserAccessErrors.tsx
+++ b/static/app/constants/superuserAccessErrors.tsx
@@ -5,6 +5,6 @@ export enum ErrorCodes {
   INVALID_SSO_SESSION = 'Your SSO Session has expired, please reauthenticate',
   INVALID_ACCESS_CATEGORY = 'Please fill out the access category and reason correctly',
   MISSING_PASSWORD_OR_U2F = 'Password or U2F challenge/response was not sent',
-  NO_AUTHENTICATOR = 'Please add a U2F authenticator to your account',
+  NO_AUTHENTICATOR = 'Please add a U2F authenticator to your Sentry account',
   UNKNOWN_ERROR = 'An error occurred, please try again',
 }


### PR DESCRIPTION
Specify the account type in this error message so it's not ambiguous

![Screenshot 2024-03-28 at 4 14 32 PM](https://github.com/getsentry/sentry/assets/67301797/4a120376-5c10-4e63-a064-417a3bc89ce4)
