### PR TITLE
ref(perf): Hide user misery chart in transaction summary page

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -174,6 +174,16 @@ function TransactionSummaryCharts({
     organization
   );
 
+  const hasTransactionSummaryCleanupFlag = organization.features.includes(
+    'performance-transaction-summary-cleanup'
+  );
+
+  const displayOptions = generateDisplayOptions(currentFilter).filter(
+    option =>
+      (hasTransactionSummaryCleanupFlag && option.value !== DisplayModes.USER_MISERY) ||
+      !hasTransactionSummaryCleanupFlag
+  );
+
   return (
     <Panel>
       <ChartContainer data-test-id="transaction-summary-charts">
@@ -291,7 +301,7 @@ function TransactionSummaryCharts({
           <OptionSelector
             title={t('Display')}
             selected={display}
-            options={generateDisplayOptions(currentFilter)}
+            options={displayOptions}
             onChange={handleDisplayChange}
           />
         </InlineContainer>

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -44,6 +44,10 @@ function UserStats({
   transactionName,
   eventView,
 }: Props) {
+  const hasTransactionSummaryCleanupFlag = organization.features.includes(
+    'performance-transaction-summary-cleanup'
+  );
+
   let userMisery = error !== null ? <div>{'\u2014'}</div> : <Placeholder height="34px" />;
 
   if (!isLoading && error === null && totals) {
@@ -117,17 +121,22 @@ function UserStats({
           <SidebarSpacer />
         </Fragment>
       )}
-      <GuideAnchor target="user_misery" position="left">
-        <SectionHeading>
-          {t('User Misery')}
-          <QuestionTooltip
-            position="top"
-            title={getTermHelp(organization, PerformanceTerm.USER_MISERY)}
-            size="sm"
-          />
-        </SectionHeading>
-      </GuideAnchor>
-      {userMisery}
+      {!hasTransactionSummaryCleanupFlag && (
+        <Fragment>
+          <GuideAnchor target="user_misery" position="left">
+            <SectionHeading>
+              {t('User Misery')}
+              <QuestionTooltip
+                position="top"
+                title={getTermHelp(organization, PerformanceTerm.USER_MISERY)}
+                size="sm"
+              />
+            </SectionHeading>
+          </GuideAnchor>
+          {userMisery}
+        </Fragment>
+      )}
+
       <SidebarSpacer />
     </Fragment>
   );


### PR DESCRIPTION
Hides the user misery chart in the transaction summary page, as we will be moving away from displaying this.

This removes the chart from the right sidebar, as well as removes it as an option in the big chart dropdown.