### PR TITLE
chore(api-idorslug): Created Options for EA & Option Wrapper

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -480,3 +480,22 @@ class Timer:
             return self._duration
         else:
             return time.time() - self._start
+
+
+def id_or_slug_path_params_enabled(organization_slug: str | None = None) -> bool:
+    # GA option
+    if options.get("api.id-or-slug-enabled"):
+        return True
+
+    # EA option for endpoints where organization is not available
+    if options.get("api.id-or-slug-enabled-ea"):
+        return True
+
+    # EA option for endpoints where organization is available
+    if organization_slug is not None:
+        if organization_slug in options.get("api.id-or-slug-enabled-ea-org"):
+            return True
+
+        return False
+
+    return False

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -482,7 +482,9 @@ class Timer:
             return time.time() - self._start
 
 
-def id_or_slug_path_params_enabled(qual_name: str, organization_slug: str | None = None) -> bool:
+def id_or_slug_path_params_enabled(
+    convert_args_class: str, organization_slug: str | None = None
+) -> bool:
     # GA option
     if options.get("api.id-or-slug-enabled"):
         return True
@@ -492,7 +494,7 @@ def id_or_slug_path_params_enabled(qual_name: str, organization_slug: str | None
         return False
 
     # EA option for endpoints where organization is not available
-    if qual_name in options.get("api.id-or-slug-enabled-ea-endpoints"):
+    if convert_args_class in options.get("api.id-or-slug-enabled-ea-endpoints"):
         return True
 
     return False

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -482,20 +482,17 @@ class Timer:
             return time.time() - self._start
 
 
-def id_or_slug_path_params_enabled(organization_slug: str | None = None) -> bool:
+def id_or_slug_path_params_enabled(qual_name: str, organization_slug: str | None = None) -> bool:
     # GA option
     if options.get("api.id-or-slug-enabled"):
         return True
 
-    # EA option for endpoints where organization is not available
-    if options.get("api.id-or-slug-enabled-ea"):
-        return True
-
     # EA option for endpoints where organization is available
-    if organization_slug is not None:
-        if organization_slug in options.get("api.id-or-slug-enabled-ea-org"):
-            return True
-
+    if organization_slug and organization_slug not in options.get("api.id-or-slug-enabled-ea-org"):
         return False
+
+    # EA option for endpoints where organization is not available
+    if qual_name in options.get("api.id-or-slug-enabled-ea-endpoints"):
+        return True
 
     return False

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -279,23 +279,21 @@ register(
 )
 
 # API
-# Killswitch for GA endpoints to work with id or slug as path parameters
+# GA Option for endpoints to work with id or slug as path parameters
 register(
     "api.id-or-slug-enabled",
     type=Bool,
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-# Killswitch to enable EA endpoints to work with id or slug as path parameters
+# Enable EA endpoints to work with id or slug as path parameters
 register(
     "api.id-or-slug-enabled-ea-endpoints",
     type=Sequence,
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-# Killswitch to enable id or slug path parameters for certain organizations in EA, if available
+# EA option limiting to certain specific organizations for endpoints where organization is available
 register(
     "api.id-or-slug-enabled-ea-org",
     type=Sequence,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -279,23 +279,23 @@ register(
 )
 
 # API
-# Killswitch for apis to work with id or slug as path parameters
+# Killswitch for GA endpoints to work with id or slug as path parameters
 register(
     "api.id-or-slug-enabled",
-    default=False,
     type=Bool,
+    default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Killswitch to enable id or slug path parameters for some endpoints
+# Killswitch to enable EA endpoints to work with id or slug as path parameters
 register(
-    "api.id-or-slug-enabled-ea",
-    default=False,
-    type=Bool,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+    "api.id-or-slug-enabled-ea-endpoints",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Killswitch to enable id or slug path parameters for some endpoints for certain organizations, if available
+# Killswitch to enable id or slug path parameters for certain organizations in EA, if available
 register(
     "api.id-or-slug-enabled-ea-org",
     type=Sequence,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -287,6 +287,22 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Killswitch to enable id or slug path parameters for some endpoints
+register(
+    "api.id-or-slug-enabled-ea",
+    default=False,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Killswitch to enable id or slug path parameters for some endpoints for certain organizations, if available
+register(
+    "api.id-or-slug-enabled-ea-org",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # API Tokens
 register(
     "apitoken.auto-add-last-chars",

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -259,17 +259,21 @@ class HandleQueryErrorsTest:
 
 class IdOrSlugPathParamsEnabledTest(TestCase):
     def test_no_options_enabled(self):
-        assert not id_or_slug_path_params_enabled()
+        assert not id_or_slug_path_params_enabled("TestEndpoint.convert_args")
 
     @override_options({"api.id-or-slug-enabled": True})
     def test_ga_option_enabled(self):
-        assert id_or_slug_path_params_enabled()
-
-    @override_options({"api.id-or-slug-enabled-ea": True})
-    def test_ea_option_enabled(self):
-        assert id_or_slug_path_params_enabled()
+        assert id_or_slug_path_params_enabled(qual_name="TestEndpoint.convert_args")
 
     @override_options({"api.id-or-slug-enabled-ea-org": ["sentry"]})
+    @override_options({"api.id-or-slug-enabled-ea-endpoints": ["TestEndpoint.convert_args"]})
     def test_ea_org_option_enabled(self):
-        assert not id_or_slug_path_params_enabled(organization_slug="not-sentry")
-        assert id_or_slug_path_params_enabled(organization_slug="sentry")
+        assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "not-sentry")
+        assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "sentry")
+        assert not id_or_slug_path_params_enabled("TestEndpoint.convert_args", "not-sentry")
+        assert id_or_slug_path_params_enabled("TestEndpoint.convert_args", "sentry")
+
+    @override_options({"api.id-or-slug-enabled-ea-endpoints": ["TestEndpoint.convert_args"]})
+    def test_ea_endpoint_option_enabled(self):
+        assert not id_or_slug_path_params_enabled(qual_name="NotTestEndpoint.convert_args")
+        assert id_or_slug_path_params_enabled(qual_name="TestEndpoint.convert_args")

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -263,17 +263,22 @@ class IdOrSlugPathParamsEnabledTest(TestCase):
 
     @override_options({"api.id-or-slug-enabled": True})
     def test_ga_option_enabled(self):
-        assert id_or_slug_path_params_enabled(qual_name="TestEndpoint.convert_args")
+        assert id_or_slug_path_params_enabled(convert_args_class="TestEndpoint.convert_args")
+
+    @override_options({"api.id-or-slug-enabled-ea-endpoints": ["TestEndpoint.convert_args"]})
+    def test_ea_endpoint_option_enabled(self):
+        assert not id_or_slug_path_params_enabled(convert_args_class="NotTestEndpoint.convert_args")
+        assert id_or_slug_path_params_enabled(convert_args_class="TestEndpoint.convert_args")
+
+    @override_options({"api.id-or-slug-enabled-ea-org": ["sentry"]})
+    def test_ea_org_option_enabled(self):
+        assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "not-sentry")
+        assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "sentry")
 
     @override_options({"api.id-or-slug-enabled-ea-org": ["sentry"]})
     @override_options({"api.id-or-slug-enabled-ea-endpoints": ["TestEndpoint.convert_args"]})
-    def test_ea_org_option_enabled(self):
+    def test_ea_org_and_endpointoption_enabled(self):
         assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "not-sentry")
         assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "sentry")
         assert not id_or_slug_path_params_enabled("TestEndpoint.convert_args", "not-sentry")
         assert id_or_slug_path_params_enabled("TestEndpoint.convert_args", "sentry")
-
-    @override_options({"api.id-or-slug-enabled-ea-endpoints": ["TestEndpoint.convert_args"]})
-    def test_ea_endpoint_option_enabled(self):
-        assert not id_or_slug_path_params_enabled(qual_name="NotTestEndpoint.convert_args")
-        assert id_or_slug_path_params_enabled(qual_name="TestEndpoint.convert_args")

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -12,11 +12,13 @@ from sentry.api.utils import (
     customer_domain_path,
     get_date_range_from_params,
     handle_query_errors,
+    id_or_slug_path_params_enabled,
     print_and_capture_handler_exception,
 )
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidParams, InvalidSearchQuery
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.snuba import (
     DatasetSelectionError,
     QueryConnectionFailed,
@@ -253,3 +255,21 @@ class HandleQueryErrorsTest:
                     raise ex
             except Exception as e:
                 assert isinstance(e, (FooBarError, APIException))
+
+
+class IdOrSlugPathParamsEnabledTest(TestCase):
+    def test_no_options_enabled(self):
+        assert not id_or_slug_path_params_enabled()
+
+    @override_options({"api.id-or-slug-enabled": True})
+    def test_ga_option_enabled(self):
+        assert id_or_slug_path_params_enabled()
+
+    @override_options({"api.id-or-slug-enabled-ea": True})
+    def test_ea_option_enabled(self):
+        assert id_or_slug_path_params_enabled()
+
+    @override_options({"api.id-or-slug-enabled-ea-org": ["sentry"]})
+    def test_ea_org_option_enabled(self):
+        assert not id_or_slug_path_params_enabled(organization_slug="not-sentry")
+        assert id_or_slug_path_params_enabled(organization_slug="sentry")


### PR DESCRIPTION
To start the rollout id or slug as path params, we plan to rollout support for subset of the endpoints during EA.

Currently, the logic all uses the `api.id-or-slug-enabled` which will be our GA flag. 

I created two new options, which we will be used for EA:
* `api.id-or-slug-enabled-ea-org`: For endpoints for which we have organization context (so we can enable the endpoints only for `sentry`)
* `api.id-or-slug-enabled-ea-endpoints`: Contains list of EA endpoints.

I also created a wrapper which we will replace the checks for  `api.id-or-slug-enabled` that we currently have in our `convert_args`

We can get the class of convert_args using `self.convert_args.__qualname__`

For: https://github.com/getsentry/team-core-product-foundations/issues/194