### PR TITLE
fix(hybridcloud) Add mailbox sharding to high volume gitlab too

### DIFF
--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -5,14 +5,18 @@ import logging
 from django.http.response import HttpResponseBase
 from django.urls import resolve
 
+from sentry import options
 from sentry.integrations.gitlab.webhooks import GitlabWebhookEndpoint, GitlabWebhookMixin
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.outbox import WebhookProviderIdentifier
+from sentry.ratelimits import backend as ratelimiter
+from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -76,9 +80,31 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
         except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
             return self.get_default_missing_integration_response()
 
-        return self.get_response_from_webhookpayload_for_integration(
-            regions=regions, integration=integration
+        identifier = self.get_mailbox_identifier(integration)
+        return self.get_response_from_webhookpayload(
+            regions=regions, identifier=identifier, integration_id=integration.id
         )
+
+    def get_mailbox_identifier(self, integration: RpcIntegration) -> str:
+        try:
+            data = json.loads(self.request.body)
+        except ValueError:
+            data = {}
+        enabled = options.get("hybridcloud.webhookpayload.use_mailbox_buckets")
+        project_id = data.get("project", {}).get("id", None)
+        if not project_id or not enabled:
+            return str(integration.id)
+
+        # If we get fewer than 3000 in 1 hour we don't need to split into buckets
+        ratelimit_key = f"webhookpayload:{self.provider}:{integration.id}"
+        if not ratelimiter.is_limited(key=ratelimit_key, window=60 * 60, limit=3000):
+            return str(integration.id)
+
+        # Split high volume integrations into 100 buckets.
+        # 100 is arbitrary but we can't leave it unbounded.
+        bucket_number = project_id % 100
+
+        return f"{integration.id}:{bucket_number}"
 
     def get_response(self) -> HttpResponseBase:
         if self.view_class == GitlabWebhookEndpoint:

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import responses
 from django.db import router, transaction
 from django.http import HttpRequest, HttpResponse
@@ -12,6 +14,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.outbox import ControlOutbox, OutboxCategory, outbox_context
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import assert_no_webhook_payloads, assert_webhook_payloads_for_mailbox
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
@@ -129,6 +132,36 @@ class GitlabRequestParserTest(TestCase):
         assert_webhook_payloads_for_mailbox(
             request=request,
             mailbox_name=f"gitlab:{integration.id}",
+            region_names=[region.name],
+        )
+
+    @override_regions(region_config)
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_options({"hybridcloud.webhookpayload.use_mailbox_buckets": True})
+    @responses.activate
+    def test_routing_webhook_with_mailbox_buckets(self):
+        integration = self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+        with mock.patch(
+            "sentry.middleware.integrations.parsers.gitlab.ratelimiter.is_limited"
+        ) as mock_is_limited:
+            mock_is_limited.return_value = True
+            parser = GitlabRequestParser(request=request, response_handler=self.get_response)
+            response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 202
+        assert response.content == b""
+        assert len(responses.calls) == 0
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"gitlab:{integration.id}:15",
             region_names=[region.name],
         )
 


### PR DESCRIPTION
We have a few gitlab integrations that are shared by many organizations. Splitting up the high-volume gitlab instances into many mailboxes will allow us to process messages more quickly.