### PR TITLE
feat(relocation): Improve claim user emails

### DIFF
--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -1097,6 +1097,7 @@ def postprocessing(uuid: str) -> None:
                 user_id=relocation.owner_id,
                 role="owner",
             )
+
         # Last, but certainly not least: trigger signals, so that interested subscribers in eg:
         # getsentry can do whatever postprocessing they need to. If even a single one fails, we fail
         # the entire task.
@@ -1104,8 +1105,8 @@ def postprocessing(uuid: str) -> None:
             if isinstance(result, Exception):
                 raise result
 
-        # This signal nust come after the relocated signal, to ensure that the subscription and customer models
-        # have been appropriately set up before attempting to redeem a promo code.
+        # This signal must come after the relocated signal, to ensure that the subscription and
+        # customer models have been appropriately set up before attempting to redeem a promo code.
         relocation_redeem_promo_code.send_robust(
             sender=postprocessing,
             user_id=relocation.owner_id,
@@ -1166,6 +1167,12 @@ def notifying_users(uuid: str) -> None:
         for chunk in chunks:
             imported_user_ids = imported_user_ids.union(set(chunk.inserted_map.values()))
 
+        imported_org_slugs: set[int] = set()
+        for chunk in RegionImportChunk.objects.filter(
+            import_uuid=str(uuid), model="sentry.organization"
+        ):
+            imported_org_slugs = imported_org_slugs.union(set(chunk.inserted_identifiers.values()))
+
         # Do a sanity check on pk-mapping before we go and reset the passwords of random users - are
         # all of these usernames plausibly ones that were included in the import, based on username
         # prefix matching?
@@ -1184,7 +1191,7 @@ def notifying_users(uuid: str) -> None:
         # Okay, everything seems fine - go ahead and send those emails.
         for user in imported_users:
             hash = lost_password_hash_service.get_or_create(user_id=user.id).hash
-            LostPasswordHash.send_relocate_account_email(user, hash, relocation.want_org_slugs)
+            LostPasswordHash.send_relocate_account_email(user, hash, list(imported_org_slugs))
 
         relocation.latest_unclaimed_emails_sent_at = datetime.now(UTC)
         relocation.save()
@@ -1223,12 +1230,18 @@ def notifying_owner(uuid: str) -> None:
         attempts_left,
         ERR_NOTIFYING_INTERNAL,
     ):
+        imported_org_slugs: set[int] = set()
+        for chunk in RegionImportChunk.objects.filter(
+            import_uuid=str(uuid), model="sentry.organization"
+        ):
+            imported_org_slugs = imported_org_slugs.union(set(chunk.inserted_identifiers.values()))
+
         send_relocation_update_email(
             relocation,
             Relocation.EmailKind.SUCCEEDED,
             {
                 "uuid": str(relocation.uuid),
-                "orgs": relocation.want_org_slugs,
+                "orgs": list(imported_org_slugs),
             },
         )
 

--- a/src/sentry/templates/sentry/account/relocate/claimed.html
+++ b/src/sentry/templates/sentry/account/relocate/claimed.html
@@ -8,5 +8,5 @@
 {% block auth_main %}
 	<h3>{% trans "Claim Account" %}</h3>
 
-	<p>This user has already been claimed - you should be able to log in as normal. You can always <a href="{% url 'sentry-account-recover' %}">reset your password</a> if you have forgotten it.</p>
+	<p>This account has already been claimed - you should be able to log in as normal. You can always <a href="{% url 'sentry-account-recover' %}">reset your password</a> if you have forgotten it.</p>
 {% endblock %}

--- a/src/sentry/templates/sentry/account/relocate/claimed.html
+++ b/src/sentry/templates/sentry/account/relocate/claimed.html
@@ -1,0 +1,12 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Claim Account" %} | {{ block.super }}{% endblock %}
+
+{% block auth_main %}
+	<h3>{% trans "Claim Account" %}</h3>
+
+	<p>This user has already been claimed - you should be able to log in as normal. You can always <a href="{% url 'sentry-account-recover' %}">reset your password</a> if you have forgotten it.</p>
+{% endblock %}

--- a/src/sentry/templates/sentry/account/relocate/error.html
+++ b/src/sentry/templates/sentry/account/relocate/error.html
@@ -1,0 +1,14 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Claim Account" %} | {{ block.super }}{% endblock %}
+
+{% block auth_main %}
+	<h3>{% trans "Claim Account" %}</h3>
+
+	<p>{% blocktrans %}We were unable to locate this user.{% endblocktrans %}</p>
+
+  <p>Please <a href="https://help.sentry.io">contact support</a> for further assistance if necessary.</p>
+{% endblock %}

