### PR TITLE
feat(event-tags): Allow meta to influence tag values

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -183,4 +183,51 @@ describe('EventTagsTree', function () {
     await userEvent.click(dropdown);
     expect(screen.getByLabelText(labelText)).toBeInTheDocument();
   });
+
+  it('renders error message tooltips instead of dropdowns', function () {
+    const featuredOrganization = OrganizationFixture({features: ['event-tags-tree-ui']});
+    const errorTagEvent = EventFixture({
+      _meta: {
+        tags: {
+          0: {
+            value: {
+              '': {
+                err: ['value_too_long'],
+              },
+            },
+          },
+          2: {
+            value: {
+              '': {
+                err: [
+                  [
+                    'invalid_data',
+                    {
+                      reason: "invalid character '\\n'",
+                    },
+                  ],
+                ],
+                val: 'invalid\ncharacters\n🇨🇦🔥🤡',
+              },
+            },
+          },
+        },
+      },
+      tags: [
+        {key: 'some-super-long-tag', value: null},
+        {key: 'some-acceptable-tag', value: 'im acceptable'},
+        {key: 'some-invalid-char-tag', value: null},
+      ],
+    });
+    render(<EventTags projectSlug={project.slug} event={errorTagEvent} />, {
+      organization: featuredOrganization,
+    });
+
+    // Should only be one dropdown, others have errors
+    const dropdown = screen.getByLabelText('Tag Actions Menu');
+    expect(dropdown).toBeInTheDocument();
+
+    const errorRows = screen.queryAllByTestId('tag-tree-row-errors');
+    expect(errorRows.length).toBe(2);
+  });
 });

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -1,21 +1,13 @@
-import {Fragment, useMemo, useRef, useState} from 'react';
+import {Fragment, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
-import * as qs from 'query-string';
 
-import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
-import {navigateTo} from 'sentry/actionCreators/navigation';
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import Version from 'sentry/components/version';
-import VersionHoverCard from 'sentry/components/versionHoverCard';
-import {IconEllipsis} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import EventTagsTreeRow, {
+  type EventTagsTreeRowProps,
+} from 'sentry/components/events/eventTags/eventTagsTreeRow';
 import {space} from 'sentry/styles/space';
 import type {EventTag} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
-import {generateQueryWithTag, isUrl} from 'sentry/utils';
 import {useDimensions} from 'sentry/utils/useDimensions';
-import useOrganization from 'sentry/utils/useOrganization';
-import useRouter from 'sentry/utils/useRouter';
 
 const MAX_TREE_DEPTH = 4;
 const INVALID_BRANCH_REGEX = /\.{2,}/;
@@ -36,15 +28,6 @@ interface TagTreeColumnData {
   columns: React.ReactNode[];
   runningTotal: number;
   startIndex: number;
-}
-
-interface TagTreeRowProps {
-  content: TagTreeContent;
-  event: Event;
-  projectSlug: string;
-  tagKey: string;
-  isLast?: boolean;
-  spacerCount?: number;
 }
 
 interface EventTagsTreeProps {
@@ -89,164 +72,17 @@ function addToTagTree(
   return tree;
 }
 
-function TagTreeRow({
-  event,
-  content,
-  tagKey,
-  spacerCount = 0,
-  isLast = false,
-  projectSlug,
-}: TagTreeRowProps) {
-  const organization = useOrganization();
-  const router = useRouter();
-  const [isVisible, setIsVisible] = useState(false);
-  const originalTag = content.originalTag;
-
-  if (!originalTag) {
-    return (
-      <TreeRow data-test-id="tag-tree-row">
-        <TreeKeyTrunk spacerCount={spacerCount}>
-          {spacerCount > 0 && (
-            <Fragment>
-              <TreeSpacer spacerCount={spacerCount} isLast={isLast} />
-              <TreeBranchIcon />
-            </Fragment>
-          )}
-          <TreeKey>{tagKey}</TreeKey>
-        </TreeKeyTrunk>
-        <TreeValueTrunk />
-      </TreeRow>
-    );
-  }
-
-  const referrer = 'event-tags-tree';
-  const query = generateQueryWithTag({referrer}, originalTag);
-  const searchQuery = `?${qs.stringify(query)}`;
-
-  return (
-    <TreeRow data-test-id="tag-tree-row">
-      <TreeKeyTrunk spacerCount={spacerCount}>
-        {spacerCount > 0 && (
-          <Fragment>
-            <TreeSpacer spacerCount={spacerCount} isLast={isLast} />
-            <TreeBranchIcon />
-          </Fragment>
-        )}
-        <TreeSearchKey aria-hidden>{originalTag.key}</TreeSearchKey>
-        <TreeKey title={originalTag.key}>{tagKey}</TreeKey>
-      </TreeKeyTrunk>
-      <TreeValueTrunk>
-        <TreeValue>
-          {originalTag.key === 'release' ? (
-            <VersionHoverCard
-              organization={organization}
-              projectSlug={projectSlug}
-              releaseVersion={content.value}
-              showUnderline
-              underlineColor="linkUnderline"
-            >
-              <Version version={content.value} truncate />
-            </VersionHoverCard>
-          ) : (
-            content.value
-          )}
-        </TreeValue>
-        <TreeValueDropdown
-          preventOverflowOptions={{padding: 4}}
-          className={isVisible ? '' : 'invisible'}
-          position="bottom-end"
-          size="xs"
-          onOpenChange={isOpen => setIsVisible(isOpen)}
-          triggerProps={{
-            'aria-label': t('Tag Actions Menu'),
-            icon: <IconEllipsis />,
-            showChevron: false,
-            className: 'tag-button',
-          }}
-          items={[
-            {
-              key: 'view-events',
-              label: t('View other events with this tag value'),
-              hidden: !event.groupID,
-              onAction: () => {
-                navigateTo(
-                  `/organizations/${organization.slug}/issues/${event.groupID}/events/${searchQuery}`,
-                  router
-                );
-              },
-            },
-            {
-              key: 'view-issues',
-              label: t('View issues with this tag value'),
-              onAction: () => {
-                navigateTo(
-                  `/organizations/${organization.slug}/issues/${searchQuery}`,
-                  router
-                );
-              },
-            },
-            {
-              key: 'release',
-              label: t('View this release'),
-              hidden: originalTag.key !== 'release',
-              onAction: () => {
-                navigateTo(
-                  `/organizations/${organization.slug}/releases/${encodeURIComponent(
-                    content.value
-                  )}/`,
-                  router
-                );
-              },
-            },
-            {
-              key: 'transaction',
-              label: t('View this transaction'),
-              hidden: originalTag.key !== 'transaction',
-              onAction: () => {
-                const transactionQuery = qs.stringify({
-                  project: event.projectID,
-                  transaction: content.value,
-                  referrer,
-                });
-                navigateTo(
-                  `/organizations/${organization.slug}/performance/summary/?${transactionQuery}`,
-                  router
-                );
-              },
-            },
-            {
-              key: 'replay',
-              label: t('View this replay'),
-              hidden: originalTag.key !== 'replay_id' && originalTag.key !== 'replayId',
-              onAction: () => {
-                const replayQuery = qs.stringify({referrer});
-                navigateTo(
-                  `/organizations/${organization.slug}/replays/${encodeURIComponent(content.value)}/?${replayQuery}`,
-                  router
-                );
-              },
-            },
-            {
-              key: 'external-link',
-              label: t('Visit this external link'),
-              hidden: !isUrl(content.value),
-              onAction: () => {
-                openNavigateToExternalLinkModal({linkText: content.value});
-              },
-            },
-          ]}
-        />
-      </TreeValueTrunk>
-    </TreeRow>
-  );
-}
-
 /**
  * Function to recursively create a flat list of all rows to be rendered for a given TagTree
  * @param props The props for rendering the root of the TagTree
  * @returns A list of TagTreeRow components to be rendered in this tree
  */
-function getTagTreeRows({tagKey, content, spacerCount = 0, ...props}: TagTreeRowProps) {
+function getTagTreeRows({
+  tagKey,
+  content,
+  spacerCount = 0,
+  ...props
+}: EventTagsTreeRowProps) {
   const subtreeTags = Object.keys(content.subtree);
   const subtreeRows = subtreeTags.reduce((rows, tag, i) => {
     const branchRows = getTagTreeRows({
@@ -260,7 +96,7 @@ function getTagTreeRows({tagKey, content, spacerCount = 0, ...props}: TagTreeRow
   }, []);
 
   return [
-    <TagTreeRow
+    <EventTagsTreeRow
       key={`${tagKey}-${spacerCount}`}
       tagKey={tagKey}
       content={content}
@@ -367,96 +203,6 @@ const TreeColumn = styled('div')`
   &:not(:last-child) {
     border-right: 1px solid ${p => p.theme.innerBorder};
     padding-right: ${space(2)};
-  }
-`;
-
-const TreeRow = styled('div')`
-  border-radius: ${space(0.5)};
-  padding-left: ${space(1)};
-  position: relative;
-  display: grid;
-  align-items: center;
-  grid-column: span 2;
-  grid-template-columns: subgrid;
-  :nth-child(odd) {
-    background-color: ${p => p.theme.backgroundSecondary};
-  }
-  .invisible {
-    visibility: hidden;
-  }
-  &:hover,
-  &:active {
-    .invisible {
-      visibility: visible;
-    }
-  }
-`;
-
-const TreeSpacer = styled('div')<{isLast: boolean; spacerCount: number}>`
-  grid-column: span 1;
-  /* Allows TreeBranchIcons to appear connected vertically */
-  border-right: 1px solid ${p => (!p.isLast ? p.theme.border : 'transparent')};
-  margin-right: -1px;
-  height: 100%;
-`;
-
-const TreeBranchIcon = styled('div')`
-  border: 1px solid ${p => p.theme.border};
-  border-width: 0 0 1px 1px;
-  border-radius: 0 0 0 5px;
-  grid-column: span 1;
-  height: 12px;
-  align-self: start;
-  margin-right: ${space(0.5)};
-`;
-
-const TreeKeyTrunk = styled('div')<{spacerCount: number}>`
-  grid-column: 1 / 2;
-  display: grid;
-  height: 100%;
-  align-items: center;
-  grid-template-columns: ${p =>
-    p.spacerCount > 0 ? `${(p.spacerCount - 1) * 20 + 3}px 1rem 1fr` : '1fr'};
-`;
-
-const TreeValueTrunk = styled('div')`
-  grid-column: 2 / 3;
-  display: grid;
-  height: 100%;
-  align-items: center;
-  min-height: 22px;
-  grid-template-columns: 1fr auto;
-  grid-column-gap: ${space(0.5)};
-`;
-
-const TreeValue = styled('div')`
-  font-family: ${p => p.theme.text.familyMono};
-  font-size: ${p => p.theme.fontSizeSmall};
-  word-break: break-word;
-  grid-column: span 1;
-`;
-
-const TreeKey = styled(TreeValue)`
-  color: ${p => p.theme.gray300};
-`;
-
-/**
- * Hidden element to allow browser searching for exact key name
- */
-const TreeSearchKey = styled('span')`
-  font-size: 0;
-  position: absolute;
-`;
-
-const TreeValueDropdown = styled(DropdownMenu)`
-  margin: 1px;
-  height: 20px;
-  .tag-button {
-    height: 20px;
-    min-height: 20px;
-    padding: ${space(0)} ${space(0.75)};
-    border-radius: ${space(0.5)};
-    z-index: 0;
   }
 `;
 

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -86,7 +86,7 @@ export default function EventTagsTreeRow({
           )}
         </TreeValue>
         {hasTagErrors ? (
-          <TreeValueErrors>
+          <TreeValueErrors data-test-id="tag-tree-row-errors">
             <AnnotatedTextErrors errors={tagErrors} />
           </TreeValueErrors>
         ) : (
@@ -269,7 +269,7 @@ const TreeValueTrunk = styled('div')`
 `;
 
 const TreeValue = styled('div')`
-  padding-top: ${space(0.25)};
+  padding: ${space(0.25)} 0;
   align-self: start;
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -1,0 +1,307 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+import * as qs from 'query-string';
+
+import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import {navigateTo} from 'sentry/actionCreators/navigation';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import type {TagTreeContent} from 'sentry/components/events/eventTags/eventTagsTree';
+import {AnnotatedTextErrors} from 'sentry/components/events/meta/annotatedText/annotatedTextErrors';
+import Version from 'sentry/components/version';
+import VersionHoverCard from 'sentry/components/versionHoverCard';
+import {IconEllipsis} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event} from 'sentry/types/event';
+import {generateQueryWithTag, isUrl} from 'sentry/utils';
+import useOrganization from 'sentry/utils/useOrganization';
+import useRouter from 'sentry/utils/useRouter';
+
+export interface EventTagsTreeRowProps {
+  content: TagTreeContent;
+  event: Event;
+  projectSlug: string;
+  tagKey: string;
+  isLast?: boolean;
+  spacerCount?: number;
+}
+
+export default function EventTagsTreeRow({
+  event,
+  content,
+  tagKey,
+  projectSlug,
+  spacerCount = 0,
+  isLast = false,
+}: EventTagsTreeRowProps) {
+  const organization = useOrganization();
+  const originalTag = content.originalTag;
+  const tagErrors = content.meta?.value?.['']?.err ?? [];
+  const hasTagErrors = tagErrors.length > 0;
+
+  if (!originalTag) {
+    return (
+      <TreeRow data-test-id="tag-tree-row" hasErrors={hasTagErrors}>
+        <TreeKeyTrunk spacerCount={spacerCount}>
+          {spacerCount > 0 && (
+            <Fragment>
+              <TreeSpacer spacerCount={spacerCount} isLast={isLast} />
+              <TreeBranchIcon hasErrors={hasTagErrors} />
+            </Fragment>
+          )}
+          <TreeKey hasErrors={hasTagErrors}>{tagKey}</TreeKey>
+        </TreeKeyTrunk>
+        <TreeValueTrunk />
+      </TreeRow>
+    );
+  }
+  return (
+    <TreeRow data-test-id="tag-tree-row" hasErrors={hasTagErrors}>
+      <TreeKeyTrunk spacerCount={spacerCount}>
+        {spacerCount > 0 && (
+          <Fragment>
+            <TreeSpacer spacerCount={spacerCount} isLast={isLast} />
+            <TreeBranchIcon hasErrors={hasTagErrors} />
+          </Fragment>
+        )}
+        <TreeSearchKey aria-hidden>{originalTag.key}</TreeSearchKey>
+        <TreeKey hasErrors={hasTagErrors} title={originalTag.key}>
+          {tagKey}
+        </TreeKey>
+      </TreeKeyTrunk>
+      <TreeValueTrunk>
+        <TreeValue>
+          {originalTag.key === 'release' ? (
+            <VersionHoverCard
+              organization={organization}
+              projectSlug={projectSlug}
+              releaseVersion={content.value}
+              showUnderline
+              underlineColor="linkUnderline"
+            >
+              <Version version={content.value} truncate />
+            </VersionHoverCard>
+          ) : (
+            content.value
+          )}
+        </TreeValue>
+        {hasTagErrors ? (
+          <TreeValueErrors>
+            <AnnotatedTextErrors errors={tagErrors} />
+          </TreeValueErrors>
+        ) : (
+          <EventTagsTreeRowDropdown content={content} event={event} />
+        )}
+      </TreeValueTrunk>
+    </TreeRow>
+  );
+}
+
+function EventTagsTreeRowDropdown({
+  event,
+  content,
+}: Pick<EventTagsTreeRowProps, 'content' | 'event'>) {
+  const organization = useOrganization();
+  const router = useRouter();
+  const [isVisible, setIsVisible] = useState(false);
+  const originalTag = content.originalTag;
+
+  if (!originalTag) {
+    return null;
+  }
+
+  const referrer = 'event-tags-tree';
+  const query = generateQueryWithTag({referrer}, originalTag);
+  const searchQuery = `?${qs.stringify(query)}`;
+
+  return (
+    <TreeValueDropdown
+      preventOverflowOptions={{padding: 4}}
+      className={isVisible ? '' : 'invisible'}
+      position="bottom-end"
+      size="xs"
+      onOpenChange={isOpen => setIsVisible(isOpen)}
+      triggerProps={{
+        'aria-label': t('Tag Actions Menu'),
+        icon: <IconEllipsis />,
+        showChevron: false,
+        className: 'tag-button',
+      }}
+      items={[
+        {
+          key: 'view-events',
+          label: t('View other events with this tag value'),
+          hidden: !event.groupID,
+          onAction: () => {
+            navigateTo(
+              `/organizations/${organization.slug}/issues/${event.groupID}/events/${searchQuery}`,
+              router
+            );
+          },
+        },
+        {
+          key: 'view-issues',
+          label: t('View issues with this tag value'),
+          onAction: () => {
+            navigateTo(
+              `/organizations/${organization.slug}/issues/${searchQuery}`,
+              router
+            );
+          },
+        },
+        {
+          key: 'release',
+          label: t('View this release'),
+          hidden: originalTag.key !== 'release',
+          onAction: () => {
+            navigateTo(
+              `/organizations/${organization.slug}/releases/${encodeURIComponent(
+                content.value
+              )}/`,
+              router
+            );
+          },
+        },
+        {
+          key: 'transaction',
+          label: t('View this transaction'),
+          hidden: originalTag.key !== 'transaction',
+          onAction: () => {
+            const transactionQuery = qs.stringify({
+              project: event.projectID,
+              transaction: content.value,
+              referrer,
+            });
+            navigateTo(
+              `/organizations/${organization.slug}/performance/summary/?${transactionQuery}`,
+              router
+            );
+          },
+        },
+        {
+          key: 'replay',
+          label: t('View this replay'),
+          hidden: originalTag.key !== 'replay_id' && originalTag.key !== 'replayId',
+          onAction: () => {
+            const replayQuery = qs.stringify({referrer});
+            navigateTo(
+              `/organizations/${organization.slug}/replays/${encodeURIComponent(content.value)}/?${replayQuery}`,
+              router
+            );
+          },
+        },
+        {
+          key: 'external-link',
+          label: t('Visit this external link'),
+          hidden: !isUrl(content.value),
+          onAction: () => {
+            openNavigateToExternalLinkModal({linkText: content.value});
+          },
+        },
+      ]}
+    />
+  );
+}
+
+const TreeRow = styled('div')<{hasErrors: boolean}>`
+  border-radius: ${space(0.5)};
+  padding-left: ${space(1)};
+  position: relative;
+  display: grid;
+  align-items: center;
+  grid-column: span 2;
+  grid-template-columns: subgrid;
+  :nth-child(odd) {
+    background-color: ${p =>
+      p.hasErrors ? p.theme.alert.error.backgroundLight : p.theme.backgroundSecondary};
+  }
+  .invisible {
+    visibility: hidden;
+  }
+  &:hover,
+  &:active {
+    .invisible {
+      visibility: visible;
+    }
+  }
+  color: ${p => (p.hasErrors ? p.theme.alert.error.color : p.theme.subText)};
+  background-color: ${p =>
+    p.hasErrors ? p.theme.alert.error.backgroundLight : p.theme.background};
+  box-shadow: inset 0 0 0 1px
+    ${p => (p.hasErrors ? p.theme.alert.error.border : 'transparent')};
+`;
+
+const TreeSpacer = styled('div')<{isLast: boolean; spacerCount: number}>`
+  grid-column: span 1;
+  /* Allows TreeBranchIcons to appear connected vertically */
+  border-right: 1px solid ${p => (!p.isLast ? p.theme.border : 'transparent')};
+  margin-right: -1px;
+  height: 100%;
+`;
+
+const TreeBranchIcon = styled('div')<{hasErrors: boolean}>`
+  border: 1px solid ${p => (p.hasErrors ? p.theme.alert.error.border : p.theme.border)};
+  border-width: 0 0 1px 1px;
+  border-radius: 0 0 0 5px;
+  grid-column: span 1;
+  height: 12px;
+  align-self: start;
+  margin-right: ${space(0.5)};
+`;
+
+const TreeKeyTrunk = styled('div')<{spacerCount: number}>`
+  grid-column: 1 / 2;
+  display: grid;
+  height: 100%;
+  align-items: center;
+  grid-template-columns: ${p =>
+    p.spacerCount > 0 ? `${(p.spacerCount - 1) * 20 + 3}px 1rem 1fr` : '1fr'};
+`;
+
+const TreeValueTrunk = styled('div')`
+  grid-column: 2 / 3;
+  display: grid;
+  height: 100%;
+  align-items: center;
+  min-height: 22px;
+  grid-template-columns: 1fr auto;
+  grid-column-gap: ${space(0.5)};
+`;
+
+const TreeValue = styled('div')`
+  padding-top: ${space(0.25)};
+  align-self: start;
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSizeSmall};
+  word-break: break-word;
+  grid-column: span 1;
+`;
+
+const TreeKey = styled(TreeValue)<{hasErrors: boolean}>`
+  color: ${p => (p.hasErrors ? 'inherit' : p.theme.gray300)};
+`;
+
+/**
+ * Hidden element to allow browser searching for exact key name
+ */
+const TreeSearchKey = styled('span')`
+  font-size: 0;
+  position: absolute;
+`;
+
+const TreeValueDropdown = styled(DropdownMenu)`
+  margin: 1px;
+  height: 20px;
+  .tag-button {
+    height: 20px;
+    min-height: 20px;
+    padding: ${space(0)} ${space(0.75)};
+    border-radius: ${space(0.5)};
+    z-index: 0;
+  }
+`;
+
+const TreeValueErrors = styled('div')`
+  height: 20px;
+  margin-right: ${space(0.75)};
+`;


### PR DESCRIPTION
This PR allows for event meta to show incorrect values for tags with the new design. Prior to this, we were not surfacing tag errors visually with the tree UI

![image](https://github.com/getsentry/sentry/assets/35509934/850dad78-3d98-479f-9f8b-297fdc0585e6)

It ended up ballooning the `EventTagsTree.tsx` file so I split the rows off to their own file for legibility.

Unfortunately due to https://github.com/getsentry/sentry/issues/68351, the errors aren't actually aligned with the tag raising the issue, but this is due to bad data coming in. Assuming the correct data comes in, this should work fine.

**todo**
- [x] Add tests to ensure error tags have their dropdown replaced with the tooltip
