### PR TITLE
chore(api-idorslug): Switch option check to `from sentry.api.utils import id_or_slug_path_params_enabled` wrapper

### DIFF
--- a/src/sentry/api/bases/doc_integrations.py
+++ b/src/sentry/api/bases/doc_integrations.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from django.http import Http404
 from rest_framework.request import Request
 
-from sentry import options
 from sentry.api.base import Endpoint
 from sentry.api.bases.integration import PARANOID_GET
 from sentry.api.permissions import SentryPermission, StaffPermissionMixin
+from sentry.api.utils import id_or_slug_path_params_enabled
 from sentry.api.validators.doc_integration import METADATA_PROPERTIES
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.integrations.doc_integration import DocIntegration
@@ -78,7 +78,7 @@ class DocIntegrationBaseEndpoint(DocIntegrationsBaseEndpoint):
 
     def convert_args(self, request: Request, doc_integration_slug: str, *args, **kwargs):
         try:
-            if options.get("api.id-or-slug-enabled"):
+            if id_or_slug_path_params_enabled(self.convert_args.__qualname__):
                 doc_integration = DocIntegration.objects.get(slug__id_or_slug=doc_integration_slug)
             else:
                 doc_integration = DocIntegration.objects.get(slug=doc_integration_slug)

--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -4,11 +4,11 @@ import logging
 
 from rest_framework.request import Request
 
-from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.base import Endpoint
 from sentry.api.bases.project import ProjectPermission
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.utils import id_or_slug_path_params_enabled
 from sentry.models.group import Group, GroupStatus, get_group_with_redirect
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
@@ -53,7 +53,12 @@ class GroupEndpoint(Endpoint):
         # `issue_id` keyword argument.
         if organization_slug:
             try:
-                if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+                if (
+                    id_or_slug_path_params_enabled(
+                        self.convert_args.__qualname__, str(organization_slug)
+                    )
+                    and str(organization_slug).isnumeric()
+                ):
                     organization = Organization.objects.get_from_cache(id=organization_slug)
                 else:
                     organization = Organization.objects.get_from_cache(slug=organization_slug)

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -8,12 +8,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import Scope
 
-from sentry import options
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ProjectMoved, ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
 from sentry.api.permissions import StaffPermissionMixin
-from sentry.api.utils import get_date_range_from_params
+from sentry.api.utils import get_date_range_from_params, id_or_slug_path_params_enabled
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
@@ -118,7 +117,9 @@ class ProjectEndpoint(Endpoint):
         **kwargs,
     ):
         try:
