### PR TITLE
fix(new-trace-url) Updated node path encoding.

### DIFF
--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -35,7 +35,7 @@ export function getTraceDetailsUrl(
 
   if (organization.features.includes('trace-view-v1')) {
     if (spanId) {
-      queryParams.node = [`span:${spanId}`, `txn:${eventId}`];
+      queryParams.node = [`span-${spanId}`, `txn-${eventId}`];
     }
     return {
       pathname: normalizeUrl(


### PR DESCRIPTION
Trace view page expects `[`span-${spanId}`, `txn-${eventId}`]` to look for and scroll to span but we were passing [`span:${spanId}`, `txn:${eventId}`]