### PR TITLE
fix(ui): Rename react 18 concurrent option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -466,7 +466,7 @@ register(
 
 # React concurrent renderer
 register(
-    "organizations:react-concurrent-renderer-enabled",
+    "frontend.react-concurrent-renderer-enabled",
     type=Bool,
     default=False,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -221,7 +221,7 @@ class _ClientConfig:
             "organizations:multi-region-selector", actor=self.user
         ):
             yield "organizations:multi-region-selector"
-        if options.get("organizations:react-concurrent-renderer-enabled"):
+        if options.get("frontend.react-concurrent-renderer-enabled"):
             yield "organizations:react-concurrent-renderer-enabled"
 
     @property

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -163,7 +163,7 @@ class ClientConfigViewTest(TestCase):
             assert data["features"] == ["organizations:create", "organizations:customer-domains"]
 
     def test_react_concurrent_feature(self):
-        with override_options({"organizations:react-concurrent-renderer-enabled": True}):
+        with override_options({"frontend.react-concurrent-renderer-enabled": True}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
@@ -173,7 +173,7 @@ class ClientConfigViewTest(TestCase):
                 "organizations:react-concurrent-renderer-enabled",
             ]
 
-        with override_options({"organizations:react-concurrent-renderer-enabled": False}):
+        with override_options({"frontend.react-concurrent-renderer-enabled": False}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"


### PR DESCRIPTION
Messed up and put a colon in the option name. Removing it and following the pattern other options use.
