### PR TITLE
feat(testing): allow forcing in_test_environment via env var

### DIFF
--- a/src/sentry/utils/env.py
+++ b/src/sentry/utils/env.py
@@ -9,7 +9,11 @@ from sentry.utils import json
 
 
 def in_test_environment() -> bool:
-    return "pytest" in sys.argv[0] or "vscode" in sys.argv[0]
+    return (
+        "pytest" in sys.argv[0]
+        or "vscode" in sys.argv[0]
+        or os.environ.get("SENTRY_IN_TEST_ENVIRONMENT") in {"1", "true"}
+    )
 
 
 def gcp_project_id() -> str:


### PR DESCRIPTION
Enables forcing `in_test_environment` to True via `SENTRY_IN_TEST_ENVIRONMENT` env var.

This allows invoking pytest via other scripts directly from Python code via `pytest.main(...)` 