### PR TITLE
fix(crons): Support timezone in MockTimelineVisualization

### DIFF
--- a/static/app/views/monitors/components/mockTimelineVisualization.tsx
+++ b/static/app/views/monitors/components/mockTimelineVisualization.tsx
@@ -21,6 +21,7 @@ interface ScheduleConfig {
   intervalFrequency?: FieldValue;
   intervalUnit?: FieldValue;
   scheduleType?: FieldValue;
+  timezone?: FieldValue;
 }
 
 const NUM_SAMPLE_TICKS = 9;
@@ -38,13 +39,16 @@ interface Props {
 }
 
 export function MockTimelineVisualization({schedule}: Props) {
-  const {scheduleType, cronSchedule, intervalFrequency, intervalUnit} = schedule;
+  const {scheduleType, cronSchedule, timezone, intervalFrequency, intervalUnit} =
+    schedule;
+
   const organization = useOrganization();
   const {form} = useContext(FormContext);
 
   const query = {
     num_ticks: NUM_SAMPLE_TICKS,
     schedule_type: scheduleType,
+    timezone,
     schedule:
       scheduleType === 'interval' ? [intervalFrequency, intervalUnit] : cronSchedule,
   };

--- a/static/app/views/monitors/components/monitorCreateForm.tsx
+++ b/static/app/views/monitors/components/monitorCreateForm.tsx
@@ -204,11 +204,13 @@ export default function MonitorCreateForm() {
           {() => {
             const scheduleType = form.current.getValue('config.scheduleType');
             const cronSchedule = form.current.getValue('config.schedule');
+            const timezone = form.current.getValue('config.timezone');
             const intervalFrequency = form.current.getValue('config.schedule.frequency');
             const intervalUnit = form.current.getValue('config.schedule.interval');
 
             const schedule = {
               scheduleType,
+              timezone,
               cronSchedule,
               intervalFrequency,
               intervalUnit,


### PR DESCRIPTION
The visualization will now provide the timezone to the sample schedule data endpoint.

Refs GH-68473