### PR TITLE
style(feedback): remove border from screenshot

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -127,7 +127,7 @@ const StyledPanelHeader = styled(PanelHeader)`
 `;
 
 const StyledPanelBody = styled(PanelBody)<{hasHeader: boolean}>`
-  border: 1px solid ${p => p.theme.border};
+  border: none;
   min-height: 48px;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
cleaning up something i missed from the previous screenshot UI PR.

if you look closely there's this light grey border around the screenshot. this PR removes it:

<img width="535" alt="SCR-20240401-kzic" src="https://github.com/getsentry/sentry/assets/56095982/599f5889-a17c-456d-a3e9-48782dd0f960">

after:
<img width="563" alt="SCR-20240401-kzdj" src="https://github.com/getsentry/sentry/assets/56095982/5b023a31-4400-43f3-94bd-659dc60588a4">

