### PR TITLE
feat(integrations): Send workflow notifications in slack thread

### DIFF
--- a/src/sentry/integrations/msteams/notifications.py
+++ b/src/sentry/integrations/msteams/notifications.py
@@ -113,7 +113,7 @@ def send_notification_as_msteams(
 
                         notification.record_notification_sent(recipient, ExternalProviders.MSTEAMS)
                     except Exception:
-                        logger.exception("Exception occured while trying to send the notification")
+                        logger.exception("Exception occurred while trying to send the notification")
 
     metrics.incr(
         f"{notification.metrics_key}.notifications.sent",

--- a/src/sentry/integrations/repository/issue_alert.py
+++ b/src/sentry/integrations/repository/issue_alert.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Generator
 from dataclasses import dataclass
 from logging import Logger, getLogger
+
+from django.db.models import Q
 
 from sentry.integrations.repository.base import (
     BaseNewNotificationMessage,
@@ -87,6 +90,15 @@ class IssueAlertNotificationMessageRepository:
     def default(cls) -> IssueAlertNotificationMessageRepository:
         return cls(logger=_default_logger)
 
+    @classmethod
+    def _parent_notification_message_base_filter(cls) -> Q:
+        """
+        Returns the query used to filter the notification messages for parent notification messages.
+        Parent notification messages are notification message instances without a parent notification message itself,
+        and where the error code is null.
+        """
+        return Q(parent_notification_message__isnull=True, error_code__isnull=True)
+
     def get_parent_notification_message(
         self, rule_id: int, group_id: int, rule_action_uuid: str
     ) -> IssueAlertNotificationMessage | None:
@@ -95,12 +107,11 @@ class IssueAlertNotificationMessageRepository:
         Will raise an exception if the query fails and logs the error with associated data.
         """
         try:
-            instance: NotificationMessage = self._model.objects.get(
+            base_filter = self._parent_notification_message_base_filter()
+            instance: NotificationMessage = self._model.objects.filter(base_filter).get(
                 rule_fire_history__rule__id=rule_id,
                 rule_fire_history__group__id=group_id,
                 rule_action_uuid=rule_action_uuid,
-                parent_notification_message__isnull=True,
-                error_code__isnull=True,
             )
             return IssueAlertNotificationMessage.from_model(instance=instance)
         except NotificationMessage.DoesNotExist:
@@ -140,3 +151,32 @@ class IssueAlertNotificationMessageRepository:
                 extra=data.__dict__,
             )
             raise
+
+    def get_all_parent_notification_messages_by_filters(
+        self, group_ids: list[int] | None = None, project_ids: list[int] | None = None
+    ) -> Generator[IssueAlertNotificationMessage, None, None]:
+        """
+        If no filters are passed, then all parent notification objects are returned.
+        Because all parent notification objects can be returned, this method leverages generator to control the usage of
+        memory in the application.
+        It is up to the caller to iterate over all the data, or store in memory if they need all objects concurrently.
+        """
+        try:
+            group_id_filter = Q(rule_fire_history__group__id__in=group_ids) if group_ids else Q()
+            project_id_filter = (
+                Q(rule_fire_history__project_id__in=project_ids) if project_ids else Q()
+            )
+
+            query = self._model.objects.filter(group_id_filter & project_id_filter).filter(
+                self._parent_notification_message_base_filter()
+            )
+        except Exception as e:
+            self._logger.exception(
+                "Failed to get parent notifications on filters",
+                exc_info=e,
+                extra=filter.__dict__,
+            )
+            raise
+
+        for instance in query:
+            yield IssueAlertNotificationMessage.from_model(instance=instance)

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from logging import Logger, getLogger
+
+from sentry.integrations.repository import get_default_issue_alert_repository
+from sentry.integrations.repository.issue_alert import (
+    IssueAlertNotificationMessage,
+    IssueAlertNotificationMessageRepository,
+)
+from sentry.integrations.slack import BlockSlackMessageBuilder, SlackClient
+from sentry.models.activity import Activity
+from sentry.models.organization import OrganizationStatus
+from sentry.models.rule import Rule
+from sentry.notifications.notifications.activity import EMAIL_CLASSES_BY_TYPE
+from sentry.services.hybrid_cloud.integration import integration_service
+
+_default_logger = getLogger(__name__)
+
+
+class SlackService:
+    def __init__(
+        self,
+        notification_message_repository: IssueAlertNotificationMessageRepository,
+        message_block_builder: BlockSlackMessageBuilder,
+        logger: Logger,
+    ) -> None:
+        self._notification_message_repository = notification_message_repository
+        self._slack_block_builder = message_block_builder
+        self._logger = logger
+
+    @classmethod
+    def default(cls) -> SlackService:
+        return SlackService(
+            notification_message_repository=get_default_issue_alert_repository(),
+            message_block_builder=BlockSlackMessageBuilder(),
+            logger=_default_logger,
+        )
+
+    def notify_all_threads_for_activity(self, activity: Activity) -> None:
+        """
+        For an activity related to an issue group, send notifications in a Slack thread to all parent notifications for
+        that specific group and project.
+
+        If the group is not associated with an activity, return early as there's nothing to do.
+        """
+        if activity.group is None:
+            self._logger.info(
+                "no group associated on the activity, nothing to do",
+                extra={
+                    "activity_id": activity.id,
+                },
+            )
+            return None
+
+        # The same message is sent to all the threads, so this needs to only happen once
+        notification_to_send = self._get_notification_message_to_send(activity=activity)
+        if not notification_to_send:
+            self._logger.info(
+                "notification to send is invalid",
+                extra={
+                    "activity_id": activity.id,
+                },
+            )
+            return None
+
+        try:
+            integration = integration_service.get_integration(
+                organization_id=activity.project.organization_id,
+                status=OrganizationStatus.ACTIVE,
+                provider="slack",
+            )
+        except Exception as err:
+            self._logger.info(
+                "error getting integration",
+                exc_info=err,
+                extra={
+                    "activity_id": activity.id,
+                },
+            )
+            return None
+
+        if integration is None:
+            self._logger.info(
+                "no integration found for activity",
+                extra={
+                    "activity_id": activity.id,
+                    "organization_id": activity.project.organization_id,
+                    "project_id": activity.project.id,
+                },
+            )
+
+        slack_client = SlackClient(integration_id=integration.id)
+
+        # Get all parent notifications, which will have the message identifier to use to reply in a thread
+        parent_notifications = (
+            self._notification_message_repository.get_all_parent_notification_messages_by_filters(
+                group_ids=[activity.group.id],
+                project_ids=[activity.project.id],
+            )
+        )
+        for parent_notification in parent_notifications:
+            try:
+                self._handle_parent_notification(
+                    parent_notification=parent_notification,
+                    notification_to_send=notification_to_send,
+                    client=slack_client,
+                )
+            except Exception as err:
+                self._logger.info(
+                    "failed to send notification",
+                    exc_info=err,
+                    extra={
+                        "activity_id": activity.id,
+                        "parent_notification_id": parent_notification.id,
+                        "notification_to_send": notification_to_send,
+                        "integration_id": integration.id,
+                    },
+                )
+
+    def _handle_parent_notification(
+        self,
+        parent_notification: IssueAlertNotificationMessage,
+        notification_to_send: str,
+        client: SlackClient,
+    ) -> None:
+        # For each parent notification, we need to get the channel that the notification is replied to
+        # Get the channel by using the action uuid
+        rule: Rule = parent_notification.rule_fire_history.rule
+        rule_action = rule.get_rule_action_details_by_uuid(parent_notification.rule_action_uuid)
+        if not rule_action:
+            raise Exception(
+                f"failed to find rule action {parent_notification.rule_action_uuid} for rule {rule.id}"
+            )
+
+        channel_id: str | None = rule_action.get("channel_id", None)
+        if not channel_id:
+            raise Exception(
+                f"failed to get channel_id for rule {rule.id} and rule action {parent_notification.rule_action_uuid}"
+            )
+
+        block = self._slack_block_builder.get_markdown_block(text=notification_to_send)
+        payload = {"channel": channel_id, "thread_ts": parent_notification.message_identifier}
+        slack_payload = self._slack_block_builder._build_blocks(
+            block, fallback_text=notification_to_send
+        )
+        payload.update(slack_payload)
+        client.post("/chat.postMessage", data=payload, timeout=5)
+
+    def _get_notification_message_to_send(self, activity: Activity) -> str | None:
+        """
+        Get the notification message that we need to send in a slack thread based on the activity type.
+
+        Apparently the get_context is a very computation heavy call, so make sure to only call this once.
+        """
+        notification_cls = EMAIL_CLASSES_BY_TYPE.get(activity.type, None)
+        if not notification_cls:
+            self._logger.info(
+                "activity type is not currently supported",
+                extra={
+                    "activity_id": activity.id,
+                    "activity_type": activity.type,
+                },
+            )
+            return None
+
+        notification_obj = notification_cls(activity=activity)
+        context = notification_obj.get_context()
+        text_template = context.get("text_template", None)
+        if not text_template:
+            self._logger.info(
+                "context did not contain text_template",
+                extra={
+                    "activity_id": activity.id,
+                    "notification_type": activity.type,
+                    "notification_cls": notification_cls.__name__,
+                    "context": context,
+                },
+            )
+            return None
+
+        return text_template

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -42,6 +42,7 @@ class SlackService:
         that specific group and project.
 
         If the group is not associated with an activity, return early as there's nothing to do.
+        If the user is not associated with an activity, return early as we only care about user activities.
         """
         if activity.group is None:
             self._logger.info(

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -52,6 +52,15 @@ class SlackService:
             )
             return None
 
+        if activity.user_id is None:
+            self._logger.info(
+                "machine/system updates are ignored at this time, nothing to do",
+                extra={
+                    "activity_id": activity.id,
+                },
+            )
+            return None
+
         # The same message is sent to all the threads, so this needs to only happen once
         notification_to_send = self._get_notification_message_to_send(activity=activity)
         if not notification_to_send:

--- a/src/sentry/models/rule.py
+++ b/src/sentry/models/rule.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from enum import Enum, IntEnum
-from typing import ClassVar, Self
+from typing import Any, ClassVar, Self
 
 from django.db import models
 from django.utils import timezone
@@ -109,6 +109,22 @@ class Rule(Model):
             "status": self.status,
             "environment": self.environment_id,
         }
+
+    def get_rule_action_details_by_uuid(self, rule_action_uuid: str) -> dict[str, Any] | None:
+        actions = self.data.get("actions", None)
+        if not actions:
+            return None
+
+        for action in actions:
+            action_uuid = action.get("uuid", None)
+            if action_uuid is None:
+                # This should not happen, but because the data object is a dictionary, it's better to be safe
+                continue
+
+            if action_uuid == rule_action_uuid:
+                return action
+
+        return None
 
 
 class RuleActivityType(Enum):

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -1,5 +1,7 @@
 import logging
 
+from sentry import features
+from sentry.integrations.slack.service import SlackService
 from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils.safe import safe_execute
@@ -46,3 +48,7 @@ def send_activity_notifications(activity_id):
 
     for notifier in get_activity_notifiers(activity.project):
         notifier.notify_about_activity(activity)
+
+    if features.has("organizations:slack-thread-issue-alert", organization):
+        slack_service = SlackService.default()
+        slack_service.notify_all_threads_for_activity(activity=activity)

--- a/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
+++ b/tests/sentry/integrations/repository/issue_alert/test_issue_alert_notification_message_repository.py
@@ -10,24 +10,29 @@ from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.testutils.cases import TestCase
 
 
-class TestGetParentNotificationMessage(TestCase):
+class BaseIssueAlertNotificationMessageRepositoryTest(TestCase):
     def setUp(self) -> None:
         self.action_uuid = str(uuid4())
+        self.notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": self.action_uuid,
+            }
+        ]
         self.rule = self.create_project_rule(
-            project=self.project,
-            action_match=[
-                {
-                    "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
-                    "service": "mail",
-                    "name": "Send a notification via mail",
-                    "uuid": self.action_uuid,
-                },
-            ],
+            project=self.project, action_match=self.notify_issue_owners_action
         )
