### PR TITLE
fix(staff): Let staff handle user tokens in _admin

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -15,7 +15,7 @@ from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.fields import MultipleChoiceField
 from sentry.api.serializers import serialize
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.elevated_mode import has_elevated_mode
 from sentry.models.apitoken import ApiToken
 from sentry.models.outbox import outbox_context
 from sentry.security.utils import capture_security_activity
@@ -50,7 +50,7 @@ class ApiTokensEndpoint(Endpoint):
         """
         # Get the user id for the user that made the current request as a baseline default
         user_id = request.user.id
-        if is_active_superuser(request):
+        if has_elevated_mode(request):
             datastore = request.GET if request.GET else request.data
             # If a userId override is not found, use the id for the user who made the request
             user_id = datastore.get("userId", user_id)

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -1,8 +1,10 @@
 from django.urls import reverse
+from pytest import fixture
 from rest_framework import status
 
 from sentry.models.apitoken import ApiToken
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -151,75 +153,147 @@ class ApiTokensDeleteTest(APITestCase):
         assert ApiToken.objects.filter(id=token.id).exists()
 
 
+# TODO(schew2381): Delete this testcase after staff is released
 @control_silo_test
-class ApiTokensSuperUserTest(APITestCase):
+class ApiTokensSuperuserTest(APITestCase):
     url = reverse("sentry-api-0-api-tokens")
 
+    def setUp(self):
+        self.superuser = self.create_user(is_superuser=True)
+        self.superuser_token = self.create_user_auth_token(self.superuser)
+        self.user_token = ApiToken.objects.create(user=self.user)
+
     def test_get_as_su(self):
-        super_user = self.create_user(is_superuser=True)
-        user_token = ApiToken.objects.create(user=self.user)
-        self.login_as(super_user, superuser=True)
+        self.login_as(self.superuser, superuser=True)
 
         response = self.client.get(self.url, {"userId": self.user.id})
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
-        assert response.data[0]["id"] == str(user_token.id)
+        assert response.data[0]["id"] == str(self.user_token.id)
 
     def test_get_as_su_implicit_userid(self):
-        super_user = self.create_user(is_superuser=True)
-        superuser_token = ApiToken.objects.create(user=super_user)
-        user_token = ApiToken.objects.create(user=self.user)
-        self.login_as(super_user, superuser=True)
+        self.login_as(self.superuser, superuser=True)
 
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
-        assert response.data[0]["id"] != str(user_token.id)
-        assert response.data[0]["id"] == str(superuser_token.id)
+        assert response.data[0]["id"] != str(self.user_token.id)
+        assert response.data[0]["id"] == str(self.superuser_token.id)
 
     def test_get_as_user(self):
-        super_user = self.create_user(is_superuser=True)
-        su_token = ApiToken.objects.create(user=super_user)
-        self.login_as(super_user)
+        self.login_as(self.superuser)
+
         # Ignores trying to fetch the user's token, since we're not an active superuser
         response = self.client.get(self.url, {"userId": self.user.id})
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
-        assert response.data[0]["id"] == str(su_token.id)
+        assert response.data[0]["id"] == str(self.superuser_token.id)
 
     def test_delete_as_su(self):
-        super_user = self.create_user(is_superuser=True)
-        user_token = ApiToken.objects.create(user=self.user)
-        self.login_as(super_user, superuser=True)
+        self.login_as(self.superuser, superuser=True)
 
-        response = self.client.delete(self.url, {"userId": self.user.id, "tokenId": user_token.id})
+        response = self.client.delete(
+            self.url, {"userId": self.user.id, "tokenId": self.user_token.id}
+        )
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        assert not ApiToken.objects.filter(id=user_token.id).exists()
+        assert not ApiToken.objects.filter(id=self.user_token.id).exists()
 
     def test_delete_as_su_implicit_userid(self):
-        super_user = self.create_user(is_superuser=True)
-        user_token = ApiToken.objects.create(user=self.user)
-        su_token = ApiToken.objects.create(user=super_user)
-        self.login_as(super_user, superuser=True)
+        self.login_as(self.superuser, superuser=True)
 
-        response = self.client.delete(self.url, {"tokenId": user_token.id})
+        response = self.client.delete(self.url, {"tokenId": self.user_token.id})
         # The superusers' id will be used since no override is sent, and because it does not exist, it is a bad request
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert ApiToken.objects.filter(id=user_token.id).exists()
-        assert ApiToken.objects.filter(id=su_token.id).exists()
+        assert ApiToken.objects.filter(id=self.user_token.id).exists()
+        assert ApiToken.objects.filter(id=self.superuser_token.id).exists()
 
-        response = self.client.delete(self.url, {"tokenId": su_token.id})
+        response = self.client.delete(self.url, {"tokenId": self.superuser_token.id})
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        assert ApiToken.objects.filter(id=user_token.id).exists()
-        assert not ApiToken.objects.filter(id=su_token.id).exists()
+        assert ApiToken.objects.filter(id=self.user_token.id).exists()
+        assert not ApiToken.objects.filter(id=self.superuser_token.id).exists()
 
     def test_delete_as_user(self):
-        super_user = self.create_user(is_superuser=True)
-        user_token = ApiToken.objects.create(user=self.user)
-        su_token = ApiToken.objects.create(user=super_user)
-        self.login_as(super_user)
+        self.login_as(self.superuser)
+
         # Fails trying to delete the user's token, since we're not an active superuser
-        response = self.client.delete(self.url, {"userId": self.user.id, "tokenId": user_token.id})
+        response = self.client.delete(
+            self.url, {"userId": self.user.id, "tokenId": self.user_token.id}
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert ApiToken.objects.filter(id=user_token.id).exists()
-        assert ApiToken.objects.filter(id=su_token.id).exists()
+        assert ApiToken.objects.filter(id=self.user_token.id).exists()
+        assert ApiToken.objects.filter(id=self.superuser_token.id).exists()
+
+
+@control_silo_test
+class ApiTokensStaffTest(APITestCase):
+    url = reverse("sentry-api-0-api-tokens")
+
+    @fixture(autouse=True)
+    def _set_staff_option(self):
+        with override_options({"staff.ga-rollout": True}):
+            yield
+
+    def setUp(self):
+        self.staff_user = self.create_user(is_staff=True)
+        self.staff_token = self.create_user_auth_token(self.staff_user)
+        self.user_token = ApiToken.objects.create(user=self.user)
+
+    def test_get_as_staff(self):
+        self.login_as(self.staff_user, staff=True)
+
+        response = self.client.get(self.url, {"userId": self.user.id})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.user_token.id)
+
+    def test_get_as_staff_implicit_userid(self):
+        self.login_as(self.staff_user, staff=True)
+
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["id"] != str(self.user_token.id)
+        assert response.data[0]["id"] == str(self.staff_token.id)
+
+    def test_get_as_user(self):
+        self.login_as(self.staff_user)
+
+        # Ignores trying to fetch the user's token, since we're not an active superuser
+        response = self.client.get(self.url, {"userId": self.user.id})
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.staff_token.id)
+
+    def test_delete_as_staff(self):
+        self.login_as(self.staff_user, staff=True)
+
+        response = self.client.delete(
+            self.url, {"userId": self.user.id, "tokenId": self.user_token.id}
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not ApiToken.objects.filter(id=self.user_token.id).exists()
+
+    def test_delete_as_staff_implicit_userid(self):
+        self.login_as(self.staff_user, staff=True)
+
+        response = self.client.delete(self.url, {"tokenId": self.user_token.id})
+        # The staff' id will be used since no override is sent, and because it does not exist, it is a bad request
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert ApiToken.objects.filter(id=self.user_token.id).exists()
+        assert ApiToken.objects.filter(id=self.staff_token.id).exists()
+
+        response = self.client.delete(self.url, {"tokenId": self.staff_token.id})
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert ApiToken.objects.filter(id=self.user_token.id).exists()
+        assert not ApiToken.objects.filter(id=self.staff_token.id).exists()
+
+    def test_delete_as_user(self):
+        self.login_as(self.staff_user)
+
+        # Fails trying to delete the user's token, since we're not an active superuser
+        response = self.client.delete(
+            self.url, {"userId": self.user.id, "tokenId": self.user_token.id}
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert ApiToken.objects.filter(id=self.user_token.id).exists()
+        assert ApiToken.objects.filter(id=self.staff_token.id).exists()


### PR DESCRIPTION
Fix staff being unable to see and delete user tokens in _admin. It would only show you your own user tokens no matter which user page you were on.