### PR TITLE
fix(new-trace): Fixes infinite loading state for empty traces bug.

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -713,12 +713,12 @@ function TraceViewContent(props: TraceViewContentProps) {
             rerender={rerender}
           />
 
-          {tree.type === 'loading' || scrollQueueRef.current ? (
-            <TraceLoading />
-          ) : tree.type === 'error' ? (
+          {tree.type === 'error' ? (
             <TraceError />
           ) : tree.type === 'empty' ? (
             <TraceEmpty />
+          ) : tree.type === 'loading' || scrollQueueRef.current ? (
+            <TraceLoading />
           ) : null}
 
           <TraceDrawer


### PR DESCRIPTION
Correctly displays the empty trace ui:
<img width="1282" alt="Screenshot 2024-04-02 at 4 02 03 PM" src="https://github.com/getsentry/sentry/assets/60121741/caf755dc-51ed-4de3-b41c-9149cdc9097f">
