### PR TITLE
ref(feedback): update screenshot display in feedback details

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -8,7 +8,6 @@ import FeedbackItemHeader from 'sentry/components/feedback/feedbackItem/feedback
 import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
 import FeedbackReplay from 'sentry/components/feedback/feedbackItem/feedbackReplay';
 import MessageSection from 'sentry/components/feedback/feedbackItem/messageSection';
-import {ScreenshotSection} from 'sentry/components/feedback/feedbackItem/screenshotSection';
 import TagsSection from 'sentry/components/feedback/feedbackItem/tagsSection';
 import PanelItem from 'sentry/components/panels/panelItem';
 import QuestionTooltip from 'sentry/components/questionTooltip';
@@ -48,14 +47,6 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
         <Section>
           <MessageSection eventData={eventData} feedbackItem={feedbackItem} />
         </Section>
-
-        {eventData && (
-          <ScreenshotSection
-            event={eventData}
-            organization={organization}
-            projectSlug={feedbackItem.project.slug}
-          />
-        )}
 
         {!crashReportId || (crashReportId && url) ? (
           <Section icon={<IconLink size="xs" />} title={t('URL')}>

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -153,10 +153,13 @@ const StyledLoadingIndicator = styled('div')`
   height: 100%;
 `;
 
-const StyledImageWrapper = styled('div')`
-  :hover {
-    cursor: zoom-in;
-  }
+const StyledImageWrapper = styled('button')`
+  cursor: zoom-in;
+  background: none;
+  padding: 0;
+  border-radius: ${p => p.theme.borderRadius};
+  border: 0;
+  overflow: hidden;
 `;
 
 const StyledImageVisualization = styled(ImageVisualization)`

--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -1,0 +1,169 @@
+import type {ReactEventHandler} from 'react';
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Role} from 'sentry/components/acl/role';
+import {Button} from 'sentry/components/button';
+import ImageVisualization from 'sentry/components/events/eventTagsAndScreenshot/screenshot/imageVisualization';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import {IconChevron} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event, EventAttachment, Organization, Project} from 'sentry/types';
+
+type Props = {
+  eventId: Event['id'];
+  openVisualizationModal: (eventAttachment: EventAttachment) => void;
+  organization: Organization;
+  projectSlug: Project['slug'];
+  screenshot: EventAttachment;
+  screenshotInFocus: number;
+  totalScreenshots: number;
+  onNext?: ReactEventHandler;
+  onPrevious?: ReactEventHandler;
+};
+
+function FeedbackScreenshot({
+  eventId,
+  organization,
+  screenshot,
+  screenshotInFocus,
+  onNext,
+  onPrevious,
+  totalScreenshots,
+  projectSlug,
+  openVisualizationModal,
+}: Props) {
+  const orgSlug = organization.slug;
+  const [loadingImage, setLoadingImage] = useState(true);
+
+  function renderContent(screenshotAttachment: EventAttachment) {
+    return (
+      <Fragment>
+        {totalScreenshots > 1 && (
+          <StyledPanelHeader lightText>
+            <Button
+              disabled={screenshotInFocus === 0}
+              aria-label={t('Previous Screenshot')}
+              onClick={onPrevious}
+              icon={<IconChevron direction="left" />}
+              size="xs"
+            />
+            {tct('[currentScreenshot] of [totalScreenshots]', {
+              currentScreenshot: screenshotInFocus + 1,
+              totalScreenshots,
+            })}
+            <Button
+              disabled={screenshotInFocus + 1 === totalScreenshots}
+              aria-label={t('Next Screenshot')}
+              onClick={onNext}
+              icon={<IconChevron direction="right" />}
+              size="xs"
+            />
+          </StyledPanelHeader>
+        )}
+        <StyledPanelBody hasHeader={totalScreenshots > 1}>
+          {loadingImage && (
+            <StyledLoadingIndicator>
+              <LoadingIndicator mini />
+            </StyledLoadingIndicator>
+          )}
+          <StyledImageWrapper
+            onClick={() => openVisualizationModal(screenshotAttachment)}
+          >
+            <StyledImageVisualization
+              attachment={screenshotAttachment}
+              orgId={orgSlug}
+              projectSlug={projectSlug}
+              eventId={eventId}
+              onLoad={() => setLoadingImage(false)}
+              onError={() => setLoadingImage(false)}
+            />
+          </StyledImageWrapper>
+        </StyledPanelBody>
+      </Fragment>
+    );
+  }
+
+  return (
+    <Role organization={organization} role={organization.attachmentsRole}>
+      {({hasRole}) => {
+        if (!hasRole) {
+          return null;
+        }
+        return <StyledPanel>{renderContent(screenshot)}</StyledPanel>;
+      }}
+    </Role>
+  );
+}
+
+export default FeedbackScreenshot;
+
+const StyledPanel = styled(Panel)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 0;
+  max-width: 360px;
+  max-height: 360px;
+  border: 0;
+`;
+
+const StyledPanelHeader = styled(PanelHeader)`
+  padding: ${space(1)};
+  width: 100%;
+  border: 1px solid ${p => p.theme.border};
+  border-bottom: 0;
+  border-top-left-radius: ${p => p.theme.borderRadius};
+  border-top-right-radius: ${p => p.theme.borderRadius};
+  display: flex;
+  justify-content: space-between;
+  text-transform: none;
+  background: ${p => p.theme.background};
+`;
+
+const StyledPanelBody = styled(PanelBody)<{hasHeader: boolean}>`
+  border: 1px solid ${p => p.theme.border};
+  min-height: 48px;
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+
+  ${p =>
+    !p.hasHeader &&
+    `
+  border-top-left-radius: ${p.theme.borderRadius};
+  border-top-right-radius: ${p.theme.borderRadius};
+  `}
+`;
+
+const StyledLoadingIndicator = styled('div')`
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+`;
+
+const StyledImageWrapper = styled('div')`
+  :hover {
+    cursor: zoom-in;
+  }
+`;
+
+const StyledImageVisualization = styled(ImageVisualization)`
+  z-index: 1;
+  border: 0;
+  img {
+    width: auto;
+    height: auto;
+  }
+`;

--- a/static/app/components/feedback/feedbackItem/messageSection.tsx
+++ b/static/app/components/feedback/feedbackItem/messageSection.tsx
@@ -4,12 +4,14 @@ import styled from '@emotion/styled';
 import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedbackItemUsername';
 import FeedbackTimestampsTooltip from 'sentry/components/feedback/feedbackItem/feedbackTimestampsTooltip';
 import FeedbackViewers from 'sentry/components/feedback/feedbackItem/feedbackViewers';
+import {ScreenshotSection} from 'sentry/components/feedback/feedbackItem/screenshotSection';
 import {Flex} from 'sentry/components/profiling/flex';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
   eventData: Event | undefined;
@@ -17,6 +19,7 @@ interface Props {
 }
 
 export default function MessageSection({eventData, feedbackItem}: Props) {
+  const organization = useOrganization();
   return (
     <Fragment>
       <Flex wrap="wrap" flex="1 1 auto" gap={space(1)} justify="space-between">
@@ -33,7 +36,14 @@ export default function MessageSection({eventData, feedbackItem}: Props) {
         />
       </Flex>
       <Blockquote>
-        <pre>{feedbackItem.metadata.message}</pre>
+        <p>{feedbackItem.metadata.message}</p>
+        {eventData && (
+          <ScreenshotSection
+            event={eventData}
+            organization={organization}
+            projectSlug={feedbackItem.project.slug}
+          />
+        )}
       </Blockquote>
       <Flex justify="flex-end">
         <Flex gap={space(1)} align="center">
@@ -61,11 +71,15 @@ const Blockquote = styled('blockquote')`
   margin: 0;
   background: ${p => p.theme.purple100};
 
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+
   border-left: 2px solid ${p => p.theme.purple300};
   padding: ${space(2)};
 