+        self.event_id = 456
+        self.notification_uuid = str(uuid4())
         self.rule_fire_history = RuleFireHistory.objects.create(
             project=self.project,
             rule=self.rule,
             group=self.group,
+            event_id=self.event_id,
+            notification_uuid=self.notification_uuid,
         )
         self.parent_notification_message = NotificationMessage.objects.create(
             rule_fire_history=self.rule_fire_history,
@@ -36,6 +41,8 @@ class TestGetParentNotificationMessage(TestCase):
         )
         self.repository = IssueAlertNotificationMessageRepository.default()
 
+
+class TestGetParentNotificationMessage(BaseIssueAlertNotificationMessageRepositoryTest):
     def test_returns_parent_notification_message(self) -> None:
         instance = self.repository.get_parent_notification_message(
             rule_id=self.rule.id,
@@ -79,37 +86,12 @@ class TestGetParentNotificationMessage(TestCase):
         )
 
 
-class TestCreateNotificationMessage(TestCase):
-    def setUp(self):
-        self.action_uuid = str(uuid4())
-        self.notify_issue_owners_action = [
-            {
-                "targetType": "IssueOwners",
-                "fallthroughType": "ActiveMembers",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "",
-                "uuid": self.action_uuid,
-            }
-        ]
-        self.rule = self.create_project_rule(
-            project=self.project, action_match=self.notify_issue_owners_action
-        )
-        self.event_id = 456
-        self.notification_uuid = str(uuid4())
-        self.rule_fire_history = RuleFireHistory.objects.create(
-            project=self.project,
-            rule=self.rule,
-            group=self.group,
-            event_id=self.event_id,
-            notification_uuid=self.notification_uuid,
-        )
-        self.repository = IssueAlertNotificationMessageRepository.default()
-
+class TestCreateNotificationMessage(BaseIssueAlertNotificationMessageRepositoryTest):
     def test_simple(self) -> None:
         message_identifier = "1a2b3c"
         data = NewIssueAlertNotificationMessage(
             rule_fire_history_id=self.rule_fire_history.id,
-            rule_action_uuid=self.action_uuid,
+            rule_action_uuid=str(uuid4()),
             message_identifier=message_identifier,
         )
 
