### PR TITLE
chore(slack): attachments logger

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -116,6 +116,10 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     "link_names": 1,
                     "attachments": json.dumps(attachments),
                 }
+                self.logger.info(
+                    "rule.slack_post.attachments",
+                    extra={"organization_id": event.group.project.organization_id},
+                )
 
             client = SlackClient(integration_id=integration.id)
             try:


### PR DESCRIPTION
We have a suspicion that we still may be sending attachment payloads when at this point, we should be only sending block payloads. Adds a logger to confirm/deny the theory.