### PR TITLE
fix(ddm): Cap limit at SNUBA_QUERY_LIMIT

### DIFF
--- a/src/sentry/sentry_metrics/querying/data/execution.py
+++ b/src/sentry/sentry_metrics/querying/data/execution.py
@@ -246,7 +246,7 @@ class ScheduledQuery:
 
         # We want to modify only the limit of the actual query and not the one of the `ScheduledQuery` since we want
         # to keep that as it was supplied by the executor.
-        updated_metrics_query = updated_metrics_query.set_limit(limit)
+        updated_metrics_query = updated_metrics_query.set_limit(min(limit, SNUBA_QUERY_LIMIT))
 
         return updated_metrics_query, dynamic_limit
 

--- a/src/sentry/sentry_metrics/querying/data/execution.py
+++ b/src/sentry/sentry_metrics/querying/data/execution.py
@@ -244,9 +244,10 @@ class ScheduledQuery:
             limit += 1
             dynamic_limit = True
 
-        # We want to modify only the limit of the actual query and not the one of the `ScheduledQuery` since we want
-        # to keep that as it was supplied by the executor.
-        updated_metrics_query = updated_metrics_query.set_limit(min(limit, SNUBA_QUERY_LIMIT))
+        if limit is not None:
+            # We want to modify only the limit of the actual query and not the one of the `ScheduledQuery` since we want
+            # to keep that as it was supplied by the executor.
+            updated_metrics_query = updated_metrics_query.set_limit(min(limit, SNUBA_QUERY_LIMIT))
 
         return updated_metrics_query, dynamic_limit
 


### PR DESCRIPTION
This PR caps the limit of the totals query at the `SNUBA_QUERY_LIMIT` since otherwise the layer will throw an error and we prefer to do our best effort when querying for data.

Closes: https://github.com/getsentry/sentry/issues/68403