### PR TITLE
ref(crons): Remove usage of useTeams in sentryMemberTeamSelectorField

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -16,7 +15,6 @@ describe('SentryMemberTeamSelectorField', () => {
   const org = OrganizationFixture();
   const mockUsers = [UserFixture()];
   const mockTeams = [TeamFixture()];
-  const mockProjects = [ProjectFixture()];
 
   beforeEach(() => {
     MemberListStore.init();
@@ -46,7 +44,6 @@ describe('SentryMemberTeamSelectorField', () => {
         label="Select Owner"
         onChange={mock}
         name="team-or-member"
-        projects={mockProjects}
       />
     );
 
@@ -68,7 +65,6 @@ describe('SentryMemberTeamSelectorField', () => {
         label="Select Owner"
         onChange={mock}
         name="team-or-member"
-        projects={mockProjects}
       />
     );
 
@@ -90,7 +86,6 @@ describe('SentryMemberTeamSelectorField', () => {
         label="Select Owner"
         onChange={mock}
         name="team-or-member"
-        projects={mockProjects}
         multiple
       />
     );

--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -3,8 +3,8 @@ import {useContext, useEffect, useMemo} from 'react';
 import Avatar from 'sentry/components/avatar';
 import {t} from 'sentry/locale';
 import {useMembers} from 'sentry/utils/useMembers';
-import {useTeams} from 'sentry/utils/useTeams';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
+import {useUserTeams} from 'sentry/utils/useUserTeams';
 
 import FormContext from '../formContext';
 
@@ -70,12 +70,7 @@ function SentryMemberTeamSelectorField({
   );
   useTeamsById({ids: ensureTeamIds});
 
-  const {
-    teams,
-    fetching: fetchingTeams,
-    onSearch: onTeamSearch,
-    loadMore: loadMoreTeams,
-  } = useTeams({provideUserTeams: true});
+  const {teams, isLoading: loadingTeams} = useUserTeams();
 
   const teamOptions = teams?.map(team => ({
     value: `team:${team.id}`,
@@ -92,7 +87,6 @@ function SentryMemberTeamSelectorField({
   useEffect(
     () => {
       loadMoreMembers();
-      loadMoreTeams();
     },
     // Only ensure things are loaded at mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -105,9 +99,8 @@ function SentryMemberTeamSelectorField({
       allowClear
       onInputChange={value => {
         onMemberSearch(value);
-        onTeamSearch(value);
       }}
-      isLoading={fetchingMembers || fetchingTeams}
+      isLoading={fetchingMembers || loadingTeams}
       options={[
         {
           label: t('Members'),

--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -2,7 +2,6 @@ import {useContext, useEffect, useMemo} from 'react';
 
 import Avatar from 'sentry/components/avatar';
 import {t} from 'sentry/locale';
-import type {Project} from 'sentry/types';
 import {useMembers} from 'sentry/utils/useMembers';
 import {useTeams} from 'sentry/utils/useTeams';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
@@ -16,7 +15,6 @@ import SelectField from './selectField';
 // projects can be passed as a direct prop as well
 export interface RenderFieldProps extends SelectFieldProps<any> {
   avatarSize?: number;
-  projects?: Project[];
   /**
    * Use the slug as the select field value. Without setting this the numeric id
    * of the project will be used.


### PR DESCRIPTION
Deprecated, replacing in favor of useUserTeams

the loadMore and search shouldn't be needed here since when we get all user teams it is not a paginated api request