### PR TITLE
fix(replay): change state for selected replay

### DIFF
--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -263,13 +263,17 @@ const Row = styled('div')<{
           }`
       : `display: contents;
   & > * {
-    background-color: ${p.isPlaying ? p.theme.translucentInnerBorder : 'inherit'};
+    background-color: ${p.isPlaying ? p.theme.translucentGray200 : 'inherit'};
     border-top: 1px solid ${p.theme.border};
     cursor: ${p.showCursor ? 'pointer' : 'default'};
   }
   :hover {
     background-color: ${p.showCursor ? p.theme.translucentInnerBorder : 'inherit'};
-  }`}
+  }
+  :active {
+    background-color: ${p.theme.translucentGray200};
+  }
+  `}
 `;
 
 export default ReplayTable;


### PR DESCRIPTION
This PR makes the selected state darker than the hover state for the rows in the replay table.

![Screenshot 2024-04-02 at 9 50 14 AM](https://github.com/getsentry/sentry/assets/8533851/192a6155-db90-4851-8c2b-e4bad7bb66ff)
