### PR TITLE
Hide "Processing Issues" setting if it was never activated

### DIFF
--- a/api-docs/components/schemas/project.json
+++ b/api-docs/components/schemas/project.json
@@ -69,12 +69,7 @@
       },
       "status": {
         "type": "string",
-        "enum": [
-          "active",
-          "disabled",
-          "pending_deletion",
-          "deletion_in_progress"
-        ]
+        "enum": ["active", "disabled", "pending_deletion", "deletion_in_progress"]
       }
     }
   },
@@ -462,9 +457,6 @@
             "type": "string"
           },
           "sentry:csp_ignored_sources_defaults": {
-            "type": "boolean"
-          },
-          "sentry:reprocessing_active": {
             "type": "boolean"
           }
         }

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1021,14 +1021,13 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
     def format_options(self, attrs: dict[str, Any]) -> dict[str, Any]:
         options = attrs["options"]
 
-        return {
+        formatted_options = {
             "sentry:csp_ignored_sources_defaults": bool(
                 options.get("sentry:csp_ignored_sources_defaults", True)
             ),
             "sentry:csp_ignored_sources": "\n".join(
                 options.get("sentry:csp_ignored_sources", []) or []
             ),
-            "sentry:reprocessing_active": bool(options.get("sentry:reprocessing_active", False)),
             "filters:blacklisted_ips": "\n".join(options.get("sentry:blacklisted_ips", [])),
             # This option was defaulted to string but was changed at runtime to a boolean due to an error in the
             # implementation. In order to bring it back to a string, we need to repair on read stored options. This is
@@ -1052,6 +1051,12 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:replay_rage_click_issues": options.get("sentry:replay_rage_click_issues"),
             "quotas:spike-protection-disabled": options.get("quotas:spike-protection-disabled"),
         }
+
+        reprocessing_active = options.get("sentry:reprocessing_active")
+        if reprocessing_active is not None:
+            formatted_options["sentry:reprocessing_active"] = reprocessing_active
+
+        return formatted_options
 
     def get_value_with_default(self, attrs, key):
         value = attrs["options"].get(key)

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -134,7 +134,6 @@ DETAILED_PROJECT = {
         "sentry:verify_ssl": True,
         "sentry:csp_ignored_sources_defaults": True,
         "sentry:csp_ignored_sources": "",
-        "sentry:reprocessing_active": False,
         "filters:blacklisted_ips": "",
         "filters:react-hydration-errors": True,
         "filters:chunk-load-error": True,

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -81,15 +81,14 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/processing-issues/`,
           title: t('Processing Issues'),
+          show: () => {
+            // NOTE: both `project` and `options` are non-null here.
+            return 'sentry:reprocessing_active' in (project?.options ?? {});
+          },
           // eslint-disable-next-line @typescript-eslint/no-shadow
           badge: ({project}) => {
-            if (!project) {
-              return null;
-            }
-            if (project.processingIssues <= 0) {
-              return null;
-            }
-            return project.processingIssues > 99 ? '99+' : project.processingIssues;
+            const issues = project?.processingIssues ?? 0;
+            return issues <= 0 ? null : issues > 99 ? '99+' : issues;
           },
         },
         {


### PR DESCRIPTION
As one step towards deprecating "Legacy Reprocessing", this hides the "Processing Issues" settings page completely if it has never been active before.

It is still showing up for projects which have it active, or have ever had it active.

Along with that, it will now display a deprecation notice, though I might remove it from this PR if it is too early for that.