-            if options.get("api.id-or-slug-enabled"):
+            if id_or_slug_path_params_enabled(
+                self.convert_args.__qualname__, str(organization_slug)
+            ):
                 project = (
                     Project.objects.filter(
                         organization__slug__id_or_slug=organization_slug,
@@ -139,7 +140,9 @@ class ProjectEndpoint(Endpoint):
             try:
                 # Project may have been renamed
                 redirect = ProjectRedirect.objects.select_related("project")
-                if options.get("api.id-or-slug-enabled"):
+                if id_or_slug_path_params_enabled(
+                    self.convert_args.__qualname__, str(organization_slug)
+                ):
                     redirect = redirect.get(
                         organization__id=organization_slug,
                         redirect_slug__id_or_slug=project_slug,

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -10,11 +10,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
-from sentry import options
 from sentry.api.authentication import ClientIdSecretAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.bases.integration import PARANOID_GET
 from sentry.api.permissions import SentryPermission, StaffPermissionMixin
+from sentry.api.utils import id_or_slug_path_params_enabled
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser, superuser_has_permission
 from sentry.coreapi import APIError
@@ -252,7 +252,7 @@ class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):
 
     def convert_args(self, request: Request, sentry_app_slug: str | int, *args: Any, **kwargs: Any):
         try:
-            if options.get("api.id-or-slug-enabled"):
+            if id_or_slug_path_params_enabled(self.convert_args.__qualname__):
                 sentry_app = SentryApp.objects.get(slug__id_or_slug=sentry_app_slug)
             else:
                 sentry_app = SentryApp.objects.get(slug=sentry_app_slug)
@@ -270,7 +270,10 @@ class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):
 
 class RegionSentryAppBaseEndpoint(IntegrationPlatformEndpoint):
     def convert_args(self, request: Request, sentry_app_slug: str | int, *args: Any, **kwargs: Any):
-        if options.get("api.id-or-slug-enabled") and str(sentry_app_slug).isnumeric():
+        if (
+            id_or_slug_path_params_enabled(self.convert_args.__qualname__)
+            and str(sentry_app_slug).isnumeric()
+        ):
             sentry_app = app_service.get_sentry_app_by_id(id=int(sentry_app_slug))
         else:
             sentry_app = app_service.get_sentry_app_by_slug(slug=sentry_app_slug)
@@ -321,7 +324,10 @@ class SentryAppInstallationsBaseEndpoint(IntegrationPlatformEndpoint):
         if not is_active_superuser(request):
             extra_args["user_id"] = request.user.id
 
-        if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+        if (
+            id_or_slug_path_params_enabled(self.convert_args.__qualname__, str(organization_slug))
+            and str(organization_slug).isnumeric()
+        ):
             organization = organization_service.get_org_by_id(
                 id=int(organization_slug), **extra_args
             )

--- a/src/sentry/api/bases/team.py
+++ b/src/sentry/api/bases/team.py
@@ -1,9 +1,9 @@
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 
-from sentry import options
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.utils import id_or_slug_path_params_enabled
 from sentry.models.team import Team, TeamStatus
 from sentry.utils.sdk import bind_organization_context
 
@@ -38,7 +38,7 @@ class TeamEndpoint(Endpoint):
 
     def convert_args(self, request: Request, organization_slug, team_slug, *args, **kwargs):
         try:
-            if options.get("api.id-or-slug-enabled"):
+            if id_or_slug_path_params_enabled(self.convert_args.__qualname__):
                 team = (
                     Team.objects.filter(
                         organization__slug__id_or_slug=organization_slug, slug__id_or_slug=team_slug

--- a/src/sentry/api/endpoints/organization_region.py
+++ b/src/sentry/api/endpoints/organization_region.py
@@ -4,12 +4,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import capture_message
 
-from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import SentryPermission
+from sentry.api.utils import id_or_slug_path_params_enabled
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.types.region import get_region_by_name
@@ -61,7 +61,12 @@ class OrganizationRegionEndpoint(Endpoint):
 
         try:
             # We don't use the lookup since OrganizationMapping uses a BigIntField for organization_id instead of a ForeignKey
-            if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+            if (
+                id_or_slug_path_params_enabled(
+                    self.convert_args.__qualname__, str(organization_slug)
+                )
+                and str(organization_slug).isnumeric()
+            ):
                 org_mapping = OrganizationMapping.objects.get(organization_id=organization_slug)
             else:
                 org_mapping = OrganizationMapping.objects.get(slug=organization_slug)

--- a/src/sentry/api/endpoints/organization_sentry_function_details.py
+++ b/src/sentry/api/endpoints/organization_sentry_function_details.py
@@ -3,13 +3,14 @@ from google.api_core.exceptions import FailedPrecondition, InvalidArgument, NotF
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
-from sentry import features, options
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.endpoints.organization_sentry_function import SentryFunctionSerializer
 from sentry.api.serializers import serialize
+from sentry.api.utils import id_or_slug_path_params_enabled
 from sentry.models.sentryfunction import SentryFunction
 from sentry.utils.cloudfunctions import delete_function, update_function
 
@@ -27,7 +28,7 @@ class OrganizationSentryFunctionDetailsEndpoint(OrganizationEndpoint):
         args, kwargs = super().convert_args(request, organization_slug, *args, **kwargs)
 
         try:
-            if options.get("api.id-or-slug-enabled"):
+            if id_or_slug_path_params_enabled(self.convert_args.__qualname__):
                 function = SentryFunction.objects.get(
                     slug__id_or_slug=function_slug, organization=kwargs["organization"].id
                 )

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -7,7 +7,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import configure_scope
 
-from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import (
@@ -19,6 +18,7 @@ from sentry.api.authentication import (
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.exceptions import ParameterValidationError, ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.api.utils import id_or_slug_path_params_enabled
 from sentry.constants import ObjectStatus
 from sentry.models.files.file import File
 from sentry.models.organization import Organization
@@ -95,7 +95,12 @@ class MonitorIngestCheckinAttachmentEndpoint(Endpoint):
             if organization_slug:
                 try:
                     # Try lookup by slug first. This requires organization context.
-                    if options.get("api.id-or-slug-enabled") and str(organization_slug).isnumeric():
+                    if (
+                        id_or_slug_path_params_enabled(
+                            self.convert_args.__qualname__, str(organization_slug)
+                        )
+                        and str(organization_slug).isnumeric()
+                    ):
                         organization = Organization.objects.get_from_cache(id=organization_slug)
                     else:
                         organization = Organization.objects.get_from_cache(slug=organization_slug)

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -25,7 +25,11 @@ from django.views.generic import View
 from rest_framework.request import Request
 
 from sentry import options
-from sentry.api.utils import generate_organization_url, is_member_disabled_from_limit
+from sentry.api.utils import (
+    generate_organization_url,
+    id_or_slug_path_params_enabled,
+    is_member_disabled_from_limit,
+)
 from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import ObjectStatus
@@ -252,7 +256,9 @@ class OrganizationMixin:
         self, request: HttpRequest, organization: RpcOrganization, project_slug: str | int
     ) -> Project | None:
         try:
-            if options.get("api.id-or-slug-enabled"):
+            if id_or_slug_path_params_enabled(
+                self.convert_args.__qualname__, str(organization.slug)
+            ):
                 project = Project.objects.get(
                     slug__id_or_slug=project_slug, organization=organization
                 )

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -277,7 +277,7 @@ class IdOrSlugPathParamsEnabledTest(TestCase):
 
     @override_options({"api.id-or-slug-enabled-ea-org": ["sentry"]})
     @override_options({"api.id-or-slug-enabled-ea-endpoints": ["TestEndpoint.convert_args"]})
-    def test_ea_org_and_endpointoption_enabled(self):
+    def test_ea_org_and_endpoint_option_enabled(self):
         assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "not-sentry")
         assert not id_or_slug_path_params_enabled("NotTestEndpoint.convert_args", "sentry")
         assert not id_or_slug_path_params_enabled("TestEndpoint.convert_args", "not-sentry")


### PR DESCRIPTION
I switched over all the options checks with the wrapper I created in https://github.com/getsentry/sentry/pull/68233

For: https://github.com/getsentry/team-core-product-foundations/issues/263

Some places, I was able to get the `organization_slug` from arguments passed in or from previous conversions. We will have to add Sentry's slug and id in the option.