### PR TITLE
ref(a11y): Give Alerts role=status

### DIFF
--- a/static/app/components/alert.tsx
+++ b/static/app/components/alert.tsx
@@ -78,6 +78,7 @@ function Alert({
 
   return (
     <Wrap
+      role="status"
       type={type}
       system={system}
       opaque={opaque}


### PR DESCRIPTION
Most of our alerts should have this role https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role

>The status role defines a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) containing advisory information for the user that is not important enough to be an [alert](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role).

I think this seems right