### PR TITLE
style(feedback): screenshot in fullscreen is full width & height

### DIFF
--- a/static/app/components/feedback/feedbackItem/openScreenshotModal.tsx
+++ b/static/app/components/feedback/feedbackItem/openScreenshotModal.tsx
@@ -176,9 +176,11 @@ const StyledImageVisualization = styled(ImageVisualization)`
     border-radius: ${p => p.theme.borderRadius};
     max-height: calc(100vh - 300px);
   }
+  background: ${p => p.theme.black};
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 export const modalCss = css`
   height: 100%;
-  width: auto;
+  width: 100%;
 `;


### PR DESCRIPTION
right now it's just full width; need to add full height:
<img width="1432" alt="SCR-20240401-labi" src="https://github.com/getsentry/sentry/assets/56095982/af15d54b-fbfb-4281-8eb8-64bf7df760dd">
<img width="1423" alt="SCR-20240401-kzzg" src="https://github.com/getsentry/sentry/assets/56095982/a58db621-1033-4106-a0aa-2e5fcf949503">

- [figma design](https://www.figma.com/file/hIUACYgu3lenuAPLgg22a3/Specs%3A-Screenshots-v1?type=design&node-id=29-1698&mode=design&t=31jjAiEiaBhYtsnq-0)
- relates to https://github.com/getsentry/sentry/issues/67707