### PR TITLE
chore: Add some observability to perf issue detection pipeline

### DIFF
--- a/src/sentry/spans/buffer/redis.py
+++ b/src/sentry/spans/buffer/redis.py
@@ -97,7 +97,7 @@ class RedisSpansBuffer:
 
         self.client.ltrim(key, ltrim_index, -1)
 
-        sentry_sdk.set_tag("current_timestamp", now)
-        sentry_sdk.set_tag("segment_timestamp", processed_segment_ts)
+        segment_context = {"current_timestamp": now, "segment_timestamp": processed_segment_ts}
+        sentry_sdk.set_context("processed_segment", segment_context)
 
         return segment_keys

--- a/src/sentry/spans/buffer/redis.py
+++ b/src/sentry/spans/buffer/redis.py
@@ -62,7 +62,7 @@ class RedisSpansBuffer:
 
         return timestamp > int(last_processed_timestamp)
 
-    def read_and_expire_many_segments(self, keys: list[str]) -> list[tuple[str, list[str | bytes]]]:
+    def read_and_expire_many_segments(self, keys: list[str]) -> list[list[str | bytes]]:
         values = []
         with self.client.pipeline() as p:
             for key in keys:

--- a/src/sentry/spans/consumers/detect_performance_issues/factory.py
+++ b/src/sentry/spans/consumers/detect_performance_issues/factory.py
@@ -11,6 +11,7 @@ from sentry_kafka_schemas.codecs import Codec, ValidationError
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import BufferedSegment
 
 from sentry.spans.consumers.detect_performance_issues.message import process_segment
+from sentry.utils import metrics
 from sentry.utils.arroyo import MultiprocessingPool, RunTaskWithMultiprocessing
 
 BUFFERED_SEGMENT_SCHEMA: Codec[BufferedSegment] = get_codec("buffered-segments")
@@ -28,6 +29,8 @@ def process_message(message: Message[KafkaPayload]):
     except ValidationError:
         logger.exception("Failed to deserialize segment payload")
         return
+
+    metrics.incr("detect_performance_issues.spans.count", len(segment["spans"]))
 
     process_segment(segment["spans"])
 

--- a/src/sentry/spans/consumers/detect_performance_issues/factory.py
+++ b/src/sentry/spans/consumers/detect_performance_issues/factory.py
@@ -42,8 +42,8 @@ def _process_message(message: Message[KafkaPayload]):
     try:
         with sentry_sdk.start_transaction(
             op="process", name="spans.detect_performance_issues.process_message"
-        ) as txn:
-            txn.set_measurement("message_size.bytes", len(message.payload.value))
+        ):
+            sentry_sdk.set_measurement("message_size.bytes", len(message.payload.value))
             process_message(message)
     except Exception:
         sentry_sdk.capture_exception()

--- a/src/sentry/spans/consumers/detect_performance_issues/factory.py
+++ b/src/sentry/spans/consumers/detect_performance_issues/factory.py
@@ -8,7 +8,7 @@ from arroyo.processing.strategies.abstract import ProcessingStrategy, Processing
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.types import BrokerValue, Commit, Message, Partition
 from sentry_kafka_schemas import get_codec
-from sentry_kafka_schemas.codecs import Codec, ValidationError
+from sentry_kafka_schemas.codecs import Codec
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import BufferedSegment
 
 from sentry.spans.consumers.detect_performance_issues.message import process_segment
@@ -25,12 +25,8 @@ def _deserialize_segment(value: bytes) -> Mapping[str, Any]:
 
 
 def process_message(message: Message[KafkaPayload]):
-    try:
-        segment = _deserialize_segment(message.payload.value)
-    except ValidationError:
-        logger.exception("Failed to deserialize segment payload")
-        return
-
+    value = message.payload.value
+    segment = _deserialize_segment(value)
     metrics.incr("detect_performance_issues.spans.count", len(segment["spans"]))
 
     process_segment(segment["spans"])

--- a/src/sentry/spans/consumers/detect_performance_issues/factory.py
+++ b/src/sentry/spans/consumers/detect_performance_issues/factory.py
@@ -42,7 +42,8 @@ def _process_message(message: Message[KafkaPayload]):
     try:
         with sentry_sdk.start_transaction(
             op="process", name="spans.detect_performance_issues.process_message"
-        ):
+        ) as txn:
+            txn.set_measurement("message_size.bytes", len(message.payload.value))
             process_message(message)
     except Exception:
         sentry_sdk.capture_exception()

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -133,7 +133,8 @@ def _produce_segment(message: Message[ProduceSegmentContext | None]):
                             example_segment = segment[0]
                         produce_segment_to_kafka(segment)
 
