### PR TITLE
feat(rca): Add any function to span metrics

### DIFF
--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -518,6 +518,19 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     ),
                     default_result_type="rate",
                 ),
+                fields.MetricsFunction(
+                    "any",
+                    required_args=[fields.MetricArg("column")],
+                    # Not actually using `any` so that this function returns consistent results
+                    snql_distribution=lambda args, alias: Function(
+                        "min",
+                        [self.builder.column(args["column"])],
+                        alias,
+                    ),
+                    result_type_fn=self.reflective_result_type(),
+                    default_result_type="string",
+                    redundant_grouping=True,
+                ),
             ]
         }
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1351,6 +1351,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                     "any(span.description)",
                 ],
                 "query": "",
+                "orderby": ["transaction"],
                 "project": self.project.id,
                 "dataset": "spansMetrics",
                 "statsPeriod": "1h",
@@ -1359,8 +1360,8 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
 
         assert response.status_code == 200, response.content
         assert response.data["data"] == [
-            {"transaction": "foo", "any(span.description)": "a"},
             {"transaction": "bar", "any(span.description)": "a"},
+            {"transaction": "foo", "any(span.description)": "a"},
         ]
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1334,6 +1334,35 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             == "epm_by_timestamp: condition argument invalid: string must be one of ['greater', 'less']"
         )
 
+    def test_any_function(self):
+        for char in "abc":
+            for transaction in ["foo", "bar"]:
+                self.store_span_metric(
+                    1,
+                    internal_metric=constants.SELF_TIME_LIGHT,
+                    timestamp=self.six_min_ago,
+                    tags={"span.description": char, "transaction": transaction},
+                )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "any(span.description)",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {"transaction": "foo", "any(span.description)": "a"},
+            {"transaction": "bar", "any(span.description)": "a"},
+        ]
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest


### PR DESCRIPTION
Adds an any function so that we can group by span.description even though they are not normalized which would result in duplicates.