--- a/src/sentry/templates/sentry/account/relocate/error.html
+++ b/src/sentry/templates/sentry/account/relocate/error.html
@@ -8,7 +8,7 @@
 {% block auth_main %}
 	<h3>{% trans "Claim Account" %}</h3>
 
-	<p>{% blocktrans %}We were unable to locate this user.{% endblocktrans %}</p>
+	<p>{% blocktrans %}We were unable to locate this account.{% endblocktrans %}</p>
 
   <p>Please <a href="https://help.sentry.io">contact support</a> for further assistance if necessary.</p>
 {% endblock %}

--- a/src/sentry/templates/sentry/account/relocate/failure.html
+++ b/src/sentry/templates/sentry/account/relocate/failure.html
@@ -7,7 +7,7 @@
 
 {% block auth_main %}
 	<h3>{% trans "Claim Account" %}</h3>
-	<p>{% blocktrans %}This link has expired. Request a new account claiming email to set your account
+	<p>{% blocktrans %}This link has expired. Request a new claim account email to set your account
 	  password and claim your account.{% endblocktrans %}</p>
   <form method="POST" action="{% url 'sentry-account-relocate-reclaim' user_id %}">
     <fieldset class="form-actions">

--- a/src/sentry/templates/sentry/account/relocate/failure.html
+++ b/src/sentry/templates/sentry/account/relocate/failure.html
@@ -7,7 +7,11 @@
 
 {% block auth_main %}
 	<h3>{% trans "Claim Account" %}</h3>
-	<p>{% blocktrans %}This password link has expired. Request a new password recovery code to set
-		your account password and claim your account.{% endblocktrans %}</p>
-	<p><a href="{% url 'sentry-account-recover' %}" class="btn btn-primary">Request Reset Code</a></p>
+	<p>{% blocktrans %}This link has expired. Request a new account claiming email to set your account
+	  password and claim your account.{% endblocktrans %}</p>
+  <form method="POST" action="{% url 'sentry-account-relocate-reclaim' user_id %}">
+    <fieldset class="form-actions">
+      <button type="submit" class="btn btn-primary">{% trans "Resend Email" %}</button>
+    </fieldset>
+  </form>
 {% endblock %}

--- a/src/sentry/templates/sentry/account/relocate/sent.html
+++ b/src/sentry/templates/sentry/account/relocate/sent.html
@@ -1,0 +1,12 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}{% trans "Claim Account" %} | {{ block.super }}{% endblock %}
+
+{% block auth_main %}
+	<h3>{% trans "Claim Account" %}</h3>
+
+	<p>{% blocktrans %}We have sent an email to the address registered with this account containing further instructions to set your password and claim this user.{% endblocktrans %}</p>
+{% endblock %}

--- a/src/sentry/templates/sentry/account/relocate/sent.html
+++ b/src/sentry/templates/sentry/account/relocate/sent.html
@@ -8,5 +8,5 @@
 {% block auth_main %}
 	<h3>{% trans "Claim Account" %}</h3>
 
-	<p>{% blocktrans %}We have sent an email to the address registered with this account containing further instructions to set your password and claim this user.{% endblocktrans %}</p>
+	<p>{% blocktrans %}We have sent an email to the address registered with this account containing further instructions to set your password and claim this account.{% endblocktrans %}</p>
 {% endblock %}

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -165,7 +165,7 @@ def relocate_reclaim(request, user_id):
 
     # Make a new `LostPasswordHash`, and send the "this user has been relocated ..." email again.
     password_hash = lost_password_hash_service.get_or_create(user_id=user_id)
-    LostPasswordHash.send_relocate_account_email(user.email, password_hash.hash, org_slugs)
+    LostPasswordHash.send_relocate_account_email(user, password_hash.hash, org_slugs)
     extra["passwordhash_id"] = password_hash.id
     extra["org_slugs"] = org_slugs
 

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -112,6 +112,56 @@ def recover(request):
 
 @set_referrer_policy("strict-origin-when-cross-origin")
 @control_silo_function
