### PR TITLE
chore(hybridcloud) Don't use integration proxy for bitbucket server

### DIFF
--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -6,10 +6,8 @@ from requests import PreparedRequest
 from requests_oauthlib import OAuth1
 
 from sentry.integrations.client import ApiClient
-from sentry.models.identity import Identity
+from sentry.services.hybrid_cloud.identity.model import RpcIdentity
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
-from sentry.services.hybrid_cloud.util import control_silo_function
-from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import ApiError
 
 logger = logging.getLogger("sentry.integrations.bitbucket_server")
@@ -97,7 +95,7 @@ class BitbucketServerSetupClient(ApiClient):
         return self._request(*args, **kwargs)
 
 
-class BitbucketServerClient(IntegrationProxyClient):
+class BitbucketServerClient(ApiClient):
     """
     Contains the BitBucket Server specifics in order to communicate with bitbucket
 
@@ -111,29 +109,29 @@ class BitbucketServerClient(IntegrationProxyClient):
     def __init__(
         self,
         integration: RpcIntegration,
-        identity_id: int,
-        org_integration_id: int,
+        identity: RpcIdentity,
     ):
         self.base_url = integration.metadata["base_url"]
-        self.identity_id = identity_id
+        self.identity = identity
+
         super().__init__(
-            org_integration_id=org_integration_id,
             verify_ssl=integration.metadata["verify_ssl"],
             integration_id=integration.id,
             logging_context=None,
         )
 
-    @control_silo_function
+    def finalize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
+        return self.authorize_request(prepared_request=prepared_request)
+
     def authorize_request(self, prepared_request: PreparedRequest):
         """Bitbucket Server authorizes with RSA-signed OAuth1 scheme"""
-        identity = Identity.objects.filter(id=self.identity_id).first()
-        if not identity:
+        if not self.identity:
             return prepared_request
         auth_scheme = OAuth1(
-            client_key=identity.data["consumer_key"],
-            rsa_key=identity.data["private_key"],
-            resource_owner_key=identity.data["access_token"],
-            resource_owner_secret=identity.data["access_token_secret"],
+            client_key=self.identity.data["consumer_key"],
+            rsa_key=self.identity.data["private_key"],
+            resource_owner_key=self.identity.data["access_token"],
+            resource_owner_secret=self.identity.data["access_token_secret"],
             signature_method=SIGNATURE_RSA,
             signature_type="auth_header",
         )

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -243,8 +243,7 @@ class BitbucketServerIntegration(IntegrationInstallation, RepositoryMixin):
 
         return BitbucketServerClient(
             integration=self.model,
-            identity_id=self.org_integration.default_auth_id,
-            org_integration_id=self.org_integration.id,
+            identity=self.default_identity,
         )
 
     @property

--- a/tests/sentry/integrations/bitbucket_server/test_client.py
+++ b/tests/sentry/integrations/bitbucket_server/test_client.py
@@ -1,19 +1,16 @@
-import re
-
 import responses
 from django.test import override_settings
 from requests import Request
 
+from fixtures.bitbucket_server import REPO
 from sentry.integrations.bitbucket_server.client import (
     BitbucketServerAPIPath,
     BitbucketServerClient,
 )
-from sentry.silo.base import SiloMode
-from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import BaseTestCase, TestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.utils import json
 from tests.sentry.integrations.jira_server import EXAMPLE_PRIVATE_KEY
-from tests.sentry.integrations.test_helpers import add_control_silo_proxy_response
 
 control_address = "http://controlserver"
 secret = "hush-hush-im-invisible"
@@ -70,78 +67,17 @@ class BitbucketServerClientTest(TestCase, BaseTestCase):
             assert hc in str(request.headers["Authorization"])
 
     @responses.activate
-    def test_integration_proxy_is_active(self):
-        class BitbucketServerProxyTestClient(BitbucketServerClient):
-            _use_proxy_url_for_tests = True
-
-            def assert_proxy_request(self, request, is_proxy=True):
-                assert (PROXY_BASE_PATH in request.url) == is_proxy
-                assert (PROXY_OI_HEADER in request.headers) == is_proxy
-                assert (PROXY_SIGNATURE_HEADER in request.headers) == is_proxy
-                assert ("Authorization" in request.headers) != is_proxy
-                if is_proxy:
-                    assert request.headers[PROXY_OI_HEADER] is not None
-
-        expected_header_path = (
-            BitbucketServerAPIPath.repositories.lstrip("/") + "?limit=250&permission=REPO_ADMIN"
+    def test_get_repo_authentication(self):
+        responses.add(
+            responses.GET,
+            f"{self.bb_server_client.base_url}{BitbucketServerAPIPath.repository.format(project='laurynsentry', repo='helloworld')}",
+            body=json.dumps(REPO),
         )
 
-        control_proxy_response = add_control_silo_proxy_response(
-            method=responses.GET,
-            path=expected_header_path,
-            json={"ok": True},
-            status=200,
-        )
+        res = self.bb_server_client.get_repo("laurynsentry", "helloworld")
 
-        jira_response = responses.add(
-            method=responses.GET,
-            url=re.compile(rf"\S+{BitbucketServerAPIPath.repositories}"),
-            json={"ok": True},
-        )
+        assert isinstance(res, dict)
+        assert res["slug"] == "helloworld"
 
-        assert self.install.org_integration is not None
-        org_integration_id = self.install.org_integration.id
-
-        with override_settings(SILO_MODE=SiloMode.MONOLITH):
-            client = BitbucketServerProxyTestClient(
-                integration=self.integration,
-                identity_id=self.identity.id,
-                org_integration_id=org_integration_id,
-            )
-            client.get_repos()
-            request = responses.calls[0].request
-
-            assert BitbucketServerAPIPath.repositories in request.url
-            assert client.base_url in request.url
-            assert jira_response.call_count == 1
-            client.assert_proxy_request(request, is_proxy=False)
-
-        responses.calls.reset()
-        with override_settings(SILO_MODE=SiloMode.CONTROL):
-            client = BitbucketServerProxyTestClient(
-                integration=self.integration,
-                identity_id=self.identity.id,
-                org_integration_id=org_integration_id,
-            )
-            client.get_repos()
-            request = responses.calls[0].request
-
-            assert BitbucketServerAPIPath.repositories in request.url
-            assert client.base_url in request.url
-            assert jira_response.call_count == 2
-            client.assert_proxy_request(request, is_proxy=False)
-
-        responses.calls.reset()
-        assert control_proxy_response.call_count == 0
-        with override_settings(SILO_MODE=SiloMode.REGION):
-            client = BitbucketServerProxyTestClient(
-                integration=self.integration,
-                identity_id=self.identity.id,
-                org_integration_id=org_integration_id,
-            )
-            client.get_repos()
-            request = responses.calls[0].request
-
-            assert client.base_url not in request.url
-            assert control_proxy_response.call_count == 1
-            client.assert_proxy_request(request, is_proxy=True)
+        assert len(responses.calls) == 1
+        assert b"oauth_consumer_key" in responses.calls[0].request.headers["Authorization"]

--- a/tests/sentry/integrations/bitbucket_server/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket_server/test_webhook.py
@@ -4,6 +4,7 @@ from typing import Any
 import responses
 from requests.exceptions import ConnectionError
 
+from fixtures.bitbucket_server import EXAMPLE_PRIVATE_KEY
 from sentry.integrations.bitbucket_server.webhook import PROVIDER_NAME
 from sentry.models.identity import Identity
 from sentry.models.repository import Repository
@@ -44,7 +45,13 @@ class WebhookTestBase(APITestCase):
                 idp=self.create_identity_provider(type=PROVIDER),
                 user=self.user,
                 external_id="user_identity",
-                data={"access_token": "vsts-access-token", "expires": time() + 50000},
+                data={
+                    "access_token": "bitbucket-access-token",
+                    "access_token_secret": "access-token-secret",
+                    "consumer_key": "bitbucket-app",
+                    "private_key": EXAMPLE_PRIVATE_KEY,
+                    "expires": time() + 50000,
+                },
             )
 
     def create_repository(self, **kwargs: Any) -> Repository:


### PR DESCRIPTION
We don't need to go through control silo for bitbucket server as it doesn't use refresh tokens.