### PR TITLE
feat(grouping): return project events in pseudo-random order

### DIFF
--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -11,6 +11,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
+from sentry.snuba.events import Columns
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -42,6 +43,9 @@ class ProjectEventsEndpoint(ProjectEndpoint):
                            include the full event body, including the stacktrace.
                            Set to 1 to enable.
 
+        :qparam bool sample: return events in pseudo-random order. This is deterministic,
+                             same query will return the same events in the same order.
+
         :pparam string organization_slug: the slug of the organization the
                                           groups belong to.
         :pparam string project_slug: the slug of the project the groups
@@ -61,6 +65,7 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             event_filter.start = timezone.now() - timedelta(days=7)
 
         full = request.GET.get("full", False)
+        sample = request.GET.get("sample", False)
 
         data_fn = partial(
             eventstore.backend.get_events,
@@ -68,6 +73,11 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             referrer="api.project-events",
             tenant_ids={"organization_id": project.organization_id},
         )
+
+        if sample:
+            # not a true random ordering, but event_id is UUID, that's random enough
+            # for our purposes and doesn't have heavy performance impact
+            data_fn = partial(data_fn, orderby=[Columns.EVENT_ID.value.alias])
 
         serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(


### PR DESCRIPTION
Return project's events in pseudo-random order. This used ordering by event.id, which is an UUID, thus should be more or less in pseudo-random order. 