### PR TITLE
feat(data-consent): Add region check to data consent option

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -327,12 +327,21 @@ class OrganizationSerializer(BaseOrganizationSerializer):
             )
         return value
 
+    def validate_aggregatedDataConsent(self, value):
+        request = self.context["request"]
+        if not request.access.has_scope("org:billing"):
+            raise serializers.ValidationError("You do not have permission to change this option")
+        return value
+
     def validate_genAIConsent(self, value):
+        request = self.context["request"]
+        if not request.access.has_scope("org:billing"):
+            raise serializers.ValidationError("You do not have permission to change this option")
+
         if get_local_region().name != "us":
             raise serializers.ValidationError(
                 "the genAiConsent option is only available to customers in the US region"
             )
-
         return value
 
     def validate(self, attrs):

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -72,6 +72,7 @@ from sentry.services.organization.provisioning import (
     OrganizationSlugCollisionException,
     organization_provisioning_service,
 )
+from sentry.types.region import get_local_region
 from sentry.utils.audit import create_audit_entry
 
 ERR_DEFAULT_ORG = "You cannot remove the default organization."
@@ -324,6 +325,14 @@ class OrganizationSerializer(BaseOrganizationSerializer):
             raise serializers.ValidationError(
                 "The accountRateLimit option cannot be configured for this organization"
             )
+        return value
+
+    def validate_genAIConsent(self, value):
+        if get_local_region().name != "us":
+            raise serializers.ValidationError(
+                "the genAiConsent option is only available to customers in the US region"
+            )
+
         return value
 
     def validate(self, attrs):

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -424,7 +424,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "defaultRole": "owner",
             "require2FA": True,
             "allowJoinRequests": False,
-            "aggregatedDataConsent": True,
         }
 
         # needed to set require2FA
@@ -486,7 +485,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "to {}".format(data["githubPRBot"]) in log.data["githubPRBot"]
         assert "to {}".format(data["githubOpenPRBot"]) in log.data["githubOpenPRBot"]
         assert "to {}".format(data["githubNudgeInvite"]) in log.data["githubNudgeInvite"]
-        assert "to {}".format(data["aggregatedDataConsent"]) in log.data["aggregatedDataConsent"]
 
     @responses.activate
     @patch(

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -425,7 +425,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "require2FA": True,
             "allowJoinRequests": False,
             "aggregatedDataConsent": True,
-            "genAIConsent": True,
         }
 
         # needed to set require2FA
@@ -488,7 +487,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "to {}".format(data["githubOpenPRBot"]) in log.data["githubOpenPRBot"]
         assert "to {}".format(data["githubNudgeInvite"]) in log.data["githubNudgeInvite"]
         assert "to {}".format(data["aggregatedDataConsent"]) in log.data["aggregatedDataConsent"]
-        assert "to {}".format(data["genAIConsent"]) in log.data["genAIConsent"]
 
     @responses.activate
     @patch(


### PR DESCRIPTION
this pr adds a check for the region, since the genAIConsent option is limited to those organizations in the US region