### PR TITLE
chore(hybridcloud) Remove JiraServer from Integration proxy

### DIFF
--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -13,7 +13,6 @@ from sentry.integrations.client import ApiClient
 from sentry.models.identity import Identity
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.util import control_silo_function
-from sentry.shared_integrations.client.proxy import IntegrationProxyClient, infer_org_integration
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
@@ -26,7 +25,7 @@ ISSUE_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
 CUSTOMFIELD_PREFIX = "customfield_"
 
 
-class JiraServerClient(IntegrationProxyClient):
+class JiraServerClient(ApiClient):
     COMMENTS_URL = "/rest/api/2/issue/%s/comment"
     COMMENT_URL = "/rest/api/2/issue/%s/comment/%s"
     STATUS_URL = "/rest/api/2/status"
@@ -57,17 +56,12 @@ class JiraServerClient(IntegrationProxyClient):
         self,
         integration: RpcIntegration,
         identity_id: int,
-        org_integration_id: int | None = None,
         logging_context: JSONData | None = None,
     ):
         self.base_url = integration.metadata["base_url"]
         self.identity_id = identity_id
-        if not org_integration_id:
-            org_integration_id = infer_org_integration(
-                integration_id=integration.id, ctx_logger=logger
-            )
         super().__init__(
-            org_integration_id=org_integration_id,
+            integration_id=integration.id,
             verify_ssl=integration.metadata["verify_ssl"],
             logging_context=logging_context,
         )

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -70,6 +70,9 @@ class JiraServerClient(ApiClient):
     def get_cache_prefix(self):
         return "sentry-jira-server:"
 
+    def finalize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
+        return self.authorize_request(prepared_request=prepared_request)
+
     def authorize_request(self, prepared_request: PreparedRequest):
         """Jira Server authorizes with RSA-signed OAuth1 scheme"""
         if not self.identity:

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -28,6 +28,7 @@ from sentry.integrations import (
 from sentry.integrations.jira_server.utils.choice import build_user_choice
 from sentry.integrations.mixins import IssueSyncMixin, ResolveSyncAction
 from sentry.models.group import Group
+from sentry.models.identity import Identity
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.integrations.integration_external_project import IntegrationExternalProject
 from sentry.pipeline import PipelineView
@@ -282,9 +283,14 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
     default_identity = None
 
     def get_client(self):
+        try:
+            self.default_identity = self.get_default_identity()
+        except Identity.DoesNotExist:
+            raise IntegrationError("Identity not found.")
+
         return JiraServerClient(
             integration=self.model,
-            identity_id=self.org_integration.default_auth_id,
+            identity=self.default_identity,
         )
 
     def get_organization_config(self):

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -285,7 +285,6 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
         return JiraServerClient(
             integration=self.model,
             identity_id=self.org_integration.default_auth_id,
-            org_integration_id=self.org_integration.id,
         )
 
     def get_organization_config(self):

--- a/tests/sentry/integrations/jira_server/test_ticket_action.py
+++ b/tests/sentry/integrations/jira_server/test_ticket_action.py
@@ -6,7 +6,9 @@ from sentry.eventstore.models import Event
 from sentry.integrations.jira_server import JiraServerCreateTicketAction, JiraServerIntegration
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.rule import Rule
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import RuleTestCase
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.rules import RuleFuture
 
@@ -18,16 +20,29 @@ class JiraServerTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
 
     def setUp(self):
         super().setUp()
-        self.integration, _ = self.create_provider_integration_for(
+        self.integration, org_integration = self.create_provider_integration_for(
             self.organization,
             self.user,
             provider="jira_server",
             name="Jira Server",
             metadata={"base_url": "https://jira.example.com", "verify_ssl": True},
         )
+        identity = self.create_identity(
+            user=self.user,
+            external_id="jiraserver:123",
+            identity_provider=self.create_identity_provider(integration=self.integration),
+            data={
+                "consumer_key": "abc123",
+                "private_key": "key",
+                "access_token": "token",
+                "access_token_secret": "token_secret",
+            },
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            org_integration.default_auth_id = identity.id
+            org_integration.save()
 
         self.installation = self.integration.get_installation(self.organization.id)
-
         self.login_as(user=self.user)
 
     def trigger(self, event, rule_object):

--- a/tests/sentry/integrations/jira_server/test_ticket_action.py
+++ b/tests/sentry/integrations/jira_server/test_ticket_action.py
@@ -11,6 +11,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.rules import RuleFuture
+from tests.sentry.integrations.jira_server import EXAMPLE_PRIVATE_KEY
 
 pytestmark = [requires_snuba]
 
@@ -32,10 +33,10 @@ class JiraServerTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
             external_id="jiraserver:123",
             identity_provider=self.create_identity_provider(integration=self.integration),
             data={
-                "consumer_key": "abc123",
-                "private_key": "key",
-                "access_token": "token",
-                "access_token_secret": "token_secret",
+                "consumer_key": "sentry-test",
+                "private_key": EXAMPLE_PRIVATE_KEY,
+                "access_token": "access-token",
+                "access_token_secret": "access-token-secret",
             },
         )
         with assume_test_silo_mode(SiloMode.CONTROL):


### PR DESCRIPTION
Jira Server does not use refresh tokens and thus doesn't need to go through the integration proxy. This helps simplify operations and clarify when the integration proxy is required.
