### PR TITLE
fix(replay): Fix order that react hooks are called

### DIFF
--- a/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/domNodesChart.tsx
@@ -4,7 +4,7 @@ import {useTheme} from '@emotion/react';
 import type {AreaChartProps} from 'sentry/components/charts/areaChart';
 import {AreaChart} from 'sentry/components/charts/areaChart';
 import Grid from 'sentry/components/charts/components/grid';
-import {ChartTooltip} from 'sentry/components/charts/components/tooltip';
+import {computeChartTooltip} from 'sentry/components/charts/components/tooltip';
 import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import type {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -48,23 +48,24 @@ export default function DomNodesChart({
       left: space(1),
       right: space(1),
     }),
-    tooltip: ChartTooltip({
-      appendToBody: true,
-      trigger: 'axis',
-      renderMode: 'html',
-      chartId: 'replay-dom-nodes-chart',
-      formatter: values => {
-        const firstValue = Array.isArray(values) ? values[0] : values;
-        const seriesTooltips = toArray(values).map(
-          value => `
+    tooltip: computeChartTooltip(
+      {
+        appendToBody: true,
+        trigger: 'axis',
+        renderMode: 'html',
+        chartId: 'replay-dom-nodes-chart',
+        formatter: values => {
+          const firstValue = Array.isArray(values) ? values[0] : values;
+          const seriesTooltips = toArray(values).map(
+            value => `
             <div>
               <span className="tooltip-label">${value.marker}<strong>${value.seriesName}</strong></span>
               ${value.data[1]}
             </div>
           `
-        );
+          );
 
-        return `
+          return `
           <div class="tooltip-series">${seriesTooltips.join('')}</div>
             <div class="tooltip-footer">
               ${t('Date: %s', getFormattedDate(startOffsetMs + firstValue.axisValue, 'MMM D, YYYY hh:mm:ss A z', {local: false}))}
@@ -74,8 +75,10 @@ export default function DomNodesChart({
             </div>
           <div class="tooltip-arrow"></div>
         `;
+        },
       },
-    }),
+      theme
+    ),
     xAxis: XAxis({
       type: 'time',
       axisLabel: {

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -4,7 +4,7 @@ import {useTheme} from '@emotion/react';
 import type {AreaChartProps} from 'sentry/components/charts/areaChart';
 import {AreaChart} from 'sentry/components/charts/areaChart';
 import Grid from 'sentry/components/charts/components/grid';
-import {ChartTooltip} from 'sentry/components/charts/components/tooltip';
+import {computeChartTooltip} from 'sentry/components/charts/components/tooltip';
 import XAxis from 'sentry/components/charts/components/xAxis';
 import YAxis from 'sentry/components/charts/components/yAxis';
 import type {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -48,22 +48,23 @@ export default function MemoryChart({
         left: space(1),
         right: space(1),
       }),
-      tooltip: ChartTooltip({
-        appendToBody: true,
-        trigger: 'axis',
-        renderMode: 'html',
-        chartId: 'replay-memory-chart',
-        formatter: values => {
-          const firstValue = Array.isArray(values) ? values[0] : values;
-          const seriesTooltips = toArray(values).map(
-            value => `
+      tooltip: computeChartTooltip(
+        {
+          appendToBody: true,
+          trigger: 'axis',
+          renderMode: 'html',
+          chartId: 'replay-memory-chart',
+          formatter: values => {
+            const firstValue = Array.isArray(values) ? values[0] : values;
+            const seriesTooltips = toArray(values).map(
+              value => `
               <div>
                 <span className="tooltip-label">${value.marker}<strong>${value.seriesName}</strong></span>
                 ${formatBytesBase2(value.data[1])}
               </div>
             `
-          );
-          return `
+            );
+            return `
             <div class="tooltip-series">${seriesTooltips.join('')}</div>
               <div class="tooltip-footer">
                 ${t('Date: %s', getFormattedDate(startOffsetMs + firstValue.axisValue, 'MMM D, YYYY hh:mm:ss A z', {local: false}))}
@@ -73,8 +74,10 @@ export default function MemoryChart({
               </div>
             <div class="tooltip-arrow"></div>
           `;
+          },
         },
-      }),
+        theme
+      ),
       xAxis: XAxis({
         type: 'time',
         axisLabel: {


### PR DESCRIPTION
The dev tools were complaining about this:
<img width="904" alt="SCR-20240329-kxfd" src="https://github.com/getsentry/sentry/assets/187460/76839975-cdfb-4602-bfc4-f3ed74fedb55">


Turns out that `ChartTooltip()` was calling `useTheme()` itself., and we can't have hooks calling hooks like that.