### PR TITLE
chore(utils): Remove unused `get_login_url` import causing startup crash

### DIFF
--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -8,7 +8,6 @@ from django.http import HttpRequest, HttpResponse
 from django.template import loader
 from django.utils import timezone
 
-from sentry.utils.auth import get_login_url  # NOQA: backwards compatibility
 from sentry.utils.dates import AVAILABLE_TIMEZONES
 
 logger = logging.getLogger("sentry")


### PR DESCRIPTION
[Way back in 2016](https://github.com/getsentry/sentry/pull/4165), a helper function called `get_login_url` was moved from `web/helpers.py` to `utils/auth.py`. At the time, there was a file in `getsentry` which [imported it from the old location](https://github.com/getsentry/getsentry/blob/275888a8e4e5c4950d6d4455fa2ae188b211dd83/getsentry/web/superuser_template.py#L6), and so a reference to it was left in the old spot, in order to preserve backwards compatibility. That old reference was never fixed, but it _was_ removed [about two years later](https://github.com/getsentry/getsentry/pull/2082), and there are now no references to `get_login_url` which point to the old location, [in any of our repos](https://github.com/search?q=org%3Agetsentry%20get_login_url&type=code).  This therefore removes the old reference, since it's no longer needed.

But okay, sure, keeping things tidy is great, but why now, if it's been there not bothering anyone for the last half dozen years? Well, it turns out it's a crash waiting to happen. It goes like this:

- The new home of `get_login_url` imports django's auth model backend, which [looks for a user model](https://github.com/django/django/blob/ca5cd3e3e8e53f15e68ccd727ec8fe719cc48099/django/contrib/auth/backends.py#L5) when it loads.
- The old home (`helpers.py`) imports from the new home.
- If anything tries to import a different helper from `helpers.py` before the `User` model has loaded, django's auth  backend fails in its search and everything crashes.

Up until now, nothing which loads before the `User` model has tried to import any of the other helpers and we've been fine, but that's about to change. As of https://github.com/getsentry/sentry/pull/68360, the import chain that starts with the `GroupAssignee` model (which loads before the `User` model, because #isort) will include a helper from `helpers.py`. In order to prevent that change from breaking the world we need to instead break the import chain, and getting rid of this legacy import is the easiest (and most future-proof) way to do it.

h/t @wedamija for suggesting I look at model loading order, which was the clue I needed to debug this.