### PR TITLE
ref(daily summary): Remove 'internal only' text

### DIFF
--- a/src/sentry/notifications/notifications/daily_summary.py
+++ b/src/sentry/notifications/notifications/daily_summary.py
@@ -55,9 +55,7 @@ class DailySummaryNotification(BaseNotification):
         return ""
 
     def get_message_description(self, recipient: RpcActor, provider: ExternalProviders) -> Any:
-        return (
-            f"Daily Summary for Your {self.organization.slug.title()} Projects (internal only!!!)"
-        )
+        return f"Daily Summary for Your {self.organization.slug.title()} Projects"
 
     def get_title_link(self, recipient: RpcActor, provider: ExternalProviders) -> str | None:
         return None

--- a/tests/sentry/tasks/test_daily_summary.py
+++ b/tests/sentry/tasks/test_daily_summary.py
@@ -644,10 +644,7 @@ class DailySummaryTest(
             ).send()
         blocks, fallback_text = get_blocks_and_fallback_text()
         link_text = "http://testserver/organizations/baz/issues/{}/?referrer=daily_summary-slack"
-        assert (
-            fallback_text
-            == f"Daily Summary for Your {self.organization.slug.title()} Projects (internal only!!!)"
-        )
+        assert fallback_text == f"Daily Summary for Your {self.organization.slug.title()} Projects"
         assert f":bell: *{fallback_text}*" in blocks[0]["text"]["text"]
         assert (
             "Your comprehensive overview for today - key issues, performance insights, and more."
@@ -720,10 +717,7 @@ class DailySummaryTest(
             "yAxis": "count()",
         }
         query_string = urlencode(query_params, doseq=True)
-        assert (
-            fallback_text
-            == f"Daily Summary for Your {self.organization.slug.title()} Projects (internal only!!!)"
-        )
+        assert fallback_text == f"Daily Summary for Your {self.organization.slug.title()} Projects"
         assert f":bell: *{fallback_text}*" in blocks[0]["text"]["text"]
         assert (
             "Your comprehensive overview for today - key issues, performance insights, and more."


### PR DESCRIPTION
We want to release this to some select customers to get feedback, so remove the text about it being internal only. 