### PR TITLE
fix(issue-priority): Fix determining previous priority for ongoing groups

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -449,15 +449,6 @@ class GroupManager(BaseManager["Group"]):
             from_substatus == GroupSubStatus.ESCALATING
             and activity_type == ActivityType.AUTO_SET_ONGOING
         )
-        logger.info(
-            "group.update_group_status.should_update_priority",
-            extra={
-                "should_update_priority": should_update_priority,
-                "from_substatus": from_substatus,
-                "activity_type": activity_type,
-                "new_substatus": substatus,
-            },
-        )
 
         updated_priority = {}
         for group in selected_groups:
@@ -474,8 +465,6 @@ class GroupManager(BaseManager["Group"]):
                         extra={
                             "group_id": group.id,
                             "from_substatus": from_substatus,
-                            "activity_type": activity_type,
-                            "new_substatus": substatus,
                             "priority": priority,
                         },
                     )
@@ -485,8 +474,6 @@ class GroupManager(BaseManager["Group"]):
                         extra={
                             "group_id": group.id,
                             "from_substatus": from_substatus,
-                            "activity_type": activity_type,
-                            "new_substatus": substatus,
                             "new_priority": priority,
                             "current_priority": group.priority,
                         },

--- a/tests/sentry/issues/test_ongoing.py
+++ b/tests/sentry/issues/test_ongoing.py
@@ -42,7 +42,15 @@ class TransitionNewToOngoingTest(TestCase):
 
     def test_escalating_to_ongoing(self) -> None:
         group = self.create_group(
-            status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ESCALATING
+            status=GroupStatus.UNRESOLVED,
+            substatus=GroupSubStatus.ESCALATING,
+            priority=GroupHistoryStatus.PRIORITY_MEDIUM,
+        )
+        GroupHistory.objects.create(
+            group=group,
+            status=GroupHistoryStatus.PRIORITY_MEDIUM,
+            project=self.project,
+            organization=self.organization,
         )
         GroupHistory.objects.create(
             group=group,

--- a/tests/sentry/issues/test_ongoing.py
+++ b/tests/sentry/issues/test_ongoing.py
@@ -5,7 +5,7 @@ from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.types.activity import ActivityType
-from sentry.types.group import GroupSubStatus
+from sentry.types.group import GroupSubStatus, PriorityLevel
 
 
 @apply_feature_flag_on_cls("projects:issue-priority")
@@ -44,20 +44,10 @@ class TransitionNewToOngoingTest(TestCase):
         group = self.create_group(
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.ESCALATING,
-            priority=GroupHistoryStatus.PRIORITY_MEDIUM,
+            priority=PriorityLevel.HIGH,
         )
-        GroupHistory.objects.create(
-            group=group,
-            status=GroupHistoryStatus.PRIORITY_MEDIUM,
-            project=self.project,
-            organization=self.organization,
-        )
-        GroupHistory.objects.create(
-            group=group,
-            status=GroupHistoryStatus.PRIORITY_MEDIUM,
-            project=self.project,
-            organization=self.organization,
-        )
+        group.data.get("metadata", {}).update({"initial_priority": PriorityLevel.MEDIUM})
+        group.save()
 
         bulk_transition_group_to_ongoing(
             GroupStatus.UNRESOLVED, GroupSubStatus.ESCALATING, [group.id]
@@ -66,6 +56,8 @@ class TransitionNewToOngoingTest(TestCase):
             group=group, type=ActivityType.AUTO_SET_ONGOING.value
         ).exists()
 
+        group.refresh_from_db()
+        assert group.priority == PriorityLevel.MEDIUM
         assert GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.PRIORITY_MEDIUM
         ).exists()

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -138,6 +138,12 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             organization=self.organization,
             status=GroupHistoryStatus.PRIORITY_MEDIUM,
         )
+        GroupHistory.objects.create(
+            group=self.group,
+            project=self.group.project,
+            organization=self.organization,
+            status=GroupHistoryStatus.PRIORITY_HIGH,
+        )
         message = get_test_message_status_change(
             self.project.id,
             fingerprint=self.fingerprint,

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -132,18 +132,9 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             substatus=GroupSubStatus.ESCALATING,
             priority=PriorityLevel.HIGH,
         )
-        GroupHistory.objects.create(
-            group=self.group,
-            project=self.group.project,
-            organization=self.organization,
-            status=GroupHistoryStatus.PRIORITY_MEDIUM,
-        )
-        GroupHistory.objects.create(
-            group=self.group,
-            project=self.group.project,
-            organization=self.organization,
-            status=GroupHistoryStatus.PRIORITY_HIGH,
-        )
+        self.group.data.get("metadata", {}).update({"initial_priority": PriorityLevel.MEDIUM})
+        self.group.save()
+
         message = get_test_message_status_change(
             self.project.id,
             fingerprint=self.fingerprint,


### PR DESCRIPTION
There's a bug in this logic when trying to get the previous priority from GroupHistory which has resulted in the auto escalating to ongoing transition not updating priority. 

We need to skip the most recent GroupHistory record, since that record matches the current priority, and instead revert to either 
- the priority from the second to last GroupHistory record, or
- the initial priority when the group was created