+def relocate_reclaim(request, user_id):
+    """
+    Ask to receive a new "claim this user" email.
+    """
+
+    extra = {
+        "ip_address": request.META["REMOTE_ADDR"],
+        "user_agent": request.META.get("HTTP_USER_AGENT"),
+        "user_id": user_id,
+    }
+    if request.method != "POST":
+        logger.warning("reclaim.error", extra=extra)
+        return render_to_response(get_template("relocate", "error"), {}, request)
+
+    # Verify that the user is unclaimed. If they are already claimed, tell the requester that this
+    # is the case, since of course claiming this account would be impossible.
+    user = User.objects.filter(id=user_id).first()
+    if user is None:
+        logger.warning("reclaim.user_not_found", extra=extra)
+        return render_to_response(get_template("relocate", "error"), {}, request)
+    if not user.is_unclaimed:
+        logger.warning("reclaim.already_claimed", extra=extra)
+        return render_to_response(get_template("relocate", "claimed"), {}, request)
+
+    # Get all orgs for user. We'll need this info to properly compose the new relocation email.
+    org_ids = OrganizationMemberMapping.objects.filter(user_id=user_id).values_list(
+        "organization_id", flat=True
+    )
+    org_slugs = list(
+        OrganizationMapping.objects.filter(organization_id__in=org_ids).values_list(
+            "slug", flat=True
+        )
+    )
+    if len(org_slugs) == 0:
+        logger.warning("reclaim.error", extra=extra)
+        return render_to_response(get_template("relocate", "error"), {}, request)
+
+    # Make a new `LostPasswordHash`, and send the "this user has been relocated ..." email again.
+    password_hash = lost_password_hash_service.get_or_create(user_id=user_id)
+    LostPasswordHash.send_relocate_account_email(user.email, password_hash.hash, org_slugs)
+    extra["passwordhash_id"] = password_hash.id
+    extra["org_slugs"] = org_slugs
+
+    # Let the user know that we've sent them a new email.
+    logger.info("recover.sent", extra=extra)
+    return render_to_response(get_template("relocate", "sent"), {}, request)
+
+
+@set_referrer_policy("strict-origin-when-cross-origin")
+@control_silo_function
 def recover_confirm(request, user_id, hash, mode="recover"):
     try:
         password_hash = LostPasswordHash.objects.get(user=user_id, hash=hash)
@@ -120,7 +170,7 @@ def recover_confirm(request, user_id, hash, mode="recover"):
             raise LostPasswordHash.DoesNotExist
         user = password_hash.user
     except LostPasswordHash.DoesNotExist:
-        return render_to_response(get_template(mode, "failure"), {}, request)
+        return render_to_response(get_template(mode, "failure"), {"user_id": user_id}, request)
 
     # TODO(getsentry/team-ospo#190): Clean up ternary logic and only show relocation form if user is unclaimed
     form_cls = RelocationForm if mode == "relocate" else ChangePasswordRecoverForm

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -299,6 +299,11 @@ urlpatterns += [
                     name="sentry-account-recover-confirm",
                 ),
                 re_path(
+                    r"^relocation/reclaim/(?P<user_id>[\d]+)/$",
+                    accounts.relocate_reclaim,
+                    name="sentry-account-relocate-reclaim",
+                ),
+                re_path(
                     r"^password/confirm/(?P<user_id>[\d]+)/(?P<hash>[0-9a-zA-Z]+)/$",
                     accounts.set_password_confirm,
                     name="sentry-account-set-password-confirm",

--- a/tests/sentry/tasks/test_relocation.py
+++ b/tests/sentry/tasks/test_relocation.py
@@ -98,6 +98,17 @@ class FakeCloudBuildClient:
 class RelocationTaskTestCase(TestCase):
     def setUp(self):
         super().setUp()
+
+        # Create a collision with the org slug we'll be requesting.
+        self.requested_org_slug = "testing"
+        self.existing_org_owner = self.create_user(
+            email="existing_org_owner@example.com",
+            is_superuser=False,
+            is_staff=False,
+            is_active=True,
+        )
+        self.existing_org = self.create_organization(name=self.requested_org_slug)
+
         self.owner = self.create_user(
             email="owner@example.com", is_superuser=False, is_staff=False, is_active=True
         )
@@ -1859,11 +1870,20 @@ class NotifyingUsersTest(RelocationTaskTestCase):
                 printer=Printer(),
             )
 
