### PR TITLE
ref(ui): Avoid gap in invite member modal

### DIFF
--- a/static/app/components/modals/inviteMembersModal/inviteStatusMessage.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteStatusMessage.tsx
@@ -48,9 +48,11 @@ export default function InviteStatusMessage({
       return (
         <StatusMessage status="success">
           <IconCheckmark size="sm" />
-          {errorCount > 0
-            ? tct('Sent [invites], [failed] failed to send.', tctComponents)
-            : tct('Sent [invites]', tctComponents)}
+          <span>
+            {errorCount > 0
+              ? tct('Sent [invites], [failed] failed to send.', tctComponents)
+              : tct('Sent [invites]', tctComponents)}
+          </span>
         </StatusMessage>
       );
     }

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -130,9 +130,11 @@ export function InviteMissingMembersModal({
       return (
         <StatusMessage status="success">
           <IconCheckmark size="sm" />
-          {errorCount > 0
-            ? tct('Sent [invites], [failed] failed to send.', tctComponents)
-            : tct('Sent [invites]', tctComponents)}
+          <span>
+            {errorCount > 0
+              ? tct('Sent [invites], [failed] failed to send.', tctComponents)
+              : tct('Sent [invites]', tctComponents)}
+          </span>
         </StatusMessage>
       );
     }


### PR DESCRIPTION
Because there was a `<strong>` element squished in here it was being affected by the display flex.

Refs https://github.com/getsentry/sentry/issues/68181