### PR TITLE
fix(traces): Allow for traces with even more events

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -29,6 +29,7 @@ from sentry.search.utils import parse_datetime_string
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
+from sentry.utils.iterators import chunked
 from sentry.utils.numbers import base32_encode, format_grouped_length
 from sentry.utils.sdk import set_measurement
 from sentry.utils.snuba import bulk_snql_query
@@ -670,23 +671,24 @@ def augment_transactions_with_spans(
 
     # If we're querying over 100 span ids, lets split the query into 3
     sentry_sdk.set_tag("trace_view.use_spans.span_len", len(query_spans))
+
+    # The max query size according to snuba/clickhouse docs is 256KiB, or about 256 thousand characters
+    # Each span id maps to being 20 characters; 16 characters turned back into a number maxes out at 20
+    # which at 10k transaction span ids, and even another 10k error span ids (which would only happen if there's no
+    # crossover) that's 20k * 20 = 400k bytes, with 3 queries that should be 133,333 bytes  which shouldn't be anywhere
+    # near the 256KiB max even with the other parts of the query.
+    # Experimentally (running queries in snuba admin) we've found the max query size is actually 131,535 bytes or
+    # 128.45KiB. Taking that into account, (131,535-10,000(for projects etc))/20 = 6000, means that we can fit at most
+    # 6000 span ids per query, Adding a bit of a buffer, if the query is for more than 12,500 spans we'll do 4 chunks
+    # instead of 3
     if len(query_spans) > 100:
         list_spans = list(query_spans)
-        if len(query_spans) < 7_500:
-            chunks = [
-                list_spans[: len(list_spans) // 3],
-                list_spans[len(list_spans) // 3 : len(list_spans) // 3 * 2],
-                list_spans[len(list_spans) // 3 * 2 :],
-            ]
-        # We're hitting the query size limit, lets do 5 queries for now so we dont hit parallel queries limit
+        if len(query_spans) < 12_500:
+            total_chunks = 3
         else:
-            chunks = [
-                list_spans[: len(list_spans) // 5],
-                list_spans[len(list_spans) // 5 : len(list_spans) // 5 * 2],
-                list_spans[len(list_spans) // 5 * 2 : len(list_spans) // 5 * 3],
-                list_spans[len(list_spans) // 5 * 3 : len(list_spans) // 5 * 4],
-                list_spans[len(list_spans) // 5 * 4 :],
-            ]
+            total_chunks = 4
+        sentry_sdk.set_measurement("trace_view.span_query.total_chunks", total_chunks)
+        chunks = chunked(list_spans, (len(list_spans) // total_chunks) + 1)
         queries = [build_span_query(trace_id, spans_params, chunk) for chunk in chunks]
         results = bulk_snql_query(
             [query.get_snql_query() for query in queries],


### PR DESCRIPTION
- Hopefully fixes SENTRY-31FK
- We're bumping into Clickhouse's max query size of 256KiB, even though I think we should be under that (20k span ids divided by 3 -> 6666 ids at 16bytes each should only be ~104KiB, so unless projects are taking up the other 150 somehow?...) lets just increase the number of parallel queries to 5, in the worst case of 20k that should be 2/3rds of what we're seeing today