-            txn.set_tag("sample_span", example_segment)
+            if example_segment:
+                txn.set_tag("sample_span", example_segment)
 
 
 def produce_segment(message: Message[ProduceSegmentContext | None]):

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -75,7 +75,7 @@ def _process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | 
 
         txn.set_tag("trace.id", trace_id)
         txn.set_tag("segment.id", segment_id)
-        txn.set_measurement("num_keys", len(span))
+        sentry_sdk.set_measurement("num_keys", len(span))
 
         client = RedisSpansBuffer()
 
@@ -95,6 +95,7 @@ def process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | N
         return _process_message(message)
     except Exception:
         sentry_sdk.capture_exception()
+        return None
 
 
 def _produce_segment(message: Message[ProduceSegmentContext | None]):
@@ -119,7 +120,7 @@ def _produce_segment(message: Message[ProduceSegmentContext | None]):
                     context.timestamp, context.partition
                 )
 
-            txn.set_measurement("segments.count", len(keys))
+            sentry_sdk.set_measurement("segments.count", len(keys))
 
             example_segment = None
 

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -116,6 +116,8 @@ def _produce_segment(message: Message[ProduceSegmentContext | None]):
                 )
 
             sentry_sdk.set_measurement("segments.count", len(keys))
+            if len(keys) > 0:
+                txn.set_tag("sample_key", keys[0])
 
             example_segment = None
             total_spans_read = 0

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+import sentry_sdk
 from arroyo.backends.kafka.consumer import Headers, KafkaPayload
 from arroyo.processing.strategies import RunTask
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
@@ -15,6 +16,7 @@ from sentry_kafka_schemas.schema_types.snuba_spans_v1 import SpanEvent
 from sentry import options
 from sentry.spans.buffer.redis import RedisSpansBuffer
 from sentry.spans.produce_segment import produce_segment_to_kafka
+from sentry.utils import metrics
 from sentry.utils.arroyo import MultiprocessingPool, RunTaskWithMultiprocessing
 
 logger = logging.getLogger(__name__)
@@ -42,7 +44,7 @@ def _deserialize_span(value: bytes) -> Mapping[str, Any]:
     return SPAN_SCHEMA.decode(value)
 
 
-def process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | None:
+def _process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | None:
     if not options.get("standalone-spans.process-spans-consumer.enable"):
         return None
 
@@ -58,45 +60,87 @@ def process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | N
         return None
 
     assert isinstance(message.value, BrokerValue)
-    try:
-        span = _deserialize_span(message.payload.value)
+
+    with sentry_sdk.start_transaction(op="process", name="spans.process.process_message") as txn:
+        payload_value = message.payload.value
+        timestamp = int(message.value.timestamp.timestamp())
+        partition = message.value.partition.index
+
+        span = _deserialize_span(payload_value)
         segment_id = span["segment_id"]
-    except Exception:
-        logger.exception("Failed to process span payload")
-        return None
+        trace_id = span["trace_id"]
 
-    timestamp = int(message.value.timestamp.timestamp())
-    partition = message.value.partition.index
+        txn.set_tag("trace.id", trace_id)
+        txn.set_tag("segment.id", segment_id)
+        txn.set_tag("payload", payload_value)
 
-    client = RedisSpansBuffer()
+        client = RedisSpansBuffer()
 
-    should_process_segments = client.write_span_and_check_processing(
-        project_id, segment_id, timestamp, partition, message.payload.value
-    )
+        should_process_segments = client.write_span_and_check_processing(
+            project_id, segment_id, timestamp, partition, payload_value
+        )
+
+        metrics.incr("process_spans.spans.write.count")
 
     return ProduceSegmentContext(
         should_process_segments=should_process_segments, timestamp=timestamp, partition=partition
     )
 
 
-def produce_segment(message: Message[ProduceSegmentContext | None]):
+def process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | None:
+    try:
+        _process_message(message)
+    except Exception:
+        sentry_sdk.capture_exception()
+
+
+def _produce_segment(message: Message[ProduceSegmentContext | None]):
     if message.payload is None:
         return
 
     context: ProduceSegmentContext = message.payload
+
+    metrics.incr(
+        "spans.process_spans.should_process_segments",
+        int(context.should_process_segments),
+    )
+
     if context.should_process_segments:
