### PR TITLE
feat(api-idorslug) Finished testing all `convert_args` with Resouce Ids & Slugs

### DIFF
--- a/src/sentry/api/endpoints/organization_sentry_function_details.py
+++ b/src/sentry/api/endpoints/organization_sentry_function_details.py
@@ -3,7 +3,7 @@ from google.api_core.exceptions import FailedPrecondition, InvalidArgument, NotF
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import features, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -27,9 +27,14 @@ class OrganizationSentryFunctionDetailsEndpoint(OrganizationEndpoint):
         args, kwargs = super().convert_args(request, organization_slug, *args, **kwargs)
 
         try:
-            function = SentryFunction.objects.get(
-                slug=function_slug, organization=kwargs["organization"].id
-            )
+            if options.get("api.id-or-slug-enabled"):
+                function = SentryFunction.objects.get(
+                    slug__id_or_slug=function_slug, organization=kwargs["organization"].id
+                )
+            else:
+                function = SentryFunction.objects.get(
+                    slug=function_slug, organization=kwargs["organization"].id
+                )
         except SentryFunction.DoesNotExist:
             raise Http404
 

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -355,7 +355,7 @@ def method_dispatch(**dispatch_mapping):
         return handler(request, *args, **kwargs)
 
     # This allows us to surface the mapping when iterating through the URL patterns
-    # Check `tes_id_or_slug_path_params.py` for usage
+    # Check `test_id_or_slug_path_params.py` for usage
     dispatcher.dispatch_mapping = dispatch_mapping  # type: ignore[attr-defined]
 
     if dispatch_mapping.get("csrf_exempt"):

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -342,7 +342,7 @@ def customer_domain_path(path: str) -> str:
 
 def method_dispatch(**dispatch_mapping):
     """
-    Dispatches a incoming request to a different handler based on the HTTP method
+    Dispatches an incoming request to a different handler based on the HTTP method
 
     >>> re_path('^foo$', method_dispatch(POST = post_handler, GET = get_handler)))
     """
@@ -353,6 +353,10 @@ def method_dispatch(**dispatch_mapping):
     def dispatcher(request, *args, **kwargs):
         handler = dispatch_mapping.get(request.method, invalid_method)
         return handler(request, *args, **kwargs)
+
+    # This allows us to surface the mapping when iterating through the URL patterns
+    # Check `tes_id_or_slug_path_params.py` for usage
+    dispatcher.dispatch_mapping = dispatch_mapping  # type: ignore[attr-defined]
 
     if dispatch_mapping.get("csrf_exempt"):
         return csrf_exempt(dispatcher)

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -147,12 +147,6 @@ class MonitorIngestCheckinAttachmentEndpoint(Endpoint):
         ):
             raise ResourceDoesNotExist
 
-        if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
-            if project.organization.id != organization.id:
-                raise ResourceDoesNotExist
-        elif project.organization.slug != organization_slug:
-            raise ResourceDoesNotExist
-
         # Check project permission. Required for Token style authentication
         self.check_object_permissions(request, project)
 

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -63,7 +63,7 @@ class MonitorIngestCheckinAttachmentEndpoint(Endpoint):
         request: Request,
         monitor_slug: str | int,
         checkin_id: str,
-        organization_slug: str | None = None,
+        organization_slug: str | int | None = None,
         *args,
         **kwargs,
     ):
@@ -137,7 +137,14 @@ class MonitorIngestCheckinAttachmentEndpoint(Endpoint):
 
         # When looking up via GUID we do not check the organization slug,
         # validate that the slug matches the org of the monitors project
-        if not organization_slug:
+
+        # We only raise if the organization_slug was set and it doesn't match.
+        # We don't check the api.id-or-slug-enabled option here because slug and id are unique
+        if (
+            organization_slug
+            and project.organization.slug != organization_slug
+            and project.organization.id != organization_slug
+        ):
             raise ResourceDoesNotExist
 
         if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -249,10 +249,15 @@ class OrganizationMixin:
         return is_member_disabled_from_limit(request, organization)
 
     def get_active_project(
-        self, request: HttpRequest, organization: RpcOrganization, project_slug: str
+        self, request: HttpRequest, organization: RpcOrganization, project_slug: str | int
     ) -> Project | None:
         try:
