### PR TITLE
chore(invite): Added help center link to member invite email

### DIFF
--- a/src/sentry/templates/sentry/emails/member-invite.html
+++ b/src/sentry/templates/sentry/emails/member-invite.html
@@ -13,5 +13,7 @@
 {% endblock %}
 
 {% block footer %}
-<a href="{% absolute_uri %}">Home</a>
+  <a href="https://sentry.zendesk.com/hc/en-us/">Help Center</a>
+
+  <a href="{% absolute_uri %}" style="float:right">Home</a>
 {% endblock %}


### PR DESCRIPTION
Added help center link to be consistent with other email templates.
<img width="764" alt="Screenshot 2024-04-09 at 10 21 17 AM" src="https://github.com/getsentry/sentry/assets/8451987/b8e52844-4f49-4686-823e-e3ac62c1b3db">


Addresses: https://github.com/getsentry/sentry/issues/67684
