### PR TITLE
ref: break the generic / inheritance of redis ClusterManager

### DIFF
--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable
 from contextlib import contextmanager
 from typing import Any
 
-import rb
 from rb.clients import LocalClient
 from redis.exceptions import ResponseError
 
@@ -73,7 +72,6 @@ class RedisBackend(Backend):
 
     def __init__(self, **options: Any) -> None:
         cluster, options = get_cluster_from_options("SENTRY_DIGESTS_OPTIONS", options)
-        assert isinstance(cluster, rb.Cluster)
         self.cluster = cluster
         self.locks = LockManager(RedisLockBackend(self.cluster))
 

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -121,10 +121,7 @@ class RedisTSDB(BaseTSDB):
 
     def __init__(self, prefix: str = "ts:", vnodes: int = 64, **options: Any):
         cluster, options = get_cluster_from_options("SENTRY_TSDB_OPTIONS", options)
-        if is_instance_rb_cluster(cluster, False):
-            self.cluster = cluster
-        else:
-            raise AssertionError("unreachable")
+        self.cluster = cluster
         self.prefix = prefix
         self.vnodes = vnodes
         self.enable_frequency_sketches = options.pop("enable_frequency_sketches", False)

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Callable
 from copy import deepcopy
 from threading import Lock
-from typing import Any, Protocol, TypeGuard, TypeVar
+from typing import Any, TypeGuard
 
 import rb
 from django.utils.functional import SimpleLazyObject
@@ -25,14 +25,6 @@ from sentry.utils.versioning import Version, check_versions
 from sentry.utils.warnings import DeprecatedSettingWarning
 
 logger = logging.getLogger(__name__)
-
-
-T = TypeVar("T", rb.Cluster, RedisCluster | StrictRedis, covariant=True)
-
-
-class ClusterManager(Protocol[T]):
-    def get(self, key: str, *, decode_responses: bool = True) -> T:
-        ...
 
 
 _REDIS_DEFAULT_CLIENT_ARGS = {
@@ -217,8 +209,8 @@ redis_clusters = RedisClusterManager(options.default_manager)
 def get_cluster_from_options(
     setting: str,
     options: dict[str, Any],
-    cluster_manager: ClusterManager[T] = clusters,
-) -> tuple[T, dict[str, Any]]:
+    cluster_manager: RBClusterManager = clusters,
+) -> tuple[rb.Cluster, dict[str, Any]]:
     cluster_option_name = "cluster"
     default_cluster_name = "default"
     cluster_constructor_option_names = frozenset(("hosts",))

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -23,10 +23,7 @@ def config() -> dict[str, Any]:
 
 @pytest.fixture
 def redis_cluster(config: dict[str, Any]) -> StrictRedis:
-    cluster, options = redis.get_cluster_from_options(
-        "TEST_CLUSTER", config, cluster_manager=redis.redis_clusters
-    )
-    return cluster
+    return redis.redis_clusters.get("default")
 
 
 @pytest.fixture

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import pytest
-import rb
 
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
@@ -46,12 +45,10 @@ class RedisTSDBTest(TestCase):
             cluster="tsdb",
         )
 
-        assert isinstance(self.db.cluster, rb.Cluster)
         # the point of this test is to demonstrate behaviour with a multi-host cluster
         assert len(self.db.cluster.hosts) == 3
 
     def tearDown(self):
-        assert isinstance(self.db.cluster, rb.Cluster)
         with self.db.cluster.all() as client:
             client.flushdb()
 
@@ -594,7 +591,6 @@ class RedisTSDBTest(TestCase):
         ) == {"organization:1": [], "organization:2": []}
 
     def test_frequency_table_import_export_no_estimators(self):
-        assert isinstance(self.db.cluster, rb.Cluster)
         client = self.db.cluster.get_local_client_for_key("key")
 
         parameters = [64, 5, 10]
@@ -645,7 +641,6 @@ class RedisTSDBTest(TestCase):
         assert client.exists("1:e")
 
     def test_frequency_table_import_export_both_estimators(self):
-        assert isinstance(self.db.cluster, rb.Cluster)
         client = self.db.cluster.get_local_client_for_key("key")
 
         parameters = [64, 5, 5]
@@ -708,7 +703,6 @@ class RedisTSDBTest(TestCase):
         ]
 
     def test_frequency_table_import_export_source_estimators(self):