-            project = Project.objects.get(slug=project_slug, organization=organization)
+            if options.get("api.id-or-slug-enabled"):
+                project = Project.objects.get(
+                    slug__id_or_slug=project_slug, organization=organization
+                )
+            else:
+                project = Project.objects.get(slug=project_slug, organization=organization)
         except Project.DoesNotExist:
             return None
 
@@ -710,7 +715,7 @@ class ProjectView(OrganizationView):
             return False
         return True
 
-    def convert_args(self, request: HttpRequest, organization_slug: str, project_slug: str, *args: Any, **kwargs: Any) -> tuple[tuple[Any, ...], dict[str, Any]]:  # type: ignore[override]
+    def convert_args(self, request: HttpRequest, organization_slug: str, project_slug: str | int, *args: Any, **kwargs: Any) -> tuple[tuple[Any, ...], dict[str, Any]]:  # type: ignore[override]
         organization: Organization | None = None
         active_project: Project | None = None
         if self.active_organization:

--- a/tests/sentry/api/path_params/resources/test_function_slug.py
+++ b/tests/sentry/api/path_params/resources/test_function_slug.py
@@ -1,0 +1,18 @@
+from rest_framework.request import Request
+
+from sentry.testutils.cases import TestCase
+
+from .test_id_or_slug_path_params_mixin import APIIdOrSlugTestMixin
+
+
+class FunctionSlugTests(TestCase, APIIdOrSlugTestMixin):
+    def organization_sentry_function_details_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(request=self.make_request())
+
+        _, converted_slugs = endpoint_class().convert_args(request=request, **slug_kwargs)
+        _, converted_ids = endpoint_class().convert_args(request=request, **id_kwargs)
+
+        self.assert_conversion(endpoint_class, converted_slugs, converted_ids)

--- a/tests/sentry/api/path_params/resources/test_id_or_slug_path_params_mixin.py
+++ b/tests/sentry/api/path_params/resources/test_id_or_slug_path_params_mixin.py
@@ -5,14 +5,19 @@ from sentry.api.endpoints.organization_member.team_details import (
     OrganizationMemberTeamDetailsEndpoint,
 )
 from sentry.api.endpoints.project_team_details import ProjectTeamDetailsEndpoint
+from sentry.incidents.models.incident import Incident, IncidentActivity
+from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.monitors.models import MonitorCheckIn, MonitorEnvironment
 
 
 class APIIdOrSlugTestMixin:
     slug_mappings: dict[str, Any]
     reverse_slug_mappings: dict[str, Any]
-    incident: Any
-    code_mapping: Any
-    incident_activity: Any
+    incident: Incident
+    code_mapping: RepositoryProjectPathConfig
+    incident_activity: IncidentActivity
+    monitor_checkin: MonitorCheckIn
+    monitor_environment: MonitorEnvironment
 
     @property
     def no_slugs_in_kwargs_allowlist(self) -> set[Any]:

