### PR TITLE
feat: hashed user auth tokens

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -331,17 +331,10 @@ class UserAuthTokenAuthentication(StandardAuthentication):
             except ApiTokenReplica.DoesNotExist:
                 try:
                     # If we can't find it by hash, use the plaintext string
-                    api_token_replica = ApiTokenReplica.objects.get(token=token_str)
+                    return ApiTokenReplica.objects.get(token=token_str)
                 except ApiTokenReplica.DoesNotExist:
                     # If the token does not exist by plaintext either, it is not a valid token
                     raise AuthenticationFailed("Invalid token")
-                else:
-                    # If found by plaintext, update the ApiToken with the hashed value
-                    # which will replicate back to the region
-                    api_token = ApiToken.objects.get(token=token_str)
-                    api_token.hashed_token = hashed_token
-                    api_token.save(update_fields=["hashed_token"])
-                    return api_token_replica
         else:
             try:
                 # Try to find the token by its hashed value first

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -324,25 +324,44 @@ class UserAuthTokenAuthentication(StandardAuthentication):
 
         hashed_token = hashlib.sha256(token_str.encode()).hexdigest()
 
-        try:
-            # Try to find the token by its hashed value first
-            return ApiToken.objects.select_related("user", "application").get(
-                hashed_token=hashed_token
-            )
-        except ApiToken.DoesNotExist:
+        if SiloMode.get_current_mode() == SiloMode.REGION:
             try:
