### PR TITLE
fix(grouping): release support in custom fingerprinting

### DIFF
--- a/src/sentry/grouping/fingerprinting/__init__.py
+++ b/src/sentry/grouping/fingerprinting/__init__.py
@@ -81,6 +81,7 @@ class EventAccess:
         self._tags = None
         self._sdk = None
         self._family = None
+        self._release = None
 
     def get_messages(self):
         if self._messages is None:
@@ -164,6 +165,10 @@ class EventAccess:
             {"family": get_behavior_family_for_platform(self.event.get("platform"))}
         ]
         return self._family
+
+    def get_release(self):
+        self._release = self._release or [{"release": self.event.get("release")}]
+        return self._release
 
     def get_values(self, match_group):
         return getattr(self, "get_" + match_group)()
@@ -313,6 +318,8 @@ class Match:
             return "sdk"
         if self.key == "family":
             return "family"
+        if self.key == "release":
+            return "release"
         return "frames"
 
     def matches(self, values):
@@ -365,6 +372,9 @@ class Match:
         elif self.key == "sdk":
             flags = self.pattern.split(",")
             if "all" in flags or value in flags:
+                return True
+        elif self.key == "release":
+            if self._positive_path_match(value):
                 return True
         elif self.key == "app":
             ref_val = get_rule_bool(self.pattern)

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-release.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-release.json
@@ -1,0 +1,38 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        ["release", "foo.bar@*"]
+      ],
+      "fingerprint": ["foo.bar-release"],
+      "__test_description": "Shows that the custom fingerprinting rule is applied when release matches"
+    }
+  ],
+  "fingerprint": ["my-route", "{{ default }}"],
+  "exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "main",
+              "abs_path": "Application.java",
+              "module": "io.sentry.example.Application",
+              "filename": "Application.java",
+              "lineno": 13,
+              "in_app": false
+            }
+          ]
+        },
+        "type": "DatabaseUnavailable",
+        "value": "For some reason the database went away"
+      }
+    ]
+  },
+  "release": "foo.bar@1.2.3",
+  "platform": "java",
+  "sdk": {
+    "name": "sentry.java",
+    "version": "1.7.30"
+  }
+}

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
@@ -1,0 +1,35 @@
+---
+created: '2024-04-02T20:02:29.936258+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - attributes: {}
+    fingerprint:
+    - foo.bar-release
+    matchers:
+    - - release
+      - foo.bar@*
+  version: 1
+fingerprint:
+- my-route
+- '{{ default }}'
+title: 'DatabaseUnavailable: For some reason the database went away'
+variants:
+  app:
+    component:
+      contributes: false
+      hint: exception of system takes precedence
+    type: salted-component
+    values:
+    - my-route
+    - '{{ default }}'
+  system:
+    component:
+      contributes: true
+      hint: null
+    type: salted-component
+    values:
+    - my-route
+    - '{{ default }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-04-02T20:02:29.936258+00:00'
+created: '2024-04-02T20:25:06.571127+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,23 +13,24 @@ config:
       - foo.bar@*
   version: 1
 fingerprint:
-- my-route
-- '{{ default }}'
+- foo.bar-release
 title: 'DatabaseUnavailable: For some reason the database went away'
 variants:
   app:
     component:
       contributes: false
-      hint: exception of system takes precedence
-    type: salted-component
-    values:
+      hint: custom fingerprint takes precedence
+    type: component
+  custom-fingerprint:
+    client_values:
     - my-route
     - '{{ default }}'
+    matched_rule: release:"foo.bar@*" -> "foo.bar-release"
+    type: custom-fingerprint
+    values:
+    - foo.bar-release
   system:
     component:
-      contributes: true
-      hint: null
-    type: salted-component
-    values:
-    - my-route
-    - '{{ default }}'
+      contributes: false
+      hint: custom fingerprint takes precedence
+    type: component

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -130,7 +130,7 @@ error.type:DatabaseUnavailable                        -> DatabaseUnavailable
 stack.function:assertion_failed stack.module:foo      -> AssertionFailed, foo
 app:true                                        -> aha
 app:true                                        -> {{ default }}
-release:foo                                     -> {{ default }}
+release:foo                                     -> release-foo
 """
     )
     assert rules._to_config_structure() == {
@@ -147,7 +147,7 @@ release:foo                                     -> {{ default }}
             },
             {"matchers": [["app", "true"]], "fingerprint": ["aha"], "attributes": {}},
             {"matchers": [["app", "true"]], "fingerprint": ["{{ default }}"], "attributes": {}},
-            {"matchers": [["release", "foo"]], "fingerprint": ["{{ default }}"], "attributes": {}},
+            {"matchers": [["release", "foo"]], "fingerprint": ["release-foo"], "attributes": {}},
         ],
         "version": 1,
     }


### PR DESCRIPTION
The discovery fields are _not_ automatically exposed to fingerprint matchers.
This adds "release" as a field. 

Fix for code related to #67836

