### PR TITLE
ref: mypy --disallow-any-generics for relay metric_extraction

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -345,7 +345,7 @@ def _update_state_with_spec_limit(
     under the limit and not have churn.
     """
 
-    widget_queries: dict[int, set] = {}
+    widget_queries: dict[int, set[DashboardWidgetQuery]] = {}
 
     for spec in trimmed_specs:
         spec_hash, _, spec_version = spec


### PR DESCRIPTION
I'm planning to add this setting to our "stricter" mypy allowlist -- need to fix it here first though!

<!-- Describe your PR here. -->