--- a/tests/sentry/api/path_params/resources/test_monitor_slug.py
+++ b/tests/sentry/api/path_params/resources/test_monitor_slug.py
@@ -1,0 +1,104 @@
+from typing import Any
+
+from rest_framework.request import Request
+
+from sentry.testutils.cases import TestCase
+
+from .test_id_or_slug_path_params_mixin import APIIdOrSlugTestMixin
+
+
+class MonitorSlugTests(TestCase, APIIdOrSlugTestMixin):
+    def monitor_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        _, converted_slugs = endpoint_class().convert_args(request=request, **slug_kwargs)
+        _, converted_ids = endpoint_class().convert_args(request=request, **id_kwargs)
+
+        self.assert_conversion(endpoint_class, converted_slugs, converted_ids)
+
+    def project_monitor_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        _, converted_slugs = endpoint_class().convert_args(request=request, **slug_kwargs)
+        _, converted_ids = endpoint_class().convert_args(request=request, **id_kwargs)
+
+        self.assert_conversion(endpoint_class, converted_slugs, converted_ids)
+
+    def project_monitor_checkin_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        non_slug_mappings: dict[str, Any] = {
+            "checkin_id": self.monitor_checkin.guid,
+        }
+        reverse_non_slug_mappings: dict[str, Any] = {
+            "checkin": self.monitor_checkin,
+        }
+
+        _, converted_slugs = endpoint_class().convert_args(
+            request=request, **slug_kwargs, **non_slug_mappings
+        )
+        _, converted_ids = endpoint_class().convert_args(
+            request=request, **id_kwargs, **non_slug_mappings
+        )
+
+        self.assert_conversion(
+            endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
+        )
+
+    def project_monitor_environment_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        non_slug_mappings: dict[str, Any] = {
+            "environment": self.environment.name,
+        }
+        reverse_non_slug_mappings: dict[str, Any] = {
+            "monitor_environment": self.monitor_environment,
+        }
+
+        _, converted_slugs = endpoint_class().convert_args(
+            request=request, **slug_kwargs, **non_slug_mappings
+        )
+        _, converted_ids = endpoint_class().convert_args(
+            request=request, **id_kwargs, **non_slug_mappings
+        )
+
+        self.assert_conversion(
+            endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
+        )
+
+    def monitor_ingest_checkin_attachment_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        # We can do this because the code path for when checkin_id is not "latest" has no logic for slug/id
+        non_slug_mappings: dict[str, Any] = {
+            "checkin_id": "latest",
+        }
+        reverse_non_slug_mappings: dict[str, Any] = {
+            "checkin": self.monitor_checkin,
+        }
+
+        _, converted_slugs = endpoint_class().convert_args(
+            request=request, **slug_kwargs, **non_slug_mappings
+        )
+        _, converted_ids = endpoint_class().convert_args(
+            request=request, **id_kwargs, **non_slug_mappings
+        )
+
+        self.assert_conversion(
+            endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
+        )

--- a/tests/sentry/api/path_params/resources/test_project_slug.py
+++ b/tests/sentry/api/path_params/resources/test_project_slug.py
@@ -98,7 +98,6 @@ class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "release_threshold": release_threshold.id,
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "release_threshold": release_threshold,
         }
@@ -130,7 +129,6 @@ class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
         non_slug_mappings: dict[str, Any] = {
             "rule_id": str(rule.id),
         }
-
         reverse_non_slug_mappings: dict[str, Any] = {
             "rule": rule,
         }

--- a/tests/sentry/api/path_params/resources/test_project_slug.py
+++ b/tests/sentry/api/path_params/resources/test_project_slug.py
@@ -1,9 +1,12 @@
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from rest_framework.request import Request
 
+from sentry.models.release_threshold import ReleaseThreshold
+from sentry.models.rule import Rule
 from sentry.testutils.cases import TestCase
+from sentry.web.frontend.base import ProjectView
 
 from .test_id_or_slug_path_params_mixin import APIIdOrSlugTestMixin
 
@@ -77,3 +80,93 @@ class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
         self.assert_conversion(
             endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
         )
