### PR TITLE
fix(crons): Fix monitor form errors

### DIFF
--- a/static/app/views/monitors/components/monitorForm.spec.tsx
+++ b/static/app/views/monitors/components/monitorForm.spec.tsx
@@ -136,12 +136,12 @@ describe('MonitorForm', function () {
     await userEvent.click(screen.getByRole('button', {name: 'Add Monitor'}));
 
     const config = {
-      checkin_margin: '5',
-      max_runtime: '20',
-      failure_issue_threshold: '4',
-      recovery_threshold: '2',
+      checkinMargin: '5',
+      maxRuntime: '20',
+      failureIssueThreshold: '4',
+      recoveryThreshold: '2',
       schedule: '5 * * * *',
-      schedule_type: 'crontab',
+      scheduleType: 'crontab',
       timezone: 'America/Los_Angeles',
     };
 
@@ -247,13 +247,13 @@ describe('MonitorForm', function () {
     // monitor they come in as numbers, when changed via the toggles they
     // are translated to strings :(
     const config = {
-      max_runtime: monitor.config.max_runtime,
-      checkin_margin: monitor.config.checkin_margin,
-      recovery_threshold: monitor.config.recovery_threshold,
+      maxRuntime: monitor.config.max_runtime,
+      checkinMargin: monitor.config.checkin_margin,
+      recoveryThreshold: monitor.config.recovery_threshold,
       schedule: monitor.config.schedule,
-      schedule_type: monitor.config.schedule_type,
+      scheduleType: monitor.config.schedule_type,
       timezone: monitor.config.timezone,
-      failure_issue_threshold: '10',
+      failureIssueThreshold: '10',
     };
 
     const alertRule = {

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -74,7 +74,7 @@ interface TransformedData extends Partial<Omit<Monitor, 'config' | 'alertRule'>>
  * Transform sub-fields for what the API expects
  */
 export function transformMonitorFormData(_data: Record<string, any>, model: FormModel) {
-  const schedType = model.getValue('config.schedule_type');
+  const schedType = model.getValue('config.scheduleType');
   // Remove interval fields if the monitor schedule is crontab
   const filteredFields = model.fields
     .toJSON()
@@ -181,11 +181,11 @@ function MonitorForm({
     const rv = {};
     switch (type) {
       case 'cron_job':
-        rv['config.schedule_type'] = config.schedule_type;
-        rv['config.checkin_margin'] = config.checkin_margin;
-        rv['config.max_runtime'] = config.max_runtime;
-        rv['config.failure_issue_threshold'] = config.failure_issue_threshold;
-        rv['config.recovery_threshold'] = config.recovery_threshold;
+        rv['config.scheduleType'] = config.schedule_type;
+        rv['config.checkinMargin'] = config.checkin_margin;
+        rv['config.maxRuntime'] = config.max_runtime;
+        rv['config.failureIssueThreshold'] = config.failure_issue_threshold;
+        rv['config.recoveryThreshold'] = config.recovery_threshold;
 
         switch (config.schedule_type) {
           case 'interval':
@@ -307,7 +307,7 @@ function MonitorForm({
             </StyledAlert>
           )}
           <StyledSelectField
-            name="config.schedule_type"
+            name="config.scheduleType"
             aria-label={t('Schedule Type')}
             options={SCHEDULE_OPTIONS}
             defaultValue={ScheduleType.CRONTAB}
@@ -318,7 +318,7 @@ function MonitorForm({
           />
           <Observer>
             {() => {
-              const scheduleType = form.current.getValue('config.schedule_type');
+              const scheduleType = form.current.getValue('config.scheduleType');
 
               const parsedSchedule =
                 scheduleType === 'crontab'
@@ -393,7 +393,7 @@ function MonitorForm({
           <Panel>
             <PanelBody>
               <NumberField
-                name="config.checkin_margin"
+                name="config.checkinMargin"
                 min={CHECKIN_MARGIN_MINIMUM}
                 placeholder={tn(
                   'Defaults to %s minute',
@@ -404,7 +404,7 @@ function MonitorForm({
                 label={t('Grace Period')}
               />
               <NumberField
-                name="config.max_runtime"
+                name="config.maxRuntime"
                 min={TIMEOUT_MINIMUM}
                 placeholder={tn(
                   'Defaults to %s minute',
@@ -429,7 +429,7 @@ function MonitorForm({
               <Panel>
                 <PanelBody>
                   <NumberField
-                    name="config.failure_issue_threshold"
+                    name="config.failureIssueThreshold"
                     min={1}
                     placeholder="1"
                     help={t(
@@ -438,7 +438,7 @@ function MonitorForm({
                     label={t('Failure Tolerance')}
                   />
                   <NumberField
-                    name="config.recovery_threshold"
+                    name="config.recoveryThreshold"
                     min={1}
                     placeholder="1"
                     help={t(


### PR DESCRIPTION
Changing these form fields to camelCase so when errors are returned to the frontend from the backend in camelCase (because the backend is using the CamelSnakeSerializer): 
https://github.com/getsentry/sentry/blob/67d2a53775de672b5a7e6e7a44178825eea7612a/src/sentry/monitors/validators.py#L236

they are correctly shown next to the field, e.g.:

<img width="927" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/5b049e9b-6514-4cc2-8cd2-63ea0336950e">

closes: https://github.com/getsentry/team-crons/issues/159
