### PR TITLE
feat(replay): Add "buffering" state for mobile replays 

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -101,6 +101,11 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   isSkippingInactive: boolean;
 
   /**
+   * Set to true while the current video is loading
+   */
+  isVideoBuffering: boolean;
+
+  /**
    * Whether the replay is considered a video replay
    */
   isVideoReplay: boolean;
@@ -170,6 +175,7 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   addHighlight: () => {},
   initRoot: () => {},
   isBuffering: false,
+  isVideoBuffering: false,
   isFetching: false,
   isFinished: false,
   isPlaying: false,
@@ -264,6 +270,7 @@ function ProviderNonMemo({
   const [speed, setSpeedState] = useState(savedReplayConfigRef.current.playbackSpeed);
   const [fastForwardSpeed, setFFSpeed] = useState(0);
   const [buffer, setBufferTime] = useState({target: -1, previous: -1});
+  const [isVideoBuffering, setVideoBuffering] = useState(false);
   const playTimer = useRef<number | undefined>(undefined);
   const didApplyInitialOffset = useRef(false);
   const [timelineScale, setTimelineScale] = useState(1);
@@ -407,17 +414,24 @@ function ProviderNonMemo({
       // check if this is a video replay and if we can use the video replayer
       if (isVideoReplay && videoEvents && startTimestampMs) {
         const inst = new VideoReplayer(videoEvents, {
-          videoApiPrefix: `/api/0/projects/${
+          videoApiPrefix: `${window.origin}/api/0/projects/${
             organization.slug
           }/${projectSlug}/replays/${replay?.getReplay().id}/videos/`,
           root,
           start: startTimestampMs,
           onFinished: setReplayFinished,
           onLoaded: event => {
+            const {videoHeight, videoWidth} = event.target;
+            if (!videoHeight || !videoWidth) {
+              return;
+            }
             setDimensions({
               height: event.target.videoHeight,
               width: event.target.videoWidth,
             });
+          },
+          onBuffer: buffering => {
+            setVideoBuffering(buffering);
           },
         });
         // `.current` is marked as readonly, but it's safe to set the value from
@@ -615,6 +629,7 @@ function ProviderNonMemo({
         addHighlight,
         initRoot,
         isBuffering,
+        isVideoBuffering,
         isFetching,
         isVideoReplay,
         isFinished,

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -101,7 +101,8 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   isSkippingInactive: boolean;
 
   /**
-   * Set to true while the current video is loading
+   * Set to true while the current video is loading (this is used
+   * only for video replays and in lieu of `isBuffering`)
    */
   isVideoBuffering: boolean;
 

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -427,8 +427,8 @@ function ProviderNonMemo({
               return;
             }
             setDimensions({
-              height: event.target.videoHeight,
-              width: event.target.videoWidth,
+              height: videoHeight,
+              width: videoWidth,
             });
           },
           onBuffer: buffering => {

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -414,7 +414,7 @@ function ProviderNonMemo({
       // check if this is a video replay and if we can use the video replayer
       if (isVideoReplay && videoEvents && startTimestampMs) {
         const inst = new VideoReplayer(videoEvents, {
-          videoApiPrefix: `${window.origin}/api/0/projects/${
+          videoApiPrefix: `/api/0/projects/${
             organization.slug
           }/${projectSlug}/replays/${replay?.getReplay().id}/videos/`,
           root,

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -64,6 +64,7 @@ function BasePlayerRoot({className, overlayContent, isPreview = false}: Props) {
     fastForwardSpeed,
     initRoot,
     isBuffering,
+    isVideoBuffering,
     isFetching,
     isFinished,
     isVideoReplay,
@@ -127,6 +128,7 @@ function BasePlayerRoot({className, overlayContent, isPreview = false}: Props) {
         </Overlay>
       )}
       <StyledNegativeSpaceContainer ref={windowEl} className="sentry-block">
+        {isVideoBuffering ? <OverlayBuffering /> : null}
         <div ref={viewEl} className={className} />
         {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
         {isBuffering ? <PositionedBuffering /> : null}
@@ -149,6 +151,9 @@ const PositionedBuffering = styled(BufferingOverlay)`
   left: 0;
   right: 0;
   bottom: 0;
+`;
+const OverlayBuffering = styled(PositionedBuffering)`
+  z-index: 100;
 `;
 
 const PositionedLoadingIndicator = styled(LoadingIndicator)`

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -128,10 +128,9 @@ function BasePlayerRoot({className, overlayContent, isPreview = false}: Props) {
         </Overlay>
       )}
       <StyledNegativeSpaceContainer ref={windowEl} className="sentry-block">
-        {isVideoBuffering ? <PositionedBuffering /> : null}
         <div ref={viewEl} className={className} />
         {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
-        {isBuffering ? <PositionedBuffering /> : null}
+        {isBuffering || isVideoBuffering ? <PositionedBuffering /> : null}
         {isPreview || isVideoReplay ? null : <PlayerDOMAlert />}
         {isFetching ? <PositionedLoadingIndicator /> : null}
       </StyledNegativeSpaceContainer>

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -128,7 +128,7 @@ function BasePlayerRoot({className, overlayContent, isPreview = false}: Props) {
         </Overlay>
       )}
       <StyledNegativeSpaceContainer ref={windowEl} className="sentry-block">
-        {isVideoBuffering ? <OverlayBuffering /> : null}
+        {isVideoBuffering ? <PositionedBuffering /> : null}
         <div ref={viewEl} className={className} />
         {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
         {isBuffering ? <PositionedBuffering /> : null}
@@ -151,9 +151,6 @@ const PositionedBuffering = styled(BufferingOverlay)`
   left: 0;
   right: 0;
   bottom: 0;
-`;
-const OverlayBuffering = styled(PositionedBuffering)`
-  z-index: 100;
 `;
 
 const PositionedLoadingIndicator = styled(LoadingIndicator)`

--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -114,8 +114,10 @@ describe('VideoReplayer - no starting gap', () => {
       onBuffer: jest.fn(),
     });
     const playPromise = inst.play(18100);
+    // @ts-expect-error private
+    const video = inst.getVideo(2)!;
     // the replay is actually stopped right now to wait for loading
-    fireEvent(inst.getVideo(2), createEvent.loadedData(inst.getVideo(2)));
+    fireEvent(video, createEvent.loadedData(video));
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from
     // the beginning.
     jest.advanceTimersByTime(2500);
@@ -311,8 +313,10 @@ describe('VideoReplayer - with starting gap', () => {
       onBuffer: jest.fn(),
     });
     const playPromise = inst.play(18100);
+    // @ts-expect-error private
+    const video = inst.getVideo(2)!;
     // the replay is actually stopped right now to wait for loading
-    fireEvent(inst.getVideo(2), createEvent.loadedData(inst.getVideo(2)));
+    fireEvent(video, createEvent.loadedData(video));
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from
     // the beginning.
     jest.advanceTimersByTime(2500);

--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -1,3 +1,5 @@
+import {createEvent, fireEvent} from 'sentry-test/reactTestingLibrary';
+
 import {VideoReplayer} from './videoReplayer';
 
 // XXX: Not quite sure the best way to mock RAF - here we use fake timers
@@ -112,6 +114,8 @@ describe('VideoReplayer - no starting gap', () => {
       onBuffer: jest.fn(),
     });
     const playPromise = inst.play(18100);
+    // the replay is actually stopped right now to wait for loading
+    fireEvent(inst.getVideo(2), createEvent.loadedData(inst.getVideo(2)));
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from
     // the beginning.
     jest.advanceTimersByTime(2500);
@@ -307,6 +311,8 @@ describe('VideoReplayer - with starting gap', () => {
       onBuffer: jest.fn(),
     });
     const playPromise = inst.play(18100);
+    // the replay is actually stopped right now to wait for loading
+    fireEvent(inst.getVideo(2), createEvent.loadedData(inst.getVideo(2)));
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from
     // the beginning.
     jest.advanceTimersByTime(2500);

--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -84,10 +84,10 @@ describe('VideoReplayer - no starting gap', () => {
       start: 0,
       onFinished: jest.fn(),
       onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
     });
     // @ts-expect-error private
-    // currentIndex is undefined before we ever press play
-    expect(inst._currentIndex).toEqual(undefined);
+    expect(inst._currentIndex).toEqual(0);
 
     const playPromise = inst.play(6500);
     jest.advanceTimersByTime(10000);
@@ -109,6 +109,7 @@ describe('VideoReplayer - no starting gap', () => {
       start: 0,
       onFinished: jest.fn(),
       onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
     });
     const playPromise = inst.play(18100);
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from
@@ -132,6 +133,7 @@ describe('VideoReplayer - no starting gap', () => {
       // so can't check that onFinished is called
       onFinished: jest.fn(),
       onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
     });
     const playPromise = inst.play(50000);
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from
@@ -153,6 +155,7 @@ describe('VideoReplayer - no starting gap', () => {
       start: 0,
       onFinished: jest.fn(),
       onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
     });
     const playPromise = inst.play(0);
     jest.advanceTimersByTime(2500);
@@ -171,6 +174,7 @@ describe('VideoReplayer - no starting gap', () => {
       start: 0,
       onFinished: jest.fn(),
       onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
     });
     // play at segment 7
     const playPromise = inst.play(45_003);
@@ -204,6 +208,7 @@ describe('VideoReplayer - no starting gap', () => {
       start: 0,
       onFinished: jest.fn(),
       onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
     });
     // play at segment 7
     const playPromise = inst.play(45_003);
@@ -276,9 +281,10 @@ describe('VideoReplayer - with starting gap', () => {
       start: 0,
       onFinished: jest.fn(),
       onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
     });
     // @ts-expect-error private
-    expect(inst._currentIndex).toEqual(undefined);
+    expect(inst._currentIndex).toEqual(0);
     const playPromise = inst.play(1500);
     jest.advanceTimersByTime(2000);
     await playPromise;
@@ -298,6 +304,7 @@ describe('VideoReplayer - with starting gap', () => {
       start: 0,
       onFinished: jest.fn(),
       onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
     });
     const playPromise = inst.play(18100);
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from
@@ -321,6 +328,7 @@ describe('VideoReplayer - with starting gap', () => {
       // so can't check that onFinished is called
       onFinished: jest.fn(),
       onLoaded: jest.fn(),
+      onBuffer: jest.fn(),
     });
     const playPromise = inst.play(50000);
     // 15000 -> 20000 is a gap, so player should start playing @ index 3, from

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -346,10 +346,13 @@ export class VideoReplayer {
       this.setBuffering(true);
     }
 
-    await video.play();
+    const playPromise = video.play();
+    await playPromise;
 
     // Buffering is over after play promise is resolved
     this.setBuffering(false);
+
+    return playPromise;
   }
 
   protected setVideoTime(video: HTMLVideoElement, timeMs: number) {

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -143,7 +143,7 @@ export class VideoReplayer {
 
   /**
    * Resume timer only if replay is running. This accounts for
-   * playing through "dead air". This is used only in `setBuffering`. 
+   * playing through "dead air". This is used only in `setBuffering`.
    */
   private resumeTimer() {
     if (!this._isPlaying) {

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -346,13 +346,10 @@ export class VideoReplayer {
       this.setBuffering(true);
     }
 
-    const playPromise = video.play();
-    await playPromise;
+    await video.play();
 
     // Buffering is over after play promise is resolved
     this.setBuffering(false);
-
-    return playPromise;
   }
 
   protected setVideoTime(video: HTMLVideoElement, timeMs: number) {

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -143,7 +143,7 @@ export class VideoReplayer {
 
   /**
    * Resume timer only if replay is running. This accounts for
-   * playing through "dead air".
+   * playing through "dead air". This is used only in `setBuffering`. 
    */
   private resumeTimer() {
     if (!this._isPlaying) {

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -396,9 +396,6 @@ export class VideoReplayer {
     const nextVideo = this.getVideo(index);
 
     if (nextVideo) {
-      // Will need to hide previous video if next video is ready to
-      // be played immediately
-      // const previousVideoIndex = this._currentIndex;
       // Set video to proper offset
       this.setVideoTime(nextVideo, segmentOffsetMs);
       this._currentIndex = index;

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -462,6 +462,12 @@ export class VideoReplayer {
     // timestamp before playing.
     else if (segmentIndex === undefined && previousSegmentIndex !== undefined) {
       const previousSegment = this.getSegment(previousSegmentIndex)!;
+
+      // XXX: Note that loading the previous segment will require waiting for
+      // it to be loaded before it "plays" through the gap. Some future
+      // improvements can be made here. (e.g. do we play through gaps at all?
+      // should it skip buffering state?)
+
       // Load the last frame of the previous segment
       await this.loadSegment(previousSegmentIndex, {
         segmentOffsetMs: previousSegment.duration,

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -7,7 +7,7 @@ type RootElem = HTMLDivElement | null;
 
 // The number of segments to load on either side of the requested segment (around 15 seconds)
 // Also the number of segments we load initially
-const PRELOAD_BUFFER = 1;
+const PRELOAD_BUFFER = 3;
 
 interface OffsetOptions {
   segmentOffsetMs?: number;

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -99,11 +99,16 @@ export class VideoReplayer {
       }
     });
 
+    // Finished loading data, ready to play
     el.addEventListener('loadeddata', () => {
-      // Only call this for current segment?
+      // Only call this for current segment as we preload multiple
+      // segments simultaneously
       if (index === this._currentIndex) {
-        this.resumeTimer();
-        this._callbacks.onBuffer(false);
+        this.setBuffering(false);
+
+        // We want to display the previous segment until next video
+        // is loaded and ready to play and since video is loaded and
+        // ready here, we hide the previous video
         if (this._currentIndex > 0) {
           this.hideVideo(this._currentIndex - 1);
         }
@@ -160,6 +165,12 @@ export class VideoReplayer {
     this._isPlaying = false;
   }
 
+  /**
+   * Sets the current buffering state by:
+   *
+   * - calling `onBuffer` callback to propagate up
+   * - control timers as they should not run while buffering
+   */
   private setBuffering(isBuffering: boolean) {
     if (isBuffering) {
       this.pauseTimer();

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -147,7 +147,7 @@ export class VideoReplayer {
     if (!this._isPlaying) {
       return;
     }
-    this._timer.pause();
+    this._timer.stop();
   }
 
   private startReplay(videoOffsetMs: number) {

--- a/static/app/utils/replays/timer.spec.tsx
+++ b/static/app/utils/replays/timer.spec.tsx
@@ -3,6 +3,47 @@ import {Timer} from './timer';
 jest.useFakeTimers();
 
 describe('Replay Timer', () => {
+  it('works', () => {
+    const timer = new Timer();
+
+    timer.start();
+    jest.advanceTimersByTime(1008);
+
+    timer.stop();
+    expect(timer.getTime()).toBe(1008);
+    jest.advanceTimersByTime(1008);
+    expect(timer.getTime()).toBe(1008);
+
+    timer.stop();
+    expect(timer.getTime()).toBe(1008);
+    jest.advanceTimersByTime(1008);
+    expect(timer.getTime()).toBe(1008);
+
+    timer.resume();
+    jest.advanceTimersByTime(1008);
+    timer.stop();
+    expect(timer.getTime()).toBe(2016);
+  });
+
+  it('sets a custom time', () => {
+    const timer = new Timer();
+
+    timer.setTime(5678);
+    expect(timer.getTime()).toBe(5678);
+    jest.advanceTimersByTime(1008);
+    // not started yet
+    expect(timer.getTime()).toBe(5678);
+
+    // starting the timer will wipe out the set time!
+    timer.start();
+    expect(timer.getTime()).toBe(0);
+    jest.advanceTimersByTime(1008);
+    expect(timer.getTime()).toBe(1008);
+
+    // so that the timer doesn't infinitely run
+    timer.stop();
+  });
+
   it('handles multiple callbacks', () => {
     const timer = new Timer();
     const spy1 = jest.fn();
@@ -24,27 +65,5 @@ describe('Replay Timer', () => {
     expect(spy2).toHaveBeenCalledTimes(1);
     expect(spy3).toHaveBeenCalledTimes(0);
     expect(spy4).toHaveBeenCalledTimes(0);
-  });
-
-  it('works', () => {
-    const timer = new Timer();
-
-    timer.start();
-    jest.advanceTimersByTime(1008);
-
-    timer.stop();
-    expect(timer.getTime()).toBe(1008);
-    jest.advanceTimersByTime(1008);
-    expect(timer.getTime()).toBe(1008);
-
-    timer.stop();
-    expect(timer.getTime()).toBe(1008);
-    jest.advanceTimersByTime(1008);
-    expect(timer.getTime()).toBe(1008);
-
-    timer.resume();
-    jest.advanceTimersByTime(1008);
-    timer.stop();
-    expect(timer.getTime()).toBe(2016);
   });
 });

--- a/static/app/utils/replays/timer.spec.tsx
+++ b/static/app/utils/replays/timer.spec.tsx
@@ -25,4 +25,26 @@ describe('Replay Timer', () => {
     expect(spy3).toHaveBeenCalledTimes(0);
     expect(spy4).toHaveBeenCalledTimes(0);
   });
+
+  it('works', () => {
+    const timer = new Timer();
+
+    timer.start();
+    jest.advanceTimersByTime(1008);
+
+    timer.pause();
+    expect(timer.getTime()).toBe(1008);
+    jest.advanceTimersByTime(1008);
+    expect(timer.getTime()).toBe(1008);
+
+    timer.pause();
+    expect(timer.getTime()).toBe(1008);
+    jest.advanceTimersByTime(1008);
+    expect(timer.getTime()).toBe(1008);
+
+    timer.resume();
+    jest.advanceTimersByTime(1008);
+    timer.stop();
+    expect(timer.getTime()).toBe(2016);
+  });
 });

--- a/static/app/utils/replays/timer.spec.tsx
+++ b/static/app/utils/replays/timer.spec.tsx
@@ -14,11 +14,6 @@ describe('Replay Timer', () => {
     jest.advanceTimersByTime(1008);
     expect(timer.getTime()).toBe(1008);
 
-    timer.stop();
-    expect(timer.getTime()).toBe(1008);
-    jest.advanceTimersByTime(1008);
-    expect(timer.getTime()).toBe(1008);
-
     timer.resume();
     jest.advanceTimersByTime(1008);
     timer.stop();

--- a/static/app/utils/replays/timer.spec.tsx
+++ b/static/app/utils/replays/timer.spec.tsx
@@ -32,12 +32,12 @@ describe('Replay Timer', () => {
     timer.start();
     jest.advanceTimersByTime(1008);
 
-    timer.pause();
+    timer.stop();
     expect(timer.getTime()).toBe(1008);
     jest.advanceTimersByTime(1008);
     expect(timer.getTime()).toBe(1008);
 
-    timer.pause();
+    timer.stop();
     expect(timer.getTime()).toBe(1008);
     jest.advanceTimersByTime(1008);
     expect(timer.getTime()).toBe(1008);

--- a/static/app/utils/replays/timer.tsx
+++ b/static/app/utils/replays/timer.tsx
@@ -39,6 +39,7 @@ export class Timer extends EventTarget {
     this._pausedAt = 0;
     this._start = window.performance.now() - (seconds ?? 0);
     this.resume();
+    this.step();
   }
 
   /**
@@ -77,6 +78,17 @@ export class Timer extends EventTarget {
     this._start = 0;
     this._time = 0;
     this._pausedAt = 0;
+  }
+
+  /**
+   * Allow updating `_time` directly. Needed for replay in the case
+   * where we seek to a place in the replay before we start the
+   * replay. `play()` in ReplayContext will call `this.getTime()`
+   * when the play button is pressed, so we need to have the correct
+   * playtime to start at.
+   */
+  setTime(time: number) {
+    this._time = time;
   }
 
   getTime() {

--- a/static/app/utils/replays/timer.tsx
+++ b/static/app/utils/replays/timer.tsx
@@ -14,13 +14,6 @@ export class Timer extends EventTarget {
     super();
   }
 
-  private _stopTimer() {
-    if (this._id) {
-      window.cancelAnimationFrame(this._id);
-    }
-    this._active = false;
-  }
-
   step = () => {
     if (!this._active) {
       return;
@@ -49,19 +42,18 @@ export class Timer extends EventTarget {
   }
 
   /**
-   * Stops timer and moves time to `seconds` if provided
+   * Stops/pauses timer, can use `resume` to restart
    */
   stop() {
-    this._stopTimer();
-  }
-
-  pause() {
     if (!this._active) {
       // already paused, do nothing
       return;
     }
     this._pausedAt = window.performance.now();
-    this._stopTimer();
+    if (this._id) {
+      window.cancelAnimationFrame(this._id);
+    }
+    this._active = false;
   }
 
   resume() {
@@ -84,6 +76,7 @@ export class Timer extends EventTarget {
     this.stop();
     this._start = 0;
     this._time = 0;
+    this._pausedAt = 0;
   }
 
   getTime() {


### PR DESCRIPTION
Adds a buffering state for mobile replays to show a "Buffering" messages when it is busy. Also fixes some timer syncing issues when buffering/not ready. 

- Fixes https://github.com/getsentry/sentry/issues/67727
- Fixes https://github.com/getsentry/sentry/issues/67712
- Fixes https://github.com/getsentry/sentry/issues/68111


To test locally: change `PRELOAD_BUFFER` in `videoReplayer` from "3" to "1"
To test on preview deployment: change browser throttling to 3g *after* Sentry UI has loaded and before you play the replay:

![image](https://github.com/getsentry/sentry/assets/79684/0b165bce-e2c3-4417-a6ef-e00887dd3c1f)


Preview (via removing preload):

[Screen Recording 2024-04-03 at 17.11.59.mov](https://github.com/getsentry/sentry/assets/79684/775f4006-8c6c-4acd-9e69-f833a29e43e9)