### PR TITLE
ref(crons): Drop removed useGUIDs parameter

### DIFF
--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -59,7 +59,6 @@ export function CronTimelineSection({event, organization, project}: Props) {
         query: {
           until: Math.floor(end.getTime() / 1000),
           since: Math.floor(start.getTime() / 1000),
-          useGUIDs: true,
           monitor: monitorId,
           resolution: `${rollup}s`,
         },

--- a/static/app/views/monitors/components/cronDetailsTimeline.tsx
+++ b/static/app/views/monitors/components/cronDetailsTimeline.tsx
@@ -46,7 +46,6 @@ export function CronDetailsTimeline({monitor, organization}: Props) {
       {
         query: {
           monitor: monitor.id,
-          useGUIDs: true,
           ...selectionQuery,
           ...location.query,
         },

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -49,7 +49,6 @@ export function OverviewTimeline({monitorList}: Props) {
       {
         query: {
           monitor: monitorList.map(m => m.id),
-          useGUIDs: true,
           ...selectionQuery,
           ...location.query,
         },


### PR DESCRIPTION
We no longer need this as this API always uses the GUIDs now