### PR TITLE
fix(crons): Set received timestamp for crons occurrences to be relay received time

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -751,7 +751,10 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span):
             # 04
             # Update monitor status
             if check_in.status == CheckInStatus.ERROR:
-                mark_failed(check_in, ts=start_time, received=item.ts)
+                # Note: We use `start_time` for received here since it's the time that this
+                # checkin was received by relay. Potentially, `ts` should be the client
+                # timestamp. If we change that, leave `received` the same.
+                mark_failed(check_in, ts=start_time, received=start_time)
             else:
                 mark_ok(check_in, ts=start_time)
 

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -291,7 +291,7 @@ def create_issue_platform_occurrence(
         "fingerprint": [fingerprint],
         "platform": "other",
         "project_id": monitor_env.monitor.project_id,
-        # We set this to the time that the checkin that triggered the occurrence was written to the ingest topic
+        # We set this to the time that the checkin that triggered the occurrence was written to relay if available
         "received": (received if received else current_timestamp).isoformat(),
         "sdk": None,
         "tags": {


### PR DESCRIPTION
We were previously using Kafka write time, but we want full end to end latency, so using `start_time` here.
