### PR TITLE
Fully enable `reprocessing-v2` (frontend) and update logic showing "Reprocess Event" action

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.tsx
@@ -257,7 +257,7 @@ export function DebugImageDetails({
   );
   const hasReprocessWarning =
     haveCandidatesUnappliedDebugFile &&
-    displayReprocessEventAction(organization.features, event) &&
+    displayReprocessEventAction(event) &&
     !!onReprocessEvent;
 
   if (isError) {

--- a/static/app/components/modals/reprocessEventModal.spec.tsx
+++ b/static/app/components/modals/reprocessEventModal.spec.tsx
@@ -24,7 +24,6 @@ describe('ReprocessEventModal', function () {
       organization: {
         id: '4660',
         slug: 'org',
-        features: ['reprocessing-v2'],
       },
     });
 
@@ -73,7 +72,6 @@ describe('ReprocessEventModal', function () {
       organization: {
         id: '4660',
         slug: 'org',
-        features: ['reprocessing-v2'],
       },
     });
 

--- a/static/app/utils/displayReprocessEventAction.spec.tsx
+++ b/static/app/utils/displayReprocessEventAction.spec.tsx
@@ -6,25 +6,18 @@ import {
 import {displayReprocessEventAction} from 'sentry/utils/displayReprocessEventAction';
 
 describe('DisplayReprocessEventAction', function () {
-  const orgFeatures = ['reprocessing-v2'];
-
-  it('returns false in case of no reprocessing-v2 feature', function () {
-    const event = EventStacktraceMessageFixture();
-    expect(displayReprocessEventAction([], event)).toBe(false);
-  });
-
   it('returns false in case of no event', function () {
-    expect(displayReprocessEventAction(orgFeatures)).toBe(false);
+    expect(displayReprocessEventAction()).toBe(false);
   });
 
   it('returns false if no exception entry is found', function () {
     const event = EventStacktraceMessageFixture();
-    expect(displayReprocessEventAction(orgFeatures, event)).toBe(false);
+    expect(displayReprocessEventAction(event)).toBe(false);
   });
 
   it('returns false if the event is not a mini-dump event or an Apple crash report event or a Native event', function () {
     const event = EventStacktraceExceptionFixture();
-    expect(displayReprocessEventAction(orgFeatures, event)).toBe(false);
+    expect(displayReprocessEventAction(event)).toBe(false);
   });
 
   describe('returns true', function () {
@@ -35,7 +28,7 @@ describe('DisplayReprocessEventAction', function () {
             platform: 'native',
           });
 
-          expect(displayReprocessEventAction(orgFeatures, event)).toBe(true);
+          expect(displayReprocessEventAction(event)).toBe(true);
         });
 
         it('cocoa', function () {
@@ -43,7 +36,7 @@ describe('DisplayReprocessEventAction', function () {
             platform: 'cocoa',
           });
 
-          expect(displayReprocessEventAction(orgFeatures, event)).toBe(true);
+          expect(displayReprocessEventAction(event)).toBe(true);
         });
       });
 
@@ -55,7 +48,7 @@ describe('DisplayReprocessEventAction', function () {
 
           event.entries[0].data.values[0].stacktrace.frames[0].platform = 'native';
 
-          expect(displayReprocessEventAction(orgFeatures, event)).toBe(true);
+          expect(displayReprocessEventAction(event)).toBe(true);
         });
 
         it('cocoa', function () {
@@ -65,7 +58,7 @@ describe('DisplayReprocessEventAction', function () {
 
           event.entries[0].data.values[0].stacktrace.frames[0].platform = 'cocoa';
 
-          expect(displayReprocessEventAction(orgFeatures, event)).toBe(true);
+          expect(displayReprocessEventAction(event)).toBe(true);
         });
       });
     });
@@ -82,7 +75,7 @@ describe('DisplayReprocessEventAction', function () {
         },
       };
 
-      expect(displayReprocessEventAction(orgFeatures, event)).toBe(true);
+      expect(displayReprocessEventAction(event)).toBe(true);
     });
 
     it('apple crash report event', function () {
@@ -97,7 +90,7 @@ describe('DisplayReprocessEventAction', function () {
         },
       };
 
-      expect(displayReprocessEventAction(orgFeatures, event)).toBe(true);
+      expect(displayReprocessEventAction(event)).toBe(true);
     });
   });
 });

