### PR TITLE
style(replay): fix widget bottom border corners

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -279,6 +279,7 @@ const StyledButton = styled(LinkButton)`
   border-left: none;
   border-right: none;
   font-size: ${p => p.theme.fontSizeMedium};
+  background-color: transparent;
 `;
 
 const StyledAccordionHeader = styled('div')`


### PR DESCRIPTION
the widget bottom corners were being covered up by the "see all selectors" button:

<img width="765" alt="SCR-20240402-ogkr" src="https://github.com/getsentry/sentry/assets/56095982/548d9381-1d27-4201-bd7f-e780b3fe443c">

setting the button `background-color: transparent` fixes this:

<img width="672" alt="SCR-20240402-oglz" src="https://github.com/getsentry/sentry/assets/56095982/fefcab0b-4dbf-4162-8778-db37a9966be0">
