### PR TITLE
fix(hybridcloud) Refactor and start cleanup on webhook bucketing

### DIFF
--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -203,13 +203,22 @@ class BaseRequestParser(abc.ABC):
             # buckets for the next day.
             cache.set(use_buckets_key, 1, timeout=ONE_DAY)
             use_buckets = True
+            logging.info(
+                "integrations.parser.activate_buckets",
+                extra={"provider": self.provider, "integration_id": integration.id},
+            )
 
         if not use_buckets:
             return str(integration.id)
 
         mailbox_bucket_id = self.mailbox_bucket_id(data)
         if mailbox_bucket_id is None:
+            logging.info(
+                "integrations.parser.no_bucket_id",
+                extra={"provider": self.provider, "integration_id": integration.id},
+            )
             return str(integration.id)
+
         # Split high volume integrations into 100 buckets.
         # 100 is arbitrary but we can't leave it unbounded.
         bucket_number = mailbox_bucket_id % 100

--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -6,15 +6,18 @@ from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any
 
+from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse
 from django.http.response import HttpResponseBase
 from django.urls import ResolverMatch, resolve
 from rest_framework import status
 
+from sentry.api.base import ONE_DAY
 from sentry.hybridcloud.models.webhookpayload import WebhookPayload
 from sentry.models.integrations import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.outbox import WebhookProviderIdentifier
+from sentry.ratelimits import backend as ratelimiter
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
@@ -180,6 +183,42 @@ class BaseRequestParser(abc.ABC):
         """
         return self.get_response_from_webhookpayload(
             regions=regions, identifier=integration.id, integration_id=integration.id
+        )
+
+    def get_mailbox_identifier(self, integration: RpcIntegration, data: Mapping[str, Any]) -> str:
+        """
+        Used by integrations with higher hook volumes to create smaller mailboxes
+        that can be delivered in parallel. Requires the integration to implement
+        `mailbox_bucket_id`
+        """
+        # If we get fewer than 3000 in 1 hour we don't need to split into buckets
+        ratelimit_key = f"webhookpayload:{self.provider}:{integration.id}"
+        use_buckets_key = f"{ratelimit_key}:use_buckets"
+
+        use_buckets = cache.get(use_buckets_key)
+        if not use_buckets and ratelimiter.is_limited(
+            key=ratelimit_key, window=60 * 60, limit=3000
+        ):
+            # Once we have gone over the rate limit in a day, we use smaller
+            # buckets for the next day.
+            cache.set(use_buckets_key, 1, timeout=ONE_DAY)
+            use_buckets = True
+
+        if not use_buckets:
+            return str(integration.id)
+
+        mailbox_bucket_id = self.mailbox_bucket_id(data)
+        if mailbox_bucket_id is None:
+            return str(integration.id)
+        # Split high volume integrations into 100 buckets.
+        # 100 is arbitrary but we can't leave it unbounded.
+        bucket_number = mailbox_bucket_id % 100
+
+        return f"{integration.id}:{bucket_number}"
+
+    def mailbox_bucket_id(self, data: Mapping[str, Any]) -> int | None:
+        raise NotImplementedError(
+            "You must implement mailbox_bucket_id to use bucketed identifiers"
         )
 
     def get_response_from_first_region(self):

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from typing import Any
 
 from django.http.response import HttpResponseBase
 from django.urls import resolve
 
-from sentry import options
 from sentry.integrations.gitlab.webhooks import GitlabWebhookEndpoint, GitlabWebhookMixin
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.outbox import WebhookProviderIdentifier
-from sentry.ratelimits import backend as ratelimiter
-from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json
@@ -80,31 +79,27 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
         except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
             return self.get_default_missing_integration_response()
 
-        identifier = self.get_mailbox_identifier(integration)
-        return self.get_response_from_webhookpayload(
-            regions=regions, identifier=identifier, integration_id=integration.id
-        )
-
-    def get_mailbox_identifier(self, integration: RpcIntegration) -> str:
         try:
             data = json.loads(self.request.body)
         except ValueError:
             data = {}
-        enabled = options.get("hybridcloud.webhookpayload.use_mailbox_buckets")
+
+        return self.get_response_from_webhookpayload(
+            regions=regions,
+            identifier=self.get_mailbox_identifier(integration, data),
+            integration_id=integration.id,
+        )
+
+    def mailbox_bucket_id(self, data: Mapping[str, Any]) -> int | None:
+        """
+        Used by get_mailbox_identifier to find the project.id a payload is for.
+        In high volume gitlab instances we shard messages by project for greater
+        delivery throughput.
+        """
         project_id = data.get("project", {}).get("id", None)
-        if not project_id or not enabled:
-            return str(integration.id)
-
-        # If we get fewer than 3000 in 1 hour we don't need to split into buckets
-        ratelimit_key = f"webhookpayload:{self.provider}:{integration.id}"
-        if not ratelimiter.is_limited(key=ratelimit_key, window=60 * 60, limit=3000):
-            return str(integration.id)
-
-        # Split high volume integrations into 100 buckets.
-        # 100 is arbitrary but we can't leave it unbounded.
-        bucket_number = project_id % 100
-
-        return f"{integration.id}:{bucket_number}"
+        if not project_id:
+            return None
+        return project_id
 
     def get_response(self) -> HttpResponseBase:
         if self.view_class == GitlabWebhookEndpoint:

--- a/src/sentry/middleware/integrations/parsers/jira_server.py
+++ b/src/sentry/middleware/integrations/parsers/jira_server.py
@@ -6,15 +6,12 @@ from typing import Any
 
 from django.http import HttpResponse
 
-from sentry import options
 from sentry.integrations.jira_server.webhooks import (
     JiraServerIssueUpdatedWebhook,
     get_integration_from_token,
 )
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.outbox import WebhookProviderIdentifier
-from sentry.ratelimits import backend as ratelimiter
-from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
@@ -45,39 +42,25 @@ class JiraServerRequestParser(BaseRequestParser):
             logger.info("missing-changelog", extra={"integration_id": integration.id})
             return HttpResponse(status=200)
 
-        identifier = self.get_mailbox_identifier(integration, data)
         return self.get_response_from_webhookpayload(
             regions=regions,
-            identifier=identifier,
+            identifier=self.get_mailbox_identifier(integration, data),
             integration_id=integration.id,
         )
 
-    def get_mailbox_identifier(self, integration: RpcIntegration, data: Mapping[str, Any]) -> str:
+    def mailbox_bucket_id(self, data: Mapping[str, Any]) -> int | None:
         """
