### PR TITLE
fix: Correctly check for None before reading stacktraces

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import posixpath
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from symbolic.debuginfo import normalize_debug_id
@@ -456,7 +456,7 @@ def process_native_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
 
 def get_native_symbolication_function(
-    data: Any, stacktraces: list[StacktraceInfo]
+    data: Mapping[str, Any], stacktraces: list[StacktraceInfo]
 ) -> Callable[[Symbolicator, Any], Any] | None:
     """
     Returns the appropriate symbolication function (or `None`) that will process

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from collections.abc import Mapping
 from typing import Any
 
 from sentry.attachments import attachment_cache
@@ -53,7 +54,7 @@ def native_images_from_data(data):
     return get_path(data, "debug_meta", "images", default=(), filter=is_native_image)
 
 
-def is_native_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:
+def is_native_event(data: Mapping[str, Any], stacktraces: list[StacktraceInfo]) -> bool:
     """Returns whether `data` is a native event, based on its platform and
     the supplied stacktraces."""
 

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from time import time
 from typing import Any
 
@@ -85,7 +85,7 @@ def should_demote_symbolication(
 
 def get_symbolication_function_for_platform(
     platform: SymbolicatorPlatform,
-    data: Any,
+    data: Mapping[str, Any],
     stacktraces: list[StacktraceInfo],
 ) -> Callable[[Symbolicator, Any], Any]:
     """Returns the symbolication function for the given platform
@@ -106,7 +106,7 @@ def get_symbolication_function_for_platform(
 
 
 def get_symbolication_platforms(
-    data: Any, stacktraces: list[StacktraceInfo]
+    data: Mapping[str, Any], stacktraces: list[StacktraceInfo]
 ) -> list[SymbolicatorPlatform]:
     """Returns a list of Symbolicator platforms
     that apply to this event."""
@@ -116,7 +116,7 @@ def get_symbolication_platforms(
 
     platforms = []
 
-    if should_use_symbolicator_for_proguard(data.get("project")) and is_jvm_event(
+    if should_use_symbolicator_for_proguard(int(data["project"])) and is_jvm_event(
         data, stacktraces
     ):
         platforms.append(SymbolicatorPlatform.jvm)
@@ -145,6 +145,18 @@ def _do_symbolicate_event(
     if data is None:
         data = processing.event_processing_store.get(cache_key)
 
+    if data is None:
+        metrics.incr(
+            "events.failed", tags={"reason": "cache", "stage": "symbolicate"}, skip_internal=False
+        )
+        error_logger.error("symbolicate.failed.empty", extra={"cache_key": cache_key})
+        return
+
+    data = CanonicalKeyDict(data)
+    event_id = str(data["event_id"])
+    project_id = data["project"]
+    has_changed = False
+
     stacktraces = find_stacktraces_in_data(data)
 
     # Backwards compatibility: If the current platform is JS, we may need to do
@@ -157,18 +169,6 @@ def _do_symbolicate_event(
             symbolicate_platforms = [SymbolicatorPlatform.native]
         else:
             symbolicate_platforms = []
-
-    if data is None:
-        metrics.incr(
-            "events.failed", tags={"reason": "cache", "stage": "symbolicate"}, skip_internal=False
-        )
-        error_logger.error("symbolicate.failed.empty", extra={"cache_key": cache_key})
-        return
-
-    data = CanonicalKeyDict(data)
-    event_id = str(data["event_id"])
-    project_id = data["project"]
-    has_changed = False
 
     set_current_event_project(project_id)
 


### PR DESCRIPTION
We erroneously called `find_stacktraces_in_data` before checking whether `data` is `None`.

This also tightens up some function types.

Fixes SENTRY-33Z0.
Fixes SENTRY-33Z1.
Fixes SENTRY-33ZX.
Fixes SENTRY-34QK.