### PR TITLE
update alert_rule details endpoint to accept activation condition

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -286,6 +286,7 @@ Metric alert rule trigger actions follow the following structure:
         child=ProjectField(scope="project:read"), required=False
     )
     thresholdPeriod = serializers.IntegerField(required=False, default=1, min_value=1, max_value=20)
+    monitorType = serializers.IntegerField(required=False, min_value=0)
     activationCondition = serializers.IntegerField(required=False, allow_null=True, min_value=0)
 
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -286,6 +286,7 @@ Metric alert rule trigger actions follow the following structure:
         child=ProjectField(scope="project:read"), required=False
     )
     thresholdPeriod = serializers.IntegerField(required=False, default=1, min_value=1, max_value=20)
+    activationCondition = serializers.IntegerField(required=False, allow_null=True, min_value=0)
 
 
 @extend_schema(tags=["Alerts"])

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -286,8 +286,17 @@ Metric alert rule trigger actions follow the following structure:
         child=ProjectField(scope="project:read"), required=False
     )
     thresholdPeriod = serializers.IntegerField(required=False, default=1, min_value=1, max_value=20)
-    monitorType = serializers.IntegerField(required=False, min_value=0)
-    activationCondition = serializers.IntegerField(required=False, allow_null=True, min_value=0)
+    monitorType = serializers.IntegerField(
+        required=False,
+        min_value=0,
+        help_text="Monitor type represents whether the alert rule is actively being monitored or is monitored given a specific activation condition.",
+    )
+    activationCondition = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        min_value=0,
+        help_text="Optional int that represents a trigger condition for when to start monitoring",
+    )
 
 
 @extend_schema(tags=["Alerts"])

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -387,8 +387,17 @@ Metric alert rule trigger actions follow the following structure:
         child=ProjectField(scope="project:read"), required=False
     )
     thresholdPeriod = serializers.IntegerField(required=False, default=1, min_value=1, max_value=20)
-    monitorType = serializers.IntegerField(required=False, min_value=0)
-    activationCondition = serializers.IntegerField(required=False, allow_null=True, min_value=0)
+    monitorType = serializers.IntegerField(
+        required=False,
+        min_value=0,
+        help_text="Monitor type represents whether the alert rule is actively being monitored or is monitored given a specific activation condition.",
+    )
+    activationCondition = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        min_value=0,
+        help_text="Optional int that represents a trigger condition for when to start monitoring",
+    )
 
 
 @extend_schema(tags=["Alerts"])

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -387,6 +387,8 @@ Metric alert rule trigger actions follow the following structure:
         child=ProjectField(scope="project:read"), required=False
     )
     thresholdPeriod = serializers.IntegerField(required=False, default=1, min_value=1, max_value=20)
+    monitorType = serializers.IntegerField(required=False, min_value=0)
+    activationCondition = serializers.IntegerField(required=False, allow_null=True, min_value=0)
 
 
 @extend_schema(tags=["Alerts"])

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -93,6 +93,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         as_actor=True,
     )  # This will be set to required=True once the frontend starts sending it.
     monitor_type = serializers.IntegerField(required=False, min_value=0)
+    activation_condition = serializers.IntegerField(required=False, allow_null=True, min_value=0)
 
     class Meta:
         model = AlertRule

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -32,6 +32,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleThresholdType,
     AlertRuleTrigger,
 )
+from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
@@ -114,6 +115,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             "triggers",
             "event_types",
             "monitor_type",
+            "activation_condition",
         ]
         extra_kwargs = {
             "name": {"min_length": 1, "max_length": 256},
@@ -210,6 +212,18 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             raise serializers.ValidationError("Invalid monitor type")
 
         return AlertRuleMonitorType(monitor_type)
+
+    def validate_activation_condition(self, activation_condition):
+        if activation_condition is None:
+            return activation_condition
+
+        try:
+            return AlertRuleActivationConditionType(activation_condition)
+        except ValueError:
+            raise serializers.ValidationError(
+                "Invalid activation condition, valid values are %s"
+                % [item.value for item in AlertRuleActivationConditionType]
+            )
 
     def validate(self, data):
         """

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -17,12 +17,14 @@ from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.auth.access import OrganizationGlobalAccess
 from sentry.incidents.models.alert_rule import (
     AlertRule,
+    AlertRuleMonitorType,
     AlertRuleStatus,
     AlertRuleTrigger,
     AlertRuleTriggerAction,
 )
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.serializers import AlertRuleSerializer
+from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.integrations.slack.client import SlackClient
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
@@ -362,6 +364,39 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             resp.renderer_context["request"].META["REMOTE_ADDR"]
             == list(audit_log_entry)[0].ip_address
         )
+
+    def test_monitor_type_with_condition(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+
+        self.login_as(self.user)
+        alert_rule = self.alert_rule
+        serialized_alert_rule = self.get_serialized_alert_rule()
+        serialized_alert_rule["monitorType"] = AlertRuleMonitorType.ACTIVATED.value
+        serialized_alert_rule[
+            "activationCondition"
+        ] = AlertRuleActivationConditionType.RELEASE_CREATION.value
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:activated-alert-rules"]),
+        ):
+            resp = self.get_success_response(
+                self.organization.slug, alert_rule.id, **serialized_alert_rule
+            )
+        alert_rule = AlertRule.objects.get(id=resp.data["id"])
+        alert_rule.monitorType = AlertRuleMonitorType.ACTIVATED.value
+        alert_rule.activationCondition = AlertRuleActivationConditionType.RELEASE_CREATION.value
+        alert_rule.date_modified = resp.data["dateModified"]
+        assert resp.data == serialize(alert_rule)
+
+        # TODO: determine how to convert activated alert into continuous alert and vice versa (see logic.py)
+        # assert resp.data["monitorType"] == AlertRuleMonitorType.ACTIVATED.value
+        # assert (
+        #     resp.data["activationCondition"]
+        #     == AlertRuleActivationConditionType.RELEASE_CREATION.value
+        # )
+        assert resp.data["dateModified"] > serialized_alert_rule["dateModified"]
 
     def test_not_updated_fields(self):
         self.create_member(


### PR DESCRIPTION
enables us to send activation conditions along with POST/PUT updates to alert rules

NOTE: currently PUTs to modify the alert rule monitor type are disabled
We'll need to think about whether we even want to allow users to convert normal alert rules into activated ones and what that would require