### PR TITLE
ref(issue-details): Refactor context items into separate functions

### DIFF
--- a/static/app/components/events/contexts/app/getAppKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/app/getAppKnownDataDetails.tsx
@@ -1,15 +1,10 @@
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 
-import {getRelativeTimeFromEventDateCreated} from '../utils';
+import {getRelativeTimeFromEventDateCreated, type KnownDataDetails} from '../utils';
 
 import type {AppData} from './types';
 import {AppKnownDataType} from './types';
-
-type Output = {
-  subject: string;
-  value?: React.ReactNode;
-};
 
 type Props = {
   data: AppData;
@@ -17,7 +12,7 @@ type Props = {
   type: AppKnownDataType;
 };
 
-export function getAppKnownDataDetails({data, event, type}: Props): Output | undefined {
+export function getAppKnownDataDetails({data, event, type}: Props): KnownDataDetails {
   switch (type) {
     case AppKnownDataType.ID:
       return {

--- a/static/app/components/events/contexts/app/index.tsx
+++ b/static/app/components/events/contexts/app/index.tsx
@@ -30,7 +30,7 @@ export const appKnownDataValues = [
   AppKnownDataType.IN_FOREGROUND,
 ];
 
-const appIgnoredDataValues: string[] = [];
+const appIgnoredDataValues = [];
 
 export function getKnownAppContextData({data, event, meta}: Props) {
   return getKnownData<AppData, AppKnownDataType>({

--- a/static/app/components/events/contexts/app/index.tsx
+++ b/static/app/components/events/contexts/app/index.tsx
@@ -3,11 +3,15 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types/event';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {getAppKnownDataDetails} from './getAppKnownDataDetails';
-import type {AppData} from './types';
-import {AppKnownDataType} from './types';
+import {type AppData, AppKnownDataType} from './types';
 
 type Props = {
   data: AppData;
@@ -26,27 +30,35 @@ export const appKnownDataValues = [
   AppKnownDataType.IN_FOREGROUND,
 ];
 
-const appIgnoredDataValues = [];
+const appIgnoredDataValues: string[] = [];
+
+export function getKnownAppContextData({data, event, meta}: Props) {
+  return getKnownData<AppData, AppKnownDataType>({
+    data,
+    meta,
+    knownDataTypes: appKnownDataValues,
+    onGetKnownDataDetails: v => getAppKnownDataDetails({...v, event}),
+    raw: true,
+  });
+}
+
+export function getUnknownAppContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  return getUnknownData({
+    allData: data,
+    knownKeys: [...appKnownDataValues, ...appIgnoredDataValues],
+    meta,
+  });
+}
 
 export function AppEventContext({data, event, meta: propsMeta}: Props) {
   const meta = propsMeta ?? getContextMeta(event, 'app');
+  const knownData = getKnownAppContextData({data, event, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownAppContextData({data, meta});
   return (
     <Fragment>
-      <ContextBlock
-        data={getKnownData<AppData, AppKnownDataType>({
-          data,
-          meta,
-          knownDataTypes: appKnownDataValues,
-          onGetKnownDataDetails: v => getAppKnownDataDetails({...v, event}),
-        })}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: data,
-          knownKeys: [...appKnownDataValues, ...appIgnoredDataValues],
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
     </Fragment>
   );
 }

--- a/static/app/components/events/contexts/app/index.tsx
+++ b/static/app/components/events/contexts/app/index.tsx
@@ -38,7 +38,6 @@ export function getKnownAppContextData({data, event, meta}: Props) {
     meta,
     knownDataTypes: appKnownDataValues,
     onGetKnownDataDetails: v => getAppKnownDataDetails({...v, event}),
-    raw: true,
   });
 }
 

--- a/static/app/components/events/contexts/browser/getBrowserKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/browser/getBrowserKnownDataDetails.tsx
@@ -1,19 +1,15 @@
+import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import {t} from 'sentry/locale';
 
 import type {BrowserKnownData} from './types';
 import {BrowserKnownDataType} from './types';
-
-type Output = {
-  subject: string;
-  value: React.ReactNode | null;
-};
 
 type Props = {
   data: BrowserKnownData;
   type: BrowserKnownDataType;
 };
 
-export function getBrowserKnownDataDetails({data, type}: Props): Output | undefined {
+export function getBrowserKnownDataDetails({data, type}: Props): KnownDataDetails {
   switch (type) {
     case BrowserKnownDataType.NAME:
       return {

--- a/static/app/components/events/contexts/browser/index.tsx
+++ b/static/app/components/events/contexts/browser/index.tsx
@@ -31,7 +31,6 @@ export function getKnownBrowserContextData({data, meta}: Pick<Props, 'data' | 'm
     meta,
     knownDataTypes: browserKnownDataValues,
     onGetKnownDataDetails: v => getBrowserKnownDataDetails(v),
-    raw: true,
   });
 }
 

--- a/static/app/components/events/contexts/browser/index.tsx
+++ b/static/app/components/events/contexts/browser/index.tsx
@@ -3,7 +3,12 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {getBrowserKnownDataDetails} from './getBrowserKnownDataDetails';
 import type {BrowserKnownData} from './types';
@@ -20,25 +25,33 @@ export const browserKnownDataValues = [
   BrowserKnownDataType.VERSION,
 ];
 
+export function getKnownBrowserContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  return getKnownData<BrowserKnownData, BrowserKnownDataType>({
+    data,
+    meta,
+    knownDataTypes: browserKnownDataValues,
+    onGetKnownDataDetails: v => getBrowserKnownDataDetails(v),
+    raw: true,
+  });
+}
+
+export function getUnknownBrowserContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  return getUnknownData({
+    allData: data,
+    knownKeys: [...browserKnownDataValues],
+    meta,
+  });
+}
+
 export function BrowserEventContext({data, event, meta: propsMeta}: Props) {
   const meta = propsMeta ?? getContextMeta(event, 'browser');
+  const knownData = getKnownBrowserContextData({data, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownBrowserContextData({data, meta});
   return (
     <Fragment>
-      <ContextBlock
-        data={getKnownData<BrowserKnownData, BrowserKnownDataType>({
-          data,
-          meta,
-          knownDataTypes: browserKnownDataValues,
-          onGetKnownDataDetails: v => getBrowserKnownDataDetails(v),
-        })}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: data,
-          knownKeys: [...browserKnownDataValues],
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
     </Fragment>
   );
 }

--- a/static/app/components/events/contexts/default.tsx
+++ b/static/app/components/events/contexts/default.tsx
@@ -7,7 +7,7 @@ type Props = {
   event: Event;
 };
 
-function getKnownData(data: Props['data']) {
+export function getDefaultContextData(data: Props['data']) {
   return Object.entries(data)
     .filter(([k]) => k !== 'type' && k !== 'title')
     .map(([key, value]) => ({
@@ -18,5 +18,5 @@ function getKnownData(data: Props['data']) {
 }
 
 export function DefaultContext({data}: Props) {
-  return <ContextBlock data={getKnownData(data)} />;
+  return <ContextBlock data={getDefaultContextData(data)} />;
 }

--- a/static/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
@@ -5,7 +5,7 @@ import type {DeviceContext, Event} from 'sentry/types/event';
 import {DeviceContextKey} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 
-import {getRelativeTimeFromEventDateCreated} from '../utils';
+import {getRelativeTimeFromEventDateCreated, type KnownDataDetails} from '../utils';
 
 import {formatMemory, formatStorage} from './utils';
 
@@ -18,22 +18,13 @@ export const deviceKnownDataValues = [
   'storage',
 ];
 
-type Output = {
-  subject: string;
-  value?: React.ReactNode;
-};
-
 type Props = {
   data: DeviceContext;
   event: Event;
   type: (typeof deviceKnownDataValues)[number];
 };
 
-export function getDeviceKnownDataDetails({
-  data,
-  event,
-  type,
-}: Props): Output | undefined {
+export function getDeviceKnownDataDetails({data, event, type}: Props): KnownDataDetails {
   switch (type) {
     case DeviceContextKey.NAME:
       return {

--- a/static/app/components/events/contexts/device/index.tsx
+++ b/static/app/components/events/contexts/device/index.tsx
@@ -31,7 +31,6 @@ export function getKnownDeviceContextData({data, event, meta}: Props) {
     meta,
     knownDataTypes: deviceKnownDataValues,
     onGetKnownDataDetails: v => getDeviceKnownDataDetails({...v, event}),
-    raw: true,
   }).map(v => ({
     ...v,
     subjectDataTestId: `device-context-${v.key.toLowerCase()}-value`,

--- a/static/app/components/events/contexts/device/index.tsx
+++ b/static/app/components/events/contexts/device/index.tsx
@@ -3,7 +3,12 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {DeviceContext, Event} from 'sentry/types/event';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {
   deviceKnownDataValues,
@@ -19,30 +24,39 @@ type Props = {
 
 const deviceIgnoredDataValues = [];
 
-export function DeviceEventContext({data, event, meta: propsMeta}: Props) {
+export function getKnownDeviceContextData({data, event, meta}: Props) {
   const inferredData = getInferredData(data);
+  return getKnownData<DeviceContext, (typeof deviceKnownDataValues)[number]>({
+    data: inferredData,
+    meta,
+    knownDataTypes: deviceKnownDataValues,
+    onGetKnownDataDetails: v => getDeviceKnownDataDetails({...v, event}),
+    raw: true,
+  }).map(v => ({
+    ...v,
+    subjectDataTestId: `device-context-${v.key.toLowerCase()}-value`,
+  }));
+}
+
+export function getUnknownDeviceContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  const inferredData = getInferredData(data);
+  return getUnknownData({
+    allData: inferredData,
+    knownKeys: [...deviceKnownDataValues, ...deviceIgnoredDataValues],
+    meta,
+  });
+}
+
+export function DeviceEventContext({data, event, meta: propsMeta}: Props) {
   const meta = propsMeta ?? getContextMeta(event, 'device');
+  const knownData = getKnownDeviceContextData({data, event, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownDeviceContextData({data, meta});
 
   return (
     <Fragment>
-      <ContextBlock
-        data={getKnownData<DeviceContext, (typeof deviceKnownDataValues)[number]>({
-          data: inferredData,
-          meta,
-          knownDataTypes: deviceKnownDataValues,
-          onGetKnownDataDetails: v => getDeviceKnownDataDetails({...v, event}),
-        }).map(v => ({
-          ...v,
-          subjectDataTestId: `device-context-${v.key.toLowerCase()}-value`,
-        }))}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: inferredData,
-          knownKeys: [...deviceKnownDataValues, ...deviceIgnoredDataValues],
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
     </Fragment>
   );
 }

--- a/static/app/components/events/contexts/gpu/getGPUKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/gpu/getGPUKnownDataDetails.tsx
@@ -1,20 +1,16 @@
+import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import {t} from 'sentry/locale';
 
 import formatMemory from './formatMemory';
 import type {GPUData} from './types';
 import {GPUKnownDataType} from './types';
 
-type Output = {
-  subject: string;
-  value?: React.ReactNode;
-};
-
 type Props = {
   data: GPUData;
   type: GPUKnownDataType;
 };
 
-export function getGPUKnownDataDetails({data, type}: Props): Output | undefined {
+export function getGPUKnownDataDetails({data, type}: Props): KnownDataDetails {
   switch (type) {
     case GPUKnownDataType.NAME:
       return {

--- a/static/app/components/events/contexts/gpu/index.tsx
+++ b/static/app/components/events/contexts/gpu/index.tsx
@@ -50,7 +50,6 @@ export function getKnownGpuContextData({data, meta}: Pick<Props, 'data' | 'meta'
     meta,
     knownDataTypes: gpuValues,
     onGetKnownDataDetails: v => getGPUKnownDataDetails(v),
-    raw: true,
   });
 }
 

--- a/static/app/components/events/contexts/gpu/index.tsx
+++ b/static/app/components/events/contexts/gpu/index.tsx
@@ -3,7 +3,12 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types/event';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {getGPUKnownDataDetails} from './getGPUKnownDataDetails';
 import type {GPUData} from './types';
@@ -27,35 +32,46 @@ export const gpuKnownDataValues = [
 
 const gpuIgnoredDataValues = [];
 
-export function GPUEventContext({data, event, meta: propsMeta}: Props) {
+function getGpuValues({data}: Pick<Props, 'data'>) {
   const gpuValues = [...gpuKnownDataValues];
-  const meta = propsMeta ?? getContextMeta(event, 'gpu');
-
   if (data.vendor_id > 0) {
     gpuValues.unshift(GPUKnownDataType.VENDOR_ID);
   }
-
   if (data.id > 0) {
     gpuValues.unshift(GPUKnownDataType.ID);
   }
+  return gpuValues;
+}
 
+export function getKnownGpuContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  const gpuValues = getGpuValues({data});
+  return getKnownData<GPUData, GPUKnownDataType>({
+    data,
+    meta,
+    knownDataTypes: gpuValues,
+    onGetKnownDataDetails: v => getGPUKnownDataDetails(v),
+    raw: true,
+  });
+}
+
+export function getUnknownGpuContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  const gpuValues = getGpuValues({data});
+  return getUnknownData({
+    allData: data,
+    knownKeys: [...gpuValues, ...gpuIgnoredDataValues],
+    meta,
+  });
+}
+
+export function GPUEventContext({data, event, meta: propsMeta}: Props) {
+  const meta = propsMeta ?? getContextMeta(event, 'gpu');
+  const knownData = getKnownGpuContextData({data, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownGpuContextData({data, meta});
   return (
     <Fragment>
-      <ContextBlock
-        data={getKnownData<GPUData, GPUKnownDataType>({
-          data,
-          meta,
-          knownDataTypes: gpuValues,
-          onGetKnownDataDetails: v => getGPUKnownDataDetails(v),
-        })}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: data,
-          knownKeys: [...gpuValues, ...gpuIgnoredDataValues],
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
     </Fragment>
   );
 }

--- a/static/app/components/events/contexts/memoryInfo/getMemoryInfoKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/memoryInfo/getMemoryInfoKnownDataDetails.tsx
@@ -1,13 +1,9 @@
+import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import {t} from 'sentry/locale';
 import type {Event, MemoryInfoContext} from 'sentry/types/event';
 import {MemoryInfoContextKey} from 'sentry/types/event';
 
 export const memoryInfoKnownDataValues = Object.values(MemoryInfoContextKey);
-
-type Output = {
-  subject: string;
-  value: React.ReactNode | null;
-};
 
 type Props = {
   data: MemoryInfoContext;
@@ -15,7 +11,7 @@ type Props = {
   type: (typeof memoryInfoKnownDataValues)[number];
 };
 
-export function getMemoryInfoKnownDataDetails({data, type}: Props): Output | undefined {
+export function getMemoryInfoKnownDataDetails({data, type}: Props): KnownDataDetails {
   switch (type) {
     case MemoryInfoContextKey.ALLOCATED_BYTES:
       return {

--- a/static/app/components/events/contexts/memoryInfo/index.tsx
+++ b/static/app/components/events/contexts/memoryInfo/index.tsx
@@ -3,7 +3,12 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event, MemoryInfoContext} from 'sentry/types/event';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {
   getMemoryInfoKnownDataDetails,
@@ -16,31 +21,46 @@ type Props = {
   meta?: Record<string, any>;
 };
 
+export function getKnownMemoryInfoContextData({data, event, meta}: Props) {
+  if (!data) {
+    return [];
+  }
+  return getKnownData<MemoryInfoContext, (typeof memoryInfoKnownDataValues)[number]>({
+    data,
+    meta,
+    knownDataTypes: memoryInfoKnownDataValues,
+    onGetKnownDataDetails: v => getMemoryInfoKnownDataDetails({...v, event}),
+    raw: true,
+  });
+}
+
+export function getUnknownMemoryInfoContextData({
+  data,
+  meta,
+}: Pick<Props, 'data' | 'meta'>) {
+  if (!data) {
+    return [];
+  }
+  return getUnknownData({
+    allData: data,
+    knownKeys: memoryInfoKnownDataValues,
+    meta,
+  });
+}
+
 export function MemoryInfoEventContext({data, event, meta: propsMeta}: Props) {
   if (!data) {
     return null;
   }
   const meta = propsMeta ?? getContextMeta(event, 'memory_info');
+  const knownData = getKnownMemoryInfoContextData({data, event, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownMemoryInfoContextData({data, meta});
 
   return (
     <Fragment>
-      <ContextBlock
-        data={getKnownData<MemoryInfoContext, (typeof memoryInfoKnownDataValues)[number]>(
-          {
-            data,
-            meta,
-            knownDataTypes: memoryInfoKnownDataValues,
-            onGetKnownDataDetails: v => getMemoryInfoKnownDataDetails({...v, event}),
-          }
-        )}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: data,
-          knownKeys: memoryInfoKnownDataValues,
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
     </Fragment>
   );
 }

--- a/static/app/components/events/contexts/memoryInfo/index.tsx
+++ b/static/app/components/events/contexts/memoryInfo/index.tsx
@@ -30,7 +30,6 @@ export function getKnownMemoryInfoContextData({data, event, meta}: Props) {
     meta,
     knownDataTypes: memoryInfoKnownDataValues,
     onGetKnownDataDetails: v => getMemoryInfoKnownDataDetails({...v, event}),
-    raw: true,
   });
 }
 

--- a/static/app/components/events/contexts/operatingSystem/getOperatingSystemKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/operatingSystem/getOperatingSystemKnownDataDetails.tsx
@@ -1,13 +1,9 @@
+import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 
 import type {OperatingSystemKnownData} from './types';
 import {OperatingSystemKnownDataType} from './types';
-
-type Output = {
-  subject: string;
-  value: React.ReactNode | null;
-};
 
 type Props = {
   data: OperatingSystemKnownData;
@@ -17,7 +13,7 @@ type Props = {
 export function getOperatingSystemKnownDataDetails({
   data,
   type,
-}: Props): Output | undefined {
+}: Props): KnownDataDetails {
   switch (type) {
     case OperatingSystemKnownDataType.NAME:
       return {

--- a/static/app/components/events/contexts/operatingSystem/index.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.tsx
@@ -3,7 +3,12 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {getOperatingSystemKnownDataDetails} from './getOperatingSystemKnownDataDetails';
 import type {OperatingSystemKnownData} from './types';
@@ -24,28 +29,39 @@ export const operatingSystemKnownDataValues = [
 
 const operatingSystemIgnoredDataValues = [OperatingSystemIgnoredDataType.BUILD];
 
+export function getKnownOperatingSystemContextData({
+  data,
+  meta,
+}: Pick<Props, 'data' | 'meta'>) {
+  return getKnownData<OperatingSystemKnownData, OperatingSystemKnownDataType>({
+    data,
+    meta,
+    knownDataTypes: operatingSystemKnownDataValues,
+    onGetKnownDataDetails: v => getOperatingSystemKnownDataDetails(v),
+    raw: true,
+  });
+}
+
+export function getUnknownOperatingSystemContextData({
+  data,
+  meta,
+}: Pick<Props, 'data' | 'meta'>) {
+  return getUnknownData({
+    allData: data,
+    knownKeys: [...operatingSystemKnownDataValues, ...operatingSystemIgnoredDataValues],
+    meta,
+  });
+}
+
 export function OperatingSystemEventContext({data, event, meta: propsMeta}: Props) {
   const meta = propsMeta ?? getContextMeta(event, 'os');
+  const knownData = getKnownOperatingSystemContextData({data, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownOperatingSystemContextData({data, meta});
   return (
     <Fragment>
-      <ContextBlock
-        data={getKnownData<OperatingSystemKnownData, OperatingSystemKnownDataType>({
-          data,
-          meta,
-          knownDataTypes: operatingSystemKnownDataValues,
-          onGetKnownDataDetails: v => getOperatingSystemKnownDataDetails(v),
-        })}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: data,
-          knownKeys: [
-            ...operatingSystemKnownDataValues,
-            ...operatingSystemIgnoredDataValues,
-          ],
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
     </Fragment>
   );
 }

--- a/static/app/components/events/contexts/operatingSystem/index.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.tsx
@@ -38,7 +38,6 @@ export function getKnownOperatingSystemContextData({
     meta,
     knownDataTypes: operatingSystemKnownDataValues,
     onGetKnownDataDetails: v => getOperatingSystemKnownDataDetails(v),
-    raw: true,
   });
 }
 

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -16,6 +16,7 @@ import {
   getKnownData,
   getKnownStructuredData,
   getUnknownData,
+  type KnownDataDetails,
 } from '../utils';
 
 const PROFILE_KNOWN_DATA_VALUES = [ProfileContextKey.PROFILE_ID];
@@ -92,7 +93,7 @@ function getProfileKnownDataDetails({
   organization: Organization;
   type: ProfileContextKey;
   project?: Project;
-}) {
+}): KnownDataDetails {
   switch (type) {
     case ProfileContextKey.PROFILE_ID: {
       const profileId = data.profile_id || '';

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -40,7 +40,6 @@ export function getKnownProfileContextData({
     meta,
     knownDataTypes: PROFILE_KNOWN_DATA_VALUES,
     onGetKnownDataDetails: v => getProfileKnownDataDetails({...v, organization, project}),
-    raw: true,
   }).map(v => ({
     ...v,
     subjectDataTestId: `profile-context-${v.key.toLowerCase()}-value`,

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -11,7 +11,12 @@ import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 const PROFILE_KNOWN_DATA_VALUES = [ProfileContextKey.PROFILE_ID];
 
@@ -21,41 +26,58 @@ interface ProfileContextProps {
   meta?: Record<string, any>;
 }
 
+export function getKnownProfileContextData({
+  data,
+  meta,
+  organization,
+  project,
+}: Pick<ProfileContextProps, 'data' | 'meta'> & {
+  organization?: Organization;
+  project?: Project;
+}) {
+  return getKnownData<ProfileContext, ProfileContextKey>({
+    data,
+    meta,
+    knownDataTypes: PROFILE_KNOWN_DATA_VALUES,
+    onGetKnownDataDetails: v => getProfileKnownDataDetails({...v, organization, project}),
+    raw: true,
+  }).map(v => ({
+    ...v,
+    subjectDataTestId: `profile-context-${v.key.toLowerCase()}-value`,
+  }));
+}
+
+export function getUnknownProfileContextData({
+  data,
+  meta,
+}: Pick<ProfileContextProps, 'data' | 'meta'>) {
+  return getUnknownData({
+    allData: data,
+    knownKeys: PROFILE_KNOWN_DATA_VALUES,
+    meta,
+  });
+}
+
 export function ProfileEventContext({event, data, meta: propsMeta}: ProfileContextProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const project = projects.find(p => p.id === event.projectID);
   const meta = propsMeta ?? getContextMeta(event, 'profile');
 
+  const knownData = getKnownProfileContextData({data, meta, organization, project});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownProfileContextData({data, meta});
+
   return (
     <Feature organization={organization} features="profiling">
       <ErrorBoundary mini>
         <KeyValueList
-          data={getKnownData<ProfileContext, ProfileContextKey>({
-            data,
-            meta,
-            knownDataTypes: PROFILE_KNOWN_DATA_VALUES,
-            onGetKnownDataDetails: v =>
-              getProfileKnownDataDetails({...v, organization, project}),
-          }).map(v => ({
-            ...v,
-            subjectDataTestId: `profile-context-${v.key.toLowerCase()}-value`,
-          }))}
+          data={knownStructuredData}
           shouldSort={false}
           raw={false}
           isContextData
         />
-
-        <KeyValueList
-          data={getUnknownData({
-            allData: data,
-            knownKeys: PROFILE_KNOWN_DATA_VALUES,
-            meta,
-          })}
-          shouldSort={false}
-          raw={false}
-          isContextData
-        />
+        <KeyValueList data={unknownData} shouldSort={false} raw={false} isContextData />
       </ErrorBoundary>
     </Feature>
   );
@@ -68,15 +90,15 @@ function getProfileKnownDataDetails({
   type,
 }: {
   data: ProfileContext;
-  organization: Organization;
   type: ProfileContextKey;
+  organization?: Organization;
   project?: Project;
 }) {
   switch (type) {
     case ProfileContextKey.PROFILE_ID: {
       const profileId = data.profile_id || '';
 
-      if (!profileId) {
+      if (!profileId || !organization) {
         return undefined;
       }
 

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -32,7 +32,7 @@ export function getKnownProfileContextData({
   organization,
   project,
 }: Pick<ProfileContextProps, 'data' | 'meta'> & {
-  organization?: Organization;
+  organization: Organization;
   project?: Project;
 }) {
   return getKnownData<ProfileContext, ProfileContextKey>({
@@ -89,15 +89,15 @@ function getProfileKnownDataDetails({
   type,
 }: {
   data: ProfileContext;
+  organization: Organization;
   type: ProfileContextKey;
-  organization?: Organization;
   project?: Project;
 }) {
   switch (type) {
     case ProfileContextKey.PROFILE_ID: {
       const profileId = data.profile_id || '';
 
-      if (!profileId || !organization) {
+      if (!profileId) {
         return undefined;
       }
 

--- a/static/app/components/events/contexts/redux/index.tsx
+++ b/static/app/components/events/contexts/redux/index.tsx
@@ -11,19 +11,22 @@ type Props = {
   meta?: Record<string, any>;
 };
 
+export function getReduxContextData({data}: Pick<Props, 'data'>) {
+  return [
+    {
+      key: 'value',
+      subject: t('Latest State'),
+      // TODO(TS): Objects cannot be rendered to the dom
+      value: JSON.stringify(data),
+    },
+  ];
+}
+
 export function ReduxContext({data}: Props) {
+  const reduxData = getReduxContextData({data});
   return (
     <ClippedBox clipHeight={250}>
-      <ContextBlock
-        data={[
-          {
-            key: 'value',
-            subject: t('Latest State'),
-            // TODO(TS): Objects cannot be rendered to the dom
-            value: data as any,
-          },
-        ]}
-      />
+      <ContextBlock data={reduxData} />
     </ClippedBox>
   );
 }

--- a/static/app/components/events/contexts/runtime/getRuntimeKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/runtime/getRuntimeKnownDataDetails.tsx
@@ -1,19 +1,15 @@
+import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import {t} from 'sentry/locale';
 
 import type {RuntimeData} from './types';
 import {RuntimeKnownDataType} from './types';
-
-type Output = {
-  subject: string;
-  value?: React.ReactNode;
-};
 
 type Props = {
   data: RuntimeData;
   type: RuntimeKnownDataType;
 };
 
-export function getRuntimeKnownDataDetails({type, data}: Props): Output | undefined {
+export function getRuntimeKnownDataDetails({type, data}: Props): KnownDataDetails {
   switch (type) {
     case RuntimeKnownDataType.NAME:
       return {

--- a/static/app/components/events/contexts/runtime/index.tsx
+++ b/static/app/components/events/contexts/runtime/index.tsx
@@ -3,7 +3,12 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event} from 'sentry/types/event';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {getRuntimeKnownDataDetails} from './getRuntimeKnownDataDetails';
 import type {RuntimeData} from './types';
@@ -22,25 +27,33 @@ export const runtimeKnownDataValues = [
 
 const runtimeIgnoredDataValues = [RuntimeIgnoredDataType.BUILD];
 
+export function getKnownRuntimeContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  return getKnownData<RuntimeData, RuntimeKnownDataType>({
+    data,
+    meta,
+    knownDataTypes: runtimeKnownDataValues,
+    onGetKnownDataDetails: v => getRuntimeKnownDataDetails(v),
+    raw: true,
+  });
+}
+
+export function getUnknownRuntimeContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  return getUnknownData({
+    allData: data,
+    knownKeys: [...runtimeKnownDataValues, ...runtimeIgnoredDataValues],
+    meta,
+  });
+}
+
 export function RuntimeEventContext({data, event, meta: propsMeta}: Props) {
   const meta = propsMeta ?? getContextMeta(event, 'runtime');
+  const knownData = getKnownRuntimeContextData({data, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownRuntimeContextData({data, meta});
   return (
     <Fragment>
-      <ContextBlock
-        data={getKnownData<RuntimeData, RuntimeKnownDataType>({
-          data,
-          meta,
-          knownDataTypes: runtimeKnownDataValues,
-          onGetKnownDataDetails: v => getRuntimeKnownDataDetails(v),
-        })}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: data,
-          knownKeys: [...runtimeKnownDataValues, ...runtimeIgnoredDataValues],
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
     </Fragment>
   );
 }

--- a/static/app/components/events/contexts/runtime/index.tsx
+++ b/static/app/components/events/contexts/runtime/index.tsx
@@ -33,7 +33,6 @@ export function getKnownRuntimeContextData({data, meta}: Pick<Props, 'data' | 'm
     meta,
     knownDataTypes: runtimeKnownDataValues,
     onGetKnownDataDetails: v => getRuntimeKnownDataDetails(v),
-    raw: true,
   });
 }
 

--- a/static/app/components/events/contexts/state/index.tsx
+++ b/static/app/components/events/contexts/state/index.tsx
@@ -17,7 +17,7 @@ type Props = {
     state: StateDescription;
   };
   event: Event;
-  meta: Record<string, any>;
+  meta?: Record<string, any>;
 };
 
 function getStateTitle(name: string, type?: string) {
@@ -38,14 +38,14 @@ export function getKnownStateContextData({
       subject: getStateTitle(t('State'), data.state.type),
       // TODO(TS): Objects cannot be rendered to dom
       value: data.state.value as string,
-      meta: meta.state?.value?.[''],
+      meta: meta?.state?.value?.[''],
     },
   ];
 }
 
 export function getUnknownStateContextData({
   data,
-  meta,
+  meta = {},
 }: Pick<Props, 'data' | 'meta'>): KeyValueListData {
   return Object.entries(data)
     .filter(([key]) => !['type', 'title', 'state'].includes(key))

--- a/static/app/components/events/contexts/state/index.tsx
+++ b/static/app/components/events/contexts/state/index.tsx
@@ -17,48 +17,55 @@ type Props = {
     state: StateDescription;
   };
   event: Event;
-  meta?: Record<string, any>;
+  meta: Record<string, any>;
 };
+
+function getStateTitle(name: string, type?: string) {
+  return `${name}${type ? ` (${upperFirst(type)})` : ''}`;
+}
+
+export function getKnownStateContextData({
+  data,
+  meta,
+}: Pick<Props, 'data' | 'meta'>): KeyValueListData {
+  if (!data.state) {
+    return [];
+  }
+
+  return [
+    {
+      key: 'state',
+      subject: getStateTitle(t('State'), data.state.type),
+      // TODO(TS): Objects cannot be rendered to dom
+      value: data.state.value as string,
+      meta: meta.state?.value?.[''],
+    },
+  ];
+}
+
+export function getUnknownStateContextData({
+  data,
+  meta,
+}: Pick<Props, 'data' | 'meta'>): KeyValueListData {
+  return Object.entries(data)
+    .filter(([key]) => !['type', 'title', 'state'].includes(key))
+    .map<KeyValueListDataItem>(([name, state]) => ({
+      key: name,
+      // TODO(TS): Objects cannot be rendered to dom
+      value: state.value as string,
+      subject: getStateTitle(name, state.type),
+      meta: meta[name]?.value?.[''],
+    }));
+}
 
 export function StateEventContext({data, event, meta: propsMeta}: Props) {
   const meta = propsMeta ?? getContextMeta(event, 'state');
-
-  function getStateTitle(name: string, type?: string) {
-    return `${name}${type ? ` (${upperFirst(type)})` : ''}`;
-  }
-
-  function getKnownData(): KeyValueListData {
-    if (!data.state) {
-      return [];
-    }
-
-    return [
-      {
-        key: 'state',
-        subject: getStateTitle(t('State'), data.state.type),
-        // TODO(TS): Objects cannot be rendered to dom
-        value: data.state.value as string,
-        meta: meta.state?.value?.[''],
-      },
-    ];
-  }
-
-  function getUnknownData(): KeyValueListData {
-    return Object.entries(data)
-      .filter(([key]) => !['type', 'title', 'state'].includes(key))
-      .map<KeyValueListDataItem>(([name, state]) => ({
-        key: name,
-        // TODO(TS): Objects cannot be rendered to dom
-        value: state.value as string,
-        subject: getStateTitle(name, state.type),
-        meta: meta[name]?.value?.[''],
-      }));
-  }
-
+  const knownData = getKnownStateContextData({data, meta});
+  const unknownData = getUnknownStateContextData({data, meta});
   return (
     <ClippedBox clipHeight={250}>
-      <ContextBlock data={getKnownData()} />
-      <ContextBlock data={getUnknownData()} />
+      <ContextBlock data={knownData} />
+      <ContextBlock data={unknownData} />
     </ClippedBox>
   );
 }

--- a/static/app/components/events/contexts/threadPoolInfo/getThreadPoolInfoKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/getThreadPoolInfoKnownDataDetails.tsx
@@ -1,13 +1,9 @@
+import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import {t} from 'sentry/locale';
 import type {Event, ThreadPoolInfoContext} from 'sentry/types/event';
 import {ThreadPoolInfoContextKey} from 'sentry/types/event';
 
 export const threadPoolInfoKnownDataValues = Object.values(ThreadPoolInfoContextKey);
-
-type Output = {
-  subject: string;
-  value: React.ReactNode | null;
-};
 
 type Props = {
   data: ThreadPoolInfoContext;
@@ -15,10 +11,7 @@ type Props = {
   type: (typeof threadPoolInfoKnownDataValues)[number];
 };
 
-export function getThreadPoolInfoKnownDataDetails({
-  data,
-  type,
-}: Props): Output | undefined {
+export function getThreadPoolInfoKnownDataDetails({data, type}: Props): KnownDataDetails {
   switch (type) {
     case ThreadPoolInfoContextKey.AVAILABLE_COMPLETION_PORT_THREADS:
       return {

--- a/static/app/components/events/contexts/threadPoolInfo/index.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/index.tsx
@@ -33,7 +33,6 @@ export function getKnownThreadPoolInfoContextData({data, event, meta}: Props) {
     meta,
     knownDataTypes: threadPoolInfoKnownDataValues,
     onGetKnownDataDetails: v => getThreadPoolInfoKnownDataDetails({...v, event}),
-    raw: true,
   });
 }
 

--- a/static/app/components/events/contexts/threadPoolInfo/index.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/index.tsx
@@ -3,7 +3,12 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event, ThreadPoolInfoContext} from 'sentry/types/event';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {
   getThreadPoolInfoKnownDataDetails,
@@ -16,32 +21,49 @@ type Props = {
   meta?: Record<string, any>;
 };
 
+export function getKnownThreadPoolInfoContextData({data, event, meta}: Props) {
+  if (!data) {
+    return [];
+  }
+  return getKnownData<
+    ThreadPoolInfoContext,
+    (typeof threadPoolInfoKnownDataValues)[number]
+  >({
+    data,
+    meta,
+    knownDataTypes: threadPoolInfoKnownDataValues,
+    onGetKnownDataDetails: v => getThreadPoolInfoKnownDataDetails({...v, event}),
+    raw: true,
+  });
+}
+
+export function getUnknownThreadPoolInfoContextData({
+  data,
+  meta,
+}: Pick<Props, 'data' | 'meta'>) {
+  if (!data) {
+    return [];
+  }
+  return getUnknownData({
+    allData: data,
+    knownKeys: threadPoolInfoKnownDataValues,
+    meta,
+  });
+}
+
 export function ThreadPoolInfoEventContext({data, event, meta: propsMeta}: Props) {
   if (!data) {
     return null;
   }
   const meta = propsMeta ?? getContextMeta(event, 'threadpool_info');
+  const knownData = getKnownThreadPoolInfoContextData({data, event, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownThreadPoolInfoContextData({data, meta});
 
   return (
     <Fragment>
-      <ContextBlock
-        data={getKnownData<
-          ThreadPoolInfoContext,
-          (typeof threadPoolInfoKnownDataValues)[number]
-        >({
-          data,
-          meta,
-          knownDataTypes: threadPoolInfoKnownDataValues,
-          onGetKnownDataDetails: v => getThreadPoolInfoKnownDataDetails({...v, event}),
-        })}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: data,
-          knownKeys: threadPoolInfoKnownDataValues,
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
     </Fragment>
   );
 }

--- a/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -17,8 +17,8 @@ type Output = {
 type Props = {
   data: TraceKnownData;
   event: Event;
+  organization: Organization;
   type: TraceKnownDataType;
-  organization?: Organization;
 };
 
 export function getTraceKnownDataDetails({
@@ -35,7 +35,7 @@ export function getTraceKnownDataDetails({
         return undefined;
       }
 
-      if (!organization || !organization.features.includes('discover-basic')) {
+      if (!organization.features.includes('discover-basic')) {
         return {
           subject: t('Trace ID'),
           value: traceId,
@@ -91,7 +91,7 @@ export function getTraceKnownDataDetails({
       }
       const transactionName = eventTag.value;
 
-      if (!organization || !organization.features.includes('performance-view')) {
+      if (!organization.features.includes('performance-view')) {
         return {
           subject: t('Transaction'),
           value: transactionName,

--- a/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -17,8 +17,8 @@ type Output = {
 type Props = {
   data: TraceKnownData;
   event: Event;
-  organization: Organization;
   type: TraceKnownDataType;
+  organization?: Organization;
 };
 
 export function getTraceKnownDataDetails({
@@ -35,7 +35,7 @@ export function getTraceKnownDataDetails({
         return undefined;
       }
 
-      if (!organization.features.includes('discover-basic')) {
+      if (!organization || !organization.features.includes('discover-basic')) {
         return {
           subject: t('Trace ID'),
           value: traceId,
@@ -91,19 +91,19 @@ export function getTraceKnownDataDetails({
       }
       const transactionName = eventTag.value;
 
+      if (!organization || !organization.features.includes('performance-view')) {
+        return {
+          subject: t('Transaction'),
+          value: transactionName,
+        };
+      }
+
       const to = transactionSummaryRouteWithQuery({
         orgSlug: organization.slug,
         transaction: transactionName,
         projectID: event.projectID,
         query: {},
       });
-
-      if (!organization.features.includes('performance-view')) {
-        return {
-          subject: t('Transaction'),
-          value: transactionName,
-        };
-      }
 
       return {
         subject: t('Transaction'),

--- a/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/trace/getTraceKnownDataDetails.tsx
@@ -1,4 +1,5 @@
 import {Button} from 'sentry/components/button';
+import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types';
@@ -7,12 +8,6 @@ import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transac
 
 import type {TraceKnownData} from './types';
 import {TraceKnownDataType} from './types';
-
-type Output = {
-  subject: string;
-  value: React.ReactNode;
-  actionButton?: React.ReactNode;
-};
 
 type Props = {
   data: TraceKnownData;
@@ -26,7 +21,7 @@ export function getTraceKnownDataDetails({
   event,
   organization,
   type,
-}: Props): Output | undefined {
+}: Props): KnownDataDetails {
   switch (type) {
     case TraceKnownDataType.TRACE_ID: {
       const traceId = data.trace_id || '';

--- a/static/app/components/events/contexts/trace/index.tsx
+++ b/static/app/components/events/contexts/trace/index.tsx
@@ -45,7 +45,6 @@ export function getKnownTraceContextData({
     meta,
     knownDataTypes: traceKnownDataValues,
     onGetKnownDataDetails: v => getTraceKnownDataDetails({...v, organization, event}),
-    raw: true,
   }).map(v => ({
     ...v,
     subjectDataTestId: `trace-context-${v.key.toLowerCase()}-value`,

--- a/static/app/components/events/contexts/trace/index.tsx
+++ b/static/app/components/events/contexts/trace/index.tsx
@@ -1,9 +1,15 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import type {Organization} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {getTraceKnownDataDetails} from './getTraceKnownDataDetails';
 import type {TraceKnownData} from './types';
@@ -26,38 +32,51 @@ type Props = {
   meta?: Record<string, any>;
 };
 
+export function getKnownTraceContextData({
+  data,
+  event,
+  meta,
+  organization,
+}: Props & {
+  organization?: Organization;
+}) {
+  return getKnownData<TraceKnownData, TraceKnownDataType>({
+    data,
+    meta,
+    knownDataTypes: traceKnownDataValues,
+    onGetKnownDataDetails: v => getTraceKnownDataDetails({...v, organization, event}),
+    raw: true,
+  }).map(v => ({
+    ...v,
+    subjectDataTestId: `trace-context-${v.key.toLowerCase()}-value`,
+  }));
+}
+
+export function getUnknownTraceContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  return getUnknownData({
+    allData: data,
+    knownKeys: [...traceKnownDataValues, ...traceIgnoredDataValues],
+    meta,
+  });
+}
+
 export function TraceEventContext({event, data, meta: propsMeta}: Props) {
   const organization = useOrganization();
   const meta = propsMeta ?? getContextMeta(event, 'trace');
 
+  const knownData = getKnownTraceContextData({data, event, meta, organization});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownTraceContextData({data, meta});
+
   return (
     <ErrorBoundary mini>
       <KeyValueList
-        data={getKnownData<TraceKnownData, TraceKnownDataType>({
-          data,
-          meta,
-          knownDataTypes: traceKnownDataValues,
-          onGetKnownDataDetails: v =>
-            getTraceKnownDataDetails({...v, organization, event}),
-        }).map(v => ({
-          ...v,
-          subjectDataTestId: `trace-context-${v.key.toLowerCase()}-value`,
-        }))}
+        data={knownStructuredData}
         shouldSort={false}
         raw={false}
         isContextData
       />
-
-      <KeyValueList
-        data={getUnknownData({
-          allData: data,
-          knownKeys: [...traceKnownDataValues, ...traceIgnoredDataValues],
-          meta,
-        })}
-        shouldSort={false}
-        raw={false}
-        isContextData
-      />
+      <KeyValueList data={unknownData} shouldSort={false} raw={false} isContextData />
     </ErrorBoundary>
   );
 }

--- a/static/app/components/events/contexts/trace/index.tsx
+++ b/static/app/components/events/contexts/trace/index.tsx
@@ -38,7 +38,7 @@ export function getKnownTraceContextData({
   meta,
   organization,
 }: Props & {
-  organization?: Organization;
+  organization: Organization;
 }) {
   return getKnownData<TraceKnownData, TraceKnownDataType>({
     data,

--- a/static/app/components/events/contexts/unity/getUnityKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/unity/getUnityKnownDataDetails.tsx
@@ -1,20 +1,16 @@
+import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import {t} from 'sentry/locale';
 import type {UnityContext} from 'sentry/types/event';
 import {UnityContextKey} from 'sentry/types/event';
 
 export const unityKnownDataValues = Object.values(UnityContextKey);
 
-type Output = {
-  subject: string;
-  value: React.ReactNode | null;
-};
-
 type Props = {
   data: UnityContext;
   type: (typeof unityKnownDataValues)[number];
 };
 
-export function getUnityKnownDataDetails({data, type}: Props): Output | undefined {
+export function getUnityKnownDataDetails({data, type}: Props): KnownDataDetails {
   switch (type) {
     case UnityContextKey.COPY_TEXTURE_SUPPORT:
       return {

--- a/static/app/components/events/contexts/unity/index.tsx
+++ b/static/app/components/events/contexts/unity/index.tsx
@@ -27,7 +27,6 @@ export function getKnownUnityContextData({data, meta}: Pick<Props, 'data' | 'met
     meta,
     knownDataTypes: unityKnownDataValues,
     onGetKnownDataDetails: v => getUnityKnownDataDetails(v),
-    raw: true,
   });
 }
 

--- a/static/app/components/events/contexts/unity/index.tsx
+++ b/static/app/components/events/contexts/unity/index.tsx
@@ -3,7 +3,12 @@ import {Fragment} from 'react';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import type {Event, UnityContext} from 'sentry/types';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {getUnityKnownDataDetails, unityKnownDataValues} from './getUnityKnownDataDetails';
 
@@ -13,29 +18,43 @@ type Props = {
   meta?: Record<string, any>;
 };
 
+export function getKnownUnityContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  if (!data) {
+    return [];
+  }
+  return getKnownData<UnityContext, (typeof unityKnownDataValues)[number]>({
+    data,
+    meta,
+    knownDataTypes: unityKnownDataValues,
+    onGetKnownDataDetails: v => getUnityKnownDataDetails(v),
+    raw: true,
+  });
+}
+
+export function getUnknownUnityContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  if (!data) {
+    return [];
+  }
+  return getUnknownData({
+    allData: data,
+    knownKeys: unityKnownDataValues,
+    meta,
+  });
+}
+
 export function UnityEventContext({data, event, meta: propsMeta}: Props) {
   if (!data) {
     return null;
   }
   const meta = propsMeta ?? getContextMeta(event, 'unity');
+  const knownData = getKnownUnityContextData({data, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownUnityContextData({data, meta});
 
   return (
     <Fragment>
-      <ContextBlock
-        data={getKnownData<UnityContext, (typeof unityKnownDataValues)[number]>({
-          data,
-          meta,
-          knownDataTypes: unityKnownDataValues,
-          onGetKnownDataDetails: v => getUnityKnownDataDetails(v),
-        })}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: data,
-          knownKeys: unityKnownDataValues,
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
     </Fragment>
   );
 }

--- a/static/app/components/events/contexts/user/getUserKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/user/getUserKnownDataDetails.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import type {KnownDataDetails} from 'sentry/components/events/contexts/utils';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {IconMail} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -10,18 +11,12 @@ import {UserKnownDataType} from '.';
 
 const EMAIL_REGEX = /[^@]+@[^\.]+\..+/;
 
-type Output = {
-  subject: string;
-  value: string | null;
-  subjectIcon?: React.ReactNode;
-};
-
 type Props = {
   data: UserEventContextData;
   type: UserKnownDataType;
 };
 
-export function getUserKnownDataDetails({data, type}: Props): Output | undefined {
+export function getUserKnownDataDetails({data, type}: Props): KnownDataDetails {
   switch (type) {
     case UserKnownDataType.NAME:
       return {

--- a/static/app/components/events/contexts/user/index.tsx
+++ b/static/app/components/events/contexts/user/index.tsx
@@ -54,7 +54,6 @@ export function getKnownUserContextData({data, meta}: Pick<Props, 'data' | 'meta
     meta,
     knownDataTypes: userKnownDataValues,
     onGetKnownDataDetails: v => getUserKnownDataDetails(v),
-    raw: true,
   }).map(v => ({
     ...v,
     subjectDataTestId: `user-context-${v.key.toLowerCase()}-value`,

--- a/static/app/components/events/contexts/user/index.tsx
+++ b/static/app/components/events/contexts/user/index.tsx
@@ -7,7 +7,12 @@ import type {AvatarUser} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 
-import {getContextMeta, getKnownData, getUnknownData} from '../utils';
+import {
+  getContextMeta,
+  getKnownData,
+  getKnownStructuredData,
+  getUnknownData,
+} from '../utils';
 
 import {getUserKnownDataDetails} from './getUserKnownDataDetails';
 
@@ -43,32 +48,39 @@ export const userKnownDataValues = [
 
 const userIgnoredDataValues = [UserIgnoredDataType.DATA];
 
+export function getKnownUserContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  return getKnownData<UserEventContextData, UserKnownDataType>({
+    data,
+    meta,
+    knownDataTypes: userKnownDataValues,
+    onGetKnownDataDetails: v => getUserKnownDataDetails(v),
+    raw: true,
+  }).map(v => ({
+    ...v,
+    subjectDataTestId: `user-context-${v.key.toLowerCase()}-value`,
+  }));
+}
+
+export function getUnknownUserContextData({data, meta}: Pick<Props, 'data' | 'meta'>) {
+  return getUnknownData({
+    allData: data,
+    knownKeys: [...userKnownDataValues, ...userIgnoredDataValues],
+    meta,
+  });
+}
 export function UserEventContext({data, event, meta: propsMeta}: Props) {
   const meta = propsMeta ?? getContextMeta(event, 'user');
+  const knownData = getKnownUserContextData({data, meta});
+  const knownStructuredData = getKnownStructuredData(knownData, meta);
+  const unknownData = getUnknownUserContextData({data, meta});
 
   return (
     <div className="user-widget">
       <div className="pull-left">
         <UserAvatar user={removeFilterMaskedEntries(data)} size={48} gravatar={false} />
       </div>
-      <ContextBlock
-        data={getKnownData<UserEventContextData, UserKnownDataType>({
-          data,
-          meta,
-          knownDataTypes: userKnownDataValues,
-          onGetKnownDataDetails: v => getUserKnownDataDetails(v),
-        }).map(v => ({
-          ...v,
-          subjectDataTestId: `user-context-${v.key.toLowerCase()}-value`,
-        }))}
-      />
-      <ContextBlock
-        data={getUnknownData({
-          allData: data,
-          knownKeys: [...userKnownDataValues, ...userIgnoredDataValues],
-          meta,
-        })}
-      />
+      <ContextBlock data={knownStructuredData} />
+      <ContextBlock data={unknownData} />
       {defined(data?.data) && (
         <ErrorBoundary mini>
           <KeyValueList

--- a/static/app/components/events/contexts/utils.spec.tsx
+++ b/static/app/components/events/contexts/utils.spec.tsx
@@ -22,7 +22,7 @@ describe('contexts utils', function () {
     });
   });
 
-  describe('getKknownData', function () {
+  describe('getKnownData', function () {
     it('filters out known data and transforms into the right way', function () {
       const data = {
         device_app_hash: '2421fae1ac9237a8131e74883e52b0f7034a143f',
@@ -89,7 +89,6 @@ describe('contexts utils', function () {
       const knownData = getKnownData({
         data,
         knownDataTypes,
-        raw: true,
         onGetKnownDataDetails: v => {
           if (v.type === 'device_app_hash') {
             return {
@@ -111,5 +110,7 @@ describe('contexts utils', function () {
         },
       ]);
     });
+
+    // TODO(Leander): Add tests here for getContextMeta, getKnownStructuredData and getFormattedContextData
   });
 });

--- a/static/app/components/events/contexts/utils.spec.tsx
+++ b/static/app/components/events/contexts/utils.spec.tsx
@@ -156,7 +156,7 @@ describe('contexts utils', function () {
       const knownStructuredData = getKnownStructuredData(knownData, errMeta);
       expect(knownData[0].key).toEqual(knownStructuredData[0].key);
       expect(knownData[0].subject).toEqual(knownStructuredData[0].subject);
-      render(<Fragment>{knownStructuredData[0].value}</Fragment>);
+      render(<Fragment>{knownStructuredData[0].value as React.ReactNode}</Fragment>);
       expect(screen.getByText(`${knownData[0].value}`)).toBeInTheDocument();
       expect(screen.getByTestId('annotated-text-error-icon')).toBeInTheDocument();
     });

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -321,8 +321,8 @@ export function getFormattedContextData({
         ...getKnownDeviceContextData({data: contextValue, event, meta}),
         ...getUnknownDeviceContextData({data: contextValue, meta}),
       ];
-    case 'memory_info':
-    case 'Memory Info':
+    case 'memory_info': // Current
+    case 'Memory Info': // Legacy
       return [
         ...getKnownMemoryInfoContextData({data: contextValue, event, meta}),
         ...getUnknownMemoryInfoContextData({data: contextValue, meta}),
@@ -362,8 +362,8 @@ export function getFormattedContextData({
         ...getKnownTraceContextData({data: contextValue, event, meta, organization}),
         ...getUnknownTraceContextData({data: contextValue, meta}),
       ];
-    case 'threadpool_info':
-    case 'ThreadPool Info':
+    case 'threadpool_info': // Current
+    case 'ThreadPool Info': // Legacy
       return [
         ...getKnownThreadPoolInfoContextData({data: contextValue, event, meta}),
         ...getUnknownThreadPoolInfoContextData({data: contextValue, meta}),

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -146,9 +146,8 @@ export function getRelativeTimeFromEventDateCreated(
 export function getKnownData<Data, DataType>({
   data,
   knownDataTypes,
-  meta,
-  raw,
   onGetKnownDataDetails,
+  meta,
 }: {
   data: Data;
   knownDataTypes: string[];
@@ -159,7 +158,6 @@ export function getKnownData<Data, DataType>({
       }
     | undefined;
   meta?: Record<any, any>;
-  raw?: boolean;
 }): KeyValueListData {
   const filteredTypes = knownDataTypes.filter(knownDataType => {
     if (
@@ -186,15 +184,7 @@ export function getKnownData<Data, DataType>({
       return {
         key: type,
         ...knownDataDetails,
-        value: raw ? (
-          knownDataDetails.value
-        ) : (
-          <StructuredEventData
-            data={knownDataDetails.value}
-            meta={meta?.[type]}
-            withAnnotatedText
-          />
-        ),
+        value: knownDataDetails.value,
       };
     })
     .filter(defined);

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -305,7 +305,7 @@ export function getFormattedContextData({
   contextType: string;
   contextValue: any;
   event: Event;
-  organization?: Organization;
+  organization: Organization;
   project?: Project;
 }) {
   const meta = getContextMeta(event, contextType);

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -7,7 +7,13 @@ import StructuredEventData from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
 import plugins from 'sentry/plugins';
 import {space} from 'sentry/styles/space';
-import type {Event, KeyValueListData, Organization, Project} from 'sentry/types';
+import type {
+  Event,
+  KeyValueListData,
+  KeyValueListDataItem,
+  Organization,
+  Project,
+} from 'sentry/types';
 import {defined, toTitleCase} from 'sentry/utils';
 
 import {AppEventContext, getKnownAppContextData, getUnknownAppContextData} from './app';
@@ -143,6 +149,8 @@ export function getRelativeTimeFromEventDateCreated(
   );
 }
 
+export type KnownDataDetails = Omit<KeyValueListDataItem, 'key'> | undefined;
+
 export function getKnownData<Data, DataType>({
   data,
   knownDataTypes,
@@ -151,12 +159,7 @@ export function getKnownData<Data, DataType>({
 }: {
   data: Data;
   knownDataTypes: string[];
-  onGetKnownDataDetails: (props: {data: Data; type: DataType}) =>
-    | {
-        subject: string;
-        value?: React.ReactNode;
-      }
-    | undefined;
+  onGetKnownDataDetails: (props: {data: Data; type: DataType}) => KnownDataDetails;
   meta?: Record<any, any>;
 }): KeyValueListData {
   const filteredTypes = knownDataTypes.filter(knownDataType => {

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -7,24 +7,68 @@ import StructuredEventData from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
 import plugins from 'sentry/plugins';
 import {space} from 'sentry/styles/space';
-import type {Event, KeyValueListData} from 'sentry/types';
+import type {Event, KeyValueListData, Organization, Project} from 'sentry/types';
 import {defined, toTitleCase} from 'sentry/utils';
 
-import {AppEventContext} from './app';
-import {BrowserEventContext} from './browser';
-import {DefaultContext} from './default';
-import {DeviceEventContext} from './device';
-import {GPUEventContext} from './gpu';
-import {MemoryInfoEventContext} from './memoryInfo';
-import {OperatingSystemEventContext} from './operatingSystem';
-import {ProfileEventContext} from './profile';
-import {ReduxContext} from './redux';
-import {RuntimeEventContext} from './runtime';
-import {StateEventContext} from './state';
-import {ThreadPoolInfoEventContext} from './threadPoolInfo';
-import {TraceEventContext} from './trace';
-import {UnityEventContext} from './unity';
-import {UserEventContext} from './user';
+import {AppEventContext, getKnownAppContextData, getUnknownAppContextData} from './app';
+import {
+  BrowserEventContext,
+  getKnownBrowserContextData,
+  getUnknownBrowserContextData,
+} from './browser';
+import {DefaultContext, getDefaultContextData} from './default';
+import {
+  DeviceEventContext,
+  getKnownDeviceContextData,
+  getUnknownDeviceContextData,
+} from './device';
+import {getKnownGpuContextData, getUnknownGpuContextData, GPUEventContext} from './gpu';
+import {
+  getKnownMemoryInfoContextData,
+  getUnknownMemoryInfoContextData,
+  MemoryInfoEventContext,
+} from './memoryInfo';
+import {
+  getKnownOperatingSystemContextData,
+  getUnknownOperatingSystemContextData,
+  OperatingSystemEventContext,
+} from './operatingSystem';
+import {
+  getKnownProfileContextData,
+  getUnknownProfileContextData,
+  ProfileEventContext,
+} from './profile';
+import {getReduxContextData, ReduxContext} from './redux';
+import {
+  getKnownRuntimeContextData,
+  getUnknownRuntimeContextData,
+  RuntimeEventContext,
+} from './runtime';
+import {
+  getKnownStateContextData,
+  getUnknownStateContextData,
+  StateEventContext,
+} from './state';
+import {
+  getKnownThreadPoolInfoContextData,
+  getUnknownThreadPoolInfoContextData,
+  ThreadPoolInfoEventContext,
+} from './threadPoolInfo';
+import {
+  getKnownTraceContextData,
+  getUnknownTraceContextData,
+  TraceEventContext,
+} from './trace';
+import {
+  getKnownUnityContextData,
+  getUnknownUnityContextData,
+  UnityEventContext,
+} from './unity';
+import {
+  getKnownUserContextData,
+  getUnknownUserContextData,
+  UserEventContext,
+} from './user';
 
 const CONTEXT_TYPES = {
   default: DefaultContext,
@@ -156,6 +200,18 @@ export function getKnownData<Data, DataType>({
     .filter(defined);
 }
 
+export function getKnownStructuredData(
+  knownData: KeyValueListData,
+  meta: Record<string, any>
+): KeyValueListData {
+  return knownData.map(kd => ({
+    ...kd,
+    value: (
+      <StructuredEventData data={kd.value} meta={meta?.[kd.key]} withAnnotatedText />
+    ),
+  }));
+}
+
 export function getUnknownData({
   allData,
   knownKeys,
@@ -233,9 +289,9 @@ export function getContextTitle({
   }
 }
 
-export function getContextMeta(event: Event, type: string): Record<string, any> {
-  const defaultMeta = event._meta?.contexts?.[type] ?? {};
-  switch (type) {
+export function getContextMeta(event: Event, contextType: string): Record<string, any> {
+  const defaultMeta = event._meta?.contexts?.[contextType] ?? {};
+  switch (contextType) {
     case 'memory_info': // Current
     case 'Memory Info': // Legacy
       return event._meta?.contexts?.['Memory Info'] ?? defaultMeta;
@@ -246,6 +302,96 @@ export function getContextMeta(event: Event, type: string): Record<string, any> 
       return event._meta?.user ?? defaultMeta;
     default:
       return defaultMeta;
+  }
+}
+
+export function getFormattedContextData({
+  event,
+  contextType,
+  contextValue,
+  organization,
+  project,
+}: {
+  contextType: string;
+  contextValue: any;
+  event: Event;
+  organization?: Organization;
+  project?: Project;
+}) {
+  const meta = getContextMeta(event, contextType);
+
+  switch (contextType) {
+    case 'app':
+      return [
+        ...getKnownAppContextData({data: contextValue, event, meta}),
+        ...getUnknownAppContextData({data: contextValue, meta}),
+      ];
+    case 'device':
+      return [
+        ...getKnownDeviceContextData({data: contextValue, event, meta}),
+        ...getUnknownDeviceContextData({data: contextValue, meta}),
+      ];
+    case 'memory_info':
+    case 'Memory Info':
+      return [
+        ...getKnownMemoryInfoContextData({data: contextValue, event, meta}),
+        ...getUnknownMemoryInfoContextData({data: contextValue, meta}),
+      ];
+    case 'browser':
+      return [
+        ...getKnownBrowserContextData({data: contextValue, meta}),
+        ...getUnknownBrowserContextData({data: contextValue, meta}),
+      ];
+    case 'os':
+      return [
+        ...getKnownOperatingSystemContextData({data: contextValue, meta}),
+        ...getUnknownOperatingSystemContextData({data: contextValue, meta}),
+      ];
+    case 'unity':
+      return [
+        ...getKnownUnityContextData({data: contextValue, meta}),
+        ...getUnknownUnityContextData({data: contextValue, meta}),
+      ];
+    case 'runtime':
+      return [
+        ...getKnownRuntimeContextData({data: contextValue, meta}),
+        ...getUnknownRuntimeContextData({data: contextValue, meta}),
+      ];
+    case 'user':
+      return [
+        ...getKnownUserContextData({data: contextValue, meta}),
+        ...getUnknownUserContextData({data: contextValue, meta}),
+      ];
+    case 'gpu':
+      return [
+        ...getKnownGpuContextData({data: contextValue, meta}),
+        ...getUnknownGpuContextData({data: contextValue, meta}),
+      ];
+    case 'trace':
+      return [
+        ...getKnownTraceContextData({data: contextValue, event, meta, organization}),
+        ...getUnknownTraceContextData({data: contextValue, meta}),
+      ];
+    case 'threadpool_info':
+    case 'ThreadPool Info':
+      return [
+        ...getKnownThreadPoolInfoContextData({data: contextValue, event, meta}),
+        ...getUnknownThreadPoolInfoContextData({data: contextValue, meta}),
+      ];
+    case 'redux.state':
+      return getReduxContextData({data: contextValue});
+    case 'state':
+      return [
+        ...getKnownStateContextData({data: contextValue, meta}),
+        ...getUnknownStateContextData({data: contextValue, meta}),
+      ];
+    case 'profile':
+      return [
+        ...getKnownProfileContextData({data: contextValue, meta, organization, project}),
+        ...getUnknownProfileContextData({data: contextValue, meta}),
+      ];
+    default:
+      return getDefaultContextData({data: contextValue});
   }
 }
 

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -381,7 +381,7 @@ export function getFormattedContextData({
         ...getUnknownProfileContextData({data: contextValue, meta}),
       ];
     default:
-      return getDefaultContextData({data: contextValue});
+      return getDefaultContextData(contextValue);
   }
 }
 

--- a/static/app/components/events/meta/annotatedText/annotatedTextErrors.tsx
+++ b/static/app/components/events/meta/annotatedText/annotatedTextErrors.tsx
@@ -60,7 +60,7 @@ export function AnnotatedTextErrors({errors = []}: {errors: Array<MetaError>}) {
         )
       }
     >
-      <StyledIconWarning color="errorText" />
+      <StyledIconWarning color="errorText" data-test-id="annotated-text-error-icon" />
     </StyledTooltip>
   );
 }


### PR DESCRIPTION
Another PR similar to https://github.com/getsentry/sentry/pull/68349 to help with simplifying https://github.com/getsentry/sentry/pull/68081

The goal of this PR is to extract the logic for how we display the known/unknown key value pairs for context items into their own functions and create a util function to easily receive a list of `KeyValueListItem[]` objects which we'll be able to render in our new component. This will prevent them from diverging while we're iterating on the new UI.

I had to do this in the verbose helper function way since the logic for converting context keys (e.g. `transaction.op` to `t('Operation Name')`) is unique for EACH context, and lived within the component which rendered the data. Now the data can be accessed outside that specific component, which will make swapping it much easier. It also now defaults to the `raw` data, rather than returning `<StructuredEventData />` components which make the value inaccessible. That formatting can be accessed by calling `getKnownStructuredData` on the result of `getKnownData`.

todo
- [x] Add test for `getKnownStructuredData`
- [x] Ensure CI passes