### PR TITLE
feat(ui): support formatting negative numbers

### DIFF
--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -223,16 +223,24 @@ describe('formatAbbreviatedNumber()', function () {
     expect(formatAbbreviatedNumber(11911)).toBe('11k');
   });
 
-  it('should round to set amount of significant digits', () => {
+  it('should round to set amount of significant digits', function () {
     expect(formatAbbreviatedNumber(100.12, 3)).toBe('100');
     expect(formatAbbreviatedNumber(199.99, 3)).toBe('200');
     expect(formatAbbreviatedNumber(1500, 3)).toBe('1.5k');
     expect(formatAbbreviatedNumber(1213122, 3)).toBe('1.21m');
+    expect(formatAbbreviatedNumber(-1213122, 3)).toBe('-1.21m');
     expect(formatAbbreviatedNumber(1500000000000, 3)).toBe('1500b');
 
     expect(formatAbbreviatedNumber('1249.23421', 3)).toBe('1.25k');
     expect(formatAbbreviatedNumber('1239567891299', 3)).toBe('1240b');
     expect(formatAbbreviatedNumber('158.80421626984128', 3)).toBe('159');
+  });
+
+  it('should format negative numbers', function () {
+    expect(formatAbbreviatedNumber(-100)).toBe('-100');
+    expect(formatAbbreviatedNumber(-1095)).toBe('-1k');
+    expect(formatAbbreviatedNumber(-10000000)).toBe('-10m');
+    expect(formatAbbreviatedNumber(-1000000000000)).toBe('-1000b');
   });
 });
 

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -404,10 +404,13 @@ export function formatAbbreviatedNumber(
 ): string {
   number = Number(number);
 
+  const prefix = number < 0 ? '-' : '';
+  const numAbsValue = Math.abs(number);
+
   for (const step of numberFormatSteps) {
     const [suffixNum, suffix] = step;
-    const shortValue = Math.floor(number / suffixNum);
-    const fitsBound = number % suffixNum === 0;
+    const shortValue = Math.floor(numAbsValue / suffixNum);
+    const fitsBound = numAbsValue % suffixNum === 0;
 
     if (shortValue <= 0) {
       continue;
@@ -417,22 +420,22 @@ export function formatAbbreviatedNumber(
 
     if (useShortValue) {
       if (maximumSignificantDigits === undefined) {
-        return `${shortValue}${suffix}`;
+        return `${prefix}${shortValue}${suffix}`;
       }
       const formattedNumber = parseFloat(
         shortValue.toPrecision(maximumSignificantDigits)
       ).toString();
-      return `${formattedNumber}${suffix}`;
+      return `${prefix}${formattedNumber}${suffix}`;
     }
 
     const formattedNumber = formatFloat(
-      number / suffixNum,
+      numAbsValue / suffixNum,
       maximumSignificantDigits || 1
     ).toLocaleString(undefined, {
       maximumSignificantDigits,
     });
 
-    return `${formattedNumber}${suffix}`;
+    return `${prefix}${formattedNumber}${suffix}`;
   }
 
   return number.toLocaleString(undefined, {maximumSignificantDigits});


### PR DESCRIPTION
- closes: #68415 

Before: 
<img width="1214" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/fb26090e-911b-42fd-ade5-65f7be65f7d0">

After:
<img width="1214" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/df0a3a11-9668-4898-a36c-ea8ff36ecd20">
