### PR TITLE
fix: Don't sample any consumer metrics

### DIFF
--- a/src/sentry/utils/arroyo.py
+++ b/src/sentry/utils/arroyo.py
@@ -65,6 +65,7 @@ class MetricsWrapper(Metrics):
             amount=value,
             tags=self.__merge_tags(tags),
             stacklevel=stacklevel + 1,
+            sample_rate=1,
         )
 
     def gauge(
@@ -79,6 +80,7 @@ class MetricsWrapper(Metrics):
             value=value,
             tags=self.__merge_tags(tags),
             stacklevel=stacklevel + 1,
+            sample_rate=1,
         )
 
     def timing(
@@ -93,6 +95,7 @@ class MetricsWrapper(Metrics):
             value=value,
             tags=self.__merge_tags(tags),
             stacklevel=stacklevel + 1,
+            sample_rate=1,
         )
 
 


### PR DESCRIPTION
We need a sample rate of 1 otherwise counters will not be correct.

Arroyo already buffers all metrics and only flushes them once a second so it's safe to run with a sample rate of 1.
