### PR TITLE
fix(feedback): Tall screenshots should be contained better

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackScreenshot.tsx
@@ -68,6 +68,7 @@ const StyledImageButton = styled('button')`
   background: none;
   padding: 0;
   border: 0;
+  overflow: auto;
 `;
 
 const StyledImageVisualization = styled(ImageVisualization)`


### PR DESCRIPTION
Before:
<img width="197" alt="SCR-20240408-oism" src="https://github.com/getsentry/sentry/assets/187460/4da79525-f780-4e68-8b5f-e60364a37ef0">


After:
<img width="308" alt="SCR-20240408-oily" src="https://github.com/getsentry/sentry/assets/187460/aa2479b9-8b5a-46df-bd12-929a5a822410">


Fixes https://github.com/getsentry/sentry/issues/68474

