### PR TITLE
fix(proguard): Don't symbolicate events without images

### DIFF
--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -152,8 +152,19 @@ def should_use_symbolicator_for_proguard(project_id: int) -> bool:
 
 
 def is_jvm_event(data: Any, stacktraces: list[StacktraceInfo]) -> bool:
-    """Returns whether `data` is a JVM event, based on its platform and
+    """Returns whether `data` is a JVM event, based on its platform, images, and
     the supplied stacktraces."""
+
+    # check if there are any JVM or Proguard images
+    images = get_path(
+        data,
+        "debug_meta",
+        "images",
+        filter=lambda x: is_valid_jvm_image(x) or is_valid_proguard_image(x),
+        default=(),
+    )
+    if not images:
+        return False
 
     if data.get("platform") == "java":
         return True

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -1591,3 +1591,101 @@ class BasicResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase):
             ]
 
             assert received == expected
+
+    def test_is_jvm_event(self):
+        from sentry.lang.java.utils import is_jvm_event
+        from sentry.stacktraces.processing import find_stacktraces_in_data
+
+        event = {
+            "user": {"ip_address": "31.172.207.97"},
+            "extra": {},
+            "project": self.project.id,
+            "platform": "java",
+            "debug_meta": {"images": [{"type": "jvm", "debug_id": PROGUARD_INLINE_UUID}]},
+            "exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "whoops4",
+                                    "abs_path": "SourceFile",
+                                    "module": "io.sentry.samples.MainActivity$OneMoreInnerClass",
+                                    "filename": "SourceFile",
+                                    "lineno": 38,
+                                },
+                            ]
+                        },
+                        "module": "io.sentry.samples",
+                        "type": "RuntimeException",
+                        "value": "whoops",
+                    }
+                ]
+            },
+            "timestamp": iso_format(before_now(seconds=1)),
+        }
+        stacktraces = find_stacktraces_in_data(event)
+        assert is_jvm_event(event, stacktraces)
+
+        event = {
+            "user": {"ip_address": "31.172.207.97"},
+            "extra": {},
+            "project": self.project.id,
+            "debug_meta": {"images": [{"type": "jvm", "debug_id": PROGUARD_INLINE_UUID}]},
+            "exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "whoops4",
+                                    "abs_path": "SourceFile",
+                                    "module": "io.sentry.samples.MainActivity$OneMoreInnerClass",
+                                    "filename": "SourceFile",
+                                    "lineno": 38,
+                                },
+                            ]
+                        },
+                        "module": "io.sentry.samples",
+                        "type": "RuntimeException",
+                        "value": "whoops",
+                    }
+                ]
+            },
+            "timestamp": iso_format(before_now(seconds=1)),
+        }
+        stacktraces = find_stacktraces_in_data(event)
+        # has no platform
+        assert not is_jvm_event(event, stacktraces)
+
+        event = {
+            "user": {"ip_address": "31.172.207.97"},
+            "extra": {},
+            "project": self.project.id,
+            "platform": "java",
+            "debug_meta": {},
+            "exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "whoops4",
+                                    "abs_path": "SourceFile",
+                                    "module": "io.sentry.samples.MainActivity$OneMoreInnerClass",
+                                    "filename": "SourceFile",
+                                    "lineno": 38,
+                                },
+                            ]
+                        },
+                        "module": "io.sentry.samples",
+                        "type": "RuntimeException",
+                        "value": "whoops",
+                    }
+                ]
+            },
+            "timestamp": iso_format(before_now(seconds=1)),
+        }
+        stacktraces = find_stacktraces_in_data(event)
+        # has no modules
+        assert not is_jvm_event(event, stacktraces)


### PR DESCRIPTION
The `JavaStacktraceProcessor` and the `JavaSourceLookupStacktraceProcessor` reject events containing no proguard and JVM (source) images, respectively. The new Symbolicator implementation is intended to subsume both those classes, so it should reject events that don't have either.

Therefore we check in `is_jvm_event` whether there is at least one valid proguard or source image in the event.