### PR TITLE
fix(performance): Use existing type narrowing on string

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -367,19 +367,19 @@ function TraceDrawerTab(props: TraceDrawerTabProps) {
         className={typeof props.tab.node === 'string' ? 'Static' : ''}
         active={props.tab === props.tabs.current}
         onClick={() => {
-          if (props.tab.node !== 'vitals') {
+          if (node !== 'vitals') {
             props.scrollToNode(root);
           }
           props.tabsDispatch({type: 'activate tab', payload: props.index});
         }}
       >
         {/* A trace is technically an entry in the list, so it has a color */}
-        {props.tab.node === 'trace' ? null : (
+        {node === 'trace' ? null : (
           <TabButtonIndicator
             backgroundColor={makeTraceNodeBarColor(props.theme, root)}
           />
         )}
-        <TabButton>{props.tab.label ?? props.tab.node}</TabButton>
+        <TabButton>{props.tab.label ?? node}</TabButton>
       </Tab>
     );
   }


### PR DESCRIPTION
fixes a type error in react 18 when an object type might be rendered

```
Error: static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx(382,20): error TS2322: Type 'string | TraceTreeNode<NodeValue>' is not assignable to type 'ReactNode'.
  Type 'TraceTreeNode<NodeValue>' is not assignable to type 'ReactNode'.
    Type 'TraceTreeNode<NodeValue>' is missing the following properties from type 'ReactPortal': type, props, key
```

part of https://github.com/getsentry/frontend-tsc/issues/22