### PR TITLE
ref(rules): Collect metrics on rule create/edit notifications

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -45,6 +45,7 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.actions.utils import get_changed_data, get_updated_rule_data
 from sentry.signals import alert_rule_edited
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -378,6 +379,10 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
                 new_rule_data = get_updated_rule_data(rule)
                 changed_data = get_changed_data(rule, new_rule_data, rule_data_before)
                 send_confirmation_notification(rule=rule, new=False, changed=changed_data)
+                metrics.incr(
+                    "rule_confirmation.edit.notification.sent",
+                    skip_internal=False,
+                )
             return Response(serialize(updated_rule, request.user))
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -35,6 +35,7 @@ from sentry.rules.actions.base import instantiate_action
 from sentry.rules.processor import is_condition_slow
 from sentry.signals import alert_rule_created
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
+from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 
 
@@ -869,5 +870,9 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             "organizations:rule-create-edit-confirm-notification", project.organization
         ):
             send_confirmation_notification(rule=rule, new=True)
+            metrics.incr(
+                "rule_confirmation.create.notification.sent",
+                skip_internal=False,
+            )
 
         return Response(serialize(rule, request.user))


### PR DESCRIPTION
Add some metrics for the rule edit and create Slack notifications since we currently only have logs for when it fails and it'd be nice to see it running happily.