### PR TITLE
feat(webvitals): Escapes asterisk in transaction name for page overview

### DIFF
--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -2,6 +2,7 @@ import type {Tag} from 'sentry/types';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -16,6 +17,13 @@ export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props =
   const organization = useOrganization();
   const pageFilters = usePageFilters();
   const location = useLocation();
+  const search = new MutableSearch([]);
+  if (transaction) {
+    search.addFilterValue('transaction', transaction);
+  }
+  if (tag) {
+    search.addFilterValue(tag.key, tag.name);
+  }
 
   const projectEventView = EventView.fromNewQueryWithPageFilters(
     {
@@ -38,8 +46,7 @@ export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props =
       query: [
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
-        ...(transaction ? [`transaction:"${transaction}"`] : []),
-        ...(tag ? [`{tag.key}:"${tag.name}"`] : []),
+        search.formatString(),
       ].join(' '),
       version: 2,
       dataset: dataset ?? DiscoverDatasets.METRICS,

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -47,7 +47,9 @@ export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props =
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
         search.formatString(),
-      ].join(' '),
+      ]
+        .join(' ')
+        .trim(),
       version: 2,
       dataset: dataset ?? DiscoverDatasets.METRICS,
     },

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsTimeseriesQuery.tsx
@@ -6,6 +6,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import type {DiscoverQueryProps} from 'sentry/utils/discover/genericDiscoverQuery';
 import {useGenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -35,6 +36,13 @@ export const useProjectRawWebVitalsTimeseriesQuery = ({
   const pageFilters = usePageFilters();
   const location = useLocation();
   const organization = useOrganization();
+  const search = new MutableSearch(['transaction.op:pageload']);
+  if (transaction) {
+    search.addFilterValue('transaction', transaction);
+  }
+  if (tag) {
+    search.addFilterValue(tag.key, tag.name);
+  }
   const projectTimeSeriesEventView = EventView.fromNewQueryWithPageFilters(
     {
       yAxis: [
@@ -46,11 +54,7 @@ export const useProjectRawWebVitalsTimeseriesQuery = ({
         'count()',
       ],
       name: 'Web Vitals',
-      query: [
-        'transaction.op:pageload',
-        transaction ? `transaction:"${transaction}"` : '',
-        tag ? `${tag.key}:"${tag.name}"` : '',
-      ].join(' '),
+      query: search.formatString(),
       version: 2,
       fields: [],
       interval: getInterval(pageFilters.selection.datetime, 'low'),

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -44,7 +44,9 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
         search.formatString(),
-      ].join(' '),
+      ]
+        .join(' ')
+        .trim(),
       version: 2,
       fields: [],
       interval: getInterval(pageFilters.selection.datetime, 'low'),

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -6,6 +6,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import type {DiscoverQueryProps} from 'sentry/utils/discover/genericDiscoverQuery';
 import {useGenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -22,6 +23,10 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
   const pageFilters = usePageFilters();
   const location = useLocation();
   const organization = useOrganization();
+  const search = new MutableSearch([]);
+  if (transaction) {
+    search.addFilterValue('transaction', transaction);
+  }
   const projectTimeSeriesEventView = EventView.fromNewQueryWithPageFilters(
     {
       yAxis: [
@@ -38,7 +43,7 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
       query: [
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
-        ...(transaction ? [`transaction:"${transaction}"`] : []),
+        search.formatString(),
       ].join(' '),
       version: 2,
       fields: [],

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawSamplesWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawSamplesWebVitalsQuery.tsx
@@ -2,6 +2,7 @@ import type {ReactText} from 'react';
 
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -73,11 +74,9 @@ export const useTransactionRawSamplesWebVitalsQuery = ({
         'project',
       ],
       name: 'Web Vitals',
-      query: [
-        'transaction.op:pageload',
-        `transaction:"${transaction}"`,
-        ...(query ? [query] : []),
-      ].join(' '),
+      query: new MutableSearch(['transaction.op:pageload', ...(query ? [query] : [])])
+        .addStringFilter(`transaction:"${transaction}"`)
+        .formatString(),
       orderby: mapWebVitalToOrderBy(orderBy) ?? withProfiles ? '-profile.id' : undefined,
       version: 2,
     },

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawWebVitalsQuery.tsx
@@ -2,6 +2,7 @@ import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -32,6 +33,13 @@ export const useTransactionRawWebVitalsQuery = ({
 
   const sort = useWebVitalsSort({sortName, defaultSort});
 
+  const search = new MutableSearch([
+    'transaction.op:pageload',
+    ...(query ? [query] : []),
+  ]);
+  if (transaction) {
+    search.addFilterValue('transaction', transaction);
+  }
   const eventView = EventView.fromNewQueryWithPageFilters(
     {
       fields: [
@@ -50,11 +58,7 @@ export const useTransactionRawWebVitalsQuery = ({
         'count()',
       ],
       name: 'Web Vitals',
-      query: [
-        'transaction.op:pageload',
-        ...(transaction ? [`transaction:"${transaction}"`] : []),
-        ...(query ? [query] : []),
-      ].join(' '),
+      query: search.formatString(),
       version: 2,
       dataset: DiscoverDatasets.METRICS,
     },

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -67,7 +67,9 @@ export const useProjectWebVitalsScoresQuery = ({
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
         search.formatString(),
-      ].join(' '),
+      ]
+        .join(' ')
+        .trim(),
       version: 2,
       dataset: dataset ?? DiscoverDatasets.METRICS,
     },

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -2,6 +2,7 @@ import type {Tag} from 'sentry/types';
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -29,6 +30,13 @@ export const useProjectWebVitalsScoresQuery = ({
   const shouldReplaceFidWithInp = useReplaceFidWithInpSetting();
   const inpOrFid = shouldReplaceFidWithInp ? 'inp' : 'fid';
 
+  const search = new MutableSearch([]);
+  if (transaction) {
+    search.addFilterValue('transaction', transaction);
+  }
+  if (tag) {
+    search.addFilterValue(tag.key, tag.name);
+  }
   const projectEventView = EventView.fromNewQueryWithPageFilters(
     {
       fields: [
@@ -58,8 +66,7 @@ export const useProjectWebVitalsScoresQuery = ({
       query: [
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
-        ...(transaction ? [`transaction:"${transaction}"`] : []),
-        ...(tag ? [`${tag.key}:"${tag.name}"`] : []),
+        search.formatString(),
       ].join(' '),
       version: 2,
       dataset: dataset ?? DiscoverDatasets.METRICS,

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -65,7 +65,9 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
         search.formatString(),
-      ].join(' '),
+      ]
+        .join(' ')
+        .trim(),
       version: 2,
       fields: [],
       interval: getInterval(pageFilters.selection.datetime, 'low'),

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -6,6 +6,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import type {DiscoverQueryProps} from 'sentry/utils/discover/genericDiscoverQuery';
 import {useGenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -35,6 +36,13 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
   const pageFilters = usePageFilters();
   const location = useLocation();
   const organization = useOrganization();
+  const search = new MutableSearch([
+    'has:measurements.score.total',
+    ...(tag ? [`${tag.key}:"${tag.name}"`] : []),
+  ]);
+  if (transaction) {
+    search.addFilterValue('transaction', transaction);
+  }
   const projectTimeSeriesEventView = EventView.fromNewQueryWithPageFilters(
     {
       yAxis: [
@@ -56,9 +64,7 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
       query: [
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
-        'has:measurements.score.total',
-        ...(transaction ? [`transaction:"${transaction}"`] : []),
-        ...(tag ? [`${tag.key}:"${tag.name}"`] : []),
+        search.formatString(),
       ].join(' '),
       version: 2,
       fields: [],

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
@@ -2,6 +2,7 @@ import type {ReactText} from 'react';
 
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -78,12 +79,13 @@ export const useTransactionSamplesWebVitalsScoresQuery = ({
           : []),
       ],
       name: 'Web Vitals',
-      query: [
+      query: new MutableSearch([
         'transaction.op:pageload',
-        `transaction:"${transaction}"`,
         'has:measurements.score.total',
         ...(query ? [query] : []),
-      ].join(' '),
+      ])
+        .addStringFilter(`transaction:"${transaction}"`)
+        .formatString(),
       orderby: mapWebVitalToOrderBy(orderBy) ?? withProfiles ? '-profile.id' : undefined,
       version: 2,
     },

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -2,6 +2,7 @@ import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -37,6 +38,13 @@ export const useTransactionWebVitalsScoresQuery = ({
 
   const sort = useWebVitalsSort({sortName, defaultSort});
 
+  const search = new MutableSearch([
+    'avg(measurements.score.total):>=0',
+    ...(query ? [query] : []),
+  ]);
+  if (transaction) {
+    search.addFilterValue('transaction', transaction);
+  }
   const eventView = EventView.fromNewQueryWithPageFilters(
     {
       fields: [
@@ -64,9 +72,7 @@ export const useTransactionWebVitalsScoresQuery = ({
       query: [
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
-        'avg(measurements.score.total):>=0',
-        ...(transaction ? [`transaction:"${transaction}"`] : []),
-        ...(query ? [query] : []),
+        search.formatString(),
       ].join(' '),
       version: 2,
       dataset: DiscoverDatasets.METRICS,

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -73,7 +73,9 @@ export const useTransactionWebVitalsScoresQuery = ({
         'transaction.op:[pageload,""]',
         'span.op:[ui.interaction.click,""]',
         search.formatString(),
-      ].join(' '),
+      ]
+        .join(' ')
+        .trim(),
       version: 2,
       dataset: DiscoverDatasets.METRICS,
     },


### PR DESCRIPTION
Transaction names with asterisks break queries in the page overview. This fix escapes asterisks in transaction names before querying.