### PR TITLE
fix(crons): Fix bugs related to seat assignment when updating a monitor

### DIFF
--- a/src/sentry/monitors/endpoints/base_monitor_details.py
+++ b/src/sentry/monitors/endpoints/base_monitor_details.py
@@ -112,22 +112,8 @@ class MonitorDetailsMixin(BaseEndpointMixin):
         if "project" in result and result["project"].id != monitor.project_id:
             raise ParameterValidationError("existing monitors may not be moved between projects")
 
-        # Update monitor slug
-        if "slug" in result:
-            quotas.backend.update_monitor_slug(monitor.slug, params["slug"], monitor.project_id)
-
-        # Attempt to assign a monitor seat
-        if params["status"] == ObjectStatus.ACTIVE:
-            outcome = quotas.backend.assign_monitor_seat(monitor)
-            # The MonitorValidator checks if a seat assignment is availble.
-            # This protects against a race condition
-            if outcome != Outcome.ACCEPTED:
-                raise ParameterValidationError("Failed to enable monitor, please try again")
-
-        # Attempt to unassign the monitor seat
-        if params["status"] == ObjectStatus.DISABLED:
-            quotas.backend.disable_monitor_seat(monitor)
-
+        old_slug = monitor.slug
+        old_status = monitor.status
         if params:
             monitor.update(**params)
             self.create_audit_entry(
@@ -137,6 +123,22 @@ class MonitorDetailsMixin(BaseEndpointMixin):
                 event=audit_log.get_event_id("MONITOR_EDIT"),
                 data=monitor.get_audit_log_data(),
             )
+
+        # Update monitor slug
+        if "slug" in result:
+            quotas.backend.update_monitor_slug(old_slug, params["slug"], monitor.project_id)
+
+        # Attempt to assign a monitor seat
+        if params["status"] == ObjectStatus.ACTIVE and old_status != ObjectStatus.ACTIVE:
+            outcome = quotas.backend.assign_monitor_seat(monitor)
+            # The MonitorValidator checks if a seat assignment is availble.
+            # This protects against a race condition
+            if outcome != Outcome.ACCEPTED:
+                raise ParameterValidationError("Failed to enable monitor, please try again")
+
+        # Attempt to unassign the monitor seat
+        if params["status"] == ObjectStatus.DISABLED and old_status != ObjectStatus.DISABLED:
+            quotas.backend.disable_monitor_seat(monitor)
 
         # Update alert rule after in case slug or name changed
         if "alert_rule" in result:

--- a/tests/sentry/monitors/endpoints/test_base_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_details.py
@@ -723,7 +723,7 @@ class BaseUpdateMonitorTest(MonitorTestCase):
         check_assign_monitor_seat.return_value = SeatAssignmentResult(assignable=True)
 
         def dummy_assign(monitor):
-            assert monitor.slug == new_slug
+            assert monitor.slug == old_slug
             return Outcome.ACCEPTED
 
         assign_monitor_seat.side_effect = dummy_assign
@@ -743,9 +743,6 @@ class BaseUpdateMonitorTest(MonitorTestCase):
         assert monitor.status == ObjectStatus.ACTIVE
         update_call_args = update_monitor_slug.call_args
         assert update_call_args[0] == (old_slug, new_slug, monitor.project_id)
-
-        assign_call_args = assign_monitor_seat.call_args
-        assert assign_call_args[0][0].slug == new_slug
 
     @patch("sentry.quotas.backend.check_assign_monitor_seat")
     @patch("sentry.quotas.backend.assign_monitor_seat")

--- a/tests/sentry/monitors/endpoints/test_base_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_details.py
@@ -688,6 +688,67 @@ class BaseUpdateMonitorTest(MonitorTestCase):
 
     @patch("sentry.quotas.backend.check_assign_monitor_seat")
     @patch("sentry.quotas.backend.assign_monitor_seat")
+    def test_no_activate_if_already_activated(self, assign_monitor_seat, check_assign_monitor_seat):
+        check_assign_monitor_seat.return_value = SeatAssignmentResult(assignable=True)
+        assign_monitor_seat.return_value = Outcome.ACCEPTED
+
+        monitor = self._create_monitor()
+
+        self.get_success_response(
+            self.organization.slug, monitor.slug, method="PUT", **{"status": "active"}
+        )
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == ObjectStatus.ACTIVE
+        assert not assign_monitor_seat.called
+
+    @patch("sentry.quotas.backend.disable_monitor_seat")
+    def test_no_disable_if_already_disabled(self, disable_monitor_seat):
+        monitor = self._create_monitor()
+
+        self.get_success_response(
+            self.organization.slug, monitor.slug, method="PUT", **{"status": "active"}
+        )
+        monitor.update(status=ObjectStatus.DISABLED)
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == ObjectStatus.DISABLED
+        assert not disable_monitor_seat.called
+
+    @patch("sentry.quotas.backend.update_monitor_slug")
+    @patch("sentry.quotas.backend.check_assign_monitor_seat")
+    @patch("sentry.quotas.backend.assign_monitor_seat")
+    def test_update_slug_sends_right_slug_to_assign(
+        self, assign_monitor_seat, check_assign_monitor_seat, update_monitor_slug
+    ):
+        check_assign_monitor_seat.return_value = SeatAssignmentResult(assignable=True)
+
+        def dummy_assign(monitor):
+            assert monitor.slug == new_slug
+            return Outcome.ACCEPTED
+
+        assign_monitor_seat.side_effect = dummy_assign
+
+        monitor = self._create_monitor()
+        monitor.update(status=ObjectStatus.DISABLED)
+        old_slug = monitor.slug
+        new_slug = "new_slug"
+        self.get_success_response(
+            self.organization.slug,
+            monitor.slug,
+            method="PUT",
+            **{"status": "active", "slug": new_slug},
+        )
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == ObjectStatus.ACTIVE
+        update_call_args = update_monitor_slug.call_args
+        assert update_call_args[0] == (old_slug, new_slug, monitor.project_id)
+
+        assign_call_args = assign_monitor_seat.call_args
+        assert assign_call_args[0][0].slug == new_slug
+
+    @patch("sentry.quotas.backend.check_assign_monitor_seat")
+    @patch("sentry.quotas.backend.assign_monitor_seat")
     def test_activate_monitor_invalid(self, assign_monitor_seat, check_assign_monitor_seat):
         result = SeatAssignmentResult(
             assignable=False,


### PR DESCRIPTION
@isabellaenriquez reported that we are getting duplicate seat assignments when updating slugs, and that it's caused by us updating the slug on the monitor after we make the call to `assign_monitor_seat`.

This pr moves updating the monitor to before we update billing. While looking into this I also noticed that we will always call `assign_monitor_seat` and `disable_monitor_seat` whenever status is passed, because we don't check if the status has changed before we call them. This might not be causing any bugs but still seems incorrect, so added fixes and tests for that as well.
