### PR TITLE
fix(staff): Remove idle expiration time for staff

### DIFF
--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -64,7 +64,7 @@ def has_staff_option(user) -> bool:
     return email in options.get("staff.user-email-allowlist")
 
 
-def seconds_to_timestamp(seconds: str) -> datetime:
+def _seconds_to_timestamp(seconds: str) -> datetime:
     return datetime.fromtimestamp(float(seconds), timezone.utc)
 
 
@@ -180,7 +180,7 @@ class Staff(ElevatedMode):
             current_datetime = django_timezone.now()
 
         try:
-            expires_date = seconds_to_timestamp(data["exp"])
+            expires_date = _seconds_to_timestamp(data["exp"])
         except (TypeError, ValueError):
             logger.warning(
                 "staff.invalid-expiration",
@@ -213,7 +213,7 @@ class Staff(ElevatedMode):
         if not data:
             self._set_logged_out()
         else:
-            self._set_logged_in(seconds_to_timestamp(data["exp"]), token=data["tok"], user=user)
+            self._set_logged_in(_seconds_to_timestamp(data["exp"]), token=data["tok"], user=user)
 
             if not self.is_active:
                 if self._inactive_reason:

--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.conf import settings
 from django.core.signing import BadSignature
@@ -62,6 +62,10 @@ def has_staff_option(user) -> bool:
     if (email := getattr(user, "email", None)) is None:
         return False
     return email in options.get("staff.user-email-allowlist")
+
+
+def _seconds_to_timestamp(seconds: str) -> datetime:
+    return datetime.fromtimestamp(float(seconds), timezone.utc)
 
 
 class Staff(ElevatedMode):
@@ -176,7 +180,7 @@ class Staff(ElevatedMode):
             current_datetime = django_timezone.now()
 
         try:
-            expires_date = data["exp"]
+            expires_date = _seconds_to_timestamp(data["exp"])
         except (TypeError, ValueError):
             logger.warning(
                 "staff.invalid-expiration",
@@ -209,7 +213,7 @@ class Staff(ElevatedMode):
         if not data:
             self._set_logged_out()
         else:
-            self._set_logged_in(expires=data["exp"], token=data["tok"], user=user)
+            self._set_logged_in(_seconds_to_timestamp(data["exp"]), token=data["tok"], user=user)
 
             if not self.is_active:
                 if self._inactive_reason:
@@ -245,7 +249,7 @@ class Staff(ElevatedMode):
         self._is_active, self._inactive_reason = self.is_privileged_request()
 
         session_info = {
-            "exp": expires,
+            "exp": expires.strftime("%s"),
             "tok": self.token,
             # XXX(dcramer): do we really need the uid safety mechanism
             "uid": self.uid,

--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -213,7 +213,9 @@ class Staff(ElevatedMode):
         if not data:
             self._set_logged_out()
         else:
-            self._set_logged_in(_seconds_to_timestamp(data["exp"]), token=data["tok"], user=user)
+            self._set_logged_in(
+                expires=_seconds_to_timestamp(data["exp"]), token=data["tok"], user=user
+            )
 
             if not self.is_active:
                 if self._inactive_reason:

--- a/tests/sentry/auth/test_staff.py
+++ b/tests/sentry/auth/test_staff.py
@@ -78,7 +78,9 @@ class StaffTestCase(TestCase):
             ).sign(self.default_token if cookie_token is UNSET else cookie_token)
         if session_data:
             request.session[SESSION_KEY] = {
-                "exp": self.current_datetime + MAX_AGE if expires is UNSET else expires,
+                "exp": (self.current_datetime + MAX_AGE if expires is UNSET else expires).strftime(
+                    "%s"
+                ),
                 "tok": self.default_token if session_token is UNSET else session_token,
                 "uid": str(user.id) if uid is UNSET else uid,
             }
@@ -176,7 +178,7 @@ class StaffTestCase(TestCase):
         # See mypy issue: https://github.com/python/mypy/issues/9457
         data = request.session.get(SESSION_KEY)  # type:ignore[unreachable]
         assert data
-        assert data["exp"] == self.current_datetime + MAX_AGE
+        assert data["exp"] == (self.current_datetime + MAX_AGE).strftime("%s")
         assert len(data["tok"]) == 12
         assert data["uid"] == str(self.staff_user.id)
 
@@ -198,9 +200,10 @@ class StaffTestCase(TestCase):
         # session wasn't replaced
         assert request.session.modified is False
 
+        # See mypy issue: https://github.com/python/mypy/issues/9457
         data = request.session.get(SESSION_KEY)
         assert data
-        assert data["exp"] == self.current_datetime + MAX_AGE
+        assert data["exp"] == (self.current_datetime + MAX_AGE).strftime("%s")
         assert len(data["tok"]) == 12
         assert data["uid"] == str(self.staff_user.id)
 

--- a/tests/sentry/auth/test_staff.py
+++ b/tests/sentry/auth/test_staff.py
@@ -78,9 +78,7 @@ class StaffTestCase(TestCase):
             ).sign(self.default_token if cookie_token is UNSET else cookie_token)
         if session_data:
             request.session[SESSION_KEY] = {
-                "exp": (self.current_datetime + MAX_AGE if expires is UNSET else expires).strftime(
-                    "%s"
-                ),
+                "exp": self.current_datetime + MAX_AGE if expires is UNSET else expires,
                 "tok": self.default_token if session_token is UNSET else session_token,
                 "uid": str(user.id) if uid is UNSET else uid,
             }
@@ -178,7 +176,7 @@ class StaffTestCase(TestCase):
         # See mypy issue: https://github.com/python/mypy/issues/9457
         data = request.session.get(SESSION_KEY)  # type:ignore[unreachable]
         assert data
-        assert data["exp"] == (self.current_datetime + MAX_AGE).strftime("%s")
+        assert data["exp"] == self.current_datetime + MAX_AGE
         assert len(data["tok"]) == 12
         assert data["uid"] == str(self.staff_user.id)
 
@@ -200,10 +198,9 @@ class StaffTestCase(TestCase):
         # session wasn't replaced
         assert request.session.modified is False
 
-        # See mypy issue: https://github.com/python/mypy/issues/9457
         data = request.session.get(SESSION_KEY)
         assert data
-        assert data["exp"] == (self.current_datetime + MAX_AGE).strftime("%s")
+        assert data["exp"] == self.current_datetime + MAX_AGE
         assert len(data["tok"]) == 12
         assert data["uid"] == str(self.staff_user.id)
 


### PR DESCRIPTION
Remove idle expiration time for staff so we don't send the session cookie back on every new staff request and reduce the max age for staff.

Django's [session modified check](https://github.com/django/django/blob/main/django/contrib/sessions/backends/base.py#L57-L67) is basic because it will always say it's modified if you add or remove a key, regardless of whether or not the value existed before and was identical. Therefore we need to incorporate that logic directly into the staff logic.

Closes https://github.com/getsentry/team-core-product-foundations/issues/249