### PR TITLE
fix(backup): Fix option exclusion typo

### DIFF
--- a/src/sentry/models/options/option.py
+++ b/src/sentry/models/options/option.py
@@ -53,7 +53,7 @@ class BaseOption(OverwritableConfigMixin, Model):
         # in exports. More broadly, we don't really care about comparing them for accuracy.
         return q & ~models.Q(
             key__in={
-                "sentry:sentry:install-id",  # Only used on self-hosted
+                "sentry:install-id",  # Only used on self-hosted
                 "sentry:last_worker_ping",  # Changes very frequently
                 "sentry:last_worker_version",  # Changes very frequently
                 "sentry:latest_version",  # Auto-generated periodically, which defeats comparison


### PR DESCRIPTION
The typo is from https://github.com/getsentry/sentry/pull/68302