### PR TITLE
Clean up Metrics/Tracing Instrumentation

### DIFF
--- a/src/sentry/datascrubbing.py
+++ b/src/sentry/datascrubbing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+import sentry_sdk
 from rest_framework import serializers
 from sentry_relay.processing import (
     convert_datascrubbing_config,
@@ -80,6 +81,7 @@ def get_all_pii_configs(project):
     yield convert_datascrubbing_config(get_datascrubbing_settings(project))
 
 
+@sentry_sdk.tracing.trace
 def scrub_data(project, event):
     for config in get_all_pii_configs(project):
         metrics.distribution(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ipaddress
 import logging
-import re
 import uuid
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
@@ -402,7 +401,7 @@ class EventManager:
     def get_data(self) -> CanonicalKeyDict:
         return self._data
 
-    @metrics.wraps("event_manager.save")
+    @sentry_sdk.tracing.trace
     def save(
         self,
         project_id: int | None,
@@ -437,13 +436,10 @@ class EventManager:
                 self.normalize(project_id=project_id)
             self._normalized = True
 
-        with metrics.timer("event_manager.save.project.get_from_cache"):
-            project = Project.objects.get_from_cache(id=project_id)
-
-        with metrics.timer("event_manager.save.organization.get_from_cache"):
-            project.set_cached_field_value(
-                "organization", Organization.objects.get_from_cache(id=project.organization_id)
-            )
+        project = Project.objects.get_from_cache(id=project_id)
+        project.set_cached_field_value(
+            "organization", Organization.objects.get_from_cache(id=project.organization_id)
+        )
 
         projects = {project.id: project}
 
@@ -455,8 +451,7 @@ class EventManager:
         }
 
         # After calling _pull_out_data we get some keys in the job like the platform
-        with sentry_sdk.start_span(op="event_manager.save.pull_out_data"):
-            _pull_out_data([job], projects)
+        _pull_out_data([job], projects)
 
         event_type = self._data.get("type")
         if event_type == "transaction":
@@ -522,19 +517,15 @@ class EventManager:
 
         is_reprocessed = is_reprocessed_event(job["data"])
 
-        with sentry_sdk.start_span(op="event_manager.save.get_or_create_release_many"):
-            _get_or_create_release_many(jobs, projects)
-
-        with sentry_sdk.start_span(op="event_manager.save.get_event_user_many"):
-            _get_event_user_many(jobs, projects)
+        _get_or_create_release_many(jobs, projects)
+        _get_event_user_many(jobs, projects)
 
         job["project_key"] = None
         if job["key_id"] is not None:
-            with metrics.timer("event_manager.load_project_key"):
-                try:
-                    job["project_key"] = ProjectKey.objects.get_from_cache(id=job["key_id"])
-                except ProjectKey.DoesNotExist:
-                    pass
+            try:
+                job["project_key"] = ProjectKey.objects.get_from_cache(id=job["key_id"])
+            except ProjectKey.DoesNotExist:
+                pass
 
         _derive_plugin_tags_many(jobs, projects)
         _derive_interface_tags_many(jobs)
@@ -544,17 +535,12 @@ class EventManager:
         # incremented for sure. Also wait for grouping to remove attachments
         # based on the group counter.
         if has_attachments:
-            with metrics.timer("event_manager.get_attachments"):
-                with sentry_sdk.start_span(op="event_manager.save.get_attachments"):
-                    attachments = get_attachments(cache_key, job)
+            attachments = get_attachments(cache_key, job)
         else:
             attachments = []
 
         try:
-            with sentry_sdk.start_span(op="event_manager.save.save_aggregate_fn"):
-                group_info = assign_event_to_group(
-                    event=job["event"], job=job, metric_tags=metric_tags
-                )
+            group_info = assign_event_to_group(event=job["event"], job=job, metric_tags=metric_tags)
 
         except HashDiscarded as err:
             logger.info(
@@ -595,8 +581,7 @@ class EventManager:
         )
 
         if attachments:
-            with metrics.timer("event_manager.filter_attachments_for_group"):
-                attachments = filter_attachments_for_group(attachments, job)
+            attachments = filter_attachments_for_group(attachments, job)
 
         # XXX: DO NOT MUTATE THE EVENT PAYLOAD AFTER THIS POINT
         _materialize_event_metrics(jobs)
@@ -644,8 +629,7 @@ class EventManager:
         # group_id on existing models in post_process_group, which already does
         # this because of indiv. attachments.
         if not is_reprocessed and attachments:
-            with metrics.timer("event_manager.save_attachments"):
-                save_attachments(cache_key, attachments, job)
+            save_attachments(cache_key, attachments, job)
 
         metric_tags = {"from_relay": str("_relay_processed" in job["data"])}
 
@@ -670,7 +654,7 @@ class EventManager:
         return job["event"]
 
 
-@metrics.wraps("save_event.pull_out_data")
+@sentry_sdk.tracing.trace
 def _pull_out_data(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     """
     Update every job in the list with required information and store it in the nodestore.
@@ -729,11 +713,7 @@ def _pull_out_data(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
         job["groups"] = []
 
 
-def _is_commit_sha(version: str) -> bool:
-    return re.match(r"[0-9a-f]{40}", version) is not None
-
-
-@metrics.wraps("save_event.get_or_create_release_many")
+@sentry_sdk.tracing.trace
 def _get_or_create_release_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     jobs_with_releases: dict[tuple[int, Release], list[Job]] = {}
     release_date_added: dict[tuple[int, Release], datetime] = {}
@@ -829,7 +809,7 @@ def _get_environment_from_transaction(data: EventDict) -> str | None:
     return environment
 
 
-@metrics.wraps("save_event.get_event_user_many")
+@sentry_sdk.tracing.trace
 def _get_event_user_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     for job in jobs:
         data = job["data"]
@@ -842,7 +822,6 @@ def _get_event_user_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None
         job["user"] = user
 
 
-@metrics.wraps("save_event.derive_plugin_tags_many")
 def _derive_plugin_tags_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     # XXX: We ought to inline or remove this one for sure
     plugins_for_projects = {p.id: plugins.for_project(p, version=None) for p in projects.values()}
@@ -858,7 +837,6 @@ def _derive_plugin_tags_many(jobs: Sequence[Job], projects: ProjectsMapping) -> 
                         set_tag(data, key, value)
 
 
-@metrics.wraps("save_event.derive_interface_tags_many")
 def _derive_interface_tags_many(jobs: Sequence[Job]) -> None:
     # XXX: We ought to inline or remove this one for sure
     for job in jobs:
@@ -872,7 +850,6 @@ def _derive_interface_tags_many(jobs: Sequence[Job]) -> None:
                 data.pop(iface.path, None)
 
 
-@metrics.wraps("save_event.materialize_metadata_many")
 def _materialize_metadata_many(jobs: Sequence[Job]) -> None:
     for job in jobs:
         # we want to freeze not just the metadata and type in but also the
@@ -957,7 +934,6 @@ def _get_group_processing_kwargs(job: Job) -> dict[str, Any]:
     return kwargs
 
 
-@metrics.wraps("save_event.get_or_create_environment_many")
 def _get_or_create_environment_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     for job in jobs:
         job["environment"] = Environment.get_or_create(
@@ -965,7 +941,6 @@ def _get_or_create_environment_many(jobs: Sequence[Job], projects: ProjectsMappi
         )
 
 
-@metrics.wraps("save_event.get_or_create_group_environment_many")
 def _get_or_create_group_environment_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     for job in jobs:
         _get_or_create_group_environment(job["environment"], job["release"], job["groups"])
@@ -982,7 +957,6 @@ def _get_or_create_group_environment(
         )[1]
 
 
-@metrics.wraps("save_event.get_or_create_release_associated_models")
 def _get_or_create_release_associated_models(
     jobs: Sequence[Job], projects: ProjectsMapping
 ) -> None:
@@ -1050,7 +1024,6 @@ def _increment_release_associated_counts(
         )
 
 
-@metrics.wraps("save_event.get_or_create_group_release_many")
 def _get_or_create_group_release_many(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     for job in jobs:
         _get_or_create_group_release(
@@ -1074,7 +1047,6 @@ def _get_or_create_group_release(
             )
 
 
-@metrics.wraps("save_event.tsdb_record_all_metrics")
 def _tsdb_record_all_metrics(jobs: Sequence[Job]) -> None:
     """
     Do all tsdb-related things for save_event in here s.t. we can potentially
@@ -1133,7 +1105,6 @@ def _tsdb_record_all_metrics(jobs: Sequence[Job]) -> None:
             tsdb.backend.record_frequency_multi(frequencies, timestamp=event.datetime)
 
 
-@metrics.wraps("save_event.nodestore_save_many")
 def _nodestore_save_many(jobs: Sequence[Job], app_feature: str) -> None:
     inserted_time = datetime.now(timezone.utc).timestamp()
     for job in jobs:
@@ -1165,7 +1136,6 @@ def _nodestore_save_many(jobs: Sequence[Job], app_feature: str) -> None:
         job["event"].data.save(subkeys=subkeys)
 
 
-@metrics.wraps("save_event.eventstream_insert_many")
 def _eventstream_insert_many(jobs: Sequence[Job]) -> None:
     for job in jobs:
         if is_sample_event(job):
@@ -1236,7 +1206,6 @@ def _eventstream_insert_many(jobs: Sequence[Job]) -> None:
         )
 
 
-@metrics.wraps("save_event.track_outcome_accepted_many")
 def _track_outcome_accepted_many(jobs: Sequence[Job]) -> None:
     for job in jobs:
         event = job["event"]
@@ -1253,7 +1222,6 @@ def _track_outcome_accepted_many(jobs: Sequence[Job]) -> None:
         )
 
 
-@metrics.wraps("event_manager.get_event_instance")
 def _get_event_instance(data: Mapping[str, Any], project_id: int) -> Event:
     return eventstore.backend.create_event(
         project_id=project_id,
@@ -1350,6 +1318,7 @@ def get_culprit(data: Mapping[str, Any]) -> str:
     )
 
 
+@sentry_sdk.tracing.trace
 def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> GroupInfo | None:
     if job["optimized_grouping"]:
         group_info = _save_aggregate_new(
@@ -2512,6 +2481,7 @@ def discard_event(job: Job, attachments: Sequence[Attachment]) -> None:
     )
 
 
+@sentry_sdk.tracing.trace
 def get_attachments(cache_key: str | None, job: Job) -> list[Attachment]:
     """
     Retrieves the list of attachments for this event.
@@ -2537,6 +2507,7 @@ def get_attachments(cache_key: str | None, job: Job) -> list[Attachment]:
     return [attachment for attachment in attachments if not attachment.rate_limited]
 
 
+@sentry_sdk.tracing.trace
 def filter_attachments_for_group(attachments: list[Attachment], job: Job) -> list[Attachment]:
     """
     Removes crash reports exceeding the group-limit.
@@ -2741,7 +2712,7 @@ def save_attachments(cache_key: str | None, attachments: list[Attachment], job: 
         )
 
 
-@metrics.wraps("event_manager.save_transactions.materialize_event_metrics")
+@sentry_sdk.tracing.trace
 def _materialize_event_metrics(jobs: Sequence[Job]) -> None:
     for job in jobs:
         # Ensure the _metrics key exists. This is usually created during
@@ -2759,15 +2730,14 @@ def _materialize_event_metrics(jobs: Sequence[Job]) -> None:
         job["event_metrics"] = event_metrics
 
 
-@metrics.wraps("save_event.calculate_span_grouping")
+@sentry_sdk.tracing.trace
 def _calculate_span_grouping(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     for job in jobs:
         # Make sure this snippet doesn't crash ingestion
         # as the feature is under development.
         try:
             event = job["event"]
-            with metrics.timer("event_manager.save.get_span_groupings.default"):
-                groupings = event.get_span_groupings()
+            groupings = event.get_span_groupings()
             groupings.write_to_event(event.data)
 
             metrics.distribution("save_event.transaction.span_count", len(groupings.results))
@@ -2784,7 +2754,7 @@ def _calculate_span_grouping(jobs: Sequence[Job], projects: ProjectsMapping) -> 
             sentry_sdk.capture_exception()
 
 
-@metrics.wraps("save_event.detect_performance_problems")
+@sentry_sdk.tracing.trace
 def _detect_performance_problems(
     jobs: Sequence[Job], projects: ProjectsMapping, is_standalone_spans: bool = False
 ) -> None:
@@ -2807,7 +2777,7 @@ class PerformanceJob(TypedDict, total=False):
     release: Release
 
 
-def _save_grouphash_and_group(
+def save_grouphash_and_group(
     project: Project,
     event: Event,
     new_grouphash: str,
@@ -2829,7 +2799,6 @@ def _save_grouphash_and_group(
     return group, created
 
 
-@metrics.wraps("save_event.send_occurrence_to_platform")
 def _send_occurrence_to_platform(jobs: Sequence[Job], projects: ProjectsMapping) -> None:
     for job in jobs:
         event = job["event"]
@@ -2857,24 +2826,16 @@ def _send_occurrence_to_platform(jobs: Sequence[Job], projects: ProjectsMapping)
             produce_occurrence_to_kafka(payload_type=PayloadType.OCCURRENCE, occurrence=occurrence)
 
 
-@metrics.wraps("event_manager.save_transaction_events")
+@sentry_sdk.tracing.trace
 def save_transaction_events(jobs: Sequence[Job], projects: ProjectsMapping) -> Sequence[Job]:
-    with metrics.timer("event_manager.save_transactions.collect_organization_ids"):
-        organization_ids = {project.organization_id for project in projects.values()}
+    organization_ids = {project.organization_id for project in projects.values()}
+    organizations = {o.id: o for o in Organization.objects.get_many_from_cache(organization_ids)}
 
-    with metrics.timer("event_manager.save_transactions.fetch_organizations"):
-        organizations = {
-            o.id: o for o in Organization.objects.get_many_from_cache(organization_ids)
-        }
-
-    with metrics.timer("event_manager.save_transactions.set_organization_cache"):
-        for project in projects.values():
-            try:
-                project.set_cached_field_value(
-                    "organization", organizations[project.organization_id]
-                )
-            except KeyError:
-                continue
+    for project in projects.values():
+        try:
+            project.set_cached_field_value("organization", organizations[project.organization_id])
+        except KeyError:
+            continue
 
     set_measurement(measurement_name="jobs", value=len(jobs))
     set_measurement(measurement_name="projects", value=len(projects))
@@ -2897,24 +2858,16 @@ def save_transaction_events(jobs: Sequence[Job], projects: ProjectsMapping) -> S
     return jobs
 
 
-@metrics.wraps("event_manager.save_generic_events")
+@sentry_sdk.tracing.trace
 def save_generic_events(jobs: Sequence[Job], projects: ProjectsMapping) -> Sequence[Job]:
-    with metrics.timer("event_manager.save_generic.organization_ids"):
-        organization_ids = {project.organization_id for project in projects.values()}
+    organization_ids = {project.organization_id for project in projects.values()}
+    organizations = {o.id: o for o in Organization.objects.get_many_from_cache(organization_ids)}
 
-    with metrics.timer("event_manager.save_generic.fetch_organizations"):
-        organizations = {
-            o.id: o for o in Organization.objects.get_many_from_cache(organization_ids)
-        }
-
-    with metrics.timer("event_manager.save_generic.set_organization_cache"):
-        for project in projects.values():
-            try:
-                project.set_cached_field_value(
-                    "organization", organizations[project.organization_id]
-                )
-            except KeyError:
-                continue
+    for project in projects.values():
+        try:
+            project.set_cached_field_value("organization", organizations[project.organization_id])
+        except KeyError:
+            continue
 
     _get_or_create_release_many(jobs, projects)
     _get_event_user_many(jobs, projects)

--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -39,23 +39,22 @@ class EventProcessingStore(Service):
 
     @sentry_sdk.tracing.trace
     def store(self, event: Event, unprocessed: bool = False) -> str:
-        with sentry_sdk.start_span(op="eventstore.processing.store"):
-            key = cache_key_for_event(event)
-            if unprocessed:
-                key = self.__get_unprocessed_key(key)
-            self.inner.set(key, event, self.timeout)
-            return key
+        key = cache_key_for_event(event)
+        if unprocessed:
+            key = self.__get_unprocessed_key(key)
+        self.inner.set(key, event, self.timeout)
+        return key
 
+    @sentry_sdk.tracing.trace
     def get(self, key: str, unprocessed: bool = False) -> Event | None:
-        with sentry_sdk.start_span(op="eventstore.processing.get"):
-            if unprocessed:
-                key = self.__get_unprocessed_key(key)
-            return self.inner.get(key)
+        if unprocessed:
+            key = self.__get_unprocessed_key(key)
+        return self.inner.get(key)
 
+    @sentry_sdk.tracing.trace
     def delete_by_key(self, key: str) -> None:
-        with sentry_sdk.start_span(op="eventstore.processing.delete_by_key"):
-            self.inner.delete(key)
-            self.inner.delete(self.__get_unprocessed_key(key))
+        self.inner.delete(key)
+        self.inner.delete(self.__get_unprocessed_key(key))
 
     def delete(self, event: Event) -> None:
         key = cache_key_for_event(event)

--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from django.core.cache import BaseCache, InvalidCacheBackendError, caches
 from django.utils.functional import cached_property
 
-from sentry.utils import json
+from sentry.utils import json, metrics
 from sentry.utils.services import Service
 
 # Cache an instance of the encoder we want to use
@@ -138,6 +138,7 @@ class NodeStorage(local, Service):
             if subkey is None:
                 item_from_cache = self._get_cache_item(id)
                 if item_from_cache:
+                    metrics.incr("nodestore.get", tags={"cache": "hit"})
                     span.set_tag("origin", "from_cache")
                     span.set_tag("found", bool(item_from_cache))
                     return item_from_cache
@@ -153,6 +154,7 @@ class NodeStorage(local, Service):
             if bytes_data:
                 span.set_tag("bytes.size", len(bytes_data))
             span.set_tag("found", bool(rv))
+            metrics.incr("nodestore.get", tags={"cache": "miss", "found": bool(rv)})
 
             return rv
 
@@ -222,6 +224,7 @@ class NodeStorage(local, Service):
         """
         >>> nodestore.set_bytes('key1', b"{'foo': 'bar'}")
         """
+        metrics.distribution("nodestore.set_bytes", len(data))
         return self._set_bytes(item_id, data, ttl)
 
     def _set_bytes(self, item_id: str, data: bytes, ttl: timedelta | None = None) -> None:
@@ -236,6 +239,7 @@ class NodeStorage(local, Service):
         """
         return self.set_subkeys(item_id, {None: data}, ttl=ttl)
 
+    @sentry_sdk.tracing.trace
     def set_subkeys(
         self, item_id: str, data: dict[str | None, dict[str, str]], ttl: timedelta | None = None
     ) -> None:
@@ -252,15 +256,11 @@ class NodeStorage(local, Service):
         >>> nodestore.get('key1', subkey='reprocessing')
         {'foo': 'bam'}
         """
-        with sentry_sdk.start_span(op="nodestore", description="set_subkeys") as span:
-            sentry_sdk.set_tag("nodestore.set_subkeys", True)
-            span.set_tag("node_id", item_id)
-            span.set_data("subkeys_count", len(data))
-            cache_item = data.get(None)
-            bytes_data = self._encode(data)
-            self._set_bytes(item_id, bytes_data, ttl=ttl)
-            # set cache only after encoding and write to nodestore has succeeded
-            self._set_cache_item(item_id, cache_item)
+        cache_item = data.get(None)
+        bytes_data = self._encode(data)
+        self.set_bytes(item_id, bytes_data, ttl=ttl)
+        # set cache only after encoding and write to nodestore has succeeded
+        self._set_cache_item(item_id, cache_item)
 
     def cleanup(self, cutoff_timestamp: datetime) -> None:
         raise NotImplementedError

--- a/src/sentry/nodestore/django/backend.py
+++ b/src/sentry/nodestore/django/backend.py
@@ -6,7 +6,6 @@ import pickle
 from datetime import datetime, timedelta
 from typing import Any
 
-import sentry_sdk
 from django.utils import timezone
 
 from sentry.db.models import create_or_update
@@ -53,7 +52,6 @@ class DjangoNodeStorage(NodeStorage):
         Node.objects.filter(id__in=id_list).delete()
         self._delete_cache_items(id_list)
 
-    @sentry_sdk.tracing.trace
     def _set_bytes(self, id: str, data: Any, ttl: timedelta | None = None) -> None:
         create_or_update(Node, id=id, values={"data": compress(data), "timestamp": timezone.now()})
 

--- a/src/sentry/nodestore/filesystem/backend.py
+++ b/src/sentry/nodestore/filesystem/backend.py
@@ -1,7 +1,6 @@
 import os
 from datetime import datetime, timedelta, timezone
 
-import sentry_sdk
 from django.conf import settings
 
 from sentry.nodestore.base import NodeStorage
@@ -27,7 +26,6 @@ class FileSystemNodeStorage(NodeStorage):
         with open(self.node_path(id), "rb") as file:
             return file.read()
 
-    @sentry_sdk.tracing.trace
     def _set_bytes(self, id: str, data: bytes, ttl: timedelta | None = None) -> None:
         with open(self.node_path(id), "wb") as file:
             file.write(data)

--- a/src/sentry/reprocessing.py
+++ b/src/sentry/reprocessing.py
@@ -9,7 +9,6 @@ REPROCESSING_OPTION = "sentry:processing-rev"
 logger = logging.getLogger("sentry.events")
 
 
-@sentry_sdk.tracing.trace
 def event_supports_reprocessing(data):
     """Only events of a certain format support reprocessing."""
     from sentry.lang.native.utils import NATIVE_PLATFORMS
@@ -29,6 +28,7 @@ def event_supports_reprocessing(data):
     return False
 
 
+@sentry_sdk.tracing.trace
 def get_reprocessing_revision(project, cached=True):
     """Returns the current revision of the projects reprocessing config set."""
     from sentry.models.options.project_option import ProjectOption

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -470,7 +470,6 @@ def pop_batched_events_from_redis(key: str) -> tuple[list[str], datetime | None,
     return reprocessing_store.pop_batched_events_by_key(key)
 
 
-@sentry_sdk.tracing.trace
 def mark_event_reprocessed(
     data: dict[str, Any] | None = None,
     group_id: str | None = None,

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -578,6 +578,7 @@ def dedup_errors(errors):
     return rv
 
 
+@sentry_sdk.tracing.trace
 def process_stacktraces(data, make_processors=None, set_raw_stacktrace=True):
     infos = find_stacktraces_in_data(data, include_empty_exceptions=True)
     if make_processors is None:

--- a/src/sentry/utils/canonical.py
+++ b/src/sentry/utils/canonical.py
@@ -4,7 +4,6 @@ import copy
 from collections.abc import Mapping, MutableMapping
 from typing import TypeVar
 
-import sentry_sdk
 from django.conf import settings
 
 K = TypeVar("K")
@@ -94,7 +93,6 @@ class CanonicalKeyDict(MutableMapping[K, V]):
         self.legacy = legacy
         self.__init(data)
 
-    @sentry_sdk.tracing.trace
     def __init(self, data: Mapping[K, V]) -> None:
         legacy = self.legacy
         if legacy is None:

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -38,10 +38,10 @@ from sentry.dynamic_sampling import (
 from sentry.event_manager import (
     EventManager,
     _get_event_instance,
-    _save_grouphash_and_group,
     get_event_type,
     has_pending_commit_resolution,
     materialize_metadata,
+    save_grouphash_and_group,
 )
 from sentry.eventstore.models import Event
 from sentry.exceptions import HashDiscarded
@@ -3390,13 +3390,13 @@ class TestSaveGroupHashAndGroup(TransactionTestCase):
         perf_data = load_data("transaction-n-plus-one", timestamp=before_now(minutes=10))
         event = _get_event_instance(perf_data, project_id=self.project.id)
         group_hash = "some_group"
-        group, created = _save_grouphash_and_group(self.project, event, group_hash)
+        group, created = save_grouphash_and_group(self.project, event, group_hash)
         assert created
-        group_2, created = _save_grouphash_and_group(self.project, event, group_hash)
+        group_2, created = save_grouphash_and_group(self.project, event, group_hash)
         assert group.id == group_2.id
         assert not created
         assert Group.objects.filter(grouphash__hash=group_hash).count() == 1
-        group_3, created = _save_grouphash_and_group(self.project, event, "new_hash")
+        group_3, created = save_grouphash_and_group(self.project, event, "new_hash")
         assert created
         assert group_2.id != group_3.id
         assert Group.objects.filter(grouphash__hash=group_hash).count() == 1


### PR DESCRIPTION
There is a bunch of cleanup included here:
- Replaces a ton of manual `start_span` invocations with `trace` annotations
- Removes a bunch of existing `trace` annotations for trivially small functions
- Adds some `trace` annotations where I believe they are useful
- Adds metrics to nodestore in particular
- Removes a ton of metrics timers. A lot of them were redundant with tracing spans anyway, and for others I checked that they are not actively used in DD.

---

A lot of the removed metrics were part of the [`EventManager.save() debugging`](https://app.datadoghq.com/dashboard/px2-q48-77h/eventmanagersave-debugging?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1711701387474&to_ts=1712306187474&live=true) dashboard. Though that dashboard looks broken and mostly empty. I doubt anyone cares about it.

The [`Issues Overview`](https://app.datadoghq.com/dashboard/ik2-86m-3gk?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1712300060599&to_ts=1712303660599&live=true) dashboard has one widget with some timings, but I would just suggest people to use our own tracing product instead.

---

Interestingly enough, the broken dashboard above clearly shows that the big DD breakage we had a while back that removed tags and aggregations from certain metrics has left a ton of dashboards broken and was really good in the sense that it showed that people don’t seem to care about most of those.

In a sense, I want to intentionally rather remove too much, and add it back again later, than to remove too little.
I saw that @lobsterkatie recently changed / added a bunch of metrics / spans, so I left those alone.