-  & > pre {
-    margin: 0;
+  & > p {
+    margin-bottom: 0;
     background: none;
     font-family: inherit;
     font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/components/feedback/feedbackItem/messageSection.tsx
+++ b/static/app/components/feedback/feedbackItem/messageSection.tsx
@@ -36,7 +36,7 @@ export default function MessageSection({eventData, feedbackItem}: Props) {
         />
       </Flex>
       <Blockquote>
-        <p>{feedbackItem.metadata.message}</p>
+        <pre>{feedbackItem.metadata.message}</pre>
         {eventData && (
           <ScreenshotSection
             event={eventData}
@@ -78,7 +78,7 @@ const Blockquote = styled('blockquote')`
   border-left: 2px solid ${p => p.theme.purple300};
   padding: ${space(2)};
 
-  & > p {
+  & > pre {
     margin-bottom: 0;
     background: none;
     font-family: inherit;

--- a/static/app/components/feedback/feedbackItem/openScreenshotModal.tsx
+++ b/static/app/components/feedback/feedbackItem/openScreenshotModal.tsx
@@ -1,0 +1,184 @@
+import type {ComponentProps} from 'react';
+import {Fragment, useState} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import ImageVisualization from 'sentry/components/events/eventTagsAndScreenshot/screenshot/imageVisualization';
+import ScreenshotPagination from 'sentry/components/events/eventTagsAndScreenshot/screenshot/screenshotPagination';
+import type {CursorHandler} from 'sentry/components/pagination';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {EventAttachment, IssueAttachment, Organization, Project} from 'sentry/types';
+import type {Event} from 'sentry/types/event';
+import {defined} from 'sentry/utils';
+import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
+import {MAX_SCREENSHOTS_PER_PAGE} from 'sentry/views/issueDetails/groupEventAttachments/groupEventAttachments';
+
+type Props = ModalRenderProps & {
+  eventAttachment: EventAttachment;
+  orgSlug: Organization['slug'];
+  projectSlug: Project['slug'];
+  attachmentIndex?: number;
+  attachments?: EventAttachment[];
+  event?: Event;
+  groupId?: string;
+  pageLinks?: string | null | undefined;
+};
+
+function OpenScreenshotModal({
+  eventAttachment,
+  orgSlug,
+  projectSlug,
+  Header,
+  Body,
+  pageLinks: initialPageLinks,
+  attachmentIndex,
+  attachments,
+  groupId,
+}: Props) {
+  // copied from issues screenshot modal - handles paginating through multiple screenshots
+  const api = useApi();
+  const location = useLocation();
+
+  const [currentEventAttachment, setCurrentAttachment] =
+    useState<EventAttachment>(eventAttachment);
+  const [currentAttachmentIndex, setCurrentAttachmentIndex] = useState<
+    number | undefined
+  >(attachmentIndex);
+  const [memoizedAttachments, setMemoizedAttachments] = useState<
+    IssueAttachment[] | undefined
+  >(attachments);
+
+  const [pageLinks, setPageLinks] = useState<string | null | undefined>(initialPageLinks);
+
+  const handleCursor: CursorHandler = (cursor, _pathname, query, delta) => {
+    if (defined(currentAttachmentIndex) && memoizedAttachments?.length) {
+      const newAttachmentIndex = currentAttachmentIndex + delta;
+      if (newAttachmentIndex === MAX_SCREENSHOTS_PER_PAGE || newAttachmentIndex === -1) {
+        api
+          .requestPromise(`/issues/${groupId}/attachments/`, {
+            method: 'GET',
+            includeAllArgs: true,
+            query: {
+              ...query,
+              per_page: MAX_SCREENSHOTS_PER_PAGE,
+              types: undefined,
+              screenshot: 1,
+              cursor,
+            },
+          })
+          .then(([data, _, resp]) => {
+            if (newAttachmentIndex === MAX_SCREENSHOTS_PER_PAGE) {
+              setCurrentAttachmentIndex(0);
+              setCurrentAttachment(data[0]);
+            } else {
+              setCurrentAttachmentIndex(MAX_SCREENSHOTS_PER_PAGE - 1);
+              setCurrentAttachment(data[MAX_SCREENSHOTS_PER_PAGE - 1]);
+            }
+            setMemoizedAttachments(data);
+            setPageLinks(resp?.getResponseHeader('Link'));
+          });
+        return;
+      }
+      setCurrentAttachmentIndex(newAttachmentIndex);
+      setCurrentAttachment(memoizedAttachments[newAttachmentIndex]);
+    }
+  };
+
+  const path = location.pathname;
+  const query = location.query;
+  const links = pageLinks ? parseLinkHeader(pageLinks) : undefined;
+
+  let paginationProps: ComponentProps<typeof ScreenshotPagination> | null = null;
+  if (links) {
+    paginationProps = {
+      previousDisabled:
+        links?.previous?.results === false && currentAttachmentIndex === 0,
+      nextDisabled:
+        links?.next?.results === false &&
+        currentAttachmentIndex === MAX_SCREENSHOTS_PER_PAGE - 1,
+      onPrevious: () => {
+        handleCursor(links.previous?.cursor, path, query, -1);
+      },
+      onNext: () => {
+        handleCursor(links.next?.cursor, path, query, 1);
+      },
+    };
+  } else if (
+    memoizedAttachments &&
+    memoizedAttachments.length > 1 &&
+    defined(currentAttachmentIndex)
+  ) {
+    paginationProps = {
+      previousDisabled: currentAttachmentIndex === 0,
+      nextDisabled: currentAttachmentIndex === memoizedAttachments.length - 1,
+      onPrevious: () => {
+        setCurrentAttachment(memoizedAttachments[currentAttachmentIndex - 1]);
+        setCurrentAttachmentIndex(currentAttachmentIndex - 1);
+      },
+      onNext: () => {
+        setCurrentAttachment(memoizedAttachments[currentAttachmentIndex + 1]);
+        setCurrentAttachmentIndex(currentAttachmentIndex + 1);
+      },
+      headerText: tct('[currentScreenshotIndex] of [totalScreenshotCount]', {
+        currentScreenshotIndex: currentAttachmentIndex + 1,
+        totalScreenshotCount: memoizedAttachments.length,
+      }),
+    };
+  }
+
+  // end copy from issues screenshot modal
+
+  return (
+    <Fragment>
+      <StyledHeaderWrapper hasPagination={defined(paginationProps)}>
+        <Header closeButton>{t('Screenshot')}</Header>
+        {defined(paginationProps) && (
+          <Header>
+            <ScreenshotPagination {...paginationProps} />
+          </Header>
+        )}
+      </StyledHeaderWrapper>
+      <Body>
+        <StyledImageVisualization
+          attachment={currentEventAttachment}
+          orgId={orgSlug}
+          projectSlug={projectSlug}
+          eventId={currentEventAttachment.event_id}
+        />
+      </Body>
+    </Fragment>
+  );
+}
+
+export default OpenScreenshotModal;
+
+const StyledHeaderWrapper = styled('div')<{hasPagination: boolean}>`
+  ${p =>
+    p.hasPagination &&
+    `
+  header {
+    margin-bottom: 0;
+  }
+
+  header:last-of-type {
+    margin-top: 0;
+    margin-bottom: ${space(3)};
+  }
+  `}
+`;
+
+const StyledImageVisualization = styled(ImageVisualization)`
+  img {
+    border-radius: ${p => p.theme.borderRadius};
+    max-height: calc(100vh - 300px);
+  }
+`;
+
+export const modalCss = css`
+  height: 100%;
+  width: auto;
+`;

--- a/static/app/components/feedback/feedbackItem/screenshotSection.tsx
+++ b/static/app/components/feedback/feedbackItem/screenshotSection.tsx
@@ -95,7 +95,7 @@ export function ScreenshotSection({projectSlug, event, organization}: Props) {
             priority: 'danger',
           });
         }}
-        aria-label="delete screenshot"
+        aria-label={t('Delete screenshot')}
       />
     </ScreenshotWrapper>
   ) : null;

--- a/static/app/components/feedback/feedbackItem/screenshotSection.tsx
+++ b/static/app/components/feedback/feedbackItem/screenshotSection.tsx
@@ -1,14 +1,18 @@
 import {useCallback, useState} from 'react';
+import styled from '@emotion/styled';
 
 import {useDeleteEventAttachmentOptimistic} from 'sentry/actionCreators/events';
 import {openModal} from 'sentry/actionCreators/modal';
-import Screenshot from 'sentry/components/events/eventTagsAndScreenshot/screenshot';
-import Modal, {
+import {Button} from 'sentry/components/button';
+import {openConfirmModal} from 'sentry/components/confirm';
+import FeedbackScreenshot from 'sentry/components/feedback/feedbackItem/feedbackScreenshot';
+import OpenScreenshotModal, {
   modalCss,
-} from 'sentry/components/events/eventTagsAndScreenshot/screenshot/modal';
-import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
+} from 'sentry/components/feedback/feedbackItem/openScreenshotModal';
 import useFeedbackScreenshot from 'sentry/components/feedback/feedbackItem/useFeedbackHasScreenshot';
+import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import type {EventAttachment} from 'sentry/types/group';
@@ -39,22 +43,15 @@ export function ScreenshotSection({projectSlug, event, organization}: Props) {
   );
 
   const handleOpenVisualizationModal = useCallback(
-    (eventAttachment: EventAttachment, downloadUrl: string) => {
-      function handleDelete() {
-        handleDeleteScreenshot(eventAttachment.id);
-      }
-
+    (eventAttachment: EventAttachment) => {
       openModal(
         modalProps => (
-          <Modal
+          <OpenScreenshotModal
             {...modalProps}
             event={event}
             orgSlug={organization.slug}
             projectSlug={projectSlug}
             eventAttachment={eventAttachment}
-            downloadUrl={downloadUrl}
-            onDelete={handleDelete}
-            onDownload={() => undefined}
             attachments={screenshots}
             attachmentIndex={screenshotInFocus}
           />
@@ -62,14 +59,7 @@ export function ScreenshotSection({projectSlug, event, organization}: Props) {
         {modalCss}
       );
     },
-    [
-      event,
-      handleDeleteScreenshot,
-      organization.slug,
-      projectSlug,
-      screenshotInFocus,
-      screenshots,
-    ]
+    [event, organization.slug, projectSlug, screenshotInFocus, screenshots]
   );
 
   if (!hasContext && !screenshots.length) {
@@ -80,19 +70,38 @@ export function ScreenshotSection({projectSlug, event, organization}: Props) {
   const screenshot = screenshots[screenshotInFocus];
 
   return showScreenshot ? (
-    <Section title={t('Screenshot')}>
-      <Screenshot
+    <ScreenshotWrapper>
+      <FeedbackScreenshot
         organization={organization}
         eventId={event.id}
         projectSlug={projectSlug}
         screenshot={screenshot}
-        onDelete={handleDeleteScreenshot}
         onNext={() => setScreenshotInFocus(screenshotInFocus + 1)}
         onPrevious={() => setScreenshotInFocus(screenshotInFocus - 1)}
         screenshotInFocus={screenshotInFocus}
         totalScreenshots={screenshots.length}
         openVisualizationModal={handleOpenVisualizationModal}
       />
-    </Section>
+      <Button
+        icon={<IconDelete />}
+        borderless
+        size="xs"
+        onClick={() => {
+          openConfirmModal({
+            header: t('Delete screenshot?'),
+            message: t('This action cannot be undone.'),
+            confirmText: t('Delete screenshot'),
+            onConfirm: () => handleDeleteScreenshot(screenshot.id),
+            priority: 'danger',
+          });
+        }}
+        aria-label="delete screenshot"
+      />
+    </ScreenshotWrapper>
   ) : null;
 }
+
+const ScreenshotWrapper = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+`;


### PR DESCRIPTION
- Relates to https://github.com/getsentry/sentry/issues/67707
- Implements some of the design updates from this [figma](https://github.com/getsentry/sentry/issues/67707) (see followup todos at the bottom)
- Updates screenshot display in feedback UI to be part of the purple message section. Removes extraneous buttons and adds a small delete button to the right
- Removes extraneous buttons in full screen modal view

## Max dimensions are currently `360px` x `360px`:
<img width="743" alt="SCR-20240329-kqdj" src="https://github.com/getsentry/sentry/assets/56095982/ba45f3c8-0d21-4824-a3ca-0215bdbb58ae">
<img width="829" alt="SCR-20240329-kqak" src="https://github.com/getsentry/sentry/assets/56095982/007b9040-d756-4807-98c0-e747a973f848">
<img width="819" alt="SCR-20240329-kpyc" src="https://github.com/getsentry/sentry/assets/56095982/94a5f111-2618-4798-9b70-73a35bc4022b">

## Full screen / zoom view 
- scales nicely
- zoom-in pointer on hover

https://github.com/getsentry/sentry/assets/56095982/3c97fa45-2109-4f19-9a71-d8e8084397dd



## Screenshot display scales nicely

https://github.com/getsentry/sentry/assets/56095982/0ce3e5b4-b455-4fbf-b48b-280e0a151363

## Delete button with confirmation modal

https://github.com/getsentry/sentry/assets/56095982/79ac0349-18cf-49a3-af77-3b779f00d817

## TODOS
- Currently, if you delete a screenshot, it will not show up in UI anymore. The design specifies that we should instead show this message instead:
<img width="396" alt="SCR-20240329-kuoq" src="https://github.com/getsentry/sentry/assets/56095982/dddf4e47-6f1b-4ac8-88c5-e7b43b50628d">

- Pagination code largely copied from the issues component; not tested since we can't currently add multiple screenshots in a FB submission yet
- Screenshot display in details isn't scaling properly -- if a screenshot comes in that's extra wide or extra long (e.g. more than `360px` in either dimension, it'll get cropped to fit within `360px` x `360px`. However the design specifies that the entire image should instead scale down to fit within this box, rather than getting cropped
- When clicking into full screen/zoom-in mode, the modal should take up the whole screen rather than staying the same dimensions as the image. (see designs for reference)