### PR TITLE
feat(replays): Add support for Range header

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_video_details.py
+++ b/src/sentry/replays/endpoints/project_replay_video_details.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+import logging
 from io import BytesIO
 
-from django.http import StreamingHttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
@@ -17,9 +17,17 @@ from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, R
 from sentry.apidocs.examples.replay_examples import ReplayExamples
 from sentry.apidocs.parameters import GlobalParams, ReplayParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.replays.lib.http import RangeProtocol, parse_range_header
+from sentry.replays.lib.http import (
+    MalformedRangeHeader,
+    UnsatisfiableRange,
+    content_length,
+    content_range,
+    parse_range_header,
+)
 from sentry.replays.lib.storage import make_video_filename
 from sentry.replays.usecases.reader import download_video, fetch_segment_metadata
+
+logger = logging.getLogger()
 
 
 @region_silo_endpoint
@@ -61,53 +69,53 @@ class ProjectReplayVideoDetailsEndpoint(ProjectEndpoint):
         if video is None:
             return self.respond({"detail": "Replay recording segment not found."}, status=404)
 
-        video_io = BytesIO(video)
-
         if range_header := request.headers.get("Range"):
-            ranges = parse_range_header(range_header)
-
-            iterator = iter_from_range(ranges, video_io)
-            status_code = 206
-
-            headers = {}
-            if len(ranges) == 1:
-                positions = ranges[0].make_range(len(video) - 1)
-                if positions is None:
-                    length = 0
-                    byte_range = "*"
-                else:
-                    length = positions[1] - positions[0] + 1
-                    byte_range = f"{positions[0]}-{positions[1]}"
-
-                headers["Content-Length"] = length
-                headers["Content-Range"] = f"bytes {byte_range}/{len(video)}"
-            else:
-                headers["Content-Length"] = len(video)
+            response = handle_range_response(range_header, video)
         else:
+            video_io = BytesIO(video)
             iterator = iter(lambda: video_io.read(4096), b"")
-            status_code = 200
-            headers = {"Content-Length": len(video)}
+            response = StreamingHttpResponse(iterator, content_type="application/octet-stream")
+            response["Content-Length"] = len(video)
 
-        response = StreamingHttpResponse(
-            iterator,
-            content_type="application/octet-stream",
-            status=status_code,
-        )
         response["Accept-Ranges"] = "bytes"
         response["Content-Disposition"] = f'attachment; filename="{make_video_filename(segment)}"'
-        for key, value in headers.items():
-            response[key] = value
         return response
 
 
-def iter_from_range(ranges: list[RangeProtocol], video_io: BytesIO) -> Iterator[bytes]:
-    for range_ in ranges:
-        yield range_.read_range(video_io)
+def handle_range_response(range_header: str, video: bytes) -> HttpResponseBase:
+    try:
+        ranges = parse_range_header(range_header)
+        offsets = [range.make_range(len(video) - 1) for range in ranges]
 
+        # For now we're going to raise an exception if more than one range is specified. This
+        # stackoverflow post shows how to use a multi-part response to enable multiple byte
+        # range responses.
+        #
+        # https://stackoverflow.com/questions/18315787/http-1-1-response-to-multiple-range
+        if len(ranges) > 1:
+            raise MalformedRangeHeader("Too many ranges specified.")
+    except (MalformedRangeHeader, UnsatisfiableRange):
+        logger.exception("Malformed range request.")
 