-        Some Jira server instances send us high volumes of hooks.
-        Splitting these hooks across multiple mailboxes allows us to deliver messages in parallel
-        without sacrificing linearization that customers care about.
+        Used by get_mailbox_identifier to find the issue.id a payload is for.
+        In high volume jira_server instances we shard messages by issue for greater
+        delivery throughput.
         """
-        enabled = options.get("hybridcloud.webhookpayload.use_mailbox_buckets")
         issue_id = data.get("issue", {}).get("id", None)
-        if not issue_id or not enabled:
-            return str(integration.id)
-
+        if not issue_id:
+            return None
         try:
-            issue_id = int(issue_id)
+            return int(issue_id)
         except ValueError:
-            return str(integration.id)
-
-        # If we get fewer than 3000 in 1 hour we don't need to split into buckets
-        ratelimit_key = f"webhookpayload:{self.provider}:{integration.id}"
-        if not ratelimiter.is_limited(key=ratelimit_key, window=60 * 60, limit=3000):
-            return str(integration.id)
-
-        # Split high volume integrations into 100 buckets.
-        # 100 is arbitrary but we can't leave it unbounded.
-        bucket_number = issue_id % 100
-
-        return f"{integration.id}:{bucket_number}"
+            return None
 
     def get_response(self):
         if self.view_class == JiraServerIssueUpdatedWebhook:

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -14,7 +14,6 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.outbox import ControlOutbox, OutboxCategory, outbox_context
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import assert_no_webhook_payloads, assert_webhook_payloads_for_mailbox
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
@@ -137,7 +136,6 @@ class GitlabRequestParserTest(TestCase):
 
     @override_regions(region_config)
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_options({"hybridcloud.webhookpayload.use_mailbox_buckets": True})
     @responses.activate
     def test_routing_webhook_with_mailbox_buckets(self):
         integration = self.get_integration()
@@ -149,7 +147,7 @@ class GitlabRequestParserTest(TestCase):
             HTTP_X_GITLAB_EVENT="Push Hook",
         )
         with mock.patch(
-            "sentry.middleware.integrations.parsers.gitlab.ratelimiter.is_limited"
+            "sentry.middleware.integrations.parsers.base.ratelimiter.is_limited"
         ) as mock_is_limited:
             mock_is_limited.return_value = True
             parser = GitlabRequestParser(request=request, response_handler=self.get_response)

--- a/tests/sentry/middleware/integrations/parsers/test_jira_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira_server.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest import mock
 
 import responses
+from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
@@ -10,7 +11,6 @@ from fixtures.integrations.stub_service import StubService
 from sentry.middleware.integrations.parsers.jira_server import JiraServerRequestParser
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import assert_no_webhook_payloads, assert_webhook_payloads_for_mailbox
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
@@ -84,7 +84,6 @@ class JiraServerRequestParserTest(TestCase):
 
     @override_regions(region_config)
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_options({"hybridcloud.webhookpayload.use_mailbox_buckets": True})
     @responses.activate
     def test_routing_webhook_with_mailbox_buckets_low_volume(self):
         route = reverse("sentry-extensions-jiraserver-issue-updated", kwargs={"token": "TOKEN"})
@@ -111,7 +110,6 @@ class JiraServerRequestParserTest(TestCase):
 
     @override_regions(region_config)
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_options({"hybridcloud.webhookpayload.use_mailbox_buckets": True})
     @responses.activate
     def test_routing_webhook_with_mailbox_buckets_high_volume(self):
         route = reverse("sentry-extensions-jiraserver-issue-updated", kwargs={"token": "TOKEN"})
@@ -122,13 +120,45 @@ class JiraServerRequestParserTest(TestCase):
         parser = JiraServerRequestParser(request=request, response_handler=self.get_response)
 
         with mock.patch(
-            "sentry.middleware.integrations.parsers.jira_server.ratelimiter.is_limited"
+            "sentry.middleware.integrations.parsers.base.ratelimiter.is_limited"
         ) as mock_is_limited, mock.patch(
             "sentry.middleware.integrations.parsers.jira_server.get_integration_from_token"
         ) as mock_get_token:
             mock_is_limited.return_value = True
             mock_get_token.return_value = self.integration
             response = parser.get_response()
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 202
+        assert response.content == b""
+        assert len(responses.calls) == 0
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            # Mailbox name should have an extra segment
+            mailbox_name=f"jira_server:{self.integration.id}:1",
+            region_names=[region.name],
+        )
+
+    @override_regions(region_config)
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @responses.activate
+    def test_routing_webhook_with_mailbox_bucket_mode_active(self):
+        route = reverse("sentry-extensions-jiraserver-issue-updated", kwargs={"token": "TOKEN"})
+
+        request = self.factory.post(
+            route, data=issue_updated_payload, content_type="application/json"
+        )
+        parser = JiraServerRequestParser(request=request, response_handler=self.get_response)
+
+        use_bucket_key = f"webhookpayload:jira_server:{self.integration.id}:use_buckets"
+        cache.set(use_bucket_key, 1)
+
+        with mock.patch(
+            "sentry.middleware.integrations.parsers.jira_server.get_integration_from_token"
+        ) as mock_get_token:
+            mock_get_token.return_value = self.integration
+            response = parser.get_response()
+
+        cache.delete(use_bucket_key)
         assert isinstance(response, HttpResponse)
         assert response.status_code == 202
         assert response.content == b""


### PR DESCRIPTION
Webhook bucketing has been working pretty well in production for the past few days. These changes move the common code up and add a new template method that parsers can implement to use bucketing.

I've added an additional cache key that is used to track bucketing mode being active over a longer period of time. With only the rate limit, we get a bundle of payloads in the main mailbox at the top of each hour. I'd prefer that we do that less often as it can cause out of order delivery.