### PR TITLE
ref(crons): Use a max-width on the monitorCreateForm

### DIFF
--- a/static/app/views/monitors/components/monitorCreateForm.tsx
+++ b/static/app/views/monitors/components/monitorCreateForm.tsx
@@ -220,7 +220,7 @@ export default function MonitorCreateForm() {
 }
 
 const FieldContainer = styled('div')`
-  width: 800px;
+  max-width: 800px;
 `;
 
 const SchedulePanel = styled(Panel)<{highlighted: boolean}>`


### PR DESCRIPTION
Otherwise this can happen

<img alt="clipboard.png" width="852" src="https://i.imgur.com/yzOaT5u.png" />