### PR TITLE
fix(relocation): Only use relocation storage

### DIFF
--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -30,7 +30,7 @@ from sentry.backup.exports import export_in_config_scope, export_in_user_scope
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.imports import import_in_organization_scope
 from sentry.models.files.file import File
-from sentry.models.files.utils import get_relocation_storage, get_storage
+from sentry.models.files.utils import get_relocation_storage
 from sentry.models.importchunk import ControlImportChunkReplica, RegionImportChunk
 from sentry.models.lostpasswordhash import LostPasswordHash as LostPasswordHash
 from sentry.models.organization import Organization
@@ -951,7 +951,7 @@ def validating_complete(uuid: str, build_id: str) -> None:
         attempts_left,
         ERR_VALIDATING_INTERNAL,
     ):
-        storage = get_storage()
+        storage = get_relocation_storage()
         final_status = ValidationStatus.VALID
         (_, findings_files) = storage.listdir(f"runs/{uuid}/findings")
         for file in sorted(findings_files, reverse=True):

--- a/tests/sentry/tasks/test_relocation.py
+++ b/tests/sentry/tasks/test_relocation.py
@@ -23,7 +23,7 @@ from sentry.backup.dependencies import NormalizedModelName, get_model_name
 from sentry.backup.helpers import ImportFlags, Printer
 from sentry.backup.imports import import_in_organization_scope
 from sentry.models.files.file import File
-from sentry.models.files.utils import get_relocation_storage, get_storage
+from sentry.models.files.utils import get_relocation_storage
 from sentry.models.importchunk import (
     ControlImportChunk,
     ControlImportChunkReplica,
@@ -1469,7 +1469,7 @@ class ValidatingCompleteTest(RelocationTaskTestCase):
             )
         )
 
-        self.storage = get_storage()
+        self.storage = get_relocation_storage()
         self.storage.save(
             f"runs/{self.uuid}/findings/artifacts-prefixes-are-ignored.json",
             BytesIO(b"invalid-json"),
@@ -2092,7 +2092,7 @@ class EndToEndTest(RelocationTaskTestCase, TransactionTestCase):
         RelocationTaskTestCase.setUp(self)
         TransactionTestCase.setUp(self)
 
-        self.storage = get_storage()
+        self.storage = get_relocation_storage()
         files = [
             "null.json",
             "import-baseline-config.json",


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/67915, I added a new `filestore.relocation-backend` option. This is because we discovered that we cannot reuse the default `filestore.backend` in prod: we route prod through an instance of the Filestore service, which is not necessary for relocation (we want to talk to GCS directly instead). This PR just completes that process, converting one errant use of the old `get_storage()` method (which does use Filestore) to `get_relocation_storage()`.