### PR TITLE
feat(platforms): Make UI the same as native for Nintendo

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/rawContent.tsx
@@ -51,7 +51,7 @@ class RawContent extends Component<Props, State> {
 
   isNative() {
     const {platform} = this.props;
-    return platform === 'cocoa' || platform === 'native';
+    return platform === 'cocoa' || platform === 'native' || platform === 'nintendo';
   }
 
   getAppleCrashReportEndpoint(organization: Organization) {

--- a/static/app/components/events/interfaces/frame/line/index.tsx
+++ b/static/app/components/events/interfaces/frame/line/index.tsx
@@ -98,6 +98,7 @@ function Line({
       case 'objc':
       case 'cocoa':
       case 'native':
+      case 'nintendo':
         return (
           <Native
             event={event}

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -247,7 +247,12 @@ export function TraceEventDataSection({
     disabled?: boolean;
     tooltip?: string;
   }[] {
-    if (platform === 'objc' || platform === 'native' || platform === 'cocoa') {
+    if (
+      platform === 'objc' ||
+      platform === 'native' ||
+      platform === 'cocoa' ||
+      platform === 'nintendo'
+    ) {
       return [
         {
           label: displayOptions['absolute-addresses'],

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -42,6 +42,7 @@ export function isNativePlatform(platform: string | undefined) {
     case 'native':
     case 'swift':
     case 'c':
+    case 'nintendo':
       return true;
     default:
       return false;

--- a/static/app/views/performance/utils/index.tsx
+++ b/static/app/views/performance/utils/index.tsx
@@ -98,7 +98,9 @@ const FRONTEND_PLATFORMS: string[] = frontend.filter(
     // Next, Remix and Sveltekit have both, frontend and backend transactions.
     !['javascript-nextjs', 'javascript-remix', 'javascript-sveltekit'].includes(platform)
 );
-const BACKEND_PLATFORMS: string[] = backend.filter(platform => platform !== 'native');
+const BACKEND_PLATFORMS: string[] = backend.filter(
+  platform => platform !== 'native' && platform !== 'nintendo'
+);
 const MOBILE_PLATFORMS: string[] = [...mobile];
 
 export function platformToPerformanceType(

--- a/static/app/views/releases/utils/sessionTerm.tsx
+++ b/static/app/views/releases/utils/sessionTerm.tsx
@@ -145,6 +145,7 @@ function getTermDescriptions(platform: PlatformKey | null) {
     case 'apple-ios':
     case 'minidump':
     case 'native':
+    case 'nintendo':
       return {
         ...commonTermsDescription,
         ...desktopTermDescriptions,


### PR DESCRIPTION
So far we used `native` for Nintendo and it worked fine so now that we're adding a new platform we want to make sure the previous experience doesn't change.