### PR TITLE
ref: remove client_class customization for redis single-node

### DIFF
--- a/src/sentry/processing/backpressure/memory.py
+++ b/src/sentry/processing/backpressure/memory.py
@@ -39,7 +39,6 @@ def query_rabbitmq_memory_usage(host: str) -> ServiceMemory:
 # Based on configuration, this could be:
 # - a `rediscluster` Cluster (actually `RetryingRedisCluster`)
 # - a `rb.Cluster` (client side routing cluster client)
-# - or any class configured via `client_class`.
 Cluster = Union[RedisCluster, rb.Cluster]
 
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -21,7 +21,6 @@ from sentry import options
 from sentry.exceptions import InvalidConfiguration
 from sentry.options import OptionsManager
 from sentry.utils import warnings
-from sentry.utils.imports import import_string
 from sentry.utils.versioning import Version, check_versions
 from sentry.utils.warnings import DeprecatedSettingWarning
 
@@ -143,11 +142,7 @@ class _RedisCluster:
                 assert len(hosts_list) > 0, "Hosts should have at least 1 entry"
                 host = dict(hosts_list[0])
                 host["decode_responses"] = decode_responses
-                return (
-                    import_string(config["client_class"])
-                    if "client_class" in config
-                    else FailoverRedis
-                )(**host, **client_args)
+                return FailoverRedis(**host, **client_args)
 
         return SimpleLazyObject(cluster_factory)
 

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -52,7 +52,7 @@ class ClusterManagerTestCase(TestCase):
         # We wrap the cluster in a Simple Lazy Object, force creation of the
         # object to verify it's correct.
 
-        # cluster foo is fine since it's a single node, without specific client_class
+        # cluster foo is fine since it's a single node
         assert isinstance(manager.get("foo")._setupfunc(), FailoverRedis)  # type: ignore[attr-defined]
         # baz works becasue it's explicitly is_redis_cluster
         assert manager.get("baz")._setupfunc() is RetryingRedisCluster.return_value  # type: ignore[attr-defined]


### PR DESCRIPTION
this is never used in sentry / getsentry

<!-- Describe your PR here. -->