### PR TITLE
fix(grid-editable): First cell padding

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -216,7 +216,9 @@ export const GridBodyCell = styled('td')`
 
   font-size: ${p => p.theme.fontSizeMedium};
 
-  &:first-child {
+  /* Need to select the 2nd child to select the first cell
+     as the first child is the interaction state layer */
+  &:nth-child(2) {
     padding: ${space(1)} 0 ${space(1)} ${space(3)};
   }
 


### PR DESCRIPTION
Adding the InteractionStateLayer to the grid rows broke one of the css selectors, changing the padding on the first grid cell.
This PR fixes the selector.