### PR TITLE
fix(api): Fix `id_or_slug` Lookup

### DIFF
--- a/src/sentry/db/models/fields/slug.py
+++ b/src/sentry/db/models/fields/slug.py
@@ -19,7 +19,8 @@ class IdOrSlugLookup(Lookup):
         lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
 
-        # Use Django's method to properly quote table and column names
+        # Use Django's built-in SQL compiler methods to properly quote table and column names
+        # lhs initially looks like "table_name"."column_name"
         table_name = lhs.split(".")[0] if "." in lhs else None
 
         if table_name:

--- a/src/sentry/db/models/fields/slug.py
+++ b/src/sentry/db/models/fields/slug.py
@@ -16,16 +16,33 @@ class IdOrSlugLookup(Lookup):
     lookup_name = "id_or_slug"
 
     def as_sql(self, compiler, connection):
-        # We can ignore the lhs because we know that the lhs will
-        # query either 'slug' or 'id'
+        lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
+
+        # Use Django's method to properly quote table and column names
+        table_name = lhs.split(".")[0] if "." in lhs else None
+
+        if table_name:
+            table_name_quoted = compiler.quote_name_unless_alias(table_name)
+            id_column_quoted = compiler.quote_name_unless_alias("id")
+            slug_column_quoted = compiler.quote_name_unless_alias("slug")
+        else:
+            # If no table name, assume default quoting
+            id_column_quoted = '"id"'
+            slug_column_quoted = '"slug"'
 
         if rhs_params and str(rhs_params[0]).isnumeric():
             # If numeric, use the 'id' field for comparison
-            return f"id = {rhs}", rhs_params
+            if table_name:
+                return f"{table_name_quoted}.{id_column_quoted} = {rhs}", rhs_params
+            else:
+                return f"{id_column_quoted} = {rhs}", rhs_params
         else:
             # If not numeric, use the 'slug' field for comparison
-            return f"slug = {rhs}", rhs_params
+            if table_name:
+                return f"{table_name_quoted}.{slug_column_quoted} = {rhs}", rhs_params
+            else:
+                return f"{slug_column_quoted} = {rhs}", rhs_params
 
 
 SentrySlugField.register_lookup(IdOrSlugLookup)

--- a/tests/sentry/db/models/fields/test_slug.py
+++ b/tests/sentry/db/models/fields/test_slug.py
@@ -54,36 +54,44 @@ class TestSentryOrgSlugField(TestCase):
 class IdOrSlugLookupTests(TestCase):
     def setUp(self) -> None:
         self.compiler = Mock()
+        # Simulate the quoting behavior for simplicity in tests
+        self.compiler.quote_name_unless_alias = (
+            lambda name: f"{name}" if '"' in name else f'"{name}"'
+        )
         self.connection = Mock()
 
     @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_rhs")
-    def test_as_sql_with_numeric_rhs(self, mock_process_rhs) -> None:
+    @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_lhs")
+    def test_as_sql_with_numeric_rhs(self, mock_process_lhs, mock_process_rhs):
+        mock_process_lhs.return_value = ('"table"."id"', [])
         mock_process_rhs.return_value = ("%s", ["123"])
 
         lookup = IdOrSlugLookup("id__id_or_slug", "123")
         sql, params = lookup.as_sql(self.compiler, self.connection)
 
-        self.assertEqual(sql, "id = %s")
+        self.assertEqual(sql, '"table"."id" = %s')
         self.assertEqual(params, ["123"])
 
     @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_rhs")
-    def test_as_sql_with_non_numeric_rhs(self, mock_process_rhs) -> None:
+    @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_lhs")
+    def test_as_sql_with_non_numeric_rhs(self, mock_process_lhs, mock_process_rhs):
+        mock_process_lhs.return_value = ('"table"."slug"', [])
         mock_process_rhs.return_value = ("%s", ["123slug"])
 
         lookup = IdOrSlugLookup("slug__id_or_slug", "123slug")
-
         sql, params = lookup.as_sql(self.compiler, self.connection)
 
-        self.assertEqual(sql, "slug = %s")
+        self.assertEqual(sql, '"table"."slug" = %s')
         self.assertEqual(params, ["123slug"])
 
     @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_rhs")
-    def test_as_sql_with_alphabetic_rhs(self, mock_process_rhs) -> None:
+    @patch("sentry.db.models.fields.slug.IdOrSlugLookup.process_lhs")
+    def test_as_sql_with_alphabetic_rhs(self, mock_process_lhs, mock_process_rhs):
+        mock_process_lhs.return_value = ('"table"."slug"', [])
         mock_process_rhs.return_value = ("%s", ["slug"])
 
         lookup = IdOrSlugLookup("slug__id_or_slug", "slug")
-
         sql, params = lookup.as_sql(self.compiler, self.connection)
 
-        self.assertEqual(sql, "slug = %s")
+        self.assertEqual(sql, '"table"."slug" = %s')
         self.assertEqual(params, ["slug"])


### PR DESCRIPTION
We need to fix the `id_or_slug` lookup so that it return the table name as well. This is important when filtering on both, org and project for example. Without adding the table name, we will get ambiguous column name errors if we filter on two slug fields at the same time.