### PR TITLE
Revert "fix(event-details): Apply minmax to tags table values (#67688)"

### DIFF
--- a/static/app/components/keyValueTable.tsx
+++ b/static/app/components/keyValueTable.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const KeyValueTable = styled('dl')<{noMargin?: boolean}>`
   display: grid;
-  grid-template-columns: fit-content(50%) minmax(0, 1fr);
+  grid-template-columns: 50% 50%;
   ${p => (p.noMargin ? 'margin-bottom: 0;' : null)}
 `;
 


### PR DESCRIPTION
This reverts commit c913bc48e5fd95f1c7bbb369ede0c28bad00f479. We tried so hard, and got so far. The layout still breaks for some customers who have very long tag names and short values.
