### PR TITLE
ref(metrics-extraction): Record span for bulk cache

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -210,7 +210,10 @@ def _bulk_cache_query_key(project: Project) -> str:
 
 def _get_bulk_cached_query(project: Project) -> dict[str, Any]:
     query_bulk_cache_key = _bulk_cache_query_key(project)
-    return cache.get(query_bulk_cache_key, None)
+    cache_result = cache.get(query_bulk_cache_key, None)
+
+    with sentry_sdk.start_span(op="on_demand_metrics.query_cache", description=bool(cache_result)):
+        return cache_result
 
 
 def _set_bulk_cached_query(project: Project, query_cache: dict[str, Any]) -> None:

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -211,9 +211,8 @@ def _bulk_cache_query_key(project: Project) -> str:
 def _get_bulk_cached_query(project: Project) -> dict[str, Any]:
     query_bulk_cache_key = _bulk_cache_query_key(project)
     cache_result = cache.get(query_bulk_cache_key, None)
-
-    with sentry_sdk.start_span(op="on_demand_metrics.query_cache", description=bool(cache_result)):
-        return cache_result
+    sentry_sdk.set_tag("on_demand_metrics.query_cache", cache_result is None)
+    return cache_result
 
 
 def _set_bulk_cached_query(project: Project, query_cache: dict[str, Any]) -> None:


### PR DESCRIPTION
### Summary
This indicates whether the bulk cache entirely missed so we can find how frequent we get full misses vs partial misses
