### PR TITLE
feat(ui): Add `onRowMouseOver` and `onRowMouseOut` to `GridEditable`

### DIFF
--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -123,6 +123,35 @@ export default storyBook(GridEditable, story => {
     </SideBySide>
   ));
 
+  story('Row Mouse Events', () => {
+    const [activeRow, setActiveRow] = useState<ExampleDataItem | undefined>(undefined);
+
+    return (
+      <Fragment>
+        <p>
+          You can provide a <JSXProperty name="onRowMouseOver" value={Function} /> and a{' '}
+          <JSXProperty name="onRowMouseOut" value={Function} /> callback.
+        </p>
+        <p>
+          Hovered Row: {activeRow?.category} {activeRow?.name}
+        </p>
+        <GridEditable
+          data={data}
+          columnOrder={columns}
+          columnSortBy={[]}
+          grid={{}}
+          location={mockLocation}
+          onRowMouseOver={dataRow => {
+            setActiveRow(dataRow);
+          }}
+          onRowMouseOut={() => {
+            setActiveRow(undefined);
+          }}
+        />
+      </Fragment>
+    );
+  });
+
   function useStatefulColumnWidths() {
     const [columnsWithDynamicWidths, setColumns] =
       useState<GridColumnOrder<keyof ExampleDataItem | 'other'>[]>(columnsWithWidth);

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -109,6 +109,9 @@ type GridEditableProps<DataRow, ColumnKey> = {
 
   minimumColWidth?: number;
 
+  onRowMouseOut?: (row: DataRow, event: React.MouseEvent) => void;
+  onRowMouseOver?: (row: DataRow, event: React.MouseEvent) => void;
+
   scrollable?: boolean;
   stickyHeader?: boolean;
   /**
@@ -373,13 +376,18 @@ class GridEditable<
   }
 
   renderGridBodyRow = (dataRow: DataRow, row: number) => {
-    const {columnOrder, grid} = this.props;
+    const {columnOrder, grid, onRowMouseOver, onRowMouseOut} = this.props;
     const prependColumns = grid.renderPrependColumns
       ? grid.renderPrependColumns(false, dataRow, row)
       : [];
 
     return (
-      <GridRow key={row} data-test-id="grid-body-row">
+      <GridRow
+        key={row}
+        onMouseOver={event => onRowMouseOver?.(dataRow, event)}
+        onMouseOut={event => onRowMouseOut?.(dataRow, event)}
+        data-test-id="grid-body-row"
+      >
         {prependColumns?.map((item, i) => (
           <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`}>
             {item}


### PR DESCRIPTION
The handlers are delegated to each `GridRow` component, excluding the header. This is very handy for tracking which table row is hovered over. For example, in Performance we sometimes have a chart _and_ a table of samples, and when someone hovers over a row in the table we highlight a sample in the chart.

Right now we do this by adding a hover wrapper manually around the content of each cell, which is yucky. This is simple, and more obvious.
