### PR TITLE
chore(slack): remove non-block kit tests from notification tests pt 1

### DIFF
--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -8,7 +8,7 @@ from sentry.notifications.notifications.activity.assigned import AssignedActivit
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
@@ -112,22 +112,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert channel == self.identity.external_id
 
     @responses.activate
-    def test_assignment(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue is assigned
-        """
-        with self.tasks():
-            self.create_notification(self.group, AssignedActivityNotification).send()
-        attachment, text = get_attachment()
-        assert text == f"Issue assigned to {self.name} by themselves"
-        assert attachment["title"] == self.group.title
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
     @with_feature("organizations:slack-block-kit")
     def test_assignment_block(self):
         """
@@ -147,29 +131,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    def test_assignment_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type is assigned
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-
-        with self.tasks():
-            self.create_notification(group_event.group, AssignedActivityNotification).send()
-        attachment, text = get_attachment()
-        assert text == f"Issue assigned to {self.name} by themselves"
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "assigned_activity-slack-user"
         )
 
     @responses.activate
@@ -200,26 +161,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             group_event.project.slug,
             group_event.group,
             "assigned_activity-slack",
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    def test_assignment_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue is assigned
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group, AssignedActivityNotification).send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue assigned to {self.name} by themselves"
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "assigned_activity-slack-user"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -65,37 +65,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    def test_issue_alert_user(self):
-        """Test that issue alerts are sent to a Slack user."""
-
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
-        notification_uuid = str(uuid.uuid4())
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=self.rule),
-            ActionTargetType.MEMBER,
-            self.user.id,
-            notification_uuid=notification_uuid,
-        )
-
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-
-        assert attachment["title"] == "Hello world"
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-        assert event.group
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue"
-        )
-
-    @responses.activate
     @with_feature("organizations:slack-block-kit")
     def test_issue_alert_user_block(self):
         """
@@ -242,30 +211,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    def test_generic_issue_alert_user(self, occurrence):
-        """Test that generic issue alerts are sent to a Slack user."""
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-
-        notification = AlertRuleNotification(
-            Notification(event=group_event, rule=self.rule), ActionTargetType.MEMBER, self.user.id
-        )
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "issue_alert-slack-user", "alerts"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
     @with_feature("organizations:slack-block-kit")
     def test_generic_issue_alert_user_block(self, occurrence):
         """
@@ -321,51 +266,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert len(responses.calls) == 0
 
     @responses.activate
