### PR TITLE
ref(sidebar): change sidebar to light color in light mode

### DIFF
--- a/static/app/components/progressRing.tsx
+++ b/static/app/components/progressRing.tsx
@@ -55,7 +55,7 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   justify-content: center;
   height: 100%;
   width: 100%;
-  color: ${p => p.theme.chartLabel};
+  color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   transition: color 100ms;
   ${p => p.textCss?.(p)}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -597,59 +597,62 @@ function Sidebar() {
             hidePanel={hidePanel}
             {...sidebarItemProps}
           />
-          <SidebarSection noMargin noPadding>
-            <OnboardingStatus
-              org={organization}
-              currentPanel={activePanel}
-              onShowPanel={() => togglePanel(SidebarPanelKey.ONBOARDING_WIZARD)}
-              hidePanel={hidePanel}
-              {...sidebarItemProps}
-            />
-          </SidebarSection>
 
-          <SidebarSection>
-            {HookStore.get('sidebar:bottom-items').length > 0 &&
-              HookStore.get('sidebar:bottom-items')[0]({
-                orientation,
-                collapsed,
-                hasPanel,
-                organization,
-              })}
-            <SidebarHelp
-              orientation={orientation}
-              collapsed={collapsed}
-              hidePanel={hidePanel}
-              organization={organization}
-            />
-            <Broadcasts
-              orientation={orientation}
-              collapsed={collapsed}
-              currentPanel={activePanel}
-              onShowPanel={() => togglePanel(SidebarPanelKey.BROADCASTS)}
-              hidePanel={hidePanel}
-              organization={organization}
-            />
-            <ServiceIncidents
-              orientation={orientation}
-              collapsed={collapsed}
-              currentPanel={activePanel}
-              onShowPanel={() => togglePanel(SidebarPanelKey.SERVICE_INCIDENTS)}
-              hidePanel={hidePanel}
-            />
-          </SidebarSection>
-
-          {!horizontal && (
-            <SidebarSection>
-              <SidebarCollapseItem
-                id="collapse"
-                data-test-id="sidebar-collapse"
+          <SidebarGradientWrapper>
+            <SidebarSection noMargin noPadding>
+              <OnboardingStatus
+                org={organization}
+                currentPanel={activePanel}
+                onShowPanel={() => togglePanel(SidebarPanelKey.ONBOARDING_WIZARD)}
+                hidePanel={hidePanel}
                 {...sidebarItemProps}
-                icon={<IconChevron direction={collapsed ? 'right' : 'left'} size="sm" />}
-                label={collapsed ? t('Expand') : t('Collapse')}
-                onClick={toggleCollapse}
               />
             </SidebarSection>
-          )}
+            <SidebarSection>
+              {HookStore.get('sidebar:bottom-items').length > 0 &&
+                HookStore.get('sidebar:bottom-items')[0]({
+                  orientation,
+                  collapsed,
+                  hasPanel,
+                  organization,
+                })}
+              <SidebarHelp
+                orientation={orientation}
+                collapsed={collapsed}
+                hidePanel={hidePanel}
+                organization={organization}
+              />
+              <Broadcasts
+                orientation={orientation}
+                collapsed={collapsed}
+                currentPanel={activePanel}
+                onShowPanel={() => togglePanel(SidebarPanelKey.BROADCASTS)}
+                hidePanel={hidePanel}
+                organization={organization}
+              />
+              <ServiceIncidents
+                orientation={orientation}
+                collapsed={collapsed}
+                currentPanel={activePanel}
+                onShowPanel={() => togglePanel(SidebarPanelKey.SERVICE_INCIDENTS)}
+                hidePanel={hidePanel}
+              />
+            </SidebarSection>
+            {!horizontal && (
+              <SidebarSection>
+                <SidebarCollapseItem
+                  id="collapse"
+                  data-test-id="sidebar-collapse"
+                  {...sidebarItemProps}
+                  icon={
+                    <IconChevron direction={collapsed ? 'right' : 'left'} size="sm" />
+                  }
+                  label={collapsed ? t('Expand') : t('Collapse')}
+                  onClick={toggleCollapse}
+                />
+              </SidebarSection>
+            )}
+          </SidebarGradientWrapper>
         </SidebarSectionGroup>
       )}
     </SidebarWrapper>
