### PR TITLE
Moved timestamp col to after title col

### DIFF
--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -149,6 +149,7 @@ const getColumns = (group: Group, organization: Organization): ColumnInfo => {
     'id',
     'transaction',
     'title',
+    'timestamp',
     'release',
     'environment',
     'user.display',
@@ -156,13 +157,13 @@ const getColumns = (group: Group, organization: Organization): ColumnInfo => {
     'os',
     ...platformSpecificFields,
     ...(isPerfIssue ? ['transaction.duration'] : []),
-    'timestamp',
   ];
 
   const columnTitles: string[] = [
     t('event id'),
     t('transaction'),
     t('title'),
+    t('timestamp'),
     t('release'),
     t('environment'),
     t('user'),
@@ -170,7 +171,6 @@ const getColumns = (group: Group, organization: Organization): ColumnInfo => {
     t('os'),
     ...platformSpecificColumnTitles,
     ...(isPerfIssue ? [t('total duration')] : []),
-    t('timestamp'),
     t('minidump'),
   ];
 


### PR DESCRIPTION
Resolves #68015 

Moves the Timestamp column from the rightmost column to in between the Title and Release column

**Before (wide screen):**
<img width="1612" alt="Pasted Graphic 2" src="https://github.com/getsentry/sentry/assets/55160142/21b79b80-e02f-4a10-a8bc-9b7415abdfbb">


**After (wide screen):**
<img width="1851" alt="Pasted Graphic 1" src="https://github.com/getsentry/sentry/assets/55160142/cf92fd7b-4010-45f8-bc05-9947da5f9f52">

**Before (narrow screen):**
<img width="1083" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/174b7075-0574-43e6-8892-a839bc131013">

**After (narrow screen):**
<img width="1085" alt="image" src="https://github.com/getsentry/sentry/assets/55160142/24ad4c13-8d3f-4efa-b0bf-f72910d2b812">
