### PR TITLE
fix(sidebar): fix bottom nav color

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -723,7 +723,7 @@ const PrimaryItems = styled('div')`
   gap: 1px;
   -ms-overflow-style: -ms-autohiding-scrollbar;
   @media (max-height: 675px) and (min-width: ${p => p.theme.breakpoints.medium}) {
-    border-bottom: 1px solid ${p => p.theme.translucentGray400};
+    border-bottom: 1px solid ${p => p.theme.sidebarBorder};
     padding-bottom: ${space(1)};
     box-shadow: rgba(0, 0, 0, 0.15) 0px -10px 10px inset;
   }
@@ -732,7 +732,7 @@ const PrimaryItems = styled('div')`
     flex-direction: row;
     height: 100%;
     align-items: center;
-    border-right: 1px solid ${p => p.theme.translucentGray400};
+    border-right: 1px solid ${p => p.theme.sidebarBorder};
     padding-right: ${space(1)};
     margin-right: ${space(0.5)};
     box-shadow: rgba(0, 0, 0, 0.15) -10px 0px 10px inset;

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -723,7 +723,7 @@ const PrimaryItems = styled('div')`
   gap: 1px;
   -ms-overflow-style: -ms-autohiding-scrollbar;
   @media (max-height: 675px) and (min-width: ${p => p.theme.breakpoints.medium}) {
-    border-bottom: 1px solid ${p => p.theme.gray400};
+    border-bottom: 1px solid ${p => p.theme.translucentGray400};
     padding-bottom: ${space(1)};
     box-shadow: rgba(0, 0, 0, 0.15) 0px -10px 10px inset;
   }
@@ -732,7 +732,7 @@ const PrimaryItems = styled('div')`
     flex-direction: row;
     height: 100%;
     align-items: center;
-    border-right: 1px solid ${p => p.theme.gray400};
+    border-right: 1px solid ${p => p.theme.translucentGray400};
     padding-right: ${space(1)};
     margin-right: ${space(0.5)};
     box-shadow: rgba(0, 0, 0, 0.15) -10px 0px 10px inset;

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -38,7 +38,6 @@ export const lightColors = {
    * Alternative version of gray200 that's translucent.
    * Useful for borders on tooltips, popovers, and dialogs.
    */
-  translucentGray400: '#3E3446E6',
   translucentGray200: 'rgba(58, 17, 95, 0.14)',
   translucentGray100: 'rgba(45, 0, 85, 0.06)',
 
@@ -106,7 +105,6 @@ export const darkColors = {
    * Alternative version of gray200 that's translucent.
    * Useful for borders on tooltips, popovers, and dialogs.
    */
-  translucentGray400: '#D6D0DC2A',
   translucentGray200: 'rgba(218, 184, 245, 0.16)',
   translucentGray100: 'rgba(208, 168, 240, 0.07)',
 

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -38,6 +38,7 @@ export const lightColors = {
    * Alternative version of gray200 that's translucent.
    * Useful for borders on tooltips, popovers, and dialogs.
    */
+  translucentGray400: '#3E3446E6',
   translucentGray200: 'rgba(58, 17, 95, 0.14)',
   translucentGray100: 'rgba(45, 0, 85, 0.06)',
 
@@ -105,6 +106,7 @@ export const darkColors = {
    * Alternative version of gray200 that's translucent.
    * Useful for borders on tooltips, popovers, and dialogs.
    */
+  translucentGray400: '#D6D0DC2A',
   translucentGray200: 'rgba(218, 184, 245, 0.16)',
   translucentGray100: 'rgba(208, 168, 240, 0.07)',
 


### PR DESCRIPTION
Dark mode border in the primary items was _very_ gray as it was not using the translucent shade.

Before:
![CleanShot 2024-03-30 at 10 41 36@2x](https://github.com/getsentry/sentry/assets/9317857/d45afeb8-a028-48cd-b2f7-67c25db9f179)

After:
![CleanShot 2024-03-30 at 10 41 41@2x](https://github.com/getsentry/sentry/assets/9317857/9c7fb8be-bf26-4fce-bd02-53dea335bd5b)

cc @vuluongj20 if you wanna review the color (feel free to just make changes to this PR), I just added 20% to the color equiv of surface400