### PR TITLE
feat(rca): Add avg_by_timestamp to span metrics

### DIFF
--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -491,6 +491,24 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     snql_distribution=self._resolve_regression_score,
                     default_result_type="number",
                 ),
+                fields.MetricsFunction(
+                    "avg_by_timestamp",
+                    required_args=[
+                        fields.MetricArg(
+                            "column",
+                            allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
+                        ),
+                        fields.FunctionArg(
+                            "condition",
+                        ),
+                        fields.TimestampArg("timestamp"),
+                    ],
+                    calculated_args=[resolve_metric_id],
+                    snql_distribution=lambda args, alias: self._resolve_avg_condition(
+                        args, args["condition"], alias
+                    ),
+                    default_result_type="number",
+                ),
             ]
         }
 
@@ -881,6 +899,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         self,
         args: Mapping[str, str | Column | SelectType | int | float],
         condition: str,
+        alias: str | None = None,
     ) -> SelectType:
         conditional_aggregate = Function(
             "avgIf",
@@ -908,6 +927,7 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                 0,
                 conditional_aggregate,
             ],
+            alias,
         )
 
     @property

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -901,6 +901,9 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         condition: str,
         alias: str | None = None,
     ) -> SelectType:
+        if condition not in {"greater", "less"}:
+            raise InvalidSearchQuery(f"Unsupported condition for avg: {condition}")
+
         conditional_aggregate = Function(
             "avgIf",
             [

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -498,16 +498,14 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                             "column",
                             allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
                         ),
-                        fields.FunctionArg(
-                            "condition",
-                        ),
+                        fields.SnQLStringArg("condition", allowed_strings=["greater", "less"]),
                         fields.TimestampArg("timestamp"),
                     ],
                     calculated_args=[resolve_metric_id],
                     snql_distribution=lambda args, alias: self._resolve_avg_condition(
                         args, args["condition"], alias
                     ),
-                    default_result_type="number",
+                    default_result_type="duration",
                 ),
             ]
         }

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -899,9 +899,6 @@ class SpansMetricsDatasetConfig(DatasetConfig):
         condition: str,
         alias: str | None = None,
     ) -> SelectType:
-        if condition not in {"greater", "less"}:
-            raise InvalidSearchQuery(f"Unsupported condition for avg: {condition}")
-
         conditional_aggregate = Function(
             "avgIf",
             [

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1224,6 +1224,42 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         # a way to filter out removed spans when necessary
         assert data[1][f"regression_score(span.self_time,{int(self.two_min_ago.timestamp())})"] < 0
 
+    def test_avg_self_time_by_timestamp(self):
+        self.store_span_metric(
+            1,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.six_min_ago,
+            tags={},
+        )
+
+        self.store_span_metric(
+            3,
+            internal_metric=constants.SELF_TIME_LIGHT,
+            timestamp=self.min_ago,
+            tags={},
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    f"avg_by_timestamp(span.self_time,less,{int(self.two_min_ago.timestamp())})",
+                    f"avg_by_timestamp(span.self_time,greater,{int(self.two_min_ago.timestamp())})",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0] == {
+            f"avg_by_timestamp(span.self_time,less,{int(self.two_min_ago.timestamp())})": 1.0,
+            f"avg_by_timestamp(span.self_time,greater,{int(self.two_min_ago.timestamp())})": 3.0,
+        }
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1260,6 +1260,25 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             f"avg_by_timestamp(span.self_time,greater,{int(self.two_min_ago.timestamp())})": 3.0,
         }
 
+    def test_avg_self_time_by_timestamp_invalid_condition(self):
+        response = self.do_request(
+            {
+                "field": [
+                    f"avg_by_timestamp(span.self_time,INVALID_ARG,{int(self.two_min_ago.timestamp())})",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 400, response.content
+        assert (
+            response.data["detail"]
+            == "avg_by_timestamp: condition argument invalid: string must be one of ['greater', 'less']"
+        )
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest


### PR DESCRIPTION
Used for returning the average of duration columns greater/less than a breakpoint. Will replace how we retrieve baseline self time for RCA.