### PR TITLE
feat(perf): Plot HTTP module span samples

### DIFF
--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -30,6 +30,8 @@ export type Series = {
   markLine?: LineSeriesOption['markLine'];
   stack?: string;
   // https://echarts.apache.org/en/option.html#series-line.stack
+  symbol?: LineSeriesOption['symbol'];
+  symbolSize?: LineSeriesOption['symbolSize'];
   z?: number;
 };
 

--- a/static/app/views/performance/http/durationChart.tsx
+++ b/static/app/views/performance/http/durationChart.tsx
@@ -1,3 +1,5 @@
+import type {PropsOf} from '@emotion/react';
+
 import type {Series} from 'sentry/types/echarts';
 import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
 import {AVG_COLOR} from 'sentry/views/starfish/colours';
@@ -9,9 +11,10 @@ interface Props {
   isLoading: boolean;
   series: Series[];
   error?: Error | null;
+  scatterPlot?: PropsOf<typeof Chart>['scatterPlot'];
 }
 
-export function DurationChart({series, isLoading, error}: Props) {
+export function DurationChart({series, scatterPlot, isLoading, error}: Props) {
   return (
     <ChartPanel title={getDurationChartTitle('http')}>
       <Chart
@@ -23,6 +26,7 @@ export function DurationChart({series, isLoading, error}: Props) {
           bottom: '0',
         }}
         data={series}
+        scatterPlot={scatterPlot}
         loading={isLoading}
         error={error}
         chartColors={[AVG_COLOR]}

--- a/static/app/views/performance/http/durationChart.tsx
+++ b/static/app/views/performance/http/durationChart.tsx
@@ -1,4 +1,4 @@
-import type {PropsOf} from '@emotion/react';
+import type {ComponentProps} from 'react';
 
 import type {Series} from 'sentry/types/echarts';
 import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
@@ -11,7 +11,7 @@ interface Props {
   isLoading: boolean;
   series: Series[];
   error?: Error | null;
-  scatterPlot?: PropsOf<typeof Chart>['scatterPlot'];
+  scatterPlot?: ComponentProps<typeof Chart>['scatterPlot'];
 }
 
 export function DurationChart({series, scatterPlot, isLoading, error}: Props) {

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -38,6 +38,7 @@ import {
   type SpanMetricsQueryFilters,
 } from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
+import {useSampleScatterPlotSeries} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries';
 
 export function HTTPSamplesPanel() {
   const router = useRouter();
@@ -142,6 +143,11 @@ export function HTTPSamplesPanel() {
     enabled: query.panel === 'duration' && durationAxisMax > 0,
     referrer: 'api.starfish.http-module-samples-panel-samples',
   });
+
+  const sampledSpanDataSeries = useSampleScatterPlotSeries(
+    samplesData,
+    domainTransactionMetrics?.[0]?.['avg(span.self_time)']
+  );
 
   const handleClose = () => {
     router.replace({
@@ -277,6 +283,7 @@ export function HTTPSamplesPanel() {
                       markLine: AverageValueMarkLine(),
                     },
                   ]}
+                  scatterPlot={sampledSpanDataSeries}
                   isLoading={isDurationDataFetching}
                   error={durationError}
                 />

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/getSampleChartSymbol.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/getSampleChartSymbol.tsx
@@ -1,0 +1,31 @@
+import type {Theme} from '@emotion/react';
+
+import {isNearAverage as areAlmostEqual} from 'sentry/views/starfish/components/samplesTable/common';
+import {
+  crossIconPath,
+  downwardPlayIconPath,
+  upwardPlayIconPath,
+} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/symbol';
+
+export function getSampleChartSymbol(
+  value: number,
+  baseline: number,
+  theme: Theme
+): {color: string; symbol: string} {
+  if (areAlmostEqual(value, baseline)) {
+    return {
+      symbol: crossIconPath,
+      color: theme.gray500,
+    };
+  }
+
+  return value > baseline
+    ? {
+        symbol: upwardPlayIconPath,
+        color: theme.red300,
+      }
+    : {
+        symbol: downwardPlayIconPath,
+        color: theme.green300,
+      };
+}

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -1,4 +1,3 @@
-import type {Theme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
 
 import {t} from 'sentry/locale';
@@ -14,18 +13,13 @@ import {AverageValueMarkLine} from 'sentry/views/performance/charts/averageValue
 import {AVG_COLOR} from 'sentry/views/starfish/colours';
 import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
-import {isNearAverage} from 'sentry/views/starfish/components/samplesTable/common';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import type {SpanSample} from 'sentry/views/starfish/queries/useSpanSamples';
 import {useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
 import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {
-  crossIconPath,
-  downwardPlayIconPath,
-  upwardPlayIconPath,
-} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/symbol';
+import {getSampleChartSymbol} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/getSampleChartSymbol';
 
 const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 
@@ -44,29 +38,6 @@ type Props = {
   spanDescription?: string;
   transactionMethod?: string;
 };
-
-export function getSampleSymbol(
-  duration: number,
-  compareToDuration: number,
-  theme: Theme
-): {color: string; symbol: string} {
-  if (isNearAverage(duration, compareToDuration)) {
-    return {
-      symbol: crossIconPath,
-      color: theme.gray500,
-    };
-  }
-
-  return duration > compareToDuration
-    ? {
-        symbol: upwardPlayIconPath,
-        color: theme.red300,
-      }
-    : {
-        symbol: downwardPlayIconPath,
-        color: theme.green300,
-      };
-}
 
 function DurationChart({
   groupId,
@@ -155,7 +126,7 @@ function DurationChart({
       'transaction.id': transaction_id,
       span_id,
     }) => {
-      const {symbol, color} = getSampleSymbol(duration, avg, theme);
+      const {symbol, color} = getSampleChartSymbol(duration, avg, theme);
       return {
         data: [
           {

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -1,5 +1,3 @@
-import {useTheme} from '@emotion/react';
-
 import {t} from 'sentry/locale';
 import type {
   EChartClickHandler,
@@ -19,7 +17,7 @@ import type {SpanSample} from 'sentry/views/starfish/queries/useSpanSamples';
 import {useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
 import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {getSampleChartSymbol} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/getSampleChartSymbol';
+import {useSampleScatterPlotSeries} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries';
 
 const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 
@@ -53,7 +51,6 @@ function DurationChart({
   platform,
   additionalFilters,
 }: Props) {
-  const theme = useTheme();
   const {setPageError} = usePageAlert();
   const pageFilter = usePageFilters();
 
@@ -119,28 +116,7 @@ function DurationChart({
     }),
   };
 
-  const sampledSpanDataSeries: Series[] = spans.map(
-    ({
-      timestamp,
-      [SPAN_SELF_TIME]: duration,
-      'transaction.id': transaction_id,
-      span_id,
-    }) => {
-      const {symbol, color} = getSampleChartSymbol(duration, avg, theme);
-      return {
-        data: [
-          {
-            name: timestamp,
-            value: duration,
-          },
-        ],
-        symbol,
-        color,
-        symbolSize: span_id === highlightedSpanId ? 19 : 14,
-        seriesName: transaction_id.substring(0, 8),
-      };
-    }
-  );
+  const sampledSpanDataSeries = useSampleScatterPlotSeries(spans, avg, highlightedSpanId);
 
   const getSample = (timestamp: string, duration: number) => {
     return spans.find(s => s.timestamp === timestamp && s[SPAN_SELF_TIME] === duration);

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/useSampleScatterPlotSeries.tsx
@@ -1,0 +1,43 @@
+import {useTheme} from '@emotion/react';
+
+import {t} from 'sentry/locale';
+import type {Series} from 'sentry/types/echarts';
+import {defined} from 'sentry/utils';
+import {AVG_COLOR} from 'sentry/views/starfish/colours';
+import type {IndexedResponse} from 'sentry/views/starfish/types';
+import {getSampleChartSymbol} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/getSampleChartSymbol';
+
+/** Given an array of indexed spans, create a `Series` for each one, and set the correct styling based on how it compares to the average value. This is a hack, in which our `Chart` component doesn't work otherwise. The right solution would be to create a single series of `type: "scatter"` but that doesn' work with the current implementation */
+export function useSampleScatterPlotSeries(
+  spans: Partial<IndexedResponse>[],
+  average?: number,
+  highlightedSpanId?: string
+): Series[] {
+  const theme = useTheme();
+
+  return spans.map(span => {
+    let symbol, color;
+
+    if (span['span.self_time'] && defined(average)) {
+      ({symbol, color} = getSampleChartSymbol(span['span.self_time'], average, theme));
+    } else {
+      symbol = 'circle';
+      color = AVG_COLOR;
+    }
+
+    const series: Series = {
+      data: [
+        {
+          name: span?.timestamp ?? span.span_id ?? t('Span'),
+          value: span?.['span.self_time'] ?? 0,
+        },
+      ],
+      symbol,
+      color,
+      symbolSize: span?.span_id === highlightedSpanId ? 19 : 14,
+      seriesName: span?.['transaction.id']?.substring(0, 8) ?? t('Sample'),
+    };
+
+    return series;
+  });
+}

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -6,7 +6,6 @@ import * as qs from 'query-string';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Button} from 'sentry/components/button';
-import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval} from 'sentry/components/charts/utils';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
@@ -49,7 +48,7 @@ import {useRoutingContext} from 'sentry/views/starfish/utils/routingContext';
 import {useEventsStatsQuery} from 'sentry/views/starfish/utils/useEventsStatsQuery';
 import SpansTable from 'sentry/views/starfish/views/spans/spansTable';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
-import {getSampleSymbol} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
+import {getSampleChartSymbol} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart/getSampleChartSymbol';
 import IssuesTable from 'sentry/views/starfish/views/webServiceView/endpointOverview/issuesTable';
 import {SpanGroupBreakdownContainer} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
@@ -358,7 +357,7 @@ export default function EndpointOverview() {
   );
   const sampleData: Series[] = data.map(
     ({timestamp, 'transaction.duration': duration, id}) => {
-      const {symbol, color} = getSampleSymbol(
+      const {symbol, color} = getSampleChartSymbol(
         duration,
         aggregatesData?.['avg(transaction.duration)'],
         theme


### PR DESCRIPTION
Plots the samples from the table onto the duration chart, like other modules. I had to do a bit of light refactoring first, extracting a few functions and making them a bit more generic.

- Update `Series` type to add a few undocumented features
- Extract `getSampleChartSymbol` into a helper
- Extract `useSampleScatterPlotSeries` into a hook
- Add `scatterPlot` support to `DurationChart` to delegate to `Chart`
- Plot samples on duration chart

**e.g.,**
<img width="590" alt="Screenshot 2024-04-08 at 8 40 19 AM" src="https://github.com/getsentry/sentry/assets/989898/7aadb38c-00dc-4546-9184-30ad52727670">
