### PR TITLE
chore(typing): Set 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -627,10 +627,15 @@ module = [
     "sentry.nodestore.django.models",
     "sentry.nodestore.filesystem.backend",
     "sentry.nodestore.models",
+    "sentry.ratelimits.*",
     "sentry.relay.config.metric_extraction",
     "sentry.reprocessing2",
     "sentry.runner.*",
     "sentry.snuba.metrics.extraction",
+    "sentry.tasks.auto_remove_inbox",
+    "sentry.tasks.auto_resolve_issues",
+    "sentry.tasks.codeowners.*",
+    "sentry.tasks.commit_context",
     "sentry.tasks.on_demand_metrics",
     "sentry.tasks.reprocessing2",
     "sentry.utils.locking.backends.redis",
@@ -640,6 +645,11 @@ module = [
     "tests.sentry.relay.config.test_metric_extraction",
     "tests.sentry.tasks.test_on_demand_metrics",
     "tools.*",
+    # "sentry.search.events.*",
+    # "sentry.search.snuba.*",
+    #"sentry.tasks.commits",
+    #"sentry.tasks.post_process",
+    #"sentry.tasks.unmerge",
 ]
 disallow_any_generics = true
 disallow_untyped_defs = true

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -235,7 +235,7 @@ class ProjectOwnership(Model):
         group: Group | None = None,
         organization_id: int | None = None,
         force_autoassign: bool = False,
-        logging_extra: dict[str, str | bool] | None = None,
+        logging_extra: dict[str, str | bool | int] | None = None,
     ):
         """
         Get the auto-assign owner for a project if there are any.

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import sentry_sdk
+from celery import Task
 from celery.exceptions import MaxRetriesExceededError
 from django.utils import timezone as django_timezone
 from sentry_sdk import set_tag
@@ -52,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 def queue_comment_task_if_needed(
     commit: Commit, group_owner: GroupOwner, repo: Repository, installation: IntegrationInstallation
-):
+) -> None:
     from sentry.tasks.integrations.github.pr_comment import github_comment_workflow
 
     logger.info(
@@ -142,15 +143,14 @@ def queue_comment_task_if_needed(
     bind=True,
 )
 def process_commit_context(
-    self,
-    event_id,
-    event_platform,
-    event_frames,
-    group_id,
-    project_id,
-    sdk_name=None,
-    **kwargs,
-):
+    self: Task,
+    event_id: str,
+    event_platform: str,
+    event_frames: Sequence[Mapping[str, Any]],
+    group_id: int,
+    project_id: int,
+    sdk_name: str | None = None,
+) -> None:
     """
     For a given event, look at the first in_app frame, and if we can find who modified the line, we can then update who is assigned to the issue.
     """


### PR DESCRIPTION
```
src/sentry/ratelimits/sliding_windows.py:125: error: Missing type parameters for generic type "StrictRedis"  [type-arg]
src/sentry/ratelimits/sliding_windows.py:130: error: Missing type parameters for generic type "StrictRedis"  [type-arg]
src/sentry/ratelimits/sliding_windows.py:137: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/tasks/codeowners/code_owners_auto_sync.py:21: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/tasks/codeowners/code_owners_auto_sync.py:21: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
src/sentry/tasks/commit_context.py:53: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/tasks/commit_context.py:144: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/tasks/auto_resolve_issues.py:35: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/tasks/auto_resolve_issues.py:35: note: Use "-> None" if function does not return a value
src/sentry/tasks/auto_resolve_issues.py:39: error: Missing type parameters for generic type "dict"  [type-arg]
src/sentry/tasks/auto_resolve_issues.py:66: error: Function is missing a type annotation  [no-untyped-def]
src/sentry/analytics/pubsub.py:8: error: Skipping analyzing "google.cloud": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/sentry/analytics/pubsub.py:8: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
src/sentry/tasks/auto_remove_inbox.py:13: error: Function is missing a return type annotation  [no-untyped-def]
src/sentry/tasks/auto_remove_inbox.py:13: note: Use "-> None" if function does not return a value
src/sentry/utils/kvstore/bigtable.py:11: error: Skipping analyzing "google.cloud": module is installed, but missing library stubs or py.typed marker  [import-untyped]
Found 13 errors in 7 files (checked 5602 source files)
```