### PR TITLE
fix(perf): Improve Span Samples Table hover state

### DIFF
--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -89,18 +89,6 @@ export function SpanSamplesTable({
   const location = useLocation();
   const organization = useOrganization();
 
-  function handleMouseOverBodyCell(row: SpanTableRow) {
-    if (onMouseOverSample) {
-      onMouseOverSample(row);
-    }
-  }
-
-  function handleMouseLeave() {
-    if (onMouseLeaveSample) {
-      onMouseLeaveSample();
-    }
-  }
-
   function renderHeadCell(column: GridColumnHeader): React.ReactNode {
     if (
       column.key === 'p95_comparison' ||
@@ -118,10 +106,6 @@ export function SpanSamplesTable({
   }
 
   function renderBodyCell(column: GridColumnHeader, row: SpanTableRow): React.ReactNode {
-    const commonProps = {
-      onMouseEnter: () => handleMouseOverBodyCell(row),
-    };
-
     if (column.key === 'span_id') {
       return (
         <Link
@@ -140,7 +124,6 @@ export function SpanSamplesTable({
             },
             spanId: row.span_id,
           })}
-          {...commonProps}
         >
           {row.span_id}
         </Link>
@@ -151,6 +134,7 @@ export function SpanSamplesTable({
       const size = parseInt(row[HTTP_RESPONSE_CONTENT_LENGTH], 10);
       return <ResourceSizeCell bytes={size} />;
     }
+
     if (column.key === 'profile_id') {
       return (
         <IconWrapper>
@@ -166,46 +150,43 @@ export function SpanSamplesTable({
               </LinkButton>
             </Tooltip>
           ) : (
-            <div {...commonProps}>(no value)</div>
+            <div>(no value)</div>
           )}
         </IconWrapper>
       );
     }
 
     if (column.key === 'duration') {
-      return (
-        <DurationCell containerProps={commonProps} milliseconds={row['span.self_time']} />
-      );
+      return <DurationCell milliseconds={row['span.self_time']} />;
     }
 
     if (column.key === 'avg_comparison') {
       return (
         <DurationComparisonCell
-          containerProps={commonProps}
           duration={row['span.self_time']}
           compareToDuration={avg}
         />
       );
     }
 
-    return <span {...commonProps}>{row[column.key]}</span>;
+    return <span>{row[column.key]}</span>;
   }
 
   return (
-    <div onMouseLeave={handleMouseLeave}>
-      <GridEditable
-        isLoading={isLoading}
-        data={data}
-        columnOrder={columnOrder ?? DEFAULT_COLUMN_ORDER}
-        columnSortBy={[]}
-        highlightedRowKey={data.findIndex(sample => sample.span_id === highlightedSpanId)}
-        grid={{
-          renderHeadCell,
-          renderBodyCell,
-        }}
-        location={location}
-      />
-    </div>
+    <GridEditable
+      isLoading={isLoading}
+      data={data}
+      columnOrder={columnOrder ?? DEFAULT_COLUMN_ORDER}
+      columnSortBy={[]}
+      onRowMouseOver={onMouseOverSample}
+      onRowMouseOut={onMouseLeaveSample}
+      highlightedRowKey={data.findIndex(sample => sample.span_id === highlightedSpanId)}
+      grid={{
+        renderHeadCell,
+        renderBodyCell,
+      }}
+      location={location}
+    />
   );
 }
 

--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {Link} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -119,10 +118,7 @@ export function SpanSamplesTable({
   }
 
   function renderBodyCell(column: GridColumnHeader, row: SpanTableRow): React.ReactNode {
-    const shouldHighlight = row.span_id === highlightedSpanId;
-
     const commonProps = {
-      style: (shouldHighlight ? {fontWeight: 'bold'} : {}) satisfies CSSProperties,
       onMouseEnter: () => handleMouseOverBodyCell(row),
     };
 
@@ -202,6 +198,7 @@ export function SpanSamplesTable({
         data={data}
         columnOrder={columnOrder ?? DEFAULT_COLUMN_ORDER}
         columnSortBy={[]}
+        highlightedRowKey={data.findIndex(sample => sample.span_id === highlightedSpanId)}
         grid={{
           renderHeadCell,
           renderBodyCell,


### PR DESCRIPTION
Now that `GridEditable` supports buit-in row hover callback props _and_ a highlighted row prop, we can improve `SpanSamplesTable` to use those.

- Use built-in `GridEditable` row highlighting
- Use built-in `GridEditable` row hover props

**Before:**
<img width="601" alt="Screenshot 2024-04-08 at 8 30 44 AM" src="https://github.com/getsentry/sentry/assets/989898/fbf29c18-7d11-4fbc-9125-262599759a6c">

**After:**
<img width="584" alt="Screenshot 2024-04-08 at 8 32 25 AM" src="https://github.com/getsentry/sentry/assets/989898/eed103c5-0def-4008-960b-45c29332eaf1">
