### PR TITLE
ref(crons): Optimize broken detection task schedule

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1038,8 +1038,8 @@ CELERYBEAT_SCHEDULE_REGION = {
     },
     "monitors-detect-broken-monitor-envs": {
         "task": "sentry.monitors.tasks.detect_broken_monitor_envs",
-        # 17:00 PDT, 20:00 EDT, 0:00 UTC
-        "schedule": crontab(minute="0", hour="0"),
+        # 8:00 PDT, 11:00 EDT, 15:00 UTC
+        "schedule": crontab(minute="0", hour="15", day_of_week="mon-fri"),
         "options": {"expires": 15 * 60},
     },
     "clear-expired-snoozes": {


### PR DESCRIPTION
As we're launching broken monitor detection to everyone: https://github.com/getsentry/sentry-options-automator/pull/1002 Lets optimize the task schedule for more likelihood that users of crons will pay attention to the emails we send. 

**Setting the schedule to 8am PDT and only for weekdays so users will get alerted at the "start" of workdays**