### PR TITLE
fix(crons): Split broken monitors task up into scheduler and processor tasks

### DIFF
--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -100,6 +100,18 @@ def generate_monitor_email_context(
     ]
 
 
+def build_open_incidents_queryset():
+    current_time = django_timezone.now()
+    return MonitorIncident.objects.select_related("monitor").filter(
+        resolving_checkin=None,
+        starting_timestamp__lte=(current_time - timedelta(days=NUM_DAYS_BROKEN_PERIOD)),
+        monitor__status=ObjectStatus.ACTIVE,
+        monitor__is_muted=False,
+        monitor_environment__is_muted=False,
+        monitorenvbrokendetection__env_muted_timestamp=None,
+    )
+
+
 @instrumented_task(
     name="sentry.monitors.tasks.detect_broken_monitor_envs",
     max_retries=0,
@@ -108,159 +120,160 @@ def generate_monitor_email_context(
     record_timing=True,
 )
 def detect_broken_monitor_envs():
-    current_time = django_timezone.now()
-    open_incidents_qs = MonitorIncident.objects.select_related("monitor").filter(
-        resolving_checkin=None,
-        starting_timestamp__lte=(current_time - timedelta(days=NUM_DAYS_BROKEN_PERIOD)),
-        monitor__status=ObjectStatus.ACTIVE,
-        monitor__is_muted=False,
-        monitor_environment__is_muted=False,
-        monitorenvbrokendetection__env_muted_timestamp=None,
-    )
-    org_ids_with_open_incidents = (
-        open_incidents_qs.all().values_list("monitor__organization_id", flat=True).distinct()
-    )
+    open_incidents_qs = build_open_incidents_queryset()
+    org_ids_with_open_incidents = open_incidents_qs.values_list(
+        "monitor__organization_id", flat=True
+    ).distinct()
 
     for org_id in org_ids_with_open_incidents:
-        try:
-            organization = Organization.objects.get_from_cache(id=org_id)
-            if not features.has(
-                "organizations:crons-broken-monitor-detection", organization=organization
-            ):
-                continue
-        except Organization.DoesNotExist:
+        detect_broken_monitor_envs_for_org.delay(org_id)
+
+
+@instrumented_task(
+    name="sentry.monitors.tasks.detect_broken_monitor_envs_for_org",
+    max_retries=0,
+    time_limit=15 * 60,
+    soft_time_limit=10 * 60,
+    record_timing=True,
+)
+def detect_broken_monitor_envs_for_org(org_id: int):
+    current_time = django_timezone.now()
+    try:
+        organization = Organization.objects.get_from_cache(id=org_id)
+        if not features.has(
+            "organizations:crons-broken-monitor-detection", organization=organization
+        ):
+            return
+    except Organization.DoesNotExist:
+        return
+
+    # Record how long it takes to process this org
+    org_process_start_time = django_timezone.now()
+
+    # Map user email to a dictionary of monitors and their earliest incident start date amongst its broken environments
+    user_broken_envs: dict[str, dict[str, Any]] = defaultdict(
+        lambda: defaultdict(
+            lambda: {"environment_names": [], "earliest_start": django_timezone.now()}
+        )
+    )
+    # Same as above but for monitors that will be automatically muted by us
+    user_muted_envs: dict[str, dict[str, Any]] = defaultdict(
+        lambda: defaultdict(
+            lambda: {"environment_names": [], "earliest_start": django_timezone.now()}
+        )
+    )
+    orgs_open_incidents = (
+        build_open_incidents_queryset()
+        .select_related("monitor_environment")
+        .filter(monitor__organization_id=org_id)
+    )
+    # Query for all the broken incidents within the current org we are processing
+    for open_incident in RangeQuerySetWrapper(
+        orgs_open_incidents,
+        order_by="starting_timestamp",
+        step=1000,
+    ):
+        # Record how long it takes to process this org's incident
+        org_incident_process_start_time = django_timezone.now()
+
+        # Verify that the most recent check-ins have been failing
+        recent_checkins = (
+            MonitorCheckIn.objects.filter(monitor_environment=open_incident.monitor_environment)
+            .order_by("-date_added")
+            .values("status")[:NUM_CONSECUTIVE_BROKEN_CHECKINS]
+        )
+        if len(recent_checkins) != NUM_CONSECUTIVE_BROKEN_CHECKINS or not all(
+            checkin["status"] in [CheckInStatus.ERROR, CheckInStatus.TIMEOUT, CheckInStatus.MISSED]
+            for checkin in recent_checkins
+        ):
             continue
 
-        # Record how long it takes to process this org
-        org_process_start_time = django_timezone.now()
+        detection, _ = MonitorEnvBrokenDetection.objects.get_or_create(
+            monitor_incident=open_incident, defaults={"detection_timestamp": current_time}
+        )
+        if not detection.user_notified_timestamp:
+            environment_name = open_incident.monitor_environment.get_environment().name
+            project = Project.objects.get_from_cache(id=open_incident.monitor.project_id)
+            for user in project.member_set:
+                if not user.user_email:
+                    continue
 
-        # Map user email to a dictionary of monitors and their earliest incident start date amongst its broken environments
-        user_broken_envs: dict[str, dict[str, Any]] = defaultdict(
-            lambda: defaultdict(
-                lambda: {"environment_names": [], "earliest_start": django_timezone.now()}
-            )
-        )
-        # Same as above but for monitors that will be automatically muted by us
-        user_muted_envs: dict[str, dict[str, Any]] = defaultdict(
-            lambda: defaultdict(
-                lambda: {"environment_names": [], "earliest_start": django_timezone.now()}
-            )
-        )
-        orgs_open_incidents = (
-            open_incidents_qs.all()
-            .select_related("monitor_environment")
-            .filter(monitor__organization_id=org_id)
-        )
-        # Query for all the broken incidents within the current org we are processing
-        for open_incident in RangeQuerySetWrapper(
-            orgs_open_incidents,
-            order_by="starting_timestamp",
-            step=1000,
+                update_user_monitor_dictionary(
+                    user_broken_envs, user.user_email, open_incident, project, environment_name
+                )
+        elif (
+            not detection.env_muted_timestamp
+            and detection.user_notified_timestamp + timedelta(days=NUM_DAYS_MUTED_PERIOD)
+            <= current_time
         ):
-            # Record how long it takes to process this org's incident
-            org_incident_process_start_time = django_timezone.now()
+            environment_name = open_incident.monitor_environment.get_environment().name
+            project = Project.objects.get_from_cache(id=open_incident.monitor.project_id)
 
-            # Verify that the most recent check-ins have been failing
-            recent_checkins = (
-                MonitorCheckIn.objects.filter(monitor_environment=open_incident.monitor_environment)
-                .order_by("-date_added")
-                .values("status")[:NUM_CONSECUTIVE_BROKEN_CHECKINS]
-            )
-            if len(recent_checkins) != NUM_CONSECUTIVE_BROKEN_CHECKINS or not all(
-                checkin["status"]
-                in [CheckInStatus.ERROR, CheckInStatus.TIMEOUT, CheckInStatus.MISSED]
-                for checkin in recent_checkins
-            ):
-                continue
+            with transaction.atomic(router.db_for_write(MonitorEnvBrokenDetection)):
+                open_incident.monitor_environment.update(is_muted=True)
+                detection.update(env_muted_timestamp=django_timezone.now())
 
-            detection, _ = MonitorEnvBrokenDetection.objects.get_or_create(
-                monitor_incident=open_incident, defaults={"detection_timestamp": current_time}
-            )
-            if not detection.user_notified_timestamp:
-                environment_name = open_incident.monitor_environment.get_environment().name
-                project = Project.objects.get_from_cache(id=open_incident.monitor.project_id)
-                for user in project.member_set:
-                    if not user.user_email:
-                        continue
+            for user in project.member_set:
+                if not user.user_email:
+                    continue
 
-                    update_user_monitor_dictionary(
-                        user_broken_envs, user.user_email, open_incident, project, environment_name
-                    )
-            elif (
-                not detection.env_muted_timestamp
-                and detection.user_notified_timestamp + timedelta(days=NUM_DAYS_MUTED_PERIOD)
-                <= current_time
-            ):
-                environment_name = open_incident.monitor_environment.get_environment().name
-                project = Project.objects.get_from_cache(id=open_incident.monitor.project_id)
-
-                with transaction.atomic(router.db_for_write(MonitorEnvBrokenDetection)):
-                    open_incident.monitor_environment.update(is_muted=True)
-                    detection.update(env_muted_timestamp=django_timezone.now())
-
-                for user in project.member_set:
-                    if not user.user_email:
-                        continue
-
-                    update_user_monitor_dictionary(
-                        user_muted_envs, user.user_email, open_incident, project, environment_name
-                    )
-
-            metrics.timing(
-                "crons.detect_broken_monitor_org_incident_time",
-                django_timezone.now().timestamp() - org_incident_process_start_time.timestamp(),
-                tags={"incident": open_incident.id},
-            )
-
-        # Record how long it takes to send all emails for an org
-        org_email_sending_start_time = django_timezone.now()
-
-        # After accumulating all users within the org and which monitors to email them, send the emails
-        for user_email, broken_monitors in user_broken_envs.items():
-            context = {
-                "broken_monitors": generate_monitor_email_context(
-                    broken_monitors.values(), organization
-                ),
-                "view_monitors_link": generate_monitor_overview_url(organization),
-            }
-            message = MessageBuilder(
-                subject="Your Cron Monitors Aren't Working",
-                template="sentry/emails/crons/broken-monitors.txt",
-                html_template="sentry/emails/crons/broken-monitors.html",
-                type="crons.broken_monitors",
-                context=context,
-            )
-            message.send_async([user_email])
-
-        for user_email, muted_monitors in user_muted_envs.items():
-            context = {
-                "muted_monitors": generate_monitor_email_context(
-                    muted_monitors.values(), organization
-                ),
-                "view_monitors_link": generate_monitor_overview_url(organization),
-            }
-            message = MessageBuilder(
-                subject="Your Cron Monitors have been muted",
-                template="sentry/emails/crons/muted-monitors.txt",
-                html_template="sentry/emails/crons/muted-monitors.html",
-                type="crons.muted_monitors",
-                context=context,
-            )
-            message.send_async([user_email])
+                update_user_monitor_dictionary(
+                    user_muted_envs, user.user_email, open_incident, project, environment_name
+                )
 
         metrics.timing(
-            "crons.detect_broken_monitor_org_email_time",
-            django_timezone.now().timestamp() - org_email_sending_start_time.timestamp(),
-            tags={"org_id": org_id},
+            "crons.detect_broken_monitor_org_incident_time",
+            django_timezone.now().timestamp() - org_incident_process_start_time.timestamp(),
+            tags={"incident": open_incident.id},
         )
 
-        # mark all open detections for this org as having had their email sent
-        MonitorEnvBrokenDetection.objects.filter(
-            monitor_incident__in=orgs_open_incidents, user_notified_timestamp=None
-        ).update(user_notified_timestamp=django_timezone.now())
+    # Record how long it takes to send all emails for an org
+    org_email_sending_start_time = django_timezone.now()
 
-        metrics.timing(
-            "crons.detect_broken_monitor_org_time",
-            django_timezone.now().timestamp() - org_process_start_time.timestamp(),
-            tags={"org_id": org_id},
+    # After accumulating all users within the org and which monitors to email them, send the emails
+    for user_email, broken_monitors in user_broken_envs.items():
+        context = {
+            "broken_monitors": generate_monitor_email_context(
+                broken_monitors.values(), organization
+            ),
+            "view_monitors_link": generate_monitor_overview_url(organization),
+        }
+        message = MessageBuilder(
+            subject="Your Cron Monitors Aren't Working",
+            template="sentry/emails/crons/broken-monitors.txt",
+            html_template="sentry/emails/crons/broken-monitors.html",
+            type="crons.broken_monitors",
+            context=context,
         )
+        message.send_async([user_email])
+
+    for user_email, muted_monitors in user_muted_envs.items():
+        context = {
+            "muted_monitors": generate_monitor_email_context(muted_monitors.values(), organization),
+            "view_monitors_link": generate_monitor_overview_url(organization),
+        }
+        message = MessageBuilder(
+            subject="Your Cron Monitors have been muted",
+            template="sentry/emails/crons/muted-monitors.txt",
+            html_template="sentry/emails/crons/muted-monitors.html",
+            type="crons.muted_monitors",
+            context=context,
+        )
+        message.send_async([user_email])
+
+    metrics.timing(
+        "crons.detect_broken_monitor_org_email_time",
+        django_timezone.now().timestamp() - org_email_sending_start_time.timestamp(),
+        tags={"org_id": org_id},
+    )
+
+    # mark all open detections for this org as having had their email sent
+    MonitorEnvBrokenDetection.objects.filter(
+        monitor_incident__in=orgs_open_incidents, user_notified_timestamp=None
+    ).update(user_notified_timestamp=django_timezone.now())
+
+    metrics.timing(
+        "crons.detect_broken_monitor_org_time",
+        django_timezone.now().timestamp() - org_process_start_time.timestamp(),
+        tags={"org_id": org_id},
+    )

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -43,7 +43,6 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
     def create_monitor_and_env(
         self, name="test monitor", organization_id=None, project_id=None, environment_id=None
     ):
-        self.tasks
         if organization_id is None:
             organization_id = self.organization.id
         if project_id is None:

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -24,6 +24,15 @@ from sentry.testutils.helpers.features import with_feature
 
 
 class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._run_tasks = self.tasks()
+        self._run_tasks.__enter__()
+
+    def tearDown(self):
+        super().tearDown()
+        self._run_tasks.__exit__(None, None, None)
+
     def create_monitor_env(self, monitor, environment_id):
         return MonitorEnvironment.objects.create(
             monitor=monitor,
@@ -34,6 +43,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
     def create_monitor_and_env(
         self, name="test monitor", organization_id=None, project_id=None, environment_id=None
     ):
+        self.tasks
         if organization_id is None:
             organization_id = self.organization.id
         if project_id is None:


### PR DESCRIPTION
Right now we have all the logic for broken monitors in a single task. I suspect the reason that we're failing to run these is that one large org is blocking everyone else. Splitting this up will let us see if it is a specific org and which one it is.
