### PR TITLE
feat(new-trace): Changing duration comparison text.

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -146,10 +146,10 @@ function Duration(props: DurationProps) {
 
   const deltaText =
     status === 'equal'
-      ? t(`Equal to avg %s`, `${deltaPct}%`, formattedAvgDuration)
+      ? t(`equal to the avg of %s`, `${deltaPct}%`, formattedAvgDuration)
       : status === 'faster'
-        ? t(`%s faster than avg %s`, `${deltaPct}%`, formattedAvgDuration)
-        : t(`%s slower than avg %s`, `${deltaPct}%`, formattedAvgDuration);
+        ? t(`%s faster than the avg of %s`, `${deltaPct}%`, formattedAvgDuration)
+        : t(`%s slower than the avg of %s`, `${deltaPct}%`, formattedAvgDuration);
 
   return (
     <Fragment>


### PR DESCRIPTION
From `25% faster than avg XXXms` to `25% faster than the avg of XXXms`