### PR TITLE
feat(profiles): Enable deobfuscation via Symbolicator

### DIFF
--- a/src/sentry/profiles/java.py
+++ b/src/sentry/profiles/java.py
@@ -148,6 +148,8 @@ def merge_jvm_frames_with_android_methods(frames: list[dict], methods: list[dict
             _merge_jvm_frame_and_android_method(f, m)
         # Otherwise, it's an additional method returned, we add it to the inline frames.
         else:
+            # We copy the frame triggering the inline ones so we only have to
+            # look at this field later one to construct a stack trace.
             if "inline_frames" not in m:
                 m["inline_frames"] = [m.copy()]
             im: dict = {}

--- a/src/sentry/profiles/java.py
+++ b/src/sentry/profiles/java.py
@@ -141,7 +141,7 @@ def _merge_jvm_frame_and_android_method(f: dict, m: dict) -> None:
 
 
 def merge_jvm_frames_with_android_methods(frames: list[dict], methods: list[dict]) -> None:
-    for f in reversed(frames):
+    for f in frames:
         m = methods[f["index"]]
         # Update the method if it's the first time we see it.
         if m.get("data", {}).get("deobfuscation_status", "") != "deobfuscated":

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -832,7 +832,8 @@ def _deobfuscate(profile: Profile, project: Project) -> None:
                 m["signature"] = format_signature(types)
         return
 
-    if project.id in options.get("profiling.deobfuscate-using-symbolicator.enable-for-project"):
+    # We re-use this option as a deny list before we remove it completely.
+    if project.id not in options.get("profiling.deobfuscate-using-symbolicator.enable-for-project"):
         try:
             with sentry_sdk.start_span(op="deobfuscate_with_symbolicator"):
                 success = _deobfuscate_using_symbolicator(


### PR DESCRIPTION
We've validated the deobfuscation works and compared profiles deobfuscated locally and via Symbolicator and they come out the same.

We'll activate it by default and keep a way to fallback on the local deobfuscation for some projects if need be.