### PR TITLE
feat(feedback): feedback email type

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -31,7 +31,11 @@ class GroupCategory(Enum):
     FEEDBACK = 6
 
 
-GROUP_CATEGORIES_CUSTOM_EMAIL = (GroupCategory.ERROR, GroupCategory.PERFORMANCE)
+GROUP_CATEGORIES_CUSTOM_EMAIL = (
+    GroupCategory.ERROR,
+    GroupCategory.PERFORMANCE,
+    GroupCategory.FEEDBACK,
+)
 # GroupCategories which have customized email templates. If not included here, will fall back to a generic template.
 
 DEFAULT_IGNORE_LIMIT: int = 3

--- a/src/sentry/templates/sentry/emails/feedback.html
+++ b/src/sentry/templates/sentry/emails/feedback.html
@@ -228,7 +228,7 @@
 
     {# support for gmail actions #}
     <div itemscope itemtype="http://schema.org/EmailMessage">
-      <meta itemprop="description" content="View Issue Details in Sentry"/>
+      <meta itemprop="description" content="View Feedback Details in Sentry"/>
       <div itemprop="action" itemscope itemtype="http://schema.org/ViewAction">
         <link itemprop="url" href="{{ link }}"/>
         <meta itemprop="name" content="View in Sentry"/>

--- a/src/sentry/templates/sentry/emails/feedback.html
+++ b/src/sentry/templates/sentry/emails/feedback.html
@@ -74,8 +74,8 @@
           {% endif %}
       </div>
 
-      <div class="notice">Details about this issue are not shown in this notification since enhanced privacy
-        controls are enabled. For more details about this issue, <a href="{{ link }}">view this issue on Sentry</a>.</div>
+      <div class="notice">Details about this feedback are not shown in this notification since enhanced privacy
+        controls are enabled. For more details about this feedback, <a href="{{ link }}">view this issue on Sentry</a>.</div>
     {% else %}
       <table class="event-list">
         <tr>

--- a/src/sentry/templates/sentry/emails/feedback.html
+++ b/src/sentry/templates/sentry/emails/feedback.html
@@ -1,0 +1,243 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load timezone from tz %}
+{% load sentry_avatars %}
+{% load sentry_helpers %}
+{% load sentry_features %}
+{% load sentry_assets %}
+{% load i18n static %}
+
+{% block head %}
+  {{ block.super }}
+  <style type="text/css" inline="false">
+    @media only screen and (max-device-width: 480px) {
+      /* Hide CTA in header on mobile */
+      .header-buttons .integration-link {
+        display: none !important;
+      }
+      .banner {
+        display: none !important;
+      }
+    }
+    @media only screen and (max-device-width: 768px) {
+      .text-desktop-only {
+        display: none !important;
+      }
+    }
+  </style>
+{% endblock %}
+
+{% block preheader %}
+  {{ group_header }} from {{ project_label }}.
+{% endblock %}
+
+{% block header %}
+  <div class="header-with-buttons">
+    {{ block.super }}
+    <div class="header-buttons">
+      {% if not has_alert_integration %}
+        <a href="{{ slack_link }}" class="btn btn-default integration-link">
+          <img src="{% absolute_asset_url 'sentry' 'images/email/slack-logo.png' %}" class="logo-small" />
+          Set up in Slack
+        </a>
+      {% endif %}
+      <a href="{{ link }}" class="btn view-on-sentry">View on Sentry</a>
+    </div>
+  </div>
+{% endblock %}
+
+{% block content %}
+
+<div class="container">
+  <div class="inner">
+    <h2 {% if notification_reason %}style="margin-bottom: 4px"{% else %}style="margin-bottom: 15px"{% endif %}>
+        {% if has_issue_states and group_header %}
+        {{ group_header }}
+        {% else %}
+        New Feedback from <a href="{{group.project.get_absolute_url}}">{{ project_label }}</a>
+        {% if environment %} in {{ environment }}{% endif %}
+        {% endif %}
+    </h2>
+    {% if notification_reason %}
+      <div class="event-notification-reason">
+        {{ notification_reason }}
+      </div>
+    {% endif %}
+
+    {% if enhanced_privacy %}
+      <div class="event">
+        <div class="event-id">ID: {{ event.event_id }}</div>
+          {% if timezone %}
+            <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
+          {% else %}
+            <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
+          {% endif %}
+      </div>
+
+      <div class="notice">Details about this issue are not shown in this notification since enhanced privacy
+        controls are enabled. For more details about this issue, <a href="{{ link }}">view this issue on Sentry</a>.</div>
+    {% else %}
+      <table class="event-list">
+        <tr>
+            <th colspan="2">User Feedback</th>
+        </tr>
+        <tr>
+          <td class="event-detail">
+            <div class="issue">
+              {% with type=event.get_event_type metadata=group.get_event_metadata transaction=event.transaction %}
+                  <div class="event-type default">
+                    <h3>
+                      {% if issue_title %}
+                      <a href="{% absolute_uri link %}">{{ issue_title|truncatechars:40 }}</a>
+                      {% else %}
+                      <a href="{% absolute_uri link %}">{{ event.title|truncatechars:40 }}</a>
+                      {% endif %}
+                      {% if     culprit %}
+                        <span class="event-subtitle">{{ culprit }}</span>
+                      {% elif transaction %}
+                        <span class="event-subtitle">{{ transaction }}</span>
+                      {% endif %}
+                      <br />
+                      <br />
+                      {% if metadata.name and metadata.contact_email %}
+                      <p><strong>{{ metadata.name }}</strong> {{ metadata.contact_email }}</p>
+                      {% elif metadata.name %}
+                      <p><strong>{{ metadata.name }}</strong></p>
+                      {% elif metadata.contact_email %}
+                      <p>{{ metadata.contact_email }}</p>
+                      {% endif %}
+                      <br />
+                      <div class="event">
+                        <div class="event-id">ID: {{ event.event_id }}</div>
+                        {% if timezone %}
+                            <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
+                        {% else %}
+                            <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
+                        {% endif %}
+                      </div>
+                      {% if subtitle %}
+                      <h3>Message</h3>
+                        <div class="inner"><div class="note-body"><p>{{ subtitle }}</p></div></div>
+                      {% endif %}
+                    </h3>
+                  </div>
+              {% endwith %}
+            </div>
+          </td>
+        </tr>
+      </table>
+
+
+      {% if has_issue_states %}
+      <div class="interface">
+        <table>
+          <colgroup>
+            <col style="width:130px;">
+          </colgroup>
+          <tbody>
+            <tr>
+              <th>project</th>
+              <td><a href="{{group.project.get_absolute_url}}">{{ project_label }}</a></td>
+            </tr>
+            {% if environment %}
+              <tr>
+                <th>environment</th>
+                <td>{{ environment }}</td>
+              </tr>
+            {% endif %}
+            <tr>
+              <th>level</th>
+              <td>{{ group.get_level_display }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+
+
+      {% block table %}{% endblock %}
+
+      {% if issue_replays_url %}
+      <div class="interface">
+        <h3 class="title">Session Replay</h3>
+        <table>
+          <colgroup>
+            <col style="width:130px;">
+          </colgroup>
+          <tbody>
+            <tr>
+              <th>Session Replay:</th>
+              <td>
+                <a href="{{ issue_replays_url }}">
+                  <img src="{% absolute_asset_url 'sentry' 'images/email/icon-play.png' %}" width="12px" height="12px"
+                    alt="Session Replay">
+                  See a replay of this issue
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+
+
+      {% block stacktrace %}{% endblock %}
+
+      {% if tags %}
+        <h3>Tags</h3>
+
+        <ul class="tag-list">
+        {% for tag_key, tag_value in tags %}
+          <li>
+              <strong>{{ tag_key|as_tag_alias }}</strong>
+              <em>=</em>
+              <span>
+              {% with query=tag_key|as_tag_alias|add:":\""|add:tag_value|add:"\""|urlencode %}
+                <a href="{% absolute_uri '/organizations/{}/issues/' group.project.organization.slug %}?project={{ group.project.id }}&query={{ query }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
+              {% endwith %}
+              </span>
+          </li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endif %}
+
+    <p class="info-box">
+      {% if snooze_alert %}
+         <a class='mute' href="{% absolute_uri snooze_alert_url %}">Mute this alert</a>
+      {% endif %}
+      This email was triggered by
+      {% for rule in rules %}
+          <a href="{% absolute_uri rule.status_url %}">{{ rule.label }}</a>{% if not forloop.last %}, {% endif %}
+      {% endfor %}
+  </p>
+
+    {% if not has_integrations %}
+        <div class="logo-container">
+            <img src="{% static 'sentry/images/logos/logo-slack.svg' %}" class="logo" alt="Slack"/>
+            <img src="{% static 'sentry/images/logos/logo-pagerduty.svg' %}" class="logo" alt="PagerDuty"/>
+            <img src="{% static 'sentry/images/logos/logo-msteams.svg' %}" class="logo" alt="MS Teams"/>
+            <img src="{% static 'sentry/images/logos/logo-opsgenie.svg' %}" class="logo" alt="OpsGenie"/>
+            <img src="{% static 'sentry/images/logos/logo-twilio.svg' %}" class="logo" alt="Twilio"/>
+            <img src="{% static 'sentry/images/logos/logo-victorops.svg' %}" class="logo" alt="VictorOps"/>
+        </div>
+        <p class="align-center">
+            <a href="{% absolute_uri 'settings/{}/integrations/?referrer=alert_email' group.project.organization.slug %}">{{ "Get this alert wherever you work" }}</a>
+        </p>
+    {% endif %}
+
+    {# support for gmail actions #}
+    <div itemscope itemtype="http://schema.org/EmailMessage">
+      <meta itemprop="description" content="View Issue Details in Sentry"/>
+      <div itemprop="action" itemscope itemtype="http://schema.org/ViewAction">
+        <link itemprop="url" href="{{ link }}"/>
+        <meta itemprop="name" content="View in Sentry"/>
+      </div>
+      <div itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+        <meta itemprop="name" content="GetSentry"/>
+        <link itemprop="url" href="https://sentry.io/"/>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/feedback.html
+++ b/src/sentry/templates/sentry/emails/feedback.html
@@ -75,7 +75,7 @@
       </div>
 
       <div class="notice">Details about this feedback are not shown in this notification since enhanced privacy
-        controls are enabled. For more details about this feedback, <a href="{{ link }}">view this issue on Sentry</a>.</div>
+        controls are enabled. For more details about this feedback, <a href="{{ link }}">view this feedback on Sentry</a>.</div>
     {% else %}
       <table class="event-list">
         <tr>

--- a/src/sentry/templates/sentry/emails/feedback.html
+++ b/src/sentry/templates/sentry/emails/feedback.html
@@ -100,11 +100,11 @@
                       <br />
                       <br />
                       {% if metadata.name and metadata.contact_email %}
-                      <p><strong>{{ metadata.name }}</strong> {{ metadata.contact_email }}</p>
+                      <p><strong>{{ metadata.name }}</strong> <a href="mailto:{{ metadata.contact_email }}">{{ metadata.contact_email }}</a></p>
                       {% elif metadata.name %}
                       <p><strong>{{ metadata.name }}</strong></p>
                       {% elif metadata.contact_email %}
-                      <p>{{ metadata.contact_email }}</p>
+                      <p><a href="mailto:{{ metadata.contact_email }}">{{ metadata.contact_email }}</a></p>
                       {% endif %}
                       <br />
                       <div class="event">

--- a/src/sentry/templates/sentry/emails/feedback.html
+++ b/src/sentry/templates/sentry/emails/feedback.html
@@ -171,7 +171,7 @@
                 <a href="{{ issue_replays_url }}">
                   <img src="{% absolute_asset_url 'sentry' 'images/email/icon-play.png' %}" width="12px" height="12px"
                     alt="Session Replay">
-                  See a replay of this issue
+                  See a replay of this feedback
                 </a>
               </td>
             </tr>

--- a/src/sentry/templates/sentry/feedback.txt
+++ b/src/sentry/templates/sentry/feedback.txt
@@ -1,0 +1,41 @@
+{% spaceless %}
+{% autoescape off %}
+{% if enhanced_privacy %}
+Details about this issue are not shown in this notification since enhanced
+privacy controls are enabled. For more details about this issue, view this
+issue on Sentry.
+Details
+-------
+
+{{ link }}
+{% else %}
+Details
+-------
+
+{{ link }}
+
+
+{% if generic_issue_data %}
+Issue Data
+----------
+{% for label, html, _ in generic_issue_data %}
+    {{ label }}  {{ html }}
+{% endfor %}{% endif %}
+
+Tags
+----
+{% for tag_key, tag_value in tags %}
+* {{ tag_key }} = {{ tag_value }}{% endfor %}
+
+{% if interfaces %}{% for label, _, text in interfaces %}
+{{ label }}
+-----------
+
+{{ text }}
+
+{% endfor %}
+{% endif %}{% endif %}
+
+Unsubscribe: {{ unsubscribe_link }}
+{% endautoescape %}
+{% endspaceless %}

--- a/src/sentry/templates/sentry/feedback.txt
+++ b/src/sentry/templates/sentry/feedback.txt
@@ -1,8 +1,8 @@
 {% spaceless %}
 {% autoescape off %}
 {% if enhanced_privacy %}
-Details about this issue are not shown in this notification since enhanced
-privacy controls are enabled. For more details about this issue, view this
+Details about this feedback are not shown in this notification since enhanced
+privacy controls are enabled. For more details about this feedback, view this
 issue on Sentry.
 Details
 -------

--- a/src/sentry/templates/sentry/feedback.txt
+++ b/src/sentry/templates/sentry/feedback.txt
@@ -16,7 +16,7 @@ Details
 
 
 {% if generic_issue_data %}
-Issue Data
+User Feedback
 ----------
 {% for label, html, _ in generic_issue_data %}
     {{ label }}  {{ html }}

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from sentry.issues.grouptype import (
+    FeedbackGroup,
     PerformanceNPlusOneAPICallsGroupType,
     PerformanceNPlusOneGroupType,
     PerformanceRenderBlockingAssetSpanGroupType,
@@ -118,6 +119,33 @@ TEST_ISSUE_OCCURRENCE = IssueOccurrence(
     datetime.now(UTC),
     "info",
     "/api/123/",
+)
+TEST_FEEDBACK_ISSUE_OCCURENCE = IssueOccurrence(
+    id=uuid.uuid4().hex,
+    project_id=1,
+    event_id=uuid.uuid4().hex,
+    fingerprint=["c" * 32],
+    issue_title="User Feedback",
+    subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel aliquam velit, nec condimentum mi. Maecenas accumsan, nunc ac venenatis hendrerit, mi libero facilisis nunc, fringilla molestie dui est vulputate diam. Duis ac justo euismod, sagittis est at, bibendum purus. Praesent nec tortor vel ante accumsan lobortis. Morbi mollis augue nec dolor feugiat congue. Nullam eget blandit nisi. Sed in arcu odio. Aenean malesuada tortor quis felis dapibus congue.d",
+    culprit="api/123",
+    resource_id="1234",
+    evidence_data={
+        "contact_email": "test@test.com",
+        "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel aliquam velit, nec condimentum mi. Maecenas accumsan, nunc ac venenatis hendrerit, mi libero facilisis nunc, fringilla molestie dui est vulputate diam. Duis ac justo euismod, sagittis est at, bibendum purus. Praesent nec tortor vel ante accumsan lobortis. Morbi mollis augue nec dolor feugiat congue. Nullam eget blandit nisi. Sed in arcu odio. Aenean malesuada tortor quis felis dapibus congue.",
+        "name": "Test Name",
+    },
+    evidence_display=[
+        IssueEvidence("contact_email", "test@test.com", False),
+        IssueEvidence(
+            "message",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel aliquam velit, nec condimentum mi. Maecenas accumsan, nunc ac venenatis hendrerit, mi libero facilisis nunc, fringilla molestie dui est vulputate diam. Duis ac justo euismod, sagittis est at, bibendum purus. Praesent nec tortor vel ante accumsan lobortis. Morbi mollis augue nec dolor feugiat congue. Nullam eget blandit nisi. Sed in arcu odio. Aenean malesuada tortor quis felis dapibus congue.",
+            True,
+        ),
+        IssueEvidence("name", "Test Name", False),
+    ],
+    type=FeedbackGroup,
+    detection_time=datetime.now(UTC),
+    level="info",
 )
 TEST_PERF_ISSUE_OCCURRENCE = IssueOccurrence(
     uuid.uuid4().hex,

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -17,6 +17,7 @@ from sentry.web.frontend.debug.debug_cron_broken_monitor_email import (
 )
 from sentry.web.frontend.debug.debug_cron_muted_monitor_email import DebugCronMutedMonitorEmailView
 from sentry.web.frontend.debug.debug_error_embed import DebugErrorPageEmbedView
+from sentry.web.frontend.debug.debug_feedback_issue import DebugFeedbackIssueEmailView
 from sentry.web.frontend.debug.debug_generic_issue import DebugGenericIssueEmailView
 from sentry.web.frontend.debug.debug_incident_activity_email import DebugIncidentActivityEmailView
 from sentry.web.frontend.debug.debug_incident_trigger_email import DebugIncidentTriggerEmailView
@@ -83,6 +84,7 @@ from sentry.web.frontend.debug.debug_weekly_report import DebugWeeklyReportView
 
 urlpatterns = [
     re_path(r"^debug/mail/error-alert/$", sentry.web.frontend.debug.mail.alert),
+    re_path(r"^debug/mail/feedback-alert/$", DebugFeedbackIssueEmailView.as_view()),
     re_path(
         r"^debug/mail/performance-alert/(?P<sample_name>[^\/]+)?/$",
         DebugPerformanceIssueEmailView.as_view(),

--- a/src/sentry/web/frontend/debug/debug_feedback_issue.py
+++ b/src/sentry/web/frontend/debug/debug_feedback_issue.py
@@ -1,4 +1,4 @@
-import pytz
+from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.views.generic import View
 
@@ -31,7 +31,7 @@ class DebugFeedbackIssueEmailView(View):
                 "rules": get_rules([rule], org, project),
                 "group": group,
                 "event": event,
-                "timezone": pytz.timezone("Europe/Vienna"),
+                "timezone": settings.SENTRY_DEFAULT_TIME_ZONE,
                 "link": get_group_settings_link(group, None, get_rules([rule], org, project), 1337),
                 "generic_issue_data": [(section_header, mark_safe(generic_issue_data_html), None)],
                 "tags": event.tags,

--- a/src/sentry/web/frontend/debug/debug_feedback_issue.py
+++ b/src/sentry/web/frontend/debug/debug_feedback_issue.py
@@ -1,0 +1,44 @@
+import pytz
+from django.utils.safestring import mark_safe
+from django.views.generic import View
+
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.rule import Rule
+from sentry.notifications.utils import get_generic_data, get_group_settings_link, get_rules
+from sentry.utils import json
+
+from .mail import COMMIT_EXAMPLE, MailPreview, make_feedback_issue
+
+
+class DebugFeedbackIssueEmailView(View):
+    def get(self, request):
+        org = Organization(id=1, slug="example", name="Example")
+        project = Project(id=1, slug="example", name="Example", organization=org)
+
+        event = make_feedback_issue(project)
+        group = event.group
+
+        rule = Rule(id=1, label="An example rule")
+
+        generic_issue_data_html = get_generic_data(event)
+        section_header = "Issue Data" if generic_issue_data_html else ""
+        return MailPreview(
+            html_template="sentry/emails/feedback.html",
+            text_template="sentry/emails/feedback.txt",
+            context={
+                "rule": rule,
+                "rules": get_rules([rule], org, project),
+                "group": group,
+                "event": event,
+                "timezone": pytz.timezone("Europe/Vienna"),
+                "link": get_group_settings_link(group, None, get_rules([rule], org, project), 1337),
+                "generic_issue_data": [(section_header, mark_safe(generic_issue_data_html), None)],
+                "tags": event.tags,
+                "project_label": project.slug,
+                "commits": json.loads(COMMIT_EXAMPLE),
+                "issue_title": event.occurrence.issue_title,
+                "subtitle": event.occurrence.subtitle,
+                "culprit": event.occurrence.culprit,
+            },
+        ).render(request)

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -57,6 +57,7 @@ from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.testutils.helpers.datetime import before_now  # NOQA:S007
 from sentry.testutils.helpers.notifications import (  # NOQA:S007
     SAMPLE_TO_OCCURRENCE_MAP,
+    TEST_FEEDBACK_ISSUE_OCCURENCE,
     TEST_ISSUE_OCCURRENCE,
 )
 from sentry.types.group import GroupSubStatus
@@ -104,6 +105,8 @@ COMMIT_EXAMPLE = """[
     }
 }
 ]"""
+
+REPLAY_ID = "9188182919744ea987d8e4e58f4a6dec"
 
 
 def get_random(request) -> Random:
@@ -248,6 +251,26 @@ def make_generic_event(project: Project):
     assert group_info is not None
     generic_group = group_info.group
     return generic_group.get_latest_event()
+
+
+def make_feedback_issue(project):
+    event_id = uuid.uuid4().hex
+    occurrence_data = TEST_FEEDBACK_ISSUE_OCCURENCE.to_dict()
+    occurrence_data["event_id"] = event_id
+    occurrence_data["fingerprint"] = [
+        md5(part.encode("utf-8")).hexdigest() for part in occurrence_data["fingerprint"]
+    ]
+    occurrence, group_info = process_event_and_issue_occurrence(
+        occurrence_data,
+        {
+            "event_id": event_id,
+            "project_id": project.id,
+            "timestamp": before_now(minutes=1).isoformat(),
+            "tags": [("logger", "javascript"), ("environment", "prod"), ("replayId", REPLAY_ID)],
+        },
+    )
+    feedback_issue = group_info.group
+    return feedback_issue.get_latest_event()
 
 
 def get_shared_context(rule, org, project: Project, group, event):
@@ -423,9 +446,6 @@ class ActivityMailDebugView(View):
         )
 
 
-replay_id = "9188182919744ea987d8e4e58f4a6dec"
-
-
 @login_required
 def alert(request):
     random = get_random(request)
@@ -463,7 +483,7 @@ def alert(request):
             "culprit": random.choice(["sentry.tasks.culprit.culprit", None]),
             "subtitle": random.choice(["subtitles are cool", None]),
             "issue_type": group.issue_type.description,
-            "replay_id": replay_id,
+            "replay_id": REPLAY_ID,
             "issue_replays_url": get_issue_replay_link(group, "?referrer=alert_email"),
         },
     ).render(request)

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -269,6 +269,8 @@ def make_feedback_issue(project):
             "tags": [("logger", "javascript"), ("environment", "prod"), ("replayId", REPLAY_ID)],
         },
     )
+    if not group_info.group:
+        raise ValueError("No group found")
     feedback_issue = group_info.group
     return feedback_issue.get_latest_event()
 

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -269,7 +269,7 @@ def make_feedback_issue(project):
             "tags": [("logger", "javascript"), ("environment", "prod"), ("replayId", REPLAY_ID)],
         },
     )
-    if not group_info.group:
+    if not group_info:
         raise ValueError("No group found")
     feedback_issue = group_info.group
     return feedback_issue.get_latest_event()


### PR DESCRIPTION
Figma: https://www.figma.com/file/nLS7ZsjVmuSoCmEkMG5nHn/Specs%3A-Alerting-Emails-for-Feedback-v1?type=design&node-id=67-96&mode=design&t=uNuoqR4pcKz4W4Xo-0

screenshot:
<img width="709" alt="Screenshot 2024-04-02 at 4 10 33 PM" src="https://github.com/getsentry/sentry/assets/1976777/19eed01c-a18e-4752-9c23-842debedbca1">

differences:
- the email field in the figma is blue and linked, but i'm not sure what that would link to
- i didn't move the important tags up (replay, url), let me know if we feel strongly about this
- changed 'description' to 'message'
- haven't added screenshots yet, can do that in a follow up.