### PR TITLE
fix(backup): Properly handle exceptions

### DIFF
--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -385,6 +385,7 @@ def compare(
                 input: IO[bytes] = BytesIO(decrypt_encrypted_tarball(src, decryptor))
             except DecryptionError as e:
                 click.echo(f"Invalid {side.name} side tarball: {str(e)}", err=True)
+                raise
         else:
             input = src
 
@@ -393,22 +394,29 @@ def compare(
             data = json.load(input)
         except json.JSONDecodeError:
             click.echo(f"Invalid {side.name} JSON", err=True)
+            raise
 
         return data
 
-    with left:
-        left_data = load_data(Side.left, left, decrypt_left_with, decrypt_left_with_gcp_kms)
-    with right:
-        right_data = load_data(Side.right, right, decrypt_right_with, decrypt_right_with_gcp_kms)
+    try:
+        with left:
+            left_data = load_data(Side.left, left, decrypt_left_with, decrypt_left_with_gcp_kms)
+        with right:
+            right_data = load_data(
+                Side.right, right, decrypt_right_with, decrypt_right_with_gcp_kms
+            )
 
-    printer = InputOutputPrinter()
-    res = validate(left_data, right_data, get_default_comparators())
-    if res:
-        click.echo(f"\n\nDone, found {len(res.findings)} differences:")
-        write_findings(findings_file, res.findings, printer)
-    else:
-        click.echo("\n\nDone, found 0 differences!")
-        write_findings(findings_file, [], printer)
+        printer = InputOutputPrinter()
+        res = validate(left_data, right_data, get_default_comparators())
+        if res:
+            click.echo(f"\n\nDone, found {len(res.findings)} differences:")
+            write_findings(findings_file, res.findings, printer)
+        else:
+            click.echo("\n\nDone, found 0 differences!")
+            write_findings(findings_file, [], printer)
+    except (DecryptionError, json.JSONDecodeError):
+        # Already reported to the user from the `load_data` function.
+        pass
 
 
 @backup.command(name="decrypt")
@@ -447,11 +455,10 @@ def decrypt(
 
     try:
         decrypted = decrypt_encrypted_tarball(src, decryptor)
+        with dest:
+            dest.write(decrypted)
     except DecryptionError as e:
         click.echo(f"Invalid tarball: {str(e)}", err=True)
-
-    with dest:
-        dest.write(decrypted)
 
 
 @backup.command(name="encrypt")
@@ -490,12 +497,11 @@ def encrypt(
 
     try:
         data = json.load(src)
+        encrypted = create_encrypted_export_tarball(data, encryptor)
+        with dest:
+            dest.write(encrypted.getbuffer())
     except json.JSONDecodeError:
         click.echo("Invalid input JSON", err=True)
-
-    encrypted = create_encrypted_export_tarball(data, encryptor)
-    with dest:
-        dest.write(encrypted.getbuffer())
 
 
 @click.group(name="import")


### PR DESCRIPTION
I considered just letting the stacktrace print in the terminal, but decided against it to provide more legible error output for cases where the user has supplied incorrect data.