### PR TITLE
chore(migrations): Change `is_dangerous` to `is_post_deploy` in migration template

### DIFF
--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -118,13 +118,14 @@ class SentryMigrationExecutor(MigrationExecutor):
                 _check_bitfield_flags(migration.name, previous_flags, operation.field.flags)
 
     def _check_fake(self, migration: Migration, fake: bool) -> bool:
-        if os.environ.get("MIGRATION_SKIP_DANGEROUS", "0") == "1" and getattr(
-            migration, "is_dangerous", False
+        if os.environ.get("MIGRATION_SKIP_DANGEROUS", "0") == "1" and (
+            getattr(migration, "is_dangerous", False)
+            or getattr(migration, "is_post_deployment", False)
         ):
             # If we plan to skip migrations we just set `fake` to True here. This causes
             # Django to skip running the migration, but records the row as expected.
             fake = True
-            logger.warning("(too dangerous)")
+            logger.warning("(skipping post deploy migration)")
         return fake
 
     def apply_migration(

--- a/src/sentry/runner/commands/migrations.py
+++ b/src/sentry/runner/commands/migrations.py
@@ -36,7 +36,9 @@ def run_for_connection(app_name: str, migration_name: str, connection_name: str)
     connection = connections[connection_name]
     executor = MigrationExecutor(connection)
     migration = executor.loader.get_migration_by_prefix(app_name, migration_name)
-    if not getattr(migration, "is_dangerous", None):
+    if not getattr(migration, "is_dangerous", None) and not getattr(
+        migration, "is_post_deployment", None
+    ):
         raise click.ClickException(
             f"This is not a post-deployment migration: {migration.name}\n"
             f"To apply this migration, please run: make apply-migrations"


### PR DESCRIPTION
The `is_dangerous` wording is confusing and tends to make people think that any risky operation should be marked as dangerous. We really only intend this option to be used for adding indexes and running large backfills, so renaming this to align with that.

I might retroactively update existing migrations in a separate pr so that we can remove the backwards compat code as well.
