### PR TITLE
ref(autofix): fallback to latest event if no recommended event

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -154,9 +154,12 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
         if event_id is None:
             event = group.get_recommended_event_for_environments()
             if not event:
+                event = group.get_latest_event()
+
+            if not event:
                 return Response(
                     {
-                        "detail": "Could not find recommended event for issue, please try providing an event_id"
+                        "detail": "Could not find an event for the issue, please try providing an event_id"
                     },
                     status=400,
                 )


### PR DESCRIPTION
If an event_id is not passed to the autofix endpoint, we try to find the recommended event. This PR adds attempting to fetch the latest event if we cannot find a recommended event. If we can't find any event, we return a 400.