### PR TITLE
fix(trace): clear clicked node on outside click

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -290,6 +290,9 @@ function TraceViewContent(props: TraceViewContentProps) {
     last_clicked: null,
   });
 
+  const tabsStateRef = useRef<TraceTabsReducerState>(tabs);
+  tabsStateRef.current = tabs;
+
   const onRowClick = useCallback(
     (
       node: TraceTreeNode<TraceTree.NodeValue> | null,
@@ -500,8 +503,12 @@ function TraceViewContent(props: TraceViewContentProps) {
       query: queryParamsWithoutNode,
     });
 
+    tabsDispatch({type: 'clear clicked tab'});
+    rovingTabIndexDispatch({type: 'clear index'});
+    searchDispatch({type: 'clear node'});
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [tree]);
 
   const traceContainerRef = useRef<HTMLElement | null>(null);
   useOnClickOutside(traceContainerRef, onOutsideClick);

--- a/static/app/views/performance/newTraceDetails/traceSearch.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch.tsx
@@ -19,6 +19,7 @@ export type TraceSearchAction =
       resultIteratorIndex: number;
       type: 'set iterator index';
     }
+  | {type: 'clear node'}
   | {type: 'clear iterator index'}
   | {type: 'clear query'}
   | {
@@ -152,6 +153,10 @@ export function traceSearchReducer(
 
     case 'clear iterator index': {
       return {...state, resultIteratorIndex: null, resultIndex: null, node: null};
+    }
+
+    case 'clear node': {
+      return {...state, node: null};
     }
 
     default: {

--- a/static/app/views/performance/newTraceDetails/traceTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabs.tsx
@@ -169,6 +169,18 @@ export function traceTabsReducer(
       };
     }
 
+    case 'clear clicked tab': {
+      const next =
+        state.last_clicked === state.current
+          ? state.tabs[state.tabs.length - 1]
+          : state.current;
+      return {
+        ...state,
+        current: next,
+        last_clicked: null,
+      };
+    }
+
     default: {
       throw new Error('Invalid action');
     }


### PR DESCRIPTION
When clicking outside of the trace container, clear the last clicked node (somewhat pseudo dismiss action)