### PR TITLE
feat(ui): Add `highlightedRowKey` prop to `GridEditable`

### DIFF
--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -124,16 +124,13 @@ export default storyBook(GridEditable, story => {
   ));
 
   story('Row Mouse Events', () => {
-    const [activeRowKey, setActiveRowKey] = useState<number | undefined>(undefined);
-    const activeRow = activeRowKey ? data[activeRowKey] : undefined;
+    const [activeRow, setActiveRow] = useState<ExampleDataItem | undefined>(undefined);
 
     return (
       <Fragment>
         <p>
           You can provide a <JSXProperty name="onRowMouseOver" value={Function} /> and a{' '}
-          <JSXProperty name="onRowMouseOut" value={Function} /> callback. You can also
-          combine that with the <JSXProperty name="highlightedRowKey" value={Number} />{' '}
-          prop to highlight a row.
+          <JSXProperty name="onRowMouseOut" value={Function} /> callback.
         </p>
         <p>
           Hovered Row: {activeRow?.category} {activeRow?.name}
@@ -144,13 +141,12 @@ export default storyBook(GridEditable, story => {
           columnSortBy={[]}
           grid={{}}
           location={mockLocation}
-          onRowMouseOver={(_dataRow, key) => {
-            setActiveRowKey(key);
+          onRowMouseOver={dataRow => {
+            setActiveRow(dataRow);
           }}
           onRowMouseOut={() => {
-            setActiveRowKey(undefined);
+            setActiveRow(undefined);
           }}
-          highlightedRowKey={activeRowKey}
         />
       </Fragment>
     );

--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -124,13 +124,16 @@ export default storyBook(GridEditable, story => {
   ));
 
   story('Row Mouse Events', () => {
-    const [activeRow, setActiveRow] = useState<ExampleDataItem | undefined>(undefined);
+    const [activeRowKey, setActiveRowKey] = useState<number | undefined>(undefined);
+    const activeRow = activeRowKey ? data[activeRowKey] : undefined;
 
     return (
       <Fragment>
         <p>
           You can provide a <JSXProperty name="onRowMouseOver" value={Function} /> and a{' '}
-          <JSXProperty name="onRowMouseOut" value={Function} /> callback.
+          <JSXProperty name="onRowMouseOut" value={Function} /> callback. You can also
+          combine that with the <JSXProperty name="highlightedRowKey" value={Number} />{' '}
+          prop to highlight a row.
         </p>
         <p>
           Hovered Row: {activeRow?.category} {activeRow?.name}
@@ -141,12 +144,13 @@ export default storyBook(GridEditable, story => {
           columnSortBy={[]}
           grid={{}}
           location={mockLocation}
-          onRowMouseOver={dataRow => {
-            setActiveRow(dataRow);
+          onRowMouseOver={(_dataRow, key) => {
+            setActiveRowKey(key);
           }}
           onRowMouseOut={() => {
-            setActiveRow(undefined);
+            setActiveRowKey(undefined);
           }}
+          highlightedRowKey={activeRowKey}
         />
       </Fragment>
     );

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -392,7 +392,7 @@ class GridEditable<
         onMouseOut={event => onRowMouseOut?.(dataRow, row, event)}
         data-test-id="grid-body-row"
       >
-        <InteractionStateLayer isHovered={row === highlightedRowKey} as="div" />
+        <InteractionStateLayer isHovered={row === highlightedRowKey} as="td" />
 
         {prependColumns?.map((item, i) => (
           <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`}>

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -3,6 +3,7 @@ import {Component, createRef, Fragment} from 'react';
 import type {Location} from 'history';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -389,9 +390,10 @@ class GridEditable<
         key={row}
         onMouseOver={event => onRowMouseOver?.(dataRow, row, event)}
         onMouseOut={event => onRowMouseOut?.(dataRow, row, event)}
-        isHighlighted={row === highlightedRowKey}
         data-test-id="grid-body-row"
       >
+        <InteractionStateLayer isHovered={row === highlightedRowKey} />
+
         {prependColumns?.map((item, i) => (
           <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`}>
             {item}

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -129,6 +129,7 @@ type GridEditableProps<DataRow, ColumnKey> = {
 };
 
 type GridEditableState = {
+  highlightedRowKey: number | undefined;
   numColumn: number;
 };
 
@@ -150,6 +151,7 @@ class GridEditable<
 
   state: GridEditableState = {
     numColumn: 0,
+    highlightedRowKey: undefined,
   };
 
   componentDidMount() {
@@ -378,17 +380,31 @@ class GridEditable<
   }
 
   renderGridBodyRow = (dataRow: DataRow, row: number) => {
-    const {columnOrder, grid, onRowMouseOver, onRowMouseOut, highlightedRowKey} =
-      this.props;
+    const {columnOrder, grid, onRowMouseOver, onRowMouseOut} = this.props;
     const prependColumns = grid.renderPrependColumns
       ? grid.renderPrependColumns(false, dataRow, row)
       : [];
 
+    const highlightedRowKey =
+      this.props.highlightedRowKey ?? this.state.highlightedRowKey;
+
     return (
       <GridRow
         key={row}
-        onMouseOver={event => onRowMouseOver?.(dataRow, row, event)}
-        onMouseOut={event => onRowMouseOut?.(dataRow, row, event)}
+        onMouseOver={event => {
+          this.setState(state => ({
+            ...state,
+            highlightedRowKey: row,
+          }));
+          onRowMouseOver?.(dataRow, row, event);
+        }}
+        onMouseOut={event => {
+          this.setState(state => ({
+            ...state,
+            highlightedRowKey: undefined,
+          }));
+          onRowMouseOut?.(dataRow, row, event);
+        }}
         isHighlighted={row === highlightedRowKey}
         data-test-id="grid-body-row"
       >

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -105,12 +105,14 @@ type GridEditableProps<DataRow, ColumnKey> = {
   headerButtons?: () => React.ReactNode;
 
   height?: string | number;
+  highlightedRowKey?: number;
+
   isLoading?: boolean;
 
   minimumColWidth?: number;
 
-  onRowMouseOut?: (row: DataRow, event: React.MouseEvent) => void;
-  onRowMouseOver?: (row: DataRow, event: React.MouseEvent) => void;
+  onRowMouseOut?: (row: DataRow, key: number, event: React.MouseEvent) => void;
+  onRowMouseOver?: (row: DataRow, key: number, event: React.MouseEvent) => void;
 
   scrollable?: boolean;
   stickyHeader?: boolean;
@@ -376,7 +378,8 @@ class GridEditable<
   }
 
   renderGridBodyRow = (dataRow: DataRow, row: number) => {
-    const {columnOrder, grid, onRowMouseOver, onRowMouseOut} = this.props;
+    const {columnOrder, grid, onRowMouseOver, onRowMouseOut, highlightedRowKey} =
+      this.props;
     const prependColumns = grid.renderPrependColumns
       ? grid.renderPrependColumns(false, dataRow, row)
       : [];
@@ -384,8 +387,9 @@ class GridEditable<
     return (
       <GridRow
         key={row}
-        onMouseOver={event => onRowMouseOver?.(dataRow, event)}
-        onMouseOut={event => onRowMouseOut?.(dataRow, event)}
+        onMouseOver={event => onRowMouseOver?.(dataRow, row, event)}
+        onMouseOut={event => onRowMouseOut?.(dataRow, row, event)}
+        isHighlighted={row === highlightedRowKey}
         data-test-id="grid-body-row"
       >
         {prependColumns?.map((item, i) => (

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -392,7 +392,7 @@ class GridEditable<
         onMouseOut={event => onRowMouseOut?.(dataRow, row, event)}
         data-test-id="grid-body-row"
       >
-        <InteractionStateLayer isHovered={row === highlightedRowKey} />
+        <InteractionStateLayer isHovered={row === highlightedRowKey} as="div" />
 
         {prependColumns?.map((item, i) => (
           <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`}>

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -409,9 +409,6 @@ class GridEditable<
       ? grid.renderPrependColumns(false, dataRow, row)
       : [];
 
-    const highlightedRowKey =
-      this.props.highlightedRowKey ?? this.state.highlightedRowKey;
-
     return (
       <GridRow
         key={row}
@@ -431,7 +428,6 @@ class GridEditable<
 
           onRowMouseOut?.(dataRow, row, event);
         }}
-        isHighlighted={row === highlightedRowKey}
         data-test-id="grid-body-row"
       >
         {prependColumns?.map((item, i) => (

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -130,7 +130,6 @@ type GridEditableProps<DataRow, ColumnKey> = {
 };
 
 type GridEditableState = {
-  highlightedRowKey: number | undefined;
   numColumn: number;
 };
 
@@ -152,7 +151,6 @@ class GridEditable<
 
   state: GridEditableState = {
     numColumn: 0,
-    highlightedRowKey: undefined,
   };
 
   componentDidMount() {

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -180,17 +180,13 @@ export const GridBody = styled('tbody')`
   grid-column: 1/-1;
 `;
 
-export const GridRow = styled('tr')`
+export const GridRow = styled('tr')<{isHighlighted?: boolean}>`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1/-1;
 
   &:not(thead > &) {
-    background-color: ${p => p.theme.background};
-
-    &.highlighted {
-      background-color: ${p => p.theme.gray100};
-    }
+    background-color: ${p => (p.isHighlighted ? p.theme.gray100 : p.theme.background)};
 
     &:not(:last-child) {
       border-bottom: 1px solid ${p => p.theme.innerBorder};

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -186,7 +186,11 @@ export const GridRow = styled('tr')<{isHighlighted?: boolean}>`
   grid-column: 1/-1;
 
   &:not(thead > &) {
-    background-color: ${p => (p.isHighlighted ? p.theme.gray100 : p.theme.background)};
+    background-color: ${p => p.theme.background};
+
+    &.highlighted {
+      background-color: ${p => p.theme.gray100};
+    }
 
     &:not(:last-child) {
       border-bottom: 1px solid ${p => p.theme.innerBorder};

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -180,13 +180,13 @@ export const GridBody = styled('tbody')`
   grid-column: 1/-1;
 `;
 
-export const GridRow = styled('tr')`
+export const GridRow = styled('tr')<{isHighlighted?: boolean}>`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1/-1;
 
   &:not(thead > &) {
-    background-color: ${p => p.theme.background};
+    background-color: ${p => (p.isHighlighted ? p.theme.gray100 : p.theme.background)};
 
     &:not(:last-child) {
       border-bottom: 1px solid ${p => p.theme.innerBorder};

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -180,13 +180,14 @@ export const GridBody = styled('tbody')`
   grid-column: 1/-1;
 `;
 
-export const GridRow = styled('tr')<{isHighlighted?: boolean}>`
+export const GridRow = styled('tr')`
   display: grid;
+  position: relative;
   grid-template-columns: subgrid;
   grid-column: 1/-1;
 
   &:not(thead > &) {
-    background-color: ${p => (p.isHighlighted ? p.theme.gray100 : p.theme.background)};
+    background-color: ${p => p.theme.background};
 
     &:not(:last-child) {
       border-bottom: 1px solid ${p => p.theme.innerBorder};

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -180,7 +180,7 @@ export const GridBody = styled('tbody')`
   grid-column: 1/-1;
 `;
 
-export const GridRow = styled('tr')<{isHighlighted?: boolean}>`
+export const GridRow = styled('tr')`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1/-1;

--- a/static/app/components/interactionStateLayer.tsx
+++ b/static/app/components/interactionStateLayer.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {defined} from 'sentry/utils';
 
 interface StateLayerProps extends React.HTMLAttributes<HTMLSpanElement> {
+  as?: React.ElementType;
   color?: string;
   higherOpacity?: boolean;
   isHovered?: boolean;
@@ -12,8 +13,17 @@ interface StateLayerProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 const InteractionStateLayer = styled(
-  (props: StateLayerProps) => <span role="presentation" {...props} />,
-  {shouldForwardProp: p => typeof p === 'string' && isPropValid(p)}
+  (props: StateLayerProps) => {
+    const {children, as: Element = 'span', ...rest} = props;
+
+    // Here, using `as` directly doesn't work because it loses the `role` prop. Instead, manually propagating the props does the right thing.
+    return (
+      <Element {...rest} role="presentation">
+        {children}
+      </Element>
+    );
+  },
+  {shouldForwardProp: p => isPropValid(p) || p === 'as'}
 )`
   position: absolute;
   top: 50%;


### PR DESCRIPTION
Adds a way to specify which row in a table should be "highlighted". A "highlighted row" shows up a little differently in the UI.

We have functionality in Performance where hovering on a sample plotted in a chart will highlight the corresponding row in the table, so people know which row in the table corresponds with which sample. 

Right now, we accomplish that by wrapping every data cell in a special `div` and setting styles on it. This is very awkward, since it makes it harder to use field renderers, and requires some yucky setup work.

Here, I introduce a prop to allow showing a highlighted row in a simpler way.

**e.g.,**
<img width="831" alt="Screenshot 2024-04-04 at 4 52 49 PM" src="https://github.com/getsentry/sentry/assets/989898/6b83c85c-a789-4bc5-a241-814270aee941">


## Questions

- what should a highlighted row look like? In Performance, we _bold_ it. Here, I decided to add a background colour (arbitrarily chosen). What's best?
- is this API sensible? I waffled on this, since I thought it might be better to provide a matcher function, but this was the simplest approach by a _lot_
