### PR TITLE
feat(platforms): Add temporary type checking category

### DIFF
--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -143,10 +143,15 @@ DESKTOP = [
     "unreal",
 ]
 
+# TODO: @athena Remove this
+# This is only temporary since we decide the right category. Don't add anything here or your frontend experience will be broken
+TEMPORARY = ["nintendo"]
+
 CATEGORY_LIST = [
     {id: "browser", "name": _("Browser"), "platforms": FRONTEND},
     {id: "server", "name": _("Server"), "platforms": BACKEND},
     {id: "mobile", "name": _("Mobile"), "platforms": MOBILE},
     {id: "desktop", "name": _("Desktop"), "platforms": DESKTOP},
     {id: "serverless", "name": _("Serverless"), "platforms": SERVERLESS},
+    {id: "temporary", "name": _("Temporary"), "platforms": TEMPORARY},
 ]


### PR DESCRIPTION
This file is only used for type checking in getsentry. All our platforms need to be added somewhere in this file but Nintendo's category is undecided. To enable internal testing of the sdk I add a temporary category to remove.

More context on this conversation here:
https://sentry.slack.com/archives/C04N08752BG/p1712268816703209