-        client = RedisSpansBuffer()
+        with sentry_sdk.start_transaction(
+            op="process", name="spans.process.produce_segment"
+        ) as txn:
+            client = RedisSpansBuffer()
 
-        keys = client.get_unprocessed_segments_and_prune_bucket(
-            context.timestamp, context.partition
-        )
-        # With pipelining, redis server is forced to queue replies using
-        # up memory, so batching the keys we fetch.
-        for i in range(0, len(keys), BATCH_SIZE):
-            segments = client.read_and_expire_many_segments(keys[i : i + BATCH_SIZE])
+            with txn.start_child(op="process", description="fetch_unprocessed_segments"):
+                keys = client.get_unprocessed_segments_and_prune_bucket(
+                    context.timestamp, context.partition
+                )
 
-            for segment in segments:
-                produce_segment_to_kafka(segment)
+            txn.set_measurement("segments.count", len(keys))
+
+            example_segment = None
+
+            # With pipelining, redis server is forced to queue replies using
+            # up memory, so batching the keys we fetch.
+            with txn.start_child(op="process", description="produce_fetched_segments"):
+                for i in range(0, len(keys), BATCH_SIZE):
+                    segments = client.read_and_expire_many_segments(keys[i : i + BATCH_SIZE])
+
+                    for segment in segments:
+                        num_spans = len(segment)
+                        metrics.incr("process_spans.spans.read.count", num_spans)
+                        if num_spans > 0:
+                            example_segment = segment[0]
+                        produce_segment_to_kafka(segment)
+
+            txn.set_tag("sample_span", example_segment)
+
+
+def produce_segment(message: Message[ProduceSegmentContext | None]):
+    try:
+        _produce_segment(message)
+    except Exception:
+        sentry_sdk.capture_exception()
 
 
 class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -119,7 +119,7 @@ def _produce_segment(message: Message[ProduceSegmentContext | None]):
             if len(keys) > 0:
                 txn.set_tag("sample_key", keys[0])
 
-            example_segment = None
+            sample_span = None
             total_spans_read = 0
             # With pipelining, redis server is forced to queue replies using
             # up memory, so batching the keys we fetch.
@@ -130,12 +130,12 @@ def _produce_segment(message: Message[ProduceSegmentContext | None]):
                     for segment in segments:
                         total_spans_read += len(segment)
                         if len(segment) > 0:
-                            example_segment = segment[0]
+                            sample_span = segment[0]
                         produce_segment_to_kafka(segment)
 
             metrics.incr("process_spans.spans.read.count", total_spans_read)
-            if example_segment:
-                txn.set_tag("sample_span", example_segment)
+            if sample_span:
+                txn.set_tag("sample_span", sample_span)
 
 
 def produce_segment(message: Message[ProduceSegmentContext | None]):

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -67,7 +67,7 @@ def _process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | 
         timestamp = int(message.value.timestamp.timestamp())
         partition = message.value.partition.index
 
-        sentry_sdk.set_context("payload", {"value", payload_value})
+        sentry_sdk.set_context("payload", {"value": str(payload_value)})
 
         span = _deserialize_span(payload_value)
         segment_id = span["segment_id"]
@@ -136,7 +136,7 @@ def _produce_segment(message: Message[ProduceSegmentContext | None]):
 
             metrics.incr("process_spans.spans.read.count", total_spans_read)
             if sample_span:
-                payload_context["sample_span"] = sample_span
+                payload_context["sample_span"] = str(sample_span)
 
             sentry_sdk.set_context("payload", payload_context)
 


### PR DESCRIPTION
Adding some observability to the pipeline to help narrow down what's causing the funkiness we're seeing.

1. We have fields missing from spans, so we're capturing transactions and dumping some of the span payloads into the tags so we can see where the fields get dropped.
2. Don't receive all the spans we expect to receive in a segment, so I'm adding a couple metrics to see if we're significantly dropping spans at a certain step: `process_spans.spans.received.count`: how many we receive -> `process_spans.spans.write.count`: how many we write to redis, `process_spans.spans.read.count`: how many we read from redis and `detect_performance_issues.spans.count`: how many we run through perf issue detector.
3. We could be processing the wrong bucket, so tagging some timestamps and sample keys to help debug.
4. Explicitly capture exceptions in sentry

Note: there are no functional changes to the code, this PR just adds logging/observability. I'd like to merge this first, get some data to see if it supports our theories and then follow up with simplifications to the code that might solve the issues so we can pinpoint a root cause.