### PR TITLE
feat(useProject): Create a hook to fetch individual projects and move away from the ProjectStore

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -20,9 +20,15 @@ export type Project = {
   digestsMinDelay: number;
   dynamicSamplingBiases: DynamicSamplingBias[] | null;
   environments: string[];
+  /**
+   * @deprecated
+   */
   eventProcessing: {
     symbolicationDegraded: boolean;
   };
+  /**
+   * @deprecated
+   */
   features: string[];
   firstEvent: string | null;
   firstTransactionEvent: boolean;
@@ -52,6 +58,7 @@ export type Project = {
   scrapeJavaScript: boolean;
   scrubIPAddresses: boolean;
   sensitiveFields: string[];
+  slug: string;
   subjectTemplate: string;
   team: Team;
   teams: Team[];
@@ -59,9 +66,13 @@ export type Project = {
   builtinSymbolSources?: string[];
   defaultEnvironment?: string;
   hasUserReports?: boolean;
+  /**
+   * @deprecated
+   */
   latestDeploys?: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;
   latestRelease?: {version: string} | null;
   options?: Record<string, boolean | string>;
+  platform?: PlatformKey;
   securityToken?: string;
   securityTokenHeader?: string;
   sessionStats?: {

--- a/static/app/utils/project/useProject.spec.tsx
+++ b/static/app/utils/project/useProject.spec.tsx
@@ -1,0 +1,123 @@
+import type {ReactNode} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import useProject from 'sentry/utils/project/useProject';
+import type {QueryClient} from 'sentry/utils/queryClient';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+jest.mock('sentry/utils/useOrganization');
+
+function makeWrapper(queryClient: QueryClient) {
+  return function wrapper({children}: {children?: ReactNode}) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useProject', () => {
+  const mockOrg = OrganizationFixture();
+  jest.mocked(useOrganization).mockReturnValue(mockOrg);
+
+  const project10 = ProjectFixture({id: '10', slug: 'ten'});
+  const project20 = ProjectFixture({id: '20', slug: 'twenty'});
+
+  it('should fetch by id when an id is passed in', async () => {
+    const mockResponse = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project10],
+      match: [MockApiClient.matchQuery({query: 'id:10'})],
+    });
+
+    const {waitFor} = reactHooks.renderHook(useProject, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {id: project10.id},
+    });
+
+    await waitFor(() => expect(mockResponse).toHaveBeenCalled());
+    expect(mockResponse).toHaveBeenCalledWith(
+      '/organizations/org-slug/projects/',
+      expect.objectContaining({query: {query: 'id:10'}})
+    );
+  });
+
+  it('should batch and fetch by id when an id is passed in', async () => {
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/projects/`,
+      body: [project10, project20],
+      match: [MockApiClient.matchQuery({query: 'id:10 id:20'})],
+    });
+
+    const queryClient = makeTestQueryClient();
+    const {waitFor} = reactHooks.renderHook(useProject, {
+      wrapper: makeWrapper(queryClient),
+      initialProps: {id: project10.id},
+    });
+    reactHooks.renderHook(useProject, {
+      wrapper: makeWrapper(queryClient),
+      initialProps: {id: project20.id},
+    });
+
+    await waitFor(() => expect(mockResponse).toHaveBeenCalled());
+    expect(mockResponse).toHaveBeenCalledWith(
+      '/organizations/org-slug/projects/',
+      expect.objectContaining({query: {query: 'id:10 id:20'}})
+    );
+  });
+
+  it('should fetch by slug when a slug is passed in', async () => {
+    const mockResponse = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project10],
+      match: [MockApiClient.matchQuery({query: 'slug:ten'})],
+    });
+
+    const {waitFor} = reactHooks.renderHook(useProject, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {slug: project10.slug},
+    });
+
+    await waitFor(() => expect(mockResponse).toHaveBeenCalled());
+    expect(mockResponse).toHaveBeenCalledWith(
+      '/organizations/org-slug/projects/',
+      expect.objectContaining({query: {query: 'slug:ten'}})
+    );
+  });
+
+  it('should return projects by id if they are in the cache', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project10],
+      match: [MockApiClient.matchQuery({query: 'id:10'})],
+    });
+
+    const {result, waitFor} = reactHooks.renderHook(useProject, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {id: project10.id},
+    });
+
+    expect(result.current).toBeUndefined();
+
+    await waitFor(() => expect(result.current).toBe(project10));
+  });
+
+  it('should return projects by slug if they are in the cache', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project10],
+      match: [MockApiClient.matchQuery({query: 'slug:ten'})],
+    });
+
+    const {result, waitFor} = reactHooks.renderHook(useProject, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {slug: project10.slug},
+    });
+
+    expect(result.current).toBeUndefined();
+
+    await waitFor(() => expect(result.current).toBe(project10));
+  });
+});

--- a/static/app/utils/project/useProject.tsx
+++ b/static/app/utils/project/useProject.tsx
@@ -1,0 +1,73 @@
+import {useCallback, useEffect, useMemo} from 'react';
+
+import type {ApiResult} from 'sentry/api';
+import type {Project} from 'sentry/types';
+import useAggregatedQueryKeys from 'sentry/utils/api/useAggregatedQueryKeys';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type Props =
+  | {slug: string | undefined; id?: never}
+  | {id: string | undefined; slug?: never};
+
+type AggQueryKey = string;
+
+type ProjectStore = Record<string, Project>;
+
+function makeResponseReducer(fieldName: string) {
+  return (
+    prevState: undefined | ProjectStore,
+    response: ApiResult,
+    _aggregates: readonly AggQueryKey[]
+  ) => ({
+    ...prevState,
+    ...Object.fromEntries(response[0].map(project => [project[fieldName], project])),
+  });
+}
+
+export default function useProject({slug, id}: Props) {
+  const organization = useOrganization();
+
+  const getQueryKey = useCallback(
+    (ids: readonly AggQueryKey[]): ApiQueryKey => [
+      `/organizations/${organization.slug}/projects/`,
+      {
+        query: {
+          query: ids.join(' '),
+        },
+      },
+    ],
+    [organization.slug]
+  );
+
+  const byIdCache = useAggregatedQueryKeys<AggQueryKey, ProjectStore>({
+    cacheKey: `/organizations/${organization.slug}/projects/#project-by-id`,
+    bufferLimit: 5,
+    getQueryKey,
+    responseReducer: useMemo(() => makeResponseReducer('id'), []),
+  });
+
+  const bySlugCache = useAggregatedQueryKeys<AggQueryKey, ProjectStore>({
+    cacheKey: `/organizations/${organization.slug}/projects/#project-by-slug`,
+    bufferLimit: 5,
+    getQueryKey,
+    responseReducer: useMemo(() => makeResponseReducer('slug'), []),
+  });
+
+  useEffect(() => {
+    if (id) {
+      byIdCache.buffer([`id:${id}`]);
+    } else if (slug) {
+      if (bySlugCache.data?.[slug]) {
+        bySlugCache.buffer([`slug:${slug}`]);
+      } else {
+        bySlugCache.buffer([`slug:${slug}`]);
+      }
+    }
+  }, [id, slug, byIdCache, bySlugCache]);
+
+  const lookupId = id ?? slug;
+  return lookupId
+    ? byIdCache.data?.[lookupId] ?? bySlugCache.data?.[lookupId]
+    : undefined;
+}


### PR DESCRIPTION
This first appeared in https://github.com/getsentry/sentry/pull/66511. Trouble with that PR is the `useAllProjectsOptions` idea in there might not be great, so I wanted to skip that business for now, land what we can and come back to it after.

In order to move away from the pre-populated `ProjectStore` and `useProjects()` we need something else to move into. Why? We want to get rid of the pre-populated ProjectStore because it slows down every initial pageload by fetching every single project within an org. Not all orgs are needed on each page. `useProjects()` is the hook we us most often to interact with that store, but the trouble with `useProjects()` is that while it does return `fetching: boolean`, no callsites actually check the value. So if we were were to stop pre-populating the store, pages all over could look weird or throw because projects are not fetched. 

So we need to update each callsite to check that `fetching` value before reading the project value. If we're going to touch each callsite then we might as well change out the backend so it's not ProjectStore anymore, this is where `useProject()` (singular now, not plural) comes in. By using a different method name we create an easy way to verify that a given callsite is checking `isFetching` or not, calls to the new method must do the check!



Related to https://github.com/getsentry/sentry/issues/65949