### PR TITLE
fix(code-mappings): Wrap root derivation logic in try-except 

### DIFF
--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -8,6 +8,7 @@ from sentry.integrations.utils.code_mapping import (
     FrameFilename,
     Repo,
     RepoTree,
+    UnexpectedPathException,
     UnsupportedFrameFilename,
     convert_stacktrace_frame_path_to_source_path,
     filter_source_code_files,
@@ -315,6 +316,14 @@ class TestDerivedCodeMappings(TestCase):
         stacktrace_root, source_path = find_roots("app:///../services/", "services/")
         assert stacktrace_root == "app:///../"
         assert source_path == ""
+
+    def test_find_roots_bad_stack_path(self):
+        with pytest.raises(UnexpectedPathException):
+            find_roots("https://yrurlsinyourstackpath.com/", "sentry/something.py")
+
+    def test_find_roots_bad_source_path(self):
+        with pytest.raises(UnexpectedPathException):
+            find_roots("sentry/random.py", "nothing/something.js")
 
 
 class TestConvertStacktraceFramePathToSourcePath(TestCase):


### PR DESCRIPTION
Wraps calls to `find_roots` in a try except. Also adds root validation logic to manual code mappings (which exists for automatic code mappings already). 

Users send us garbage in the `file_name` all the time, we are inevitably going to run into situations where a root derivation fails. We should not throw an Exception here, and should instead just log what happens and move on. 

This will resolve SENTRY-34KF