### PR TITLE
feat(replay): Adds click to search on component name

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -100,7 +100,18 @@ function BreadcrumbItem({
 
         {typeof description === 'string' ||
         (description !== undefined && isValidElement(description)) ? (
-          <HTMLTree description={description.toString()} frame={frame as ClickFrame} />
+          <Description
+            title={
+              <HTMLTree
+                description={description.toString()}
+                frame={frame as ClickFrame}
+              />
+            }
+            showOnlyOnOverflow
+            isHoverable
+          >
+            <HTMLTree description={description.toString()} frame={frame as ClickFrame} />
+          </Description>
         ) : (
           <InspectorWrapper>
             <ObjectInspector
@@ -212,7 +223,7 @@ function HTMLTree({description, frame}: {description: string; frame: ClickFrame}
     description.lastIndexOf('>') === -1 ? 0 : description.lastIndexOf('>') + 2;
 
   return (
-    <Description title={description} showOnlyOnOverflow isHoverable>
+    <Fragment>
       {componentName ? (
         <Fragment>
           <div style={{display: 'inline'}}>
@@ -235,7 +246,7 @@ function HTMLTree({description, frame}: {description: string; frame: ClickFrame}
       ) : (
         description
       )}
-    </Description>
+    </Fragment>
   );
 }
 

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -18,7 +18,7 @@ import {getShortEventId} from 'sentry/utils/events';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
 import type {ClickFrame, ErrorFrame, ReplayFrame} from 'sentry/utils/replays/types';
-import {isErrorFrame, isFeedbackFrame} from 'sentry/utils/replays/types';
+import {isClickFrame, isErrorFrame, isFeedbackFrame} from 'sentry/utils/replays/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
@@ -206,7 +206,8 @@ function HTMLTree({description, frame}: {description: string; frame: ClickFrame}
   const location = useLocation();
   const organization = useOrganization();
 
-  const componentName = frame.data.node?.attributes['data-sentry-component'];
+  const componentName =
+    isClickFrame(frame) && frame.data.node?.attributes['data-sentry-component'];
   const lastComponentIndex =
     description.lastIndexOf('>') === -1 ? 0 : description.lastIndexOf('>') + 2;
 

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -216,7 +216,7 @@ function HTMLTree({description, frame}: {description: string; frame: ClickFrame}
       {componentName ? (
         <Fragment>
           <div style={{display: 'inline'}}>
-            {description?.toString().substring(0, lastComponentIndex)}
+            {description.substring(0, lastComponentIndex)}
           </div>
           <Tooltip title={t('Search by this component')} isHoverable>
             <Link

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -1,5 +1,5 @@
 import type {CSSProperties, MouseEvent} from 'react';
-import {isValidElement, memo} from 'react';
+import {Fragment, isValidElement, memo} from 'react';
 import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
@@ -12,14 +12,17 @@ import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {useReplayGroupContext} from 'sentry/components/replays/replayGroupContext';
 import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getShortEventId} from 'sentry/utils/events';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
-import type {ErrorFrame, ReplayFrame} from 'sentry/utils/replays/types';
+import type {ClickFrame, ErrorFrame, ReplayFrame} from 'sentry/utils/replays/types';
 import {isErrorFrame, isFeedbackFrame} from 'sentry/utils/replays/types';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import IconWrapper from 'sentry/views/replays/detail/iconWrapper';
 import TraceGrid from 'sentry/views/replays/detail/perfTable/traceGrid';
 import type {ReplayTraceRow} from 'sentry/views/replays/detail/perfTable/useReplayPerfData';
@@ -97,9 +100,7 @@ function BreadcrumbItem({
 
         {typeof description === 'string' ||
         (description !== undefined && isValidElement(description)) ? (
-          <Description title={description} showOnlyOnOverflow isHoverable>
-            {description}
-          </Description>
+          <HTMLTree description={description.toString()} frame={frame as ClickFrame} />
         ) : (
           <InspectorWrapper>
             <ObjectInspector
@@ -198,6 +199,42 @@ function CrumbErrorIssue({frame}: {frame: ErrorFrame}) {
       {projectBadge}
       <Link to={url}>{frame.data.groupShortId}</Link>
     </CrumbIssueWrapper>
+  );
+}
+
+function HTMLTree({description, frame}: {description: string; frame: ClickFrame}) {
+  const location = useLocation();
+  const organization = useOrganization();
+
+  const componentName = frame.data.node?.attributes['data-sentry-component'];
+  const lastComponentIndex =
+    description.lastIndexOf('>') === -1 ? 0 : description.lastIndexOf('>') + 2;
+
+  return (
+    <Description title={description} showOnlyOnOverflow isHoverable>
+      {componentName ? (
+        <Fragment>
+          <div style={{display: 'inline'}}>
+            {description?.toString().substring(0, lastComponentIndex)}
+          </div>
+          <Tooltip title={t('Search by this component')} isHoverable>
+            <Link
+              to={{
+                pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
+                query: {
+                  ...location.query,
+                  query: `click.component_name:${componentName}`,
+                },
+              }}
+            >
+              {componentName}
+            </Link>
+          </Tooltip>
+        </Fragment>
+      ) : (
+        description
+      )}
+    </Description>
   );
 }
 

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -89,6 +89,10 @@ export function isErrorFrame(frame: ReplayFrame | undefined): frame is ErrorFram
   return Boolean(frame && 'category' in frame && frame.category === 'issue');
 }
 
+export function isClickFrame(frame: ReplayFrame): frame is ClickFrame {
+  return Boolean(frame && 'category' in frame && frame.category === 'ui.click');
+}
+
 export function getFrameOpOrCategory(frame: ReplayFrame) {
   const val = ('op' in frame && frame.op) || ('category' in frame && frame.category);
   invariant(val, 'Frame has no category or op');


### PR DESCRIPTION
If the component that was clicked on is of type React Component Name, then you can click on it to search for replays that also have those clicks. 
We only have data on whether or not the clicked component has a component name, the parents in the tree come in as a string so there's no type data, so only the clicked component will have the ability to click to search. Since the entire HTML tree comes in as one string, some string manipulation was required.

<img width="716" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/84297982-5c52-498c-9bdc-afa31cae51ca">
<img width="596" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/2da53340-77e5-453c-b15b-be04b6d34682">

Relates to: https://github.com/getsentry/sentry/issues/64673