### PR TITLE
fix(avatarList): show number of overflow teams

### DIFF
--- a/static/app/components/avatar/avatarList.spec.tsx
+++ b/static/app/components/avatar/avatarList.spec.tsx
@@ -68,4 +68,16 @@ describe('AvatarList', () => {
     expect(screen.getByText('D')).toBeInTheDocument();
     expect(screen.queryByTestId('avatarList-collapsedavatars')).not.toBeInTheDocument();
   });
+
+  it('renders with collapsed avatar count if > 5 teams', () => {
+    const teams = [
+      {...team, id: '1', name: 'A', slug: 'A', type: 'team'},
+      {...team, id: '2', name: 'B', slug: 'B', type: 'team'},
+    ];
+
+    renderComponent({users: [], teams});
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.queryByTestId('avatarList-collapsedavatars')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -36,7 +36,8 @@ function AvatarList({
   // Reverse the order since css flex-reverse is used to display the avatars
   const visibleTeamAvatars = teams.slice(0, numVisibleTeams).reverse();
   const visibleUserAvatars = users.slice(0, maxVisibleUsers).reverse();
-  const numCollapsedAvatars = users.length - visibleUserAvatars.length;
+  const numCollapsedAvatars =
+    users.length + teams.length - (visibleUserAvatars.length + visibleTeamAvatars.length);
 
   if (!tooltipOptions.position) {
     tooltipOptions.position = 'top';


### PR DESCRIPTION
before: there are more than 3 teams in this list, but when `maxVisibleAvatars` is set to 3, we don't see any overflow, unlike the `AvatarList` for users:
<img width="675" alt="SCR-20240408-peni" src="https://github.com/getsentry/sentry/assets/56095982/1ae04d5b-874f-4967-b1f9-36f4b121394e">

<img width="651" alt="SCR-20240408-perp" src="https://github.com/getsentry/sentry/assets/56095982/b6e13557-3e55-465f-b27c-79267b2c3ed3">


after:
<img width="665" alt="SCR-20240408-pdvg" src="https://github.com/getsentry/sentry/assets/56095982/bcde1752-cc76-451f-b4f4-69029cd9582a">

