### PR TITLE
fix(trace): use old path format and fix autogrouping edge case

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.spec.tsx
@@ -527,10 +527,10 @@ describe('TreeNode', () => {
       }
 
       it('first txn node', () => {
-        expect(child.parent.parent.path).toEqual(['txn:parent']);
+        expect(child.parent.parent.path).toEqual(['txn-parent']);
       });
       it('leafmost node', () => {
-        expect(child.path).toEqual(['txn:grandchild', 'txn:child', 'txn:parent']);
+        expect(child.path).toEqual(['txn-grandchild', 'txn-child', 'txn-parent']);
       });
     });
 
@@ -542,7 +542,7 @@ describe('TreeNode', () => {
         })
       );
 
-      expect(tree.list[1].path).toEqual(['error:error_id']);
+      expect(tree.list[1].path).toEqual(['error-error_id']);
     });
 
     describe('spans', () => {
@@ -590,13 +590,13 @@ describe('TreeNode', () => {
         });
 
         expect(tree.list[tree.list.length - 1].path).toEqual([
-          'span:span',
-          'txn:event_id',
+          'span-span',
+          'txn-event_id',
         ]);
       });
 
       it('missing instrumentation', () => {
-        expect(tree.list[3].path).toEqual(['ms:span', 'txn:event_id']);
+        expect(tree.list[3].path).toEqual(['ms-span', 'txn-event_id']);
       });
     });
 
@@ -663,14 +663,14 @@ describe('TreeNode', () => {
         });
         tree.expand(tree.list[2], true);
         assertAutogroupedNode(tree.list[2]);
-        expect(tree.list[2].path).toEqual(['ag:2', 'txn:event_id']);
+        expect(tree.list[2].path).toEqual(['ag-2', 'txn-event_id']);
       });
 
       it('child is part of autogrouping', () => {
         expect(tree.list[tree.list.length - 1].path).toEqual([
-          'span:5',
-          'ag:2',
-          'txn:event_id',
+          'span-5',
+          'ag-2',
+          'txn-event_id',
         ]);
       });
     });
@@ -758,13 +758,13 @@ describe('TreeNode', () => {
           expect(tree.list.length).toBe(4);
         });
         assertAutogroupedNode(tree.list[2]);
