### PR TITLE
fix: double tooltips shown on discover export button

### DIFF
--- a/static/app/views/discover/table/tableActions.tsx
+++ b/static/app/views/discover/table/tableActions.tsx
@@ -66,9 +66,9 @@ function renderBrowserExportButton(canEdit: boolean, props: Props) {
       onClick={onClick}
       data-test-id="grid-download-csv"
       icon={<IconDownload />}
-      title={t(
+      title={!disabled ? t(
         "There aren't that many results, start your export and it'll download immediately."
-      )}
+      ) : undefined}
     >
       {t('Export All')}
     </Button>


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/64553

Export button shows the Feature gate tooltip as well as the small export size tooltip. 
Should not show the small export size tooltip if Feature is not available.

Quick help : I couldn't seem to run the prettier / linter properly for some reason nor do i see how to set those up for this project in the contributing section or the readme, please forgive me if i break any linting tests. 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
