### PR TITLE
feat(spans): Enable span metrics ingestion by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2015,10 +2015,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable similarity embeddings grouping
     "projects:similarity-embeddings-grouping": False,
     # Starfish: extract metrics from the spans
-    "projects:span-metrics-extraction": False,
-    "projects:span-metrics-extraction-ga-modules": False,
-    "projects:span-metrics-extraction-all-modules": False,
-    "projects:span-metrics-extraction-resource": False,
+    "projects:span-metrics-extraction": True,
     "projects:discard-transaction": False,
     # Enable suspect resolutions feature
     "projects:suspect-resolutions": False,


### PR DESCRIPTION
This feature is enabled by default for all projects and we have a deny list still. This would mostly turned the feature on for developers.