### PR TITLE
devenv: remove legacy sentry-cli bash reporting

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -27,11 +27,6 @@ source "${SENTRY_ROOT}/scripts/lib.sh"
 #      consequently, using "exit" anywhere will skip this notice from showing.
 #      so need to use set -e, and return 1.
 trap notice ERR
-# This is used to group issues on Sentry.io.
-# If an issue does not call info() or die() it will be grouped under this
-error_message="Unknown issue"
-# This has to be the same value as what sentry-cli accepts
-log_level="info"
 
 help_message() {
     cat <<EOF
@@ -52,17 +47,6 @@ EOF
 notice() {
     [ $? -eq 0 ] && return
     failure_message
-    [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ] && report_to_sentry
-}
-
-report_to_sentry() {
-    if ! require sentry-cli; then
-        curl -sL https://sentry.io/get-cli/ | bash
-    fi
-    # Report to sentry-dev-env project
-    SENTRY_DSN="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503" \
-        sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE" --level "$log_level"
-    rm "$_SENTRY_LOG_FILE"
 }
 
 debug() {
@@ -82,10 +66,6 @@ warn() {
 
 die() {
     echo -e "${red}${bold}FATAL: ${*}${reset}" >&2
-    # When reporting to Sentry, this will allow grouping the errors differently
-    # NOTE: The first line of the output is used to group issues
-    error_message=("${@}")
-    log_level="error"
     return 1
 }
 
@@ -139,19 +119,6 @@ else
     export SENTRY_DEVSERVICES_DSN=https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057
 fi
 
-# We can remove these lines in few months
-if [ "$SHELL" == "/bin/zsh" ]; then
-    zshrc_path="${HOME}/.zshrc"
-    header="# Apple M1 environment variables"
-    if grep -qF "${header}" "${zshrc_path}"; then
-        echo -e "\n${red}Please delete from ${zshrc_path}, the following three lines:${reset}"
-        echo -e "${header}
-export CPATH=/opt/homebrew/Cellar/librdkafka/1.8.2/include
-export LDFLAGS=-L/opt/homebrew/Cellar/gettext/0.21/lib"
-        echo -e "\nWe have moved exporting of these variables to the right place."
-        return 1
-    fi
-fi
 
 ### System ###
 

--- a/.envrc
+++ b/.envrc
@@ -28,6 +28,8 @@ source "${SENTRY_ROOT}/scripts/lib.sh"
 #      so need to use set -e, and return 1.
 trap notice ERR
 
+complete_success="yup"
+
 help_message() {
     cat <<EOF
 For more help run: make direnv-help
@@ -61,7 +63,7 @@ info() {
 
 warn() {
     echo -e "${yellow}${*}${reset}" >&2
-    log_level="warning"
+    complete_success="nope"
 }
 
 die() {
@@ -200,7 +202,7 @@ if [ ${#commands_to_run[@]} -ne 0 ]; then
     show_commands_info
 fi
 
-if [ "${log_level}" != "info" ]; then
+if [ "${complete_success}" != "yup" ]; then
     help_message
     warn "\nPartial success. The virtualenv is active, however, you're not fully up-to-date (see messages above)."
 else

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -9,10 +9,6 @@ HERE="$(
 # shellcheck disable=SC1090
 source "${HERE}/lib.sh"
 
-# This block is to enable reporting issues to Sentry.io
-# SENTRY_DSN already defined in .envrc
-configure-sentry-cli
-
 # This guarantees that we're within a venv. A caller that is not within
 # a venv can avoid enabling this by setting SENTRY_NO_VENV_CHECK
 [ -z "${SENTRY_NO_VENV_CHECK+x}" ] && eval "${HERE}/ensure-venv.sh"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -34,18 +34,6 @@ require() {
     command -v "$1" >/dev/null 2>&1
 }
 
-configure-sentry-cli() {
-    if [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
-        if ! require sentry-cli; then
-            if [ -f "${venv_name}/bin/pip" ]; then
-                pip-install sentry-cli
-            else
-                curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.14.4 bash
-            fi
-        fi
-    fi
-}
-
 query-valid-python-version() {
     python_version=$(python3 -V 2>&1 | awk '{print $2}')
     if [[ -n "${SENTRY_PYTHON_VERSION:-}" ]]; then


### PR DESCRIPTION
this removes [sentry-cli](https://sentry.sentry.io/issues/?project=1&query=SENTRY-cli) bash reporting as it's shown little utility... here are all the issues from that SDK in the last week https://sentry.sentry.io/issues/?limit=5&project=5723503&query=sdk.name%3Asentry-cli&sort=new&statsPeriod=7d and it's pretty much just all grouped into this gigantic unactionable issue: https://sentry.sentry.io/issues/2610656899/?project=5723503&query=sdk.name%3Asentry-cli&sort=new&statsPeriod=7d&stream_index=3

the goal is to cleanup legacy stuff as possible AND soon improve error reporting from devenv's python SDK