-def get_index_position(range: RangeProtocol, last_index: int) -> str:
-    positions = range.make_range(last_index)
-    if positions is None:
-        return "*"
-    else:
-        return f"{positions[0]}-{positions[1]}"
+        # Malformed ranges receive an empty 416 status response which includes a
+        # header to demonstrate the correct range format.
+        response = HttpResponse(b"", content_type="application/octet-stream", status=416)
+        response["Content-Range"] = f"bytes */{len(video)}"
+        return response
+
+    # Hard-coded single byte-range handling. These assertions should be impossible to fail
+    # due to the validation above.
+    assert len(ranges) == 1
+    assert len(offsets) == 1
+
+    video_range = BytesIO(ranges[0].read_range(BytesIO(video)))
+    response_iterator = iter(lambda: video_range.read(4096), b"")
+
+    range_response = StreamingHttpResponse(
+        response_iterator,
+        content_type="application/octet-stream",
+        status=206,
+    )
+    range_response["Content-Length"] = content_length(offsets)
+    range_response["Content-Range"] = content_range(offsets[0], resource_size=len(video))
+    return range_response

--- a/src/sentry/replays/endpoints/project_replay_video_details.py
+++ b/src/sentry/replays/endpoints/project_replay_video_details.py
@@ -86,10 +86,7 @@ class ProjectReplayVideoDetailsEndpoint(ProjectEndpoint):
         else:
             iterator = iter(lambda: video_io.read(4096), b"")
             status_code = 200
