### PR TITLE
ref(rules): Add process_pending_batch task

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -23,7 +23,7 @@ class Buffer(Service):
     keep up with the updates.
     """
 
-    __all__ = ("get", "incr", "process", "process_pending", "validate")
+    __all__ = ("get", "incr", "process", "process_pending", "process_batch", "validate")
 
     def get(
         self,
@@ -62,6 +62,9 @@ class Buffer(Service):
         )
 
     def process_pending(self, partition: int | None = None) -> None:
+        return
+
+    def process_batch(self, partition: int | None = None) -> None:
         return
 
     def process(

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1019,6 +1019,12 @@ CELERYBEAT_SCHEDULE_REGION = {
         "schedule": timedelta(seconds=10),
         "options": {"expires": 10, "queue": "buffers.process_pending"},
     },
+    "flush-buffers-batch": {
+        "task": "sentry.tasks.process_buffer.process_pending_batch",
+        # Run every 1 minute
+        "schedule": crontab(minute="*/1"),
+        "options": {"expires": 10, "queue": "buffers.process_pending_batch"},
+    },
     "sync-options": {
         "task": "sentry.tasks.options.sync_options",
         # Run every 10 seconds
@@ -1797,6 +1803,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:performance-trace-explorer": False,
     # Hides some fields and sections in the transaction summary page that are being deprecated
     "organizations:performance-transaction-summary-cleanup": False,
+    # Enable processing slow issue alerts
+    "organizations:process-slow-alerts": False,
     # Enable profiling
     "organizations:profiling": False,
     # Enabled for those orgs who participated in the profiling Beta program

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -844,6 +844,7 @@ CELERY_QUEUES_REGION = [
     Queue("appstoreconnect", routing_key="sentry.tasks.app_store_connect.#"),
     Queue("assemble", routing_key="assemble"),
     Queue("buffers.process_pending", routing_key="buffers.process_pending"),
+    Queue("buffers.process_pending_batch", routing_key="buffers.process_pending_batch"),
     Queue("buffers.incr", routing_key="buffers.incr"),
     Queue("cleanup", routing_key="cleanup"),
     Queue("code_owners", routing_key="code_owners"),

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -177,6 +177,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-transaction-name-only-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-transaction-name-only-search-indexed", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-transaction-summary-cleanup", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:process-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:performance-trends-issues", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-trends-new-data-date-range-default", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-use-metrics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -10,7 +10,7 @@ from sentry.utils.locking import UnableToAcquireLock
 logger = logging.getLogger(__name__)
 
 
-def get_process_lock(lock_name: str, partition: str = None):
+def get_process_lock(lock_name: str, partition: str | None = None):
     from sentry.locks import locks
 
     if partition is None:

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -16,7 +16,7 @@ def get_process_lock(partition: str = None):
     if partition is None:
         lock_key = "buffer:process_pending"
     else:
-        lock_key = "buffer:process_pending:%d" % partition
+        lock_key = f"buffer:process_pending:{partition}"
 
     return locks.get(lock_key, duration=60, name="process_pending")
 

--- a/tests/sentry/tasks/test_process_buffer.py
+++ b/tests/sentry/tasks/test_process_buffer.py
@@ -3,7 +3,12 @@ from unittest import mock
 from django.test import override_settings
 
 from sentry.models.group import Group
-from sentry.tasks.process_buffer import buffer_incr, process_incr, process_pending
+from sentry.tasks.process_buffer import (
+    buffer_incr,
+    process_incr,
+    process_pending,
+    process_pending_batch,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -28,6 +33,18 @@ class ProcessPendingTest(TestCase):
         process_pending(partition=1)
         assert len(mock_process_pending.mock_calls) == 2
         mock_process_pending.assert_any_call(partition=1)
+
+
+class ProcessPendingBatchTest(TestCase):
+    @mock.patch("sentry.buffer.backend.process_batch")
+    def test_process_pending_batch(self, mock_process_pending_batch):
+        process_pending_batch()
+        assert len(mock_process_pending_batch.mock_calls) == 1
+        mock_process_pending_batch.assert_any_call(partition=None)
+
+        process_pending_batch(partition=1)
+        assert len(mock_process_pending_batch.mock_calls) == 2
+        mock_process_pending_batch.assert_any_call(partition=1)
 
 
 class BufferIncrTest(TestCase):

--- a/tests/sentry/tasks/test_process_buffer.py
+++ b/tests/sentry/tasks/test_process_buffer.py
@@ -49,9 +49,7 @@ class ProcessPendingBatchTest(TestCase):
 
     @mock.patch("sentry.buffer.backend.process_batch")
     def test_process_pending_batch_locked_out(self, mock_process_pending_batch):
-        with mock.patch("sentry.buffer.redis.RedisBuffer.process_batch"), self.assertLogs(
-            "sentry.tasks.process_buffer", level="WARNING"
-        ) as logger:
+        with self.assertLogs("sentry.tasks.process_buffer", level="WARNING") as logger:
             lock = get_process_lock("process_pending_batch", None)
             with lock.acquire():
                 process_pending_batch()


### PR DESCRIPTION
Add a task that will process the batches of rules to be processed. Note that I didn't actually enable it yet (it's missing a cronjob entry in `server.py`), but when we're ready we'll put enqueuing data behind a flag and actually turn this on.

Closes: https://github.com/getsentry/team-core-product-foundations/issues/241