### PR TITLE
ref(slack): increase max chars for user feedback issues

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -9,8 +9,6 @@ from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
 from sentry.notifications.utils.actions import MessageAction
 
-MAX_BLOCK_TEXT_LENGTH = 256
-
 
 class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     @staticmethod
@@ -40,9 +38,9 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         }
 
     @staticmethod
-    def get_markdown_quote_block(text: str) -> SlackBlock:
-        if len(text) > MAX_BLOCK_TEXT_LENGTH:
-            text = text[: MAX_BLOCK_TEXT_LENGTH - 3] + "..."
+    def get_markdown_quote_block(text: str, max_block_text_length: int) -> SlackBlock:
+        if len(text) > max_block_text_length:
+            text = text[: max_block_text_length - 3] + "..."
 
         markdown_text = "```" + text + "```"
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -73,6 +73,9 @@ SUPPORTED_COMMIT_PROVIDERS = (
     "integrations:bitbucket",
 )
 
+MAX_BLOCK_TEXT_LENGTH = 256
+USER_FEEDBACK_MAX_BLOCK_TEXT_LENGTH = 1500
+
 
 def get_approx_start_time(group: Group):
     event = group.get_recommended_event_for_environments()
@@ -661,7 +664,12 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             text = text.lstrip(" ")
             # XXX(CEO): sometimes text is " " and slack will error if we pass an empty string (now "")
             if text:
-                blocks.append(self.get_markdown_quote_block(text))
+                if self.group.issue_category == GroupCategory.FEEDBACK:
+                    max_block_text_length = USER_FEEDBACK_MAX_BLOCK_TEXT_LENGTH
+                else:
+                    max_block_text_length = MAX_BLOCK_TEXT_LENGTH
+
+                blocks.append(self.get_markdown_quote_block(text, max_block_text_length))
 
         # build up actions text
         if self.actions and self.identity and not action_text:

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -977,10 +977,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
     @with_feature("organizations:slack-block-kit")
     def test_block_kit_truncates_long_query(self):
-        # text = "a" * 5000
-        # block = BlockSlackMessageBuilder().get_markdown_quote_block(text)
-        # assert "a" * 253 + "..." in block["text"]["text"]
-
         event = self.store_event(
             data={"message": "a" * 5000, "level": "error"}, project_id=self.project.id
         )


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/68433

tl;dr a customer wants longer (preferably the entire) text lengths for User Feedback issues