### PR TITLE
chore(issue-details): Move logic into utils

### DIFF
--- a/static/app/components/events/contexts/app/index.tsx
+++ b/static/app/components/events/contexts/app/index.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types/event';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {getAppKnownDataDetails} from './getAppKnownDataDetails';
 import type {AppData} from './types';
@@ -28,7 +28,8 @@ export const appKnownDataValues = [
 
 const appIgnoredDataValues = [];
 
-export function AppEventContext({data, event, meta = {}}: Props) {
+export function AppEventContext({data, event, meta: propsMeta}: Props) {
+  const meta = propsMeta ?? getContextMeta(event, 'app');
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/app/index.tsx
+++ b/static/app/components/events/contexts/app/index.tsx
@@ -12,7 +12,7 @@ import {AppKnownDataType} from './types';
 type Props = {
   data: AppData;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
 export const appKnownDataValues = [
@@ -28,7 +28,7 @@ export const appKnownDataValues = [
 
 const appIgnoredDataValues = [];
 
-export function AppEventContext({data, event, meta}: Props) {
+export function AppEventContext({data, event, meta = {}}: Props) {
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/app/index.tsx
+++ b/static/app/components/events/contexts/app/index.tsx
@@ -12,6 +12,7 @@ import {AppKnownDataType} from './types';
 type Props = {
   data: AppData;
   event: Event;
+  meta: Record<string, any>;
 };
 
 export const appKnownDataValues = [
@@ -27,8 +28,7 @@ export const appKnownDataValues = [
 
 const appIgnoredDataValues = [];
 
-export function AppEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.app ?? {};
+export function AppEventContext({data, event, meta}: Props) {
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/browser/index.tsx
+++ b/static/app/components/events/contexts/browser/index.tsx
@@ -12,6 +12,7 @@ import {BrowserKnownDataType} from './types';
 type Props = {
   data: BrowserKnownData;
   event: Event;
+  meta: Record<string, any>;
 };
 
 export const browserKnownDataValues = [
@@ -19,8 +20,7 @@ export const browserKnownDataValues = [
   BrowserKnownDataType.VERSION,
 ];
 
-export function BrowserEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.browser ?? {};
+export function BrowserEventContext({data, meta}: Props) {
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/browser/index.tsx
+++ b/static/app/components/events/contexts/browser/index.tsx
@@ -12,7 +12,7 @@ import {BrowserKnownDataType} from './types';
 type Props = {
   data: BrowserKnownData;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
 export const browserKnownDataValues = [
@@ -20,7 +20,7 @@ export const browserKnownDataValues = [
   BrowserKnownDataType.VERSION,
 ];
 
-export function BrowserEventContext({data, meta}: Props) {
+export function BrowserEventContext({data, meta = {}}: Props) {
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/browser/index.tsx
+++ b/static/app/components/events/contexts/browser/index.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {getBrowserKnownDataDetails} from './getBrowserKnownDataDetails';
 import type {BrowserKnownData} from './types';
@@ -20,7 +20,8 @@ export const browserKnownDataValues = [
   BrowserKnownDataType.VERSION,
 ];
 
-export function BrowserEventContext({data, meta = {}}: Props) {
+export function BrowserEventContext({data, event, meta: propsMeta}: Props) {
+  const meta = propsMeta ?? getContextMeta(event, 'browser');
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/chunk.tsx
+++ b/static/app/components/events/contexts/chunk.tsx
@@ -6,7 +6,12 @@ import type {Group} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 
-import {getContextComponent, getContextMeta, getSourcePlugin, getTitle} from './utils';
+import {
+  getContextComponent,
+  getContextMeta,
+  getContextTitle,
+  getSourcePlugin,
+} from './utils';
 
 type Props = {
   alias: string;
@@ -77,7 +82,7 @@ export function Chunk({group, type, alias, value = {}, event}: Props) {
       type={`context-${alias}`}
       title={
         <Fragment>
-          {getTitle({value, alias, type})}
+          {getContextTitle({value, alias, type})}
           {defined(type) && type !== 'default' && alias !== type && (
             <small>({alias})</small>
           )}

--- a/static/app/components/events/contexts/chunk.tsx
+++ b/static/app/components/events/contexts/chunk.tsx
@@ -1,13 +1,12 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
 
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
-import {t} from 'sentry/locale';
 import plugins from 'sentry/plugins';
 import type {Group} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
-import {defined, toTitleCase} from 'sentry/utils';
+import {defined} from 'sentry/utils';
 
-import {getContextComponent, getSourcePlugin} from './utils';
+import {getContextComponent, getContextMeta, getSourcePlugin, getTitle} from './utils';
 
 type Props = {
   alias: string;
@@ -16,50 +15,6 @@ type Props = {
   group?: Group;
   value?: Record<string, any>;
 };
-
-function getTitle({value = {}, alias, type}: Pick<Props, 'alias' | 'type' | 'value'>) {
-  if (defined(value.title) && typeof value.title !== 'object') {
-    return value.title;
-  }
-
-  if (!defined(type)) {
-    return toTitleCase(alias);
-  }
-
-  switch (type) {
-    case 'app':
-      return t('App');
-    case 'device':
-      return t('Device');
-    case 'os':
-      return t('Operating System');
-    case 'user':
-      return t('User');
-    case 'gpu':
-      return t('Graphics Processing Unit');
-    case 'runtime':
-      return t('Runtime');
-    case 'trace':
-      return t('Trace Details');
-    case 'otel':
-      return t('OpenTelemetry');
-    case 'unity':
-      return t('Unity');
-    case 'memory_info': // Future new value for memory info
-    case 'Memory Info': // Current value for memory info
-      return t('Memory Info');
-    case 'threadpool_info': // Future new value for thread pool info
-    case 'ThreadPool Info': // Current value for thread pool info
-      return t('Thread Pool Info');
-    case 'default':
-      if (alias === 'state') {
-        return t('Application State');
-      }
-      return toTitleCase(alias);
-    default:
-      return toTitleCase(type);
-  }
-}
 
 export function Chunk({group, type, alias, value = {}, event}: Props) {
   const [pluginLoading, setPluginLoading] = useState(false);
@@ -129,7 +84,12 @@ export function Chunk({group, type, alias, value = {}, event}: Props) {
         </Fragment>
       }
     >
-      <ContextComponent alias={alias} event={event} data={value} />
+      <ContextComponent
+        alias={alias}
+        event={event}
+        data={value}
+        meta={getContextMeta(event, type)}
+      />
     </EventDataSection>
   );
 }

--- a/static/app/components/events/contexts/device/index.tsx
+++ b/static/app/components/events/contexts/device/index.tsx
@@ -14,12 +14,12 @@ import {getInferredData} from './utils';
 type Props = {
   data: DeviceContext;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
 const deviceIgnoredDataValues = [];
 
-export function DeviceEventContext({data, event, meta}: Props) {
+export function DeviceEventContext({data, event, meta = {}}: Props) {
   const inferredData = getInferredData(data);
 
   return (

--- a/static/app/components/events/contexts/device/index.tsx
+++ b/static/app/components/events/contexts/device/index.tsx
@@ -14,13 +14,13 @@ import {getInferredData} from './utils';
 type Props = {
   data: DeviceContext;
   event: Event;
+  meta: Record<string, any>;
 };
 
 const deviceIgnoredDataValues = [];
 
-export function DeviceEventContext({data, event}: Props) {
+export function DeviceEventContext({data, event, meta}: Props) {
   const inferredData = getInferredData(data);
-  const meta = event._meta?.contexts?.device ?? {};
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/device/index.tsx
+++ b/static/app/components/events/contexts/device/index.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {DeviceContext, Event} from 'sentry/types/event';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {
   deviceKnownDataValues,
@@ -19,8 +19,9 @@ type Props = {
 
 const deviceIgnoredDataValues = [];
 
-export function DeviceEventContext({data, event, meta = {}}: Props) {
+export function DeviceEventContext({data, event, meta: propsMeta}: Props) {
   const inferredData = getInferredData(data);
+  const meta = propsMeta ?? getContextMeta(event, 'device');
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/gpu/index.tsx
+++ b/static/app/components/events/contexts/gpu/index.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types/event';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {getGPUKnownDataDetails} from './getGPUKnownDataDetails';
 import type {GPUData} from './types';
@@ -27,8 +27,9 @@ export const gpuKnownDataValues = [
 
 const gpuIgnoredDataValues = [];
 
-export function GPUEventContext({data, meta = {}}: Props) {
+export function GPUEventContext({data, event, meta: propsMeta}: Props) {
   const gpuValues = [...gpuKnownDataValues];
+  const meta = propsMeta ?? getContextMeta(event, 'gpu');
 
   if (data.vendor_id > 0) {
     gpuValues.unshift(GPUKnownDataType.VENDOR_ID);

--- a/static/app/components/events/contexts/gpu/index.tsx
+++ b/static/app/components/events/contexts/gpu/index.tsx
@@ -12,6 +12,7 @@ import {GPUKnownDataType} from './types';
 type Props = {
   data: GPUData;
   event: Event;
+  meta: Record<string, any>;
 };
 
 export const gpuKnownDataValues = [
@@ -26,9 +27,7 @@ export const gpuKnownDataValues = [
 
 const gpuIgnoredDataValues = [];
 
-export function GPUEventContext({event, data}: Props) {
-  const meta = event._meta?.contexts?.gpu ?? {};
-
+export function GPUEventContext({data, meta}: Props) {
   const gpuValues = [...gpuKnownDataValues];
 
   if (data.vendor_id > 0) {

--- a/static/app/components/events/contexts/gpu/index.tsx
+++ b/static/app/components/events/contexts/gpu/index.tsx
@@ -12,7 +12,7 @@ import {GPUKnownDataType} from './types';
 type Props = {
   data: GPUData;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
 export const gpuKnownDataValues = [
@@ -27,7 +27,7 @@ export const gpuKnownDataValues = [
 
 const gpuIgnoredDataValues = [];
 
-export function GPUEventContext({data, meta}: Props) {
+export function GPUEventContext({data, meta = {}}: Props) {
   const gpuValues = [...gpuKnownDataValues];
 
   if (data.vendor_id > 0) {

--- a/static/app/components/events/contexts/memoryInfo/index.tsx
+++ b/static/app/components/events/contexts/memoryInfo/index.tsx
@@ -13,10 +13,10 @@ import {
 type Props = {
   data: MemoryInfoContext | null;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
-export function MemoryInfoEventContext({data, event, meta}: Props) {
+export function MemoryInfoEventContext({data, event, meta = {}}: Props) {
   if (!data) {
     return null;
   }

--- a/static/app/components/events/contexts/memoryInfo/index.tsx
+++ b/static/app/components/events/contexts/memoryInfo/index.tsx
@@ -13,15 +13,13 @@ import {
 type Props = {
   data: MemoryInfoContext | null;
   event: Event;
+  meta: Record<string, any>;
 };
 
-export function MemoryInfoEventContext({data, event}: Props) {
+export function MemoryInfoEventContext({data, event, meta}: Props) {
   if (!data) {
     return null;
   }
-
-  const meta =
-    event._meta?.contexts?.['Memory Info'] ?? event._meta?.contexts?.memory_info ?? {};
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/memoryInfo/index.tsx
+++ b/static/app/components/events/contexts/memoryInfo/index.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event, MemoryInfoContext} from 'sentry/types/event';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {
   getMemoryInfoKnownDataDetails,
@@ -16,10 +16,11 @@ type Props = {
   meta?: Record<string, any>;
 };
 
-export function MemoryInfoEventContext({data, event, meta = {}}: Props) {
+export function MemoryInfoEventContext({data, event, meta: propsMeta}: Props) {
   if (!data) {
     return null;
   }
+  const meta = propsMeta ?? getContextMeta(event, 'memory_info');
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/operatingSystem/index.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.tsx
@@ -12,7 +12,7 @@ import {OperatingSystemIgnoredDataType, OperatingSystemKnownDataType} from './ty
 type Props = {
   data: OperatingSystemKnownData;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
 export const operatingSystemKnownDataValues = [
@@ -24,7 +24,7 @@ export const operatingSystemKnownDataValues = [
 
 const operatingSystemIgnoredDataValues = [OperatingSystemIgnoredDataType.BUILD];
 
-export function OperatingSystemEventContext({data, meta}: Props) {
+export function OperatingSystemEventContext({data, meta = {}}: Props) {
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/operatingSystem/index.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.tsx
@@ -12,6 +12,7 @@ import {OperatingSystemIgnoredDataType, OperatingSystemKnownDataType} from './ty
 type Props = {
   data: OperatingSystemKnownData;
   event: Event;
+  meta: Record<string, any>;
 };
 
 export const operatingSystemKnownDataValues = [
@@ -23,8 +24,7 @@ export const operatingSystemKnownDataValues = [
 
 const operatingSystemIgnoredDataValues = [OperatingSystemIgnoredDataType.BUILD];
 
-export function OperatingSystemEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.os ?? {};
+export function OperatingSystemEventContext({data, meta}: Props) {
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/operatingSystem/index.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {getOperatingSystemKnownDataDetails} from './getOperatingSystemKnownDataDetails';
 import type {OperatingSystemKnownData} from './types';
@@ -24,7 +24,8 @@ export const operatingSystemKnownDataValues = [
 
 const operatingSystemIgnoredDataValues = [OperatingSystemIgnoredDataType.BUILD];
 
-export function OperatingSystemEventContext({data, meta = {}}: Props) {
+export function OperatingSystemEventContext({data, event, meta: propsMeta}: Props) {
+  const meta = propsMeta ?? getContextMeta(event, 'os');
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -18,13 +18,13 @@ const PROFILE_KNOWN_DATA_VALUES = [ProfileContextKey.PROFILE_ID];
 interface ProfileContextProps {
   data: ProfileContext & Record<string, any>;
   event: Event;
+  meta: Record<string, any>;
 }
 
-export function ProfileEventContext({event, data}: ProfileContextProps) {
+export function ProfileEventContext({event, data, meta}: ProfileContextProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const project = projects.find(p => p.id === event.projectID);
-  const meta = event._meta?.contexts?.profile ?? {};
 
   return (
     <Feature organization={organization} features="profiling">

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -11,7 +11,7 @@ import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 const PROFILE_KNOWN_DATA_VALUES = [ProfileContextKey.PROFILE_ID];
 
@@ -21,10 +21,11 @@ interface ProfileContextProps {
   meta?: Record<string, any>;
 }
 
-export function ProfileEventContext({event, data, meta = {}}: ProfileContextProps) {
+export function ProfileEventContext({event, data, meta: propsMeta}: ProfileContextProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const project = projects.find(p => p.id === event.projectID);
+  const meta = propsMeta ?? getContextMeta(event, 'profile');
 
   return (
     <Feature organization={organization} features="profiling">

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -18,10 +18,10 @@ const PROFILE_KNOWN_DATA_VALUES = [ProfileContextKey.PROFILE_ID];
 interface ProfileContextProps {
   data: ProfileContext & Record<string, any>;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 }
 
-export function ProfileEventContext({event, data, meta}: ProfileContextProps) {
+export function ProfileEventContext({event, data, meta = {}}: ProfileContextProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const project = projects.find(p => p.id === event.projectID);

--- a/static/app/components/events/contexts/redux/index.tsx
+++ b/static/app/components/events/contexts/redux/index.tsx
@@ -1,3 +1,5 @@
+import type {Event} from '@sentry/types';
+
 import ClippedBox from 'sentry/components/clippedBox';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import {t} from 'sentry/locale';
@@ -5,6 +7,8 @@ import {t} from 'sentry/locale';
 type Props = {
   alias: string;
   data: Record<string, any>;
+  event: Event;
+  meta: Record<string, any>;
 };
 
 export function ReduxContext({data}: Props) {

--- a/static/app/components/events/contexts/redux/index.tsx
+++ b/static/app/components/events/contexts/redux/index.tsx
@@ -8,7 +8,7 @@ type Props = {
   alias: string;
   data: Record<string, any>;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
 export function ReduxContext({data}: Props) {

--- a/static/app/components/events/contexts/runtime/index.tsx
+++ b/static/app/components/events/contexts/runtime/index.tsx
@@ -12,6 +12,7 @@ import {RuntimeIgnoredDataType, RuntimeKnownDataType} from './types';
 type Props = {
   data: RuntimeData;
   event: Event;
+  meta: Record<string, any>;
 };
 
 export const runtimeKnownDataValues = [
@@ -21,8 +22,7 @@ export const runtimeKnownDataValues = [
 
 const runtimeIgnoredDataValues = [RuntimeIgnoredDataType.BUILD];
 
-export function RuntimeEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.runtime ?? {};
+export function RuntimeEventContext({data, meta}: Props) {
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/runtime/index.tsx
+++ b/static/app/components/events/contexts/runtime/index.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types/event';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {getRuntimeKnownDataDetails} from './getRuntimeKnownDataDetails';
 import type {RuntimeData} from './types';
@@ -22,7 +22,8 @@ export const runtimeKnownDataValues = [
 
 const runtimeIgnoredDataValues = [RuntimeIgnoredDataType.BUILD];
 
-export function RuntimeEventContext({data, meta = {}}: Props) {
+export function RuntimeEventContext({data, event, meta: propsMeta}: Props) {
+  const meta = propsMeta ?? getContextMeta(event, 'runtime');
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/runtime/index.tsx
+++ b/static/app/components/events/contexts/runtime/index.tsx
@@ -12,7 +12,7 @@ import {RuntimeIgnoredDataType, RuntimeKnownDataType} from './types';
 type Props = {
   data: RuntimeData;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
 export const runtimeKnownDataValues = [
@@ -22,7 +22,7 @@ export const runtimeKnownDataValues = [
 
 const runtimeIgnoredDataValues = [RuntimeIgnoredDataType.BUILD];
 
-export function RuntimeEventContext({data, meta}: Props) {
+export function RuntimeEventContext({data, meta = {}}: Props) {
   return (
     <Fragment>
       <ContextBlock

--- a/static/app/components/events/contexts/state/index.tsx
+++ b/static/app/components/events/contexts/state/index.tsx
@@ -16,10 +16,10 @@ type Props = {
     state: StateDescription;
   };
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
-export function StateEventContext({data, meta}: Props) {
+export function StateEventContext({data, meta = {}}: Props) {
   function getStateTitle(name: string, type?: string) {
     return `${name}${type ? ` (${upperFirst(type)})` : ''}`;
   }

--- a/static/app/components/events/contexts/state/index.tsx
+++ b/static/app/components/events/contexts/state/index.tsx
@@ -2,6 +2,7 @@ import upperFirst from 'lodash/upperFirst';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {getContextMeta} from 'sentry/components/events/contexts/utils';
 import {t} from 'sentry/locale';
 import type {Event, KeyValueListData, KeyValueListDataItem} from 'sentry/types';
 
@@ -19,7 +20,9 @@ type Props = {
   meta?: Record<string, any>;
 };
 
-export function StateEventContext({data, meta = {}}: Props) {
+export function StateEventContext({data, event, meta: propsMeta}: Props) {
+  const meta = propsMeta ?? getContextMeta(event, 'state');
+
   function getStateTitle(name: string, type?: string) {
     return `${name}${type ? ` (${upperFirst(type)})` : ''}`;
   }

--- a/static/app/components/events/contexts/state/index.tsx
+++ b/static/app/components/events/contexts/state/index.tsx
@@ -16,11 +16,10 @@ type Props = {
     state: StateDescription;
   };
   event: Event;
+  meta: Record<string, any>;
 };
 
-export function StateEventContext({data, event}: Props) {
-  const meta = event._meta?.contexts?.state ?? {};
-
+export function StateEventContext({data, meta}: Props) {
   function getStateTitle(name: string, type?: string) {
     return `${name}${type ? ` (${upperFirst(type)})` : ''}`;
   }

--- a/static/app/components/events/contexts/threadPoolInfo/index.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/index.tsx
@@ -13,17 +13,13 @@ import {
 type Props = {
   data: ThreadPoolInfoContext | null;
   event: Event;
+  meta: Record<string, any>;
 };
 
-export function ThreadPoolInfoEventContext({data, event}: Props) {
+export function ThreadPoolInfoEventContext({data, event, meta}: Props) {
   if (!data) {
     return null;
   }
-
-  const meta =
-    event._meta?.contexts?.['ThreadPool Info'] ??
-    event._meta?.contexts?.threadpool_info ??
-    {};
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/threadPoolInfo/index.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/index.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event, ThreadPoolInfoContext} from 'sentry/types/event';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {
   getThreadPoolInfoKnownDataDetails,
@@ -16,10 +16,11 @@ type Props = {
   meta?: Record<string, any>;
 };
 
-export function ThreadPoolInfoEventContext({data, event, meta = {}}: Props) {
+export function ThreadPoolInfoEventContext({data, event, meta: propsMeta}: Props) {
   if (!data) {
     return null;
   }
+  const meta = propsMeta ?? getContextMeta(event, 'threadpool_info');
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/threadPoolInfo/index.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/index.tsx
@@ -13,10 +13,10 @@ import {
 type Props = {
   data: ThreadPoolInfoContext | null;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
-export function ThreadPoolInfoEventContext({data, event, meta}: Props) {
+export function ThreadPoolInfoEventContext({data, event, meta = {}}: Props) {
   if (!data) {
     return null;
   }

--- a/static/app/components/events/contexts/trace/index.tsx
+++ b/static/app/components/events/contexts/trace/index.tsx
@@ -3,7 +3,7 @@ import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import type {Event} from 'sentry/types/event';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {getTraceKnownDataDetails} from './getTraceKnownDataDetails';
 import type {TraceKnownData} from './types';
@@ -26,8 +26,9 @@ type Props = {
   meta?: Record<string, any>;
 };
 
-export function TraceEventContext({event, data, meta = {}}: Props) {
+export function TraceEventContext({event, data, meta: propsMeta}: Props) {
   const organization = useOrganization();
+  const meta = propsMeta ?? getContextMeta(event, 'trace');
 
   return (
     <ErrorBoundary mini>

--- a/static/app/components/events/contexts/trace/index.tsx
+++ b/static/app/components/events/contexts/trace/index.tsx
@@ -23,11 +23,11 @@ const traceIgnoredDataValues = [];
 type Props = {
   data: TraceKnownData & Record<string, any>;
   event: Event;
+  meta: Record<string, any>;
 };
 
-export function TraceEventContext({event, data}: Props) {
+export function TraceEventContext({event, data, meta}: Props) {
   const organization = useOrganization();
-  const meta = event._meta?.contexts?.trace ?? {};
 
   return (
     <ErrorBoundary mini>

--- a/static/app/components/events/contexts/trace/index.tsx
+++ b/static/app/components/events/contexts/trace/index.tsx
@@ -23,10 +23,10 @@ const traceIgnoredDataValues = [];
 type Props = {
   data: TraceKnownData & Record<string, any>;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
-export function TraceEventContext({event, data, meta}: Props) {
+export function TraceEventContext({event, data, meta = {}}: Props) {
   const organization = useOrganization();
 
   return (

--- a/static/app/components/events/contexts/unity/index.tsx
+++ b/static/app/components/events/contexts/unity/index.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event, UnityContext} from 'sentry/types';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {getUnityKnownDataDetails, unityKnownDataValues} from './getUnityKnownDataDetails';
 
@@ -13,10 +13,11 @@ type Props = {
   meta?: Record<string, any>;
 };
 
-export function UnityEventContext({data, meta = {}}: Props) {
+export function UnityEventContext({data, event, meta: propsMeta}: Props) {
   if (!data) {
     return null;
   }
+  const meta = propsMeta ?? getContextMeta(event, 'unity');
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/unity/index.tsx
+++ b/static/app/components/events/contexts/unity/index.tsx
@@ -10,10 +10,10 @@ import {getUnityKnownDataDetails, unityKnownDataValues} from './getUnityKnownDat
 type Props = {
   data: UnityContext | null;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
-export function UnityEventContext({data, meta}: Props) {
+export function UnityEventContext({data, meta = {}}: Props) {
   if (!data) {
     return null;
   }

--- a/static/app/components/events/contexts/unity/index.tsx
+++ b/static/app/components/events/contexts/unity/index.tsx
@@ -10,14 +10,13 @@ import {getUnityKnownDataDetails, unityKnownDataValues} from './getUnityKnownDat
 type Props = {
   data: UnityContext | null;
   event: Event;
+  meta: Record<string, any>;
 };
 
-export function UnityEventContext({data, event}: Props) {
+export function UnityEventContext({data, meta}: Props) {
   if (!data) {
     return null;
   }
-
-  const meta = event._meta?.contexts?.unity ?? {};
 
   return (
     <Fragment>

--- a/static/app/components/events/contexts/user/index.tsx
+++ b/static/app/components/events/contexts/user/index.tsx
@@ -18,6 +18,7 @@ export type UserEventContextData = {
 type Props = {
   data: UserEventContextData;
   event: Event;
+  meta: Record<string, any>;
 };
 
 export enum UserKnownDataType {
@@ -42,9 +43,7 @@ export const userKnownDataValues = [
 
 const userIgnoredDataValues = [UserIgnoredDataType.DATA];
 
-export function UserEventContext({data, event}: Props) {
-  const meta = event._meta?.user ?? event._meta?.contexts?.user ?? {};
-
+export function UserEventContext({data, meta}: Props) {
   return (
     <div className="user-widget">
       <div className="pull-left">

--- a/static/app/components/events/contexts/user/index.tsx
+++ b/static/app/components/events/contexts/user/index.tsx
@@ -18,7 +18,7 @@ export type UserEventContextData = {
 type Props = {
   data: UserEventContextData;
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
 export enum UserKnownDataType {
@@ -43,7 +43,7 @@ export const userKnownDataValues = [
 
 const userIgnoredDataValues = [UserIgnoredDataType.DATA];
 
-export function UserEventContext({data, meta}: Props) {
+export function UserEventContext({data, meta = {}}: Props) {
   return (
     <div className="user-widget">
       <div className="pull-left">

--- a/static/app/components/events/contexts/user/index.tsx
+++ b/static/app/components/events/contexts/user/index.tsx
@@ -7,7 +7,7 @@ import type {AvatarUser} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 
-import {getKnownData, getUnknownData} from '../utils';
+import {getContextMeta, getKnownData, getUnknownData} from '../utils';
 
 import {getUserKnownDataDetails} from './getUserKnownDataDetails';
 
@@ -43,7 +43,9 @@ export const userKnownDataValues = [
 
 const userIgnoredDataValues = [UserIgnoredDataType.DATA];
 
-export function UserEventContext({data, meta = {}}: Props) {
+export function UserEventContext({data, event, meta: propsMeta}: Props) {
+  const meta = propsMeta ?? getContextMeta(event, 'user');
+
   return (
     <div className="user-widget">
       <div className="pull-left">

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -8,7 +8,7 @@ import {t} from 'sentry/locale';
 import plugins from 'sentry/plugins';
 import {space} from 'sentry/styles/space';
 import type {Event, KeyValueListData} from 'sentry/types';
-import {defined} from 'sentry/utils';
+import {defined, toTitleCase} from 'sentry/utils';
 
 import {AppEventContext} from './app';
 import {BrowserEventContext} from './browser';
@@ -179,6 +179,74 @@ export function getUnknownData({
       subject: startCase(key),
       meta: meta?.[key]?.[''],
     }));
+}
+
+export function getTitle({
+  alias,
+  type,
+  value = {},
+}: {
+  alias: string;
+  type: string;
+  value?: Record<string, any>;
+}) {
+  if (defined(value.title) && typeof value.title !== 'object') {
+    return value.title;
+  }
+
+  if (!defined(type)) {
+    return toTitleCase(alias);
+  }
+
+  switch (type) {
+    case 'app':
+      return t('App');
+    case 'device':
+      return t('Device');
+    case 'os':
+      return t('Operating System');
+    case 'user':
+      return t('User');
+    case 'gpu':
+      return t('Graphics Processing Unit');
+    case 'runtime':
+      return t('Runtime');
+    case 'trace':
+      return t('Trace Details');
+    case 'otel':
+      return t('OpenTelemetry');
+    case 'unity':
+      return t('Unity');
+    case 'memory_info': // Current value for memory info
+    case 'Memory Info': // Legacy for memory info
+      return t('Memory Info');
+    case 'threadpool_info': // Current value for thread pool info
+    case 'ThreadPool Info': // Legacy value for thread pool info
+      return t('Thread Pool Info');
+    case 'default':
+      if (alias === 'state') {
+        return t('Application State');
+      }
+      return toTitleCase(alias);
+    default:
+      return toTitleCase(type);
+  }
+}
+
+export function getContextMeta(event: Event, type: string): Record<string, any> {
+  const defaultMeta = event._meta?.contexts?.[type] ?? {};
+  switch (type) {
+    case 'memory_info': // Current
+    case 'Memory Info': // Legacy
+      return event._meta?.contexts?.['Memory Info'] ?? defaultMeta;
+    case 'threadpool_info': // Current
+    case 'ThreadPool Info': // Legacy
+      return event._meta?.contexts?.['ThreadPool Info'] ?? defaultMeta;
+    case 'user':
+      return event._meta?.user ?? defaultMeta;
+    default:
+      return defaultMeta;
+  }
 }
 
 const RelativeTime = styled('span')`

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -181,7 +181,7 @@ export function getUnknownData({
     }));
 }
 
-export function getTitle({
+export function getContextTitle({
   alias,
   type,
   value = {},


### PR DESCRIPTION
Separating this out from https://github.com/getsentry/sentry/pull/68081 since it is a wider change now. 

Doing this will help simplify the above PR greatly, since it surfaces easy access to context titles and meta values (which store any error states from processing)

- `getTitle` function was just moved to utils as is, and renamed to `getContextTitle`
- `getContextMeta` was introduced and implemented for all known context sections

Here is the meta still being rendered as expected:

![image](https://github.com/getsentry/sentry/assets/35509934/b93d849a-4adf-4fcf-9077-04021c40b6da)