@@ -128,7 +110,7 @@ class TestCreateNotificationMessage(TestCase):
         }
         data = NewIssueAlertNotificationMessage(
             rule_fire_history_id=self.rule_fire_history.id,
-            rule_action_uuid=self.action_uuid,
+            rule_action_uuid=str(uuid4()),
             error_code=405,
             error_details=error_detail,
         )
@@ -136,3 +118,90 @@ class TestCreateNotificationMessage(TestCase):
         result = self.repository.create_notification_message(data=data)
         assert result is not None
         assert result.error_details == error_detail
+
+
+class TestGetAllParentNotificationMessagesByFilters(
+    BaseIssueAlertNotificationMessageRepositoryTest
+):
+    def test_returns_all_when_no_filters(self) -> None:
+        # Create additional notification messages
+        additional_notification = NotificationMessage.objects.create(
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=str(uuid4()),
+            message_identifier="123abc",
+        )
+
+        # Call the method without any filters
+        parent_notifications = list(
+            self.repository.get_all_parent_notification_messages_by_filters()
+        )
+
+        result_ids = []
+        for parent_notification in parent_notifications:
+            result_ids.append(parent_notification.id)
+        # Check if all notification messages are returned
+        assert len(result_ids) == 2
+        assert additional_notification.id in result_ids
+        assert self.parent_notification_message.id in result_ids
+
+    def test_returns_filtered_messages_for_project_id(self) -> None:
+        # Create some notification message that should not be returned
+        new_project = self.create_project()
+        additional_rule_fire_history = RuleFireHistory.objects.create(
+            project=new_project,
+            rule=self.rule,
+            group=self.group,
+            event_id=self.event_id,
+            notification_uuid=str(uuid4()),
+        )
+        notification_message_that_should_not_be_returned = NotificationMessage.objects.create(
+            rule_fire_history=additional_rule_fire_history,
+            rule_action_uuid=str(uuid4()),
+            message_identifier="zxcvb",
+        )
+
+        # Call the method with filters specifying the specific project id
+        parent_notifications = list(
+            self.repository.get_all_parent_notification_messages_by_filters(
+                project_ids=[self.project.id]
+            )
+        )
+
+        result_ids = []
+        for parent_notification in parent_notifications:
+            result_ids.append(parent_notification.id)
+        # Check if only the notifications related to the specified project
+        assert len(result_ids) == 1
+        assert result_ids[0] == self.parent_notification_message.id
+        assert notification_message_that_should_not_be_returned.id not in result_ids
+
+    def test_returns_filtered_messages_for_group_id(self) -> None:
+        # Create some notification message that should not be returned
+        new_group = self.create_group(project=self.project)
+        additional_rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.rule,
+            group=new_group,
+            event_id=self.event_id,
+            notification_uuid=str(uuid4()),
+        )
+        notification_message_that_should_not_be_returned = NotificationMessage.objects.create(
+            rule_fire_history=additional_rule_fire_history,
+            rule_action_uuid=str(uuid4()),
+            message_identifier="zxcvb",
+        )
+
+        # Call the method with filters specifying the specific project id
+        parent_notifications = list(
+            self.repository.get_all_parent_notification_messages_by_filters(
+                group_ids=[self.group.id]
+            )
+        )
+
+        result_ids = []
+        for parent_notification in parent_notifications:
+            result_ids.append(parent_notification.id)
+        # Check if only the notifications related to the specified project
+        assert len(result_ids) == 1
+        assert result_ids[0] == self.parent_notification_message.id
+        assert notification_message_that_should_not_be_returned.id not in result_ids

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -1,0 +1,11 @@
+from sentry.integrations.slack.service import SlackService
+from sentry.testutils.cases import TestCase
+
+
+class TestGetNotificationMessageToSend(TestCase):
+    def setUp(self) -> None:
+        self.service = SlackService.default()
+
+    def test_ignores_bad_activity(self) -> None:
+        result = self.service._get_notification_message_to_send(activity=self.activity)
+        assert result is None


### PR DESCRIPTION
Workflow notifications should be sent in slack threads for all updates that a user has done. Ignore all machine invoked updates. Workflow notifications are those which are highlighted in our docs: https://docs.sentry.io/product/alerts/notifications/#workflow-notifications.

We are hooking into an existing pipeline which fires when an activity model is created and notifications are sent. Based on the activity for an issue group, we find all the threads we should send a notification in a thread, and try to send it.

Resolves: https://github.com/getsentry/team-core-product-foundations/issues/188#issue-2192978404
