### PR TITLE
feat(autofix): Add Seer RPC endpoint for org slug lookup

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -22,6 +22,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.models.group import Group
+from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.rpc import RpcAuthenticationSetupException, RpcResolutionException
 from sentry.services.hybrid_cloud.sig import SerializableFunctionValueException
 from sentry.silo.base import SiloMode
@@ -190,10 +191,16 @@ def get_autofix_state(*, issue_id: int) -> dict:
     return autofix_data
 
 
+def get_organization_slug(*, org_id: int) -> dict:
+    org: Organization = Organization.objects.get(id=org_id)
+    return {"slug": org.slug}
+
+
 seer_method_registry = {
     "on_autofix_step_update": on_autofix_step_update,
     "on_autofix_complete": on_autofix_complete,
     "get_autofix_state": get_autofix_state,
+    "get_organization_slug": get_organization_slug,
 }
 
 

--- a/tests/sentry/api/endpoints/test_seer_rpc.py
+++ b/tests/sentry/api/endpoints/test_seer_rpc.py
@@ -71,3 +71,13 @@ class TestSeerRpc(APITestCase):
         )
         assert response.status_code == 200
         assert response.json() == {"status": "thing", "steps": [1, 2, 3]}
+
+    def test_get_organization_slug(self):
+        org = self.create_organization()
+        path = self._get_path("get_organization_slug")
+        data: dict[str, Any] = {"args": {"org_id": org.id}}
+        response = self.client.post(
+            path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
+        )
+        assert response.status_code == 200
+        assert response.json() == {"slug": org.slug}


### PR DESCRIPTION
Seer needs the slug to add a issue reference URL to auto-generated PRs.

<!-- Describe your PR here. -->
Adds a new Seer RPC endpoint that allows Seer to lookup the slug of an organization given its id.