### PR TITLE
feat(ui): Add a reusable GuidedSteps component

### DIFF
--- a/static/app/components/guidedSteps/guidedSteps.spec.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.spec.tsx
@@ -1,0 +1,68 @@
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
+
+describe('GuidedSteps', function () {
+  it('can navigate through steps and shows previous ones as completed', async function () {
+    render(
+      <GuidedSteps>
+        <GuidedSteps.Step title="Step 1 Title">
+          This is the first step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+        <GuidedSteps.Step title="Step 2 Title">
+          This is the second step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+        <GuidedSteps.Step title="Step 3 Title">
+          This is the third step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+      </GuidedSteps>
+    );
+
+    expect(screen.getByText('This is the first step.')).toBeInTheDocument();
+    expect(screen.queryByText('This is the second step.')).not.toBeInTheDocument();
+    expect(screen.queryByText('This is the third step.')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Next'));
+
+    expect(screen.queryByText('This is the first step.')).not.toBeInTheDocument();
+    expect(screen.getByText('This is the second step.')).toBeInTheDocument();
+    expect(screen.queryByText('This is the third step.')).not.toBeInTheDocument();
+
+    // First step is shown as completed
+    expect(
+      within(screen.getByTestId('guided-step-1')).getByTestId('icon-check-mark')
+    ).toBeInTheDocument();
+  });
+
+  it('starts at the first incomplete step', function () {
+    render(
+      <GuidedSteps>
+        <GuidedSteps.Step title="Step 1 Title" isCompleted>
+          This is the first step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+        <GuidedSteps.Step title="Step 2 Title" isCompleted={false}>
+          This is the second step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+        <GuidedSteps.Step title="Step 3 Title" isCompleted={false}>
+          This is the third step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+      </GuidedSteps>
+    );
+
+    // First step is shown as completed
+    expect(
+      within(screen.getByTestId('guided-step-1')).getByTestId('icon-check-mark')
+    ).toBeInTheDocument();
+
+    // Second step is shown as active
+    expect(screen.queryByText('This is the first step.')).not.toBeInTheDocument();
+    expect(screen.getByText('This is the second step.')).toBeInTheDocument();
+    expect(screen.queryByText('This is the third step.')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/components/guidedSteps/guidedSteps.stories.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.stories.tsx
@@ -96,11 +96,15 @@ export default storyBook(GuidedSteps, story => {
             </GuidedSteps.Step>
             <GuidedSteps.Step title="Step 2 Title" isCompleted={false}>
               You haven't completed the second step yet, here's how you do it.
-              <GuidedSteps.StepButtons />
+              <GuidedSteps.ButtonWrapper>
+                <GuidedSteps.BackButton />
+              </GuidedSteps.ButtonWrapper>
             </GuidedSteps.Step>
             <GuidedSteps.Step title="Step 3 Title" isCompleted={false}>
               You haven't completed the third step yet, here's how you do it.
-              <GuidedSteps.StepButtons />
+              <GuidedSteps.ButtonWrapper>
+                <GuidedSteps.BackButton />
+              </GuidedSteps.ButtonWrapper>
             </GuidedSteps.Step>
           </GuidedSteps>
         </SizingWindow>

--- a/static/app/components/guidedSteps/guidedSteps.stories.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.stories.tsx
@@ -1,0 +1,110 @@
+import {Fragment} from 'react';
+
+import {Button} from 'sentry/components/button';
+import {
+  GuidedSteps,
+  useGuidedStepsContext,
+} from 'sentry/components/guidedSteps/guidedSteps';
+import JSXNode from 'sentry/components/stories/jsxNode';
+import SizingWindow from 'sentry/components/stories/sizingWindow';
+import storyBook from 'sentry/stories/storyBook';
+
+export default storyBook(GuidedSteps, story => {
+  story('Default', () => (
+    <Fragment>
+      <p>
+        To create a GuideStep component, you should use <JSXNode name="GuidedSteps" /> as
+        the container and <JSXNode name="GuidedSteps.Step" /> as direct children.
+      </p>
+      <p>
+        You have complete control over what to render in the step titles and step content.
+        You may use <JSXNode name="GuidedSteps.StepButtons" /> to render the default
+        back/next buttons, but can also render your own.
+      </p>
+      <SizingWindow display="block">
+        <GuidedSteps>
+          <GuidedSteps.Step title="Step 1 Title">
+            This is the first step.
+            <GuidedSteps.StepButtons />
+          </GuidedSteps.Step>
+          <GuidedSteps.Step title="Step 2 Title">
+            This is the second step.
+            <GuidedSteps.StepButtons />
+          </GuidedSteps.Step>
+          <GuidedSteps.Step title="Step 3 Title">
+            This is the third step.
+            <GuidedSteps.StepButtons />
+          </GuidedSteps.Step>
+        </GuidedSteps>
+      </SizingWindow>
+    </Fragment>
+  ));
+
+  story('Custom button behavior', () => {
+    function SkipToLastButton() {
+      const {setCurrentStep, totalSteps} = useGuidedStepsContext();
+      return (
+        <GuidedSteps.ButtonWrapper>
+          <Button size="sm" onClick={() => setCurrentStep(totalSteps)}>
+            Skip to Last Step
+          </Button>
+        </GuidedSteps.ButtonWrapper>
+      );
+    }
+
+    return (
+      <Fragment>
+        <p>
+          A hook is provided to access and control the step state:{' '}
+          <code>useGuidedStepsContext()</code>. This can be used to create step buttons
+          with custom behavior.
+        </p>
+        <SizingWindow display="block">
+          <GuidedSteps>
+            <GuidedSteps.Step title="Step 1 Title">
+              This is the first step.
+              <SkipToLastButton />
+            </GuidedSteps.Step>
+            <GuidedSteps.Step title="Step 2 Title">
+              This is the second step.
+              <GuidedSteps.StepButtons />
+            </GuidedSteps.Step>
+            <GuidedSteps.Step title="Step 3 Title">
+              This is the third step.
+              <GuidedSteps.StepButtons />
+            </GuidedSteps.Step>
+          </GuidedSteps>
+        </SizingWindow>
+      </Fragment>
+    );
+  });
+
+  story('Controlling completed state', () => {
+    return (
+      <Fragment>
+        <p>
+          By default, previous steps are considered completed. However, if the completed
+          state is known it can be controlled using the <code>isCompleted</code> property
+          on <JSXNode name="GuidedSteps.Step" />. The GuidedStep component will begin on
+          the first incomplete step.
+        </p>
+        <SizingWindow display="block">
+          <GuidedSteps>
+            <GuidedSteps.Step title="Step 1 Title" isCompleted>
+              Congrats, you finished the first step!
+              <GuidedSteps.StepButtons />
+            </GuidedSteps.Step>
+            <GuidedSteps.Step title="Step 2 Title" isCompleted={false}>
+              You haven't completed the second step yet, here's how you do it.
+              <GuidedSteps.StepButtons />
+            </GuidedSteps.Step>
+            <GuidedSteps.Step title="Step 3 Title" isCompleted={false}>
+              You haven't completed the third step yet, here's how you do it.
+              <GuidedSteps.StepButtons />
+            </GuidedSteps.Step>
+          </GuidedSteps>
+        </SizingWindow>
+      </Fragment>
+    );
+  });
+});

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -1,0 +1,214 @@
+import {
+  Children,
+  createContext,
+  isValidElement,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import styled from '@emotion/styled';
+
+import {type BaseButtonProps, Button} from 'sentry/components/button';
+import {IconCheckmark} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+type GuidedStepsProps = {
+  children: React.ReactElement<StepProps> | React.ReactElement<StepProps>[];
+  className?: string;
+};
+
+interface GuidedStepsContextState {
+  currentStep: number;
+  setCurrentStep: (step: number) => void;
+  totalSteps: number;
+}
+
+interface StepProps {
+  children: React.ReactNode;
+  title: string;
+  isCompleted?: boolean;
+  stepNumber?: number;
+}
+
+const GuidedStepsContext = createContext<GuidedStepsContextState>({
+  currentStep: 0,
+  setCurrentStep: () => {},
+  totalSteps: 0,
+});
+
+export function useGuidedStepsContext() {
+  return useContext(GuidedStepsContext);
+}
+
+function Step({
+  stepNumber = 1,
+  title,
+  children,
+  isCompleted: completedOverride,
+}: StepProps) {
+  const {currentStep} = useGuidedStepsContext();
+  const isActive = currentStep === stepNumber;
+  const isCompleted = completedOverride ?? currentStep > stepNumber;
+
+  return (
+    <StepWrapper data-test-id={`guided-step-${stepNumber}`}>
+      <StepNumber isActive={isActive}>{stepNumber}</StepNumber>
+      <div>
+        <StepHeading isActive={isActive}>
+          {title}
+          {isCompleted && (
+            <StepDoneIcon data-test-id="step-done-icon" isActive={isActive} size="sm" />
+          )}
+        </StepHeading>
+        {isActive && <ChildrenWrapper isActive={isActive}>{children}</ChildrenWrapper>}
+      </div>
+    </StepWrapper>
+  );
+}
+
+function BackButton({children, ...props}: BaseButtonProps) {
+  const {currentStep, setCurrentStep} = useGuidedStepsContext();
+
+  if (currentStep === 1) {
+    return null;
+  }
+
+  return (
+    <Button size="sm" onClick={() => setCurrentStep(currentStep - 1)} {...props}>
+      {children ?? t('Back')}
+    </Button>
+  );
+}
+
+function NextButton({children, ...props}: BaseButtonProps) {
+  const {currentStep, setCurrentStep, totalSteps} = useGuidedStepsContext();
+
+  if (currentStep >= totalSteps) {
+    return null;
+  }
+
+  return (
+    <Button size="sm" onClick={() => setCurrentStep(currentStep + 1)} {...props}>
+      {children ?? t('Next')}
+    </Button>
+  );
+}
+
+function StepButtons() {
+  return (
+    <StepButtonsWrapper>
+      <BackButton />
+      <NextButton />
+    </StepButtonsWrapper>
+  );
+}
+
+export function GuidedSteps({className, children}: GuidedStepsProps) {
+  const [currentStep, setCurrentStep] = useState<number>(() => {
+    // If `isCompleted` has been passed in, we should start at the first incomplete step
+    const firstIncompleteStepIndex = Children.toArray(children).findIndex(child =>
+      isValidElement(child) ? child.props.isCompleted !== true : false
+    );
+
+    return Math.max(1, firstIncompleteStepIndex + 1);
+  });
+
+  const totalSteps = Children.count(children);
+
+  const value = useMemo(
+    () => ({
+      currentStep,
+      setCurrentStep,
+      totalSteps,
+    }),
+    [currentStep, setCurrentStep, totalSteps]
+  );
+
+  return (
+    <GuidedStepsContext.Provider value={value}>
+      <StepsWrapper className={className}>
+        {Children.map(children, (child, index) => {
+          if (!child) {
+            return null;
+          }
+
+          return <Step stepNumber={index + 1} {...child.props} />;
+        })}
+      </StepsWrapper>
+    </GuidedStepsContext.Provider>
+  );
+}
+
+const StepButtonsWrapper = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(1)};
+  margin-top: ${space(1.5)};
+`;
+
+const StepsWrapper = styled('div')`
+  background: ${p => p.theme.background};
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+`;
+
+const StepWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: ${space(1.5)};
+  position: relative;
+
+  :not(:last-child)::before {
+    content: '';
+    position: absolute;
+    height: calc(100% + ${space(2)});
+    width: 1px;
+    background: ${p => p.theme.border};
+    left: 17px;
+  }
+`;
+
+const StepNumber = styled('div')<{isActive: boolean}>`
+  position: relative;
+  z-index: 2;
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 34px;
+  width: 34px;
+  line-height: 34px;
+  border-radius: 50%;
+  background: ${p => (p.isActive ? p.theme.purple300 : p.theme.gray100)};
+  color: ${p => (p.isActive ? p.theme.white : p.theme.subText)};
+  border: 4px solid ${p => p.theme.background};
+`;
+
+const StepHeading = styled('h4')<{isActive: boolean}>`
+  line-height: 34px;
+  margin: 0;
+  font-weight: bold;
+  font-size: ${p => p.theme.fontSizeLarge};
+  color: ${p => (p.isActive ? p.theme.textColor : p.theme.subText)};
+`;
+
+const StepDoneIcon = styled(IconCheckmark, {
+  shouldForwardProp: prop => prop !== 'isActive',
+})<{isActive: boolean}>`
+  color: ${p => (p.isActive ? p.theme.successText : p.theme.subText)};
+  margin-left: ${space(1)};
+  vertical-align: middle;
+`;
+
+const ChildrenWrapper = styled('div')<{isActive: boolean}>`
+  color: ${p => (p.isActive ? p.theme.textColor : p.theme.subText)};
+`;
+
+GuidedSteps.Step = Step;
+GuidedSteps.BackButton = BackButton;
+GuidedSteps.NextButton = NextButton;
+GuidedSteps.StepButtons = StepButtons;
+GuidedSteps.ButtonWrapper = StepButtonsWrapper;

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -2,6 +2,7 @@ import {
   Children,
   createContext,
   isValidElement,
+  useCallback,
   useContext,
   useMemo,
   useState,
@@ -16,6 +17,7 @@ import {space} from 'sentry/styles/space';
 type GuidedStepsProps = {
   children: React.ReactElement<StepProps> | React.ReactElement<StepProps>[];
   className?: string;
+  onStepChange?: (step: number) => void;
 };
 
 interface GuidedStepsContextState {
@@ -57,9 +59,7 @@ function Step({
       <div>
         <StepHeading isActive={isActive}>
           {title}
-          {isCompleted && (
-            <StepDoneIcon data-test-id="step-done-icon" isActive={isActive} size="sm" />
-          )}
+          {isCompleted && <StepDoneIcon isActive={isActive} size="sm" />}
         </StepHeading>
         {isActive && <ChildrenWrapper isActive={isActive}>{children}</ChildrenWrapper>}
       </div>
@@ -104,7 +104,7 @@ function StepButtons() {
   );
 }
 
-export function GuidedSteps({className, children}: GuidedStepsProps) {
+export function GuidedSteps({className, children, onStepChange}: GuidedStepsProps) {
   const [currentStep, setCurrentStep] = useState<number>(() => {
     // If `isCompleted` has been passed in, we should start at the first incomplete step
     const firstIncompleteStepIndex = Children.toArray(children).findIndex(child =>
@@ -115,14 +115,21 @@ export function GuidedSteps({className, children}: GuidedStepsProps) {
   });
 
   const totalSteps = Children.count(children);
+  const handleSetCurrentStep = useCallback(
+    (step: number) => {
+      setCurrentStep(step);
+      onStepChange?.(step);
+    },
+    [onStepChange]
+  );
 
   const value = useMemo(
     () => ({
       currentStep,
-      setCurrentStep,
+      setCurrentStep: handleSetCurrentStep,
       totalSteps,
     }),
-    [currentStep, setCurrentStep, totalSteps]
+    [currentStep, handleSetCurrentStep, totalSteps]
   );
 
   return (


### PR DESCRIPTION
This implements a design that will soon be used in a couple different places ([see here](https://www.figma.com/file/Qi6W0cd8tTKyvUMGvsropQ/Q1-Issues-Empty-States?type=design&node-id=163-804&mode=design&t=eqpAaWivQeRm8b5s-0) for one of them).

It uses the compound component pattern (similar to `<Tabs />`) which should allow for a lot of flexibility.

Story can be viewed at `/stories/?name=app/components/guidedSteps/guidedSteps.stories.tsx`

![CleanShot 2024-03-29 at 09 39 45](https://github.com/getsentry/sentry/assets/10888943/86758ac4-5bad-4fee-87e2-bac244478004)
