### PR TITLE
ref(rules): Add functionality to RedisBuffer

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 # Debounce our JSON validation a bit in order to not cause too much additional
 # load everywhere
 _last_validation_log: float | None = None
+Pipeline = Any
+# TODO type Pipeline instead of using Any here
 
 
 def _validate_json_roundtrip(value: dict[str, Any], model: type[models.Model]) -> None:
@@ -216,8 +218,7 @@ class RedisBuffer(Buffer):
             col: (int(results[i]) if results[i] is not None else 0) for i, col in enumerate(columns)
         }
 
-    def get_redis_connection(self, key: str) -> Any | None:
-        # TODO type RedisPipeline instead of using Any here
+    def get_redis_connection(self, key: str) -> Pipeline | None:
         if is_instance_redis_cluster(self.cluster, self.is_redis_cluster):
             conn = self.cluster
         elif is_instance_rb_cluster(self.cluster, self.is_redis_cluster):

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -240,7 +240,7 @@ class RedisBuffer(Buffer):
     def push_to_set(self, key: str, value: list[int] | int) -> None:
         self._execute_redis_operation(key, RedisOperation.SET_ADD, value)
 
-    def get_set(self, key: str) -> list[set]:
+    def get_set(self, key: str) -> list[set[int]]:
         return self._execute_redis_operation(key, RedisOperation.SET_GET)
 
     def push_to_hash(

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -232,16 +232,16 @@ class RedisBuffer(Buffer):
         pending_key = self._make_pending_key_from_key(key)
         pipe = self.get_redis_connection(pending_key)
         if pipe:
-            getattr(pipe, operation)(key, *args)
+            getattr(pipe, operation.value)(key, *args)
             if args:
                 pipe.expire(key, self.key_expire)
             return pipe.execute()
 
     def push_to_set(self, key: str, value: list[int] | int) -> None:
-        self._execute_redis_operation(key, RedisOperation.SET_ADD.value, value)
+        self._execute_redis_operation(key, RedisOperation.SET_ADD, value)
 
     def get_set(self, key: str) -> list[set]:
-        return self._execute_redis_operation(key, RedisOperation.SET_GET.value)
+        return self._execute_redis_operation(key, RedisOperation.SET_GET)
 
     def push_to_hash(
         self,
@@ -251,13 +251,13 @@ class RedisBuffer(Buffer):
         value: int,
     ) -> None:
         key = self._make_key(model, filters)
-        self._execute_redis_operation(key, RedisOperation.HASH_ADD.value, field, value)
+        self._execute_redis_operation(key, RedisOperation.HASH_ADD, field, value)
 
     def get_hash(
         self, model: type[models.Model], field: dict[str, models.Model | str | int]
     ) -> dict[str, str]:
         key = self._make_key(model, field)
-        return self._execute_redis_operation(key, RedisOperation.HASH_GET_ALL.value)
+        return self._execute_redis_operation(key, RedisOperation.HASH_GET_ALL)
 
     def incr(
         self,

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -238,7 +238,8 @@ class RedisBuffer(Buffer):
     ) -> None:
         pending_key = self._make_pending_key_from_key(key)
         pipe = self.get_redis_connection(pending_key)
-        pipe.hsetnx(key, str(field["project_id"]), json.dumps(value))
+        for f, v in value.items():
+            pipe.hsetnx(key, f, v)
         pipe.expire(key, self.key_expire)
         pipe.execute()
 

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -268,20 +268,23 @@ class TestRedisBuffer:
         self.buf.push_to_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=project_id2)
 
         # store the rules and group per project
-        self.buf.enqueue(
+        self.buf.push_to_hash(
             model=Project,
-            field={"project_id": project_id},
-            value={f"{rule_id}:{group_id}": event_id},
+            filters={"project_id": project_id},
+            field=f"{rule_id}:{group_id}",
+            value=event_id,
         )
-        self.buf.enqueue(
+        self.buf.push_to_hash(
             model=Project,
-            field={"project_id": project_id},
-            value={f"{rule_id}:{group2_id}": event2_id},
+            filters={"project_id": project_id},
+            field=f"{rule_id}:{group2_id}",
+            value=event2_id,
         )
-        self.buf.enqueue(
+        self.buf.push_to_hash(
             model=Project,
-            field={"project_id": project_id2},
-            value={f"{rule2_id}:{group3_id}": event3_id},
+            filters={"project_id": project_id2},
+            field=f"{rule2_id}:{group3_id}",
+            value=event3_id,
         )
 
         project_ids = self.buf.get_set(PROJECT_ID_BUFFER_LIST_KEY)


### PR DESCRIPTION
Add methods to `RedisBuffer` to add data about rules that we can later use to process "slow" rules.

Closes [#238](https://github.com/getsentry/team-core-product-foundations/issues/238)