### PR TITLE
feat(tracing): Add trace_id to span aggregation response

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -48,6 +48,7 @@ class EventSpans(TypedDict):
 class SpanSample(TypedDict):
     transaction: str | None
     trace: str | None
+    timestamp: int
     span: str
 
 
@@ -158,6 +159,7 @@ class BaseAggregateSpans:
                     SpanSample(
                         {
                             "transaction": self.current_transaction,
+                            "timestamp": start_timestamp / 1000,
                             "span": span_tree["span_id"],
                             "trace": self.current_trace,
                         }
@@ -169,6 +171,7 @@ class BaseAggregateSpans:
                 SpanSample(
                     {
                         "transaction": self.current_transaction,
+                        "timestamp": start_timestamp / 1000,
                         "span": span_tree["span_id"],
                         "trace": self.current_trace,
                     }
@@ -265,6 +268,7 @@ class AggregateNodestoreSpans(BaseAggregateSpans):
 
             self.current_transaction = event["event_id"]
             self.current_trace = event["contexts"]["trace"]["trace_id"]
+
             root_span_id = event["contexts"]["trace"]["span_id"]
             span_tree[root_span_id] = {
                 "span_id": root_span_id,
@@ -366,7 +370,7 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
                 builder = SpansIndexedQueryBuilder(
                     dataset=Dataset.SpansIndexed,
                     params=params,
-                    selected_columns=["transaction_id", "trace_id", "count()"],
+                    selected_columns=["transaction_id", "trace_id", "count()", "any(timestamp)"],
                     query=query,
                     limit=100,
                 )

--- a/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
@@ -14,6 +14,7 @@ from sentry.utils.samples import load_data
 MOCK_SNUBA_RESPONSE = {
     "data": [
         {
+            "trace_id": "a" * 32,
             "transaction_id": "80fe542aea4945ffbe612646987ee449",
             "count": 71,
             "spans": [
@@ -80,6 +81,7 @@ MOCK_SNUBA_RESPONSE = {
             ],
         },
         {
+            "trace_id": "b" * 32,
             "transaction_id": "86b21833d1854d9b811000b91e7fccfa",
             "count": 71,
             "spans": [
@@ -440,11 +442,41 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                     ("80fe542aea4945ffbe612646987ee449", "root_1"),
                     ("86b21833d1854d9b811000b91e7fccfa", "root_2"),
                 }
+                assert data[root_fingerprint]["sample_spans"] == [
+                    {
+                        "transaction": "80fe542aea4945ffbe612646987ee449",
+                        "span": "root_1",
+                        "trace": "a" * 32,
+                    },
+                    {
+                        "transaction": "86b21833d1854d9b811000b91e7fccfa",
+                        "span": "root_2",
+                        "trace": "b" * 32,
+                    },
+                ]
             else:
                 assert data[root_fingerprint]["samples"] == {
-                    (self.root_event_1.event_id, self.span_ids_event_1["A"]),
-                    (self.root_event_2.event_id, self.span_ids_event_2["A"]),
+                    (
+                        self.root_event_1.event_id,
+                        self.span_ids_event_1["A"],
+                    ),
+                    (
+                        self.root_event_2.event_id,
+                        self.span_ids_event_2["A"],
+                    ),
                 }
+                assert data[root_fingerprint]["sample_spans"] == [
+                    {
+                        "transaction": self.root_event_1.event_id,
+                        "span": self.span_ids_event_1["A"],
+                        "trace": self.root_event_1.data["contexts"]["trace"]["trace_id"],
+                    },
+                    {
+                        "transaction": self.root_event_2.event_id,
+                        "span": self.span_ids_event_2["A"],
+                        "trace": self.root_event_2.data["contexts"]["trace"]["trace_id"],
+                    },
+                ]
 
             fingerprint = hashlib.md5(b"e238e6c2e2466b07-B").hexdigest()[:16]
             assert data[fingerprint]["description"] == "connect"

--- a/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
@@ -445,11 +445,13 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                 assert data[root_fingerprint]["sample_spans"] == [
                     {
                         "transaction": "80fe542aea4945ffbe612646987ee449",
+                        "timestamp": 1694625139.1,
                         "span": "root_1",
                         "trace": "a" * 32,
                     },
                     {
                         "transaction": "86b21833d1854d9b811000b91e7fccfa",
+                        "timestamp": 1694625159.1,
                         "span": "root_2",
                         "trace": "b" * 32,
                     },
@@ -468,11 +470,13 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                 assert data[root_fingerprint]["sample_spans"] == [
                     {
                         "transaction": self.root_event_1.event_id,
+                        "timestamp": self.root_event_1.data["start_timestamp"],
                         "span": self.span_ids_event_1["A"],
                         "trace": self.root_event_1.data["contexts"]["trace"]["trace_id"],
                     },
                     {
                         "transaction": self.root_event_2.event_id,
+                        "timestamp": self.root_event_2.data["start_timestamp"],
                         "span": self.span_ids_event_2["A"],
                         "trace": self.root_event_2.data["contexts"]["trace"]["trace_id"],
                     },


### PR DESCRIPTION
- This updates the span-aggregation response to include the trace_id
- Add a new span_samples attribute instead of the list of tuples so its more obvious which value is which, keeping the existing samples attribute so we can migrate over without breaking anything