### PR TITLE
feat(issues): add audit log for deletions

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -7,7 +7,7 @@ import rest_framework
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import eventstream
+from sentry import audit_log, eventstream
 from sentry.api.base import audit_logger
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group, GroupStatus
@@ -73,6 +73,11 @@ def delete_group_list(
             logger=audit_logger,
             organization_id=project.organization_id,
             target_object=group.id,
+            event=audit_log.get_event_id("ISSUE_DELETE"),
+            data={
+                "issue_id": group.id,
+                "project_slug": project.slug,
+            },
         )
 
         delete_logger.info(

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -458,3 +458,11 @@ default_manager.add(
         template="unblocked {tags} tags of metric {metric_mri} for project {project_slug}",
     )
 )
+default_manager.add(
+    AuditLogEvent(
+        event_id=186,
+        name="ISSUE_DELETE",
+        api_name="issue.delete",
+        template="Deleted issue {issue_id} for project {project_slug}",
+    )
+)

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -88,6 +88,7 @@ class AuditLogEventRegisterTest(TestCase):
             "org-auth-token.remove",
             "project-team.remove",
             "project-team.add",
+            "issue.delete",
         ]
 
         assert set(audit_log.get_api_names()) == set(audit_log_api_name_list)


### PR DESCRIPTION
Adds an audit log event for issue deletion. We were already sending an audit log, but it would only log, not appear in the UI as no event was registered. I think this is a good change as it is helpful to know who deleted issues.


Fixes https://github.com/getsentry/sentry/issues/68162