### PR TITLE
chore(grouping): Split up `grouping.ingest` module

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -50,23 +50,29 @@ from sentry.grouping.api import (
     GroupingConfig,
     get_grouping_config_dict_for_project,
 )
-from sentry.grouping.ingest import (
+from sentry.grouping.ingest.config import (
+    is_in_transition,
+    project_uses_optimized_grouping,
+    update_grouping_config_if_needed,
+)
+from sentry.grouping.ingest.hashing import (
+    find_existing_grouphash,
+    find_existing_grouphash_new,
+    get_hash_values,
+    maybe_run_background_grouping,
+    maybe_run_secondary_grouping,
+    run_primary_grouping,
+)
+from sentry.grouping.ingest.metrics import (
+    record_calculation_metric_with_result,
+    record_hash_calculation_metrics,
+    record_new_group_metrics,
+)
+from sentry.grouping.ingest.utils import (
     add_group_id_to_grouphashes,
     check_for_category_mismatch,
     check_for_group_creation_load_shed,
     extract_hashes,
-    find_existing_grouphash,
-    find_existing_grouphash_new,
-    get_hash_values,
-    is_in_transition,
-    maybe_run_background_grouping,
-    maybe_run_secondary_grouping,
-    project_uses_optimized_grouping,
-    record_calculation_metric_with_result,
-    record_hash_calculation_metrics,
-    record_new_group_metrics,
-    run_primary_grouping,
-    update_grouping_config_if_needed,
 )
 from sentry.grouping.result import CalculatedHashes
 from sentry.ingest.inbound_filters import FilterStatKeys

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, Any
+
+from django.conf import settings
+from django.core.cache import cache
+
+from sentry import features
+from sentry.locks import locks
+from sentry.models.project import Project
+from sentry.projectoptions.defaults import BETA_GROUPING_CONFIG, DEFAULT_GROUPING_CONFIG
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("sentry.events.grouping")
+
+Job = MutableMapping[str, Any]
+
+
+def update_grouping_config_if_needed(project: Project) -> None:
+    if _project_should_update_grouping(project):
+        _auto_update_grouping(project)
+
+
+def _project_should_update_grouping(project: Project) -> bool:
+    should_update_org = (
+        project.organization_id % 1000 < float(settings.SENTRY_GROUPING_AUTO_UPDATE_ENABLED) * 1000
+    )
+    return bool(project.get_option("sentry:grouping_auto_update")) and should_update_org
+
+
+def _config_update_happened_recently(project: Project, tolerance: int) -> bool:
+    """
+    Determine whether an auto-upate happened within the last `tolerance` seconds.
+
+    We can use this test to compensate for the delay between config getting updated and Relay
+    picking up the change.
+    """
+    project_transition_expiry = project.get_option("sentry:secondary_grouping_expiry") or 0
+    last_config_update = project_transition_expiry - settings.SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
+    now = int(time.time())
+    time_since_update = now - last_config_update
+
+    return time_since_update < 60
+
+
+def _auto_update_grouping(project: Project) -> None:
+    current_config = project.get_option("sentry:grouping_config")
+    new_config = DEFAULT_GROUPING_CONFIG
+
+    if current_config == new_config or current_config == BETA_GROUPING_CONFIG:
+        return
+
+    # Because the way the auto grouping upgrading happening is racy, we want to
+    # try to write the audit log entry and project option change just once.
+    # For this a cache key is used.  That's not perfect, but should reduce the
+    # risk significantly.
+    cache_key = f"grouping-config-update:{project.id}:{current_config}"
+    lock_key = f"grouping-update-lock:{project.id}"
+    if cache.get(cache_key) is not None:
+        return
+
+    with locks.get(lock_key, duration=60, name="grouping-update-lock").acquire():
+        if cache.get(cache_key) is None:
+            cache.set(cache_key, "1", 60 * 5)
+        else:
+            return
+
+        from sentry import audit_log
+        from sentry.utils.audit import create_system_audit_entry
+
+        # This is when we will stop calculating both old hashes (which we do in an effort to
+        # preserve group continuity).
+        expiry = int(time.time()) + settings.SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
+
+        changes = {
+            "sentry:secondary_grouping_config": current_config,
+            "sentry:secondary_grouping_expiry": expiry,
+            "sentry:grouping_config": new_config,
+        }
+        for key, value in changes.items():
+            project.update_option(key, value)
+
+        create_system_audit_entry(
+            organization=project.organization,
+            target_object=project.id,
+            event=audit_log.get_event_id("PROJECT_EDIT"),
+            data={**changes, **project.get_audit_log_data()},
+        )
+
+
+def is_in_transition(project: Project) -> bool:
+    secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
+    secondary_grouping_expiry = project.get_option("sentry:secondary_grouping_expiry")
+
+    return bool(secondary_grouping_config) and (secondary_grouping_expiry or 0) >= time.time()
+
+
+def project_uses_optimized_grouping(project: Project) -> bool:
+    primary_grouping_config = project.get_option("sentry:grouping_config")
+    secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
+    has_mobile_config = "mobile:2021-02-12" in [primary_grouping_config, secondary_grouping_config]
+
+    return not has_mobile_config and features.has(
+        "organizations:grouping-suppress-unnecessary-secondary-hash",
+        project.organization,
+    )

--- a/src/sentry/grouping/ingest/metrics.py
+++ b/src/sentry/grouping/ingest/metrics.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, Any
+
+from sentry import features
+from sentry.grouping.api import GroupingConfig
+from sentry.grouping.ingest.config import _config_update_happened_recently, is_in_transition
+from sentry.grouping.ingest.utils import extract_hashes
+from sentry.grouping.result import CalculatedHashes
+from sentry.models.project import Project
+from sentry.utils import metrics
+from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
+
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
+
+logger = logging.getLogger("sentry.events.grouping")
+
+Job = MutableMapping[str, Any]
+
+
+def record_hash_calculation_metrics(
+    project: Project,
+    primary_config: GroupingConfig,
+    primary_hashes: CalculatedHashes,
+    secondary_config: GroupingConfig,
+    secondary_hashes: CalculatedHashes,
+):
+    has_secondary_hashes = len(extract_hashes(secondary_hashes)) > 0
+
+    if has_secondary_hashes:
+        tags = {
+            "primary_config": primary_config["id"],
+            "secondary_config": secondary_config["id"],
+        }
+
+        # If the configs are the same, *of course* the values are going to match, so no point in
+        # recording a metric
+        #
+        # TODO: If we fix the issue outlined in https://github.com/getsentry/sentry/pull/65116, we
+        # can ditch both this check and the logging below
+        if tags["primary_config"] != tags["secondary_config"]:
+            current_values = primary_hashes.hashes
+            secondary_values = secondary_hashes.hashes
+            hashes_match = current_values == secondary_values
+
+            if hashes_match:
+                tags["result"] = "no change"
+            else:
+                shared_hashes = set(current_values) & set(secondary_values)
+                if len(shared_hashes) > 0:
+                    tags["result"] = "partial change"
+                else:
+                    tags["result"] = "full change"
+
+            metrics.incr("grouping.hash_comparison", tags=tags)
+
+        else:
+            if not _config_update_happened_recently(project, 30):
+                logger.info(
+                    "Equal primary and secondary configs",
+                    extra={
+                        "project": project.id,
+                        "primary_config": primary_config["id"],
+                    },
+                )
+
+
+# TODO: Once the legacy `_save_aggregate` goes away, this logic can be pulled into
+# `record_hash_calculation_metrics`. Right now it's split up because we don't know the value for
+# `result` at the time the legacy `_save_aggregate` (indirectly) calls `record_hash_calculation_metrics`
+def record_calculation_metric_with_result(
+    project: Project,
+    has_secondary_hashes: bool,
+    result: str,
+) -> None:
+
+    # Track the total number of grouping calculations done overall, so we can divide by the
+    # count to get an average number of calculations per event
+    tags = {
+        "in_transition": str(is_in_transition(project)),
+        "using_transition_optimization": str(
+            features.has(
+                "organizations:grouping-suppress-unnecessary-secondary-hash",
+                project.organization,
+            )
+        ),
+        "result": result,
+    }
+    metrics.incr("grouping.event_hashes_calculated", tags=tags)
+    metrics.incr("grouping.total_calculations", amount=2 if has_secondary_hashes else 1, tags=tags)
+
+
+def record_new_group_metrics(event: Event):
+    metrics.incr(
+        "group.created",
+        skip_internal=True,
+        tags={
+            "platform": event.platform or "unknown",
+            "sdk": normalized_sdk_tag_from_event(event),
+        },
+    )
+
+    # This only applies to events with stacktraces
+    frame_mix = event.get_event_metadata().get("in_app_frame_mix")
+    if frame_mix:
+        metrics.incr(
+            "grouping.in_app_frame_mix",
+            sample_rate=1.0,
+            tags={
+                "platform": event.platform or "unknown",
+                "sdk": normalized_sdk_tag_from_event(event),
+                "frame_mix": frame_mix,
+            },
+        )

--- a/src/sentry/grouping/ingest/utils.py
+++ b/src/sentry/grouping/ingest/utils.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, Any
+
+from sentry.exceptions import HashDiscarded
+from sentry.grouping.result import CalculatedHashes
+from sentry.issues.grouptype import GroupCategory
+from sentry.killswitches import killswitch_matches_context
+from sentry.models.group import Group
+from sentry.models.grouphash import GroupHash
+from sentry.models.project import Project
+
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
+
+logger = logging.getLogger("sentry.events.grouping")
+
+Job = MutableMapping[str, Any]
+
+
+def extract_hashes(calculated_hashes: CalculatedHashes | None) -> list[str]:
+    return [] if not calculated_hashes else list(calculated_hashes.hashes)
+
+
+def add_group_id_to_grouphashes(
+    group: Group,
+    grouphashes: list[GroupHash],
+) -> None:
+    """
+    Link the given group to any grouphash which doesn't yet have a group assigned.
+    """
+
+    new_grouphash_ids = [gh.id for gh in grouphashes if gh.group_id is None]
+
+    GroupHash.objects.filter(id__in=new_grouphash_ids).exclude(
+        state=GroupHash.State.LOCKED_IN_MIGRATION
+    ).update(group=group)
+
+
+def check_for_group_creation_load_shed(project: Project, event: Event):
+    """
+    Raise a `HashDiscarded` error if the load-shed killswitch is enabled
+    """
+    if killswitch_matches_context(
+        "store.load-shed-group-creation-projects",
+        {
+            "project_id": project.id,
+            "platform": event.platform,
+        },
+    ):
+        raise HashDiscarded("Load shedding group creation", reason="load_shed")
+
+
+def check_for_category_mismatch(group: Group) -> bool:
+    """
+    Make sure an error event hasn't hashed to a value assigned to a non-error-type group
+    """
+    if group.issue_category != GroupCategory.ERROR:
+        logger.info(
+            "event_manager.category_mismatch",
+            extra={
+                "issue_category": group.issue_category,
+                "event_type": "error",
+            },
+        )
+        return True
+
+    return False

--- a/tests/sentry/event_manager/grouping/test_assign_to_group.py
+++ b/tests/sentry/event_manager/grouping/test_assign_to_group.py
@@ -9,13 +9,13 @@ import pytest
 
 from sentry.event_manager import _create_group
 from sentry.eventstore.models import Event
-from sentry.grouping.ingest import (
+from sentry.grouping.ingest.hashing import (
     _calculate_primary_hash,
     _calculate_secondary_hash,
     find_existing_grouphash,
     find_existing_grouphash_new,
-    record_calculation_metric_with_result,
 )
+from sentry.grouping.ingest.metrics import record_calculation_metric_with_result
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
 from sentry.testutils.helpers.eventprocessing import save_new_event
@@ -50,11 +50,11 @@ def patch_grouping_helpers(return_values: dict[str, Any]):
             wraps=wrapped_find_existing_grouphash_new,
         ) as find_existing_grouphash_new_spy,
         mock.patch(
-            "sentry.grouping.ingest._calculate_primary_hash",
+            "sentry.grouping.ingest.hashing._calculate_primary_hash",
             wraps=wrapped_calculate_primary_hash,
         ) as calculate_primary_hash_spy,
         mock.patch(
-            "sentry.grouping.ingest._calculate_secondary_hash",
+            "sentry.grouping.ingest.hashing._calculate_secondary_hash",
             wraps=wrapped_calculate_secondary_hash,
         ) as calculate_secondary_hash_spy,
         mock.patch(

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -198,7 +198,7 @@ class EventManagerGroupingMetricsTest(TestCase):
                     )
 
     @mock.patch("sentry.event_manager.metrics.incr")
-    @mock.patch("sentry.grouping.ingest.is_in_transition", return_value=True)
+    @mock.patch("sentry.grouping.ingest.hashing.is_in_transition", return_value=True)
     def test_records_hash_comparison(self, _, mock_metrics_incr: MagicMock):
         project = self.project
         project.update_option("sentry:grouping_config", NEWSTYLE_CONFIG)
@@ -215,13 +215,13 @@ class EventManagerGroupingMetricsTest(TestCase):
 
         for primary_hashes, secondary_hashes, expected_tag in cases:
             with mock.patch(
-                "sentry.grouping.ingest._calculate_primary_hash",
+                "sentry.grouping.ingest.hashing._calculate_primary_hash",
                 return_value=CalculatedHashes(
                     hashes=primary_hashes, hierarchical_hashes=[], tree_labels=[]
                 ),
             ):
                 with mock.patch(
-                    "sentry.grouping.ingest._calculate_secondary_hash",
+                    "sentry.grouping.ingest.hashing._calculate_secondary_hash",
                     return_value=CalculatedHashes(
                         hashes=secondary_hashes, hierarchical_hashes=[], tree_labels=[]
                     ),

--- a/tests/sentry/event_manager/test_save_aggregate.py
+++ b/tests/sentry/event_manager/test_save_aggregate.py
@@ -97,7 +97,7 @@ def test_group_creation_race_new(
     def save_event():
         try:
             with patch(
-                "sentry.grouping.ingest._calculate_event_grouping",
+                "sentry.grouping.ingest.hashing._calculate_event_grouping",
                 return_value=hashes,
             ):
                 with patch(

--- a/tests/sentry/grouping/test_ingest.py
+++ b/tests/sentry/grouping/test_ingest.py
@@ -4,7 +4,7 @@ from time import time
 from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
-from sentry.grouping.ingest import (
+from sentry.grouping.ingest.hashing import (
     _calculate_background_grouping,
     _calculate_event_grouping,
     _calculate_secondary_hash,
@@ -18,7 +18,7 @@ pytestmark = [requires_snuba]
 
 class BackgroundGroupingTest(TestCase):
     @patch(
-        "sentry.grouping.ingest._calculate_background_grouping",
+        "sentry.grouping.ingest.hashing._calculate_background_grouping",
         wraps=_calculate_background_grouping,
     )
     def test_applies_background_grouping(self, mock_calc_background_grouping: MagicMock) -> None:
@@ -45,7 +45,7 @@ class BackgroundGroupingTest(TestCase):
         background_grouping_error = Exception("nope")
 
         with patch(
-            "sentry.grouping.ingest._calculate_background_grouping",
+            "sentry.grouping.ingest.hashing._calculate_background_grouping",
             side_effect=background_grouping_error,
         ):
             manager = EventManager({"message": "foo 123"})
@@ -64,7 +64,7 @@ class BackgroundGroupingTest(TestCase):
             # This proves the background grouping crash didn't crash the overall grouping process
             assert event.group
 
-    @patch("sentry.grouping.ingest._calculate_background_grouping")
+    @patch("sentry.grouping.ingest.hashing._calculate_background_grouping")
     def test_background_grouping_can_be_disabled_via_sample_rate(
         self, mock_calc_background_grouping: MagicMock
     ) -> None:
@@ -131,7 +131,9 @@ class SecondaryGroupingTest(TestCase):
         assert event3.group_id == event2.group_id
 
     @patch("sentry_sdk.capture_exception")
-    @patch("sentry.grouping.ingest._calculate_secondary_hash", wraps=_calculate_secondary_hash)
+    @patch(
+        "sentry.grouping.ingest.hashing._calculate_secondary_hash", wraps=_calculate_secondary_hash
+    )
     def test_handles_errors_with_secondary_grouping(
         self,
         mock_calculate_secondary_hash: MagicMock,
@@ -154,7 +156,7 @@ class SecondaryGroupingTest(TestCase):
         project.update_option("sentry:secondary_grouping_expiry", time() + 3600)
 
         with patch(
-            "sentry.grouping.ingest._calculate_event_grouping",
+            "sentry.grouping.ingest.hashing._calculate_event_grouping",
             wraps=mock_calculate_event_grouping,
         ):
             manager = EventManager({"message": "foo 123"})

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -508,7 +508,8 @@ def test_apply_new_fingerprinting_rules(
     )
 
     with mock.patch(
-        "sentry.grouping.ingest.get_fingerprinting_config_for_project", return_value=new_rules
+        "sentry.grouping.ingest.hashing.get_fingerprinting_config_for_project",
+        return_value=new_rules,
     ):
         # Reprocess
         with burst_task_runner() as burst_reprocess:
@@ -597,7 +598,7 @@ def test_apply_new_stack_trace_rules(
     original_issue_id = event1.group.id
 
     with mock.patch(
-        "sentry.grouping.ingest.get_grouping_config_dict_for_project",
+        "sentry.grouping.ingest.hashing.get_grouping_config_dict_for_project",
         return_value={
             "id": DEFAULT_GROUPING_CONFIG,
             "enhancements": Enhancements.from_config_string(


### PR DESCRIPTION
This splits the `grouping.ingest` module up into four smaller modules, because it'd already gotten too long and because we're about to add a bunch of seer helpers, which would just have made the problem worse.