### PR TITLE
Skip unnecessary attachments handling

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -728,6 +728,7 @@ def _do_save_event(
     start_time: int | None = None,
     event_id: str | None = None,
     project_id: int | None = None,
+    has_attachments: bool = False,
     **kwargs: Any,
 ) -> None:
     """
@@ -803,6 +804,7 @@ def _do_save_event(
                         assume_normalized=True,
                         start_time=start_time,
                         cache_key=cache_key,
+                        has_attachments=has_attachments,
                     )
                 # Put the updated event back into the cache so that post_process
                 # has the most recent data.
@@ -822,7 +824,7 @@ def _do_save_event(
 
         finally:
             reprocessing2.mark_event_reprocessed(data)
-            if cache_key:
+            if cache_key and has_attachments:
                 with metrics.timer("tasks.store.do_save_event.delete_attachment_cache"):
                     attachment_cache.delete(cache_key)
 
@@ -958,7 +960,9 @@ def save_event_attachments(
     project_id: int | None = None,
     **kwargs: Any,
 ) -> None:
-    _do_save_event(cache_key, data, start_time, event_id, project_id, **kwargs)
+    _do_save_event(
+        cache_key, data, start_time, event_id, project_id, has_attachments=True, **kwargs
+    )
 
 
 @instrumented_task(

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1716,7 +1716,9 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             with self.feature("organizations:event-attachments"):
                 with self.tasks():
                     with pytest.raises(HashDiscarded):
-                        event = manager.save(self.project.id, cache_key=cache_key)
+                        event = manager.save(
+                            self.project.id, cache_key=cache_key, has_attachments=True
+                        )
 
         assert mock_track_outcome.call_count == 3
 
@@ -1753,7 +1755,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
             with self.feature("organizations:event-attachments"):
                 with self.tasks():
-                    manager.save(self.project.id, cache_key=cache_key)
+                    manager.save(self.project.id, cache_key=cache_key, has_attachments=True)
 
         # The first minidump should be accepted, since the limit is 1
         assert mock_track_outcome.call_count == 3
@@ -1774,7 +1776,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
             with self.feature("organizations:event-attachments"):
                 with self.tasks():
-                    event = manager.save(self.project.id, cache_key=cache_key)
+                    event = manager.save(self.project.id, cache_key=cache_key, has_attachments=True)
 
         assert event.data["metadata"]["stripped_crash"] is True
 
@@ -1813,7 +1815,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         mock_track_outcome = mock.Mock()
         with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
             with self.feature("organizations:event-attachments"):
-                manager.save(self.project.id, cache_key=cache_key)
+                manager.save(self.project.id, cache_key=cache_key, has_attachments=True)
 
         assert mock_track_outcome.call_count == 3
 
@@ -1842,7 +1844,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         mock_track_outcome = mock.Mock()
         with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
             with self.feature("organizations:event-attachments"):
-                manager.save(self.project.id, cache_key=cache_key)
+                manager.save(self.project.id, cache_key=cache_key, has_attachments=True)
 
         assert mock_track_outcome.call_count == 3
 


### PR DESCRIPTION
We already have a specific Kafka queue, and `save_event_attachments` celery queue for events that have attachments. However we were still unconditionally trying to fetch attachments from Redis for *all* events, as well as timing noop functions.

Lets skip these things a bit earlier, for some slight micro-optimizations.