### PR TITLE
fix(autofix): Fix padding for result panel

### DIFF
--- a/static/app/components/events/autofix/fixResult.tsx
+++ b/static/app/components/events/autofix/fixResult.tsx
@@ -102,7 +102,7 @@ export function AutofixResult({autofixData, onRetry}: Props) {
 
 const ResultPanel = styled(Panel)`
   padding: ${space(2)};
-  margin: 0;
+  margin: ${space(2)} 0 0 0;
 `;
 
 const PreviewContent = styled('div')`


### PR DESCRIPTION
Missed this in my last PR, quick fix to add back padding between the PR results and the steps.

Fixes this:

![CleanShot 2024-04-04 at 14 29 16@2x](https://github.com/getsentry/sentry/assets/10888943/6a39435d-785b-4b67-8576-089603b47517)
