### PR TITLE
feat(metrics): query metric stats from metrics API

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -13,7 +13,7 @@ export type MetricsOperation =
 
 export type MetricType = 'c' | 'd' | 'g' | 'e' | 's';
 
-export type UseCase = 'custom' | 'transactions' | 'sessions' | 'spans';
+export type UseCase = 'custom' | 'transactions' | 'sessions' | 'spans' | 'metric_stats';
 
 export type MRI = `${MetricType}:${UseCase}${string}@${string}`;
 

--- a/static/app/utils/metrics/useMetricsStats.spec.tsx
+++ b/static/app/utils/metrics/useMetricsStats.spec.tsx
@@ -1,0 +1,72 @@
+import type {PageFilters} from 'sentry/types';
+
+import {convertToStatsResponse, getMetricsStatsRequest} from './useMetricsStats';
+
+describe('getMetricsStatsRequest', () => {
+  it('should create a metrics query request', () => {
+    const filters = {
+      projects: [1],
+      environments: ['production'],
+      datetime: {period: '7d', utc: true} as PageFilters['datetime'],
+    };
+
+    expect(getMetricsStatsRequest(filters)).toEqual({
+      query: {
+        statsPeriod: '7d',
+        project: [1],
+        environment: ['production'],
+        interval: '30m',
+      },
+      body: {
+        queries: [
+          {
+            mql: 'sum(c:metric_stats/volume@none) by (outcome.id)',
+            name: 'query_1',
+          },
+        ],
+        formulas: [{limit: undefined, mql: '$query_1', order: undefined}],
+      },
+    });
+  });
+});
+
+describe('convertToStatsResponse', () => {
+  it('should convert a metrics query response to a usage series', () => {
+    const response = {
+      data: [
+        [
+          {
+            by: {
+              'outcome.id': '0',
+            },
+            totals: 587540585,
+            series: [433581389, 153959196],
+          },
+        ],
+      ],
+      meta: [],
+      start: '2024-04-02T14:00:00Z',
+      end: '2024-04-02T16:00:00Z',
+      intervals: ['2024-04-02T14:00:00Z', '2024-04-02T15:00:00Z'],
+    };
+
+    expect(convertToStatsResponse(response)).toEqual({
+      groups: [
+        {
+          by: {
+            outcome: 'accepted',
+          },
+          series: {
+            'sum(quantity)': [433581389, 153959196],
+          },
+          totals: {
+            'sum(quantity)': 587540585,
+          },
+        },
+      ],
+      start: '2024-04-02T14:00:00Z',
+      end: '2024-04-02T16:00:00Z',
+      intervals: ['2024-04-02T14:00:00Z', '2024-04-02T15:00:00Z'],
+    });
+  });
+});

--- a/static/app/utils/metrics/useMetricsStats.tsx
+++ b/static/app/utils/metrics/useMetricsStats.tsx
@@ -34,7 +34,8 @@ export function getMetricsStatsRequest(pageFilters: PageFilters) {
         groupBy: [OUTCOME_METRIC_TAG],
       },
     ],
-    pageFilters
+    pageFilters,
+    {intervalLadder: 'bar'}
   );
 }
 

--- a/static/app/utils/metrics/useMetricsStats.tsx
+++ b/static/app/utils/metrics/useMetricsStats.tsx
@@ -1,0 +1,83 @@
+import type {PageFilters} from 'sentry/types';
+import {getMetricsQueryApiRequestPayload} from 'sentry/utils/metrics/useMetricsQuery';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+import type {MetricsQueryApiResponse} from '../../types/metrics';
+import type {UsageSeries} from '../../views/organizationStats/types';
+
+const METRIC_STATS_MRI = 'c:metric_stats/volume@none';
+const OUTCOME_METRIC_TAG = 'outcome.id';
+const OUTCOME_STATS_TAG = 'outcome';
+const OUTCOME_FIELD = 'sum(quantity)';
+const QUERY_NAME = 'query_1';
+
+// https://github.com/getsentry/relay/blob/master/relay-server/src/services/outcome.rs#L73
+const OUTCOME_ID_MAP = {
+  '0': 'accepted',
+  '1': 'errored',
+  '2': 'filtered',
+  '3': 'rate_limited',
+  '4': 'invalid',
+  '5': 'aborted',
+  '6': 'client_discard',
+};
+
+export function getMetricsStatsRequest(pageFilters: PageFilters) {
+  return getMetricsQueryApiRequestPayload(
+    [
+      {
+        name: QUERY_NAME,
+        mri: METRIC_STATS_MRI,
+        op: 'sum',
+        groupBy: [OUTCOME_METRIC_TAG],
+      },
+    ],
+    pageFilters
+  );
+}
+
+export function convertToStatsResponse(response: MetricsQueryApiResponse): UsageSeries {
+  const groups = (response.data[0] || []).map(group => {
+    return {
+      by: {
+        [OUTCOME_STATS_TAG]: OUTCOME_ID_MAP[group.by[OUTCOME_METRIC_TAG]] ?? '<unknown>',
+      },
+      series: {
+        [OUTCOME_FIELD]: group.series as number[],
+      },
+      totals: {
+        [OUTCOME_FIELD]: group.totals,
+      },
+    };
+  });
+
+  return {
+    groups,
+    start: response.start,
+    end: response.end,
+    intervals: response.intervals,
+  };
+}
+
+export function useMetricsStats() {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const queryInfo = useApiQuery<MetricsQueryApiResponse>(
+    [
+      `/organizations/${organization.slug}/metrics/query`,
+      getMetricsStatsRequest(selection),
+    ],
+    {
+      staleTime: Infinity,
+    }
+  );
+
+  if (queryInfo.data) {
+    return {...queryInfo, data: convertToStatsResponse(queryInfo.data)};
+  }
+
+  return queryInfo;
+}


### PR DESCRIPTION
- part of: #67678
- Adds functions to query metrics API for metric outcomes and map the response to the shape used in outcomes
- will be used in getsentry repo