-            headers = {
-                "Content-Length": len(video),
-                "Content-Range": f"0-{len(video)-1}",
-            }
+            headers = {"Content-Length": len(video)}
 
         response = StreamingHttpResponse(
             iterator,

--- a/src/sentry/replays/lib/http.py
+++ b/src/sentry/replays/lib/http.py
@@ -1,0 +1,131 @@
+import io
+from collections.abc import Iterator
+from typing import Protocol
+
+
+class MalformedRangeHeader(Exception):
+    ...
+
+
+class RangeProtocol(Protocol):
+    def make_range(self, last_index: int) -> tuple[int, int] | None:
+        ...
+
+    def read_range(self, bytes: io.BytesIO) -> bytes:
+        """Return a byte range from a reader.
+
+        The rules governing the range are derived from the implementation class.
+        """
+        ...
+
+
+class BoundedRange:
+    """Bounded range header.
+
+    A bounded range header is a pair of integers representing the inclusive range of a
+    unit in the resource.
+    """
+
+    def __init__(self, start: int, end: int) -> None:
+        self.start = start
+        self.end = end
+
+    def make_range(self, last_index: int) -> tuple[int, int] | None:
+        if self.start > last_index or self.end < self.start or self.start < 0:
+            return None
+        return (self.start, min(last_index, self.end))
+
+    def read_range(self, bytes: io.BytesIO) -> bytes:
+        range = self.make_range(bytes.getbuffer().nbytes - 1)
+        if range is None:
+            return b""
+
+        bytes.seek(range[0])
+        return bytes.read(range[1] - range[0] + 1)
+
+
+class UnboundedRange:
+    """Unbounded range header.
+
+    An unbounded range header is an integer in the given unit indicating the start
+    position of the request range with no ending byte. Start range headers read to
+    the end of the resource.
+    """
+
+    def __init__(self, start: int) -> None:
+        self.start = start
+
+    def make_range(self, last_index: int) -> tuple[int, int] | None:
+        if self.start > last_index or self.start < 0:
+            return None
+        return (self.start, last_index)
+
+    def read_range(self, bytes: io.BytesIO) -> bytes:
+        range = self.make_range(bytes.getbuffer().nbytes - 1)
+        if range is None:
+            return b""
+
+        bytes.seek(range[0])
+        return bytes.read()
+
+
+class SuffixLength:
+    """Suffix length range header.
+
+    A suffix length range is an integer indicating the number of units at the end
+    of the resource to return.
+    """
+
+    def __init__(self, suffix_length: int) -> None:
+        self.suffix_length = suffix_length
+
+    def make_range(self, last_index: int) -> tuple[int, int] | None:
+        return (max(0, last_index - self.suffix_length + 1), last_index)
+
+    def read_range(self, bytes: io.BytesIO) -> bytes:
+        range = self.make_range(bytes.getbuffer().nbytes - 1)
+        if range is None:
+            return b""
+
+        bytes.seek(range[0])
+        return bytes.read()
+
+
+def parse_range_header(header: str) -> list[RangeProtocol]:
+    """Return an eagerly accumulated list of ranges."""
+    return list(iter_range_header(header))
+
+
+def iter_range_header(header: str) -> Iterator[RangeProtocol]:
+    """Lazily iterate over a range of bytes."""
+    unit, separator, ranges = header.partition("=")
+    if separator != "=":
+        raise MalformedRangeHeader("Expected `=` symbol")
+    elif unit != "bytes":
+        raise MalformedRangeHeader("Unsupported unit. Expected bytes")
+
+    for range in ranges.replace(" ", "").split(","):
+        start, separator, end = range.partition("-")
+        if separator != "-":
+            raise MalformedRangeHeader("Expected `-` symbol")
+
+        if start == "":
+            yield SuffixLength(_range_value(end))
+        elif end == "":
+            yield UnboundedRange(_range_value(start))
+        else:
+            yield BoundedRange(_range_value(start), _range_value(end))
+
+
+def _range_value(value: str) -> int:
+    """Parse a string to an integer or err."""
+    if not isinstance(value, str):
+        raise Exception("Malformed type input.")
+
+    try:
+        signed_int = int(value)
+        if signed_int < 0:
+            raise MalformedRangeHeader("Ranges must be positive integer values")
+        return signed_int
+    except ValueError:
+        raise MalformedRangeHeader(f"Expected value of type integer; received: {value}")

--- a/src/sentry/replays/lib/http.py
+++ b/src/sentry/replays/lib/http.py
@@ -80,6 +80,9 @@ class SuffixLength:
         self.suffix_length = suffix_length
 
     def make_range(self, last_index: int) -> tuple[int, int]:
+        if self.suffix_length <= 0:
+            raise UnsatisfiableRange()
+
         return (max(0, last_index - self.suffix_length + 1), last_index)
 
     def read_range(self, bytes: io.BytesIO) -> bytes:
@@ -126,3 +129,11 @@ def _range_value(value: str) -> int:
         return signed_int
     except ValueError:
         raise MalformedRangeHeader(f"Expected value of type integer; received: {value}")
+
+
+def content_length(offsets: list[tuple[int, int]]) -> int:
+    return sum(end - start + 1 for start, end in offsets)
+
+
+def content_range(offset: tuple[int, int], resource_size: int) -> str:
+    return f"bytes {f'{offset[0]}-{offset[1]}'}/{resource_size}"

--- a/tests/sentry/replays/unit/lib/test_http.py
+++ b/tests/sentry/replays/unit/lib/test_http.py
@@ -1,0 +1,125 @@
+import io
+
+import pytest
+
+from sentry.replays.lib.http import (
+    BoundedRange,
+    MalformedRangeHeader,
+    SuffixLength,
+    UnboundedRange,
+    iter_range_header,
+    parse_range_header,
+)
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected"),
+    (
+        (0, 12, b"hello, world!"),
+        (1, 12, b"ello, world!"),
+        (11, 12, b"d!"),
+        (12, 12, b"!"),
+        (1, 2, b"el"),
+        (2, 1, b""),
+        (0, 1000, b"hello, world!"),
+        (1000, 10_000, b""),
+    ),
+)
+def test_bounded_range(start: int, end: int, expected: bytes) -> None:
+    """Test bounded range reads."""
+    a = BoundedRange(start, end)
+    b = io.BytesIO(b"hello, world!")
+    assert a.read_range(b) == expected
+
+
+@pytest.mark.parametrize(
+    ("length", "expected"),
+    (
+        (13, b"hello, world!"),
+        (12, b"ello, world!"),
+        (2, b"d!"),
+        (1, b"!"),
+        (1000, b"hello, world!"),
+    ),
+)
+def test_suffix_length(length: int, expected: bytes) -> None:
+    """Test suffix length range reads."""
+    a = SuffixLength(length)
+    b = io.BytesIO(b"hello, world!")
+    assert a.read_range(b) == expected
+
+
+@pytest.mark.parametrize(
+    ("start", "expected"),
+    (
+        (0, b"hello, world!"),
+        (1, b"ello, world!"),
+        (11, b"d!"),
+        (12, b"!"),
+        (1000, b""),
+    ),
+)
+def test_unbounded_range(start: int, expected: bytes) -> None:
+    """Test unbounded range reads."""
+    a = UnboundedRange(start)
+    b = io.BytesIO(b"hello, world!")
+    assert a.read_range(b) == expected
+
+
+def test_parse_range_header_bounded() -> None:
+    ranges = parse_range_header("bytes=1-100")
+    assert isinstance(ranges, list)
+    assert isinstance(ranges[0], BoundedRange)
+    assert ranges[0].start == 1
+    assert ranges[0].end == 100
+
+
+def test_parse_range_header_suffix_length() -> None:
+    ranges = parse_range_header("bytes=-100")
+    assert isinstance(ranges, list)
+    assert isinstance(ranges[0], SuffixLength)
+    assert ranges[0].suffix_length == 100
+
+
+def test_parse_range_header_unbounded() -> None:
+    ranges = parse_range_header("bytes=100-")
+    assert isinstance(ranges, list)
+    assert isinstance(ranges[0], UnboundedRange)
+    assert ranges[0].start == 100
+
+
+@pytest.mark.parametrize(
+    ("header",),
+    (
+        ("xyz=1-2",),
+        ("bytes=1",),
+        ("bytes=1-a",),
+        ("bytes=a-1",),
+        ("bytes=a-b",),
+        ("1-2",),
+        ("bytes=1--10",),
+        ("bytes=1-10.0",),
+        ("",),
+        ("=-",),
+    ),
+)
+def test_parse_range_header_malformed_input(header: str) -> None:
+    """Test malformed inputs error correctly."""
+    with pytest.raises(MalformedRangeHeader):
+        parse_range_header(header)
+
+
+def test_iter_range_header() -> None:
+    """Test iter_range_header function."""
+    headers_generator = iter_range_header("bytes=-100, 100-500, 200-")
+    headers = list(headers_generator)
+
+    assert isinstance(headers[0], SuffixLength)
+    assert headers[0].suffix_length == 100
+
+    assert isinstance(headers[1], BoundedRange)
+    assert headers[1].start == 100
+    assert headers[1].end == 500
+
+    assert isinstance(headers[2], UnboundedRange)
+    assert headers[2].start == 200

