### PR TITLE
feat(spans): Don't check for segment span during issue detection

### DIFF
--- a/src/sentry/spans/consumers/detect_performance_issues/factory.py
+++ b/src/sentry/spans/consumers/detect_performance_issues/factory.py
@@ -30,6 +30,8 @@ def process_message(message: Message[KafkaPayload]):
     segment = _deserialize_segment(value)
     metrics.incr("detect_performance_issues.spans.count", len(segment["spans"]))
 
+    assert len(segment["spans"]) > 0
+
     process_segment(segment["spans"])
 
 

--- a/src/sentry/spans/consumers/detect_performance_issues/message.py
+++ b/src/sentry/spans/consumers/detect_performance_issues/message.py
@@ -17,7 +17,7 @@ from sentry.models.project import Project
 from sentry.utils import metrics
 from sentry.utils.canonical import CanonicalKeyDict
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sentry.spans")
 
 
 def build_tree(spans):
@@ -91,32 +91,29 @@ def _update_occurrence_group_type(jobs: Sequence[Job], projects: ProjectsMapping
 
 
 def transform_spans_to_event_dict(spans):
-    event: dict[str, Any] = {"type": "transaction", "contexts": {}}
     processed_spans: list[dict[str, Any]] = []
+
+    span = spans[0]
+    sentry_tags = span.get("sentry_tags", {})
+
+    event: dict[str, Any] = {"type": "transaction", "contexts": {}}
+    event["event_id"] = span.get("event_id")
+    event["project_id"] = span["project_id"]
+    event["transaction"] = sentry_tags.get("transaction")
+    event["release"] = sentry_tags.get("release")
+    event["environment"] = sentry_tags.get("environment")
+    event["platform"] = sentry_tags.get("platform")
+    event["contexts"]["trace"] = {
+        "trace_id": span["trace_id"],
+        "type": "trace",
+        "op": sentry_tags.get("transaction.op"),
+        "span_id": span["span_id"],
+    }
+    if (profile_id := span.get("profile_id")) is not None:
+        event["contexts"]["profile"] = {"profile_id": profile_id, "type": "profile"}
+
     for span in spans:
         sentry_tags = span.get("sentry_tags", {})
-
-        if span["is_segment"] is True:
-            event["event_id"] = span.get("event_id")
-            event["project_id"] = span["project_id"]
-            event["transaction"] = sentry_tags.get("transaction")
-            event["release"] = sentry_tags.get("release")
-            event["environment"] = sentry_tags.get("environment")
-
-            event["platform"] = sentry_tags.get("platform")
-
-            event["contexts"]["trace"] = {
-                "trace_id": span["trace_id"],
-                "type": "trace",
-                "op": sentry_tags.get("transaction.op"),
-                "span_id": span["span_id"],
-            }
-            event["received"] = span["received"]
-            event["timestamp"] = (span["start_timestamp_ms"] + span["duration_ms"]) / 1000
-            event["start_timestamp"] = span["start_timestamp_ms"] / 1000
-
-            if (profile_id := span.get("profile_id")) is not None:
-                event["contexts"]["profile"] = {"profile_id": profile_id, "type": "profile"}
 
         if (op := sentry_tags.get("op")) is not None:
             span["op"] = op
@@ -134,6 +131,11 @@ def transform_spans_to_event_dict(spans):
     tree, root_span_id = build_tree(processed_spans)
     flattened_spans = flatten_tree(tree, root_span_id)
     event["spans"] = flattened_spans
+
+    root_span = flattened_spans[0]
+    event["received"] = root_span["received"]
+    event["timestamp"] = (root_span["start_timestamp_ms"] + root_span["duration_ms"]) / 1000
+    event["start_timestamp"] = root_span["start_timestamp_ms"] / 1000
 
     return event
 

--- a/src/sentry/spans/consumers/detect_performance_issues/message.py
+++ b/src/sentry/spans/consumers/detect_performance_issues/message.py
@@ -17,7 +17,7 @@ from sentry.models.project import Project
 from sentry.utils import metrics
 from sentry.utils.canonical import CanonicalKeyDict
 
-logger = logging.getLogger("sentry.spans")
+logger = logging.getLogger(__name__)
 
 
 def build_tree(spans):

--- a/tests/sentry/spans/consumers/detect_performance_issues/test_message.py
+++ b/tests/sentry/spans/consumers/detect_performance_issues/test_message.py
@@ -53,3 +53,47 @@ class TestSpansTask(TestCase):
         )
 
         assert job["performance_problems"][0].type == PerformanceStreamedSpansGroupTypeExperimental
+
+    def test_n_plus_one_issue_detection_without_segment_span(self):
+        segment_span = build_mock_span(project_id=self.project.id, is_segment=False)
+        child_span = build_mock_span(
+            project_id=self.project.id,
+            description="OrganizationNPlusOne.get",
+            is_segment=False,
+            parent_span_id="b35b839c02985f33",
+            span_id="940ce942561548b5",
+            start_timestamp_ms=1707953018867,
+        )
+        cause_span = build_mock_span(
+            project_id=self.project.id,
+            span_op="db",
+            description='SELECT "sentry_project"."id", "sentry_project"."slug", "sentry_project"."name", "sentry_project"."forced_color", "sentry_project"."organization_id", "sentry_project"."public", "sentry_project"."date_added", "sentry_project"."status", "sentry_project"."first_event", "sentry_project"."flags", "sentry_project"."platform" FROM "sentry_project"',
+            is_segment=False,
+            parent_span_id="940ce942561548b5",
+            span_id="a974da4671bc3857",
+            start_timestamp_ms=1707953018867,
+        )
+        repeating_span_description = 'SELECT "sentry_organization"."id", "sentry_organization"."name", "sentry_organization"."slug", "sentry_organization"."status", "sentry_organization"."date_added", "sentry_organization"."default_role", "sentry_organization"."is_test", "sentry_organization"."flags" FROM "sentry_organization" WHERE "sentry_organization"."id" = %s LIMIT 21'
+
+        def repeating_span():
+            return build_mock_span(
+                project_id=self.project.id,
+                span_op="db",
+                description=repeating_span_description,
+                is_segment=False,
+                parent_span_id="940ce942561548b5",
+                span_id=uuid.uuid4().hex[:16],
+                start_timestamp_ms=1707953018869,
+            )
+
+        repeating_spans = [repeating_span() for _ in range(7)]
+        spans = [segment_span, child_span, cause_span] + repeating_spans
+
+        job = process_segment(spans)[0]
+
+        assert (
+            job["performance_problems"][0].fingerprint
+            == "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-f906d576ffde8f005fd741f7b9c8a35062361e67-1019"
+        )
+
+        assert job["performance_problems"][0].type == PerformanceStreamedSpansGroupTypeExperimental


### PR DESCRIPTION
The information we pull out doesn't require segment span.
For "event" received timestamp, we can just use whichever
span we detect as the root of the span tree.