### PR TITLE
fix(indexer): Allow more characters in units

### DIFF
--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -69,7 +69,7 @@ def _build_namespace_regex() -> str:
 MRI_METRIC_TYPE_REGEX = r"(c|s|d|g|e)"
 MRI_NAMESPACE_REGEX = _build_namespace_regex()
 MRI_NAME_REGEX = r"([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)"
-MRI_UNIT_REGEX = r"[\w.{}]*"
+MRI_UNIT_REGEX = r"[\s\S\r\n]*"
 MRI_SCHEMA_REGEX_STRING = rf"(?P<entity>{MRI_METRIC_TYPE_REGEX}):(?P<namespace>{MRI_NAMESPACE_REGEX})/(?P<name>{MRI_NAME_REGEX})@(?P<unit>{MRI_UNIT_REGEX})"
 MRI_SCHEMA_REGEX = re.compile(rf"^{MRI_SCHEMA_REGEX_STRING}$")
 MRI_EXPRESSION_REGEX = re.compile(rf"^{OP_REGEX}\(({MRI_SCHEMA_REGEX_STRING})\)$")

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -69,7 +69,7 @@ def _build_namespace_regex() -> str:
 MRI_METRIC_TYPE_REGEX = r"(c|s|d|g|e)"
 MRI_NAMESPACE_REGEX = _build_namespace_regex()
 MRI_NAME_REGEX = r"([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)"
-MRI_UNIT_REGEX = r"[\w.]*"
+MRI_UNIT_REGEX = r"[\w.{}]*"
 MRI_SCHEMA_REGEX_STRING = rf"(?P<entity>{MRI_METRIC_TYPE_REGEX}):(?P<namespace>{MRI_NAMESPACE_REGEX})/(?P<name>{MRI_NAME_REGEX})@(?P<unit>{MRI_UNIT_REGEX})"
 MRI_SCHEMA_REGEX = re.compile(rf"^{MRI_SCHEMA_REGEX_STRING}$")
 MRI_EXPRESSION_REGEX = re.compile(rf"^{OP_REGEX}\(({MRI_SCHEMA_REGEX_STRING})\)$")

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -68,7 +68,7 @@ def _build_namespace_regex() -> str:
 
 MRI_METRIC_TYPE_REGEX = r"(c|s|d|g|e)"
 MRI_NAMESPACE_REGEX = _build_namespace_regex()
-MRI_NAME_REGEX = r"([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)"
+MRI_NAME_REGEX = r"([a-zA-Z0-9_/.]+)"
 MRI_UNIT_REGEX = r"[\s\S\r\n]*"
 MRI_SCHEMA_REGEX_STRING = rf"(?P<entity>{MRI_METRIC_TYPE_REGEX}):(?P<namespace>{MRI_NAMESPACE_REGEX})/(?P<name>{MRI_NAME_REGEX})@(?P<unit>{MRI_UNIT_REGEX})"
 MRI_SCHEMA_REGEX = re.compile(rf"^{MRI_SCHEMA_REGEX_STRING}$")

--- a/tests/sentry/snuba/metrics/test_naming_layer.py
+++ b/tests/sentry/snuba/metrics/test_naming_layer.py
@@ -75,12 +75,6 @@ def test_valid_mri_schema_regex(name):
 @pytest.mark.parametrize(
     "name",
     [
-        "e:sessions/healthy.@",
-        "e:sessions/healthy..@",
-        "e:sessions/healthy..crashed@",
-        "e:sessions/.healthy@",
-        "e:sessions/..healthy@",
-        "e:sessions/healthy..crashed.crashed@",
         "t:sessions/error.preaggr@none",
         "e:foo/error.preaggr@none" "foo.bar",
     ],

--- a/tests/snuba/metrics/naming_layer/test_mri.py
+++ b/tests/snuba/metrics/naming_layer/test_mri.py
@@ -13,6 +13,7 @@ class TestMRIUtils(TestCase):
         assert format_mri_field("avg(c:custom/foo@none)") == "avg(foo)"
         assert format_mri_field("max(s:spans/user@none)") == "max(user)"
         assert format_mri_field("sum(d:spans/exclusive_time@millisecond)") == "sum(exclusive_time)"
+        assert format_mri_field("sum(c:custom/http.client.active_requests@{request})") == "sum(http.client.active_requests)"
         assert format_mri_field("invalid_mri_field") == "invalid_mri_field"
         assert format_mri_field(cast(str, None)) is None
 

--- a/tests/snuba/metrics/naming_layer/test_mri.py
+++ b/tests/snuba/metrics/naming_layer/test_mri.py
@@ -17,6 +17,7 @@ class TestMRIUtils(TestCase):
             format_mri_field("sum(c:custom/http.client.active_requests@{request})")
             == "sum(http.client.active_requests)"
         )
+        assert format_mri_field("sum(c:custom/foo...bar@{request})") == "sum(foo...bar)"
         assert format_mri_field("invalid_mri_field") == "invalid_mri_field"
         assert format_mri_field(cast(str, None)) is None
 

--- a/tests/snuba/metrics/naming_layer/test_mri.py
+++ b/tests/snuba/metrics/naming_layer/test_mri.py
@@ -13,7 +13,10 @@ class TestMRIUtils(TestCase):
         assert format_mri_field("avg(c:custom/foo@none)") == "avg(foo)"
         assert format_mri_field("max(s:spans/user@none)") == "max(user)"
         assert format_mri_field("sum(d:spans/exclusive_time@millisecond)") == "sum(exclusive_time)"
-        assert format_mri_field("sum(c:custom/http.client.active_requests@{request})") == "sum(http.client.active_requests)"
+        assert (
+            format_mri_field("sum(c:custom/http.client.active_requests@{request})")
+            == "sum(http.client.active_requests)"
+        )
         assert format_mri_field("invalid_mri_field") == "invalid_mri_field"
         assert format_mri_field(cast(str, None)) is None
 


### PR DESCRIPTION
Allow more characters in the units section of mri

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
