### PR TITLE
feat(snuba-search): skip snuba on certain filters

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -55,8 +55,6 @@ UNSUPPORTED_SNUBA_FILTERS = [
     "linked",
     "subscribed_by",
     "regressed_in_release",
-    "issue.category",
-    "issue.type",
     "issue.priority",
 ]
 

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any
 
+import sentry_sdk
 from django.utils import timezone
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.request import Request
@@ -45,6 +46,19 @@ from sentry.utils.validators import normalize_event_id
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
 allowed_inbox_search_terms = frozenset(["date", "status", "for_review", "assigned_or_suggested"])
+
+
+# these filters are currently not supported in the snuba only search
+# and will use PostgresSnubaQueryExecutor instead of GroupAttributesPostgresSnubaQueryExecutor
+UNSUPPORTED_SNUBA_FILTERS = [
+    "bookmarked_by",
+    "linked",
+    "subscribed_by",
+    "regressed_in_release",
+    "issue.category",
+    "issue.type",
+    "issue.priority",
+]
 
 
 def inbox_search(
@@ -165,10 +179,32 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                 query_kwargs.pop("sort_by")
                 result = inbox_search(**query_kwargs)
             else:
+
+                def use_group_snuba_dataset():
+                    # if useGroupSnubaDataset we consider using the snuba dataset
+                    if not request.GET.get("useGroupSnubaDataset"):
+                        return False
+                    # haven't migrated trends
+                    if query_kwargs["sort_by"] == "trends":
+                        return False
+                    # check for unsupported snuba filters
+                    return (
+                        len(
+                            list(
+                                filter(
+                                    lambda x: x.key.name in UNSUPPORTED_SNUBA_FILTERS,
+                                    query_kwargs.get("search_filters", []),
+                                )
+                            )
+                        )
+                        == 0
+                    )
+
                 query_kwargs["referrer"] = "search.group_index"
-                # optional argument to use the group snuba dataset that intentially does not support trends
-                if request.GET.get("useGroupSnubaDataset") and query_kwargs["sort_by"] != "trends":
-                    query_kwargs["use_group_snuba_dataset"] = True
+                query_kwargs["use_group_snuba_dataset"] = use_group_snuba_dataset()
+                sentry_sdk.set_tag(
+                    "search.use_group_snuba_dataset", query_kwargs["use_group_snuba_dataset"]
+                )
 
                 result = search.query(**query_kwargs)
             return result, query_kwargs

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2652,8 +2652,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
             "is:unlinked",
             "subscribed:me",
             "regressed_in_release:latest",
-            "issue.category:error",
-            "issue.type:performance_n_plus_one_db_queries",
             "issue.priority:high",
         ]:
             with patch(

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -2644,6 +2644,29 @@ class GroupListTest(APITestCase, SnubaTestCase):
             else:
                 assert False, f"Unexpected query {query}"
 
+    def test_snuba_unsupported_filters(self):
+        self.login_as(user=self.user)
+        for query in [
+            "bookmarks:me",
+            "is:linked",
+            "is:unlinked",
+            "subscribed:me",
+            "regressed_in_release:latest",
+            "issue.category:error",
+            "issue.type:performance_n_plus_one_db_queries",
+            "issue.priority:high",
+        ]:
+            with patch(
+                "sentry.search.snuba.executors.GroupAttributesPostgresSnubaQueryExecutor.query",
+                side_effect=GroupAttributesPostgresSnubaQueryExecutor.query,
+            ) as mock_query:
+                self.get_success_response(
+                    sort="new",
+                    useGroupSnubaDataset=1,
+                    query=query,
+                )
+                assert mock_query.call_count == 0
+
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-group-index"


### PR DESCRIPTION
We currently lack the ability to do certain filters with snuba search. This PR adds an exception list of filters that will force the backend to use Postgres search for certain filters.