### PR TITLE
feat(api-idorslug): Finish single `organization_slug` Tests

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -255,11 +255,11 @@ class ControlSiloOrganizationEndpoint(Endpoint):
             # It is ok that `get_organization_by_id` doesn't check for visibility as we
             # don't check the visibility in `get_organization_by_slug` either (only_active=False).
             organization_context = organization_service.get_organization_by_id(
-                id=organization_slug, user_id=request.user.id
+                id=int(organization_slug), user_id=request.user.id
             )
         else:
             organization_context = organization_service.get_organization_by_slug(
-                slug=organization_slug, only_visible=False, user_id=request.user.id
+                slug=str(organization_slug), only_visible=False, user_id=request.user.id
             )
         if organization_context is None:
             raise ResourceDoesNotExist

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -118,25 +118,16 @@ class ProjectEndpoint(Endpoint):
         **kwargs,
     ):
         try:
-            if options.get("api.id-or-slug-enabled"):
-                if str(organization_slug).isnumeric():
-                    project = (
-                        Project.objects.filter(
-                            organization__id=organization_slug, slug__id_or_slug=project_slug
-                        )
-                        .select_related("organization")
-                        .prefetch_related("teams")
-                        .get()
+            if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+                project = (
+                    Project.objects.filter(
+                        organization__slug__id_or_slug=organization_slug,
+                        slug__id_or_slug=project_slug,
                     )
-                else:
-                    project = (
-                        Project.objects.filter(
-                            organization__slug=organization_slug, slug__id_or_slug=project_slug
-                        )
-                        .select_related("organization")
-                        .prefetch_related("teams")
-                        .get()
-                    )
+                    .select_related("organization")
+                    .prefetch_related("teams")
+                    .get()
+                )
             else:
                 project = (
                     Project.objects.filter(organization__slug=organization_slug, slug=project_slug)
@@ -148,17 +139,11 @@ class ProjectEndpoint(Endpoint):
             try:
                 # Project may have been renamed
                 redirect = ProjectRedirect.objects.select_related("project")
-                if options.get("api.id-or-slug-enabled"):
-                    if str(organization_slug).isnumeric():
-                        redirect = redirect.get(
-                            organization__id=organization_slug,
-                            redirect_slug__id_or_slug=project_slug,
-                        )
-                    else:
-                        redirect = redirect.get(
-                            organization__slug=organization_slug,
-                            redirect_slug__id_or_slug=project_slug,
-                        )
+                if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+                    redirect = redirect.get(
+                        organization__id=organization_slug,
+                        redirect_slug__id_or_slug=project_slug,
+                    )
                 else:
                     redirect = redirect.get(
                         organization__slug=organization_slug, redirect_slug=project_slug

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -118,7 +118,7 @@ class ProjectEndpoint(Endpoint):
         **kwargs,
     ):
         try:
-            if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+            if options.get("api.id-or-slug-enabled"):
                 project = (
                     Project.objects.filter(
                         organization__slug__id_or_slug=organization_slug,
@@ -139,7 +139,7 @@ class ProjectEndpoint(Endpoint):
             try:
                 # Project may have been renamed
                 redirect = ProjectRedirect.objects.select_related("project")
-                if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+                if options.get("api.id-or-slug-enabled"):
                     redirect = redirect.get(
                         organization__id=organization_slug,
                         redirect_slug__id_or_slug=project_slug,

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import Scope
 
+from sentry import options
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ProjectMoved, ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
@@ -111,25 +112,57 @@ class ProjectEndpoint(Endpoint):
     def convert_args(
         self,
         request: Request,
-        organization_slug: str,
-        project_slug: str,
+        organization_slug: str | int,
+        project_slug: str | int,
         *args,
         **kwargs,
     ):
         try:
-            project = (
-                Project.objects.filter(organization__slug=organization_slug, slug=project_slug)
-                .select_related("organization")
-                .prefetch_related("teams")
-                .get()
-            )
+            if options.get("api.id-or-slug-enabled"):
+                if str(organization_slug).isnumeric():
+                    project = (
+                        Project.objects.filter(
+                            organization__id=organization_slug, slug__id_or_slug=project_slug
+                        )
+                        .select_related("organization")
+                        .prefetch_related("teams")
+                        .get()
+                    )
+                else:
+                    project = (
+                        Project.objects.filter(
+                            organization__slug=organization_slug, slug__id_or_slug=project_slug
+                        )
+                        .select_related("organization")
+                        .prefetch_related("teams")
+                        .get()
+                    )
+            else:
+                project = (
+                    Project.objects.filter(organization__slug=organization_slug, slug=project_slug)
+                    .select_related("organization")
+                    .prefetch_related("teams")
+                    .get()
+                )
         except Project.DoesNotExist:
             try:
                 # Project may have been renamed
                 redirect = ProjectRedirect.objects.select_related("project")
-                redirect = redirect.get(
-                    organization__slug=organization_slug, redirect_slug=project_slug
-                )
+                if options.get("api.id-or-slug-enabled"):
+                    if str(organization_slug).isnumeric():
+                        redirect = redirect.get(
+                            organization__id=organization_slug,
+                            redirect_slug__id_or_slug=project_slug,
+                        )
+                    else:
+                        redirect = redirect.get(
+                            organization__slug=organization_slug,
+                            redirect_slug__id_or_slug=project_slug,
+                        )
+                else:
+                    redirect = redirect.get(
+                        organization__slug=organization_slug, redirect_slug=project_slug
+                    )
                 # Without object permissions don't reveal the rename
                 self.check_object_permissions(request, redirect.project)
 

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -317,11 +317,19 @@ class SentryAppInstallationsBaseEndpoint(IntegrationPlatformEndpoint):
 
     def convert_args(self, request: Request, organization_slug, *args, **kwargs):
         if is_active_superuser(request):
-            organization = organization_service.get_org_by_slug(slug=organization_slug)
+            if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+                organization = organization_service.get_org_by_id(id=int(organization_slug))
+            else:
+                organization = organization_service.get_org_by_slug(slug=organization_slug)
         else:
-            organization = organization_service.get_org_by_slug(
-                slug=organization_slug, user_id=request.user.id
-            )
+            if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+                organization = organization_service.get_org_by_id(
+                    id=int(organization_slug), user_id=request.user.id
+                )
+            else:
+                organization = organization_service.get_org_by_slug(
+                    slug=organization_slug, user_id=request.user.id
+                )
 
         if organization is None:
             raise Http404

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -316,20 +316,20 @@ class SentryAppInstallationsBaseEndpoint(IntegrationPlatformEndpoint):
     permission_classes = (SentryAppInstallationsPermission,)
 
     def convert_args(self, request: Request, organization_slug, *args, **kwargs):
-        if is_active_superuser(request):
-            if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
-                organization = organization_service.get_org_by_id(id=int(organization_slug))
-            else:
-                organization = organization_service.get_org_by_slug(slug=organization_slug)
+
+        extra_args = {}
+        # We need to pass user_id if the user is not a superuser
+        if not is_active_superuser(request):
+            extra_args["user_id"] = request.user.id
+
+        if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+            organization = organization_service.get_org_by_id(
+                id=int(organization_slug), **extra_args
+            )
         else:
-            if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
-                organization = organization_service.get_org_by_id(
-                    id=int(organization_slug), user_id=request.user.id
-                )
-            else:
-                organization = organization_service.get_org_by_slug(
-                    slug=organization_slug, user_id=request.user.id
-                )
+            organization = organization_service.get_org_by_slug(
+                slug=organization_slug, **extra_args
+            )
 
         if organization is None:
             raise Http404

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -316,7 +316,6 @@ class SentryAppInstallationsBaseEndpoint(IntegrationPlatformEndpoint):
     permission_classes = (SentryAppInstallationsPermission,)
 
     def convert_args(self, request: Request, organization_slug, *args, **kwargs):
-
         extra_args = {}
         # We need to pass user_id if the user is not a superuser
         if not is_active_superuser(request):

--- a/src/sentry/api/endpoints/codeowners/details.py
+++ b/src/sentry/api/endpoints/codeowners/details.py
@@ -35,8 +35,8 @@ class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectCodeOwnersMixin):
     def convert_args(
         self,
         request: Request,
-        organization_slug: str,
-        project_slug: str,
+        organization_slug: str | int,
+        project_slug: str | int,
         codeowners_id: str,
         *args: Any,
         **kwargs: Any,

--- a/src/sentry/api/endpoints/organization_region.py
+++ b/src/sentry/api/endpoints/organization_region.py
@@ -60,7 +60,7 @@ class OrganizationRegionEndpoint(Endpoint):
             raise ResourceDoesNotExist
 
         try:
-            # We don't use the lookup since OrganizationMapping uses SlugField instead of SentrySlugField
+            # We don't use the lookup since OrganizationMapping uses organization_id as a BigIntField instead of a ForeignKey
             org_mapping: OrganizationMapping
             if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
                 org_mapping = OrganizationMapping.objects.get(organization_id=organization_slug)

--- a/src/sentry/api/endpoints/organization_region.py
+++ b/src/sentry/api/endpoints/organization_region.py
@@ -60,7 +60,7 @@ class OrganizationRegionEndpoint(Endpoint):
             raise ResourceDoesNotExist
 
         try:
-            # We don't use the lookup since OrganizationMapping uses organization_id as a BigIntField instead of a ForeignKey
+            # We don't use the lookup since OrganizationMapping uses a BigIntField for organization_id instead of a ForeignKey
             if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
                 org_mapping = OrganizationMapping.objects.get(organization_id=organization_slug)
             else:

--- a/src/sentry/api/endpoints/organization_region.py
+++ b/src/sentry/api/endpoints/organization_region.py
@@ -61,14 +61,11 @@ class OrganizationRegionEndpoint(Endpoint):
 
         try:
             # We don't use the lookup since OrganizationMapping uses SlugField instead of SentrySlugField
+            org_mapping: OrganizationMapping
             if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
-                org_mapping: OrganizationMapping = OrganizationMapping.objects.get(
-                    organization_id=organization_slug
-                )
+                org_mapping = OrganizationMapping.objects.get(organization_id=organization_slug)
             else:
-                org_mapping: OrganizationMapping = OrganizationMapping.objects.get(
-                    slug=organization_slug
-                )
+                org_mapping = OrganizationMapping.objects.get(slug=organization_slug)
         except OrganizationMapping.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/organization_region.py
+++ b/src/sentry/api/endpoints/organization_region.py
@@ -61,7 +61,6 @@ class OrganizationRegionEndpoint(Endpoint):
 
         try:
             # We don't use the lookup since OrganizationMapping uses organization_id as a BigIntField instead of a ForeignKey
-            org_mapping: OrganizationMapping
             if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
                 org_mapping = OrganizationMapping.objects.get(organization_id=organization_slug)
             else:

--- a/src/sentry/db/models/fields/slug.py
+++ b/src/sentry/db/models/fields/slug.py
@@ -47,3 +47,4 @@ class IdOrSlugLookup(Lookup):
 
 
 SentrySlugField.register_lookup(IdOrSlugLookup)
+SentryOrgSlugField.register_lookup(IdOrSlugLookup)

--- a/tests/sentry/api/path_params/resources/test_id_or_slug_path_params_mixin.py
+++ b/tests/sentry/api/path_params/resources/test_id_or_slug_path_params_mixin.py
@@ -1,5 +1,11 @@
 from typing import Any
 
+from sentry.api.endpoints.organization_event_details import OrganizationEventDetailsEndpoint
+from sentry.api.endpoints.organization_member.team_details import (
+    OrganizationMemberTeamDetailsEndpoint,
+)
+from sentry.api.endpoints.project_team_details import ProjectTeamDetailsEndpoint
+
 
 class APIIdOrSlugTestMixin:
     slug_mappings: dict[str, Any]
@@ -9,8 +15,12 @@ class APIIdOrSlugTestMixin:
     incident_activity: Any
 
     @property
-    def no_slugs_in_kwargs_allowlist(self):
-        return {}
+    def no_slugs_in_kwargs_allowlist(self) -> set[Any]:
+        return {
+            OrganizationEventDetailsEndpoint,
+            OrganizationMemberTeamDetailsEndpoint,
+            ProjectTeamDetailsEndpoint,
+        }
 
     def ignore_test(self, *args):
         pass
@@ -109,8 +119,6 @@ class APIIdOrSlugTestMixin:
                 for key in converted_slugs
                 if not key.endswith("_slug")
             )
-
-        # print(converted_slugs, converted_ids, reverse_non_slug_mappings)
 
         if use_id:
             self.assert_ids(

--- a/tests/sentry/api/path_params/resources/test_organization_slug.py
+++ b/tests/sentry/api/path_params/resources/test_organization_slug.py
@@ -63,7 +63,6 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "config_id": self.code_mapping.id,
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "config": self.code_mapping,
         }
@@ -89,8 +88,6 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "search_id": search.id,
         }
-
-        # mapping kwargs to the actual objects
         reverse_non_slug_mappings: dict[str, Any] = {
             "search": search,
         }
@@ -142,7 +139,6 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "team_id": self.team.id,
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "team": self.team,
         }
@@ -167,7 +163,6 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "issue_id": self.group.id,
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "group": self.group,
         }
@@ -194,7 +189,6 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "external_user_id": external_user.id,
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "external_user": external_user,
         }