-                # If we can't find it by hash, use the plaintext string
-                api_token = ApiToken.objects.select_related("user", "application").get(
-                    token=token_str
+                # Try to find the token by its hashed value first
+                return ApiTokenReplica.objects.get(hashed_token=hashed_token)
+            except ApiTokenReplica.DoesNotExist:
+                try:
+                    # If we can't find it by hash, use the plaintext string
+                    api_token_replica = ApiTokenReplica.objects.get(token=token_str)
+                except ApiTokenReplica.DoesNotExist:
+                    # If the token does not exist by plaintext either, it is not a valid token
+                    raise AuthenticationFailed("Invalid token")
+                else:
+                    # If found by plaintext, update the ApiToken with the hashed value
+                    # which will replicate back to the region
+                    api_token = ApiToken.objects.get(token=token_str)
+                    api_token.hashed_token = hashed_token
+                    api_token.save(update_fields=["hashed_token"])
+                    return api_token_replica
+        else:
+            try:
+                # Try to find the token by its hashed value first
+                return ApiToken.objects.select_related("user", "application").get(
+                    hashed_token=hashed_token
                 )
             except ApiToken.DoesNotExist:
-                # If the token does not exist by plaintext either, it is not a valid token
-                raise AuthenticationFailed("Invalid token")
-            else:
-                # Update it with the hashed value if found by plaintext
-                api_token.hashed_token = hashed_token
-                api_token.save(update_fields=["hashed_token"])
-                return api_token
+                try:
+                    # If we can't find it by hash, use the plaintext string
+                    api_token = ApiToken.objects.select_related("user", "application").get(
+                        token=token_str
+                    )
+                except ApiToken.DoesNotExist:
+                    # If the token does not exist by plaintext either, it is not a valid token
+                    raise AuthenticationFailed("Invalid token")
+                else:
+                    # Update it with the hashed value if found by plaintext
+                    api_token.hashed_token = hashed_token
+                    api_token.save(update_fields=["hashed_token"])
+                    return api_token
 
     def accepts_auth(self, auth: list[bytes]) -> bool:
         if not super().accepts_auth(auth):
@@ -366,22 +385,17 @@ class UserAuthTokenAuthentication(StandardAuthentication):
         application_is_inactive = False
 
         if not token:
+            at = token = self._find_or_update_token_by_hash(token_str)
+
             if SiloMode.get_current_mode() == SiloMode.REGION:
-                try:
-                    atr = token = ApiTokenReplica.objects.get(token=token_str)
-                except ApiTokenReplica.DoesNotExist:
-                    raise AuthenticationFailed("Invalid token")
-                user = user_service.get_user(user_id=atr.user_id)
-                application_is_inactive = not atr.application_is_active
+                user = user_service.get_user(user_id=at.user_id)
+                application_is_inactive = not at.application_is_active
             else:
-                try:
-                    at = token = self._find_or_update_token_by_hash(token_str)
-                except ApiToken.DoesNotExist:
-                    raise AuthenticationFailed("Invalid token")
                 user = at.user
                 application_is_inactive = (
                     at.application is not None and not at.application.is_active
                 )
+
         elif isinstance(token, SystemToken):
             user = token.user
 

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -311,7 +311,7 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
 class UserAuthTokenAuthentication(StandardAuthentication):
     token_name = b"bearer"
 
-    def _find_or_update_token_by_hash(self, token_str: str) -> ApiToken | ApiTokenReplica:
+    def _find_or_update_token_by_hash(self, token_str: str) -> ApiToken:
         """
         Find token by hash or update token's hash value if only found via plaintext.
         1. Hash provided plaintext token.
@@ -324,37 +324,25 @@ class UserAuthTokenAuthentication(StandardAuthentication):
 
         hashed_token = hashlib.sha256(token_str.encode()).hexdigest()
 
-        if SiloMode.get_current_mode() == SiloMode.REGION:
+        try:
+            # Try to find the token by its hashed value first
+            return ApiToken.objects.select_related("user", "application").get(
+                hashed_token=hashed_token
+            )
+        except ApiToken.DoesNotExist:
             try:
-                # Try to find the token by its hashed value first
-                return ApiTokenReplica.objects.get(hashed_token=hashed_token)
-            except ApiTokenReplica.DoesNotExist:
-                try:
-                    # If we can't find it by hash, use the plaintext string
-                    return ApiTokenReplica.objects.get(token=token_str)
-                except ApiTokenReplica.DoesNotExist:
-                    # If the token does not exist by plaintext either, it is not a valid token
-                    raise AuthenticationFailed("Invalid token")
-        else:
-            try:
-                # Try to find the token by its hashed value first
-                return ApiToken.objects.select_related("user", "application").get(
-                    hashed_token=hashed_token
+                # If we can't find it by hash, use the plaintext string
+                api_token = ApiToken.objects.select_related("user", "application").get(
+                    token=token_str
                 )
             except ApiToken.DoesNotExist:
-                try:
-                    # If we can't find it by hash, use the plaintext string
-                    api_token = ApiToken.objects.select_related("user", "application").get(
-                        token=token_str
-                    )
-                except ApiToken.DoesNotExist:
-                    # If the token does not exist by plaintext either, it is not a valid token
-                    raise AuthenticationFailed("Invalid token")
-                else:
-                    # Update it with the hashed value if found by plaintext
-                    api_token.hashed_token = hashed_token
-                    api_token.save(update_fields=["hashed_token"])
-                    return api_token
+                # If the token does not exist by plaintext either, it is not a valid token
+                raise AuthenticationFailed("Invalid token")
+            else:
+                # Update it with the hashed value if found by plaintext
+                api_token.hashed_token = hashed_token
+                api_token.save(update_fields=["hashed_token"])
+                return api_token
 
     def accepts_auth(self, auth: list[bytes]) -> bool:
         if not super().accepts_auth(auth):
@@ -378,15 +366,23 @@ class UserAuthTokenAuthentication(StandardAuthentication):
         application_is_inactive = False
 
         if not token:
-
             if SiloMode.get_current_mode() == SiloMode.REGION:
-                atr: ApiTokenReplica = self._find_or_update_token_by_hash(token_str)
-                token = atr
-                user = user_service.get_user(user_id=atr.user_id)
-                application_is_inactive = not atr.application_is_active
+                try:
+                    # Try to find the token by its hashed value first
+                    hashed_token = hashlib.sha256(token_str.encode()).hexdigest()
+                    atr = token = ApiTokenReplica.objects.get(hashed_token=hashed_token)
+                except ApiTokenReplica.DoesNotExist:
+                    try:
+                        # If we can't find it by hash, use the plaintext string
+                        atr = token = ApiTokenReplica.objects.get(token=token_str)
+                    except ApiTokenReplica.DoesNotExist:
+                        # If the token does not exist by plaintext either, it is not a valid token
+                        raise AuthenticationFailed("Invalid token")
+                    else:
+                        user = user_service.get_user(user_id=atr.user_id)
+                        application_is_inactive = not atr.application_is_active
             else:
-                at: ApiToken = self._find_or_update_token_by_hash(token_str)
-                token = at
+                at = token = self._find_or_update_token_by_hash(token_str)
                 user = at.user
                 application_is_inactive = (
                     at.application is not None and not at.application.is_active

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -332,7 +332,7 @@ class UserAuthTokenAuthentication(StandardAuthentication):
                 # If we can't find it by hash, use the plaintext string
                 api_token = ApiToken.objects.get(token=token_str)
             except ApiToken.DoesNotExist:
-                # If the token does not exist by plaintext either, return None
+                # If the token does not exist by plaintext either, it is not a valid token
                 raise AuthenticationFailed("Invalid token")
             else:
                 # Update it with the hashed value if found by plaintext

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable, Iterable
 from typing import Any, ClassVar
 
@@ -310,6 +311,35 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
 class UserAuthTokenAuthentication(StandardAuthentication):
     token_name = b"bearer"
 
+    def _find_or_update_token_by_hash(self, token_str: str) -> ApiToken:
+        """
+        Find token by hash or update token's hash value if only found via plaintext.
+        1. Hash provided plaintext token.
+        2. Perform lookup based on hashed value.
+        3. If found, return the token.
+        4. If not found, search for the token based on its plaintext value.
+        5. If found, update the token's hashed value and return the token.
+        6. If not found via hash or plaintext value, raise AuthenticationFailed
+        """
+
+        hashed_token = hashlib.sha256(token_str.encode()).hexdigest()
+
+        try:
+            # Try to find the token by its hashed value first
+            return ApiToken.objects.get(hashed_token=hashed_token)
+        except ApiToken.DoesNotExist:
+            try:
+                # If we can't find it by hash, use the plaintext string
+                api_token = ApiToken.objects.get(token=token_str)
+            except ApiToken.DoesNotExist:
+                # If the token does not exist by plaintext either, return None
+                raise AuthenticationFailed("Invalid token")
+            else:
+                # Update it with the hashed value if found by plaintext
+                api_token.hashed_token = hashed_token
+                api_token.save(update_fields=["hashed_token"])
+                return api_token
+
     def accepts_auth(self, auth: list[bytes]) -> bool:
         if not super().accepts_auth(auth):
             return False
@@ -401,9 +431,9 @@ class OrgAuthTokenAuthentication(StandardAuthentication):
                 raise AuthenticationFailed("Invalid org token")
         else:
             try:
-                token = OrgAuthToken.objects.filter(
+                token = OrgAuthToken.objects.get(
                     token_hashed=token_hashed, date_deactivated__isnull=True
-                ).get()
+                )
             except OrgAuthToken.DoesNotExist:
                 raise AuthenticationFailed("Invalid org token")
 

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -326,11 +326,15 @@ class UserAuthTokenAuthentication(StandardAuthentication):
 
         try:
             # Try to find the token by its hashed value first
-            return ApiToken.objects.get(hashed_token=hashed_token)
+            return ApiToken.objects.select_related("user", "application").get(
+                hashed_token=hashed_token
+            )
         except ApiToken.DoesNotExist:
             try:
                 # If we can't find it by hash, use the plaintext string
-                api_token = ApiToken.objects.get(token=token_str)
+                api_token = ApiToken.objects.select_related("user", "application").get(
+                    token=token_str
+                )
             except ApiToken.DoesNotExist:
                 # If the token does not exist by plaintext either, it is not a valid token
                 raise AuthenticationFailed("Invalid token")
@@ -371,11 +375,7 @@ class UserAuthTokenAuthentication(StandardAuthentication):
                 application_is_inactive = not atr.application_is_active
             else:
                 try:
-                    at = token = (
-                        ApiToken.objects.filter(token=token_str)
-                        .select_related("user", "application")
-                        .get()
-                    )
+                    at = token = self._find_or_update_token_by_hash(token_str)
                 except ApiToken.DoesNotExist:
                     raise AuthenticationFailed("Invalid token")
                 user = at.user

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -311,38 +311,54 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
 class UserAuthTokenAuthentication(StandardAuthentication):
     token_name = b"bearer"
 
-    def _find_or_update_token_by_hash(self, token_str: str) -> ApiToken:
+    def _find_or_update_token_by_hash(self, token_str: str) -> ApiToken | ApiTokenReplica:
         """
         Find token by hash or update token's hash value if only found via plaintext.
+
         1. Hash provided plaintext token.
         2. Perform lookup based on hashed value.
         3. If found, return the token.
         4. If not found, search for the token based on its plaintext value.
         5. If found, update the token's hashed value and return the token.
         6. If not found via hash or plaintext value, raise AuthenticationFailed
+
+        Returns `ApiTokenReplica` if running in REGION silo or
+        `ApiToken` if running in CONTROL silo.
         """
 
         hashed_token = hashlib.sha256(token_str.encode()).hexdigest()
 
-        try:
-            # Try to find the token by its hashed value first
-            return ApiToken.objects.select_related("user", "application").get(
-                hashed_token=hashed_token
-            )
-        except ApiToken.DoesNotExist:
+        if SiloMode.get_current_mode() == SiloMode.REGION:
             try:
-                # If we can't find it by hash, use the plaintext string
-                api_token = ApiToken.objects.select_related("user", "application").get(
-                    token=token_str
+                # Try to find the token by its hashed value first
+                return ApiTokenReplica.objects.get(hashed_token=hashed_token)
+            except ApiTokenReplica.DoesNotExist:
+                try:
+                    # If we can't find it by hash, use the plaintext string
+                    return ApiTokenReplica.objects.get(token=token_str)
+                except ApiTokenReplica.DoesNotExist:
+                    # If the token does not exist by plaintext either, it is not a valid token
+                    raise AuthenticationFailed("Invalid token")
+        else:
+            try:
+                # Try to find the token by its hashed value first
+                return ApiToken.objects.select_related("user", "application").get(
+                    hashed_token=hashed_token
                 )
             except ApiToken.DoesNotExist:
-                # If the token does not exist by plaintext either, it is not a valid token
-                raise AuthenticationFailed("Invalid token")
-            else:
-                # Update it with the hashed value if found by plaintext
-                api_token.hashed_token = hashed_token
-                api_token.save(update_fields=["hashed_token"])
-                return api_token
+                try:
+                    # If we can't find it by hash, use the plaintext string
+                    api_token = ApiToken.objects.select_related("user", "application").get(
+                        token=token_str
+                    )
+                except ApiToken.DoesNotExist:
+                    # If the token does not exist by plaintext either, it is not a valid token
+                    raise AuthenticationFailed("Invalid token")
+                else:
+                    # Update it with the hashed value if found by plaintext
+                    api_token.hashed_token = hashed_token
+                    api_token.save(update_fields=["hashed_token"])
+                    return api_token
 
     def accepts_auth(self, auth: list[bytes]) -> bool:
         if not super().accepts_auth(auth):
@@ -366,26 +382,14 @@ class UserAuthTokenAuthentication(StandardAuthentication):
         application_is_inactive = False
 
         if not token:
-            if SiloMode.get_current_mode() == SiloMode.REGION:
-                try:
-                    # Try to find the token by its hashed value first
-                    hashed_token = hashlib.sha256(token_str.encode()).hexdigest()
-                    atr = token = ApiTokenReplica.objects.get(hashed_token=hashed_token)
-                except ApiTokenReplica.DoesNotExist:
-                    try:
-                        # If we can't find it by hash, use the plaintext string
-                        atr = token = ApiTokenReplica.objects.get(token=token_str)
-                    except ApiTokenReplica.DoesNotExist:
-                        # If the token does not exist by plaintext either, it is not a valid token
-                        raise AuthenticationFailed("Invalid token")
-                    else:
-                        user = user_service.get_user(user_id=atr.user_id)
-                        application_is_inactive = not atr.application_is_active
-            else:
-                at = token = self._find_or_update_token_by_hash(token_str)
-                user = at.user
+            token = self._find_or_update_token_by_hash(token_str)
+            if isinstance(token, ApiTokenReplica):  # we're running as a REGION silo
+                user = user_service.get_user(user_id=token.user_id)
+                application_is_inactive = not token.application_is_active
+            else:  # the token returned is an ApiToken from the CONTROL silo
+                user = token.user
                 application_is_inactive = (
-                    at.application is not None and not at.application.is_active
+                    token.application is not None and not token.application.is_active
                 )
 
         elif isinstance(token, SystemToken):

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -378,12 +378,15 @@ class UserAuthTokenAuthentication(StandardAuthentication):
         application_is_inactive = False
 
         if not token:
-            at = token = self._find_or_update_token_by_hash(token_str)
 
             if SiloMode.get_current_mode() == SiloMode.REGION:
-                user = user_service.get_user(user_id=at.user_id)
-                application_is_inactive = not at.application_is_active
+                atr: ApiTokenReplica = self._find_or_update_token_by_hash(token_str)
+                token = atr
+                user = user_service.get_user(user_id=atr.user_id)
+                application_is_inactive = not atr.application_is_active
             else:
+                at: ApiToken = self._find_or_update_token_by_hash(token_str)
+                token = at
                 user = at.user
                 application_is_inactive = (
                     at.application is not None and not at.application.is_active

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -311,7 +311,7 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
 class UserAuthTokenAuthentication(StandardAuthentication):
     token_name = b"bearer"
 
-    def _find_or_update_token_by_hash(self, token_str: str) -> ApiToken:
+    def _find_or_update_token_by_hash(self, token_str: str) -> ApiToken | ApiTokenReplica:
         """
         Find token by hash or update token's hash value if only found via plaintext.
         1. Hash provided plaintext token.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -294,6 +294,12 @@ register(
     type=Bool,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "apitoken.save-hash-on-create",
+    default=True,
+    type=Bool,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "api.rate-limit.org-create",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -301,6 +301,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Controls the rate of using the hashed value of User API tokens for lookups when logging in
+# and also updates tokens which are not hashed
+register(
+    "apitoken.use-and-update-hash-rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "api.rate-limit.org-create",
     default=5,

--- a/src/sentry/services/hybrid_cloud/auth/model.py
+++ b/src/sentry/services/hybrid_cloud/auth/model.py
@@ -34,6 +34,7 @@ class RpcApiToken(RpcModel):
     application_id: int | None = None
     application_is_active: bool = False
     token: str = ""
+    hashed_token: str | None = None
     expires_at: datetime.datetime | None = None
     allowed_origins: list[str] = Field(default_factory=list)
     scope_list: list[str] = Field(default_factory=list)

--- a/src/sentry/services/hybrid_cloud/auth/serial.py
+++ b/src/sentry/services/hybrid_cloud/auth/serial.py
@@ -87,6 +87,7 @@ def serialize_api_token(at: ApiToken) -> RpcApiToken:
         organization_id=at.organization_id,
         application_is_active=at.application_id is None or at.application.is_active,
         token=at.token,
+        hashed_token=at.hashed_token,
         expires_at=at.expires_at,
         allowed_origins=list(at.get_allowed_origins()),
         scope_list=at.get_scopes(),

--- a/src/sentry/services/hybrid_cloud/replica/impl.py
+++ b/src/sentry/services/hybrid_cloud/replica/impl.py
@@ -160,6 +160,7 @@ class DatabaseBackedRegionReplicaService(RegionReplicaService):
             organization=organization,
             application_is_active=api_token.application_is_active,
             token=api_token.token,
+            hashed_token=api_token.hashed_token,
             expires_at=api_token.expires_at,
             apitoken_id=api_token.id,
             scope_list=api_token.scope_list,

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -397,11 +397,6 @@ class TestRpcSignatureAuthentication(TestCase):
 
 @no_silo_test
 class TestAuthTokens(TestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.auth = UserAuthTokenAuthentication()
-
     def test_system_tokens(self):
         sys_token = SystemToken()
         auth_token = AuthenticatedToken.from_token(sys_token)

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -32,6 +32,7 @@ from sentry.services.hybrid_cloud.rpc import (
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, no_silo_test
 from sentry.types.token import AuthTokenType
@@ -353,6 +354,11 @@ class TestRpcSignatureAuthentication(TestCase):
 
 @no_silo_test
 class TestAuthTokens(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.auth = UserAuthTokenAuthentication()
+
     def test_system_tokens(self):
         sys_token = SystemToken()
         auth_token = AuthenticatedToken.from_token(sys_token)
@@ -389,6 +395,45 @@ class TestAuthTokens(TestCase):
             assert auth_token.allowed_origins == token.get_allowed_origins()
             assert auth_token.scopes == token.get_scopes()
             assert auth_token.audit_log_data == token.get_audit_log_data()
+
+    @override_options({"apitoken.save-hash-on-create": False})
+    def test_user_auth_token_hashed_with_option_off(self):
+        # see https://github.com/getsentry/sentry/pull/65941
+        # the UserAuthTokenAuthentication middleware was updated to hash tokens as
+        # they were used, this test verifies the hash
+        api_token = ApiToken.objects.create(user=self.user, token_type=AuthTokenType.USER)
+        expected_hash = hashlib.sha256(api_token.token.encode()).hexdigest()
+
+        # we haven't authenticated to the API endpoint yet, so this value should be empty
+        assert api_token.hashed_token is None
+
+        request = HttpRequest()
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {api_token.token}"
+
+        with outbox_runner():
+            with assume_test_silo_mode(SiloMode.REGION):
+                # make sure the token was replicated
+                api_token_replica = ApiTokenReplica.objects.get(apitoken_id=api_token.id)
+                assert api_token.token == api_token_replica.token
+                assert (
+                    api_token_replica.hashed_token is None
+                )  # we don't expect to have a hashed value yet
+
+                # trigger the authentication middleware, and thus the hashing backfill
+                result = self.auth.authenticate(request)
+                assert result is not None
+
+                # check for the expected hash value
+                # it should upsert the hashed_token to ApiToken
+                api_token.refresh_from_db()
+                assert api_token.hashed_token == expected_hash
+
+                # after updating ApiToken, ApiTokenReplica should also be updated
+                api_token_replica.refresh_from_db()
+                assert api_token_replica.hashed_token == expected_hash
+
+                # just for good measure
+                assert api_token.hashed_token == api_token_replica.hashed_token
 
     def test_api_keys(self):
         ak = self.create_api_key(organization=self.organization, scope_list=["projects:read"])

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -424,11 +424,10 @@ class TestAuthTokens(TestCase):
                 assert result is not None
 
                 # check for the expected hash value
-                # it should upsert the hashed_token to ApiToken
                 api_token.refresh_from_db()
                 assert api_token.hashed_token == expected_hash
 
-                # after updating ApiToken, ApiTokenReplica should also be updated
+                # ApiTokenReplica should also be updated
                 api_token_replica.refresh_from_db()
                 assert api_token_replica.hashed_token == expected_hash
 

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1,3 +1,4 @@
+import hashlib
 import uuid
 from datetime import UTC, datetime
 
@@ -30,8 +31,10 @@ from sentry.services.hybrid_cloud.rpc import (
 )
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, no_silo_test
+from sentry.types.token import AuthTokenType
 from sentry.utils.security.orgauthtoken_token import hash_token
 
 
@@ -201,6 +204,28 @@ class TestTokenAuthentication(TestCase):
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
+
+    @override_options({"apitoken.save-hash-on-create": False})
+    def test_token_hashed_with_option_off(self):
+        # see https://github.com/getsentry/sentry/pull/65941
+        # the UserAuthTokenAuthentication middleware was updated to hash tokens as
+        # they were used, this test verifies the hash
+        api_token = ApiToken.objects.create(user=self.user, token_type=AuthTokenType.USER)
+        expected_hash = hashlib.sha256(api_token.token.encode()).hexdigest()
+
+        # we haven't authenticated to the API endpoint yet, so this value should be empty
+        assert api_token.hashed_token is None
+
+        request = HttpRequest()
+        request.META["HTTP_AUTHORIZATION"] = f"Bearer {api_token.token}"
+
+        # trigger the authentication middleware, and thus the hashing
+        result = self.auth.authenticate(request)
+        assert result is not None
+
+        # check for the expected hash value
+        api_token.refresh_from_db()
+        assert api_token.hashed_token == expected_hash
 
 
 @django_db_all

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -207,7 +207,7 @@ class TestTokenAuthentication(TestCase):
             self.auth.authenticate(request)
 
     @override_options({"apitoken.save-hash-on-create": False})
-    @override_options({"apitoken.use-and-update-hash-rate", 1.0})
+    @override_options({"apitoken.use-and-update-hash-rate": 1.0})
     def test_token_hashed_with_option_off(self):
         # see https://github.com/getsentry/sentry/pull/65941
         # the UserAuthTokenAuthentication middleware was updated to hash tokens as
@@ -230,7 +230,7 @@ class TestTokenAuthentication(TestCase):
         assert api_token.hashed_token == expected_hash
 
     @override_options({"apitoken.save-hash-on-create": False})
-    @override_options({"apitoken.use-and-update-hash-rate", 0.0})
+    @override_options({"apitoken.use-and-update-hash-rate": 0.0})
     def test_token_not_hashed_with_0_rate(self):
         api_token = ApiToken.objects.create(user=self.user, token_type=AuthTokenType.USER)
 
@@ -257,7 +257,7 @@ class TestTokenAuthenticationReplication(TestCase):
         self.auth = UserAuthTokenAuthentication()
 
     @override_options({"apitoken.save-hash-on-create": False})
-    @override_options({"apitoken.use-and-update-hash-rate", 1.0})
+    @override_options({"apitoken.use-and-update-hash-rate": 1.0})
     def test_hash_is_replicated(self):
         api_token = ApiToken.objects.create(user=self.user, token_type=AuthTokenType.USER)
         expected_hash = hashlib.sha256(api_token.token.encode()).hexdigest()


### PR DESCRIPTION
- Update the `UserAuthTokenAuthentication` middleware to support hashed token values. As tokens are used, it will store the appropriate hash value.
- Use an option, `apitoken.use-and-update-hash-rate` that will apply the code paths using the hashed values for lookups and updating the hashed values on plaintext tokens randomly based on the configured rate.
- Introduce a temporary option, `apitoken.save-hash-on-create`. This will be used in the model logic and in pre and post backfill migration tests in the future.

This previously resulted in INC-684 via PR https://github.com/getsentry/sentry/pull/65941. The `hashed_token` and `hashed_refresh_token` columns now have indexes.