### PR TITLE
Initialize project joins for alert rules

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -593,12 +593,10 @@ def create_alert_rule(
                 for project in excluded_projects
             ]
             AlertRuleExcludedProjects.objects.bulk_create(exclusions)
-        elif monitor_type == AlertRuleMonitorType.ACTIVATED and projects:
-            # initialize projects join table for activated alert rules
-            arps = [
-                AlertRuleProjects(alert_rule=alert_rule, project=project) for project in projects
-            ]
-            AlertRuleProjects.objects.bulk_create(arps)
+
+        # initialize projects join table for activated alert rules
+        arps = [AlertRuleProjects(alert_rule=alert_rule, project=project) for project in projects]
+        AlertRuleProjects.objects.bulk_create(arps)
 
         if monitor_type == AlertRuleMonitorType.ACTIVATED and activation_condition:
             # NOTE: if monitor_type is activated, activation_condition is required

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -600,7 +600,7 @@ def create_alert_rule(
                 alert_rule=alert_rule, condition_type=activation_condition.value
             )
 
-        # initialize projects join table for activated alert rules
+        # initialize projects join table for alert rules
         arps = [AlertRuleProjects(alert_rule=alert_rule, project=project) for project in projects]
         AlertRuleProjects.objects.bulk_create(arps)
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -594,15 +594,15 @@ def create_alert_rule(
             ]
             AlertRuleExcludedProjects.objects.bulk_create(exclusions)
 
-        # initialize projects join table for activated alert rules
-        arps = [AlertRuleProjects(alert_rule=alert_rule, project=project) for project in projects]
-        AlertRuleProjects.objects.bulk_create(arps)
-
         if monitor_type == AlertRuleMonitorType.ACTIVATED and activation_condition:
             # NOTE: if monitor_type is activated, activation_condition is required
             AlertRuleActivationCondition.objects.create(
                 alert_rule=alert_rule, condition_type=activation_condition.value
             )
+
+        # initialize projects join table for activated alert rules
+        arps = [AlertRuleProjects(alert_rule=alert_rule, project=project) for project in projects]
+        AlertRuleProjects.objects.bulk_create(arps)
 
         # NOTE: This constructs the query in snuba
         # NOTE: Will only subscribe if AlertRule.monitor_type === 'CONTINUOUS'

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -841,7 +841,8 @@ def update_alert_rule(
                 project for project in projects if project.slug not in existing_project_slugs
             ]
             updated_project_slugs = {project.slug for project in projects}
-            alert_rule.projects.filter(project__slug__not__in=updated_project_slugs).delete()
+
+            AlertRuleProjects.objects.exclude(project__slug__in=updated_project_slugs).delete()
             for project in projects:
                 alert_rule.projects.add(project)
             # Find any subscriptions that were removed as part of this update

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -841,6 +841,9 @@ def update_alert_rule(
                 project for project in projects if project.slug not in existing_project_slugs
             ]
             updated_project_slugs = {project.slug for project in projects}
+            alert_rule.projects.filter(project__slug__not__in=updated_project_slugs).delete()
+            for project in projects:
+                alert_rule.projects.add(project)
             # Find any subscriptions that were removed as part of this update
             deleted_subs = [
                 sub for sub in existing_subs if sub.project.slug not in updated_project_slugs

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -463,10 +463,10 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
     def test_create_alert_rule(self):
         # pytest parametrize does not work in TestCase subclasses, so hack around this
         # TODO: backfill projects so all monitor_types include 'projects' fk
-        for monitor_type, expected_projects in [
-            (None, 0),
-            (AlertRuleMonitorType.CONTINUOUS, 0),
-            (AlertRuleMonitorType.ACTIVATED, 1),
+        for monitor_type in [
+            None,
+            AlertRuleMonitorType.CONTINUOUS,
+            AlertRuleMonitorType.ACTIVATED,
         ]:
             name = "hello"
             query = "level:error"
@@ -513,7 +513,8 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             assert alert_rule.threshold_type == threshold_type.value
             assert alert_rule.resolve_threshold == resolve_threshold
             assert alert_rule.threshold_period == threshold_period
-            assert alert_rule.projects.all().count() == expected_projects
+            # We now create an AlertRuleProject for all rule monitor types
+            assert alert_rule.projects.all().count() == 1
 
     def test_create_activated_alert_rule_errors_without_condition(self):
         name = "hello"
@@ -815,6 +816,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert set(self.alert_rule.snuba_query.event_types) == set(event_types)
         assert self.alert_rule.threshold_type == threshold_type.value
         assert self.alert_rule.threshold_period == threshold_period
+        assert self.alert_rule.projects.all().count() == 2
+        assert self.alert_rule.projects.all()[0] == updated_projects[0]
 
     def test_update_subscription(self):
         old_subscription_id = self.alert_rule.snuba_query.subscriptions.get().subscription_id


### PR DESCRIPTION
separates logic from https://github.com/getsentry/sentry/pull/67563

initializes an AlertRuleProject for all alert rule types

Updates an AlertRule's projects on update of the alert rule