-        expect(tree.list[2].path).toEqual(['ag:2', 'txn:event_id']);
+        expect(tree.list[2].path).toEqual(['ag-2', 'txn-event_id']);
       });
       it('span node skips autogrouped node because it is not expanded', async () => {
         await waitFor(() => {
           expect(tree.list.length).toBe(4);
         });
-        expect(tree.list[tree.list.length - 1].path).toEqual(['span:6', 'txn:event_id']);
+        expect(tree.list[tree.list.length - 1].path).toEqual(['span-6', 'txn-event_id']);
       });
     });
   });

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -148,7 +148,7 @@ export declare namespace TraceTree {
     | null;
 
   type NodePath =
-    `${'txn' | 'span' | 'ag' | 'trace' | 'ms' | 'error' | 'empty'}:${string}`;
+    `${'txn' | 'span' | 'ag' | 'trace' | 'ms' | 'error' | 'empty'}-${string}`;
 
   type Metadata = {
     event_id: string | undefined;
@@ -1778,32 +1778,32 @@ export function makeExampleTrace(metadata: TraceTree.Metadata): TraceTree {
 
 function nodeToId(n: TraceTreeNode<TraceTree.NodeValue>): TraceTree.NodePath {
   if (isTransactionNode(n)) {
-    return `txn:${n.value.event_id}`;
+    return `txn-${n.value.event_id}`;
   }
   if (isSpanNode(n)) {
-    return `span:${n.value.span_id}`;
+    return `span-${n.value.span_id}`;
   }
   if (isAutogroupedNode(n)) {
     if (isParentAutogroupedNode(n)) {
-      return `ag:${n.head.value.span_id}`;
+      return `ag-${n.head.value.span_id}`;
     }
     if (isSiblingAutogroupedNode(n)) {
       const child = n.children[0];
       if (isSpanNode(child)) {
-        return `ag:${child.value.span_id}`;
+        return `ag-${child.value.span_id}`;
       }
     }
   }
   if (isTraceNode(n)) {
-    return `trace:root`;
+    return `trace-root`;
   }
 
   if (isTraceErrorNode(n)) {
-    return `error:${n.value.event_id}`;
+    return `error-${n.value.event_id}`;
   }
 
   if (isNoDataNode(n)) {
-    return `empty:node`;
+    return `empty-node`;
   }
 
   if (isRootNode(n)) {
@@ -1812,10 +1812,10 @@ function nodeToId(n: TraceTreeNode<TraceTree.NodeValue>): TraceTree.NodePath {
 
   if (isMissingInstrumentationNode(n)) {
     if (n.previous) {
-      return `ms:${n.previous.value.span_id}`;
+      return `ms-${n.previous.value.span_id}`;
     }
     if (n.next) {
-      return `ms:${n.next.value.span_id}`;
+      return `ms-${n.next.value.span_id}`;
     }
 
     throw new Error('Missing instrumentation node must have a previous or next node');

--- a/static/app/views/performance/newTraceDetails/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTree.tsx
@@ -786,11 +786,17 @@ export class TraceTree {
       let matchCount = 0;
 
       while (index < node.children.length) {
+        if (!isSpanNode(node.children[index])) {
+          index++;
+          matchCount = 0;
+          continue;
+        }
         const current = node.children[index] as TraceTreeNode<TraceTree.Span>;
         const next = node.children[index + 1] as TraceTreeNode<TraceTree.Span>;
 
         if (
           next &&
+          isSpanNode(next) &&
           next.children.length === 0 &&
           current.children.length === 0 &&
           next.value.op === current.value.op &&
@@ -843,12 +849,6 @@ export class TraceTree {
               child.value.start_timestamp < start_timestamp
             ) {
               start_timestamp = child.value.start_timestamp;
-            }
-
-            if (!isSpanNode(child)) {
-              throw new TypeError(
-                'Expected child of autogrouped node to be a span node.'
-              );
             }
 
             if (child.has_errors) {

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.spec.tsx
@@ -342,7 +342,7 @@ describe('VirtualizedViewManger', () => {
 
       manager.list = makeList();
 
-      const result = await manager.scrollToPath(tree, ['txn:event_id'], () => void 0, {
+      const result = await manager.scrollToPath(tree, ['txn-event_id'], () => void 0, {
         api: api,
         organization,
       });
@@ -376,13 +376,13 @@ describe('VirtualizedViewManger', () => {
       manager.list = makeList();
 
       expect(tree.list[tree.list.length - 1].path).toEqual([
-        'txn:event_id',
-        'txn:child',
-        'txn:root',
+        'txn-event_id',
+        'txn-child',
+        'txn-root',
       ]);
       const result = await manager.scrollToPath(
         tree,
-        ['txn:event_id', 'txn:child', 'txn:root'],
+        ['txn-event_id', 'txn-child', 'txn-root'],
         () => void 0,
         {
           api: api,
@@ -417,7 +417,7 @@ describe('VirtualizedViewManger', () => {
 
       const result = await manager.scrollToPath(
         tree,
-        ['span:span_id', 'txn:event_id'],
+        ['span-span_id', 'txn-event_id'],
         () => void 0,
         {
           api: api,
@@ -453,7 +453,7 @@ describe('VirtualizedViewManger', () => {
 
       const result = await manager.scrollToPath(
         tree,
-        ['empty:node', 'txn:event_id'],
+        ['empty-node', 'txn-event_id'],
         () => void 0,
         {
           api: api,
@@ -504,7 +504,7 @@ describe('VirtualizedViewManger', () => {
 
       const result = await manager.scrollToPath(
         tree,
-        ['span:other_child_span', 'txn:child_event_id', 'txn:event_id'],
+        ['span-other_child_span', 'txn-child_event_id', 'txn-event_id'],
         () => void 0,
         {
           api: api,
@@ -530,7 +530,7 @@ describe('VirtualizedViewManger', () => {
 
           const result = await manager.scrollToPath(
             tree,
-            [`ag:${headOrTailId}`, 'txn:event_id'],
+            [`ag-${headOrTailId}`, 'txn-event_id'],
             () => void 0,
             {
               api: api,
@@ -556,7 +556,7 @@ describe('VirtualizedViewManger', () => {
 
           const result = await manager.scrollToPath(
             tree,
-            ['span:middle_span', `ag:${headOrTailId}`, 'txn:event_id'],
+            ['span-middle_span', `ag-${headOrTailId}`, 'txn-event_id'],
             () => void 0,
             {
               api: api,
@@ -583,7 +583,7 @@ describe('VirtualizedViewManger', () => {
 
         const result = await manager.scrollToPath(
           tree,
-          ['span:middle_span', `ag:first_span`, 'txn:event_id'],
+          ['span-middle_span', `ag-first_span`, 'txn-event_id'],
           () => void 0,
           {
             api: api,
@@ -624,7 +624,7 @@ describe('VirtualizedViewManger', () => {
 
         const result = await manager.scrollToPath(
           tree,
-          ['ms:first_span', 'txn:event_id'],
+          ['ms-first_span', 'txn-event_id'],
           () => void 0,
           {
             api: api,
@@ -662,7 +662,7 @@ describe('VirtualizedViewManger', () => {
 
         const result = await manager.scrollToPath(
           tree,
-          ['ms:second_span', 'txn:event_id'],
+          ['ms-second_span', 'txn-event_id'],
           () => void 0,
           {
             api: api,
@@ -696,7 +696,7 @@ describe('VirtualizedViewManger', () => {
         })
       );
 
-      const result = await manager.scrollToPath(tree, ['error:ded'], () => void 0, {
+      const result = await manager.scrollToPath(tree, ['error-ded'], () => void 0, {
         api: api,
         organization,
       });

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -1112,7 +1112,7 @@ export class VirtualizedViewManager {
       return Promise.resolve(null);
     }
 
-    if (segments.length === 1 && segments[0] === 'trace:root') {
+    if (segments.length === 1 && segments[0] === 'trace-root') {
       rerender();
       this.scrollToRow(0);
       return Promise.resolve({index: 0, node: tree.root.children[0]});
@@ -1135,7 +1135,7 @@ export class VirtualizedViewManager {
         // that this is happening, we will perform a final check to see if we've actually already
         // arrived to the node in the previous search call.
         if (path) {
-          const [type, id] = path.split(':');
+          const [type, id] = path.split('-');
 
           if (
             type === 'span' &&
@@ -1160,10 +1160,10 @@ export class VirtualizedViewManager {
       if (isTransactionNode(current)) {
         const nextSegment = segments[segments.length - 1];
         if (
-          nextSegment?.startsWith('span:') ||
-          nextSegment?.startsWith('empty:') ||
-          nextSegment?.startsWith('ag:') ||
-          nextSegment?.startsWith('ms:')
+          nextSegment?.startsWith('span-') ||
+          nextSegment?.startsWith('empty-') ||
+          nextSegment?.startsWith('ag-') ||
+          nextSegment?.startsWith('ms-')
         ) {
           await tree.zoomIn(current, true, {
             api,
@@ -2130,10 +2130,10 @@ function findInTreeFromSegment(
   start: TraceTreeNode<TraceTree.NodeValue>,
   segment: TraceTree.NodePath
 ): TraceTreeNode<TraceTree.NodeValue> | null {
-  const [type, id] = segment.split(':');
+  const [type, id] = segment.split('-');
 
   if (!type || !id) {
-    throw new TypeError('Node path must be in the format of `type:id`');
+    throw new TypeError('Node path must be in the format of `type-id`');
   }
 
   return TraceTreeNode.Find(start, node => {

--- a/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/virtualizedViewManager.tsx
@@ -1186,6 +1186,7 @@ export class VirtualizedViewManager {
       // and we should scroll the view to this node.
       const index = tree.list.findIndex(node => node === current);
       if (index === -1) {
+        rerender();
         throw new Error(`Couldn't find node in list ${scrollQueue.join(',')}`);
       }
 

--- a/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
+++ b/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
@@ -49,7 +49,7 @@ function TraceDetailsRouting(props: Props) {
         const spanId = spanHashValue.split('-')[1];
 
         if (spanId) {
-          query.node = [`span:${spanId}`, `txn:${event.eventID}`];
+          query.node = [`span-${spanId}`, `txn-${event.eventID}`];
         }
       }
 


### PR DESCRIPTION
Reuse the old path format and fix an issue where a txn node might have been copied under a span node and autogrouping would throw