### PR TITLE
ref(feedback): route to feedback index from alerts page

### DIFF
--- a/static/app/views/alerts/rules/issue/details/issuesList.tsx
+++ b/static/app/views/alerts/rules/issue/details/issuesList.tsx
@@ -14,6 +14,7 @@ import {space} from 'sentry/styles/space';
 import type {Group, Project} from 'sentry/types';
 import type {IssueAlertRule} from 'sentry/types/alerts';
 import {getMessage, getTitle} from 'sentry/utils/events';
+import type {FeedbackIssue} from 'sentry/utils/feedback/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -80,23 +81,25 @@ function AlertRuleIssuesList({project, rule, period, start, end, utc, cursor}: P
         {groupHistory?.map(({group: issue, count, lastTriggered, eventId}) => {
           const message = getMessage(issue);
           const {title} = getTitle(issue);
+          const path =
+            (issue as unknown as FeedbackIssue).issueType === 'feedback'
+              ? {
+                  pathname: `/organizations/${organization.slug}/feedback/?feedbackSlug=${issue.project.slug}%3A${issue.id}`,
+                }
+              : {
+                  pathname: `/organizations/${organization.slug}/issues/${issue.id}/${
+                    eventId ? `events/${eventId}` : ''
+                  }`,
+                  query: {
+                    referrer: 'alert-rule-issue-list',
+                    ...(rule.environment ? {environment: rule.environment} : {}),
+                  },
+                };
 
           return (
             <Fragment key={issue.id}>
               <TitleWrapper>
-                <Link
-                  to={{
-                    pathname: `/organizations/${organization.slug}/issues/${issue.id}/${
-                      eventId ? `events/${eventId}` : ''
-                    }`,
-                    query: {
-                      referrer: 'alert-rule-issue-list',
-                      ...(rule.environment ? {environment: rule.environment} : {}),
-                    },
-                  }}
-                >
-                  {title}:
-                </Link>
+                <Link to={path}>{title}:</Link>
                 <MessageWrapper>{message}</MessageWrapper>
               </TitleWrapper>
               <AlignRight>


### PR DESCRIPTION
on the alerts page, if it's a feedback issue, link it to the feedback index rather than the issues page

<img width="546" alt="SCR-20240408-orlt" src="https://github.com/getsentry/sentry/assets/56095982/7ee99e9d-6772-4f84-ad26-ae1917983186">


closes https://github.com/getsentry/sentry/issues/64477