### PR TITLE
fix(releases): consider only open releases for semver check

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1056,7 +1056,9 @@ def follows_semver_versioning_scheme(org_id, project_id, release_version=None):
     if follows_semver is None:
         # Check if the latest ten releases are semver compliant
         releases_list = list(
-            Release.objects.filter(organization_id=org_id, projects__id__in=[project_id])
+            Release.objects.filter(
+                organization_id=org_id, projects__id__in=[project_id], status=ReleaseStatus.OPEN
+            )
             .using_replica()
             .order_by("-date_added")[:10]
         )

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -1240,6 +1240,30 @@ class FollowsSemverVersioningSchemeTestCase(TestCase):
             is False
         )
 
+    def test_follows_semver_check_with_archived_non_semver_releases(self):
+        """
+        Test that ensures that when a project has a mix of archived non-semver releases and active semver releases,
+        then we consider the project to be following semver.
+        """
+        proj = self.create_project(organization=self.org)
+
+        # Create semver releases that are not archived
+        for i in range(4):
+            self.create_release(version=f"{self.fake_package}@1.0.{i}", project=proj)
+
+        # Create non-semver releases and archive them
+        for i in range(6):
+            release = self.create_release(version=f"notsemver-{i}", project=proj)
+            release.update(status=ReleaseStatus.ARCHIVED)
+
+        assert (
+            follows_semver_versioning_scheme(
+                org_id=self.org.id,
+                project_id=proj.id,
+            )
+            is True
+        )
+
 
 class ClearCommitsTestCase(TestCase):
     @receivers_raise_on_send()


### PR DESCRIPTION
- If sentry users accidentally upload a bunch of non-semver releases, their regression algorithm will start to use date_added instead of semver, which can be problematic.
- There is no current way to "delete" releases, only archive them, so users can only archive these non-semver releases
- The algorithm which checks to use semver or not currently considers all releases. this PR changes it so that we only consider "Open" releases.
- Test added.


- There are code comments mentioning the goal of creating a project wide setting to use semver or not, maybe we should consider implementing this?