### PR TITLE
add x509 cert form field to saml sso edit

### DIFF
--- a/src/sentry/auth/provider.py
+++ b/src/sentry/auth/provider.py
@@ -42,6 +42,7 @@ class Provider(PipelineProvider, abc.ABC):
 
     is_partner = False
     requires_refresh = True
+    is_saml = False
 
     # All auth providers by default require the sso-basic feature
     required_feature = "organizations:sso-basic"

--- a/src/sentry/auth/providers/dummy.py
+++ b/src/sentry/auth/providers/dummy.py
@@ -2,6 +2,7 @@ from django.http import HttpResponse
 from rest_framework.request import Request
 
 from sentry.auth.provider import MigratingIdentityId, Provider
+from sentry.auth.providers.saml2.provider import Attributes, SAML2Provider
 from sentry.auth.view import AuthView
 
 PLACEHOLDER_TEMPLATE = '<form method="POST"><input type="email" name="email" /></form>'
@@ -41,3 +42,29 @@ class DummyProvider(Provider):
 
     def build_config(self, state):
         return {}
+
+
+dummy_provider_config = {
+    "idp": {
+        "entity_id": "https://example.com/saml/metadata/1234",
+        "x509cert": "foo_x509_cert",
+        "sso_url": "http://example.com/sso_url",
+        "slo_url": "http://example.com/slo_url",
+    },
+    "attribute_mapping": {
+        Attributes.IDENTIFIER: "user_id",
+        Attributes.USER_EMAIL: "email",
+        Attributes.FIRST_NAME: "first_name",
+        Attributes.LAST_NAME: "last_name",
+    },
+}
+
+
+class DummySAML2Provider(SAML2Provider):
+    name = "DummySAML2"
+
+    def get_saml_setup_pipeline(self):
+        return []
+
+    def build_config(self, state):
+        return dummy_provider_config

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -240,6 +240,7 @@ class SAML2Provider(Provider, abc.ABC):
     # SAML does nothing with refresh state -- don't waste resources calling it in check_auth job.
     requires_refresh = False
     required_feature = "organizations:sso-saml2"
+    is_saml = True
 
     def get_auth_pipeline(self):
         return [SAML2LoginView(), SAML2ACSView()]

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -170,9 +170,12 @@ class OrganizationAuthSettingsView(ControlSiloOrganizationView):
                     if key == "x509cert":
                         original_idp = form.initial.get("idp", {})
                         if original_idp.get("x509cert", "") != value:
-                            auth_provider.config["idp"] = {
-                                **original_idp,
-                                "x509cert": value,
+                            auth_provider.config = {
+                                **auth_provider.config,
+                                "idp": {
+                                    **original_idp,
+                                    "x509cert": value,
+                                },
                             }
                             auth_service.update_provider_config(
                                 organization_id=organization.id,

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -170,14 +170,14 @@ class OrganizationAuthSettingsView(ControlSiloOrganizationView):
                     if key == "x509cert":
                         original_idp = form.initial.get("idp", {})
                         if original_idp.get("x509cert", "") != value:
-                            provider.update_config(
-                                {
-                                    **provider.config,
-                                    "idp": {
-                                        **original_idp,
-                                        "x509cert": value,
-                                    },
-                                }
+                            auth_provider.config["idp"] = {
+                                **original_idp,
+                                "x509cert": value,
+                            }
+                            auth_service.update_provider_config(
+                                organization_id=organization.id,
+                                auth_provider_id=auth_provider.id,
+                                config=auth_provider.config,
                             )
                             changed_data["x509cert"] = f"to {value}"
                     elif form.initial.get(key) != value:

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -687,12 +687,6 @@ class OrganizationAuthSettingsSAML2Test(AuthProviderTestCase):
             "x509cert": "to bar_x509_cert",
         }
 
-        """
-{"idp":{"entity_id":"http://www.okta.com/exk2148vfoqFZ8qvz0h8",
-"sso_url":"https://dev-517249.oktapreview.com/app/sentry/exk2148vfoqFZ8qvz0h8/sso/saml","slo_url":null,
-"x509cert":"MIIDpDCCAoygAwIBAgIGAY5YtedBMA0GCSqGSIb3DQEBCwUAMIGSMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxEzARBgNVBAMMCmRldi01MTcyNDkxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjQwMzE5MjE1NDAwWhcNMzQwMzE5MjE1NDU5WjCBkjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRMwEQYDVQQDDApkZXYtNTE3MjQ5MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1ioQdAp+GasgbBT1bfBr0w6SNcitFkv67ZC0iEzD7n8PCm1gDCqB9ZkFeAx0UjHHLDBnasqcQ2TT4ocOr+jjjj1tCDcAq+3Cc+s6iXL8ibmo4CxOAJNtiRCpU6wMKcQKjW3X4aEs/sS4eaTEXDfc02pWb3SfHNB7zr5iieRWccG0eb7uFKUDvbBmVLJ2DigF881t/yquDrqycLP9Q7+fgBPRIz31cm/bBSLfIj22O5y4mjkhFnBpMZ9JBK+da7hj/lBd7tui6YaoIszXEFDsjL8KwC5aJguGLr2OGS3pqMhHK48lkITQ8lp1KdaQabPY1cxh0bnsCo5fNAvMfyoXKwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAvGm0MQIx3LJKmvGUaFlYKEMaC6zvBap9agVAjwc5qcgDXIxJdwg2ve4dDvmMLo4Tm/+rom7dClfB0lsnIoroPlJNrbGibQy5TdJ2eYagOCtHvQKWCiwR4BcRtziYV9JegQX9/zTiTxuv8G6dDD0O3n0EdGqC7K4J8bG5Aq1mGvot+9+TuaTcHZiL+hYLEhbmdFN5hVDBX2zbKyXA6EiNR/RNqLVvar/Bl9jasthByjqNdDsfqmhekS9UnX3eWD1WyUe4FJMEuTSuhpFQhmeGclhuGa+bDx+GFKzXwdZM1AxtpKYXfoZtEb3Lx1JVUa1OfZ6f8DA06KzRWjQnOdw83"},"auth_attributes":{"email":["nathan.hsieh@sentry.io"],"firstName":["Nathan"],"lastName":["Hsieh"],"identifier":["00u16twt7obBJCjXv0h8"]},"attribute_mapping":{"identifier":"identifier","user_email":"email","first_name":"firstName","last_name":"lastName"}}
-        """
-
 
 dummy_generic_provider_config = {
     "idp": {


### PR DESCRIPTION
Simple naive solution.
Just adds a new form field on SAML forms and prefills with the x509 cert

https://github.com/getsentry/sentry/assets/6186377/623715c4-e7e7-4a51-8cc2-857589eb049e