-        assert isinstance(self.db.cluster, rb.Cluster)
         client = self.db.cluster.get_local_client_for_key("key")
 
         parameters = [64, 5, 5]
@@ -767,7 +761,6 @@ class RedisTSDBTest(TestCase):
         ]
 
     def test_frequency_table_import_export_destination_estimators(self):
-        assert isinstance(self.db.cluster, rb.Cluster)
         client = self.db.cluster.get_local_client_for_key("key")
 
         parameters = [64, 5, 5]

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -1,26 +1,20 @@
 from __future__ import annotations
 
-import logging
 from unittest import TestCase, mock
 
 import pytest
 import rb
-from django.utils.functional import SimpleLazyObject
 from sentry_redis_tools.failover_redis import FailoverRedis
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import imports
 from sentry.utils.redis import (
-    ClusterManager,
-    _RedisCluster,
+    RBClusterManager,
+    RedisClusterManager,
     _shared_pool,
     get_cluster_from_options,
-    logger,
 )
 from sentry.utils.warnings import DeprecatedSettingWarning
-
-# Silence connection warnings
-logger.setLevel(logging.ERROR)
 
 
 def _options_manager():
@@ -38,7 +32,7 @@ class ClusterManagerTestCase(TestCase):
         imports._cache.clear()
 
     def test_get(self):
-        manager = ClusterManager(_options_manager())
+        manager = RBClusterManager(_options_manager())
         assert manager.get("foo") is manager.get("foo")
         assert manager.get("foo") is not manager.get("bar")
         assert manager.get("foo").pool_cls is _shared_pool
@@ -47,7 +41,7 @@ class ClusterManagerTestCase(TestCase):
 
     @mock.patch("sentry.utils.redis.RetryingRedisCluster")
     def test_specific_cluster(self, RetryingRedisCluster):
-        manager = ClusterManager(_options_manager(), cluster_type=_RedisCluster)
+        manager = RedisClusterManager(_options_manager())
 
         # We wrap the cluster in a Simple Lazy Object, force creation of the
         # object to verify it's correct.
@@ -62,26 +56,19 @@ class ClusterManagerTestCase(TestCase):
         with pytest.raises(KeyError):
             manager.get("bar")
 
-    def test_multiple_retrieval_do_not_setup_lazy_object(self):
-        class TestClusterType:
-            def supports(self, config):
-                return True
+    @mock.patch("sentry.utils.redis.RetryingRedisCluster")
+    def test_multiple_retrieval_do_not_setup_lazy_object(self, RetryingRedisCluster):
+        RetryingRedisCluster.side_effect = AssertionError("should not be called")
 
-            def factory(self, **config):
-                def setupfunc():
-                    assert False, "setupfunc should not be called"
-
-                return SimpleLazyObject(setupfunc)
-
-        manager = ClusterManager(_options_manager(), cluster_type=TestClusterType)
-        manager.get("foo")
+        manager = RedisClusterManager(_options_manager())
+        manager.get("baz")
         # repeated retrieval should not trigger call to setupfunc
-        manager.get("foo")
+        manager.get("baz")
 
 
 def test_get_cluster_from_options_cluster_provided():
     backend = mock.sentinel.backend
-    manager = ClusterManager(_options_manager())
+    manager = RBClusterManager(_options_manager())
 
     cluster, options = get_cluster_from_options(
         backend, {"cluster": "foo", "foo": "bar"}, cluster_manager=manager
@@ -95,7 +82,7 @@ def test_get_cluster_from_options_cluster_provided():
 
 def test_get_cluster_from_options_legacy_hosts_option():
     backend = mock.sentinel.backend
-    manager = ClusterManager(_options_manager())
+    manager = RBClusterManager(_options_manager())
 
     with pytest.warns(DeprecatedSettingWarning) as warninfo:
         cluster, options = get_cluster_from_options(
@@ -116,7 +103,7 @@ def test_get_cluster_from_options_legacy_hosts_option():
 
 def test_get_cluster_from_options_both_options_invalid():
     backend = mock.sentinel.backend
-    manager = ClusterManager(_options_manager())
+    manager = RBClusterManager(_options_manager())
 
     with pytest.raises(InvalidConfiguration):
         cluster, options = get_cluster_from_options(


### PR DESCRIPTION
this allow us to properly type redis with respect to `bytes` / `str` (currently it is defaulting to `Any`!)

<!-- Describe your PR here. -->