### PR TITLE
fix(reprocessing): Attempt to fix `clear_expired_raw_events`

### DIFF
--- a/src/sentry/tasks/reprocessing.py
+++ b/src/sentry/tasks/reprocessing.py
@@ -62,9 +62,9 @@ def clear_expired_raw_events():
     from sentry.models.reprocessingreport import ReprocessingReport
 
     # Max number of times to attempt to query each model
-    MAX_BATCHES_PER_MODEL = 1000
+    MAX_BATCHES_PER_MODEL = 10000
     # Number of rows to fetch/delete for each query
-    LIMIT_PER_QUERY = 1000
+    LIMIT_PER_QUERY = 100
 
     def batched_delete(model_cls, **filter):
         # Django 1.6's `Queryset.delete` runs in this order:


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/67947 I thought that this was failing because we had no date index. It turns out there's a date index in postgres that isn't listed on the model, so that wasn't the problem.

Instead, it seems like the problem is that when we load a `RawEvent` we fetch the `data` field on load, and we do all the calls serially. Figuring out how to reword this model seems risky, so I'm lowing the number of rows we fetch per query in the hopes that we actually managed to perform some deletes.

<!-- Describe your PR here. -->