### PR TITLE
chore(hc): Globally enable region info in settings

### DIFF
--- a/static/app/utils/regions/index.tsx
+++ b/static/app/utils/regions/index.tsx
@@ -51,8 +51,12 @@ export function getRegionDataFromOrganization(
   };
 }
 
+export function getRegions(): Region[] {
+  return ConfigStore.get('regions') ?? [];
+}
+
 export function getRegionChoices(): [string, string][] {
-  const regions = ConfigStore.get('regions') ?? [];
+  const regions = getRegions();
 
   return regions.map(region => {
     const {url} = region;
@@ -64,7 +68,7 @@ export function getRegionChoices(): [string, string][] {
 }
 
 export function shouldDisplayRegions(): boolean {
-  const regionCount = (ConfigStore.get('regions') ?? []).length;
+  const regionCount = getRegions().length;
   return (
     ConfigStore.get('features').has('organizations:multi-region-selector') &&
     regionCount > 1

--- a/static/app/views/settings/organizationGeneralSettings/organizationRegionAction.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationRegionAction.tsx
@@ -4,7 +4,7 @@ import FieldHelp from 'sentry/components/forms/fieldGroup/fieldHelp';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
-import {getRegionDataFromOrganization, shouldDisplayRegions} from 'sentry/utils/regions';
+import {getRegionDataFromOrganization, getRegions} from 'sentry/utils/regions';
 import {DATA_STORAGE_DOCS_LINK} from 'sentry/views/organizationCreate';
 
 type Props = {
@@ -21,7 +21,8 @@ const OrganizationFlag = styled('span')`
 `;
 
 export function OrganizationRegionAction({organization, ...props}: Props) {
-  if (!organization || !shouldDisplayRegions()) {
+  const regionCount = getRegions().length;
+  if (!organization || regionCount <= 1) {
     return null;
   }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Enables region display in Organization settings for all SaaS users. This is constrained by region count, so self-hosted users should not see any display differences.