+
+    def release_threshold_details_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        release_threshold = ReleaseThreshold.objects.create(
+            threshold_type=0,
+            trigger_type=0,
+            value=1,
+            window_in_seconds=1,
+            project=self.project,
+        )
+
+        non_slug_mappings: dict[str, Any] = {
+            "release_threshold": release_threshold.id,
+        }
+
+        reverse_non_slug_mappings: dict[str, Any] = {
+            "release_threshold": release_threshold,
+        }
+
+        _, converted_slugs = endpoint_class().convert_args(
+            request=request, **slug_kwargs, **non_slug_mappings
+        )
+        _, converted_ids = endpoint_class().convert_args(
+            request=request, **id_kwargs, **non_slug_mappings
+        )
+
+        self.assert_conversion(
+            endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
+        )
+
+    def rule_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        rule = Rule.objects.create(
+            project=self.project,
+            label="test",
+            data={},
+            environment_id=None,
+        )
+
+        non_slug_mappings: dict[str, Any] = {
+            "rule_id": str(rule.id),
+        }
+
+        reverse_non_slug_mappings: dict[str, Any] = {
+            "rule": rule,
+        }
+
+        _, converted_slugs = endpoint_class().convert_args(
+            request=request, **slug_kwargs, **non_slug_mappings
+        )
+        _, converted_ids = endpoint_class().convert_args(
+            request=request, **id_kwargs, **non_slug_mappings
+        )
+
+        self.assert_conversion(
+            endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
+        )
+
+    @patch.object(ProjectView, "active_organization", create=True, new_callable=PropertyMock)
+    @patch("sentry.web.frontend.base.ProjectView._get_organization")
+    def project_view_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        active_organization_mock = args[1]
+        active_organization_mock.return_value = True
+
+        _get_organization_mock = args[0]
+        _get_organization_mock.return_value = self.organization
+
+        request = Request(self.make_request(user=self.user))
+
+        # Even though there is 1 endpoint for this convert_args that doesn't need organization_slug, we need to pass it
+        slug_kwargs["organization_slug"] = self.slug_mappings["organization_slug"].slug
+        id_kwargs["organization_slug"] = self.slug_mappings["organization_slug"].id
+
+        request = Request(self.make_request(user=self.user))
+
+        _, converted_slugs = endpoint_class().convert_args(request=request, **slug_kwargs)
+        _, converted_ids = endpoint_class().convert_args(request=request, **id_kwargs)
+
+        self.assert_conversion(endpoint_class, converted_slugs, converted_ids)

--- a/tests/sentry/api/path_params/resources/test_team_slug.py
+++ b/tests/sentry/api/path_params/resources/test_team_slug.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+from rest_framework.request import Request
+
+from sentry.testutils.cases import TestCase
+
+from .test_id_or_slug_path_params_mixin import APIIdOrSlugTestMixin
+
+
+class TeamSlugTests(TestCase, APIIdOrSlugTestMixin):
+    def team_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        _, converted_slugs = endpoint_class().convert_args(request=request, **slug_kwargs)
+        _, converted_ids = endpoint_class().convert_args(request=request, **id_kwargs)
+
+        self.assert_conversion(endpoint_class, converted_slugs, converted_ids)
+
+    def external_team_details_test(self, endpoint_class, slug_params, *args):
+        slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
+        id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}
+
+        request = Request(self.make_request(user=self.user))
+
+        external_team = self.create_external_team(team=self.team)
+
+        non_slug_mappings: dict[str, Any] = {
+            "external_team_id": external_team.id,
+        }
+        reverse_non_slug_mappings: dict[str, Any] = {
+            "external_team": external_team,
+        }
+
+        _, converted_slugs = endpoint_class().convert_args(
+            request=request, **slug_kwargs, **non_slug_mappings
+        )
+        _, converted_ids = endpoint_class().convert_args(
+            request=request, **id_kwargs, **non_slug_mappings
+        )
+
+        self.assert_conversion(
+            endpoint_class, converted_slugs, converted_ids, reverse_non_slug_mappings
+        )

