### PR TITLE
chore(issues): Remove unused GroupManager.from_kwargs

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -354,19 +354,6 @@ class GroupManager(BaseManager["Group"]):
                 raise Group.DoesNotExist()
         return groups
 
-    def from_kwargs(self, project, **kwargs):
-        from sentry.event_manager import EventManager
-        from sentry.exceptions import HashDiscarded
-
-        manager = EventManager(kwargs)
-        manager.normalize()
-        try:
-            return manager.save(project)
-
-        # TODO(jess): this method maybe isn't even used?
-        except HashDiscarded as e:
-            logger.info("discarded.hash", extra={"project_id": project, "description": str(e)})
-
     def from_event_id(self, project, event_id):
         """Resolves the 32 character event_id string into a Group for which it is found."""
         group_id = None

--- a/tests/sentry/manager/test_group_manager.py
+++ b/tests/sentry/manager/test_group_manager.py
@@ -7,13 +7,6 @@ pytestmark = requires_snuba
 
 
 class SentryManagerTest(TestCase):
-    def test_valid_only_message(self):
-        proj = self.create_project()
-        event = Group.objects.from_kwargs(proj.id, message="foo")
-        self.assertEqual(event.group.last_seen, event.datetime)
-        self.assertEqual(event.message, "foo")
-        self.assertEqual(event.project_id, proj.id)
-
     def test_get_groups_by_external_issue(self):
         external_issue_key = "api-123"
         group = self.create_group()


### PR DESCRIPTION
This method is not called anywhere in sentry or getsentry except in the test which is also being removed.