### PR TITLE
feat(autofix): Add collapsible header to file diff

### DIFF
--- a/static/app/components/events/autofix/autofixDiff.spec.tsx
+++ b/static/app/components/events/autofix/autofixDiff.spec.tsx
@@ -1,13 +1,13 @@
-import {AutofixResultFixture} from 'sentry-fixture/autofixResult';
+import {AutofixDiffFilePatch} from 'sentry-fixture/autofixDiffFilePatch';
 
-import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
 
 describe('AutofixDiff', function () {
   const defaultProps = {
-    fix: AutofixResultFixture(),
+    diff: [AutofixDiffFilePatch()],
   };
 
   it('displays a modified file diff correctly', function () {
@@ -17,6 +17,10 @@ describe('AutofixDiff', function () {
     expect(
       screen.getByText('src/sentry/processing/backpressure/memory.py')
     ).toBeInTheDocument();
+
+    // Lines changed
+    expect(screen.getByText('+1')).toBeInTheDocument();
+    expect(screen.getByText('-1')).toBeInTheDocument();
 
     // Hunk section header
     expect(
@@ -48,6 +52,20 @@ describe('AutofixDiff', function () {
     ).toBeInTheDocument();
 
     // 6 context lines
+    expect(screen.getAllByTestId('line-context')).toHaveLength(6);
+  });
+
+  it('can collapse a file diff', async function () {
+    render(<AutofixDiff {...defaultProps} />);
+
+    expect(screen.getAllByTestId('line-context')).toHaveLength(6);
+
+    // Clicking toggle hides file context
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle file diff'}));
+    expect(screen.queryByTestId('line-context')).not.toBeInTheDocument();
+
+    // Clicking again shows file context
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle file diff'}));
     expect(screen.getAllByTestId('line-context')).toHaveLength(6);
   });
 });

--- a/static/app/components/events/autofix/fixResult.tsx
+++ b/static/app/components/events/autofix/fixResult.tsx
@@ -60,7 +60,7 @@ function AutofixResultContent({autofixData, onRetry}: Props) {
 
   return (
     <Content>
-      <AutofixDiff fix={autofixData.fix} />
+      <AutofixDiff diff={autofixData.fix.diff ?? []} />
       <PreviewContent>
         <PrefixText>
           {tct('Pull request #[prNumber] created in [repository]', {


### PR DESCRIPTION
Soon Autofix will be able to send file diffs for multiple repos, so I wanted the file header to be more integrated into the diff since we are adding an additional layer of hierarchy.

The collapsible behavior is good for long diffs, and I've also added the number of lines changed.

![CleanShot 2024-04-04 at 11 18 51](https://github.com/getsentry/sentry/assets/10888943/3c289204-fd10-4d75-87dd-4d3a2533cfe8)