-        self.imported_users = ControlImportChunkReplica.objects.get(
-            import_uuid=self.uuid, model="sentry.user"
+        self.imported_orgs = sorted(
+            RegionImportChunk.objects.get(
+                import_uuid=self.uuid, model="sentry.organization"
+            ).inserted_identifiers.values()
         )
-
-        assert len(self.imported_users.inserted_map) == 2
+        assert len(self.imported_orgs) == 1
+        assert (
+            len(
+                ControlImportChunkReplica.objects.get(
+                    import_uuid=self.uuid, model="sentry.user"
+                ).inserted_map
+            )
+            == 2
+        )
 
     def test_success(
         self,
@@ -1881,8 +1901,8 @@ class NotifyingUsersTest(RelocationTaskTestCase):
                 mock_relocation_email.call_args_list[0][0][0].username,
                 mock_relocation_email.call_args_list[1][0][0].username,
             ]
-            assert mock_relocation_email.call_args_list[0][0][2] == ["testing"]
-            assert mock_relocation_email.call_args_list[1][0][2] == ["testing"]
+            assert sorted(mock_relocation_email.call_args_list[0][0][2]) == self.imported_orgs
+            assert sorted(mock_relocation_email.call_args_list[1][0][2]) == self.imported_orgs
             assert "admin@example.com" in email_targets
             assert "member@example.com" in email_targets
 
@@ -1969,6 +1989,18 @@ class NotifyingOwnerTest(RelocationTaskTestCase):
         self.relocation.latest_task = OrderedTask.NOTIFYING_USERS.name
         self.relocation.save()
 
+        RegionImportChunk.objects.create(
+            import_uuid=self.relocation.uuid,
+            model="sentry.organization",
+            min_ordinal=0,
+            max_ordinal=0,
+            min_source_pk=1,
+            max_source_pk=1,
+            inserted_map={1: 1234},
+            inserted_identifiers={1: "testing-ab"},
+        )
+        self.imported_orgs = ["testing-ab"]
+
     def test_success_admin_assisted_relocation(
         self,
         completed_mock: Mock,
@@ -1980,6 +2012,7 @@ class NotifyingOwnerTest(RelocationTaskTestCase):
 
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.succeeded"
+        assert fake_message_builder.call_args.kwargs["context"]["orgs"] == self.imported_orgs
         fake_message_builder.return_value.send_async.assert_called_once_with(
             to=[self.owner.email, self.superuser.email]
         )
@@ -2002,6 +2035,7 @@ class NotifyingOwnerTest(RelocationTaskTestCase):
 
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.succeeded"
+        assert fake_message_builder.call_args.kwargs["context"]["orgs"] == self.imported_orgs
         fake_message_builder.return_value.send_async.assert_called_once_with(to=[self.owner.email])
 
         assert completed_mock.call_count == 1

--- a/tests/sentry/web/frontend/test_accounts.py
+++ b/tests/sentry/web/frontend/test_accounts.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from functools import cached_property
 from unittest.mock import call, patch
 
+from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -10,6 +11,7 @@ from sentry.models.lostpasswordhash import LostPasswordHash
 from sentry.models.useremail import UserEmail
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.silo import control_silo_test
 from sentry.web.frontend.accounts import recover_confirm
 
@@ -123,9 +125,9 @@ class TestAccounts(TestCase):
         header_name = "Referrer-Policy"
 
         assert resp.has_header(header_name)
-        assert resp.templates[0].name == ("sentry/account/relocate/confirm.html")
         assert resp.status_code == 200
         assert resp[header_name] == "strict-origin-when-cross-origin"
+        self.assertTemplateUsed("sentry/account/relocate/confirm.html")
 
     def test_relocate_expired_lost_password_hash(self):
         user = self.create_user()
@@ -141,9 +143,9 @@ class TestAccounts(TestCase):
         header_name = "Referrer-Policy"
 
         assert resp.has_header(header_name)
-        assert resp.templates[0].name == ("sentry/account/relocate/failure.html")
         assert resp.status_code == 200
         assert resp[header_name] == "strict-origin-when-cross-origin"
+        self.assertTemplateUsed("sentry/account/relocate/failure.html")
 
     @patch("sentry.signals.terms_accepted.send_robust")
     def test_relocate_recovery_post_multiple_orgs(self, terms_accepted_signal_mock):
@@ -171,7 +173,7 @@ class TestAccounts(TestCase):
 
         user.refresh_from_db()
         assert resp.has_header(header_name)
-        assert resp.templates[0].name == ("sentry/emails/password-changed.txt")
+        self.assertTemplateUsed("sentry/emails/password-changed.txt")
         assert not user.is_unclaimed
         assert user.username == new_username
         assert user.password != old_password
@@ -223,7 +225,7 @@ class TestAccounts(TestCase):
 
         user.refresh_from_db()
         assert resp.has_header(header_name)
-        assert resp.templates[0].name == ("sentry/emails/password-changed.txt")
+        self.assertTemplateUsed("sentry/emails/password-changed.txt")
         assert not user.is_unclaimed
         assert user.username == new_username
         assert user.password != old_password
@@ -290,7 +292,7 @@ class TestAccounts(TestCase):
 
                 user.refresh_from_db()
                 assert resp.has_header(header_name)
-                assert resp.templates[0].name == ("sentry/account/relocate/failure.html")
+                self.assertTemplateUsed("sentry/account/relocate/failure.html")
                 assert user.is_unclaimed
                 assert user.username != new_username
                 assert user.password == old_password
@@ -303,22 +305,27 @@ class TestAccounts(TestCase):
         org = self.create_organization(name="test-org")
         self.create_member(user=user, organization=org, role="member", teams=[])
 
-        with patch.object(LostPasswordHash, "send_relocate_account_email") as mock_relocation_email:
+        with BurstTaskRunner() as burst:
             resp = self.client.post(
                 self.relocation_reclaim_path(lost_password.user_id),
             )
 
+            # Sends the async email.
+            burst()
+
+            assert len(mail.outbox) == 1
+            assert mail.outbox[0].to == ["member@example.com"]
+            assert "Set Username and Password" in mail.outbox[0].subject
+            assert "test-org" in mail.outbox[0].body
+            assert "Claim Account" in mail.outbox[0].body
+            assert f"/relocation/confirm/{user.id}/{lost_password.hash}/" in mail.outbox[0].body
+
             header_name = "Referrer-Policy"
 
             assert resp.has_header(header_name)
-            assert resp.templates[0].name == ("sentry/account/relocate/sent.html")
             assert resp.status_code == 200
             assert resp[header_name] == "strict-origin-when-cross-origin"
-            assert mock_relocation_email.call_count == 1
-
-            call_args = mock_relocation_email.call_args_list[0][0]
-            assert call_args[0] == user.username
-            assert call_args[2] == [org.slug]
+            self.assertTemplateUsed("sentry/account/relocate/sent.html")
 
     def test_relocate_reclaim_user_not_found(self):
         user = self.create_user(email="member@example.com", is_unclaimed=True)
@@ -333,9 +340,9 @@ class TestAccounts(TestCase):
         header_name = "Referrer-Policy"
 
         assert resp.has_header(header_name)
-        assert resp.templates[0].name == ("sentry/account/relocate/error.html")
         assert resp.status_code == 200
         assert resp[header_name] == "strict-origin-when-cross-origin"
+        self.assertTemplateUsed("sentry/account/relocate/error.html")
 
     def test_relocate_reclaim_already_claimed(self):
         user = self.create_user(email="member@example.com", is_unclaimed=False)
@@ -350,9 +357,9 @@ class TestAccounts(TestCase):
         header_name = "Referrer-Policy"
 
         assert resp.has_header(header_name)
-        assert resp.templates[0].name == ("sentry/account/relocate/claimed.html")
         assert resp.status_code == 200
         assert resp[header_name] == "strict-origin-when-cross-origin"
+        self.assertTemplateUsed("sentry/account/relocate/claimed.html")
 
     def test_relocate_reclaim_user_not_in_any_orgs(self):
         user = self.create_user(email="member@example.com", is_unclaimed=True)
@@ -365,9 +372,9 @@ class TestAccounts(TestCase):
         header_name = "Referrer-Policy"
 
         assert resp.has_header(header_name)
-        assert resp.templates[0].name == ("sentry/account/relocate/error.html")
         assert resp.status_code == 200
         assert resp[header_name] == "strict-origin-when-cross-origin"
+        self.assertTemplateUsed("sentry/account/relocate/error.html")
 
     def test_confirm_email(self):
         self.login_as(self.user)


### PR DESCRIPTION
We make two changes here:
1. The "claim this user" email now lists the slugs of the new relocation, rather than the one being imported from self-hosted. If there was no import collision, these are one and the same, but in cases of collision (or multiple imports) it makes the email easier to parse.
2. The page for expired lost password hashes has been given custom copy for the unclaimed user case. Now, it tells you specifically that it will resend the "claim user" email, rather than a cryptic "reset password" button. Further, it resends the email directly, rather than making you type in your password again.