### PR TITLE
feat(perf): Add status page link to domain summary page

### DIFF
--- a/static/app/views/performance/http/domainStatusLink.tsx
+++ b/static/app/views/performance/http/domainStatusLink.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+import ExternalLink from 'sentry/components/links/externalLink';
+import {IconOpen} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {DOMAIN_STATUS_PAGE_URLS} from 'sentry/views/performance/http/domainStatusPageURLs';
+
+interface Props {
+  domain?: string;
+}
+
+export function DomainStatusLink({domain}: Props) {
+  if (!domain) {
+    return null;
+  }
+
+  return (
+    <ExternalDomainLink href={DOMAIN_STATUS_PAGE_URLS[domain]}>
+      {t('Status')}
+      <IconOpen />
+    </ExternalDomainLink>
+  );
+}
+
+const ExternalDomainLink = styled(ExternalLink)`
+  display: inline-flex;
+  font-weight: 300;
+  align-items: center;
+  font-size: ${p => p.theme.fontSizeMedium};
+  gap: ${space(1)};
+`;

--- a/static/app/views/performance/http/domainStatusPageURLs.tsx
+++ b/static/app/views/performance/http/domainStatusPageURLs.tsx
@@ -4,4 +4,5 @@ export const DOMAIN_STATUS_PAGE_URLS = {
   '*.atlassian.net': 'https://status.atlassian.com/api',
   '*.googleapis.com': 'https://status.cloud.google.com',
   '*.codecov.io': 'https://status.codecov.com',
+  '*.sentry.io': 'https://status.sentry.io',
 };

--- a/static/app/views/performance/http/domainStatusPageURLs.tsx
+++ b/static/app/views/performance/http/domainStatusPageURLs.tsx
@@ -1,0 +1,7 @@
+export const DOMAIN_STATUS_PAGE_URLS = {
+  '*.github.com': 'https://www.githubstatus.com',
+  '*.slack.com': 'https://slack-status.com',
+  '*.atlassian.net': 'https://status.atlassian.com/api',
+  '*.googleapis.com': 'https://status.cloud.google.com',
+  '*.codecov.io': 'https://status.codecov.com',
+};

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -20,6 +20,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {DomainStatusLink} from 'sentry/views/performance/http/domainStatusLink';
 import {
   DomainTransactionsTable,
   isAValidSort,
@@ -171,6 +172,7 @@ export function HTTPDomainSummaryPage() {
           <Layout.Title>
             {project && <ProjectAvatar project={project} size={36} />}
             {domain}
+            <DomainStatusLink domain={domain} />
             <FeatureBadge type={RELEASE_LEVEL} />
           </Layout.Title>
         </Layout.HeaderContent>


### PR DESCRIPTION
Just a few domains for now, more to be added later. Styling TBD. I'll also add more robust matching of domain wildcards to domains soon.

**e.g.,**
<img width="362" alt="Screenshot 2024-04-08 at 9 43 24 AM" src="https://github.com/getsentry/sentry/assets/989898/7df7f2c4-98de-41df-882f-1dfe94819ece">
