### PR TITLE
feat(slack): Add ability to send workflow notification to thread

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -140,6 +140,16 @@ class SlackService:
     ) -> None:
         # For each parent notification, we need to get the channel that the notification is replied to
         # Get the channel by using the action uuid
+        if not parent_notification.rule_fire_history:
+            raise RuleDataError(
+                f"parent notification {parent_notification.id} does not have a rule_fire_history"
+            )
+
+        if not parent_notification.rule_action_uuid:
+            raise RuleDataError(
+                f"parent notification {parent_notification.id} does not have a rule_action_uuid"
+            )
+
         rule: Rule = parent_notification.rule_fire_history.rule
         rule_action = rule.get_rule_action_details_by_uuid(parent_notification.rule_action_uuid)
         if not rule_action:

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -102,6 +102,7 @@ class SlackService:
                     "project_id": activity.project.id,
                 },
             )
+            return None
 
         slack_client = SlackClient(integration_id=integration.id)
 

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from logging import Logger, getLogger
+
+from sentry.integrations.repository import get_default_issue_alert_repository
+from sentry.integrations.repository.issue_alert import (
+    IssueAlertNotificationMessage,
+    IssueAlertNotificationMessageRepository,
+)
+from sentry.integrations.slack import BlockSlackMessageBuilder, SlackClient
+from sentry.models.activity import Activity
+from sentry.models.organization import OrganizationStatus
+from sentry.models.rule import Rule
+from sentry.notifications.notifications.activity import EMAIL_CLASSES_BY_TYPE
+from sentry.services.hybrid_cloud.integration import integration_service
+
+_default_logger = getLogger(__name__)
+
+
+class RuleDataError(Exception):
+    pass
+
+
+class SlackService:
+    def __init__(
+        self,
+        notification_message_repository: IssueAlertNotificationMessageRepository,
+        message_block_builder: BlockSlackMessageBuilder,
+        logger: Logger,
+    ) -> None:
+        self._notification_message_repository = notification_message_repository
+        self._slack_block_builder = message_block_builder
+        self._logger = logger
+
+    @classmethod
+    def default(cls) -> SlackService:
+        return SlackService(
+            notification_message_repository=get_default_issue_alert_repository(),
+            message_block_builder=BlockSlackMessageBuilder(),
+            logger=_default_logger,
+        )
+
+    def notify_all_threads_for_activity(self, activity: Activity) -> None:
+        """
+        For an activity related to an issue group, send notifications in a Slack thread to all parent notifications for
+        that specific group and project.
+
+        If the group is not associated with an activity, return early as there's nothing to do.
+        If the user is not associated with an activity, return early as we only care about user activities.
+        """
+        if activity.group is None:
+            self._logger.info(
+                "no group associated on the activity, nothing to do",
+                extra={
+                    "activity_id": activity.id,
+                },
+            )
+            return None
+
+        if activity.user_id is None:
+            self._logger.info(
+                "machine/system updates are ignored at this time, nothing to do",
+                extra={
+                    "activity_id": activity.id,
+                },
+            )
+            return None
+
+        # The same message is sent to all the threads, so this needs to only happen once
+        notification_to_send = self._get_notification_message_to_send(activity=activity)
+        if not notification_to_send:
+            self._logger.info(
+                "notification to send is invalid",
+                extra={
+                    "activity_id": activity.id,
+                },
+            )
+            return None
+
+        try:
+            integration = integration_service.get_integration(
+                organization_id=activity.project.organization_id,
+                status=OrganizationStatus.ACTIVE,
+                provider="slack",
+            )
+        except Exception as err:
+            self._logger.info(
+                "error getting integration",
+                exc_info=err,
+                extra={
+                    "activity_id": activity.id,
+                },
+            )
+            return None
+
+        if integration is None:
+            self._logger.info(
+                "no integration found for activity",
+                extra={
+                    "activity_id": activity.id,
+                    "organization_id": activity.project.organization_id,
+                    "project_id": activity.project.id,
+                },
+            )
+
+        slack_client = SlackClient(integration_id=integration.id)
+
+        # Get all parent notifications, which will have the message identifier to use to reply in a thread
+        parent_notifications = (
+            self._notification_message_repository.get_all_parent_notification_messages_by_filters(
+                group_ids=[activity.group.id],
+                project_ids=[activity.project.id],
+            )
+        )
+        for parent_notification in parent_notifications:
+            try:
+                self._handle_parent_notification(
+                    parent_notification=parent_notification,
+                    notification_to_send=notification_to_send,
+                    client=slack_client,
+                )
+            except Exception as err:
+                self._logger.info(
+                    "failed to send notification",
+                    exc_info=err,
+                    extra={
+                        "activity_id": activity.id,
+                        "parent_notification_id": parent_notification.id,
+                        "notification_to_send": notification_to_send,
+                        "integration_id": integration.id,
+                    },
+                )
+
+    def _handle_parent_notification(
+        self,
+        parent_notification: IssueAlertNotificationMessage,
+        notification_to_send: str,
+        client: SlackClient,
+    ) -> None:
+        # For each parent notification, we need to get the channel that the notification is replied to
+        # Get the channel by using the action uuid
+        rule: Rule = parent_notification.rule_fire_history.rule
+        rule_action = rule.get_rule_action_details_by_uuid(parent_notification.rule_action_uuid)
+        if not rule_action:
+            raise RuleDataError(
+                f"failed to find rule action {parent_notification.rule_action_uuid} for rule {rule.id}"
+            )
+
+        channel_id: str | None = rule_action.get("channel_id", None)
+        if not channel_id:
+            raise RuleDataError(
+                f"failed to get channel_id for rule {rule.id} and rule action {parent_notification.rule_action_uuid}"
+            )
+
+        block = self._slack_block_builder.get_markdown_block(text=notification_to_send)
+        payload = {"channel": channel_id, "thread_ts": parent_notification.message_identifier}
+        slack_payload = self._slack_block_builder._build_blocks(
+            block, fallback_text=notification_to_send
+        )
+        payload.update(slack_payload)
+        client.post("/chat.postMessage", data=payload, timeout=5)
+
+    def _get_notification_message_to_send(self, activity: Activity) -> str | None:
+        """
+        Get the notification message that we need to send in a slack thread based on the activity type.
+
+        Apparently the get_context is a very computation heavy call, so make sure to only call this once.
+        """
+        notification_cls = EMAIL_CLASSES_BY_TYPE.get(activity.type, None)
+        if not notification_cls:
+            self._logger.info(
+                "activity type is not currently supported",
+                extra={
+                    "activity_id": activity.id,
+                    "activity_type": activity.type,
+                },
+            )
+            return None
+
+        notification_obj = notification_cls(activity=activity)
+        context = notification_obj.get_context()
+        text_description = context.get("text_description", None)
+        if not text_description:
+            self._logger.info(
+                "context did not contain text_description",
+                extra={
+                    "activity_id": activity.id,
+                    "notification_type": activity.type,
+                    "notification_cls": notification_cls.__name__,
+                    "context": context,
+                },
+            )
+            return None
+
+        return text_description

