### PR TITLE
feat(perf): Synchronize HTTP sample chart and table

### DIFF
--- a/static/app/views/performance/http/spanSamplesTable.tsx
+++ b/static/app/views/performance/http/spanSamplesTable.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -19,6 +20,7 @@ import {SpanIndexedField} from 'sentry/views/starfish/types';
 type ColumnKeys =
   | SpanIndexedField.PROJECT
   | SpanIndexedField.TRANSACTION_ID
+  | SpanIndexedField.ID
   | SpanIndexedField.SPAN_DESCRIPTION
   | SpanIndexedField.RESPONSE_CODE;
 
@@ -48,10 +50,21 @@ interface Props {
   data: Row[];
   isLoading: boolean;
   error?: Error | null;
+  highlightedSpanId?: string;
   meta?: EventsMetaType;
+  onSampleMouseOut?: ComponentProps<typeof GridEditable>['onRowMouseOut'];
+  onSampleMouseOver?: ComponentProps<typeof GridEditable>['onRowMouseOver'];
 }
 
-export function SpanSamplesTable({data, isLoading, error, meta}: Props) {
+export function SpanSamplesTable({
+  data,
+  isLoading,
+  error,
+  meta,
+  onSampleMouseOver,
+  onSampleMouseOut,
+  highlightedSpanId,
+}: Props) {
   const location = useLocation();
   const organization = useOrganization();
 
@@ -72,6 +85,9 @@ export function SpanSamplesTable({data, isLoading, error, meta}: Props) {
         renderBodyCell: (column, row) =>
           renderBodyCell(column, row, meta, location, organization),
       }}
+      highlightedRowKey={data.findIndex(row => row.span_id === highlightedSpanId)}
+      onRowMouseOver={onSampleMouseOver}
+      onRowMouseOut={onSampleMouseOut}
       location={location}
     />
   );

--- a/static/app/views/performance/http/useDebouncedState.tsx
+++ b/static/app/views/performance/http/useDebouncedState.tsx
@@ -1,0 +1,22 @@
+import {useCallback, useState} from 'react';
+// eslint-disable-next-line no-restricted-imports
+import type {DebouncedFunc} from 'lodash';
+import debounce from 'lodash/debounce';
+
+// NOTE: This can be extracted for more general use if:
+// 1. It gets some thorough tests
+// 2. It correctly cancels debounces
+export function useDebouncedState<T>(
+  initialValue: T,
+  deps: React.DependencyList,
+  delay: number = DEFAULT_DEBOUNCE
+): [T, DebouncedFunc<React.Dispatch<React.SetStateAction<T>>>] {
+  const [value, setValue] = useState<T>(initialValue);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedSetValue = useCallback(debounce(setValue, delay), deps);
+
+  return [value, debouncedSetValue];
+}
+
+const DEFAULT_DEBOUNCE = 100;


### PR DESCRIPTION
Works just like the Queries and Resources panel! In fact, I had to introduce some temporary duplication to make it work, but in a more generic form. I'll step back and resolve the duplication in the next week or so.

In order to fully fix this, I need to make it possible to pass a regular plain-old `scatter` series to a chart, which is mysteriously impossible right now, and also doesn't have proper tooltip support.

So many crimes to undo, so little time!

- Add `onHighlight` support to `DurationChart`
- Add simple debounced state hook
- Sync the sample chart and table highlight
