### PR TITLE
fix(feedback): add  text template for feedback emails

### DIFF
--- a/src/sentry/templates/sentry/emails/feedback.txt
+++ b/src/sentry/templates/sentry/emails/feedback.txt
@@ -1,0 +1,48 @@
+{% spaceless %}
+{% autoescape off %}
+{% if enhanced_privacy %}
+Details about this feedback are not shown in this notification since enhanced
+privacy controls are enabled. For more details about this issue, view this
+issue on Sentry.
+Details
+-------
+
+{{ link }}
+{% else %}
+Details
+-------
+
+{{ link }}
+
+{% if commits %}
+Suspect Commits
+---------------
+{% for commit in commits %}
+* {{ commit.subject }}
+  {{ commit.shortId }} - {% if commit.author %}{{ commit.author.name }}{% else %}Unknown Author{% endif %}
+{% endfor %}{% endif %}
+
+{% if generic_issue_data %}
+Feedback Data
+----------
+{% for label, html, _ in generic_issue_data %}
+    {{ label }}  {{ html }}
+{% endfor %}{% endif %}
+
+Tags
+----
+{% for tag_key, tag_value in tags %}
+* {{ tag_key }} = {{ tag_value }}{% endfor %}
+
+{% if interfaces %}{% for label, _, text in interfaces %}
+{{ label }}
+-----------
+
+{{ text }}
+
+{% endfor %}
+{% endif %}{% endif %}
+
+Unsubscribe: {{ unsubscribe_link }}
+{% endautoescape %}
+{% endspaceless %}


### PR DESCRIPTION
- There was no feedback.txt file, which is used to debug logs. 

FIxes SENTRY-35F7