### PR TITLE
fix(replay): Fix playing mobile replays on Safari

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -91,10 +91,16 @@ export class VideoReplayer {
 
   private createVideo(segmentData: VideoEvent, index: number) {
     const el = document.createElement('video');
-    el.src = `${this._videoApiPrefix}${segmentData.id}/`;
+    const sourceEl = document.createElement('source');
     el.style.display = 'none';
+    sourceEl.setAttribute('type', 'video/mp4');
+    sourceEl.setAttribute('src', `${this._videoApiPrefix}${segmentData.id}/`);
     el.setAttribute('muted', '');
     el.setAttribute('playinline', '');
+    el.setAttribute('preload', 'auto');
+    // TODO: Timer needs to also account for playback speed
+    el.setAttribute('playbackRate', `${this.config.speed}`);
+    el.appendChild(sourceEl);
 
     // TODO: only attach these when needed
     el.addEventListener('ended', () => this.handleSegmentEnd(index));
@@ -131,10 +137,6 @@ export class VideoReplayer {
         this._callbacks.onLoaded(event);
       }
     });
-
-    el.preload = 'auto';
-    // TODO: Timer needs to also account for playback speed
-    el.playbackRate = this.config.speed;
 
     // Append the video element to the mobile player wrapper element
     this.wrapper.appendChild(el);


### PR DESCRIPTION
In addition to the `Range` header changes, Safari requires *something* to tell it the content type of a video source. I have opted to hint at the type using `source.type` attribute, other potential methods would be via backend by a `mp4` file extension, or a `Content-Type` header of `video/mp4` (currently it is `application/octet-stream`).