@@ -658,18 +661,8 @@ function Sidebar() {
 
 export default Sidebar;
 
-const responsiveFlex = css`
-  display: flex;
-  flex-direction: column;
-
-  @media (max-width: ${theme.breakpoints.medium}) {
-    flex-direction: row;
-  }
-`;
-
 export const SidebarWrapper = styled('nav')<{collapsed: boolean}>`
-  background: ${p => p.theme.sidebarGradient};
-  color: ${p => p.theme.sidebar.color};
+  background: ${p => p.theme.background};
   line-height: 1;
   padding: 12px 0 2px; /* Allows for 32px avatars  */
   width: ${p => p.theme.sidebar[p.collapsed ? 'collapsedWidth' : 'expandedWidth']};
@@ -679,8 +672,14 @@ export const SidebarWrapper = styled('nav')<{collapsed: boolean}>`
   bottom: 0;
   justify-content: space-between;
   z-index: ${p => p.theme.zIndex.sidebar};
-  border-right: solid 1px ${p => p.theme.sidebarBorder};
-  ${responsiveFlex};
+  border-right: solid 1px ${p => p.theme.border};
+
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: ${theme.breakpoints.medium}) {
+    flex-direction: row;
+  }
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     top: 0;
@@ -696,14 +695,46 @@ export const SidebarWrapper = styled('nav')<{collapsed: boolean}>`
   }
 `;
 
+const SidebarGradientWrapper = styled('div')`
+  &:after {
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 12px;
+    content: '';
+    display: block;
+    position: absolute;
+    transform: translateY(-100%);
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.15) 0%, transparent 100%);
+    opacity: 0;
+
+    @media (max-height: 675px) and (min-width: ${p => p.theme.breakpoints.medium}) {
+      opacity: 1;
+    }
+  }
+`;
+
 const SidebarSectionGroup = styled('div')`
-  ${responsiveFlex};
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  @media (max-width: ${theme.breakpoints.medium}) {
+    flex-direction: row;
+  }
+
   flex-shrink: 0; /* prevents shrinking on Safari */
   gap: 1px;
 `;
 
 const SidebarSectionGroupPrimary = styled('div')`
-  ${responsiveFlex};
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: ${theme.breakpoints.medium}) {
+    flex-direction: row;
+  }
+
   /* necessary for child flexing on msedge and ff */
   min-height: 0;
   min-width: 0;
@@ -722,11 +753,12 @@ const PrimaryItems = styled('div')`
   flex-direction: column;
   gap: 1px;
   -ms-overflow-style: -ms-autohiding-scrollbar;
+
   @media (max-height: 675px) and (min-width: ${p => p.theme.breakpoints.medium}) {
     border-bottom: 1px solid ${p => p.theme.sidebarBorder};
     padding-bottom: ${space(1)};
-    box-shadow: rgba(0, 0, 0, 0.15) 0px -10px 10px inset;
   }
+
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     overflow-y: visible;
     flex-direction: row;
@@ -735,8 +767,8 @@ const PrimaryItems = styled('div')`
     border-right: 1px solid ${p => p.theme.sidebarBorder};
     padding-right: ${space(1)};
     margin-right: ${space(0.5)};
-    box-shadow: rgba(0, 0, 0, 0.15) -10px 0px 10px inset;
-    ::-webkit-scrollbar {
+
+    &::-webkit-scrollbar {
       display: none;
     }
   }
@@ -758,8 +790,8 @@ const SidebarSection = styled(SidebarSectionGroup)<{
   noMargin?: boolean;
   noPadding?: boolean;
 }>`
