### PR TITLE
feat(crons): Disallow teams not part of project to be selected for alerts

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -495,13 +495,22 @@ function MonitorForm({
                   {t('Customize this monitors notification configuration in Alerts')}
                 </AlertLink>
               )}
-              <SentryMemberTeamSelectorField
-                label={t('Notify')}
-                help={t('Send notifications to a member or team.')}
-                name="alertRule.targets"
-                multiple
-                menuPlacement="auto"
-              />
+              <Observer>
+                {() => {
+                  const projectSlug = form.current.getValue('project')?.toString();
+
+                  return (
+                    <SentryMemberTeamSelectorField
+                      label={t('Notify')}
+                      help={t('Send notifications to a member or team.')}
+                      name="alertRule.targets"
+                      memberOfProjectSlug={projectSlug}
+                      multiple
+                      menuPlacement="auto"
+                    />
+                  );
+                }}
+              </Observer>
               <Observer>
                 {() => {
                   const selectedAssignee = form.current.getValue('alertRule.targets');


### PR DESCRIPTION
Adds a new `memberOfProjectSlug` prop to the sentryMemberTeamSelectorField to restrict selectable teams to only be the ones that are associated with the provided project slug

related to: https://github.com/getsentry/sentry/issues/63814