@@ -253,10 +247,8 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "incident_identifier": str(self.incident.id),
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "incident": self.incident,
-            # "activity": self.incident_activity,
         }
 
         _, converted_slugs = endpoint_class().convert_args(
@@ -289,7 +281,6 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
             "incident_identifier": str(self.incident.id),
             "activity_id": self.incident_activity.id,
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "incident": self.incident,
             "activity": self.incident_activity,
@@ -327,7 +318,6 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "action_id": notification_action.id,
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "action": notification_action,
         }

--- a/tests/sentry/api/path_params/resources/test_organization_slug.py
+++ b/tests/sentry/api/path_params/resources/test_organization_slug.py
@@ -423,7 +423,7 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
 
         request = Request(request=self.make_request())
 
-        self.reverse_non_slug_mappings = {
+        reverse_non_slug_mappings: dict[str, Any] = {
             "organization_mapping": OrganizationMapping.objects.get(slug=self.organization.slug)
         }
 
@@ -434,6 +434,6 @@ class OrganizationSlugTests(TestCase, APIIdOrSlugTestMixin):
             endpoint_class,
             converted_slugs,
             converted_ids,
-            self.reverse_non_slug_mappings,
+            reverse_non_slug_mappings,
             use_id=True,
         )

--- a/tests/sentry/api/path_params/resources/test_project_slug.py
+++ b/tests/sentry/api/path_params/resources/test_project_slug.py
@@ -52,3 +52,30 @@ class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
         self.assert_conversion(
             endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
         )
