### PR TITLE
ref(crons): Remove unnecessary error placeholder

### DIFF
--- a/static/app/views/monitors/components/mockTimelineVisualization.tsx
+++ b/static/app/views/monitors/components/mockTimelineVisualization.tsx
@@ -90,12 +90,8 @@ export function MockTimelineVisualization({schedule}: Props) {
       <TimelineWidthTracker ref={elementRef} />
       {isLoading || !start || !end || !timeWindowConfig || !mockTimestamps ? (
         <Fragment>
-          <Placeholder height="40px" />
-          {errorMessage ? (
-            <Placeholder testId="error-placeholder" height="100px" />
-          ) : (
-            <CheckInPlaceholder />
-          )}
+          <Placeholder height="50px" />
+          {errorMessage ? null : <CheckInPlaceholder />}
         </Fragment>
       ) : (
         <Fragment>


### PR DESCRIPTION
We can just let this be blank when there is an error