### PR TITLE
feat(open-pr-comments): Language Support for Ruby

### DIFF
--- a/src/sentry/tasks/integrations/github/language_parsers.py
+++ b/src/sentry/tasks/integrations/github/language_parsers.py
@@ -191,9 +191,11 @@ class PythonParser(SimpleLanguageParser):
     regexes = [python_function_regex]
 
 
-class RubyParser(SimpleLanguageParser):
+class RubyParser(LanguageParser):
     issue_row_template = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Event Count:` **{event_count}** |"
-    # @@ -152,10 +152,6 @@ six = lambda { puts "This is a lambda."}
+
+    function_prefix = "."
+
     function_declaration_regex = r"^@@.*@@\s+def\s+(?:\w+\.)?(?P<fnc>\w+).*$"
     dynamic_method_declaration_regex = r"^@@.*@@\s+define_method\s+:(?P<fnc>\w+).*$"
     lambda_arrow_function_regex = r"^@@.*@@\s+(?P<fnc>\w+)\s*=\s*->.*$"
@@ -221,13 +223,13 @@ class JavascriptParser(LanguageParser):
     """
     function_declaration_regex = r"^@@.*@@[^=]*?\s*function\s+(?P<fnc>[^\(]*)\(.*$"
     arrow_function_regex = (
-        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^=]*)\s+=[^>|^\n]*[\(^\n*\)]?\s*=>.*$"
+        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^=\n]*)\s+=[^>\n]*[\(^\n*\)]?\s*=>.*$"
     )
     function_expression_regex = (
-        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(]*)\s+=.*\s+function.*\(.*$"
+        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(\n]*)\s+=.*\s+function.*\(.*$"
     )
     function_constructor_regex = (
-        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(]*)\s+=\s+new\s+Function\(.*$"
+        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(\n]*)\s+=\s+new\s+Function\(.*$"
     )
 
     regexes = [
@@ -266,6 +268,7 @@ PATCH_PARSERS: dict[str, Any] = {
     "jsx": JavascriptParser,
     "ts": JavascriptParser,
     "tsx": JavascriptParser,
+    "php": PHPParser,
 }
 
 # for testing new parsers

--- a/src/sentry/tasks/integrations/github/language_parsers.py
+++ b/src/sentry/tasks/integrations/github/language_parsers.py
@@ -14,6 +14,54 @@ stackframe_function_name = lambda i: Function(
 )
 
 
+class SimpleLanguageParser(ABC):
+    regexes: list[str]
+
+    @classmethod
+    def extract_functions_from_patch(cls, patch: str) -> set[str]:
+        functions = set()
+        for regex in cls.regexes:
+            functions.update(set(re.findall(regex, patch, flags=re.M)))
+
+        return functions
+
+    @classmethod
+    def generate_multi_if(cls, function_names: list[str]) -> list[Function]:
+        """
+        Fetch the function name from the stackframe that matches a name within the list of function names.
+        """
+        multi_if = []
+        for i in range(-STACKFRAME_COUNT, 0):
+            # if, then conditions
+            multi_if.extend(
+                [
+                    Function(
+                        "in",
+                        [
+                            stackframe_function_name(i),
+                            function_names,
+                        ],
+                    ),
+                    stackframe_function_name(i),
+                ]
+            )
+        # else condition
+        multi_if.append(stackframe_function_name(-1))
+
+        return multi_if
+
+    @classmethod
+    def generate_function_name_conditions(
+        cls, function_names: list[str], stack_frame: int
+    ) -> Condition:
+        """Check if the function name in the stack frame is within the list of function names."""
+        return Condition(
+            stackframe_function_name(stack_frame),
+            Op.IN,
+            function_names,
+        )
+
+
 class LanguageParser(ABC):
     regexes: list[str]
     function_prefix: str
@@ -120,7 +168,7 @@ class LanguageParser(ABC):
         )
 
 
-class PythonParser(LanguageParser):
+class PythonParser(SimpleLanguageParser):
     issue_row_template = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Event Count:` **{event_count}** |"
 
     r"""
@@ -142,41 +190,21 @@ class PythonParser(LanguageParser):
 
     regexes = [python_function_regex]
 
-    @classmethod
-    def generate_multi_if(cls, function_names: list[str]) -> list[Function]:
-        """
-        Fetch the function name from the stackframe that matches a name within the list of function names.
-        """
-        multi_if = []
-        for i in range(-STACKFRAME_COUNT, 0):
-            # if, then conditions
-            multi_if.extend(
-                [
-                    Function(
-                        "in",
-                        [
-                            stackframe_function_name(i),
-                            function_names,
-                        ],
-                    ),
-                    stackframe_function_name(i),
-                ]
-            )
-        # else condition
-        multi_if.append(stackframe_function_name(-1))
 
-        return multi_if
+class RubyParser(SimpleLanguageParser):
+    issue_row_template = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Event Count:` **{event_count}** |"
+    # @@ -152,10 +152,6 @@ six = lambda { puts "This is a lambda."}
+    function_declaration_regex = r"^@@.*@@\s+def\s+(?:\w+\.)?(?P<fnc>\w+).*$"
+    dynamic_method_declaration_regex = r"^@@.*@@\s+define_method\s+:(?P<fnc>\w+).*$"
+    lambda_arrow_function_regex = r"^@@.*@@\s+(?P<fnc>\w+)\s*=\s*->.*$"
+    lambda_word_function_regex = r"^@@.*@@\s+(?P<fnc>\w+)\s*=\s*lambda.*$"
 
-    @classmethod
-    def generate_function_name_conditions(
-        cls, function_names: list[str], stack_frame: int
-    ) -> Condition:
-        """Check if the function name in the stack frame is within the list of function names."""
-        return Condition(
-            stackframe_function_name(stack_frame),
-            Op.IN,
-            function_names,
-        )
+    regexes = [
+        function_declaration_regex,
+        dynamic_method_declaration_regex,
+        lambda_arrow_function_regex,
+        lambda_word_function_regex,
+    ]
 
 
 class JavascriptParser(LanguageParser):
@@ -193,13 +221,13 @@ class JavascriptParser(LanguageParser):
     """
     function_declaration_regex = r"^@@.*@@[^=]*?\s*function\s+(?P<fnc>[^\(]*)\(.*$"
     arrow_function_regex = (
-        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^=\n]*)\s+=[^>\n]*[\(^\n*\)]?\s*=>.*$"
+        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^=]*)\s+=[^>|^\n]*[\(^\n*\)]?\s*=>.*$"
     )
     function_expression_regex = (
-        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(\n]*)\s+=.*\s+function.*\(.*$"
+        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(]*)\s+=.*\s+function.*\(.*$"
     )
     function_constructor_regex = (
-        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(\n]*)\s+=\s+new\s+Function\(.*$"
+        r"^@@.*@@.*\s+\b(?:var|const)\b\s+(?P<fnc>[^\(]*)\s+=\s+new\s+Function\(.*$"
     )
 
     regexes = [
@@ -238,7 +266,6 @@ PATCH_PARSERS: dict[str, Any] = {
     "jsx": JavascriptParser,
     "ts": JavascriptParser,
     "tsx": JavascriptParser,
-    "php": PHPParser,
 }
 
 # for testing new parsers
@@ -249,4 +276,5 @@ BETA_PATCH_PARSERS: dict[str, Any] = {
     "ts": JavascriptParser,
     "tsx": JavascriptParser,
     "php": PHPParser,
+    "rb": RubyParser,
 }

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -520,7 +520,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
                 },
             )
 