+
+    def project_codeowners_details_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        codeowners = self.create_codeowners(project=self.project)
+
+        non_slug_mappings: dict[str, Any] = {
+            "codeowners_id": codeowners.id,
+        }
+
+        reverse_non_slug_mappings: dict[str, Any] = {
+            "codeowners": codeowners,
+        }
+
+        _, converted_slugs = endpoint_class().convert_args(
+            request=request, **slug_kwargs, **non_slug_mappings
+        )
+        _, converted_ids = endpoint_class().convert_args(
+            request=request, **id_kwargs, **non_slug_mappings
+        )
+
+        self.assert_conversion(
+            endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
+        )

--- a/tests/sentry/api/path_params/resources/test_project_slug.py
+++ b/tests/sentry/api/path_params/resources/test_project_slug.py
@@ -59,7 +59,7 @@ class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
 
         request = Request(self.make_request(user=self.user))
 
-        codeowners = self.create_codeowners(project=self.project)
+        codeowners = self.create_codeowners(project=self.project, code_mapping=self.code_mapping)
 
         non_slug_mappings: dict[str, Any] = {
             "codeowners_id": codeowners.id,

--- a/tests/sentry/api/path_params/resources/test_project_slug.py
+++ b/tests/sentry/api/path_params/resources/test_project_slug.py
@@ -1,0 +1,54 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from rest_framework.request import Request
+
+from sentry.testutils.cases import TestCase
+
+from .test_id_or_slug_path_params_mixin import APIIdOrSlugTestMixin
+
+
+class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
+    def project_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        _, converted_slugs = endpoint_class().convert_args(request=request, **slug_kwargs)
+        _, converted_ids = endpoint_class().convert_args(request=request, **id_kwargs)
+
+        self.assert_conversion(endpoint_class, converted_slugs, converted_ids)
+
+    def project_alert_rule_endpoint_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = MagicMock()
+        request.configure_mock(
+            **{
+                "access.has_project_access.return_value": True,
+                "method": "DELETE",
+            }
+        )
+
+        alert_rule = self.create_alert_rule(organization=self.organization, projects=[self.project])
+
+        non_slug_mappings: dict[str, Any] = {
+            "alert_rule_id": alert_rule.id,
+        }
+
+        reverse_non_slug_mappings: dict[str, Any] = {
+            "alert_rule": alert_rule,
+        }
+
+        _, converted_slugs = endpoint_class().convert_args(
+            request=request, **slug_kwargs, **non_slug_mappings
+        )
+        _, converted_ids = endpoint_class().convert_args(
+            request=request, **id_kwargs, **non_slug_mappings
+        )
+
+        self.assert_conversion(
+            endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
+        )

--- a/tests/sentry/api/path_params/resources/test_project_slug.py
+++ b/tests/sentry/api/path_params/resources/test_project_slug.py
@@ -37,7 +37,6 @@ class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "alert_rule_id": alert_rule.id,
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "alert_rule": alert_rule,
         }
