### PR TITLE
ref(rules): Add process_batch to RedisBuffer

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -329,7 +329,7 @@ class RedisBuffer(Buffer):
         Increment the key by doing the following:
 
         - Insert/update a hashmap based on (model, columns)
-            - Perform an incrby on countersif is_instance_redis_cluster(self.cluster, self.is_redis_cluster):
+            - Perform an incrby on counters if is_instance_redis_cluster(self.cluster, self.is_redis_cluster):
             - Perform a set (last write wins) on extra
             - Perform a set on signal_only (only if True)
         - Add hashmap key to pending flushes

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -342,6 +342,14 @@ class TestRedisBuffer:
         assert mock.call_count == 1
         assert mock.call_args[0][0] == self.buf
 
+    def test_process_batch(self):
+        """Test that the registry's callbacks are invoked when we process a batch"""
+        mock = Mock()
+        redis_buffer_registry._registry[BufferHookEvent.FLUSH] = mock
+        self.buf.process_batch()
+        assert mock.call_count == 1
+        assert mock.call_args[0][0] == self.buf
+
     @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
     @mock.patch("sentry.buffer.base.Buffer.process")
     def test_process_uses_signal_only(self, process):


### PR DESCRIPTION
Add a `process_batch` function to `RedisBuffer` that will be triggered by a celery task in the future. The callbacks will process all the pending rules.

Closes https://github.com/getsentry/team-core-product-foundations/issues/240