### PR TITLE
chore(slack): turn block kit feature flag to True in server.py

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1883,7 +1883,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Upload release bundles as artifact bundles.
     "organizations:sourcemaps-upload-release-as-artifact-bundle": False,
     # Enable Slack messages using Block Kit
-    "organizations:slack-block-kit": False,
+    "organizations:slack-block-kit": True,
     # Send Slack notifications to threads for Issue Alerts
     "organizations:slack-thread-issue-alert": False,
     # Use SNQL table join on weekly reports / daily summary

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -192,7 +192,10 @@ def build_footer(
         text = rules[0].label if rules[0].label else "Test Alert"
         footer += f" via {url_format.format(text=text, url=rule_url)}"
 
-        if features.has("organizations:slack-block-kit", project.organization):
+        if (
+            features.has("organizations:slack-block-kit", project.organization)
+            and url_format == SLACK_URL_FORMAT
+        ):
             footer = url_format.format(text=text, url=rule_url)
 
         if len(rules) > 1:

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -9,6 +9,7 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.testutils.cases import APITestCase, SlackActivityNotificationTest
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.slack import get_attachment_no_text
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
@@ -187,7 +188,9 @@ class OrganizationInviteRequestCreateTest(
         assert "eric@localhost" in mail.outbox[0].body
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_request_to_invite_slack(self):
+        # TODO: make this a block kit test
         with self.tasks():
             self.get_success_response(
                 self.organization.slug,

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -175,7 +175,7 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
         assert self.organization.absolute_url("/settings/members/") in mail.outbox[0].body
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_request_to_join_slack(self):
         # TODO: convert this test to block kit
         with self.tasks():

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -175,7 +175,9 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
         assert self.organization.absolute_url("/settings/members/") in mail.outbox[0].body
 
     @responses.activate
+    @with_feature("organizations:slack-block-kit")
     def test_request_to_join_slack(self):
+        # TODO: convert this test to block kit
         with self.tasks():
             self.get_success_response(self.organization.slug, email=self.email, status_code=204)
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1002,7 +1002,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
 
     @responses.activate
     @with_feature("organizations:rule-create-edit-confirm-notification")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_slack_confirmation_notification_contents(self):
+        # TODO: make this a block kit test
         conditions = [
             {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
         ]

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -95,6 +95,7 @@ class OrganizationSerializerTest(TestCase):
             "project-stats",
             "relay",
             "shared-issues",
+            "slack-block-kit",
             "session-replay-ui",
             "sso-basic",
             "sso-saml2",

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -112,6 +112,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert channel == self.identity.external_id
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_assignment(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is assigned
@@ -155,6 +156,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_assignment_generic_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type is assigned
@@ -208,6 +210,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_assignment_performance_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is assigned

--- a/tests/sentry/integrations/slack/notifications/test_deploy.py
+++ b/tests/sentry/integrations/slack/notifications/test_deploy.py
@@ -13,6 +13,7 @@ from sentry.types.activity import ActivityType
 
 class SlackDeployNotificationTest(SlackActivityNotificationTest):
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_deploy(self):
         """
         Test that a Slack message is sent with the expected payload when a deploy happens.

--- a/tests/sentry/integrations/slack/notifications/test_escalating.py
+++ b/tests/sentry/integrations/slack/notifications/test_escalating.py
@@ -27,6 +27,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_escalating(self):
         """
         Test that a Slack message is sent with the expected payload when an issue escalates
@@ -76,6 +77,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_escalating_performance_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue escalates
@@ -136,6 +138,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_escalating_generic_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type escalates

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -65,6 +65,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_user(self):
         """Test that issue alerts are sent to a Slack user."""
 
@@ -138,6 +139,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_performance_issue_alert_user(self, occurrence):
         """Test that performance issue alerts are sent to a Slack user."""
 
@@ -242,6 +244,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_generic_issue_alert_user(self, occurrence):
         """Test that generic issue alerts are sent to a Slack user."""
         event = self.store_event(
@@ -321,6 +324,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert len(responses.calls) == 0
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_issue_owners(self):
         """Test that issue alerts are sent to issue owners in Slack."""
 
@@ -419,6 +423,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_issue_owners_environment(self):
         """Test that issue alerts are sent to issue owners in Slack with the environment in the query params when the alert rule filters by environment."""
 
@@ -533,6 +538,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_team_issue_owners(self):
         """Test that issue alerts are sent to a team in Slack via an Issue Owners rule action."""
 
@@ -777,6 +783,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
     @responses.activate
     @patch.object(sentry, "digests")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_team_issue_owners_user_settings_off_digests(self, digests):
         """Test that issue alerts are sent to a team in Slack via an Issue Owners rule action
         even when the users' issue alert notification settings are off and digests are triggered."""
@@ -878,6 +885,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_team(self):
         """Test that issue alerts are sent to a team in Slack."""
         # add a second organization
@@ -1050,6 +1058,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_team_new_project(self):
         """Test that issue alerts are sent to a team in Slack when the team has added a new project"""
 
@@ -1176,6 +1185,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert len(responses.calls) == 0
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_team_fallback(self):
         """Test that issue alerts are sent to each member of a team in Slack."""
 
@@ -1245,6 +1255,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
     @responses.activate
     @patch.object(sentry, "digests")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_digest_enabled(self, digests):
         """
         Test that with digests enabled, but Slack notification settings

--- a/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
+++ b/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
@@ -13,6 +13,7 @@ from sentry.web.frontend.debug.debug_new_processing_issues_email import get_issu
 
 class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_new_processing_issue(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is held back in reprocessing
@@ -87,6 +88,7 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
 
     @responses.activate
     @with_feature("organizations:customer-domains")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_new_processing_issue_customer_domains(self):
         notification = NewProcessingIssuesActivityNotification(
             Activity(

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -27,6 +27,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_note(self):
         """
         Test that a Slack message is sent with the expected payload when a comment is made on an issue
@@ -77,6 +78,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_note_performance_issue(self):
         """
         Test that a Slack message is sent with the expected payload when a comment is made on a performance issue
@@ -134,6 +136,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_note_generic_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a comment is made on a generic issue type

--- a/tests/sentry/integrations/slack/notifications/test_nudge.py
+++ b/tests/sentry/integrations/slack/notifications/test_nudge.py
@@ -17,6 +17,7 @@ SEED = 0
 
 class SlackNudgeNotificationTest(SlackActivityNotificationTest):
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_nudge(self):
         notification = IntegrationNudgeNotification(
             self.organization,

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -27,6 +27,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_regression(self):
         """
         Test that a Slack message is sent with the expected payload when an issue regresses
@@ -66,6 +67,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_regression_with_release(self):
         """
         Test that a Slack message is sent with the expected payload when an issue regresses
@@ -117,6 +119,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_regression_performance_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue regresses
@@ -164,6 +167,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_regression_generic_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type regresses

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -27,6 +27,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_resolved(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is resolved
@@ -80,6 +81,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_resolved_performance_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is resolved
@@ -135,6 +137,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_resolved_generic_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type is resolved

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -31,6 +31,7 @@ class SlackResolvedInReleaseNotificationTest(
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_resolved_in_release(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is resolved in a release
@@ -75,6 +76,7 @@ class SlackResolvedInReleaseNotificationTest(
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_resolved_in_release_performance_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is resolved in a release
@@ -126,6 +128,7 @@ class SlackResolvedInReleaseNotificationTest(
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_resolved_in_release_generic_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type is resolved in a release
@@ -178,6 +181,7 @@ class SlackResolvedInReleaseNotificationTest(
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_resolved_in_release_parsed_version(self):
         """
         Test that the release version is formatted to the short version

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -27,6 +27,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_unassignment(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is unassigned
@@ -71,6 +72,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_unassignment_performance_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is unassigned
@@ -118,6 +120,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_unassignment_generic_issue(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type is unassigned

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -270,6 +270,7 @@ def build_test_message(
 
 
 class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTestMixin):
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_group_attachment(self):
         group = self.create_group(project=self.project)
         assert SlackIssuesMessageBuilder(group).build() == build_test_message(
@@ -474,6 +475,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         "sentry.integrations.slack.message_builder.issues.get_option_groups",
         wraps=get_option_groups,
     )
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_group_attachment_prune_duplicate_assignees(self, mock_get_option_groups):
         user2 = self.create_user()
         self.create_member(user=user2, organization=self.organization)
@@ -507,6 +509,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert len(team_option_groups["options"]) == 2
         assert len(member_option_groups["options"]) == 2
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_group_attachment_issue_alert(self):
         issue_alert_group = self.create_group(project=self.project)
         ret = SlackIssuesMessageBuilder(issue_alert_group, issue_details=True).build()
@@ -777,6 +780,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             == expected_blocks
         )
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_team_recipient(self):
         issue_alert_group = self.create_group(project=self.project)
         ret = SlackIssuesMessageBuilder(
@@ -817,12 +821,14 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert ret["blocks"][2]["elements"][2]["initial_option"]["value"] == f"user:{self.user.id}"
 
     # XXX(CEO): skipping replicating tests relating to color since there is no block kit equivalent
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_group_attachment_color_no_event_error_fallback(self):
         group_with_no_events = self.create_group(project=self.project)
         ret = SlackIssuesMessageBuilder(group_with_no_events).build()
         assert isinstance(ret, dict)
         assert ret["color"] == "#E03E2F"
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_group_attachment_color_unexpected_level_error_fallback(self):
         unexpected_level_event = self.store_event(
             data={"level": "trace"}, project_id=self.project.id, assert_no_errors=False
@@ -832,6 +838,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert isinstance(ret, dict)
         assert ret["color"] == "#E03E2F"
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_group_attachment_color_warning(self):
         warning_event = self.store_event(data={"level": "warning"}, project_id=self.project.id)
         assert warning_event.group is not None
@@ -844,6 +851,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert isinstance(ret2, dict)
         assert ret2["color"] == "#FFC227"
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_group_generic_issue_attachment(self):
         """Test that a generic issue type's Slack alert contains the expected values"""
         event = self.store_event(
@@ -925,6 +933,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert blocks["blocks"][1]["text"]["text"] == f"```{escaped_text}```"
         assert blocks["text"] == f"[{self.project.slug}] {occurrence.issue_title}"
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_error_issue_fallback_text(self):
         event = self.store_event(data={}, project_id=self.project.id)
         assert event.group is not None
@@ -940,6 +949,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert isinstance(blocks, dict)
         assert blocks["text"] == f"[{self.project.slug}] {event.group.title}"
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_performance_issue(self):
         event = self.create_performance_issue()
         with self.feature("organizations:performance-issues"):
@@ -972,6 +982,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         block = BlockSlackMessageBuilder().get_markdown_quote_block(text)
         assert "a" * 253 + "..." in block["text"]["text"]
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_performance_issue_color_no_event_passed(self):
         """This test doesn't pass an event to the SlackIssuesMessageBuilder to mimic what
         could happen in that case (it is optional). It also creates a performance group that won't
@@ -983,6 +994,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert isinstance(attachments, dict)
         assert attachments["color"] == "#2788CE"  # blue for info level
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_escape_slack_message(self):
         group = self.create_group(
             project=self.project,
@@ -1005,6 +1017,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
 class BuildGroupAttachmentReplaysTest(TestCase):
     @patch("sentry.models.group.Group.has_replays")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_build_replay_issue(self, has_replays):
         replay1_id = "46eb3948be25448abd53fe36b5891ff2"
         self.project.flags.has_replays = True
@@ -1416,19 +1429,20 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.UNRESOLVED
         group.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
-        expected = {
-            "label": "Archive",
-            "name": "status",
-            "type": "button",
-            "value": "ignored:until_escalating",
-        }
-        self._assert_message_actions_list(
-            res[0],
-            expected,
-        )
+        with self.feature({"organizations:slack-block-kit": False}):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+            expected = {
+                "label": "Archive",
+                "name": "status",
+                "type": "button",
+                "value": "ignored:until_escalating",
+            }
+            self._assert_message_actions_list(
+                res[0],
+                expected,
+            )
 
         with self.feature("organizations:slack-block-kit"):
             res = build_actions(
@@ -1445,19 +1459,20 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.UNRESOLVED
         group.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
-        expected = {
-            "label": "Archive",
-            "name": "status",
-            "type": "button",
-            "value": "ignored:until_escalating",
-        }
-        self._assert_message_actions_list(
-            res[0],
-            expected,
-        )
+        with self.feature({"organizations:slack-block-kit": False}):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+            expected = {
+                "label": "Archive",
+                "name": "status",
+                "type": "button",
+                "value": "ignored:until_escalating",
+            }
+            self._assert_message_actions_list(
+                res[0],
+                expected,
+            )
         with self.feature("organizations:slack-block-kit"):
             res = build_actions(
                 group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
@@ -1488,19 +1503,21 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.RESOLVED
         group.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
-        expected = {
-            "label": "Unresolve",
-            "name": "status",
-            "type": "button",
-            "value": "unresolved:ongoing",
-        }
-        self._assert_message_actions_list(
-            res[0],
-            expected,
-        )
+        with self.feature({"organizations:slack-block-kit": False}):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+            expected = {
+                "label": "Unresolve",
+                "name": "status",
+                "type": "button",
+                "value": "unresolved:ongoing",
+            }
+            self._assert_message_actions_list(
+                res[0],
+                expected,
+            )
+
         with self.feature("organizations:slack-block-kit"):
             res = build_actions(
                 group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
@@ -1523,19 +1540,21 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = False
         self.project.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        with self.feature({"organizations:slack-block-kit": False}):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
 
-        self._assert_message_actions_list(
-            res[0],
-            {
-                "label": "Resolve",
-                "name": "status",
-                "type": "button",
-                "value": "resolved",
-            },
-        )
+            self._assert_message_actions_list(
+                res[0],
+                {
+                    "label": "Resolve",
+                    "name": "status",
+                    "type": "button",
+                    "value": "resolved",
+                },
+            )
+
         with self.feature("organizations:slack-block-kit"):
             res = build_actions(
                 group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
@@ -1557,19 +1576,20 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = True
         self.project.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        with self.feature({"organizations:slack-block-kit": False}):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
 
-        self._assert_message_actions_list(
-            res[0],
-            {
-                "label": "Resolve...",
-                "name": "resolve_dialog",
-                "type": "button",
-                "value": "resolve_dialog",
-            },
-        )
+            self._assert_message_actions_list(
+                res[0],
+                {
+                    "label": "Resolve...",
+                    "name": "resolve_dialog",
+                    "type": "button",
+                    "value": "resolve_dialog",
+                },
+            )
 
         with self.feature("organizations:slack-block-kit"):
             res = build_actions(

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -6,6 +6,7 @@ import responses
 from sentry.integrations.slack.notifications import _get_attachments, send_notification_as_slack
 from sentry.notifications.additional_attachment_manager import manager
 from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import DummyNotification
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -29,6 +30,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
         self.notification = DummyNotification(self.organization)
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_additional_attachment(self):
         with mock.patch.dict(
             manager.attachment_generators,
@@ -94,6 +96,7 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
             assert blocks[4]["text"]["text"] == self.integration.id
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_no_additional_attachment(self):
         with self.tasks():
             send_notification_as_slack(self.notification, [self.user], {}, {})
@@ -151,7 +154,8 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
         Tests that notifications built with the legacy system can still send successfully with
         the block kit flag enabled.
         """
-        mock_attachment.return_value = _get_attachments(self.notification, self.user, {}, {})
+        with self.feature({"organizations:slack-block-kit": False}):
+            mock_attachment.return_value = _get_attachments(self.notification, self.user, {}, {})
 
         with self.feature("organizations:slack-block-kit"):
             with self.tasks():

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -47,7 +47,9 @@ class SlackNotifyActionTest(RuleTestCase):
         assert form.cleaned_data["channel"] == expected_channel
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_no_upgrade_notice_bot_app(self):
+        # TODO: make this a block kit test
         event = self.get_event()
 
         rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
@@ -73,6 +75,7 @@ class SlackNotifyActionTest(RuleTestCase):
         assert len(attachments) == 1
         assert attachments[0]["title"] == event.title
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_render_label(self):
         rule = self.get_rule(
             data={
@@ -105,7 +108,9 @@ class SlackNotifyActionTest(RuleTestCase):
             == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] and notes fix this @colleen in notification"
         )
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_render_label_without_integration(self):
+        # TODO: make this a block kit test
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()
 
@@ -385,7 +390,9 @@ class SlackNotifyActionTest(RuleTestCase):
 
     @responses.activate
     @mock.patch("sentry.analytics.record")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_additional_attachment(self, mock_record):
+        # TODO: make this a block kit test
         with mock.patch.dict(
             manager.attachment_generators,
             {ExternalProviders.SLACK: additional_attachment_generator},

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -246,6 +246,7 @@ class UnfurlTest(TestCase):
             ).build()
         )
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_escape_issue(self):
         group = self.create_group(
             project=self.project,

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -25,6 +25,7 @@ from sentry.models.release import Release
 from sentry.models.team import Team
 from sentry.silo import SiloMode, unguarded_write
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -271,6 +272,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["response_type"] == "ephemeral"
         assert resp.data["text"] == LINK_IDENTITY_MESSAGE.format(associate_url=associate_url)
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_archive_issue(self):
         status_action = {
             "name": "status",
@@ -437,6 +439,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"].endswith(expect_status)
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_archive_issue_with_additional_user_auth(self):
         """
         Ensure that we can act as a user even when the organization has SSO enabled
@@ -573,34 +576,37 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             "selected_options": [{"value": f"user:{user2.id}"}],
         }
 
-        resp = self.post_webhook(action_data=[status_action])
+        with self.feature({"organizations:slack-block-kit": False}):
+            resp = self.post_webhook(action_data=[status_action])
 
-        assert resp.status_code == 200, resp.content
-        assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+            assert resp.status_code == 200, resp.content
+            assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
 
-        expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
+            expect_status = (
+                f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
+            )
 
-        # Assign to team
-        status_action = {
-            "name": "assign",
-            "selected_options": [{"value": f"team:{self.team.id}"}],
-        }
+            # Assign to team
+            status_action = {
+                "name": "assign",
+                "selected_options": [{"value": f"team:{self.team.id}"}],
+            }
 
-        resp = self.post_webhook(action_data=[status_action])
+            resp = self.post_webhook(action_data=[status_action])
 
-        assert resp.status_code == 200, resp.content
-        assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
-        activity = Activity.objects.filter(group=self.group).first()
-        assert activity.data == {
-            "assignee": str(user2.id),
-            "assigneeEmail": user2.email,
-            "assigneeType": "user",
-            "integration": ActivityIntegration.SLACK.value,
-        }
+            assert resp.status_code == 200, resp.content
+            assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
+            activity = Activity.objects.filter(group=self.group).first()
+            assert activity.data == {
+                "assignee": str(user2.id),
+                "assigneeEmail": user2.email,
+                "assigneeType": "user",
+                "integration": ActivityIntegration.SLACK.value,
+            }
 
-        expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
+            expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
 
-        assert resp.data["text"].endswith(expect_status), resp.data["text"]
+            assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
@@ -759,16 +765,18 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             "selected_options": [{"value": f"user:{user2.id}"}],
         }
 
-        resp = self.post_webhook(action_data=[status_action])
+        with self.feature({"organizations:slack-block-kit": False}):
+            resp = self.post_webhook(action_data=[status_action])
 
-        assert resp.status_code == 200, resp.content
-        assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+            assert resp.status_code == 200, resp.content
+            assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
 
-        expect_status = (
-            f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
-        )
+            expect_status = (
+                f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
+            )
 
-        assert resp.data["text"].endswith(expect_status), resp.data["text"]
+            assert resp.data["text"].endswith(expect_status), resp.data["text"]
+
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
             resp = self.post_webhook(action_data=[status_action])
@@ -835,16 +843,18 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             "selected_options": [{"value": f"user:{self.user.id}"}],
         }
 
-        resp = self.post_webhook(action_data=[status_action])
+        with self.feature({"organizations:slack-block-kit": False}):
+            resp = self.post_webhook(action_data=[status_action])
 
-        assert resp.status_code == 200, resp.content
-        assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
+            assert resp.status_code == 200, resp.content
+            assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
 
-        expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
-            assignee=self.external_id
-        )
+            expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
+                assignee=self.external_id
+            )
 
-        assert resp.data["text"].endswith(expect_status), resp.data["text"]
+            assert resp.data["text"].endswith(expect_status), resp.data["text"]
+
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
             resp = self.post_webhook(action_data=[status_action])
@@ -903,6 +913,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_resolve_issue(self):
         status_action = {"name": "resolve_dialog", "value": "resolve_dialog"}
 
@@ -969,29 +980,31 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             content_type="application/json",
         )
 
-        resp = self.post_webhook(action_data=[status_action])
-        assert resp.status_code == 200, resp.content
+        with self.feature({"organizations:slack-block-kit": False}):
+            resp = self.post_webhook(action_data=[status_action])
+            assert resp.status_code == 200, resp.content
 
-        # Opening dialog should *not* cause the current message to be updated
-        assert resp.content == b""
+            # Opening dialog should *not* cause the current message to be updated
+            assert resp.content == b""
 
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["trigger_id"][0] == self.trigger_id
-        assert "dialog" in data
+            data = parse_qs(responses.calls[0].request.body)
+            assert data["trigger_id"][0] == self.trigger_id
+            assert "dialog" in data
 
-        dialog = json.loads(data["dialog"][0])
-        callback_data = json.loads(dialog["callback_id"])
-        assert int(callback_data["issue"]) == self.group.id
-        assert callback_data["orig_response_url"] == self.response_url
+            dialog = json.loads(data["dialog"][0])
+            callback_data = json.loads(dialog["callback_id"])
+            assert int(callback_data["issue"]) == self.group.id
+            assert callback_data["orig_response_url"] == self.response_url
 
-        # Completing the dialog will update the message
-        responses.add(
-            method=responses.POST,
-            url=self.response_url,
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
+            # Completing the dialog will update the message
+            responses.add(
+                method=responses.POST,
+                url=self.response_url,
+                body='{"ok": true}',
+                status=200,
+                content_type="application/json",
+            )
+
         with self.feature("organizations:slack-block-kit"):
             resp = self.post_webhook(
                 type="dialog_submission",
@@ -1041,6 +1054,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert update_data["blocks"][2]["text"]["text"] == expect_status
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_resolve_issue_in_next_release(self):
         status_action = {"name": "resolve_dialog", "value": "resolve_dialog"}
 
@@ -1119,29 +1133,30 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             content_type="application/json",
         )
 
-        resp = self.post_webhook(action_data=[status_action])
-        assert resp.status_code == 200, resp.content
+        with self.feature({"organizations:slack-block-kit": False}):
+            resp = self.post_webhook(action_data=[status_action])
+            assert resp.status_code == 200, resp.content
 
-        # Opening dialog should *not* cause the current message to be updated
-        assert resp.content == b""
+            # Opening dialog should *not* cause the current message to be updated
+            assert resp.content == b""
 
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["trigger_id"][0] == self.trigger_id
-        assert "dialog" in data
+            data = parse_qs(responses.calls[0].request.body)
+            assert data["trigger_id"][0] == self.trigger_id
+            assert "dialog" in data
 
-        dialog = json.loads(data["dialog"][0])
-        callback_data = json.loads(dialog["callback_id"])
-        assert int(callback_data["issue"]) == self.group.id
-        assert callback_data["orig_response_url"] == self.response_url
+            dialog = json.loads(data["dialog"][0])
+            callback_data = json.loads(dialog["callback_id"])
+            assert int(callback_data["issue"]) == self.group.id
+            assert callback_data["orig_response_url"] == self.response_url
 
-        # Completing the dialog will update the message
-        responses.add(
-            method=responses.POST,
-            url=self.response_url,
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
+            # Completing the dialog will update the message
+            responses.add(
+                method=responses.POST,
+                url=self.response_url,
+                body='{"ok": true}',
+                status=200,
+                content_type="application/json",
+            )
 
         with self.feature("organizations:slack-block-kit"):
             resp = self.post_webhook(
@@ -1255,14 +1270,15 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
         original_message = {"type": "message"}
 
-        resp = self.post_webhook(action_data=[status_action], original_message=original_message)
-        self.group = Group.objects.get(id=self.group.id)
+        with self.feature({"organizations:slack-block-kit": False}):
+            resp = self.post_webhook(action_data=[status_action], original_message=original_message)
+            self.group = Group.objects.get(id=self.group.id)
 
-        assert self.group.get_status() == GroupStatus.IGNORED
-        assert self.group.substatus == GroupSubStatus.FOREVER
-        assert resp.status_code == 200, resp.content
-        assert "attachments" in resp.data
-        assert resp.data["attachments"][0]["title"] in self.group.title
+            assert self.group.get_status() == GroupStatus.IGNORED
+            assert self.group.substatus == GroupSubStatus.FOREVER
+            assert resp.status_code == 200, resp.content
+            assert "attachments" in resp.data
+            assert resp.data["attachments"][0]["title"] in self.group.title
 
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
@@ -1345,21 +1361,23 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
         status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
 
-        resp = self.post_webhook(
-            action_data=[status_action], slack_user={"id": user2_identity.external_id}
-        )
-        self.group = Group.objects.get(id=self.group.id)
+        with self.feature({"organizations:slack-block-kit": False}):
+            resp = self.post_webhook(
+                action_data=[status_action], slack_user={"id": user2_identity.external_id}
+            )
+            self.group = Group.objects.get(id=self.group.id)
 
-        associate_url = build_unlinking_url(
-            self.integration.id, "slack_id2", "C065W1189", self.response_url
-        )
+            associate_url = build_unlinking_url(
+                self.integration.id, "slack_id2", "C065W1189", self.response_url
+            )
 
-        assert resp.status_code == 200, resp.content
-        assert resp.data["response_type"] == "ephemeral"
-        assert not resp.data["replace_original"]
-        assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
-            associate_url=associate_url, user_email=user2.email, org_name=self.organization.name
-        )
+            assert resp.status_code == 200, resp.content
+            assert resp.data["response_type"] == "ephemeral"
+            assert not resp.data["replace_original"]
+            assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
+                associate_url=associate_url, user_email=user2.email, org_name=self.organization.name
+            )
+
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
             resp = self.post_webhook(
@@ -1528,54 +1546,56 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             content_type="application/json",
         )
 
-        resp = self.post_webhook(action_data=[status_action])
-        assert resp.status_code == 200, resp.content
+        with self.feature({"organizations:slack-block-kit": False}):
+            resp = self.post_webhook(action_data=[status_action])
+            assert resp.status_code == 200, resp.content
 
-        # Opening dialog should *not* cause the current message to be updated
-        assert resp.content == b""
+            # Opening dialog should *not* cause the current message to be updated
+            assert resp.content == b""
 
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["trigger_id"][0] == self.trigger_id
-        assert "dialog" in data
+            data = parse_qs(responses.calls[0].request.body)
+            assert data["trigger_id"][0] == self.trigger_id
+            assert "dialog" in data
 
-        dialog = json.loads(data["dialog"][0])
-        callback_data = json.loads(dialog["callback_id"])
-        assert int(callback_data["issue"]) == self.group.id
-        assert callback_data["orig_response_url"] == self.response_url
+            dialog = json.loads(data["dialog"][0])
+            callback_data = json.loads(dialog["callback_id"])
+            assert int(callback_data["issue"]) == self.group.id
+            assert callback_data["orig_response_url"] == self.response_url
 
-        # Completing the dialog will update the message
-        responses.add(
-            method=responses.POST,
-            url=self.response_url,
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
+            # Completing the dialog will update the message
+            responses.add(
+                method=responses.POST,
+                url=self.response_url,
+                body='{"ok": true}',
+                status=200,
+                content_type="application/json",
+            )
 
-        # Remove the user from the organization.
-        member = OrganizationMember.objects.get(
-            user_id=self.user.id, organization=self.organization
-        )
-        member.remove_user()
-        member.save()
+            # Remove the user from the organization.
+            member = OrganizationMember.objects.get(
+                user_id=self.user.id, organization=self.organization
+            )
+            member.remove_user()
+            member.save()
 
-        response = self.post_webhook(
-            type="dialog_submission",
-            callback_id=dialog["callback_id"],
-            data={"submission": {"resolve_type": "resolved"}},
-        )
+            response = self.post_webhook(
+                type="dialog_submission",
+                callback_id=dialog["callback_id"],
+                data={"submission": {"resolve_type": "resolved"}},
+            )
 
-        assert response.status_code == 200, response.content
-        assert response.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
-            associate_url=build_unlinking_url(
-                integration_id=self.integration.id,
-                slack_id=self.external_id,
-                channel_id="C065W1189",
-                response_url=self.response_url,
-            ),
-            user_email=self.user.email,
-            org_name=self.organization.name,
-        )
+            assert response.status_code == 200, response.content
+            assert response.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
+                associate_url=build_unlinking_url(
+                    integration_id=self.integration.id,
+                    slack_id=self.external_id,
+                    channel_id="C065W1189",
+                    response_url=self.response_url,
+                ),
+                user_email=self.user.email,
+                org_name=self.organization.name,
+            )
+
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
             response = self.post_webhook(

--- a/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
+++ b/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
@@ -100,6 +100,7 @@ class DynamicAssignmentDropdownTest(BaseEventTest):
         assert len(resp.data["option_groups"][0]["options"]) == 3
         assert len(resp.data["option_groups"][1]["options"]) == 3
 
+    @with_feature({"organizations:slack-block-kit": False})
     def test_no_flag(self):
         self.group = self.create_group(project=self.project)
         self.original_message["blocks"][0]["block_id"] = json.dumps({"issue": self.group.id})

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -5,6 +5,7 @@ from django.core.mail.message import EmailMultiAlternatives
 from sentry.models.activity import Activity
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import get_attachment, get_channel
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -58,7 +59,9 @@ class AssignedNotificationAPITest(APITestCase):
         self.login_as(self.user)
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_assignment_notification(self):
+        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is assigned.
@@ -87,7 +90,9 @@ class AssignedNotificationAPITest(APITestCase):
         assert self.project.slug in attachment["footer"]
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_reassignment_notification_user(self):
+        # TODO: make this a block kit test
         """Test that if a user is assigned to an issue and then the issue is reassigned to a different user
         that the original assignee receives an unassignment notification as well as the new assignee
         receiving an assignment notification"""
@@ -147,7 +152,9 @@ class AssignedNotificationAPITest(APITestCase):
         self.validate_slack_message(msg, self.group, self.project, user1.id, index=2)
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_reassignment_notification_team(self):
+        # TODO: make this a block kit test
         """Test that if a team is assigned to an issue and then the issue is reassigned to a different team
         that the originally assigned team receives an unassignment notification as well as the new assigned
         team receiving an assignment notification"""

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -159,6 +159,7 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
 class DigestSlackNotification(SlackActivityNotificationTest):
     @responses.activate
     @mock.patch.object(sentry, "digests")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_slack_digest_notification(self, digests):
         """
         Test that with digests enabled, but Slack notification settings

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -27,6 +27,7 @@ from sentry.tasks.post_process import post_process_group
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -116,7 +117,9 @@ class ActivityNotificationTest(APITestCase):
         self.short_id = self.group.qualified_short_id
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_note_notification(self):
+        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when a comment is created on an issue.
@@ -153,7 +156,9 @@ class ActivityNotificationTest(APITestCase):
         )
 
     @responses.activate
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_unassignment_notification(self):
+        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is unassigned.
@@ -219,7 +224,9 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_resolution_notification(self, record_analytics):
+        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is resolved.
@@ -270,7 +277,9 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_deployment_notification(self, record_analytics):
+        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when a release is deployed.
@@ -334,7 +343,9 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_regression_notification(self, record_analytics):
+        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue regresses.
@@ -398,7 +409,9 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_resolved_in_release_notification(self, record_analytics):
+        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is resolved by a release.
@@ -463,7 +476,9 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
+    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_issue_notification(self, record_analytics):
+        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue comes in that triggers an alert rule.


### PR DESCRIPTION
In order to safely remove the feature flag, we can first default the feature flag to True, add test decorators that set the feature flag to `False` where appropriate, and then remove all instances of it (incrementally).