-    def test_issue_alert_issue_owners(self):
-        """Test that issue alerts are sent to issue owners in Slack."""
-
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
-            "targetIdentifier": "",
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-        ProjectOwnership.objects.create(project_id=self.project.id)
-
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=rule),
-            ActionTargetType.ISSUE_OWNERS,
-            self.user.id,
-            FallthroughChoiceType.ACTIVE_MEMBERS,
-        )
-
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-
-        assert attachment["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group_id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
     @with_feature("organizations:slack-block-kit")
     def test_issue_alert_issue_owners_block(self):
         """
@@ -416,59 +316,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert (
             blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    def test_issue_alert_issue_owners_environment(self):
-        """Test that issue alerts are sent to issue owners in Slack with the environment in the query params when the alert rule filters by environment."""
-
-        environment = self.create_environment(self.project, name="production")
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error", "environment": environment.name},
-            project_id=self.project.id,
-        )
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
-            "targetIdentifier": "",
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-        rule = self.create_project_rule(
-            project=self.project,
-            action_match=[action_data],
-            name="ja rule",
-            environment_id=environment.id,
-        )
-        ProjectOwnership.objects.create(project_id=self.project.id)
-
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=rule),
-            ActionTargetType.ISSUE_OWNERS,
-            self.user.id,
-            FallthroughChoiceType.ACTIVE_MEMBERS,
-        )
-
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-
-        assert attachment["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group_id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment={environment.name}&alert_rule_id={rule.id}&alert_type=issue"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -530,93 +377,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert (
             blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    def test_issue_alert_team_issue_owners(self):
-        """Test that issue alerts are sent to a team in Slack via an Issue Owners rule action."""
-
-        # add a second user to the team so we can be sure it's only
-        # sent once (to the team, and not to each individual user)
-        user2 = self.create_user(is_superuser=False)
-        self.create_member(teams=[self.team], user=user2, organization=self.organization)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX2")
-            self.identity = Identity.objects.create(
-                external_id="UXXXXXXX2",
-                idp=self.idp,
-                user=user2,
-                status=IdentityStatus.VALID,
-                scopes=[],
-            )
-        # update the team's notification settings
-        ExternalActor.objects.create(
-            team_id=self.team.id,
-            organization=self.organization,
-            integration_id=self.integration.id,
-            provider=ExternalProviders.SLACK.value,
-            external_name="goma",
-            external_id="CXXXXXXX2",
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            # provider is disabled by default
-            NotificationSettingProvider.objects.create(
-                team_id=self.team.id,
-                scope_type="team",
-                scope_identifier=self.team.id,
-                provider="slack",
-                type="alerts",
-                value="always",
-            )
-
-        rule = GrammarRule(Matcher("path", "*"), [Owner("team", self.team.slug)])
-        ProjectOwnership.objects.create(project_id=self.project.id, schema=dump_schema([rule]))
-
-        event = self.store_event(
-            data={
-                "message": "Hello world",
-                "level": "error",
-                "stacktrace": {"frames": [{"filename": "foo.py"}]},
-            },
-            project_id=self.project.id,
-        )
-
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
-            "targetIdentifier": "",
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=rule), ActionTargetType.ISSUE_OWNERS, self.team.id
-        )
-
-        with self.tasks():
-            notification.send()
-
-        # check that only one was sent out - more would mean each user is being notified
-        # rather than the team
-        assert len(responses.calls) == 1
-
-        # check that the team got a notification
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["channel"] == ["CXXXXXXX2"]
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-        assert len(attachments) == 1
-        assert attachments[0]["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachments[0]["title_link"])
-        assert (
-            attachments[0]["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -875,86 +635,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert (
             attachments[0]["footer"]
             == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    def test_issue_alert_team(self):
-        """Test that issue alerts are sent to a team in Slack."""
-        # add a second organization
-        org = self.create_organization(owner=self.user)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.create_organization_integration(
-                organization_id=org.id, integration=self.integration
-            )
-
-        # add a second user to the team so we can be sure it's only
-        # sent once (to the team, and not to each individual user)
-        user2 = self.create_user(is_superuser=False)
-        self.create_member(teams=[self.team], user=user2, organization=self.organization)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX2")
-            self.identity = Identity.objects.create(
-                external_id="UXXXXXXX2",
-                idp=self.idp,
-                user=user2,
-                status=IdentityStatus.VALID,
-                scopes=[],
-            )
-        # update the team's notification settings
-        ExternalActor.objects.create(
-            team_id=self.team.id,
-            organization=self.organization,
-            integration_id=self.integration.id,
-            provider=ExternalProviders.SLACK.value,
-            external_name="goma",
-            external_id="CXXXXXXX2",
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            NotificationSettingProvider.objects.create(
-                team_id=self.team.id,
-                scope_type="team",
-                scope_identifier=self.team.id,
-                provider="slack",
-                type="alerts",
-                value="always",
-            )
-
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "Team",
-            "targetIdentifier": str(self.team.id),
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-        notification = Notification(event=event, rule=rule)
-
-        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
-            self.adapter.notify(notification, ActionTargetType.TEAM, self.team.id)
-
-        # check that only one was sent out - more would mean each user is being notified
-        # rather than the team
-        assert len(responses.calls) == 1
-
-        # check that the team got a notification
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["channel"] == ["CXXXXXXX2"]
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-        assert len(attachments) == 1
-        assert attachments[0]["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachments[0]["title_link"])
-        assert (
-            attachments[0]["footer"]
-            == f"{self.project.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -1242,33 +922,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             attachments[0]["footer"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
-
-    @responses.activate
-    @patch.object(sentry, "digests")
-    def test_digest_enabled(self, digests):
-        """
-        Test that with digests enabled, but Slack notification settings
-        (and not email settings), we send a Slack notification
-        """
-        backend = RedisBackend()
-        digests.digest = backend.digest
-        digests.enabled.return_value = True
-
-        rule = Rule.objects.create(project=self.project, label="my rule")
-        ProjectOwnership.objects.create(project_id=self.project.id)
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
-        key = f"mail:p:{self.project.id}:IssueOwners::AllMembers"
-        backend.add(key, event_to_record(event, [rule]), increment_delay=0, maximum_delay=0)
-
-        with self.tasks():
-            deliver_digest(key)
-
-        attachment, text = get_attachment()
-
-        assert attachment["title"] == "Hello world"
-        assert attachment["text"] == ""
 
     @responses.activate
     @patch.object(sentry, "digests")

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -7,7 +7,7 @@ from sentry.notifications.notifications.activity.resolved import ResolvedActivit
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -24,25 +24,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
                 type=ActivityType.SET_RESOLVED,
                 data={"assignee": ""},
             )
-        )
-
-    @responses.activate
-    def test_resolved(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue is resolved
-        """
-        with self.tasks():
-            self.create_notification(self.group).send()
-
-        attachment, text = get_attachment()
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            text
-            == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.short_id}> as resolved"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -80,30 +61,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    def test_resolved_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue is resolved
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group).send()
-
-        attachment, text = get_attachment()
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            text
-            == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.project.slug.upper()}-{event.group.short_id}> as resolved"
-        )
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "resolved_activity-slack-user"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
     @with_feature("organizations:slack-block-kit")
     def test_resolved_performance_issue_block(self, occurrence):
         """
@@ -127,33 +84,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             event.project.slug,
             event.group,
             "resolved_activity-slack",
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    def test_resolved_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type is resolved
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-        with self.tasks():
-            self.create_notification(group_event.group).send()
-
-        attachment, text = get_attachment()
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            text
-            == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{group_event.group.id}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.project.slug.upper()}-{group_event.group.short_id}> as resolved"
-        )
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "resolved_activity-slack-user"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -9,7 +9,7 @@ from sentry.notifications.notifications.activity.resolved_in_release import (
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -31,24 +31,6 @@ class SlackResolvedInReleaseNotificationTest(
         )
 
     @responses.activate
-    def test_resolved_in_release(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue is resolved in a release
-        """
-        notification = self.create_notification(self.group)
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        release_name = notification.activity.data["version"]
-        assert text == f"Issue marked as resolved in {release_name} by {self.name}"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
     @with_feature("organizations:slack-block-kit")
     def test_resolved_in_release_block(self):
         notification = self.create_notification(self.group)
