### PR TITLE
ref(grouping): Add optional `variants` attribute to `CalculatedHashes` class

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -368,7 +368,10 @@ class BaseEvent(metaclass=abc.ABCMeta):
         hierarchical_hashes = [hash_ for _, hash_ in hierarchical_hashes]
 
         return CalculatedHashes(
-            hashes=flat_hashes, hierarchical_hashes=hierarchical_hashes, tree_labels=tree_labels
+            hashes=flat_hashes,
+            hierarchical_hashes=hierarchical_hashes,
+            tree_labels=tree_labels,
+            variants=[*flat_variants, *hierarchical_variants],
         )
 
     def get_sorted_grouping_variants(self, force_config: StrategyConfiguration | None = None):

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Optional, TypedDict
 
 from sentry.db.models import NodeData
+from sentry.grouping.variants import BaseVariant
 from sentry.utils.safe import get_path, safe_execute, set_path
 
 EventMetadata = dict[str, Any]
@@ -99,6 +100,7 @@ class CalculatedHashes:
     hashes: Sequence[str]
     hierarchical_hashes: Sequence[str]
     tree_labels: Sequence[TreeLabel | None]
+    variants: list[tuple[str, BaseVariant]] | None = None
 
     def write_to_event(self, event_data: NodeData) -> None:
         event_data["hashes"] = self.hashes


### PR DESCRIPTION
As part of calculating grouping hashes for an event, we first put together "variants," which contain information about the results of applying various possible types of grouping (based on stacktrace, based on message, etc) to the event, as well as about how those results relate to each other in terms of what takes precedence and why, and though we store the resulting hashes on the event, we don't store the much larger `variants` data structure. This means that when we want access to variant data, we need to recalculate it. So far, it's only powered two features (other than the initial hash calculations) - showing grouping info at the bottom of the issue details page and making sure that seer-derived similar issues on the Similar Issues tab are based on the same normalized stacktrace used for grouping. In both cases, the relative infrequency with which those features are used and their separation from ingestion have made it worthwhile for us to pay the time penalty of the recalculation rather than store a whole bunch more data on every event.

Now we want to use seer to find similar issues during ingestion as well, though. In the long run, that may mean that we end up storing some variant information on the event. In the short run, it means that at minimum, we don't want to have to calculate the variants twice during ingest. This therefore propagates variant information farther on in the ingest pipeline, by adding it to the `CalculatedHashes` data structure we use to carry hash values from the actual calculation machinery to where those values are used.