### PR TITLE
fix(feedback): Improve aria labels for feedback mailboxes

### DIFF
--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -43,7 +43,7 @@ export default function MailboxPicker({onChange, value}: Props) {
           const title =
             count === 1 ? t('1 unassigned item') : t('%s unassigned items', display);
           return (
-            <SegmentedControl.Item key={c.key}>
+            <SegmentedControl.Item key={c.key} aria-label={c.label}>
               <Tooltip disabled={!count} title={title}>
                 <Flex align="center">
                   {c.label}


### PR DESCRIPTION
The browser dev tools was complaining about this:
<img width="844" alt="SCR-20240329-kmaz" src="https://github.com/getsentry/sentry/assets/187460/7846b0fd-a21c-4e48-b896-7cef8d07ad34">
