### PR TITLE
fix(crons): Fix monitor env broken notice type

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/monitorEnvironmentLabel.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/monitorEnvironmentLabel.tsx
@@ -34,11 +34,12 @@ const envMutedDisplay: StatusNotice = {
 
 export default function MonitorEnvironmentLabel({monitorEnv}: Props) {
   const {name, status, isMuted, activeIncident} = monitorEnv;
-  const {userNotifiedTimestamp, envMutedTimestamp} = activeIncident?.brokenNotice ?? {};
+  const {userNotifiedTimestamp, environmentMutedTimestamp} =
+    activeIncident?.brokenNotice ?? {};
   const envStatus = isMuted ? MonitorStatus.DISABLED : status;
   const {label, icon, color} = userNotifiedTimestamp
     ? userNotifiedDisplay
-    : envMutedTimestamp
+    : environmentMutedTimestamp
       ? envMutedDisplay
       : statusIconColorMap[envStatus];
 

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -89,7 +89,7 @@ export interface IntervalConfig extends BaseConfig {
 export type MonitorConfig = CrontabConfig | IntervalConfig;
 
 export interface MonitorEnvBrokenDetection {
-  envMutedTimestamp: string;
+  environmentMutedTimestamp: string;
   userNotifiedTimestamp: string;
 }
 


### PR DESCRIPTION
This should've been `environmentMutedTimestamp` from the beginning since that's what it is serialized to in the backend