### PR TITLE
ref(crons): Avoid css grid-column dependency

### DIFF
--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -18,8 +18,8 @@ import {ResolutionSelector} from 'sentry/views/monitors/components/overviewTimel
 import {CheckInPlaceholder} from 'sentry/views/monitors/components/timeline/checkInPlaceholder';
 import {CheckInTimeline} from 'sentry/views/monitors/components/timeline/checkInTimeline';
 import {
+  GridLineLabels,
   GridLineOverlay,
-  GridLineTimeLabels,
 } from 'sentry/views/monitors/components/timeline/gridLines';
 import type {
   MonitorBucketData,
@@ -139,7 +139,7 @@ const TimelineContainer = styled(Panel)`
   align-items: center;
 `;
 
-const StyledGridLineTimeLabels = styled(GridLineTimeLabels)`
+const StyledGridLineTimeLabels = styled(GridLineLabels)`
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 

--- a/static/app/views/monitors/components/detailsTimeline.tsx
+++ b/static/app/views/monitors/components/detailsTimeline.tsx
@@ -18,7 +18,7 @@ import type {Monitor} from 'sentry/views/monitors/types';
 import {makeMonitorDetailsQueryKey} from 'sentry/views/monitors/utils';
 
 import {OverviewRow} from './overviewTimeline/overviewRow';
-import {GridLineOverlay, GridLineTimeLabels} from './timeline/gridLines';
+import {GridLineLabels, GridLineOverlay} from './timeline/gridLines';
 import {useMonitorStats} from './timeline/hooks/useMonitorStats';
 import {useTimeWindowConfig} from './timeline/hooks/useTimeWindowConfig';
 
@@ -100,9 +100,9 @@ export function DetailsTimeline({monitor, organization}: Props) {
       <TimelineWidthTracker ref={elementRef} />
       <Header>
         <TimelineTitle>{t('Check-Ins')}</TimelineTitle>
-        <GridLineTimeLabels timeWindowConfig={timeWindowConfig} width={timelineWidth} />
+        <GridLineLabels timeWindowConfig={timeWindowConfig} width={timelineWidth} />
       </Header>
-      <StyledGridLineOverlay
+      <AlignedGridLineOverlay
         allowZoom={!isLoading}
         showCursor={!isLoading}
         timeWindowConfig={timeWindowConfig}
@@ -133,14 +133,14 @@ const Header = styled('div')`
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 
-const StyledGridLineOverlay = styled(GridLineOverlay)`
-  grid-column: 2;
-`;
-
 const TimelineWidthTracker = styled('div')`
   position: absolute;
   width: 100%;
   grid-row: 1;
+  grid-column: 2;
+`;
+
+const AlignedGridLineOverlay = styled(GridLineOverlay)`
   grid-column: 2;
 `;
 

--- a/static/app/views/monitors/components/mockTimelineVisualization.tsx
+++ b/static/app/views/monitors/components/mockTimelineVisualization.tsx
@@ -13,7 +13,7 @@ import {ScheduleType} from 'sentry/views/monitors/types';
 
 import {CheckInPlaceholder} from './timeline/checkInPlaceholder';
 import {MockCheckInTimeline} from './timeline/checkInTimeline';
-import {GridLineOverlay, GridLineTimeLabels} from './timeline/gridLines';
+import {GridLineLabels, GridLineOverlay} from './timeline/gridLines';
 import {getConfigFromTimeRange} from './timeline/utils/getConfigFromTimeRange';
 
 interface ScheduleConfig {
@@ -99,11 +99,11 @@ export function MockTimelineVisualization({schedule}: Props) {
         </Fragment>
       ) : (
         <Fragment>
-          <StyledGridLineTimeLabels
+          <AlignedGridLineLabels
             timeWindowConfig={timeWindowConfig}
             width={timelineWidth}
           />
-          <StyledGridLineOverlay
+          <AlignedGridLineOverlay
             showCursor={!isLoading}
             timeWindowConfig={timeWindowConfig}
             width={timelineWidth}
@@ -122,16 +122,16 @@ export function MockTimelineVisualization({schedule}: Props) {
 const TimelineContainer = styled(Panel)`
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: 40px 100px;
+  grid-template-rows: auto 60px;
   align-items: center;
 `;
 
-const StyledGridLineTimeLabels = styled(GridLineTimeLabels)`
+const AlignedGridLineLabels = styled(GridLineLabels)`
   grid-column: 0;
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 
-const StyledGridLineOverlay = styled(GridLineOverlay)`
+const AlignedGridLineOverlay = styled(GridLineOverlay)`
   grid-column: 0;
 `;
 

--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -18,7 +18,7 @@ import type {Monitor} from 'sentry/views/monitors/types';
 import {makeMonitorListQueryKey} from 'sentry/views/monitors/utils';
 
 import {DateNavigator} from '../timeline/dateNavigator';
-import {GridLineOverlay, GridLineTimeLabels} from '../timeline/gridLines';
+import {GridLineLabels, GridLineOverlay} from '../timeline/gridLines';
 import {useDateNavigation} from '../timeline/hooks/useDateNavigation';
 import {useMonitorStats} from '../timeline/hooks/useMonitorStats';
 import {useTimeWindowConfig} from '../timeline/hooks/useTimeWindowConfig';
@@ -135,7 +135,10 @@ export function OverviewTimeline({monitorList}: Props) {
             borderless
           />
         </HeaderControlsLeft>
-        <GridLineTimeLabels timeWindowConfig={timeWindowConfig} width={timelineWidth} />
+        <AlignedGridLineLabels
+          timeWindowConfig={timeWindowConfig}
+          width={timelineWidth}
+        />
         <HeaderControlsRight>
           <DateNavigator
             dateNavigation={dateNavigation}
@@ -145,7 +148,7 @@ export function OverviewTimeline({monitorList}: Props) {
           />
         </HeaderControlsRight>
       </Header>
-      <GridLineOverlay
+      <AlignedGridLineOverlay
         stickyCursor
         allowZoom
         showCursor={!isLoading}
@@ -171,11 +174,6 @@ export function OverviewTimeline({monitorList}: Props) {
   );
 }
 
-const MonitorListPanel = styled(Panel)`
-  display: grid;
-  grid-template-columns: 350px 135px 1fr max-content;
-`;
-
 const Header = styled(Sticky)`
   display: grid;
   grid-column: 1/-1;
@@ -195,6 +193,27 @@ const Header = styled(Sticky)`
   }
 `;
 
+const TimelineWidthTracker = styled('div')`
+  position: absolute;
+  width: 100%;
+  grid-row: 1;
+  grid-column: 3/-1;
+`;
+const AlignedGridLineOverlay = styled(GridLineOverlay)`
+  grid-row: 1;
+  grid-column: 3/-1;
+`;
+
+const AlignedGridLineLabels = styled(GridLineLabels)`
+  grid-row: 1;
+  grid-column: 3/-1;
+`;
+
+const MonitorListPanel = styled(Panel)`
+  display: grid;
+  grid-template-columns: 350px 135px 1fr max-content;
+`;
+
 const HeaderControlsLeft = styled('div')`
   grid-column: 1/3;
   display: flex;
@@ -207,11 +226,4 @@ const HeaderControlsRight = styled('div')`
   grid-row: 1;
   grid-column: -1;
   padding: ${space(1.5)} ${space(2)};
-`;
-
-const TimelineWidthTracker = styled('div')`
-  position: absolute;
-  width: 100%;
-  grid-row: 1;
-  grid-column: 3/-1;
 `;

--- a/static/app/views/monitors/components/timeline/gridLines.tsx
+++ b/static/app/views/monitors/components/timeline/gridLines.tsx
@@ -103,7 +103,7 @@ function getTimeMarkersFromConfig(config: TimeWindowConfig, width: number) {
   return markers;
 }
 
-export function GridLineTimeLabels({width, timeWindowConfig, className}: Props) {
+export function GridLineLabels({width, timeWindowConfig, className}: Props) {
   const markers = getTimeMarkersFromConfig(timeWindowConfig, width);
 
   return (
@@ -185,8 +185,6 @@ export function GridLineOverlay({
 }
 
 const Overlay = styled('div')`
-  grid-row: 1;
-  grid-column: 3/-1;
   height: 100%;
   width: 100%;
   position: absolute;
@@ -200,8 +198,7 @@ const GridLineContainer = styled('div')`
 `;
 
 const LabelsContainer = styled('div')`
-  grid-row: 1;
-  grid-column: 3/-1;
+  height: 50px;
   box-shadow: -1px 0 0 ${p => p.theme.translucentInnerBorder};
   position: relative;
   align-self: stretch;


### PR DESCRIPTION
Before this change the timeline components used to build a cron check-in
timeline made some assumptions about which grid cells they belong to.

This adjusts those components and their call-sites so the call sites
become responsible for declaring what cells they belong to.

This also fixes a visual issue as seen here 

<img alt="clipboard.png" width="1379" src="https://i.imgur.com/NXlZbvj.png" />