### PR TITLE
Remove routing code to `save_event_highcpu`

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -94,7 +94,6 @@ def submit_process(
 
 @dataclass(frozen=True)
 class SaveEventTaskKind:
-    is_highcpu: bool = False
     has_attachments: bool = False
     from_reprocessing: bool = False
 
@@ -114,8 +113,6 @@ def submit_save_event(
     # XXX: honor from_reprocessing
     if task_kind.has_attachments:
         task = save_event_attachments
-    elif task_kind.is_highcpu:
-        task = save_event_highcpu
     else:
         task = save_event
 
@@ -229,7 +226,6 @@ def _do_preprocess_event(
     task_kind = SaveEventTaskKind(
         has_attachments=has_attachments,
         from_reprocessing=from_reprocessing,
-        is_highcpu=data["platform"] in options.get("store.save-event-highcpu-platforms", []),
     )
     submit_save_event(
         task_kind,
@@ -353,7 +349,6 @@ def do_process_event(
         task_kind = SaveEventTaskKind(
             from_reprocessing=from_reprocessing,
             has_attachments=has_attachments,
-            is_highcpu=data["platform"] in options.get("store.save-event-highcpu-platforms", []),
         )
         submit_save_event(
             task_kind,
@@ -965,6 +960,7 @@ def save_event_attachments(
     )
 
 
+# TODO(swatinem): remove this (and related queue) once the backing worker deployment is gone
 @instrumented_task(
     name="sentry.tasks.store.save_event_highcpu",
     queue="events.save_event_highcpu",


### PR DESCRIPTION
The reason the `highcpu` variant was introduced in the first place was primarily motivated by slowness of the grouping code.
That is not the case anymore.
Events have also been routed back to the normal `save_event` queue/worker via https://github.com/getsentry/sentry-options-automator/pull/1034, and the infra seems to be happy with that.

This is the next step in removing this queue / worker pool, thus simplifying the infra and saving a couple of **$$$**.