@@ -67,28 +49,6 @@ class SlackResolvedInReleaseNotificationTest(
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    def test_resolved_in_release_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue is resolved in a release
-        """
-        event = self.create_performance_issue()
-        notification = self.create_notification(event.group)
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        release_name = notification.activity.data["version"]
-        assert text == f"Issue marked as resolved in {release_name} by {self.name}"
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "resolved_in_release_activity-slack-user"
         )
 
     @responses.activate
@@ -126,31 +86,6 @@ class SlackResolvedInReleaseNotificationTest(
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    def test_resolved_in_release_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type is resolved in a release
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-        notification = self.create_notification(group_event.group)
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        release_name = notification.activity.data["version"]
-        assert text == f"Issue marked as resolved in {release_name} by {self.name}"
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "resolved_in_release_activity-slack-user"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
     @with_feature("organizations:slack-block-kit")
     def test_resolved_in_release_generic_issue_block(self, occurrence):
         """
@@ -175,23 +110,6 @@ class SlackResolvedInReleaseNotificationTest(
             group_event.project.slug,
             group_event.group,
             "resolved_in_release_activity-slack",
-        )
-
-    @responses.activate
-    def test_resolved_in_release_parsed_version(self):
-        """
-        Test that the release version is formatted to the short version
-        """
-        notification = self.create_notification(self.group, version="frontend@1.0.0")
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue marked as resolved in 1.0.0 by {self.name}"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -7,7 +7,7 @@ from sentry.notifications.notifications.activity.unassigned import UnassignedAct
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -24,23 +24,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
                 type=ActivityType.ASSIGNED,
                 data={"assignee": ""},
             )
-        )
-
-    @responses.activate
-    def test_unassignment(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue is unassigned
-        """
-        with self.tasks():
-            self.create_notification(self.group).send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue unassigned by {self.name}"
-        assert attachment["title"] == self.group.title
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -71,26 +54,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    def test_unassignment_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue is unassigned
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group).send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue unassigned by {self.name}"
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "unassigned_activity-slack-user"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
     @with_feature("organizations:slack-block-kit")
     def test_unassignment_performance_issue_block(self, occurrence):
         """
@@ -110,29 +73,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
             event.project.slug,
             event.group,
             "unassigned_activity-slack",
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    def test_unassignment_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type is unassigned
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-        with self.tasks():
-            self.create_notification(group_event.group).send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue unassigned by {self.name}"
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "unassigned_activity-slack-user"
         )
 
     @responses.activate


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/68016 -- trying to break the changes up.

Every single test that is deleted in this PR has a block kit equivalent.