### PR TITLE
fix(hc): Removes option check for region-specific upload URLs

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -78,10 +78,12 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 int(sentrycli_version.group("patch")),
             )
 
+        relative_urls_disabled = options.get("hybrid_cloud.disable_relative_upload_urls")
         requires_region_url = sentrycli_version_split and sentrycli_version_split >= (2, 30, 0)
 
         supports_relative_url = (
-            not requires_region_url
+            not relative_urls_disabled
+            and not requires_region_url
             and sentrycli_version_split
             and sentrycli_version_split >= (1, 70, 1)
         )

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -78,12 +78,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 int(sentrycli_version.group("patch")),
             )
 
-        region_upload_urls_enabled = options.get("hybrid_cloud.use_region_specific_upload_url")
-        requires_region_url = (
-            region_upload_urls_enabled
-            and sentrycli_version_split
-            and sentrycli_version_split >= (2, 30, 0)
-        )
+        requires_region_url = sentrycli_version_split and sentrycli_version_split >= (2, 30, 0)
 
         supports_relative_url = (
             not requires_region_url
@@ -100,10 +95,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             else:
                 # We need to generate region specific upload URLs when possible to avoid hitting the API proxy
                 # which tends to cause timeouts and performance issues for uploads.
-                base_url = None
-                if region_upload_urls_enabled:
-                    base_url = generate_region_url()
-                url = absolute_uri(relative_url, base_url)
+                url = absolute_uri(relative_url, generate_region_url())
         else:
             # If user overridden upload url prefix, we want an absolute, versioned endpoint, with user-configured prefix
             url = absolute_uri(relative_url, endpoint)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1748,7 +1748,7 @@ register("hybrid_cloud.region-domain-allow-list", default=[], flags=FLAG_AUTOMAT
 register("hybrid_cloud.region-user-allow-list", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 register(
-    "hybrid_cloud.use_region_specific_upload_url", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
+    "hybrid_cloud.use_region_specific_upload_url", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
 # Retry controls

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1751,6 +1751,10 @@ register(
     "hybrid_cloud.use_region_specific_upload_url", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
+register(
+    "hybrid_cloud.disable_relative_upload_urls", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+
 # Retry controls
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -47,7 +47,7 @@ class ChunkUploadTest(APITestCase):
         assert response.data["maxFileSize"] == options.get("system.maximum-file-size")
         assert response.data["concurrency"] == MAX_CONCURRENCY
         assert response.data["hashAlgorithm"] == HASH_ALGORITHM
-        assert response.data["url"] == options.get("system.url-prefix") + self.url
+        assert response.data["url"] == generate_region_url() + self.url
         assert response.data["accept"] == CHUNK_UPLOAD_ACCEPT
 
         with override_options({"system.upload-url-prefix": "test"}):
@@ -57,12 +57,6 @@ class ChunkUploadTest(APITestCase):
 
             assert response.data["url"] == options.get("system.upload-url-prefix") + self.url
 
-        with override_options({"hybrid_cloud.use_region_specific_upload_url": True}):
-            response = self.client.get(
-                self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
-            )
-            assert response.data["url"] == generate_region_url() + self.url
-
     def test_relative_url_support(self):
         # Starting `sentry-cli@1.70.1` we added a support for relative chunk-uploads urls
 
@@ -71,14 +65,6 @@ class ChunkUploadTest(APITestCase):
             self.url,
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             HTTP_USER_AGENT="sentry-cli/1.70.1",
-            format="json",
-        )
-        assert response.data["url"] == self.url.lstrip(API_PREFIX)
-
-        response = self.client.get(
-            self.url,
-            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
-            HTTP_USER_AGENT="sentry-cli/2.77.4",
             format="json",
         )
         assert response.data["url"] == self.url.lstrip(API_PREFIX)
@@ -98,7 +84,7 @@ class ChunkUploadTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/1.70.0",
             format="json",
         )
-        assert response.data["url"] == options.get("system.url-prefix") + self.url
+        assert response.data["url"] == generate_region_url() + self.url
 
         response = self.client.get(
             self.url,
@@ -106,7 +92,7 @@ class ChunkUploadTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/0.69.3",
             format="json",
         )
-        assert response.data["url"] == options.get("system.url-prefix") + self.url
+        assert response.data["url"] == generate_region_url() + self.url
 
         # user overridden upload url prefix has priority, even when calling from sentry-cli that supports relative urls
         with override_options({"system.upload-url-prefix": "test"}):
@@ -118,7 +104,6 @@ class ChunkUploadTest(APITestCase):
             )
             assert response.data["url"] == options.get("system.upload-url-prefix") + self.url
 
-    @override_options({"hybrid_cloud.use_region_specific_upload_url": True})
     def test_region_upload_urls(self):
         response = self.client.get(
             self.url,

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -104,6 +104,15 @@ class ChunkUploadTest(APITestCase):
             )
             assert response.data["url"] == options.get("system.upload-url-prefix") + self.url
 
+        with override_options({"hybrid_cloud.disable_relative_upload_urls": True}):
+            response = self.client.get(
+                self.url,
+                HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+                HTTP_USER_AGENT="sentry-cli/1.70.1",
+                format="json",
+            )
+            assert response.data["url"] == generate_region_url() + self.url
+
     def test_region_upload_urls(self):
         response = self.client.get(
             self.url,
@@ -137,6 +146,15 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.data["url"] == generate_region_url() + self.url
+
+        with override_options({"hybrid_cloud.disable_relative_upload_urls": True}):
+            response = self.client.get(
+                self.url,
+                HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+                HTTP_USER_AGENT="sentry-cli/2.29.99",
+                format="json",
+            )
+            assert response.data["url"] == generate_region_url() + self.url
 
     def test_large_uploads(self):
         with self.feature("organizations:large-debug-files"):


### PR DESCRIPTION
Removes the check for region-specific URLs for chunk-upload. This defaults the endpoint it to always return a full region URL when a new or much older CLI client is used. CLI clients between versions 1.70.1 and 2.30.0 will still continue to use relative URL paths in the meantime.
