### PR TITLE
fix(trends): Should not allow custom fields

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -86,14 +86,13 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
 
         trend_function = request.GET.get("trendFunction", "p50()")
 
-        selected_columns = self.get_field_list(organization, request)
+        selected_columns = ["project_id", "transaction"]
 
         query = request.GET.get("query")
 
         def get_top_events(user_query, params, event_limit, referrer):
             top_event_columns = selected_columns[:]
             top_event_columns.append("count()")
-            top_event_columns.append("project_id")
 
             # Granularity is set to 1d - the highest granularity possible
             # in order to optimize the top event query since we don't care


### PR DESCRIPTION
Something is sending `project_id`, `transaction`, `timestamp` in the fields paramter but not sure where exactly. This is causing an additional group by on the timestamp which is causing repeated entries in the top events list. There's no reason to allow custom fields on the trends endpoint since it makes certain assumptions about the queries. So, let's just get rid of it and hard code in the expected columns to avoid this issue.