### PR TITLE
fix: deprecate creation of legacy API Keys

### DIFF
--- a/src/sentry/api/endpoints/organization_api_key_index.py
+++ b/src/sentry/api/endpoints/organization_api_key_index.py
@@ -1,8 +1,6 @@
-from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
@@ -21,7 +19,6 @@ class OrganizationApiKeyIndexEndpoint(ControlSiloOrganizationEndpoint):
     owner = ApiOwner.ECOSYSTEM
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
-        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (OrganizationAdminPermission,)
 
@@ -38,23 +35,3 @@ class OrganizationApiKeyIndexEndpoint(ControlSiloOrganizationEndpoint):
         )
 
         return Response(serialize(queryset, request.user))
-
-    def post(self, request: Request, organization_context, organization) -> Response:
-        """
-        Create an Organization API Key
-        ```````````````````````````````````
-
-        :pparam string organization_slug: the organization short name
-        :auth: required
-        """
-        key = ApiKey.objects.create(organization_id=organization.id, scope_list=DEFAULT_SCOPES)
-
-        self.create_audit_entry(
-            request,
-            organization=organization,
-            target_object=key.id,
-            event=audit_log.get_event_id("APIKEY_ADD"),
-            data=key.get_audit_log_data(),
-        )
-
-        return Response(serialize(key, request.user), status=status.HTTP_201_CREATED)


### PR DESCRIPTION
In our documentation we state that API Keys are deprecated, but we've had creation of these legacy keys as late as Feb 29 2024. Presumably from direct usage of the backend API.
