### PR TITLE
better saml map attrs messaging

### DIFF
--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -290,7 +290,7 @@ class SAML2Provider(Provider, abc.ABC):
             error_msg_keys = ", ".join(repr(key) for key in sorted(raw_attributes.keys()))
             raise IdentityNotValid(
                 _(
-                    f"Failed to map SAML attributes. Assertion returned the following attribute keys: {error_msg_keys}"
+                    f"Failed to map SAML attributes for: {error_msg_keys}. Please check your map attribute input values."
                 )
             )
 


### PR DESCRIPTION
We've now had multiple instances where this message has been really confusing.

SAML and SSO are confusing enough already.

We need to make it more clear that these map attributes are being used to link their IdP identity with their Sentry identity.
In order to do so, we need them to input in the attributes _from the idp identity_ that maps to the appropriate _sentry identity attr_.

hopefully this change it more clear that the attrs that failed are _*the sentry attributes*_ and they need to provide a valid idp attribute to map to