--- a/src/sentry/integrations/utils/common.py
+++ b/src/sentry/integrations/utils/common.py
@@ -1,0 +1,28 @@
+import logging
+
+from sentry.models.organization import OrganizationStatus
+from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
+from sentry.types.integrations import ExternalProviderEnum
+
+_default_logger = logging.getLogger(__name__)
+
+
+def get_active_integration_for_organization(
+    organization_id: int, provider: ExternalProviderEnum
+) -> RpcIntegration | None:
+    try:
+        return integration_service.get_integration(
+            organization_id=organization_id,
+            status=OrganizationStatus.ACTIVE,
+            provider=provider.value,
+        )
+    except Exception as err:
+        _default_logger.info(
+            "error getting active integration for organization from service",
+            exc_info=err,
+            extra={
+                "organization_id": organization_id,
+                "provider": provider.value,
+            },
+        )
+        return None

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -33,6 +33,8 @@ def get_activity_notifiers(project):
     silo_mode=SiloMode.REGION,
 )
 def send_activity_notifications(activity_id):
+    from sentry import features
+    from sentry.integrations.slack.service import SlackService
     from sentry.models.activity import Activity
     from sentry.models.organization import Organization
 
@@ -46,3 +48,7 @@ def send_activity_notifications(activity_id):
 
     for notifier in get_activity_notifiers(activity.project):
         notifier.notify_about_activity(activity)
