### PR TITLE
feat(platforms): Creating a new platform

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -110,6 +110,7 @@ GETTING_STARTED_DOCS_PLATFORMS = [
     "minidump",
     "native",
     "native-qt",
+    "nintendo",
     "node",
     "node-awslambda",
     "node-azurefunctions",

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -87,7 +87,18 @@ class PlatformPicker extends Component<PlatformPickerProps, State> {
       return currentCategory?.platforms?.has(platform.id);
     };
 
-    const filtered = selectablePlatforms
+    // temporary replacement of selectablePlatforms while `nintendo` is behind feature flag
+    const tempSelectablePlatforms = selectablePlatforms;
+    if (this.props.organization?.features.includes('selectable-nintendo-platform')) {
+      const nintendo = platforms.find(p => p.id === 'nintendo');
+      if (nintendo) {
+        if (!tempSelectablePlatforms.includes(nintendo)) {
+          tempSelectablePlatforms.push(nintendo);
+        }
+      }
+    }
+
+    const filtered = tempSelectablePlatforms
       .filter(this.state.filter ? subsetMatch : categoryMatch)
       .sort((a, b) => a.id.localeCompare(b.id));
 

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -194,6 +194,7 @@ export const withPerformanceOnboarding: Set<PlatformKey> = new Set([
 export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
   'elixir',
   'minidump',
+  'nintendo',
 ]);
 
 export const profiling: PlatformKey[] = [

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -355,6 +355,13 @@ export const platforms: PlatformIntegration[] = [
     link: 'https://docs.sentry.io/platforms/native/guides/qt/',
   },
   {
+    id: 'nintendo',
+    name: 'Nintendo',
+    type: 'framework',
+    language: 'native',
+    link: 'https://docs.sentry.io/platforms/nintendo',
+  },
+  {
     id: 'node',
     name: 'Node.js',
     type: 'language',

--- a/static/app/gettingStartedDocs/nintendo/index.spec.tsx
+++ b/static/app/gettingStartedDocs/nintendo/index.spec.tsx
@@ -1,0 +1,17 @@
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+
+import docs from '.';
+
+describe('Nintendo onboarding docs', function () {
+  it('renders docs correctly', function () {
+    renderWithOnboardingLayout(docs);
+
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', {name: 'Configure SDK'})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', {name: 'Verify'})).not.toBeInTheDocument();
+  });
+});

--- a/static/app/gettingStartedDocs/nintendo/index.tsx
+++ b/static/app/gettingStartedDocs/nintendo/index.tsx
@@ -1,0 +1,32 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import type {
+  Docs,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {tct} from 'sentry/locale';
+
+const onboarding: OnboardingConfig = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Download the SDK and follow the instructions that are provided in the [nintendoDoc:Nintendo Developer documentation].',
+        {
+          nintendoDoc: (
+            // TODO: @athena replace with the actual link
+            <ExternalLink href="https://developer.nintendo.com/" />
+          ),
+        }
+      ),
+    },
+  ],
+  configure: () => [],
+  verify: () => [],
+};
+
+const docs: Docs = {
+  onboarding,
+};
+
+export default docs;

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -211,6 +211,7 @@ export type PlatformKey =
   | 'native-breakpad'
   | 'native-minidump'
   | 'native-qt'
+  | 'nintendo'
   | 'node'
   | 'node-awslambda'
   | 'node-azurefunctions'


### PR DESCRIPTION
Adding a platform for Nintendo. This one is a bit different from other platforms because user has to go to Nintendo website to download the SDK. It only shows up in the `All` tab. I'll update the documentation when I have them. [Specs for more context](https://www.notion.so/sentry/Nintendo-Partnership-Enablement-69b1259fc1f54015a0fd4e2091df9798?pvs=4#7ccb477592164a568054b58b0ee275ae)

Pending: I plan to feature flag it but still don't know how.

This platform does not support performance, replay or user feedback.
<img width="532" alt="Screenshot 2024-03-29 at 4 34 26 PM" src="https://github.com/getsentry/sentry/assets/132939361/9010fa48-13ef-40b5-bb2c-a8246ff2630c">


<img width="1349" alt="Screenshot 2024-03-29 at 4 21 36 PM" src="https://github.com/getsentry/sentry/assets/132939361/4c075eed-ace6-473f-bcfd-1b59dfa74b1a">


<img width="1151" alt="Screenshot 2024-03-29 at 4 27 00 PM" src="https://github.com/getsentry/sentry/assets/132939361/d38e80e4-6448-4909-b2bb-41c29950e6e1">
