### PR TITLE
feat(ai): Display object values in new trace view nicely

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -38,7 +38,7 @@ import type {
   TraceTree,
   TraceTreeNode,
 } from 'sentry/views/performance/newTraceDetails/traceTree';
-import {renderSpanDetailsValue} from 'sentry/views/performance/traceDetails/newTraceDetailsValueRenderer';
+import {renderGeneralSpanDetailsValue} from 'sentry/views/performance/traceDetails/newTraceDetailsValueRenderer';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils/getPerformanceDuration';
@@ -531,13 +531,13 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
               {Object.entries(nonSizeKeys).map(([key, value]) =>
                 !isHiddenDataKey(key) ? (
                   <Row title={key} key={key}>
-                    {renderSpanDetailsValue(value)}
+                    {renderGeneralSpanDetailsValue(value)}
                   </Row>
                 ) : null
               )}
               {unknownKeys.map(key => (
                 <Row title={key} key={key}>
-                  {renderSpanDetailsValue(span[key])}
+                  {renderGeneralSpanDetailsValue(span[key])}
                 </Row>
               ))}
             </tbody>

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -38,6 +38,7 @@ import type {
   TraceTree,
   TraceTreeNode,
 } from 'sentry/views/performance/newTraceDetails/traceTree';
+import {renderSpanDetailsValue} from 'sentry/views/performance/traceDetails/newTraceDetailsValueRenderer';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils/getPerformanceDuration';
@@ -523,20 +524,20 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
                 <Row title={key} key={key}>
                   <Fragment>
                     <FileSize bytes={value} />
-                    {value >= 1024 && <span>{` (${maybeStringify(value)} B)`}</span>}
+                    {value >= 1024 && <span>{` (${value} B)`}</span>}
                   </Fragment>
                 </Row>
               ))}
               {Object.entries(nonSizeKeys).map(([key, value]) =>
                 !isHiddenDataKey(key) ? (
                   <Row title={key} key={key}>
-                    {maybeStringify(value)}
+                    {renderSpanDetailsValue(value)}
                   </Row>
                 ) : null
               )}
               {unknownKeys.map(key => (
                 <Row title={key} key={key}>
-                  {maybeStringify(span[key])}
+                  {renderSpanDetailsValue(span[key])}
                 </Row>
               ))}
             </tbody>
