### PR TITLE
ref(crons): Adjust stats bounds to included start not end

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -114,8 +114,8 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
         check_ins = MonitorCheckIn.objects.filter(
             monitor_id__in=monitor_map.keys(),
             status__in=tracked_statuses,
-            date_added__gt=args["start"],
-            date_added__lte=args["end"],
+            date_added__gte=args["start"],
+            date_added__lt=args["end"],
         )
 
         if monitor_environment_map:

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index_stats.py
@@ -152,9 +152,8 @@ class OrganizationMonitorIndexStatsTest(MonitorTestCase):
                 "production": {"in_progress": 1, "ok": 1, "error": 0, "missed": 0, "timeout": 0},
             },
         ]
+
         assert min_2 == [
             1647849540,
-            {
-                "debug": {"in_progress": 0, "ok": 1, "error": 0, "missed": 0, "timeout": 0},
-            },
+            {},
         ]


### PR DESCRIPTION
This fixes it so that we include stats for the start timestamp and not the end timestamp.

This makes more sense for stats since generally we'll want to see check-ins at the start, but the end will be clamped to the next upcoming minute.