+
+    if features.has("organizations:slack-thread-issue-alert", organization):
+        slack_service = SlackService.default()
+        slack_service.notify_all_threads_for_activity(activity=activity)

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import mock
 from uuid import uuid4
 
@@ -41,7 +42,75 @@ class TestGetNotificationMessageToSend(TestCase):
 
 class TestHandleParentNotification(TestCase):
     def setUp(self) -> None:
+        """
+        Setup default and reusable testing data or objects
+        """
         self.service = SlackService.default()
+
+        self.rule_action_uuid = str(uuid4())
+        self.notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": self.rule_action_uuid,
+            }
+        ]
+        self.rule = self.create_project_rule(
+            project=self.project, action_match=self.notify_issue_owners_action
+        )
+        self.rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=self.rule,
+            group=self.group,
+            event_id=456,
+            notification_uuid=str(uuid4()),
+        )
+
+    def test_raises_exception_when_parent_notification_does_not_have_rule_fire_history_data(
+        self,
+    ) -> None:
+        """
+        Purposefully create a domain object that does not have rule_fire_history
+        """
+        parent_notification = IssueAlertNotificationMessage(
+            id=123,
+            date_added=datetime.now(),
+            message_identifier="1a2s3d",
+            rule_action_uuid=str(uuid4()),
+        )
+        with pytest.raises(RuleDataError) as err:
+            self.service._handle_parent_notification(
+                parent_notification=parent_notification,
+                notification_to_send="",
+                client=mock.MagicMock(),
+            )
+            assert (
+                err.value
+                == f"parent notification {parent_notification.id} does not have a rule_fire_history"
+            )
+
+    def test_raises_exception_when_parent_notification_does_not_have_rule_action_uuid(self) -> None:
+        """
+        Purposefully create a domain object that does not have the rule_action_uuid
+        """
+        parent_notification = IssueAlertNotificationMessage(
+            id=123,
+            date_added=datetime.now(),
+            message_identifier="1a2s3d",
+            rule_fire_history=self.rule_fire_history,
+        )
+        with pytest.raises(RuleDataError) as err:
+            self.service._handle_parent_notification(
+                parent_notification=parent_notification,
+                notification_to_send="",
+                client=mock.MagicMock(),
+            )
+            assert (
+                err.value
+                == f"parent notification {parent_notification.id} does not have a rule_action_uuid"
+            )
 
     def test_raises_exception_when_rule_action_does_not_exist(self) -> None:
         """
@@ -84,29 +153,9 @@ class TestHandleParentNotification(TestCase):
             )
 
     def test_raises_exception_when_rule_action_does_not_have_channel_id(self) -> None:
-        rule_action_uuid = str(uuid4())
-        notify_issue_owners_action = [
-            {
-                "targetType": "IssueOwners",
-                "fallthroughType": "ActiveMembers",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "",
-                "uuid": rule_action_uuid,
-            }
-        ]
-        rule = self.create_project_rule(
-            project=self.project, action_match=notify_issue_owners_action
-        )
-        rule_fire_history = RuleFireHistory.objects.create(
-            project=self.project,
-            rule=rule,
-            group=self.group,
-            event_id=456,
-            notification_uuid=str(uuid4()),
-        )
         parent_notification_message = NotificationMessage.objects.create(
-            rule_fire_history=rule_fire_history,
-            rule_action_uuid=rule_action_uuid,
+            rule_fire_history=self.rule_fire_history,
+            rule_action_uuid=self.rule_action_uuid,
             message_identifier="123abc",
         )
         parent_notification = IssueAlertNotificationMessage.from_model(parent_notification_message)
@@ -118,5 +167,5 @@ class TestHandleParentNotification(TestCase):
             )
             assert (
                 err.value
-                == f"failed to get channel_id for rule {rule.id} and rule action {parent_notification.rule_action_uuid}"
+                == f"failed to get channel_id for rule {self.rule.id} and rule action {parent_notification.rule_action_uuid}"
             )

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -1,0 +1,122 @@
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+
+from sentry.integrations.repository.issue_alert import IssueAlertNotificationMessage
+from sentry.integrations.slack.service import RuleDataError, SlackService
+from sentry.models.activity import Activity
+from sentry.models.notificationmessage import NotificationMessage
+from sentry.models.rulefirehistory import RuleFireHistory
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+
+class TestGetNotificationMessageToSend(TestCase):
+    def setUp(self) -> None:
+        self.service = SlackService.default()
+
+    def test_ignores_unsupported_activity(self) -> None:
+        activity = Activity.objects.create(
+            group=self.group,
+            project=self.project,
+            type=ActivityType.FIRST_SEEN.value,
+            user_id=self.user.id,
+            data={},
+        )
+        result = self.service._get_notification_message_to_send(activity=activity)
+        assert result is None
+
+    def test_simple(self) -> None:
+        activity = Activity.objects.create(
+            group=self.group,
+            project=self.project,
+            type=ActivityType.NOTE.value,
+            user_id=self.user.id,
+            data={"text": "Hello world!"},
+        )
+        result = self.service._get_notification_message_to_send(activity=activity)
+        assert result == "Hello world!"
+
+
+class TestHandleParentNotification(TestCase):
+    def setUp(self) -> None:
+        self.service = SlackService.default()
+
+    def test_raises_exception_when_rule_action_does_not_exist(self) -> None:
+        """
+        Purposefully create a mismatch between the rule action uuid so that it does not exist
+        """
+        notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": (uuid4()),
+            }
+        ]
+        rule = self.create_project_rule(
+            project=self.project, action_match=notify_issue_owners_action
+        )
+        rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=rule,
+            group=self.group,
+            event_id=456,
+            notification_uuid=str(uuid4()),
+        )
+        parent_notification_message = NotificationMessage.objects.create(
+            rule_fire_history=rule_fire_history,
+            rule_action_uuid=str(uuid4()),
+            message_identifier="123abc",
+        )
+        parent_notification = IssueAlertNotificationMessage.from_model(parent_notification_message)
+        with pytest.raises(RuleDataError) as err:
+            self.service._handle_parent_notification(
+                parent_notification=parent_notification,
+                notification_to_send="",
+                client=mock.MagicMock(),
+            )
+            assert (
+                err.value
+                == f"failed to find rule action {parent_notification.rule_action_uuid} for rule {rule.id}"
+            )
+
+    def test_raises_exception_when_rule_action_does_not_have_channel_id(self) -> None:
+        rule_action_uuid = str(uuid4())
+        notify_issue_owners_action = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+                "uuid": rule_action_uuid,
+            }
+        ]
+        rule = self.create_project_rule(
+            project=self.project, action_match=notify_issue_owners_action
+        )
+        rule_fire_history = RuleFireHistory.objects.create(
+            project=self.project,
+            rule=rule,
+            group=self.group,
+            event_id=456,
+            notification_uuid=str(uuid4()),
+        )
+        parent_notification_message = NotificationMessage.objects.create(
+            rule_fire_history=rule_fire_history,
+            rule_action_uuid=rule_action_uuid,
+            message_identifier="123abc",
+        )
+        parent_notification = IssueAlertNotificationMessage.from_model(parent_notification_message)
+        with pytest.raises(RuleDataError) as err:
+            self.service._handle_parent_notification(
+                parent_notification=parent_notification,
+                notification_to_send="",
+                client=mock.MagicMock(),
+            )
+            assert (
+                err.value
+                == f"failed to get channel_id for rule {rule.id} and rule action {parent_notification.rule_action_uuid}"
+            )


### PR DESCRIPTION
- Add logic to handle sending an activity's data to a slack thread
  - Add tests
- Create new class and helper functions to consolidate repeated logic
  - Add logging for all places where things can go wrong
  - Breakup functions for more modularity and singular responsibilities 
- Invoke new class and logic in the proper location
  - Guard logic behind a FF

Requires: https://github.com/getsentry/sentry/pull/68142
Resolves: https://github.com/getsentry/team-core-product-foundations/issues/188