### PR TITLE
fix(proguard): Filter empty stacktraces in A/B test

### DIFF
--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -312,18 +312,14 @@ class JavaSourceLookupStacktraceProcessor(StacktraceProcessor):
         def exceptions_differ(a, b):
             return a.get("type") != b.get("type") or a.get("module") != b.get("module")
 
+        python_stacktraces = [
+            sinfo.stacktrace for sinfo in self.stacktrace_infos if sinfo.stacktrace is not None
+        ]
+
         different_frames = []
-        for symbolicator_stacktrace, stacktrace_info in zip(
-            symbolicator_stacktraces, self.stacktrace_infos
+        for symbolicator_stacktrace, python_stacktrace in zip(
+            symbolicator_stacktraces, python_stacktraces
         ):
-            if stacktrace_info.container is None:
-                continue
-
-            python_stacktrace = stacktrace_info.container.get("stacktrace", None)
-
-            if python_stacktrace is None:
-                continue
-
             for symbolicator_frame, python_frame in zip(
                 symbolicator_stacktrace, python_stacktrace["frames"]
             ):

--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -312,6 +312,8 @@ class JavaSourceLookupStacktraceProcessor(StacktraceProcessor):
         def exceptions_differ(a, b):
             return a.get("type") != b.get("type") or a.get("module") != b.get("module")
 
+        # During symbolication, empty stacktrace_infos are disregarded. We need to do that here as well or results
+        # won't line up.
         python_stacktraces = [
             sinfo.stacktrace for sinfo in self.stacktrace_infos if sinfo.stacktrace is not None
         ]


### PR DESCRIPTION
I've seen a case where during symbolication, the event has 2 stacktrace_infos, but then during the A/B test in the plugin, it has 3. The plugin counts stacktrace_infos with a `None` stacktrace (which results from an exception with no stacktrace), but `find_stacktraces_in_data`, which is used in symbolication, filters them. This discrepancy results in spurious A/B test failures.

We now filter empty stacktrace_infos in A/B tests as well.