### PR TITLE
ref(crons): Improve timeline marker calculations

### DIFF
--- a/static/app/views/monitors/components/mockTimelineVisualization.spec.tsx
+++ b/static/app/views/monitors/components/mockTimelineVisualization.spec.tsx
@@ -35,6 +35,8 @@ describe('MockTimelineVisualizer', () => {
     render(<MockTimelineVisualization schedule={schedule} />);
 
     expect(request).toHaveBeenCalled();
-    expect(await screen.findByText('Nov 21, 2023')).toBeInTheDocument();
+    expect(await screen.findByText('Nov 22, 2023')).toBeInTheDocument();
+    expect(await screen.findByText('Nov 24, 2023')).toBeInTheDocument();
+    expect(await screen.findByText('Nov 26, 2023')).toBeInTheDocument();
   });
 });

--- a/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/gridLines.tsx
@@ -11,6 +11,7 @@ import type {TimeWindowConfig} from 'sentry/views/monitors/components/overviewTi
 
 import {useTimelineCursor} from './timelineCursor';
 import {useTimelineZoom} from './timelineZoom';
+import {alignDateToBoundary} from './utils';
 
 interface Props {
   timeWindowConfig: TimeWindowConfig;
@@ -33,50 +34,63 @@ interface Props {
   stickyCursor?: boolean;
 }
 
-/**
- * Aligns a date to a clean offset such as start of minute, hour, day
- * based on the interval of how far each time label is placed.
- */
-function alignTimeMarkersToStartOf(date: moment.Moment, timeMarkerInterval: number) {
-  if (timeMarkerInterval < 60) {
-    date.minute(date.minutes() - (date.minutes() % timeMarkerInterval));
-  } else if (timeMarkerInterval < 60 * 24) {
-    date.startOf('hour');
-  } else {
-    date.startOf('day');
-  }
-}
-
 interface TimeMarker {
   date: Date;
+  /**
+   * Props to pass to the DateTime component
+   */
+  dateTimeProps: TimeWindowConfig['dateTimeProps'];
+  /**
+   * The position in pixels of the tick
+   */
   position: number;
 }
 
 function getTimeMarkersFromConfig(config: TimeWindowConfig, width: number) {
-  const {start, end, elapsedMinutes, timeMarkerInterval} = config;
+  const {start, end, elapsedMinutes, dateTimeProps} = config;
+  const {markerInterval, minimumMarkerInterval} = config;
+
   const msPerPixel = (elapsedMinutes * 60 * 1000) / width;
 
-  const times: TimeMarker[] = [];
+  // The first marker will always be the starting time. This always renders the
+  // full date and time
+  const markers: TimeMarker[] = [
+    {
+      date: start,
+      position: 0,
+      dateTimeProps: {},
+    },
+  ];
 
-  const lastTimeMark = moment(end);
-  alignTimeMarkersToStartOf(lastTimeMark, timeMarkerInterval);
+  // The mark after the first mark will be aligned to a boundary to make it
+  // easier to understand the rest of the marks
+  const currentMark = alignDateToBoundary(moment(start), markerInterval);
 
-  // Generate time markers which represent location of grid lines/time labels
-  for (let i = 1; i < elapsedMinutes / timeMarkerInterval; i++) {
-    const timeMark = moment(lastTimeMark).subtract(i * timeMarkerInterval, 'minute');
-    const position = (timeMark.valueOf() - start.valueOf()) / msPerPixel;
-    times.push({date: timeMark.toDate(), position});
+  // if the current mark is not at least minimumMarkerInterval from the start
+  // skip until it is
+  while (currentMark.isBefore(moment(start).add(minimumMarkerInterval, 'minutes'))) {
+    currentMark.add(markerInterval, 'minute');
   }
 
-  return times.reverse();
+  // Generate time markers which represent location of grid lines/time labels.
+  // Stop adding markers once there's no more room for more markers
+  while (moment(currentMark).add(minimumMarkerInterval, 'minutes').isBefore(end)) {
+    const position = (currentMark.valueOf() - start.valueOf()) / msPerPixel;
+    markers.push({date: currentMark.toDate(), position, dateTimeProps});
+    currentMark.add(markerInterval, 'minutes');
+  }
+
+  return markers;
 }
 
 export function GridLineTimeLabels({width, timeWindowConfig, className}: Props) {
+  const markers = getTimeMarkersFromConfig(timeWindowConfig, width);
+
   return (
     <LabelsContainer className={className}>
-      {getTimeMarkersFromConfig(timeWindowConfig, width).map(({date, position}) => (
+      {markers.map(({date, position, dateTimeProps}) => (
         <TimeLabelContainer key={date.getTime()} left={position}>
-          <TimeLabel date={date} {...timeWindowConfig.dateTimeProps} />
+          <TimeLabel date={date} {...dateTimeProps} />
         </TimeLabelContainer>
       ))}
     </LabelsContainer>
@@ -131,13 +145,14 @@ export function GridLineOverlay({
   });
 
   const overlayRef = mergeRefs(cursorContainerRef, selectionContainerRef);
+  const markers = getTimeMarkersFromConfig(timeWindowConfig, width);
 
   return (
     <Overlay ref={overlayRef} className={className}>
       {timelineCursor}
       {timelineSelector}
       <GridLineContainer>
-        {getTimeMarkersFromConfig(timeWindowConfig, width).map(({date, position}) => (
+        {markers.map(({date, position}) => (
           <Gridline key={date.getTime()} left={position} />
         ))}
       </GridLineContainer>
@@ -155,6 +170,7 @@ const Overlay = styled('div')`
 `;
 
 const GridLineContainer = styled('div')`
+  margin-left: -1px;
   position: relative;
   height: 100%;
   z-index: 1;

--- a/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.spec.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/jobTickTooltip.spec.tsx
@@ -24,7 +24,8 @@ const tickConfig: TimeWindowConfig = {
   end: new Date('2023-06-15T12:00:00Z'),
   dateLabelFormat: getFormat({timeOnly: true, seconds: true}),
   elapsedMinutes: 60,
-  timeMarkerInterval: 10,
+  markerInterval: 10,
+  minimumMarkerInterval: 10,
   dateTimeProps: {timeOnly: true},
 };
 

--- a/static/app/views/monitors/components/overviewTimeline/types.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/types.tsx
@@ -20,13 +20,18 @@ export interface TimeWindowConfig {
    */
   end: Date;
   /**
+   * The interval in minutes between each grid line and time label.
+   */
+  markerInterval: number;
+  /**
+   * The smallest allowed interval in minutes between time markers. This is
+   * used to determine the gap between the start and end timeline makers.
+   */
+  minimumMarkerInterval: number;
+  /**
    * The start of the window
    */
   start: Date;
-  /**
-   * The interval between each grid line and time label in minutes
-   */
-  timeMarkerInterval: number;
 }
 
 // TODO(davidenwang): Remove this type as its a little too specific

--- a/static/app/views/monitors/components/overviewTimeline/utils.spec.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/utils.spec.tsx
@@ -14,8 +14,24 @@ describe('Crons Timeline Utils', function () {
         end,
         dateLabelFormat: getFormat({timeOnly: true, seconds: true}),
         elapsedMinutes: 5,
-        timeMarkerInterval: 1,
+        markerInterval: 1,
+        minimumMarkerInterval: 0.625,
         dateTimeProps: {timeOnly: true},
+      });
+    });
+
+    it('displays dates when more than 1 day window size', function () {
+      const start = new Date('2023-06-15T11:00:00Z');
+      const end = new Date('2023-06-16T11:05:00Z');
+      const config = getConfigFromTimeRange(start, end, timelineWidth);
+      expect(config).toEqual({
+        start,
+        end,
+        dateLabelFormat: getFormat(),
+        elapsedMinutes: 1445,
+        markerInterval: 240,
+        minimumMarkerInterval: 198.6875,
+        dateTimeProps: {timeOnly: false},
       });
     });
 
@@ -28,7 +44,8 @@ describe('Crons Timeline Utils', function () {
         end,
         dateLabelFormat: getFormat({timeOnly: true}),
         elapsedMinutes: 900,
-        timeMarkerInterval: 240,
+        markerInterval: 120,
+        minimumMarkerInterval: 112.5,
         dateTimeProps: {timeOnly: true},
       });
     });
@@ -43,8 +60,9 @@ describe('Crons Timeline Utils', function () {
         dateLabelFormat: getFormat(),
         // 31 elapsed days
         elapsedMinutes: 31 * 24 * 60,
-        // 4 days in between each time label
-        timeMarkerInterval: 4 * 24 * 60,
+        // 5 days in between each time label
+        markerInterval: 5 * 24 * 60,
+        minimumMarkerInterval: 6138,
         dateTimeProps: {dateOnly: true},
       });
     });

--- a/static/app/views/monitors/components/overviewTimeline/utils.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/utils.tsx
@@ -10,26 +10,40 @@ export const resolutionElapsedMinutes: Record<TimeWindow, number> = {
   '30d': 60 * 24 * 30,
 };
 
-// The pixels to allocate to each time label based on (MMM DD HH:SS AM/PM)
-const TIMELABEL_WIDTH = 100;
+/**
+ * The minimum pixels to allocate to each time label when it is a full date.
+ */
+const TIMELABEL_WIDTH_DATE = 110;
+
+/**
+ * The minimum pixels to allocate to each time label when it's a timestaamp.
+ */
+const TIMELABEL_WIDTH_TIME = 100;
 
 const ONE_HOUR = 60;
 
 /**
  * Acceptable minute durations between time labels. These will be used to
- * create the TimeWindowConfig when the start and end times fit into these
- * buckets
+ * computed the timeMarkerInterval of the TimeWindow when the start and end
+ * times fit into these buckets.
  */
 const CLAMPED_MINUTE_RANGES = [
   1,
+  5,
   10,
+  20,
   30,
   ONE_HOUR,
+  ONE_HOUR * 2,
   ONE_HOUR * 4,
   ONE_HOUR * 8,
   ONE_HOUR * 12,
 ];
 
+/**
+ * Compute the TimeWindowConfig given the timeline date bounadies and the width
+ * of the timeline.
+ */
 export function getConfigFromTimeRange(
   start: Date,
   end: Date,
@@ -37,33 +51,72 @@ export function getConfigFromTimeRange(
 ): TimeWindowConfig {
   const elapsedMinutes = (end.getTime() - start.getTime()) / (1000 * 60);
 
-  const timeLabelMinutes = elapsedMinutes * (TIMELABEL_WIDTH / timelineWidth);
-  const subMinutePxBuckets = elapsedMinutes < timelineWidth;
+  // Display only the time (no date) when the window is less than 24 hours
+  const timeOnly = elapsedMinutes <= ONE_HOUR * 24;
+
+  const minimuWidth = timeOnly ? TIMELABEL_WIDTH_TIME : TIMELABEL_WIDTH_DATE;
+
+  // When one pixel represent less than at least one minute we also want to
+  // display second values on our labels.
+  const displaySeconds = elapsedMinutes < timelineWidth;
+
+  // Compute the smallest minute value that we are willing to space our ticks
+  // apart by. This will be at least minimuWidth.
+
+  // Calculate the minutes per pixel of the timeline
+  const minutesPerPixel = elapsedMinutes / timelineWidth;
+
+  // Calculate minutes at the minimuWidth
+  const minTickMinutesApart = minutesPerPixel * minimuWidth;
+
+  const baseConfig = {
+    start,
+    end,
+    elapsedMinutes,
+    minimumMarkerInterval: minTickMinutesApart,
+  };
 
   for (const minutes of CLAMPED_MINUTE_RANGES) {
-    if (minutes < Math.floor(timeLabelMinutes)) {
+    if (minutes < minTickMinutesApart) {
       continue;
     }
 
     // Configuration falls into
     return {
-      start,
-      end,
-      dateLabelFormat: getFormat({timeOnly: true, seconds: subMinutePxBuckets}),
-      elapsedMinutes,
-      timeMarkerInterval: minutes,
-      dateTimeProps: {timeOnly: true},
+      ...baseConfig,
+      markerInterval: minutes,
+      dateTimeProps: {timeOnly},
+      dateLabelFormat: getFormat({timeOnly, seconds: displaySeconds}),
     };
   }
 
-  // Calculate days between each time label interval for larger time ranges
-  const timeLabelIntervalDays = Math.ceil(timeLabelMinutes / (ONE_HOUR * 24));
+  // Calculate the days in between each tick marker at the minimum time
+  const tickIntervalDayInMinutes =
+    Math.ceil(minTickMinutesApart / (ONE_HOUR * 24)) * ONE_HOUR * 24;
+
   return {
-    start,
-    end,
-    dateLabelFormat: getFormat(),
-    elapsedMinutes,
-    timeMarkerInterval: timeLabelIntervalDays * ONE_HOUR * 24,
+    ...baseConfig,
+    markerInterval: tickIntervalDayInMinutes,
     dateTimeProps: {dateOnly: true},
+    dateLabelFormat: getFormat(),
   };
+}
+
+/**
+ * Aligns the given date to the start of a unit (minute, hour, day) based on
+ * the minuteInterval size. This will align to the right side of the boundary
+ *
+ * 01:53:43 (10m interval) => 01:54:00
+ * 01:32:00 (2hr interval) => 02:00:00
+ */
+export function alignDateToBoundary(date: moment.Moment, minuteInterval: number) {
+  if (minuteInterval < 60) {
+    return date.minute(date.minutes() - (date.minutes() % minuteInterval)).seconds(0);
+  }
+
+  if (minuteInterval < 60 * 24) {
+    return date.startOf('hour');
+  }
+
+  return date.startOf('day');
 }

--- a/static/app/views/monitors/utils/useMonitorDates.tsx
+++ b/static/app/views/monitors/utils/useMonitorDates.tsx
@@ -36,7 +36,7 @@ interface UseMonitorTimesResult {
  * selected page filters.
  */
 export function useMonitorTimes({timelineWidth}: Options): UseMonitorTimesResult {
-  const nowRef = useRef<Date>(new Date());
+  const nowRef = useRef<Date>(moment().seconds(0).add(1, 'minutes').toDate());
   const {selection} = usePageFilters();
   const {start, end, period} = selection.datetime;
 


### PR DESCRIPTION
This adjusts how we place and calculate the grid timeline markers in the
monitor timelines.

- We now compute a different width between markers depending on if we are showing just a timestamp or a full date time.

- A marker will now always be present at the start of the timeline with the precise reference starting time.

- Markers after the initial marker will always start aligned to a "clean" unit with a gaurentee taht it's at least TIMELABEL_WIDTH_DATE or TIMELABEL_WIDTH_TIME away from the initial marker.

- The last marker will also now be placed at most TIMELABEL_WIDTH_DATE or TIMELABEL_WIDTH_TIME away from the right side of the timeline.

Here is the before

<img alt="clipboard.png" width="1477" src="https://i.imgur.com/j4HxPmY.png" />

And the after

<img alt="clipboard.png" width="1465" src="https://i.imgur.com/YYRiKws.png" />