@@ -592,13 +593,6 @@ function SpanHTTPInfo({span}: {span: RawSpanType}) {
 
 function RowTimingPrefix({timing}: {timing: SubTimingInfo}) {
   return <OpsDot style={{backgroundColor: timing.color}} />;
-}
-
-function maybeStringify(value: unknown): string {
-  if (typeof value === 'string') {
-    return value;
-  }
-  return JSON.stringify(value, null, 4);
 }
 
 const StyledDiscoverButton = styled(DiscoverButton)`

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -38,7 +38,7 @@ import type {
   TraceTree,
   TraceTreeNode,
 } from 'sentry/views/performance/newTraceDetails/traceTree';
-import {renderGeneralSpanDetailsValue} from 'sentry/views/performance/traceDetails/newTraceDetailsValueRenderer';
+import {GeneralSpanDetailsValue} from 'sentry/views/performance/traceDetails/newTraceDetailsValueRenderer';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils/getPerformanceDuration';
@@ -531,13 +531,13 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
               {Object.entries(nonSizeKeys).map(([key, value]) =>
                 !isHiddenDataKey(key) ? (
                   <Row title={key} key={key}>
-                    {renderGeneralSpanDetailsValue(value)}
+                    <GeneralSpanDetailsValue value={value} />
                   </Row>
                 ) : null
               )}
               {unknownKeys.map(key => (
                 <Row title={key} key={key}>
-                  {renderGeneralSpanDetailsValue(span[key])}
+                  <GeneralSpanDetailsValue value={span[key]} />
                 </Row>
               ))}
             </tbody>

--- a/static/app/views/performance/traceDetails/newTraceDetailsValueRenderer.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsValueRenderer.tsx
@@ -3,12 +3,12 @@ import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
 
-function renderObject(obj: object): React.ReactNode {
+function ObjectView({obj}: {obj: object}) {
   if (Array.isArray(obj)) {
     return (
       <ListContainer>
         {obj.map((x, i) => (
-          <li key={'array-' + i}>{renderSpanDetailsValue(x)}</li>
+          <li key={'array-' + i}>{renderGeneralSpanDetailsValue(x)}</li>
         ))}
       </ListContainer>
     );
@@ -17,19 +17,19 @@ function renderObject(obj: object): React.ReactNode {
     <ObjectContainer>
       {Object.keys(obj).map(key => (
         <div key={key}>
-          {key}: {renderSpanDetailsValue(obj[key])}
+          {key}: {renderGeneralSpanDetailsValue(obj[key])}
         </div>
       ))}
     </ObjectContainer>
   );
 }
 
-export function renderSpanDetailsValue(value: any): React.ReactNode {
+export function renderGeneralSpanDetailsValue(value: any): React.ReactNode {
   if (typeof value === 'string') {
     return value;
   }
   if (typeof value === 'object') {
-    return renderObject(value);
+    return <ObjectView obj={value} />;
   }
   return JSON.stringify(value, null, 4);
 }

--- a/static/app/views/performance/traceDetails/newTraceDetailsValueRenderer.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsValueRenderer.tsx
@@ -1,0 +1,55 @@
+import type React from 'react';
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+function renderObject(obj: object): React.ReactNode {
+  if (Array.isArray(obj)) {
+    return (
+      <ListContainer>
+        {obj.map((x, i) => (
+          <li key={'array-' + i}>{renderSpanDetailsValue(x)}</li>
+        ))}
+      </ListContainer>
+    );
+  }
+  return (
+    <ObjectContainer>
+      {Object.keys(obj).map(key => (
+        <div key={key}>
+          {key}: {renderSpanDetailsValue(obj[key])}
+        </div>
+      ))}
+    </ObjectContainer>
+  );
+}
+
+export function renderSpanDetailsValue(value: any): React.ReactNode {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'object') {
+    return renderObject(value);
+  }
+  return JSON.stringify(value, null, 4);
+}
+
+const ListContainer = styled('ul')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+  padding: 0;
+  margin-left: ${space(1)};
+  list-style-type: '-';
+  flex-grow: 1;
+  flex-basis: full;
+`;
+
+const ObjectContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+  margin-left: ${space(1)};
+  flex-grow: 1;
+  flex-basis: full;
+`;

--- a/static/app/views/performance/traceDetails/newTraceDetailsValueRenderer.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsValueRenderer.tsx
@@ -1,4 +1,3 @@
-import type React from 'react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
@@ -8,7 +7,9 @@ function ObjectView({obj}: {obj: object}) {
     return (
       <ListContainer>
         {obj.map((x, i) => (
-          <li key={'array-' + i}>{renderGeneralSpanDetailsValue(x)}</li>
+          <li key={'array-' + i}>
+            <GeneralSpanDetailsValue value={x} />
+          </li>
         ))}
       </ListContainer>
     );
@@ -17,21 +18,21 @@ function ObjectView({obj}: {obj: object}) {
     <ObjectContainer>
       {Object.keys(obj).map(key => (
         <div key={key}>
-          {key}: {renderGeneralSpanDetailsValue(obj[key])}
+          {key}: <GeneralSpanDetailsValue value={obj[key]} />
         </div>
       ))}
     </ObjectContainer>
   );
 }
 
-export function renderGeneralSpanDetailsValue(value: any): React.ReactNode {
+export function GeneralSpanDetailsValue({value}: {value: any}) {
   if (typeof value === 'string') {
-    return value;
+    return <span>{value}</span>;
   }
   if (typeof value === 'object') {
     return <ObjectView obj={value} />;
   }
-  return JSON.stringify(value, null, 4);
+  return <span>{JSON.stringify(value, null, 4)}</span>;
 }
 
 const ListContainer = styled('ul')`


### PR DESCRIPTION
We're starting to get large objects as values (i.e., the LLM input texts) - instead of just calling json stringify on everything, render a YAML-esque view in the details view of the new trace details view.

<img width="1488" alt="Screenshot 2024-04-02 at 12 26 57 PM" src="https://github.com/getsentry/sentry/assets/161344340/c66ec03b-d0ad-4fa5-aaed-510b291623ed">
