### PR TITLE
fix(replays): resest video center when seeking while paused

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -115,12 +115,7 @@ export class VideoReplayer {
     });
 
     // Finished loading data, ready to play
-    el.addEventListener('loadeddata', event => {
-      // Used to correctly set the dimensions of the first frame
-      if (this._currentIndex === undefined && index === 0) {
-        this._callbacks.onLoaded(event);
-      }
-
+    el.addEventListener('loadeddata', () => {
       // Only call this for current segment as we preload multiple
       // segments simultaneously
       if (index === this._currentIndex) {
@@ -329,7 +324,6 @@ export class VideoReplayer {
       this._currentVideo.style.display = 'none';
     }
 
-    // TODO: resize video if it changes orientation
     nextVideo.style.display = 'block';
 
     // Update current video so that we can hide it when showing the

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -104,11 +104,9 @@ export class VideoReplayer {
 
     // TODO: only attach these when needed
     el.addEventListener('ended', () => this.handleSegmentEnd(index));
-    el.addEventListener('loadeddata', event => {
-      // Used to correctly set the dimensions of the first frame
-      if (this._currentIndex === undefined && index === 0) {
-        this._callbacks.onLoaded(event);
-      }
+    el.addEventListener('seeked', event => {
+      // Centers the video when seeking
+      this._callbacks.onLoaded(event);
     });
     el.addEventListener('play', event => {
       if (index === this._currentIndex) {
@@ -117,7 +115,12 @@ export class VideoReplayer {
     });
 
     // Finished loading data, ready to play
-    el.addEventListener('loadeddata', () => {
+    el.addEventListener('loadeddata', event => {
+      // Used to correctly set the dimensions of the first frame
+      if (this._currentIndex === undefined && index === 0) {
+        this._callbacks.onLoaded(event);
+      }
+
       // Only call this for current segment as we preload multiple
       // segments simultaneously
       if (index === this._currentIndex) {

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -104,7 +104,7 @@ export class VideoReplayer {
 
     // TODO: only attach these when needed
     el.addEventListener('ended', () => this.handleSegmentEnd(index));
-    el.addEventListener('seeked', event => {
+    el.addEventListener('seeking', event => {
       // Centers the video when seeking
       this._callbacks.onLoaded(event);
     });


### PR DESCRIPTION
- The video wasn't centering properly when seeking while pausing, if there was an orientation change
- Fix this by adding an event listener for `seeking` with the `onLoaded` callback, which resets the dimensions
- Fixes https://github.com/getsentry/sentry/issues/68438

BEFORE: 

https://github.com/getsentry/sentry/assets/56095982/8b5b49ca-9cce-429d-880e-ae95ec666f61


AFTER:



https://github.com/getsentry/sentry/assets/56095982/e067130f-7a14-409d-809c-d6a9d70a14d1

