### PR TITLE
feat(snuba): Make sure use_group_snuba_dataset is false if using trends

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -166,8 +166,8 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                 result = inbox_search(**query_kwargs)
             else:
                 query_kwargs["referrer"] = "search.group_index"
-                # optional argument to use the group snuba dataset
-                if request.GET.get("useGroupSnubaDataset"):
+                # optional argument to use the group snuba dataset that intentially does not support trends
+                if request.GET.get("useGroupSnubaDataset") and query_kwargs["sort_by"] != "trends":
                     query_kwargs["use_group_snuba_dataset"] = True
 
                 result = search.query(**query_kwargs)

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1152,16 +1152,14 @@ class GroupAttributesPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "date": last_seen_aggregation,
         "new": first_seen,
         "freq": times_seen_aggregation,
-        "user_count": Function(
-            "uniq", [Column("tags[sentry:user]", entities["event"])], "user_count"
-        ),
+        "user": Function("uniq", [Column("tags[sentry:user]", entities["event"])], "user_count"),
     }
 
     sort_strategies = {
         "new": "g.group_first_seen",
         "date": "score",
         "freq": "times_seen",
-        "user_count": "user_count",
+        "user": "user_count",
     }
 
     def calculate_start_end(


### PR DESCRIPTION
This PR forces `use_group_snuba_dataset` to `False` if the sort is `trends`. The reason is that the trends sort is quite complicated and not used very much. We might end up dropping trends in the future when we do the redesign so it's not worth trying to make trends work for `GroupAttributesPostgresSnubaQueryExecutor`. I also fixed a bug with the user count sort.