### PR TITLE
feat(new-trace): Prefetching tags on trace drawer load.

### DIFF
--- a/static/app/views/discover/tags.tsx
+++ b/static/app/views/discover/tags.tsx
@@ -21,6 +21,8 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
 import {isAPIPayloadSimilar} from 'sentry/utils/discover/eventView';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import type {UseApiQueryResult} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
 import withApi from 'sentry/utils/withApi';
 
 type Props = {
@@ -32,6 +34,7 @@ type Props = {
   totalValues: null | number;
   confirmedQuery?: boolean;
   onTagValueClick?: (title: string, value: TagSegment) => void;
+  tagsQueryResults?: UseApiQueryResult<Tag[], RequestError>;
 };
 
 type State = {
@@ -85,6 +88,29 @@ class Tags extends Component<Props, State> {
     this.setState({loading: true, error: ''});
     if (!appendTags) {
       this.setState({hasLoaded: false, tags: []});
+    }
+
+    // If we have tagsQueryResults, we can use that instead of fetching new data on mount.
+    if (!appendTags && this.props.tagsQueryResults) {
+      const pageLinks =
+        this.props.tagsQueryResults?.getResponseHeader?.('Link') ?? undefined;
+      let hasMore = false;
+      let cursor: string | undefined;
+      if (pageLinks) {
+        const paginationObject = parseLinkHeader(pageLinks);
+        hasMore = paginationObject?.next?.results ?? false;
+        cursor = paginationObject.next?.cursor;
+      }
+
+      this.setState({
+        tags: this.props.tagsQueryResults.data || [],
+        loading: this.props.tagsQueryResults.isLoading,
+        hasLoaded: !this.props.tagsQueryResults.isLoading,
+        hasMore,
+        nextCursor: cursor,
+        error: this.props.tagsQueryResults.error?.message || '',
+      });
+      return;
     }
 
     // Fetch should be forced after mounting as confirmedQuery isn't guaranteed

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/trace.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useMemo} from 'react';
 
+import type {Tag} from 'sentry/actionCreators/events';
 import type {EventTransaction, Organization} from 'sentry/types';
 import {generateQueryWithTag} from 'sentry/utils';
 import type EventView from 'sentry/utils/discover/eventView';
@@ -21,6 +22,7 @@ type TraceDetailsProps = {
   node: TraceTreeNode<TraceTree.NodeValue> | null;
   organization: Organization;
   rootEventResults: UseApiQueryResult<EventTransaction, RequestError>;
+  tagsQueryResults: UseApiQueryResult<Tag[], RequestError>;
   traceEventView: EventView;
   traces: TraceSplitResults<TraceFullDetailed> | null;
   tree: TraceTree;
@@ -51,6 +53,7 @@ export function TraceDetails(props: TraceDetailsProps) {
       <IssueList issues={issues} node={props.node} organization={props.organization} />
       {rootEvent ? (
         <Tags
+          tagsQueryResults={props.tagsQueryResults}
           generateUrl={(key: string, value: string) => {
             const url = props.traceEventView.getResultsViewUrlTarget(
               props.organization.slug,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -1,19 +1,23 @@
 import {useCallback, useMemo, useRef, useState} from 'react';
 import {type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import pick from 'lodash/pick';
 
+import type {Tag} from 'sentry/actionCreators/events';
 import {Button} from 'sentry/components/button';
 import {IconChevron, IconPanel, IconPin} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {EventTransaction, Organization} from 'sentry/types';
 import type EventView from 'sentry/utils/discover/eventView';
+import {PERFORMANCE_URL_PARAM} from 'sentry/utils/performance/constants';
 import type {
   TraceFullDetailed,
   TraceSplitResults,
 } from 'sentry/utils/performance/quickTrace/types';
-import type {UseApiQueryResult} from 'sentry/utils/queryClient';
+import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import {useLocation} from 'sentry/utils/useLocation';
 import {
   useResizableDrawer,
   type UseResizableDrawerOptions,
@@ -74,9 +78,33 @@ const LAYOUT_STORAGE: Partial<Record<TraceDrawerProps['layout'], number>> = {};
 
 export function TraceDrawer(props: TraceDrawerProps) {
   const theme = useTheme();
+  const location = useLocation();
   const panelRef = useRef<HTMLDivElement>(null);
   const [minimized, setMinimized] = useState(
     Math.round(props.drawerSize) <= getDrawerMinSize(props.layout)
+  );
+
+  // The /events-facets/ endpoint used to fetch tags for the trace tab is slow. Therefore,
+  // we try to prefetch the tags as soon as the drawer loads, hoping that the tags will be loaded
+  // by the time the user clicks on the trace tab. Also prevents the tags from being refetched.
+  const urlParams = pick(location.query, [
+    ...Object.values(PERFORMANCE_URL_PARAM),
+    'cursor',
+  ]);
+  const tagsQueryResults = useApiQuery<Tag[]>(
+    [
+      `/organizations/${props.organization.slug}/events-facets/`,
+      {
+        query: {
+          ...urlParams,
+          ...props.traceEventView.getFacetsAPIPayload(location),
+          cursor: undefined,
+        },
+      },
+    ],
+    {
+      staleTime: Infinity,
+    }
   );
 
   const minimizedRef = useRef(minimized);
@@ -296,6 +324,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
           {props.tabs.current ? (
             props.tabs.current.node === 'trace' ? (
               <TraceDetails
+                tagsQueryResults={tagsQueryResults}
                 tree={props.trace}
                 node={props.trace.root.children[0]}
                 rootEventResults={props.rootEventResults}


### PR DESCRIPTION
The /events-facets/ endpoint used to fetch tags for the trace tab is slow. Therefore,
 we try to prefetch the tags as soon as the drawer loads, hoping that the tags will be loaded
by the time the user clicks on the trace tab. Also prevents the tags from being refetched.