### PR TITLE
chore(typing): Set 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -630,6 +630,7 @@ module = [
     "sentry.relay.config.metric_extraction",
     "sentry.reprocessing2",
     "sentry.runner.*",
+    "sentry.search.events.filter",
     "sentry.snuba.metrics.extraction",
     "sentry.tasks.on_demand_metrics",
     "sentry.tasks.reprocessing2",
@@ -640,6 +641,12 @@ module = [
     "tests.sentry.relay.config.test_metric_extraction",
     "tests.sentry.tasks.test_on_demand_metrics",
     "tools.*",
+    # "sentry.search.events.builder.*",
+    # "sentry.search.snuba.*",
+    #"sentry.search.events.*",
+    #"sentry.tasks.commits",
+    #"sentry.tasks.post_process",
+    #"sentry.tasks.unmerge",
 ]
 disallow_any_generics = true
 disallow_untyped_defs = true


### PR DESCRIPTION
```
mypy
src/sentry/search/events/filter.py:56: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:75: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:86: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:100: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:119: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:129: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:152: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:189: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:208: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:235: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:255: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:274: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:292: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:312: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:507: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
src/sentry/search/events/filter.py:702: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:719: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:753: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/search/events/filter.py:842: error: Function is missing a type annotation  [no-untyped-def]
Found 19 errors in 1 file (checked 5602 source files)
```