### PR TITLE
ref(replays): disable playback speed for mobile replays

### DIFF
--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -79,9 +79,9 @@ function ReplayOptionsMenu({
           title={t('Settings')}
           aria-label={t('Settings')}
           icon={<IconSettings size="sm" />}
-          disabled={disableSettings}
         />
       )}
+      disabled={disableSettings}
     >
       <CompositeSelect.Region
         label={t('Playback Speed')}
@@ -91,26 +91,21 @@ function ReplayOptionsMenu({
           label: `${option}x`,
           value: option,
         }))}
-        isOptionDisabled={() => {
-          return disableSettings;
-        }}
       />
-      {!disableSettings && (
-        <CompositeSelect.Region
-          aria-label={t('Fast-Forward Inactivity')}
-          multiple
-          value={isSkippingInactive ? [SKIP_OPTION_VALUE] : []}
-          onChange={opts => {
-            toggleSkipInactive(opts.length > 0);
-          }}
-          options={[
-            {
-              label: t('Fast-forward inactivity'),
-              value: SKIP_OPTION_VALUE,
-            },
-          ]}
-        />
-      )}
+      <CompositeSelect.Region
+        aria-label={t('Fast-Forward Inactivity')}
+        multiple
+        value={isSkippingInactive ? [SKIP_OPTION_VALUE] : []}
+        onChange={opts => {
+          toggleSkipInactive(opts.length > 0);
+        }}
+        options={[
+          {
+            label: t('Fast-forward inactivity'),
+            value: SKIP_OPTION_VALUE,
+          },
+        ]}
+      />
     </CompositeSelect>
   );
 }

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -20,7 +20,7 @@ const COMPACT_WIDTH_BREAKPOINT = 500;
 
 interface Props {
   toggleFullscreen: () => void;
-  hideFastForward?: boolean;
+  disableSettings?: boolean;
   speedOptions?: number[];
 }
 
@@ -62,9 +62,9 @@ function ReplayPlayPauseBar() {
 
 function ReplayOptionsMenu({
   speedOptions,
-  hideFastForward = false,
+  disableSettings,
 }: {
-  hideFastForward: boolean;
+  disableSettings: boolean;
   speedOptions: number[];
 }) {
   const {setSpeed, speed, isSkippingInactive, toggleSkipInactive} = useReplayContext();
@@ -79,6 +79,7 @@ function ReplayOptionsMenu({
           title={t('Settings')}
           aria-label={t('Settings')}
           icon={<IconSettings size="sm" />}
+          disabled={disableSettings}
         />
       )}
     >
@@ -90,8 +91,11 @@ function ReplayOptionsMenu({
           label: `${option}x`,
           value: option,
         }))}
+        isOptionDisabled={() => {
+          return disableSettings;
+        }}
       />
-      {!hideFastForward && (
+      {!disableSettings && (
         <CompositeSelect.Region
           aria-label={t('Fast-Forward Inactivity')}
           multiple
@@ -113,7 +117,7 @@ function ReplayOptionsMenu({
 
 function ReplayControls({
   toggleFullscreen,
-  hideFastForward = false,
+  disableSettings = false,
   speedOptions = [0.1, 0.25, 0.5, 1, 2, 4, 8, 16],
 }: Props) {
   const barRef = useRef<HTMLDivElement>(null);
@@ -141,7 +145,7 @@ function ReplayControls({
       <ButtonBar gap={1}>
         <ReplayOptionsMenu
           speedOptions={speedOptions}
-          hideFastForward={hideFastForward}
+          disableSettings={disableSettings}
         />
         <ReplayFullscreenButton toggleFullscreen={toggleFullscreen} />
       </ButtonBar>

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -59,7 +59,7 @@ function ReplayView({toggleFullscreen}: Props) {
       {isFullscreen ? (
         <ReplayController
           toggleFullscreen={toggleFullscreen}
-          hideFastForward={isVideoReplay}
+          disableSettings={isVideoReplay}
         />
       ) : null}
     </Fragment>

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -45,7 +45,7 @@ function ReplayLayout({isVideoReplay = false}: {isVideoReplay?: boolean}) {
     <ErrorBoundary mini>
       <ReplayController
         toggleFullscreen={toggleFullscreen}
-        hideFastForward={isVideoReplay}
+        disableSettings={isVideoReplay}
       />
     </ErrorBoundary>
   );


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/67879

Settings option is disabled for mobile replays, since we won't have playback functionality for alpha 

<img width="1197" alt="SCR-20240329-mhdc" src="https://github.com/getsentry/sentry/assets/56095982/d3718866-1b5a-49a0-8430-02ad300c22a8">