@@ -64,7 +63,6 @@ class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "codeowners_id": codeowners.id,
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "codeowners": codeowners,
         }

--- a/tests/sentry/api/path_params/resources/test_sentry_app_slug.py
+++ b/tests/sentry/api/path_params/resources/test_sentry_app_slug.py
@@ -27,7 +27,6 @@ class SentryAppSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "api_token_id": api_token.id,
         }
-
         # mapping kwargs to the actual objects
         reverse_non_slug_mappings: dict[str, Any] = {
             "api_token": api_token,

--- a/tests/sentry/api/path_params/test_id_or_slug_path_params.py
+++ b/tests/sentry/api/path_params/test_id_or_slug_path_params.py
@@ -22,6 +22,7 @@ from sentry.api.bases.sentryapps import (
     SentryAppInstallationsBaseEndpoint,
 )
 from sentry.api.endpoints.broadcast_index import BroadcastIndexEndpoint
+from sentry.api.endpoints.codeowners.details import ProjectCodeOwnersDetailsEndpoint
 from sentry.api.endpoints.codeowners.external_actor.user_details import ExternalUserDetailsEndpoint
 from sentry.api.endpoints.integrations.sentry_apps import SentryInternalAppTokenDetailsEndpoint
 from sentry.api.endpoints.notifications.notification_actions_details import (
@@ -164,6 +165,7 @@ class APIIdOrSlugPathParamTest(
             OrganizationSearchDetailsEndpoint.convert_args: self.organization_search_details_test,
             ProjectAlertRuleEndpoint.convert_args: self.project_alert_rule_endpoint_test,
             ProjectEndpoint.convert_args: self.project_test,
+            ProjectCodeOwnersDetailsEndpoint.convert_args: self.project_codeowners_details_test,
             RegionOrganizationIntegrationBaseEndpoint.convert_args: self.region_organization_integration_test,
             RegionSentryAppBaseEndpoint.convert_args: self.region_sentry_app_test,
             SentryAppBaseEndpoint.convert_args: self.sentry_app_test,

--- a/tests/sentry/api/path_params/test_id_or_slug_path_params.py
+++ b/tests/sentry/api/path_params/test_id_or_slug_path_params.py
@@ -11,10 +11,17 @@ from sentry.api.base import Endpoint
 from sentry.api.bases.doc_integrations import DocIntegrationBaseEndpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.bases.incident import IncidentEndpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrganizationEndpoint
 from sentry.api.bases.organization_integrations import RegionOrganizationIntegrationBaseEndpoint
 from sentry.api.bases.organizationmember import OrganizationMemberEndpoint
-from sentry.api.bases.sentryapps import RegionSentryAppBaseEndpoint, SentryAppBaseEndpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.bases.sentryapps import (
+    RegionSentryAppBaseEndpoint,
+    SentryAppBaseEndpoint,
+    SentryAppInstallationBaseEndpoint,
+    SentryAppInstallationsBaseEndpoint,
+)
+from sentry.api.endpoints.broadcast_index import BroadcastIndexEndpoint
 from sentry.api.endpoints.codeowners.external_actor.user_details import ExternalUserDetailsEndpoint
 from sentry.api.endpoints.integrations.sentry_apps import SentryInternalAppTokenDetailsEndpoint
 from sentry.api.endpoints.notifications.notification_actions_details import (
@@ -27,8 +34,9 @@ from sentry.api.endpoints.organization_code_mapping_details import (
     OrganizationCodeMappingDetailsEndpoint,
 )
 from sentry.api.endpoints.organization_dashboard_details import OrganizationDashboardDetailsEndpoint
+from sentry.api.endpoints.organization_region import OrganizationRegionEndpoint
 from sentry.api.endpoints.organization_search_details import OrganizationSearchDetailsEndpoint
-from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
+from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint, ProjectAlertRuleEndpoint
 from sentry.incidents.endpoints.organization_incident_comment_details import CommentDetailsEndpoint
 from sentry.incidents.models.incident import IncidentActivityType
 from sentry.models.repository import Repository
@@ -36,10 +44,11 @@ from sentry.scim.endpoints.members import OrganizationSCIMMemberDetails
 from sentry.scim.endpoints.teams import OrganizationSCIMTeamDetails
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import no_silo_test
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import AbstractOrganizationView, BaseView
 
 from .resources.test_doc_integration_slug import DocIntegrationSlugTests
 from .resources.test_organization_slug import OrganizationSlugTests
+from .resources.test_project_slug import ProjectSlugTests
 from .resources.test_sentry_app_slug import SentryAppSlugTests
 
 
@@ -64,7 +73,9 @@ def extract_all_url_patterns(
 
 
 @no_silo_test
-class APIIdOrSlugPathParamTest(DocIntegrationSlugTests, SentryAppSlugTests, OrganizationSlugTests):
+class APIIdOrSlugPathParamTest(
+    DocIntegrationSlugTests, SentryAppSlugTests, OrganizationSlugTests, ProjectSlugTests
+):
     """
     This test class is used to test if all endpoints work with both slugs and ids as path parameters.
     Ex: /api/0/organizations/{organization_slug}/integrations/{doc_integration_slug}/ &
@@ -130,8 +141,11 @@ class APIIdOrSlugPathParamTest(DocIntegrationSlugTests, SentryAppSlugTests, Orga
         # Step 1: Add new endpoints to the registry
         # If a new `convert_args` method is created for an endpoint, add the endpoint to the registry and create/assign a test method
         self.convert_args_setup_registry: dict[Any, Callable] = {
+            AbstractOrganizationView.convert_args: self.ignore_test,
             BaseView.convert_args: self.ignore_test,
+            BroadcastIndexEndpoint.convert_args: self.control_silo_organization_endpoint_test,
             CommentDetailsEndpoint.convert_args: self.comment_details_test,
+            ControlSiloOrganizationEndpoint.convert_args: self.control_silo_organization_endpoint_test,
             DocIntegrationBaseEndpoint.convert_args: self.doc_integration_test,
             Endpoint.convert_args: self.ignore_test,
             ExternalUserDetailsEndpoint.convert_args: self.external_user_details_test,
@@ -144,12 +158,17 @@ class APIIdOrSlugPathParamTest(DocIntegrationSlugTests, SentryAppSlugTests, Orga
             OrganizationDashboardDetailsEndpoint.convert_args: self.organization_dashboard_details_test,
             OrganizationEndpoint.convert_args: self.organization_test,
             OrganizationMemberEndpoint.convert_args: self.organization_member_test,
+            OrganizationRegionEndpoint.convert_args: self.organization_region_test,
             OrganizationSCIMMemberDetails.convert_args: self.organization_member_test,
             OrganizationSCIMTeamDetails.convert_args: self.organization_team_test,
             OrganizationSearchDetailsEndpoint.convert_args: self.organization_search_details_test,
+            ProjectAlertRuleEndpoint.convert_args: self.project_alert_rule_endpoint_test,
+            ProjectEndpoint.convert_args: self.project_test,
             RegionOrganizationIntegrationBaseEndpoint.convert_args: self.region_organization_integration_test,
             RegionSentryAppBaseEndpoint.convert_args: self.region_sentry_app_test,
             SentryAppBaseEndpoint.convert_args: self.sentry_app_test,
+            SentryAppInstallationBaseEndpoint.convert_args: self.ignore_test,
+            SentryAppInstallationsBaseEndpoint.convert_args: self.sentry_app_installations_base_test,
             SentryInternalAppTokenDetailsEndpoint.convert_args: self.sentry_app_token_test,
         }
 
@@ -161,6 +180,8 @@ class APIIdOrSlugPathParamTest(DocIntegrationSlugTests, SentryAppSlugTests, Orga
             "doc_integration_slug": self.doc_integration,
             "sentry_app_slug": self.sentry_app,
             "organization_slug": self.organization,
+            "project_slug": self.project,
+            "team_slug": self.team,
         }
 
         # Map values in kwargs to the actual objects
@@ -168,6 +189,8 @@ class APIIdOrSlugPathParamTest(DocIntegrationSlugTests, SentryAppSlugTests, Orga
             "doc_integration": self.doc_integration,
             "sentry_app": self.sentry_app,
             "organization": self.organization,
+            "project": self.project,
+            "team": self.team,
         }
 
     def test_if_endpoints_work_with_id_or_slug(self):
@@ -180,14 +203,16 @@ class APIIdOrSlugPathParamTest(DocIntegrationSlugTests, SentryAppSlugTests, Orga
             if hasattr(callback, "convert_args"):
                 slug_path_params = extract_slug_path_params(pattern)
                 if slug_path_params:
-                    if slug_path_params == ["doc_integration_slug"] or slug_path_params == [
-                        "sentry_app_slug"
-                    ]:
+                    if (
+                        slug_path_params == ["doc_integration_slug"]
+                        or slug_path_params == ["sentry_app_slug"]
+                        or slug_path_params == ["organization_slug"]
+                    ):
                         self.convert_args_setup_registry[callback.convert_args](
                             callback, slug_path_params
                         )
-                    elif slug_path_params == ["organization_slug"]:
-                        if convert_args := self.convert_args_setup_registry.get(
-                            callback.convert_args
-                        ):
-                            convert_args(callback, slug_path_params)
+                    # Temporary for "project_slug" endpoints
+                    elif convert_args := self.convert_args_setup_registry.get(
+                        callback.convert_args
+                    ):
+                        convert_args(callback, slug_path_params)


### PR DESCRIPTION
Finished up the last of the `organization_slug` endpoints, including hybrid cloud ones & started Project slug endpoints

Have about 19 more convert_args to test

`ProjectEndpoint` has a bit of verbose logic, only because we cannot use the lookup as organization is a foreign key. I am still look up some fixes to this problem, will update in future prs if I find something.

For: https://github.com/getsentry/team-core-product-foundations/issues/194