### PR TITLE
ref(tsc): convert rrwebIntegration.tsx to FC

### DIFF
--- a/static/app/components/events/rrwebIntegration.tsx
+++ b/static/app/components/events/rrwebIntegration.tsx
@@ -25,6 +25,16 @@ function EventRRWebIntegrationContent({orgId, projectSlug, event}: Props) {
   } = useApiQuery<IssueAttachment[]>(
     [
       `/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/`,
+      // This was changed from `rrweb.json`, so that we can instead
+      // support incremental rrweb events as attachments. This is to avoid
+      // having clients uploading a single, large sized replay.
+      //
+      // Note: This will include all attachments that contain `rrweb`
+      // anywhere its name. We need to maintain compatibility with existing
+      // rrweb plugin users (single replay), but also support incremental
+      // replays as well. I can't think of a reason why someone would have
+      // a non-rrweb replay containing the string `rrweb`, but people have
+      // surprised me before.
       {query: {query: 'rrweb'}},
     ],
     {staleTime: 0}

--- a/static/app/components/events/rrwebIntegration.tsx
+++ b/static/app/components/events/rrwebIntegration.tsx
@@ -1,74 +1,60 @@
 import styled from '@emotion/styled';
 
-import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import LazyLoad from 'sentry/components/lazyLoad';
+import LoadingError from 'sentry/components/loadingError';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {IssueAttachment, Organization, Project} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
   event: Event;
   orgId: Organization['id'];
   projectSlug: Project['slug'];
-} & DeprecatedAsyncComponent['props'];
+};
 
-type State = {
-  attachmentList: Array<IssueAttachment> | null;
-} & DeprecatedAsyncComponent['state'];
+function EventRRWebIntegrationContent({orgId, projectSlug, event}: Props) {
+  const {
+    data: attachmentList,
+    isLoading,
+    isError,
+    refetch,
+  } = useApiQuery<IssueAttachment[]>(
+    [
+      `/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/`,
+      {query: {query: 'rrweb'}},
+    ],
+    {staleTime: 0}
+  );
 
-class EventRRWebIntegrationContent extends DeprecatedAsyncComponent<Props, State> {
-  getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    const {orgId, projectSlug, event} = this.props;
-    return [
-      [
-        'attachmentList',
-        `/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/`,
-
-        // This was changed from `rrweb.json`, so that we can instead
-        // support incremental rrweb events as attachments. This is to avoid
-        // having clients uploading a single, large sized replay.
-        //
-        // Note: This will include all attachments that contain `rrweb`
-        // anywhere its name. We need to maintain compatibility with existing
-        // rrweb plugin users (single replay), but also support incremental
-        // replays as well. I can't think of a reason why someone would have
-        // a non-rrweb replay containing the string `rrweb`, but people have
-        // surprised me before.
-        {query: {query: 'rrweb'}},
-      ],
-    ];
+  if (isError) {
+    return <LoadingError onRetry={refetch} />;
   }
 
-  renderLoading() {
+  if (isLoading) {
     // hide loading indicator
     return null;
   }
 
-  renderBody() {
-    const {attachmentList} = this.state;
-
-    if (!attachmentList?.length) {
-      return null;
-    }
-
-    const {orgId, projectSlug, event} = this.props;
-
-    function createAttachmentUrl(attachment: IssueAttachment) {
-      return `/api/0/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/${attachment.id}/?download`;
-    }
-
-    return (
-      <StyledReplayEventDataSection type="context-replay" title={t('Replay')}>
-        <LazyLoad
-          component={() => import('./rrwebReplayer')}
-          urls={attachmentList.map(createAttachmentUrl)}
-        />
-      </StyledReplayEventDataSection>
-    );
+  if (!attachmentList?.length) {
+    return null;
   }
+
+  const createAttachmentUrl = (attachment: IssueAttachment) => {
+    return `/api/0/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/${attachment.id}/?download`;
+  };
+
+  return (
+    <StyledReplayEventDataSection type="context-replay" title={t('Replay')}>
+      <LazyLoad
+        component={() => import('./rrwebReplayer')}
+        urls={attachmentList.map(createAttachmentUrl)}
+      />
+    </StyledReplayEventDataSection>
+  );
 }
 
 export function EventRRWebIntegration(props: Props) {

--- a/static/app/components/events/rrwebIntegration.tsx
+++ b/static/app/components/events/rrwebIntegration.tsx
@@ -53,9 +53,8 @@ function EventRRWebIntegrationContent({orgId, projectSlug, event}: Props) {
     return null;
   }
 
-  const createAttachmentUrl = (attachment: IssueAttachment) => {
-    return `/api/0/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/${attachment.id}/?download`;
-  };
+  const createAttachmentUrl = (attachment: IssueAttachment) =>
+    `/api/0/projects/${orgId}/${projectSlug}/events/${event.id}/attachments/${attachment.id}/?download`;
 
   return (
     <StyledReplayEventDataSection type="context-replay" title={t('Replay')}>


### PR DESCRIPTION
ref https://github.com/getsentry/frontend-tsc/issues/2

converts this file into FC and use `useApiQuery` instead of `DeprecatedAsync`