--- a/tests/sentry/api/path_params/test_id_or_slug_path_params.py
+++ b/tests/sentry/api/path_params/test_id_or_slug_path_params.py
@@ -278,9 +278,7 @@ class APIIdOrSlugPathParamTest(
             if hasattr(callback, "convert_args"):
                 slug_path_params = extract_slug_path_params(pattern)
                 if slug_path_params:
-                    if (
-                        convert_args := self.convert_args_setup_registry.get(callback.convert_args)
-                    ) is not None:
+                    if convert_args := self.convert_args_setup_registry.get(callback.convert_args):
                         convert_args(callback, slug_path_params)
                     else:
                         self.fail(f"Missing test method for {callback}.")

--- a/tests/sentry/api/path_params/test_id_or_slug_path_params.py
+++ b/tests/sentry/api/path_params/test_id_or_slug_path_params.py
@@ -2,6 +2,7 @@ import re
 from collections.abc import Callable, Generator
 from typing import Any
 from unittest.mock import patch
+from uuid import uuid4
 
 from django.urls import URLPattern, URLResolver
 from django.urls.resolvers import get_resolver
@@ -15,14 +16,17 @@ from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, Organ
 from sentry.api.bases.organization_integrations import RegionOrganizationIntegrationBaseEndpoint
 from sentry.api.bases.organizationmember import OrganizationMemberEndpoint
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.bases.sentryapps import (
     RegionSentryAppBaseEndpoint,
     SentryAppBaseEndpoint,
     SentryAppInstallationBaseEndpoint,
     SentryAppInstallationsBaseEndpoint,
 )
+from sentry.api.bases.team import TeamEndpoint
 from sentry.api.endpoints.broadcast_index import BroadcastIndexEndpoint
 from sentry.api.endpoints.codeowners.details import ProjectCodeOwnersDetailsEndpoint
+from sentry.api.endpoints.codeowners.external_actor.team_details import ExternalTeamDetailsEndpoint
 from sentry.api.endpoints.codeowners.external_actor.user_details import ExternalUserDetailsEndpoint
 from sentry.api.endpoints.integrations.sentry_apps import SentryInternalAppTokenDetailsEndpoint
 from sentry.api.endpoints.notifications.notification_actions_details import (
@@ -37,20 +41,39 @@ from sentry.api.endpoints.organization_code_mapping_details import (
 from sentry.api.endpoints.organization_dashboard_details import OrganizationDashboardDetailsEndpoint
 from sentry.api.endpoints.organization_region import OrganizationRegionEndpoint
 from sentry.api.endpoints.organization_search_details import OrganizationSearchDetailsEndpoint
+from sentry.api.endpoints.organization_sentry_function_details import (
+    OrganizationSentryFunctionDetailsEndpoint,
+)
+from sentry.api.endpoints.release_thresholds.release_threshold_details import (
+    ReleaseThresholdDetailsEndpoint,
+)
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint, ProjectAlertRuleEndpoint
 from sentry.incidents.endpoints.organization_incident_comment_details import CommentDetailsEndpoint
 from sentry.incidents.models.incident import IncidentActivityType
 from sentry.models.repository import Repository
+from sentry.monitors.endpoints.base import (
+    MonitorEndpoint,
+    ProjectMonitorCheckinEndpoint,
+    ProjectMonitorEndpoint,
+    ProjectMonitorEnvironmentEndpoint,
+)
+from sentry.monitors.endpoints.monitor_ingest_checkin_attachment import (
+    MonitorIngestCheckinAttachmentEndpoint,
+)
+from sentry.monitors.models import Monitor, MonitorCheckIn, MonitorEnvironment
 from sentry.scim.endpoints.members import OrganizationSCIMMemberDetails
 from sentry.scim.endpoints.teams import OrganizationSCIMTeamDetails
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import no_silo_test
-from sentry.web.frontend.base import AbstractOrganizationView, BaseView
+from sentry.web.frontend.base import AbstractOrganizationView, BaseView, ProjectView
 
 from .resources.test_doc_integration_slug import DocIntegrationSlugTests
+from .resources.test_function_slug import FunctionSlugTests
+from .resources.test_monitor_slug import MonitorSlugTests
 from .resources.test_organization_slug import OrganizationSlugTests
 from .resources.test_project_slug import ProjectSlugTests
 from .resources.test_sentry_app_slug import SentryAppSlugTests
+from .resources.test_team_slug import TeamSlugTests
 
 
 def extract_slug_path_params(path: str) -> list[str]:
@@ -64,18 +87,25 @@ def extract_all_url_patterns(
         if isinstance(pattern, URLResolver):
             yield from extract_all_url_patterns(pattern.url_patterns, base + str(pattern.pattern))
         elif isinstance(pattern, URLPattern):
-            url_pattern = base + str(pattern.pattern).replace("^", "").replace(
-                "$", ""
-            )  # Clean up pattern string
+            url_pattern = base + str(pattern.pattern).replace("^", "").replace("$", "")
             callback = pattern.callback
             if hasattr(callback, "view_class"):
-                callback = callback.view_class
-                yield (url_pattern, callback)
+                yield (url_pattern, callback.view_class)
+            elif hasattr(callback, "dispatch_mapping"):
+                for view_func in callback.dispatch_mapping.keys():
+                    if callable(view_func):
+                        yield (url_pattern, view_func.cls)
 
 
 @no_silo_test
 class APIIdOrSlugPathParamTest(
-    DocIntegrationSlugTests, SentryAppSlugTests, OrganizationSlugTests, ProjectSlugTests
+    DocIntegrationSlugTests,
+    FunctionSlugTests,
+    OrganizationSlugTests,
+    MonitorSlugTests,
+    ProjectSlugTests,
+    SentryAppSlugTests,
+    TeamSlugTests,
 ):
     """
     This test class is used to test if all endpoints work with both slugs and ids as path parameters.
@@ -105,6 +135,8 @@ class APIIdOrSlugPathParamTest(
             6b. Pass use_id=True if you want to compare the ids of the objects instead of the objects themselves.
 
 
+    NOTE: If the API callback is a method dispatch mechanism that dynamically selects a view based on the request method, you must add to the manual test.
+
     Take a look at `sentry_app_token_test` in sentry_app_slug_test.py for an example of how to add a new endpoint to the test.
     """
 
@@ -120,11 +152,15 @@ class APIIdOrSlugPathParamTest(
         self.sentry_app = self.create_sentry_app(organization=self.organization)
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
         self.project = self.create_project(organization=self.organization)
         self.group = self.create_group(project=self.project)
         self.incident = self.create_incident(organization=self.organization)
         self.incident_activity = self.create_incident_activity(
             incident=self.incident, type=IncidentActivityType.COMMENT.value, user_id=self.user.id
+        )
+        self.function = self.create_sentry_function(
+            name="test", code="test", organization_id=self.organization.id
         )
 
         self.repo = Repository.objects.create(
@@ -134,6 +170,28 @@ class APIIdOrSlugPathParamTest(
         self.code_mapping = self.create_code_mapping(
             repo=self.repo,
             project=self.project,
+        )
+
+        self.monitor = Monitor.objects.create(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            name="Test Monitor",
+        )
+
+        self.monitor_checkin = MonitorCheckIn.objects.create(
+            guid=uuid4().hex,
+            project_id=self.project.id,
+            monitor_id=self.monitor.id,
+            status=3,
+        )
+
+        self.environment = self.create_environment(
+            organization=self.organization, project=self.project, name="test"
+        )
+
+        self.monitor_environment = MonitorEnvironment.objects.create(
+            monitor_id=self.monitor.id,
+            environment_id=self.environment.id,
         )
 
     def setUp(self, *args, **kwargs):
@@ -149,9 +207,12 @@ class APIIdOrSlugPathParamTest(
             ControlSiloOrganizationEndpoint.convert_args: self.control_silo_organization_endpoint_test,
             DocIntegrationBaseEndpoint.convert_args: self.doc_integration_test,
             Endpoint.convert_args: self.ignore_test,
+            ExternalTeamDetailsEndpoint.convert_args: self.external_team_details_test,
             ExternalUserDetailsEndpoint.convert_args: self.external_user_details_test,
             GroupEndpoint.convert_args: self.group_test,
             IncidentEndpoint.convert_args: self.incident_test,
+            MonitorEndpoint.convert_args: self.monitor_test,
+            MonitorIngestCheckinAttachmentEndpoint.convert_args: self.monitor_ingest_checkin_attachment_test,
             NotificationActionsDetailsEndpoint.convert_args: self.notification_actions_details_test,
             OrganizationAlertRuleEndpoint.convert_args: self.organization_alert_rule_test,
             OrganizationCodeMappingCodeOwnersEndpoint.convert_args: self.organization_code_mapping_codeowners_test,
@@ -163,15 +224,23 @@ class APIIdOrSlugPathParamTest(
             OrganizationSCIMMemberDetails.convert_args: self.organization_member_test,
             OrganizationSCIMTeamDetails.convert_args: self.organization_team_test,
             OrganizationSearchDetailsEndpoint.convert_args: self.organization_search_details_test,
+            OrganizationSentryFunctionDetailsEndpoint.convert_args: self.organization_sentry_function_details_test,
             ProjectAlertRuleEndpoint.convert_args: self.project_alert_rule_endpoint_test,
             ProjectEndpoint.convert_args: self.project_test,
             ProjectCodeOwnersDetailsEndpoint.convert_args: self.project_codeowners_details_test,
+            ProjectMonitorCheckinEndpoint.convert_args: self.project_monitor_checkin_test,
+            ProjectMonitorEndpoint.convert_args: self.project_monitor_test,
+            ProjectMonitorEnvironmentEndpoint.convert_args: self.project_monitor_environment_test,
+            ProjectView.convert_args: self.project_view_test,
             RegionOrganizationIntegrationBaseEndpoint.convert_args: self.region_organization_integration_test,
             RegionSentryAppBaseEndpoint.convert_args: self.region_sentry_app_test,
+            ReleaseThresholdDetailsEndpoint.convert_args: self.release_threshold_details_test,
+            RuleEndpoint.convert_args: self.rule_test,
             SentryAppBaseEndpoint.convert_args: self.sentry_app_test,
             SentryAppInstallationBaseEndpoint.convert_args: self.ignore_test,
             SentryAppInstallationsBaseEndpoint.convert_args: self.sentry_app_installations_base_test,
             SentryInternalAppTokenDetailsEndpoint.convert_args: self.sentry_app_token_test,
+            TeamEndpoint.convert_args: self.team_test,
         }
 
         self.create_models()
@@ -184,6 +253,8 @@ class APIIdOrSlugPathParamTest(
             "organization_slug": self.organization,
             "project_slug": self.project,
             "team_slug": self.team,
+            "monitor_slug": self.monitor,
+            "function_slug": self.function,
         }
 
         # Map values in kwargs to the actual objects
@@ -193,6 +264,8 @@ class APIIdOrSlugPathParamTest(
             "organization": self.organization,
             "project": self.project,
             "team": self.team,
+            "monitor": self.monitor,
+            "function": self.function,
         }
 
     def test_if_endpoints_work_with_id_or_slug(self):
@@ -205,16 +278,7 @@ class APIIdOrSlugPathParamTest(
             if hasattr(callback, "convert_args"):
                 slug_path_params = extract_slug_path_params(pattern)
                 if slug_path_params:
-                    if (
-                        slug_path_params == ["doc_integration_slug"]
-                        or slug_path_params == ["sentry_app_slug"]
-                        or slug_path_params == ["organization_slug"]
-                    ):
-                        self.convert_args_setup_registry[callback.convert_args](
-                            callback, slug_path_params
-                        )
-                    # Temporary for "project_slug" endpoints
-                    elif convert_args := self.convert_args_setup_registry.get(
-                        callback.convert_args
-                    ):
+                    if (convert_args := self.convert_args_setup_registry.get(callback)) is not None:
                         convert_args(callback, slug_path_params)
+                    else:
+                        self.fail(f"Missing test method for {callback}.")

--- a/tests/sentry/api/path_params/test_id_or_slug_path_params.py
+++ b/tests/sentry/api/path_params/test_id_or_slug_path_params.py
@@ -278,7 +278,9 @@ class APIIdOrSlugPathParamTest(
             if hasattr(callback, "convert_args"):
                 slug_path_params = extract_slug_path_params(pattern)
                 if slug_path_params:
-                    if (convert_args := self.convert_args_setup_registry.get(callback)) is not None:
+                    if (
+                        convert_args := self.convert_args_setup_registry.get(callback.convert_args)
+                    ) is not None:
                         convert_args(callback, slug_path_params)
                     else:
                         self.fail(f"Missing test method for {callback}.")


### PR DESCRIPTION
* Finished testing the rest of the `convert_args` ❗  
* Modified `extract_all_url_patterns` to handle edge-case where `sentry-api-0-organization-monitor-check-in-attachment` calls `method_dispatch` to use a different class for each method.
* Added the  a property to `method_dispatch` that `extract_all_url_patterns` could user
* Updated some types


For: https://github.com/getsentry/team-core-product-foundations/issues/194