--- a/tests/sentry/replays/unit/lib/test_http.py
+++ b/tests/sentry/replays/unit/lib/test_http.py
@@ -20,9 +20,7 @@ from sentry.replays.lib.http import (
         (11, 12, b"d!"),
         (12, 12, b"!"),
         (1, 2, b"el"),
-        (2, 1, b""),
         (0, 1000, b"hello, world!"),
-        (1000, 10_000, b""),
     ),
 )
 def test_bounded_range(start: int, end: int, expected: bytes) -> None:
@@ -56,7 +54,6 @@ def test_suffix_length(length: int, expected: bytes) -> None:
         (1, b"ello, world!"),
         (11, b"d!"),
         (12, b"!"),
-        (1000, b""),
     ),
 )
 def test_unbounded_range(start: int, expected: bytes) -> None:
@@ -101,6 +98,7 @@ def test_parse_range_header_unbounded() -> None:
         ("bytes=1-10.0",),
         ("",),
         ("=-",),
+        ("bytes=-",),
     ),
 )
 def test_parse_range_header_malformed_input(header: str) -> None:


### PR DESCRIPTION
Adds support for the `Range` header to the `/replays/<replay_id>/videos/` endpoint.

Related: https://github.com/getsentry/sentry/issues/67900
RFC: https://www.rfc-editor.org/rfc/rfc9110#name-range-requests
MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range