### PR TITLE
chore: handle null segment_id since it's optional

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -1,6 +1,5 @@
 import dataclasses
 import logging
-import random
 from collections.abc import Mapping
 from typing import Any
 
@@ -68,10 +67,6 @@ def _process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | 
         timestamp = int(message.value.timestamp.timestamp())
         partition = message.value.partition.index
 
-        if random.random() < 0.005:
-            sentry_sdk.set_context("payload", {"value": str(payload_value)})
-            txn.set_tag("has_payload", True)
-
         span = _deserialize_span(payload_value)
         segment_id = span["segment_id"]
         trace_id = span["trace_id"]
@@ -123,7 +118,6 @@ def _produce_segment(message: Message[ProduceSegmentContext | None]):
             if len(keys) > 0:
                 payload_context["sample_key"] = keys[0]
 
-            sample_span = None
             total_spans_read = 0
             # With pipelining, redis server is forced to queue replies using
             # up memory, so batching the keys we fetch.
@@ -133,15 +127,9 @@ def _produce_segment(message: Message[ProduceSegmentContext | None]):
 
                     for segment in segments:
                         total_spans_read += len(segment)
-                        if len(segment) > 0:
-                            sample_span = segment[0]
                         produce_segment_to_kafka(segment)
 
             metrics.incr("process_spans.spans.read.count", total_spans_read)
-            if sample_span and random.random() < 0.01:
-                txn.set_tag("has_payload", True)
-                payload_context["sample_span"] = str(sample_span)
-
             sentry_sdk.set_context("payload", payload_context)
 
 

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -70,7 +70,10 @@ def _process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | 
         with txn.start_child(op="deserialize"):
             span = _deserialize_span(payload_value)
 
-        segment_id = span["segment_id"]
+        segment_id = span.get("segment_id", None)
+        if segment_id is None:
+            return None
+
         trace_id = span["trace_id"]
 
         txn.set_tag("trace.id", trace_id)

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -67,7 +67,11 @@ def _process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | 
         timestamp = int(message.value.timestamp.timestamp())
         partition = message.value.partition.index
 
-        span = _deserialize_span(payload_value)
+        txn.set_tag("partition_index", partition)
+
+        with txn.start_child(op="deserialize"):
+            span = _deserialize_span(payload_value)
+
         segment_id = span["segment_id"]
         trace_id = span["trace_id"]
 
@@ -75,11 +79,12 @@ def _process_message(message: Message[KafkaPayload]) -> ProduceSegmentContext | 
         txn.set_tag("segment.id", segment_id)
         sentry_sdk.set_measurement("num_keys", len(span))
 
-        client = RedisSpansBuffer()
+        with txn.start_child(op="process", description="write_span"):
+            client = RedisSpansBuffer()
 
-        should_process_segments = client.write_span_and_check_processing(
-            project_id, segment_id, timestamp, partition, payload_value
-        )
+            should_process_segments = client.write_span_and_check_processing(
+                project_id, segment_id, timestamp, partition, payload_value
+            )
 
         metrics.incr("process_spans.spans.write.count")
 
@@ -108,6 +113,8 @@ def _produce_segment(message: Message[ProduceSegmentContext | None]):
         ) as txn:
             client = RedisSpansBuffer()
             payload_context = {}
+
+            txn.set_tag("partition_index", context.partition)
 
             with txn.start_child(op="process", description="fetch_unprocessed_segments"):
                 keys = client.get_unprocessed_segments_and_prune_bucket(


### PR DESCRIPTION
handle null segment_id since it's optional
stop logging payload in process_spans
some messages take over 250ms to process, add one more span to confirm its the deserialize
