### PR TITLE
fix(perf): Add missing key prop in SampleInfo Block component

### DIFF
--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -86,7 +86,7 @@ function SampleInfo(props: Props) {
         );
       case 'time_spent_percentage()':
         return (
-          <Block title={DataTitles.timeSpent} alignment="left">
+          <Block key={metric} title={DataTitles.timeSpent} alignment="left">
             <TimeSpentCell
               containerProps={{style}}
               percentage={spanMetrics?.[`time_spent_percentage()`]}


### PR DESCRIPTION
the `time_spent_percentage` percentage block did not have a `key` prop, resulting in a console error message from React:

![image](https://github.com/getsentry/sentry/assets/16740047/02262e86-32da-4994-9904-44747a598b20)
