### PR TITLE
feat(perf): Add "Average" markline to HTTP module sample panel chart

### DIFF
--- a/static/app/views/performance/charts/averageValueMarkLine.tsx
+++ b/static/app/views/performance/charts/averageValueMarkLine.tsx
@@ -3,18 +3,18 @@ import {useTheme} from '@emotion/react';
 import MarkLine from 'sentry/components/charts/components/markLine';
 
 interface Props {
-  value: number;
+  value?: number;
 }
 
-export function AverageValueMarkLine({value}: Props) {
+export function AverageValueMarkLine({value}: Props = {}) {
   const theme = useTheme();
-
-  if (!value) return undefined;
 
   return MarkLine({
     data: [
+      // If a `value` is provided, set the markline to that value. If not, `type: 'average'` will automatically set it
       {
-        valueDim: 'x',
+        valueDim: 'y',
+        type: 'average',
         yAxis: value,
       },
     ],

--- a/static/app/views/performance/charts/averageValueMarkLine.tsx
+++ b/static/app/views/performance/charts/averageValueMarkLine.tsx
@@ -1,6 +1,7 @@
 import {useTheme} from '@emotion/react';
 
 import MarkLine from 'sentry/components/charts/components/markLine';
+import {t} from 'sentry/locale';
 
 interface Props {
   value?: number;
@@ -25,7 +26,7 @@ export function AverageValueMarkLine({value}: Props = {}) {
     emphasis: {disabled: true},
     label: {
       position: 'insideEndBottom',
-      formatter: () => `Average`,
+      formatter: () => t(`Average`),
       fontSize: 14,
       color: theme.chartLabel,
       backgroundColor: theme.chartOther,

--- a/static/app/views/performance/charts/averageValueMarkLine.tsx
+++ b/static/app/views/performance/charts/averageValueMarkLine.tsx
@@ -19,7 +19,6 @@ export function AverageValueMarkLine({value}: Props = {}) {
         yAxis: value,
       },
     ],
-    symbol: ['none', 'none'],
     lineStyle: {
       color: theme.gray400,
     },

--- a/static/app/views/performance/charts/averageValueMarkLine.tsx
+++ b/static/app/views/performance/charts/averageValueMarkLine.tsx
@@ -1,0 +1,34 @@
+import {useTheme} from '@emotion/react';
+
+import MarkLine from 'sentry/components/charts/components/markLine';
+
+interface Props {
+  value: number;
+}
+
+export function AverageValueMarkLine({value}: Props) {
+  const theme = useTheme();
+
+  if (!value) return undefined;
+
+  return MarkLine({
+    data: [
+      {
+        valueDim: 'x',
+        yAxis: value,
+      },
+    ],
+    symbol: ['none', 'none'],
+    lineStyle: {
+      color: theme.gray400,
+    },
+    emphasis: {disabled: true},
+    label: {
+      position: 'insideEndBottom',
+      formatter: () => `Average`,
+      fontSize: 14,
+      color: theme.chartLabel,
+      backgroundColor: theme.chartOther,
+    },
+  });
+}

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -18,6 +18,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {AverageValueMarkLine} from 'sentry/views/performance/charts/averageValueMarkLine';
 import {DurationChart} from 'sentry/views/performance/http/durationChart';
 import decodePanel from 'sentry/views/performance/http/queryParameterDecoders/panel';
 import {ResponseCodeBarChart} from 'sentry/views/performance/http/responseCodeBarChart';
@@ -164,6 +165,10 @@ export function HTTPSamplesPanel() {
       },
     });
   };
+
+  durationData['avg(span.self_time)'].markLine = AverageValueMarkLine({
+    value: domainTransactionMetrics?.[0]?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`],
+  });
 
   return (
     <PageAlertProvider>

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -166,8 +166,6 @@ export function HTTPSamplesPanel() {
     });
   };
 
-  durationData['avg(span.self_time)'].markLine = AverageValueMarkLine();
-
   return (
     <PageAlertProvider>
       <DetailPanel detailKey={detailKey} onClose={handleClose}>
@@ -285,7 +283,10 @@ export function HTTPSamplesPanel() {
             <Fragment>
               <ModuleLayout.Full>
                 <DurationChart
-                  series={durationData[`avg(span.self_time)`]}
+                  series={{
+                    ...durationData[`avg(span.self_time)`],
+                    markLine: AverageValueMarkLine(),
+                  }}
                   isLoading={isDurationDataFetching}
                   error={durationError}
                 />

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -166,9 +166,7 @@ export function HTTPSamplesPanel() {
     });
   };
 
-  durationData['avg(span.self_time)'].markLine = AverageValueMarkLine({
-    value: domainTransactionMetrics?.[0]?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`],
-  });
+  durationData['avg(span.self_time)'].markLine = AverageValueMarkLine();
 
   return (
     <PageAlertProvider>

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -10,6 +10,7 @@ import type {
 import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {AverageValueMarkLine} from 'sentry/views/performance/charts/averageValueMarkLine';
 import {AVG_COLOR} from 'sentry/views/starfish/colours';
 import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
@@ -142,21 +143,9 @@ function DurationChart({
   const baselineAvgSeries: Series = {
     seriesName: 'Average',
     data: [],
-    markLine: {
-      data: [{valueDim: 'x', yAxis: avg}],
-      symbol: ['none', 'none'],
-      lineStyle: {
-        color: theme.gray400,
-      },
-      emphasis: {disabled: true},
-      label: {
-        position: 'insideEndBottom',
-        formatter: () => `Average`,
-        fontSize: 14,
-        color: theme.chartLabel,
-        backgroundColor: theme.chartOther,
-      },
-    },
+    markLine: AverageValueMarkLine({
+      value: avg,
+    }),
   };
 
   const sampledSpanDataSeries: Series[] = spans.map(


### PR DESCRIPTION
- **Extract `AverageValueMarkLine` helper**
- **Add markline to duration chart**
- **Simplify behaviour**

**e.g.,**
<img width="616" alt="Screenshot 2024-04-03 at 11 32 23 PM" src="https://github.com/getsentry/sentry/assets/989898/92415e81-22b4-4b79-af1c-fed2e196e268">
