### PR TITLE
fix(crons): Do not update cursor location once cursor is inactive

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/timelineCursor.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineCursor.tsx
@@ -68,6 +68,10 @@ function useTimelineCursor<E extends HTMLElement>({
           return;
         }
 
+        if (!isInsideContainer) {
+          return;
+        }
+
         const offset = e.clientX - containerRect.left;
         const tooltipWidth = labelRef.current.offsetWidth;
 


### PR DESCRIPTION
This fixes a bug where when your mouse leaves the timeline the cursor
keeps moving