### PR TITLE
feat(perf): Change UI label of "HTTP" module to "Requests"

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -52,7 +52,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import MetricsOnboardingSidebar from 'sentry/views/metrics/ddmOnboarding/sidebar';
-import {releaseLevelAsBadgeProps as HTTPModuleBadgeProps} from 'sentry/views/performance/http/settings';
+import {
+  MODULE_TITLE as HTTP_MODULE_TITLE,
+  releaseLevelAsBadgeProps as HTTPModuleBadgeProps,
+} from 'sentry/views/performance/http/settings';
 
 import {ProfilingOnboardingSidebar} from '../profiling/ProfilingOnboarding/profilingOnboardingSidebar';
 
@@ -269,7 +272,11 @@ function Sidebar() {
               <Feature features="performance-http-view" organization={organization}>
                 <SidebarItem
                   {...sidebarItemProps}
-                  label={<GuideAnchor target="performance-http">{t('HTTP')}</GuideAnchor>}
+                  label={
+                    <GuideAnchor target="performance-http">
+                      {HTTP_MODULE_TITLE}
+                    </GuideAnchor>
+                  }
                   to={`/organizations/${organization.slug}/performance/http/`}
                   id="performance-http"
                   icon={<SubitemDot collapsed />}

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -27,7 +27,7 @@ import {
 import {DurationChart} from 'sentry/views/performance/http/durationChart';
 import {HTTPSamplesPanel} from 'sentry/views/performance/http/httpSamplesPanel';
 import {ResponseRateChart} from 'sentry/views/performance/http/responseRateChart';
-import {RELEASE_LEVEL} from 'sentry/views/performance/http/settings';
+import {MODULE_TITLE, RELEASE_LEVEL} from 'sentry/views/performance/http/settings';
 import {ThroughputChart} from 'sentry/views/performance/http/throughputChart';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
@@ -159,7 +159,7 @@ export function HTTPDomainSummaryPage() {
                 preservePageFilters: true,
               },
               {
-                label: 'HTTP',
+                label: MODULE_TITLE,
                 to: normalizeUrl(`/organizations/${organization.slug}/performance/http`),
                 preservePageFilters: true,
               },
@@ -320,7 +320,7 @@ function LandingPageWithProviders() {
   return (
     <ModulePageProviders
       baseURL="/performance/http"
-      title={[t('Performance'), t('HTTP'), t('Domain Summary')].join(' — ')}
+      title={[t('Performance'), MODULE_TITLE, t('Domain Summary')].join(' — ')}
       features="performance-http-view"
     >
       <HTTPDomainSummaryPage />

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -19,7 +19,7 @@ import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/u
 import {DomainsTable, isAValidSort} from 'sentry/views/performance/http/domainsTable';
 import {DurationChart} from 'sentry/views/performance/http/durationChart';
 import {ResponseRateChart} from 'sentry/views/performance/http/responseRateChart';
-import {RELEASE_LEVEL} from 'sentry/views/performance/http/settings';
+import {MODULE_TITLE, RELEASE_LEVEL} from 'sentry/views/performance/http/settings';
 import {ThroughputChart} from 'sentry/views/performance/http/throughputChart';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
@@ -114,13 +114,13 @@ export function HTTPLandingPage() {
                 preservePageFilters: true,
               },
               {
-                label: t('HTTP'),
+                label: MODULE_TITLE,
               },
             ]}
           />
 
           <Layout.Title>
-            {t('HTTP')}
+            {MODULE_TITLE}
             <FeatureBadge type={RELEASE_LEVEL} />
           </Layout.Title>
         </Layout.HeaderContent>
@@ -204,7 +204,7 @@ const DOMAIN_TABLE_ROW_COUNT = 10;
 function LandingPageWithProviders() {
   return (
     <ModulePageProviders
-      title={[t('Performance'), t('HTTP')].join(' — ')}
+      title={[t('Performance'), MODULE_TITLE].join(' — ')}
       baseURL="/performance/http"
       features="performance-http-view"
     >

--- a/static/app/views/performance/http/settings.ts
+++ b/static/app/views/performance/http/settings.ts
@@ -1,4 +1,7 @@
 import type {BadgeType} from 'sentry/components/featureBadge';
+import {t} from 'sentry/locale';
+
+export const MODULE_TITLE = t('HTTP');
 
 export const RELEASE_LEVEL: BadgeType = 'alpha';
 

--- a/static/app/views/performance/http/settings.ts
+++ b/static/app/views/performance/http/settings.ts
@@ -1,7 +1,7 @@
 import type {BadgeType} from 'sentry/components/featureBadge';
 import {t} from 'sentry/locale';
 
-export const MODULE_TITLE = t('HTTP');
+export const MODULE_TITLE = t('Requests');
 
 export const RELEASE_LEVEL: BadgeType = 'alpha';
 

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -14,6 +14,7 @@ import {getConfigurePerformanceDocsLink} from 'sentry/utils/docs';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {NoDataMessage} from 'sentry/views/performance/database/noDataMessage';
+import {MODULE_TITLE as HTTP_MODULE_TITLE} from 'sentry/views/performance/http/settings';
 import {getIsMultiProject} from 'sentry/views/performance/utils';
 
 type Props = {
@@ -128,7 +129,7 @@ export function WidgetAddInstrumentationWarning({type}: {type: 'db' | 'http'}) {
         {tct(
           'No transactions with [spanCategory] spans found. You may need to add integrations to your [link] to capture these spans.',
           {
-            spanCategory: type === 'db' ? t('Database') : t('HTTP'),
+            spanCategory: type === 'db' ? t('Database') : HTTP_MODULE_TITLE,
             link: (
               <ExternalLink href={docsLink}>
                 {t('performance monitoring setup')}


### PR DESCRIPTION
We like that more for now, but also this makes it easy to change later.

- Extract module title to constant
- Rename module

**e.g.,**
<img width="619" alt="Screenshot 2024-04-03 at 3 46 38 PM" src="https://github.com/getsentry/sentry/assets/989898/07bd42bf-3fa8-4464-a349-6b6c02dde4f7">
