### PR TITLE
test(ui): Fix two more act warnings in modal tests

### DIFF
--- a/static/app/components/modals/helpSearchModal.spec.tsx
+++ b/static/app/components/modals/helpSearchModal.spec.tsx
@@ -3,7 +3,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import {renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
 
 import {openHelpSearchModal} from 'sentry/actionCreators/modal';
 
@@ -59,7 +59,7 @@ describe('Docs Search Modal', function () {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
     // Open Modal
-    openHelpSearchModal();
+    await act(() => openHelpSearchModal());
 
     // Should have Modal + input
     expect(await screen.findByRole('dialog')).toBeInTheDocument();

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -971,6 +971,7 @@ describe('Modals -> WidgetViewerModal', function () {
           pageLinks:
             '<https://sentry.io>; rel="previous"; results="false"; cursor="0:0:1", <https://sentry.io>; rel="next"; results="true"; cursor="0:20:0"',
         });
+        await act(tick);
         expect(eventsMock).not.toHaveBeenCalled();
         await userEvent.click(await screen.findByLabelText('Next'));
         await waitFor(() => {


### PR DESCRIPTION
- helpSearchModal returns a promise and was not awaited, it changes a global store.
- The other modal seems to have some other issue with act, not quite sure

related to https://github.com/getsentry/frontend-tsc/issues/22