### PR TITLE
fix(metrics_layer): Fix the failure rate calculation

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -23,6 +23,7 @@ from sentry.snuba.metrics.fields.snql import (
     abnormal_sessions,
     abnormal_users,
     addition,
+    all_duration_transactions,
     all_sessions,
     all_spans,
     all_transactions,
@@ -1608,6 +1609,14 @@ DERIVED_METRICS = {
             ),
         ),
         SingularEntityDerivedMetric(
+            metric_mri=TransactionMRI.ALL_DURATION.value,
+            metrics=[TransactionMRI.DURATION.value],
+            unit="transactions",
+            snql=lambda project_ids, org_id, metric_ids, alias=None: all_duration_transactions(
+                metric_ids=metric_ids, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
             metric_mri=TransactionMRI.FAILURE_COUNT.value,
             metrics=[TransactionMRI.DURATION.value],
             unit="transactions",
@@ -1619,7 +1628,7 @@ DERIVED_METRICS = {
             metric_mri=TransactionMRI.FAILURE_RATE.value,
             metrics=[
                 TransactionMRI.FAILURE_COUNT.value,
-                TransactionMRI.ALL.value,
+                TransactionMRI.ALL_DURATION.value,
             ],
             unit="transactions",
             snql=lambda failure_count, tx_count, project_ids, org_id, metric_ids, alias=None: division_float(

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -1647,7 +1647,7 @@ DERIVED_METRICS = {
             metric_mri=TransactionMRI.HTTP_ERROR_RATE.value,
             metrics=[
                 TransactionMRI.HTTP_ERROR_COUNT.value,
-                TransactionMRI.ALL.value,
+                TransactionMRI.ALL_DURATION.value,
             ],
             unit="transactions",
             snql=lambda http_error_count, tx_count, project_ids, org_id, metric_ids, alias=None: division_float(

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -476,7 +476,7 @@ def _satisfaction_equivalence(org_id: int, satisfaction_tag_value: str) -> Funct
     )
 
 
-def _metric_id_equivalence(metric_condition: Function) -> Function:
+def _metric_id_equivalence(metric_condition: Function | int) -> Function:
     return Function(
         "equals",
         [
@@ -555,6 +555,18 @@ def all_transactions(
             _metric_id_equivalence(
                 _project_threshold_multi_if_function(project_ids, org_id, metric_ids)
             ),
+        ],
+        alias,
+    )
+
+
+def all_duration_transactions(
+    metric_ids: Sequence[int],
+    alias: str | None = None,
+) -> Function:
+    return _count_if_with_conditions(
+        [
+            _metric_id_equivalence(list(metric_ids)[0]),
         ],
         alias,
     )

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -151,6 +151,7 @@ class TransactionMRI(Enum):
 
     # Derived
     ALL = "e:transactions/all@none"
+    ALL_DURATION = "e:transactions/all_duration@none"
     FAILURE_COUNT = "e:transactions/failure_count@none"
     FAILURE_RATE = "e:transactions/failure_rate@ratio"
     SATISFIED = "e:transactions/satisfied@none"


### PR DESCRIPTION
This PR fixes the failure rate calculation which was using `duration` or `lcp` interchangeably in the denominator, causing wrong numbers to be calculated.