### PR TITLE
feat(autofix): Add reset button in header

### DIFF
--- a/static/app/components/events/autofix/autofixCard.tsx
+++ b/static/app/components/events/autofix/autofixCard.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/button';
 import {AutofixDoneLogs} from 'sentry/components/events/autofix/autofixDoneLogs';
 import {AutofixSteps} from 'sentry/components/events/autofix/autofixSteps';
 import {AutofixResult} from 'sentry/components/events/autofix/fixResult';
@@ -15,7 +16,12 @@ export function AutofixCard({data, onRetry}: {data: AutofixData; onRetry: () => 
 
   return (
     <AutofixPanel>
-      <Title>{t('Autofix')}</Title>
+      <AutofixHeader>
+        <Title>{t('Autofix')}</Title>
+        <Button size="xs" onClick={onRetry}>
+          Start Over
+        </Button>
+      </AutofixHeader>
       <AutofixResult autofixData={data} onRetry={onRetry} />
       {hasSteps && !isDone ? <AutofixSteps data={data} /> : null}
       {hasSteps && isDone ? <AutofixDoneLogs data={data} /> : null}
@@ -26,7 +32,6 @@ export function AutofixCard({data, onRetry}: {data: AutofixData; onRetry: () => 
 const Title = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   font-weight: bold;
-  margin-bottom: ${space(2)};
 `;
 
 const AutofixPanel = styled(Panel)`
@@ -34,4 +39,10 @@ const AutofixPanel = styled(Panel)`
   overflow: hidden;
   background: ${p => p.theme.backgroundSecondary};
   padding: ${space(2)} ${space(3)} ${space(3)} ${space(3)};
+`;
+
+const AutofixHeader = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr auto;
+  margin-bottom: ${space(2)};
 `;

--- a/static/app/components/events/autofix/fixResult.tsx
+++ b/static/app/components/events/autofix/fixResult.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Button, LinkButton} from 'sentry/components/button';
-import ButtonBar from 'sentry/components/buttonBar';
 import {AutofixDiff} from 'sentry/components/events/autofix/autofixDiff';
 import type {AutofixData} from 'sentry/components/events/autofix/types';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -75,19 +74,14 @@ function AutofixResultContent({autofixData, onRetry}: Props) {
         <PrTitle>{autofixData.fix.title}</PrTitle>
       </PreviewContent>
       <Actions>
-        <ButtonBar gap={1}>
-          <Button size="xs" onClick={onRetry}>
-            {t('Try Again')}
-          </Button>
-          <LinkButton
-            size="xs"
-            icon={<IconOpen size="xs" />}
-            href={autofixData.fix.pr_url}
-            external
-          >
-            {t('View Pull Request')}
-          </LinkButton>
-        </ButtonBar>
+        <LinkButton
+          size="xs"
+          icon={<IconOpen size="xs" />}
+          href={autofixData.fix.pr_url}
+          external
+        >
+          {t('View Pull Request')}
+        </LinkButton>
       </Actions>
     </Content>
   );

--- a/static/app/components/events/autofix/index.spec.tsx
+++ b/static/app/components/events/autofix/index.spec.tsx
@@ -74,6 +74,51 @@ describe('AiAutofix', () => {
     expect(screen.getByText('Second log message')).toBeInTheDocument();
   });
 
+  it('can reset and try again while running', async () => {
+    const autofixData = AutofixDataFixture({
+      steps: [
+        AutofixStepFixture({
+          id: '1',
+          progress: [
+            AutofixProgressItemFixture({message: 'First log message'}),
+            AutofixProgressItemFixture({message: 'Second log message'}),
+          ],
+        }),
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/ai-autofix/`,
+      body: autofixData,
+    });
+
+    const triggerAutofixMock = MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/ai-autofix/`,
+      method: 'POST',
+    });
+
+    render(
+      <Autofix
+        event={event}
+        group={{
+          ...group,
+          metadata: {
+            autofix: autofixData,
+          },
+        }}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Start Over'}));
+
+    expect(screen.getByText('Try Autofix')).toBeInTheDocument();
+
+    // Clicking the fix button should show the initial state "Starting Autofix..." and call the api
+    await userEvent.click(screen.getByRole('button', {name: 'Gimme Fix'}));
+    expect(await screen.findByText('Starting Autofix...')).toBeInTheDocument();
+    expect(triggerAutofixMock).toHaveBeenCalledTimes(1);
+  });
+
   it('renders the FixResult component when autofixData is present', () => {
     render(
       <Autofix


### PR DESCRIPTION
Gives the user a way to start over while the autofix is running or if it gets stuck in a weird state.

![CleanShot 2024-04-04 at 11 36 49](https://github.com/getsentry/sentry/assets/10888943/b4fb7b03-f658-453b-b679-2944c18c3f01)