--- a/static/app/utils/displayReprocessEventAction.tsx
+++ b/static/app/utils/displayReprocessEventAction.tsx
@@ -8,106 +8,134 @@ import type {
 } from 'sentry/types';
 import {EntryType} from 'sentry/types/event';
 
-const NATIVE_PLATFORMS: PlatformKey[] = ['cocoa', 'native'];
+/** All platforms that always use Debug Files. */
+const DEBUG_FILE_PLATFORMS: Set<PlatformKey> = new Set([
+  'objc',
+  'cocoa',
+  'swift',
+  'native',
+  'c',
+]);
+/** Other platforms that may use Debug Files. */
+const MAYBE_DEBUG_FILE_PLATFORMS: Set<PlatformKey> = new Set(['csharp', 'java']);
 
-// Finds all frames in a given data blob and returns it's platforms
-function getPlatforms(exceptionValue: ExceptionValue | StacktraceType | null) {
-  const frames = exceptionValue?.frames ?? [];
-  const stacktraceFrames = (exceptionValue as ExceptionValue)?.stacktrace?.frames ?? [];
-
-  if (!frames.length && !stacktraceFrames.length) {
-    return [];
-  }
-
-  return [...frames, ...stacktraceFrames]
-    .map(frame => frame.platform)
-    .filter(platform => !!platform);
-}
-
-function getStackTracePlatforms(event: Event, exceptionEntry: EntryException) {
-  // Fetch platforms in stack traces of an exception entry
-  const exceptionEntryPlatforms = (exceptionEntry.data.values ?? []).flatMap(
-    getPlatforms
-  );
-
-  // Fetch platforms in an exception entry
-  const stackTraceEntry = (event.entries.find(
-    entry => entry.type === EntryType.STACKTRACE
-  )?.data ?? {}) as StacktraceType;
-
-  // Fetch platforms in an exception entry
-  const stackTraceEntryPlatforms = Object.keys(stackTraceEntry).flatMap(key =>
-    getPlatforms(stackTraceEntry[key])
-  );
-
-  // Fetch platforms in an thread entry
-  const threadEntry = (event.entries.find(entry => entry.type === EntryType.THREADS)?.data
-    .values ?? []) as Array<Thread>;
-
-  // Fetch platforms in a thread entry
-  const threadEntryPlatforms = threadEntry.flatMap(({stacktrace}) =>
-    getPlatforms(stacktrace)
-  );
-
-  return new Set([
-    ...exceptionEntryPlatforms,
-    ...stackTraceEntryPlatforms,
-    ...threadEntryPlatforms,
-  ]);
-}
-
-// Checks whether an event indicates that it is a native event.
-function isNativeEvent(event: Event, exceptionEntry: EntryException) {
-  const {platform} = event;
-
-  if (platform && NATIVE_PLATFORMS.includes(platform)) {
-    return true;
-  }
-
-  const stackTracePlatforms = getStackTracePlatforms(event, exceptionEntry);
-
-  return NATIVE_PLATFORMS.some(nativePlatform => stackTracePlatforms.has(nativePlatform));
-}
-
-//  Checks whether an event indicates that it has an associated minidump.
-function isMinidumpEvent(exceptionEntry: EntryException) {
-  const {data} = exceptionEntry;
-  return (data.values ?? []).some(value => value.mechanism?.type === 'minidump');
-}
-
-// Checks whether an event indicates that it has an apple crash report.
-function isAppleCrashReportEvent(exceptionEntry: EntryException) {
-  const {data} = exceptionEntry;
-  return (data.values ?? []).some(value => value.mechanism?.type === 'applecrashreport');
-}
-
-export function displayReprocessEventAction(orgFeatures: Array<string>, event?: Event) {
-  if (!event || !orgFeatures.includes('reprocessing-v2')) {
+/**
+ * Returns whether to display the "Reprocess Event" action.
+ *
+ * That is the case when we have a "reprocessable" event, which is an event that needs
+ * Debug Files for proper processing, as those Debug Files could have been uploaded *after*
+ * the Event was ingested.
+ */
+export function displayReprocessEventAction(event?: Event): boolean {
+  if (!event) {
     return false;
   }
 
-  const {entries} = event;
-  const exceptionEntry = entries.find(entry => entry.type === EntryType.EXCEPTION) as
-    | EntryException
-    | undefined;
+  const eventPlatforms = getEventPlatform(event);
+  // Check Events from platforms that always use Debug Files as a fast-path
+  if (hasIntersection(eventPlatforms, DEBUG_FILE_PLATFORMS)) {
+    return true;
+  }
+
+  const hasDebugImages = (event?.entries ?? []).some(
+    entry => entry.type === EntryType.DEBUGMETA && entry.data.images.length > 0
+  );
+
+  // Otherwise, check alternative platforms if they actually have Debug Files
+  if (hasIntersection(eventPlatforms, MAYBE_DEBUG_FILE_PLATFORMS) && hasDebugImages) {
+    return true;
+  }
+
+  // Finally, fall back to checking the `platform` of each frame
+  const exceptionEntry = event.entries.find(
+    entry => entry.type === EntryType.EXCEPTION
+  ) as EntryException | undefined;
 
   if (!exceptionEntry) {
     return false;
   }
 
-  // We want to show the reprocessing button if the issue in question is native or contains native frames.
-  // The logic is taken from the symbolication pipeline in Python, where it is used to determine whether reprocessing
-  // payloads should be stored:
-  // https://github.com/getsentry/sentry/blob/cb7baef414890336881d67b7a8433ee47198c701/src/sentry/lang/native/processing.py#L425-L426
-  // It is still not ideal as one can always merge native and non-native events together into one issue,
-  // but it's the best approximation we have.
-  if (
-    !isMinidumpEvent(exceptionEntry) &&
-    !isAppleCrashReportEvent(exceptionEntry) &&
-    !isNativeEvent(event, exceptionEntry)
-  ) {
-    return false;
-  }
+  return hasIntersection(
+    getStackTracePlatforms(event, exceptionEntry),
+    DEBUG_FILE_PLATFORMS
+  );
+}
 
-  return true;
+/**
+ * Returns whether the two Sets have intersecting elements.
+ */
+function hasIntersection<T>(set1: Set<T>, set2: Set<T>): boolean {
+  for (const v of set1) {
+    if (set2.has(v)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns the event platform as a Set.
+ */
+function getEventPlatform(event: Event): Set<PlatformKey> {
+  const platforms = new Set<PlatformKey>();
+  addPlatforms(platforms, [event]);
+  return platforms;
+}
+
+/**
+ * Returns a Set of all platforms found in the `event` and `exceptionEntry`.
+ */
+function getStackTracePlatforms(
+  event: Event,
+  exceptionEntry: EntryException
+): Set<PlatformKey> {
+  const platforms = new Set<PlatformKey>();
+
+  // Add platforms in stack traces of an exception entry
+  (exceptionEntry.data.values ?? []).forEach(exc => addFramePlatforms(platforms, exc));
+
+  // Add platforms in a stack trace entry
+  const stackTraceEntry = (event.entries.find(
+    entry => entry.type === EntryType.STACKTRACE
+  )?.data ?? {}) as StacktraceType;
+
+  Object.keys(stackTraceEntry).forEach(key =>
+    addFramePlatforms(platforms, stackTraceEntry[key])
+  );
+
+  // Add platforms in a thread entry
+  const threadEntry = (event.entries.find(entry => entry.type === EntryType.THREADS)?.data
+    .values ?? []) as Array<Thread>;
+
+  threadEntry.forEach(({stacktrace}) => addFramePlatforms(platforms, stacktrace));
+
+  return platforms;
+}
+
+/**
+ * Adds all the platforms in the frames of `exceptionValue` to the `platforms` Set.
+ */
+function addFramePlatforms(
+  platforms: Set<PlatformKey>,
+  exceptionValue: ExceptionValue | StacktraceType | null
+) {
+  const frames = exceptionValue?.frames ?? [];
+  const stacktraceFrames = (exceptionValue as ExceptionValue)?.stacktrace?.frames ?? [];
+
+  addPlatforms(platforms, frames);
+  addPlatforms(platforms, stacktraceFrames);
+}
+
+/**
+ * Adds all the `platform` properties found in `iter` to the `platforms` Set.
+ */
+function addPlatforms(
+  platforms: Set<PlatformKey>,
+  iter: Array<{platform?: PlatformKey | null}>
+) {
+  for (const o of iter) {
+    if (o.platform) {
+      platforms.add(o.platform);
+    }
+  }
 }

--- a/static/app/views/issueDetails/actions/index.spec.tsx
+++ b/static/app/views/issueDetails/actions/index.spec.tsx
@@ -37,7 +37,6 @@ const group = GroupFixture({
 const organization = OrganizationFixture({
   id: '4660',
   slug: 'org',
-  features: ['reprocessing-v2'],
 });
 
 describe('GroupActions', function () {
@@ -132,7 +131,7 @@ describe('GroupActions', function () {
   });
 
   describe('reprocessing', function () {
-    it('renders ReprocessAction component if org has feature flag reprocessing-v2 and native exception event', async function () {
+    it('renders ReprocessAction component if org has native exception event', async function () {
       const event = EventStacktraceExceptionFixture({
         platform: 'native',
       });

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -412,7 +412,7 @@ export function Actions(props: Props) {
           {
             key: 'reprocess',
             label: t('Reprocess events'),
-            hidden: !displayReprocessEventAction(organization.features, event),
+            hidden: !displayReprocessEventAction(event),
             onAction: onReprocessEvent,
           },
           {

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -161,24 +161,21 @@ function getReprocessingNewRoute({
   const {routes, params, location} = router;
   const {groupId} = params;
   const {currentTab, baseUrl} = getCurrentRouteInfo({group, event, organization, router});
-  const hasReprocessingV2Feature = organization.features?.includes('reprocessing-v2');
 
   const {id: nextGroupId} = group;
 
   const reprocessingStatus = getGroupReprocessingStatus(group);
 
   if (groupId !== nextGroupId) {
-    if (hasReprocessingV2Feature) {
-      // Redirects to the Activities tab
-      if (
-        reprocessingStatus === ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT &&
-        currentTab !== Tab.ACTIVITY
-      ) {
-        return {
-          pathname: `${baseUrl}${Tab.ACTIVITY}/`,
-          query: {...params, groupId: nextGroupId},
-        };
-      }
+    // Redirects to the Activities tab
+    if (
+      reprocessingStatus === ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT &&
+      currentTab !== Tab.ACTIVITY
+    ) {
+      return {
+        pathname: `${baseUrl}${Tab.ACTIVITY}/`,
+        query: {...params, groupId: nextGroupId},
+      };
     }
 
     return recreateRoute('', {
@@ -188,48 +185,40 @@ function getReprocessingNewRoute({
     });
   }
 
-  if (hasReprocessingV2Feature) {
-    if (
-      reprocessingStatus === ReprocessingStatus.REPROCESSING &&
-      currentTab !== Tab.DETAILS
-    ) {
-      return {
-        pathname: baseUrl,
-        query: params,
-      };
-    }
-
-    if (
-      reprocessingStatus === ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT &&
-      currentTab !== Tab.ACTIVITY &&
-      currentTab !== Tab.USER_FEEDBACK
-    ) {
-      return {
-        pathname: `${baseUrl}${Tab.ACTIVITY}/`,
-        query: params,
-      };
-    }
+  if (
+    reprocessingStatus === ReprocessingStatus.REPROCESSING &&
+    currentTab !== Tab.DETAILS
+  ) {
+    return {
+      pathname: baseUrl,
+      query: params,
+    };
   }
+
+  if (
+    reprocessingStatus === ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT &&
+    currentTab !== Tab.ACTIVITY &&
+    currentTab !== Tab.USER_FEEDBACK
+  ) {
+    return {
+      pathname: `${baseUrl}${Tab.ACTIVITY}/`,
+      query: params,
+    };
+  }
+
   return undefined;
 }
 
 function useRefetchGroupForReprocessing({
   refetchGroup,
 }: Pick<FetchGroupDetailsState, 'refetchGroup'>) {
-  const organization = useOrganization();
-  const hasReprocessingV2Feature = organization.features?.includes('reprocessing-v2');
-
   useEffect(() => {
-    let refetchInterval: number;
-
-    if (hasReprocessingV2Feature) {
-      refetchInterval = window.setInterval(refetchGroup, 30000);
-    }
+    const refetchInterval = window.setInterval(refetchGroup, 30000);
 
     return () => {
       window.clearInterval(refetchInterval);
     };
-  }, [hasReprocessingV2Feature, refetchGroup]);
+  }, [refetchGroup]);
 }
 
 function useEventApiQuery({

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.tsx
@@ -70,8 +70,6 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
     eventError,
     params,
   } = props;
-  // Reprocessing
-  const hasReprocessingV2Feature = organization.features?.includes('reprocessing-v2');
   const projectId = project.id;
   const environments = useEnvironmentsFromUrl();
   const prevEnvironment = usePrevious(environments);
@@ -174,8 +172,7 @@ function GroupEventDetails(props: GroupEventDetailsProps) {
         isLoading={loadingEvent}
       >
         <StyledLayoutBody data-test-id="group-event-details">
-          {hasReprocessingV2Feature &&
-          groupReprocessingStatus === ReprocessingStatus.REPROCESSING ? (
+          {groupReprocessingStatus === ReprocessingStatus.REPROCESSING ? (
             <ReprocessingProgress
               totalEvents={
                 (getGroupMostRecentActivity(group.activity) as GroupActivityReprocess)

--- a/static/app/views/issueDetails/header.tsx
+++ b/static/app/views/issueDetails/header.tsx
@@ -173,12 +173,6 @@ function GroupHeader({
   const location = useLocation();
 
   const disabledTabs = useMemo(() => {
-    const hasReprocessingV2Feature = organization.features.includes('reprocessing-v2');
-
-    if (!hasReprocessingV2Feature) {
-      return [];
-    }
-
     if (groupReprocessingStatus === ReprocessingStatus.REPROCESSING) {
       return [
         Tab.ACTIVITY,
@@ -204,7 +198,7 @@ function GroupHeader({
     }
 
     return [];
-  }, [organization, groupReprocessingStatus]);
+  }, [groupReprocessingStatus]);
 
   const eventRoute = useMemo(() => {
     const searchTermWithoutQuery = omit(location.query, 'query');

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -960,13 +960,7 @@ class IssueListOverview extends Component<Props, State> {
   };
 
   displayReprocessingTab() {
-    const {organization} = this.props;
-    const {queryCounts} = this.state;
-
-    return (
-      organization.features.includes('reprocessing-v2') &&
-      !!queryCounts?.[Query.REPROCESSING]?.count
-    );
+    return !!this.state.queryCounts?.[Query.REPROCESSING]?.count;
   }
 
   displayReprocessingLayout(showReprocessingTab: boolean, query: string) {

--- a/static/app/views/issueList/utils.spec.tsx
+++ b/static/app/views/issueList/utils.spec.tsx
@@ -13,6 +13,7 @@ describe('getTabs', () => {
       ['is:regressed', expect.objectContaining({name: 'Regressed'})],
       ['is:escalating', expect.objectContaining({name: 'Escalating'})],
       ['is:archived', expect.objectContaining({name: 'Archived'})],
+      ['is:reprocessing', expect.objectContaining({name: 'Reprocessing'})],
     ]);
   });
 

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -124,7 +124,7 @@ export function getTabs(organization: Organization) {
         name: t('Reprocessing'),
         analyticsName: 'reprocessing',
         count: true,
-        enabled: organization.features.includes('reprocessing-v2'),
+        enabled: true,
         tooltipTitle: tct(
           `These [link:reprocessing issues] will take some time to complete.
         Any new issues that are created during reprocessing will be flagged for review.`,


### PR DESCRIPTION
This fully enables the feature by simply removing all the checks and early returns for the feature flag.

The logic to show the "Reprocess Event" action was updated so that all kinds of events that have debug files are eligible for reprocessing.