### PR TITLE
perf(nodestore): disable setting cache on write

### DIFF
--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -8,6 +8,7 @@ import sentry_sdk
 from django.core.cache import BaseCache, InvalidCacheBackendError, caches
 from django.utils.functional import cached_property
 
+from sentry import options
 from sentry.utils import json, metrics
 from sentry.utils.services import Service
 
@@ -260,7 +261,8 @@ class NodeStorage(local, Service):
         bytes_data = self._encode(data)
         self.set_bytes(item_id, bytes_data, ttl=ttl)
         # set cache only after encoding and write to nodestore has succeeded
-        self._set_cache_item(item_id, cache_item)
+        if options.get("nodestore.set-subkeys.enable-set-cache-item"):
+            self._set_cache_item(item_id, cache_item)
 
     def cleanup(self, cutoff_timestamp: datetime) -> None:
         raise NotImplementedError

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1817,6 +1817,12 @@ register("txnames.bump-lifetime-sample-rate", default=0.1, flags=FLAG_AUTOMATOR_
 # Decides whether an incoming span triggers an update of the clustering rule applied to it.
 register("span_descs.bump-lifetime-sample-rate", default=0.25, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# === Nodestore related runtime options ===
+
+register(
+    "nodestore.set-subkeys.enable-set-cache-item", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+
 # === Backpressure related runtime options ===
 
 # Enables monitoring of services for backpressure management.

--- a/tests/sentry/nodestore/bigtable/test_backend.py
+++ b/tests/sentry/nodestore/bigtable/test_backend.py
@@ -77,7 +77,7 @@ class MockedBigtableNodeStorage(BigtableNodeStorage):
 def get_temporary_bigtable_nodestorage() -> Generator[BigtableNodeStorage, None, None]:
     if "BIGTABLE_EMULATOR_HOST" not in os.environ:
         pytest.skip(
-            "Bigtable is not available, set BIGTABLE_EMULATOR_HOST enironment variable to enable"
+            "Bigtable is not available, set BIGTABLE_EMULATOR_HOST environment variable to enable"
         )
 
     ns = BigtableNodeStorage(project="test")

--- a/tests/sentry/nodestore/test_common.py
+++ b/tests/sentry/nodestore/test_common.py
@@ -7,6 +7,7 @@ from contextlib import nullcontext
 import pytest
 
 from sentry.nodestore.django.backend import DjangoNodeStorage
+from sentry.testutils.helpers import override_options
 from tests.sentry.nodestore.bigtable.test_backend import (
     MockedBigtableNodeStorage,
     get_temporary_bigtable_nodestorage,
@@ -30,6 +31,7 @@ def ns(request):
         yield ns
 
 
+@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
 def test_get_multi(ns):
     nodes = [("a" * 32, {"foo": "a"}), ("b" * 32, {"foo": "b"})]
 
@@ -40,6 +42,7 @@ def test_get_multi(ns):
     assert result == {n[0]: n[1] for n in nodes}
 
 
+@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
 def test_set(ns):
     node_id = "d2502ebbd7df41ceba8d3275595cac33"
     data = {"foo": "bar"}
@@ -47,6 +50,7 @@ def test_set(ns):
     assert ns.get(node_id) == data
 
 
+@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
 def test_delete(ns):
     node_id = "d2502ebbd7df41ceba8d3275595cac33"
     data = {"foo": "bar"}
@@ -56,6 +60,7 @@ def test_delete(ns):
     assert not ns.get(node_id)
 
 
+@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
 def test_delete_multi(ns):
     nodes = [("node_1", {"foo": "a"}), ("node_2", {"foo": "b"})]
 
@@ -67,6 +72,7 @@ def test_delete_multi(ns):
     assert not ns.get(nodes[1][0])
 
 
+@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
 def test_set_subkeys(ns):
     """
     Subkeys are used to store multiple JSON payloads under the same main key.


### PR DESCRIPTION
We are setting cache on every transaction, but not always reading it. This optimization would move the setting cache operation to `read`.

I've moved the `set_cache_item` call inside an option `nodestore.set_subkeys.enable_set_cache_item` in case we need to revert this.

Ref: https://github.com/getsentry/team-ingest/issues/400

cc @getsentry/processing 