-        if file_extension in ["php"]:
+        if file_extension == ["php"]:
             logger.info(
                 "github.open_pr_comment.php",
                 extra={
@@ -531,7 +531,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
                 },
             )
 
-        if file_extension in ["rb"]:
+        if file_extension == ["rb"]:
             logger.info(
                 "github.open_pr_comment.ruby",
                 extra={

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -530,6 +530,18 @@ def open_pr_comment_workflow(pr_id: int) -> None:
                     "has_function_names": bool(function_names),
                 },
             )
+
+        if file_extension in ["rb"]:
+            logger.info(
+                "github.open_pr_comment.ruby",
+                extra={
+                    "organization_id": org_id,
+                    "repository_id": repo.id,
+                    "extension": file_extension,
+                    "has_function_names": bool(function_names),
+                },
+            )
+
         if not len(function_names):
             continue
 

--- a/tests/sentry/tasks/integrations/github/test_language_parsers.py
+++ b/tests/sentry/tasks/integrations/github/test_language_parsers.py
@@ -2,6 +2,7 @@ from sentry.tasks.integrations.github.language_parsers import (
     JavascriptParser,
     PHPParser,
     PythonParser,
+    RubyParser,
 )
 from sentry.testutils.cases import TestCase
 
@@ -737,4 +738,71 @@ class PHPParserTestCase(TestCase):
             "eight",
             "nine",
             "ten",
+        }
+
+
+class RubyParserTestCase(TestCase):
+    def test_ruby_simple(self):
+        patch = """
+@@ -152,10 +152,6 @@ def one ()
+
+@@ -152,10 +152,6 @@ def two()
+
+@@ -152,10 +152,6 @@ def self.three()
+
+@@ -152,10 +152,6 @@ def obj.four ()
+
+@@ -152,10 +152,6 @@ define_method :five do
+
+@@ -152,10 +152,6 @@ six = -> { puts "This is a lambda." }
+
+@@ -152,10 +152,6 @@ seven = lambda { puts "This is a lambda."}
+
+"""
+
+        assert RubyParser.extract_functions_from_patch(patch) == {
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+        }
+
+    def test_ruby_example(self):
+        patch = """
+@@ -73,9 +73,7 @@ def for(name)
+
+@@ -73,9 +73,7 @@ def for_2 (name)
+
+@@ -20,6 +20,7 @@ def initialize(detach: true)
+
+@@ -27,7 +27,8 @@ def token
+
+@@ -46,7 +46,7 @@ def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+
+@@ -47,7 +47,7 @@ def message_franking
+
+@@ -821,7 +821,7 @@ def to_liquid
+
+@@ -203,4 +207,23 @@ def render_content_with_collection(content, collection_label)
+
+@@ -203,4 +207,23 @@ def render_content_with_collection_2 (content, collection_label)
+
+@@ -36,10 +36,13 @@ def require_gems
+
+"""
+
+        assert RubyParser.extract_functions_from_patch(patch) == {
+            "for",
+            "for_2",
+            "initialize",
+            "token",
+            "on_block",
+            "message_franking",
+            "to_liquid",
+            "render_content_with_collection",
+            "render_content_with_collection_2",
+            "require_gems",
         }


### PR DESCRIPTION
Adds a Ruby support for Open PR Comments.

Also refactored `language_parsers.py` to make it cleaner to add more languages to in the future!

We:
* Parse the git hunk header for function names for the code that users touched
* Run snuba query to find related issues
* Drop a comment on the pr about the related issues


Addresses: https://github.com/getsentry/team-core-product-foundations/issues/128
Test Repo with Comment: https://github.com/iamrajjoshi/ruby-test/pull/33