### PR TITLE
fix(profiling): Correctly send proguard modules

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -472,7 +472,7 @@ def symbolicate(
         return symbolicator.process_jvm(
             exceptions=[],
             stacktraces=stacktraces,
-            modules=modules,
+            modules=[{"uuid": m["uuid"], "type": "proguard"} for m in modules],
             release_package=profile.get("transaction_metadata", {}).get("app.identifier"),
         )
     return symbolicator.process_payload(

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -474,6 +474,7 @@ def symbolicate(
             stacktraces=stacktraces,
             modules=[{"uuid": m["uuid"], "type": "proguard"} for m in modules],
             release_package=profile.get("transaction_metadata", {}).get("app.identifier"),
+            apply_source_context=False,
         )
     return symbolicator.process_payload(
         stacktraces=stacktraces, modules=modules, apply_source_context=False

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -472,7 +472,7 @@ def symbolicate(
         return symbolicator.process_jvm(
             exceptions=[],
             stacktraces=stacktraces,
-            modules=[{"uuid": m["uuid"], "type": "proguard"} for m in modules],
+            modules=modules,
             release_package=profile.get("transaction_metadata", {}).get("app.identifier"),
             apply_source_context=False,
         )
@@ -784,6 +784,7 @@ def _deobfuscate_using_symbolicator(project: Project, profile: Profile, debug_fi
                 modules=[
                     {
                         "uuid": UUID(debug_file_id).hex,
+                        "type": "proguard",
                     }
                 ],
                 stacktraces=[


### PR DESCRIPTION
JVM modules sent to Symbolicator need a `type` in addition to the `uuid`.

This also calls `process_jvm` with `apply_source_context=False`, since we don't want source context for profiles. It wouldn't do anything anyway because we aren't sending any source bundles, but might as well switch it off.