### PR TITLE
fix(ui): Fix scrollbars in table loading states

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -236,8 +236,9 @@ const GridStatusWrapper = styled(GridBodyCell)`
 
 const GridStatusFloat = styled('div')`
   position: absolute;
-  top: 45px;
+  top: 0;
   left: 0;
+  right: 0;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
As of https://github.com/getsentry/sentry/pull/68304, the `tr` that wraps the status float became the nearest positioned element to the floats. Because of this, the `top: 45;` pushed the status floats way down, and caused gross scrollbars. Previously, the closest positioned element was the `table` itself, and `top: 45` pushed the float to under the table heading. This is no longer needed!

Position floats with respect to the `tr` element instead of the `tbody`.

**Before:**
<img width="621" alt="Screenshot 2024-04-09 at 10 49 20 AM" src="https://github.com/getsentry/sentry/assets/989898/cc4c0b05-7eff-4c0a-8a5b-a0bd3513c411">

**After:**
<img width="638" alt="Screenshot 2024-04-09 at 10 49 35 AM" src="https://github.com/getsentry/sentry/assets/989898/fb01bcc9-8afe-468f-8116-342d028af5f1">