-  ${p => !p.noMargin && `margin: ${space(1)} 0`};
-  ${p => !p.noPadding && `padding: 0 ${space(2)}`};
+  ${p => !p.noMargin && `margin: ${space(1)} 0;`}
+  ${p => !p.noPadding && `padding: 0 ${space(2)};`}
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     margin: 0;

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -6,11 +6,7 @@ import styled from '@emotion/styled';
 import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import OnboardingSidebar from 'sentry/components/onboardingWizard/sidebar';
 import {getMergedTasks} from 'sentry/components/onboardingWizard/taskConfig';
-import ProgressRing, {
-  RingBackground,
-  RingBar,
-  RingText,
-} from 'sentry/components/progressRing';
+import ProgressRing, {RingBar, RingText} from 'sentry/components/progressRing';
 import {isDone} from 'sentry/components/sidebar/utils';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -122,14 +118,14 @@ export default function OnboardingStatus({
 const Heading = styled('div')`
   transition: color 100ms;
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.white};
+  color: ${p => p.theme.textColor};
   margin-bottom: ${space(0.25)};
 `;
 
 const Remaining = styled('div')`
   transition: color 100ms;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.textColor};
   display: grid;
   grid-template-columns: max-content max-content;
   gap: ${space(0.75)};
@@ -143,24 +139,23 @@ const PendingSeenIndicator = styled('div')`
   width: 7px;
 `;
 
-const hoverCss = (p: {theme: Theme}) => css`
-  background: rgba(255, 255, 255, 0.05);
+const hoverCss = (p: {theme: Theme}, type: 'hover' | 'active') => css`
+  background: ${type === 'hover'
+    ? p.theme.backgroundSecondary
+    : p.theme.backgroundTertiary};
 
-  ${RingBackground} {
-    stroke: rgba(255, 255, 255, 0.3);
-  }
   ${RingBar} {
-    stroke: ${p.theme.green200};
+    stroke: ${p.theme.green300};
   }
   ${RingText} {
-    color: ${p.theme.white};
+    color: ${p.theme.textColor};
   }
 
   ${Heading} {
-    color: ${p.theme.white};
+    color: ${p.theme.textColor};
   }
   ${Remaining} {
-    color: ${p.theme.white};
+    color: ${p.theme.textColor};
   }
 `;
 
@@ -173,9 +168,9 @@ const Container = styled('div')<{isActive: boolean}>`
   align-items: center;
   transition: background 100ms;
 
-  ${p => p.isActive && hoverCss(p)};
+  ${p => p.isActive && hoverCss(p, 'active')};
 
   &:hover {
-    ${hoverCss};
+    ${p => hoverCss(p, p.isActive ? 'active' : 'hover')};
   }
 `;

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -144,7 +144,7 @@ const SidebarAccordionExpandButton = styled(Button)<{sidebarCollapsed?: boolean}
   &:hover,
   a:hover &,
   a[active] & {
-    color: ${p => p.theme.white};
+    color: ${p => p.theme.textColor};
   }
 
   ${p => p.sidebarCollapsed && `display: none;`}

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -212,7 +212,7 @@ const OrgOrUserName = styled(TextOverflow)`
   font-size: ${p => p.theme.fontSizeLarge};
   line-height: 1.2;
   font-weight: bold;
-  color: ${p => p.theme.white};
+  color: ${p => p.theme.textColor};
   text-shadow: 0 0 6px rgba(255, 255, 255, 0);
   transition: 0.15s text-shadow linear;
 `;
@@ -237,7 +237,7 @@ const SidebarDropdownActor = styled('button')`
       text-shadow: 0 0 6px rgba(255, 255, 255, 0.1);
     }
     ${UserNameOrEmail} {
-      color: ${p => p.theme.white};
+      color: ${p => p.theme.textColor};
     }
   }
 `;

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -1,7 +1,5 @@
 import {Fragment, isValidElement, useCallback, useMemo} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
-import type {Theme} from '@emotion/react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
@@ -191,13 +189,12 @@ function SidebarItem({
       <StyledSidebarItem
         {...props}
         id={`sidebar-item-${id}`}
-        active={isActive ? 'true' : undefined}
         to={toProps}
-        className={className}
+        className={[className, isActive ? 'Active' : ''].join(' ')}
         aria-current={isActive ? 'page' : undefined}
         onClick={handleItemClick}
       >
-        <InteractionStateLayer isPressed={isActive} color="white" higherOpacity />
+        <InteractionStateLayer isPressed={isActive} color={'gray400'} higherOpacity />
         <SidebarItemWrapper collapsed={collapsed}>
           <SidebarItemIcon>{icon}</SidebarItemIcon>
           {!collapsed && !isTop && (
@@ -269,30 +266,11 @@ export function isItemActive(
 
 export default SidebarItem;
 
-const getActiveStyle = ({active, theme}: {active?: string; theme?: Theme}) => {
-  if (!active) {
-    return '';
-  }
-  return css`
-    color: ${theme?.white};
-
-    &:active,
-    &:focus,
-    &:hover {
-      color: ${theme?.white};
-    }
-
-    &:before {
-      background-color: ${theme?.active};
-    }
-  `;
-};
-
 const StyledSidebarItem = styled(Link, {
   shouldForwardProp: p => typeof p === 'string' && isPropValid(p),
 })`
   display: flex;
-  color: inherit;
+  color: ${p => p.theme.textColor};
   position: relative;
   cursor: pointer;
   font-size: 15px;
@@ -328,7 +306,7 @@ const StyledSidebarItem = styled(Link, {
 
   &:hover,
   &:focus-visible {
-    color: ${p => p.theme.white};
+    color: ${p => p.theme.textColor};
   }
 
   &:focus {
@@ -340,7 +318,19 @@ const StyledSidebarItem = styled(Link, {
     box-shadow: 0 0 0 2px ${p => p.theme.purple300};
   }
 
-  ${getActiveStyle};
+  &.Active {
+    color: ${p => p.theme.textColor};
+
+    &:active,
+    &:focus,
+    &:hover {
+      color: ${p => p.theme.textColor};
+    }
+
+    &:before {
+      background-color: ${p => p.theme.purple300};
+    }
+  }
 `;
 
 const SidebarItemWrapper = styled('div')<{collapsed?: boolean}>`
@@ -348,8 +338,8 @@ const SidebarItemWrapper = styled('div')<{collapsed?: boolean}>`
   align-items: center;
   justify-content: center;
   width: 100%;
+  padding-right: ${p => (!p.collapsed ? space(1) : space(0))};
 
-  ${p => !p.collapsed && `padding-right: ${space(1)};`}
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     padding-right: 0;
   }
@@ -381,29 +371,12 @@ const SidebarItemLabel = styled('span')`
   overflow: hidden;
 `;
 
-const getCollapsedBadgeStyle = ({collapsed, theme}) => {
-  if (!collapsed) {
-    return '';
-  }
-
-  return css`
-    text-indent: -99999em;
-    position: absolute;
-    right: 0;
-    top: 1px;
-    background: ${theme.red300};
-    width: ${theme.sidebar.smallBadgeSize};
-    height: ${theme.sidebar.smallBadgeSize};
-    border-radius: ${theme.sidebar.smallBadgeSize};
-    line-height: ${theme.sidebar.smallBadgeSize};
-    box-shadow: ${theme.sidebar.boxShadow};
-  `;
-};
-
-const SidebarItemBadge = styled(({collapsed: _, ...props}) => <span {...props} />)`
+const SidebarItemBadge = styled(({collapsed, ...props}) => (
+  <span {...props} className={collapsed ? 'Collapsed' : ''} />
+))`
   display: block;
   text-align: center;
-  color: ${p => p.theme.white};
+  color: ${p => p.theme.textColor};
   font-size: 12px;
   background: ${p => p.theme.red300};
   width: ${p => p.theme.sidebar.badgeSize};
@@ -411,7 +384,18 @@ const SidebarItemBadge = styled(({collapsed: _, ...props}) => <span {...props} /
   border-radius: ${p => p.theme.sidebar.badgeSize};
   line-height: ${p => p.theme.sidebar.badgeSize};
 
-  ${getCollapsedBadgeStyle};
+  &.Collapsed {
+    text-indent: -99999em;
+    position: absolute;
+    right: 0;
+    top: 1px;
+    background: ${p => p.theme.red300};
+    width: ${p => p.theme.sidebar.smallBadgeSize};
+    height: ${p => p.theme.sidebar.smallBadgeSize};
+    border-radius: ${p => p.theme.sidebar.smallBadgeSize};
+    line-height: ${p => p.theme.sidebar.smallBadgeSize};
+    box-shadow: ${p => p.theme.sidebar.boxShadow};
+  }
 `;
 
 const CollapsedFeatureBadge = styled(FeatureBadge)`


### PR DESCRIPTION
I have punted the idea of removing the sidebar contrast on Slack a few times, but never got to opening the actual PR. I'm opening this PR so we can have an open discussion that wont ultimately get lost in slack (if not for anything else, it can serve as a future reference)

The PR changes the colors of our in-app sidebar in light mode, to no longer be the contrasting with the colors of the main page - note that this is already the case in dark mode (there is only a slight change in dark mode as we align to the theme background color used everywhere else)

The motivation is to take away the heaviness of the sidebar and have the user focus on what is in the middle of the screen. We have a lot of screens that are color heavy, especially when we are displaying a lot of charts - this would take some pressure off the reader and allow them to focus on the content.

A minor benefit here is also that our beta, alpha and whats new badges in our navigation and header cta buttons (see metrics example) stand out better as they have a higher contrast on this light colored background, bringing more attention and hopefully reducing some of the banner blindness we've been hearing about.

Feedback and opinions are very much appreciated. If you are lazy, feel free to just 👍 or 👎 the PR.

P.S. I've included a few examples of other pages from our demo app in the details below
P.P.S. I asked this question [twitter](https://twitter.com/JonasBadalic/status/1697310878809403588) a while back about what folks think of this and seems like @mitsuhiko had a hack to do this at some point :)

![CleanShot 2024-04-03 at 18 20 43@2x](https://github.com/getsentry/sentry/assets/9317857/17f3bffc-a10a-4957-8196-afbe08c01132)


**Light mode before**
![CleanShot 2024-04-03 at 17 21 08@2x](https://github.com/getsentry/sentry/assets/9317857/075f5f92-52ee-4987-ab5f-347684429fd7)

**Light mode after**
![CleanShot 2024-04-03 at 17 20 58@2x](https://github.com/getsentry/sentry/assets/9317857/e4f794b7-f348-4588-86d1-244b0f66ef39)

**Dark mode before**
![CleanShot 2024-04-03 at 17 21 21@2x](https://github.com/getsentry/sentry/assets/9317857/f05c75f4-7627-45ad-89fe-d8fff3ff69a1)

**Dark mode after**
![CleanShot 2024-04-03 at 17 21 35@2x](https://github.com/getsentry/sentry/assets/9317857/27bcca10-4828-4b36-8fe4-712706320886)


<details>
<summary>**Web vitals** (click to expand)</summary>

before
![CleanShot 2024-04-03 at 17 38 17@2x](https://github.com/getsentry/sentry/assets/9317857/de547585-acf4-446e-90fa-9c775e605672)

after
![CleanShot 2024-04-03 at 17 35 46@2x](https://github.com/getsentry/sentry/assets/9317857/ca303171-136d-479b-89e8-0029312ed00a)
</details>

<details>
<summary>**Metrics** (click to expand)</summary>

before
![CleanShot 2024-04-03 at 17 40 31@2x](https://github.com/getsentry/sentry/assets/9317857/f973745d-c203-417a-a3ac-37a0a9e41f7c)

after
![CleanShot 2024-04-03 at 17 41 35@2x](https://github.com/getsentry/sentry/assets/9317857/ff746cb6-97e2-4bbc-9a07-f219826b80fa)

</details>

