### PR TITLE
fix: Enable automator for proguard options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -625,10 +625,17 @@ register(
 )
 
 # Enable use of Symbolicator proguard processing for specific projects.
-register("symbolicator.proguard-processing-projects", type=Sequence, default=[])
+register(
+    "symbolicator.proguard-processing-projects",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Enable use of Symbolicator proguard processing for fraction of projects.
-register("symbolicator.proguard-processing-sample-rate", default=0.0)
-register("symbolicator.proguard-processing-ab-test", default=0.0)
+register(
+    "symbolicator.proguard-processing-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+register("symbolicator.proguard-processing-ab-test", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Post Process Error Hook Sampling
 register(


### PR DESCRIPTION
I would like to modify these options via the automator, but forgot to set the flags.