### PR TITLE
chore(ddm): remove xfail from tests

### DIFF
--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -154,7 +154,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert results["end"] is None
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail
     def test_query_with_empty_results(self) -> None:
         # TODO: the identities returned here to not make much sense, we need to figure out the right semantics.
         for aggregate, expected_identity_series, expected_identity_totals in (
@@ -528,7 +527,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0][1]["totals"] == self.to_reference_unit(12.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
+    @pytest.mark.xfail
     def test_query_with_group_by_on_null_tag(self) -> None:
         for value, transaction, time in (
             (1, "/hello", self.now()),
@@ -574,7 +573,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(1.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_parenthesized_filter(self) -> None:
         query_1 = self.mql("sum", TransactionMRI.DURATION.value, "(transaction:/hello)", "platform")
         plan = MetricsQueriesPlan().declare_query("query_1", query_1).apply_formula("$query_1")
@@ -609,7 +607,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_and_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:ios AND transaction:/hello", "platform"
@@ -639,7 +636,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[0]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_with_or_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:ios OR platform:android", "platform"
@@ -676,7 +672,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_negated_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "!platform:ios transaction:/hello", "platform"
@@ -706,7 +701,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[0]["totals"] == self.to_reference_unit(3.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_in_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, "platform:[android, ios]", "platform"
@@ -743,7 +737,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[1]["totals"] == self.to_reference_unit(9.0)
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
     def test_query_one_not_in_filter(self) -> None:
         query_1 = self.mql(
             "sum", TransactionMRI.DURATION.value, '!platform:["android", "ios"]', "platform"
@@ -950,8 +943,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert second_meta[0]["order"] == "DESC"
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail(reason="Bug on Snuba that returns the wrong results, removed when fixed")
-    @patch("sentry.sentry_metrics.querying.data_v2.execution.SNUBA_QUERY_LIMIT", 3)
+    @patch("sentry.sentry_metrics.querying.data.execution.SNUBA_QUERY_LIMIT", 3)
     def test_query_with_multiple_aggregations_and_single_group_by_and_dynamic_limit(
         self,
     ) -> None:
@@ -1382,7 +1374,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert first_query[2]["totals"] == 18.0
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
-    @pytest.mark.xfail(reason="this should pass when snuba pr #5676")
     def test_query_with_formula_and_filter(self):
         query_1 = self.mql("count", TransactionMRI.DURATION.value, filters="platform:android")
         query_2 = self.mql("sum", TransactionMRI.DURATION.value, filters="platform:ios")


### PR DESCRIPTION
this pr removes xfails from the tests that were waiting on the optimizer pr.