### PR TITLE
feat(hc): Adds Flagpole core data model

### DIFF
--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -150,4 +150,4 @@ class Feature(BaseModel):
         )
 
 
-__all__ = ["Feature", "InvalidFeatureFlagConfiguration"]
+__all__ = ["Feature", "InvalidFeatureFlagConfiguration", "ContextBuilder"]

--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -1,0 +1,132 @@
+"""
+Options backed feature flagging.
+
+Entry backed options. Will consume option data that is structured like
+
+```yaml
+features:
+  organizations:fury-mode:
+    enabled: True
+    name: sentry organizations
+    owner: hybrid-cloud
+    segments:
+      - name: sentry orgs
+        rollout: 50
+        conditions:
+          - property: organization_slug
+            name: internal organizations
+            operator:
+                kind: in
+                value: ["sentry-test", "sentry"]
+      - name: free accounts
+        conditions:
+          - property: subscription_is_free
+            name: free subscriptions
+            operator:
+              kind: equals
+              value: True
+```
+
+Each feature flag has a list of segments. If the conditions for a segment match
+the evaluation context a feature is granted. Segments can contain multiple conditions
+and all conditions in a segment must match. A segment with multiple conditions looks like:
+
+```yaml
+features:
+  organizations:fury-mode:
+    enabled: True
+    owner: hybrid-cloud
+    description: sentry organizations
+    segments:
+      - name: sentry organizations
+        rollout: 50
+        conditions:
+          - name: internal orgs
+            property: organization_slug
+            operator:
+              kind: in
+              value: ["sentry-test", "sentry"]
+          - name: allowed users
+            property: user_email
+            operator:
+              kind: in
+              value: ["mark@sentry.io", "gabe@sentry.io"]
+```
+
+Property names are arbitrary and read from an evaluation context
+prepared by the application.
+
+Each segment has one or more operators. All operators in a segment must
+evaluate to true. At least one segment must evaluate to true in order to
+grant a feature.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, ValidationError, constr
+
+from flagpole.conditions import Condition
+from flagpole.evaluation_context import EvaluationContext
+from sentry.utils import json
+
+
+class InvalidFeatureFlagConfiguration(Exception):
+    pass
+
+
+class Segment(BaseModel):
+    name: constr(min_length=1)  # type:ignore[valid-type]
+    conditions: list[Condition]
+    rollout: int | None = 0
+
+    def match(self, context: EvaluationContext) -> bool:
+        for condition in self.conditions:
+            match_condition = condition.match(context, segment_name=self.name)
+            if not match_condition:
+                return False
+        # Apply incremental rollout if available.
+        if self.rollout is not None and self.rollout < 100:
+            return context.id() % 100 <= self.rollout
+
+        return True
+
+
+class Feature(BaseModel):
+    name: constr(min_length=1, to_lower=True)  # type:ignore[valid-type]
+    owner: constr(min_length=1)  # type:ignore[valid-type]
+    segments: list[Segment]
+    enabled: bool = True
+    created_at: datetime = Field(default_factory=datetime.now)
+    """This datetime is when this instance was created. It can be used to decide when to re-read configuration data"""
+
+    def match(self, context: EvaluationContext) -> bool:
+        for segment in self.segments:
+            if segment.match(context):
+                return True
+        return False
+
+    def dump_schema_to_file(self, file_path: str) -> None:
+        with open(file_path, "w") as file:
+            file.write(self.schema_json())
+
+    @classmethod
+    def parse_feature_config_json(cls, name: str, config_json: str) -> Feature:
+        config_data_dict: dict | None = None
+        try:
+            config_data_dict = json.loads(config_json)
+        except json.JSONDecodeError:
+            pass
+
+        if not isinstance(config_data_dict, dict):
+            raise InvalidFeatureFlagConfiguration("Invalid feature json provided")
+
+        try:
+            feature = cls(name=name, **config_data_dict)
+        except ValidationError as exc:
+            raise InvalidFeatureFlagConfiguration("Provided JSON is not a valid feature") from exc
+
+        return feature
+
+
+__all__ = ["Feature", "InvalidFeatureFlagConfiguration"]

--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -102,11 +102,14 @@ class Feature(BaseModel):
     """Defines whether or not the feature is enabled."""
     created_at: datetime = Field(default_factory=datetime.now)
     """This datetime is when this instance was created. It can be used to decide when to re-read configuration data"""
-    context_builder: ContextBuilder = Field(default_factory=ContextBuilder)
-    """Used to generate an EvaluationContext whenever this feature is checked"""
+    context_builder: ContextBuilder | None = None
+    """Optional builder used to transform passed in data to an EvaluationContext whenever this feature is evaluated."""
 
     def match(self, context_data: dict[str, Any]) -> bool:
-        context = self.context_builder.build(context_data)
+        if self.context_builder is not None:
+            context = self.context_builder.build(context_data)
+        else:
+            context = EvaluationContext(context_data)
 
         if self.enabled:
             for segment in self.segments:

--- a/src/flagpole/conditions.py
+++ b/src/flagpole/conditions.py
@@ -1,11 +1,10 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, constr
 
 from flagpole.evaluation_context import EvaluationContext
 from flagpole.operators import AvailableOperators
 
 
 class Condition(BaseModel):
-    name: str
     property: str | None
     operator: AvailableOperators
 
@@ -16,3 +15,20 @@ class Condition(BaseModel):
         return self.operator.match(
             condition_property=context.get(self.property), segment_name=segment_name
         )
+
+
+class Segment(BaseModel):
+    name: constr(min_length=1)  # type:ignore[valid-type]
+    conditions: list[Condition]
+    rollout: int | None = 0
+
+    def match(self, context: EvaluationContext) -> bool:
+        for condition in self.conditions:
+            match_condition = condition.match(context, segment_name=self.name)
+            if not match_condition:
+                return False
+        # Apply incremental rollout if available.
+        if self.rollout is not None and self.rollout < 100:
+            return context.id() % 100 <= self.rollout
+
+        return True

--- a/src/flagpole/conditions.py
+++ b/src/flagpole/conditions.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+from flagpole.evaluation_context import EvaluationContext
+from flagpole.operators import AvailableOperators
+
+
+class Condition(BaseModel):
+    name: str
+    property: str | None
+    operator: AvailableOperators
+
+    def match(self, context: EvaluationContext, segment_name: str) -> bool:
+        if self.property is None:
+            return False
+
+        return self.operator.match(
+            condition_property=context.get(self.property), segment_name=segment_name
+        )

--- a/src/flagpole/evaluation_context.py
+++ b/src/flagpole/evaluation_context.py
@@ -1,0 +1,35 @@
+import hashlib
+from collections.abc import Mapping
+from typing import Any
+
+
+class EvaluationContext:
+    """
+    Prepared by the application and passed to flagpole to evaluate
+    feature conditions.
+    """
+
+    def __init__(self, data: Mapping[str, Any]):
+        self.__data = data
+
+    def get(self, key: str) -> Any:
+        return self.__data.get(key)
+
+    def has(self, key: str) -> Any:
+        return key in self.__data
+
+    def id(self) -> int:
+        """
+        Return a hashed identifier for this context
+
+        The identifier should be stable for a given context contents.
+        Identifiers are used to determine rollout groups deterministically
+        and consistently.
+        """
+        keys = self.__data.keys()
+        vector = []
+        for key in sorted(keys):
+            vector.append(key)
+            vector.append(str(self.__data[key]))
+        hashed = hashlib.sha1(":".join(vector).encode("utf8"))
+        return int.from_bytes(hashed.digest(), byteorder="big")

--- a/src/flagpole/evaluation_context.py
+++ b/src/flagpole/evaluation_context.py
@@ -76,7 +76,7 @@ class ContextBuilder(BaseModel):
         self.context_transformers.append(context_transformer)
         return self
 
-    def add_exception_handler(self, exception_handler: Callable[[Exception], Any]):
+    def add_exception_handler(self, exception_handler: Callable[[Exception], None]):
         """
         Add a custom exception handler to the context builder if you need custom handling
         if any of the transformer functions raise an exception. This is useful for swallowing

--- a/src/flagpole/evaluation_context.py
+++ b/src/flagpole/evaluation_context.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
+
+ValidContextTypes = TypeVar(
+    "ValidContextTypes",
+    bound=str | int | float | bool | list[str] | list[int] | list[float] | list[bool],
+)
+
+EvaluationContextDict = dict[str, ValidContextTypes]
 
 
 class EvaluationContext:
@@ -14,7 +21,7 @@ class EvaluationContext:
     feature conditions.
     """
 
-    def __init__(self, data: Mapping[str, Any]):
+    def __init__(self, data: EvaluationContextDict):
         self.__data = deepcopy(data)
 
     def get(self, key: str) -> Any:
@@ -43,14 +50,6 @@ class EvaluationContext:
         return int.from_bytes(hashed.digest(), byteorder="big")
 
 
-InputType = TypeVar("InputType")
-OutputType = TypeVar("OutputType", str, int, float, bool)
-
-ValidContextTypes = TypeVar(
-    "ValidContextTypes", str, int, float, bool, list[str], list[int], list[float], list[bool]
-)
-
-EvaluationContextDict = dict[str, ValidContextTypes]
 # A function that generates a new slice of evaluation context data as a dictionary.
 EvaluationContextTransformer = Callable[[dict[str, Any]], EvaluationContextDict]
 

--- a/src/flagpole/evaluation_context.py
+++ b/src/flagpole/evaluation_context.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import hashlib
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from copy import deepcopy
 from typing import Any
 
 
@@ -10,13 +13,16 @@ class EvaluationContext:
     """
 
     def __init__(self, data: Mapping[str, Any]):
-        self.__data = data
+        self.__data = deepcopy(data)
 
     def get(self, key: str) -> Any:
         return self.__data.get(key)
 
     def has(self, key: str) -> Any:
         return key in self.__data
+
+    def size(self) -> int:
+        return len(self.__data)
 
     def id(self) -> int:
         """
@@ -33,3 +39,26 @@ class EvaluationContext:
             vector.append(str(self.__data[key]))
         hashed = hashlib.sha1(":".join(vector).encode("utf8"))
         return int.from_bytes(hashed.digest(), byteorder="big")
+
+
+# A function that mutates the given evaluation context
+EvaluationContextTransformer = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+class ContextBuilder:
+    context_transformers: list[EvaluationContextTransformer] = []
+
+    def add_context_transformer(
+        self, context_transformer: EvaluationContextTransformer
+    ) -> ContextBuilder:
+        self.context_transformers.append(context_transformer)
+        return self
+
+    def build(self, data: dict[str, Any] | None = None) -> EvaluationContext:
+        builder_data: dict[str, Any] = data or dict()
+        context_data: dict[str, Any] = dict()
+
+        for transformer in self.context_transformers:
+            context_data = {**context_data, **transformer(builder_data)}
+
+        return EvaluationContext(context_data)

--- a/src/flagpole/evaluation_context.py
+++ b/src/flagpole/evaluation_context.py
@@ -5,6 +5,8 @@ from collections.abc import Callable, Mapping
 from copy import deepcopy
 from typing import Any
 
+from pydantic import BaseModel
+
 
 class EvaluationContext:
     """
@@ -41,11 +43,21 @@ class EvaluationContext:
         return int.from_bytes(hashed.digest(), byteorder="big")
 
 
-# A function that mutates the given evaluation context
+# A function that generates a new slice of evaluation context data as a dictionary.
 EvaluationContextTransformer = Callable[[dict[str, Any]], dict[str, Any]]
 
 
-class ContextBuilder:
+class ContextBuilder(BaseModel):
+    """
+    Used to build an EvaluationContext instance for use in Flagpole.
+    This class aggregates a list of context transformers, each of which are
+    responsible for generating a slice of context data.
+
+    This class is meant to be used with Flagpole's `Feature` class
+    >>> from flagpole import 'ContextBuilder'
+    >>> builder = ContextBuilder().add_context_transformer(lambda _dict: dict(foo="bar"))
+    """
+
     context_transformers: list[EvaluationContextTransformer] = []
 
     def add_context_transformer(

--- a/src/flagpole/operators.py
+++ b/src/flagpole/operators.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Annotated, Any, Literal, TypeVar
 
-from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr
+from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 
 def get_type_name(value: Any):
@@ -100,9 +100,12 @@ def create_case_insensitive_set_from_list(values: list[T]) -> set[T]:
     return case_insensitive_set
 
 
+InOperatorValueTypes = list[StrictInt] | list[StrictFloat] | list[StrictStr]
+
+
 class InOperator(Operator):
     kind: Literal[OperatorKind.IN] = OperatorKind.IN
-    value: list[StrictInt] | list[StrictStr]
+    value: InOperatorValueTypes
 
     def match(self, condition_property: Any, segment_name: str):
         return evaluate_in(
@@ -112,7 +115,7 @@ class InOperator(Operator):
 
 class NotInOperator(Operator):
     kind: Literal[OperatorKind.NOT_IN] = OperatorKind.NOT_IN
-    value: list[StrictInt] | list[StrictStr] = Field(default_factory=list)
+    value: InOperatorValueTypes
 
     def match(self, condition_property: Any, segment_name: str):
         return not evaluate_in(
@@ -120,9 +123,12 @@ class NotInOperator(Operator):
         )
 
 
+ContainsOperatorValueTypes = StrictInt | StrictStr | StrictFloat
+
+
 class ContainsOperator(Operator):
     kind: Literal[OperatorKind.CONTAINS] = OperatorKind.CONTAINS
-    value: StrictInt | StrictStr
+    value: StrictInt | StrictStr | StrictFloat
 
     def match(self, condition_property: Any, segment_name: str):
         return evaluate_contains(
@@ -132,7 +138,7 @@ class ContainsOperator(Operator):
 
 class NotContainsOperator(Operator):
     kind: Literal[OperatorKind.NOT_CONTAINS] = OperatorKind.NOT_CONTAINS
-    value: StrictInt | StrictStr
+    value: ContainsOperatorValueTypes
 
     def match(self, condition_property: Any, segment_name: str):
         return not evaluate_contains(
@@ -140,9 +146,20 @@ class NotContainsOperator(Operator):
         )
 
 
+EqualsOperatorValueTypes = (
+    StrictInt
+    | StrictFloat
+    | StrictStr
+    | StrictBool
+    | list[StrictInt]
+    | list[StrictFloat]
+    | list[StrictStr]
+)
+
+
 class EqualsOperator(Operator):
     kind: Literal[OperatorKind.EQUALS] = OperatorKind.EQUALS
-    value: StrictInt | StrictStr | StrictBool | list[StrictInt] | list[StrictStr]
+    value: EqualsOperatorValueTypes
 
     def match(self, condition_property: Any, segment_name: str):
         return evaluate_equals(
@@ -152,7 +169,7 @@ class EqualsOperator(Operator):
 
 class NotEqualsOperator(Operator):
     kind: Literal[OperatorKind.NOT_EQUALS] = OperatorKind.NOT_EQUALS
-    value: StrictInt | StrictStr | list[StrictInt] | list[StrictStr]
+    value: EqualsOperatorValueTypes
 
     def match(self, condition_property: Any, segment_name: str):
         return not evaluate_equals(

--- a/src/flagpole/operators.py
+++ b/src/flagpole/operators.py
@@ -1,0 +1,174 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Annotated, Any, Literal, TypeVar
+
+from pydantic import BaseModel, Field, StrictInt, StrictStr
+
+
+def get_type_name(value: Any):
+    return type(value).__name__
+
+
+class ConditionTypeMismatchException(Exception):
+    pass
+
+
+class OperatorKind(str, Enum):
+    IN = "in"
+    """Provided a list of values, check if the property value is in the list ov values"""
+
+    NOT_IN = "not_in"
+
+    CONTAINS = "contains"
+    """Provided a single value, check if the property (a list) is included"""
+
+    NOT_CONTAINS = "not_contains"
+    """Provided a single value, check if the property (a list) is not included"""
+
+    EQUALS = "equals"
+    """Comprare a value to another. Values are compared with types"""
+
+    NOT_EQUALS = "not_equals"
+    """Comprare a value to not be equal to another. Values are compared with types"""
+
+
+class Operator(BaseModel, ABC):
+    kind: OperatorKind
+    value: Any
+
+    @abstractmethod
+    def match(self, condition_property: Any, segment_name: str):
+        raise NotImplementedError("Each Operator needs to implement this method")
+
+
+def evaluate_in(condition_property: Any, operator: Operator, segment_name: str) -> bool:
+    if not isinstance(operator.value, list):
+        raise ConditionTypeMismatchException(
+            f"'In' condition value must be a list, but was provided a '{get_type_name(operator.value)}'"
+            + f" of segment {segment_name}"
+        )
+    if isinstance(condition_property, (list, dict)):
+        raise ConditionTypeMismatchException(
+            f"'In' condition property value must be str | int | float | bool | None, but was provided a '{get_type_name(operator.value)}'"
+            + f" of segment {segment_name}"
+        )
+    if isinstance(condition_property, str):
+        condition_property = condition_property.lower()
+
+    return condition_property in create_case_insensitive_set_from_list(operator.value)
+
+
+def evaluate_contains(condition_property: Any, operator: Operator, segment_name: str) -> bool:
+    if not isinstance(condition_property, list):
+        raise ConditionTypeMismatchException(
+            f"'Contains' can only be checked against a list, but was given a {get_type_name(condition_property)}"
+            + f" context property '{condition_property}' of segment '{segment_name}'"
+        )
+    value = operator.value
+    if isinstance(value, str):
+        value = value.lower()
+
+    return value in create_case_insensitive_set_from_list(condition_property)
+
+
+def evaluate_equals(condition_property: Any, operator: Operator, segment_name: str) -> bool:
+    if not isinstance(condition_property, type(operator.value)):
+        value_type = get_type_name(operator.value)
+        property_value = get_type_name(condition_property)
+        raise ConditionTypeMismatchException(
+            "'Equals' operator cannot be applied to values of mismatching types"
+            + f"({value_type} and {property_value}) for segment {segment_name}"
+        )
+
+    if isinstance(condition_property, str):
+        return condition_property.lower() == operator.value.lower()
+
+    return condition_property == operator.value
+
+
+T = TypeVar("T", str, int, float)
+
+
+def create_case_insensitive_set_from_list(values: list[T]) -> set[T]:
+    case_insensitive_set = set()
+    for value in values:
+        if isinstance(value, str):
+            case_insensitive_set.add(value.lower())
+        else:
+            case_insensitive_set.add(value)
+
+    return case_insensitive_set
+
+
+class InOperator(Operator):
+    kind: Literal[OperatorKind.IN] = OperatorKind.IN
+    value: list[StrictInt] | list[StrictStr]
+
+    def match(self, condition_property: Any, segment_name: str):
+        return evaluate_in(
+            condition_property=condition_property, segment_name=segment_name, operator=self
+        )
+
+
+class NotInOperator(Operator):
+    kind: Literal[OperatorKind.NOT_IN] = OperatorKind.NOT_IN
+    value: list[StrictInt] | list[StrictStr] = Field(default_factory=list)
+
+    def match(self, condition_property: Any, segment_name: str):
+        return not evaluate_in(
+            condition_property=condition_property, segment_name=segment_name, operator=self
+        )
+
+
+class ContainsOperator(Operator):
+    kind: Literal[OperatorKind.CONTAINS] = OperatorKind.CONTAINS
+    value: StrictInt | StrictStr
+
+    def match(self, condition_property: Any, segment_name: str):
+        return evaluate_contains(
+            condition_property=condition_property, segment_name=segment_name, operator=self
+        )
+
+
+class NotContainsOperator(Operator):
+    kind: Literal[OperatorKind.NOT_CONTAINS] = OperatorKind.NOT_CONTAINS
+    value: StrictInt | StrictStr
+
+    def match(self, condition_property: Any, segment_name: str):
+        return not evaluate_contains(
+            condition_property=condition_property, segment_name=segment_name, operator=self
+        )
+
+
+class EqualsOperator(Operator):
+    kind: Literal[OperatorKind.EQUALS] = OperatorKind.EQUALS
+    value: StrictInt | StrictStr | list[StrictInt] | list[StrictStr]
+
+    def match(self, condition_property: Any, segment_name: str):
+        return evaluate_equals(
+            condition_property=condition_property, segment_name=segment_name, operator=self
+        )
+
+
+class NotEqualsOperator(Operator):
+    kind: Literal[OperatorKind.NOT_EQUALS] = OperatorKind.NOT_EQUALS
+    value: StrictInt | StrictStr | list[StrictInt] | list[StrictStr]
+
+    def match(self, condition_property: Any, segment_name: str):
+        return not evaluate_equals(
+            condition_property=condition_property, segment_name=segment_name, operator=self
+        )
+
+
+# We have to group and annotate all the different subclasses of Operator
+# in order for Pydantic to be able to discern between the different types
+# when parsing a dict or JSON.
+AvailableOperators = Annotated[
+    InOperator
+    | NotInOperator
+    | ContainsOperator
+    | NotContainsOperator
+    | EqualsOperator
+    | NotEqualsOperator,
+    Field(discriminator="kind"),
+]

--- a/src/flagpole/operators.py
+++ b/src/flagpole/operators.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Annotated, Any, Literal, TypeVar
 
-from pydantic import BaseModel, Field, StrictInt, StrictStr
+from pydantic import BaseModel, Field, StrictBool, StrictInt, StrictStr
 
 
 def get_type_name(value: Any):
@@ -142,7 +142,7 @@ class NotContainsOperator(Operator):
 
 class EqualsOperator(Operator):
     kind: Literal[OperatorKind.EQUALS] = OperatorKind.EQUALS
-    value: StrictInt | StrictStr | list[StrictInt] | list[StrictStr]
+    value: StrictInt | StrictStr | StrictBool | list[StrictInt] | list[StrictStr]
 
     def match(self, condition_property: Any, segment_name: str):
         return evaluate_equals(

--- a/src/flagpole/sentry_flagpole_context.py
+++ b/src/flagpole/sentry_flagpole_context.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from flagpole.evaluation_context import ContextBuilder
+from flagpole.evaluation_context import ContextBuilder, EvaluationContextDict
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.user import User
@@ -13,7 +13,7 @@ class InvalidContextDataException(Exception):
 
 
 def organization_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
-    context_data = dict()
+    context_data: EvaluationContextDict = dict()
     org = data.get("organization", None)
     if org is None:
         return context_data
@@ -50,17 +50,17 @@ def project_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
     return context_data
 
 
-def team_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
+def team_context_transformer(data: dict[str, Any]) -> EvaluationContextDict:
     raise NotImplementedError()
 
 
-def user_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
-    context_data = dict()
+def user_context_transformer(data: dict[str, Any]) -> EvaluationContextDict:
+    context_data: EvaluationContextDict = dict()
     user = data.get("actor", None)
     if user is None:
         return context_data
 
-    if not isinstance(user, User) or isinstance(user, RpcUser):
+    if not isinstance(user, User) and not isinstance(user, RpcUser):
         raise InvalidContextDataException("Invalid actor object provided")
 
     if user.is_authenticated:

--- a/src/flagpole/sentry_flagpole_context.py
+++ b/src/flagpole/sentry_flagpole_context.py
@@ -12,7 +12,7 @@ class InvalidContextDataException(Exception):
     pass
 
 
-def organization_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
+def organization_context_transformer(data: dict[str, Any]) -> EvaluationContextDict:
     context_data: EvaluationContextDict = dict()
     org = data.get("organization", None)
     if org is None:
@@ -36,8 +36,8 @@ def organization_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
     return context_data
 
 
-def project_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
-    context_data = dict()
+def project_context_transformer(data: dict[str, Any]) -> EvaluationContextDict:
+    context_data: EvaluationContextDict = dict()
 
     if (proj := data.get("project", None)) is not None:
         if not isinstance(proj, Project):
@@ -48,10 +48,6 @@ def project_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
         context_data["project_id"] = proj.id
 
     return context_data
-
-
-def team_context_transformer(data: dict[str, Any]) -> EvaluationContextDict:
-    raise NotImplementedError()
 
 
 def user_context_transformer(data: dict[str, Any]) -> EvaluationContextDict:
@@ -92,6 +88,5 @@ def get_sentry_flagpole_context_builder():
         ContextBuilder()
         .add_context_transformer(organization_context_transformer)
         .add_context_transformer(project_context_transformer)
-        # .add_context_transformer(team_context_transformer)
         .add_context_transformer(user_context_transformer)
     )

--- a/src/flagpole/sentry_flagpole_context.py
+++ b/src/flagpole/sentry_flagpole_context.py
@@ -1,0 +1,97 @@
+from typing import Any
+
+from flagpole.evaluation_context import ContextBuilder
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.user import User
+from sentry.services.hybrid_cloud.organization import RpcOrganization
+from sentry.services.hybrid_cloud.user import RpcUser
+
+
+class InvalidContextDataException(Exception):
+    pass
+
+
+def organization_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
+    context_data = dict()
+    org = data.get("organization", None)
+    if org is None:
+        return context_data
+
+    if isinstance(org, Organization):
+        context_data["organization_slug"] = org.slug
+        context_data["organization_name"] = org.name
+        context_data["organization_id"] = org.id
+        early_adopter = bool(org.flags.early_adopter) if org.flags is not None else False
+        context_data["organization_is-early-adopter"] = early_adopter
+
+    elif isinstance(org, RpcOrganization):
+        context_data["organization_slug"] = org.slug
+        context_data["organization_name"] = org.name
+        context_data["organization_id"] = org.id
+        context_data["organization_is-early-adopter"] = org.flags.early_adopter
+    else:
+        raise InvalidContextDataException("Invalid organization object provided")
+
+    return context_data
+
+
+def project_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
+    context_data = dict()
+
+    if (proj := data.get("project", None)) is not None:
+        if not isinstance(proj, Project):
+            raise InvalidContextDataException("Invalid project object provided")
+
+        context_data["project_slug"] = proj.slug
+        context_data["project_name"] = proj.name
+        context_data["project_id"] = proj.id
+
+    return context_data
+
+
+def team_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
+    raise NotImplementedError()
+
+
+def user_context_transformer(data: dict[str, Any]) -> dict[str, Any]:
+    context_data = dict()
+    user = data.get("actor", None)
+    if user is None:
+        return context_data
+
+    if not isinstance(user, User) or isinstance(user, RpcUser):
+        raise InvalidContextDataException("Invalid actor object provided")
+
+    if user.is_authenticated:
+        context_data["user_id"] = user.id
+        context_data["user_is-superuser"] = user.is_superuser
+        context_data["user_is-staff"] = user.is_staff
+
+    verified_emails: list[str]
+
+    if isinstance(user, RpcUser):
+        verified_emails = list(user.emails)
+    else:
+        verified_emails = user.get_verified_emails().values_list("email", flat=True)
+
+    if user.email in verified_emails:
+        context_data["user_email"] = user.email
+        context_data["user_domain"] = user.email.rsplit("@", 1)[-1]
+
+    return context_data
+
+
+def get_sentry_flagpole_context_builder():
+    """
+    Creates and returns a new sentry flagpole context builder with Organization,
+     User, Team, and Project transformers appended to it.
+    :return:
+    """
+    return (
+        ContextBuilder()
+        .add_context_transformer(organization_context_transformer)
+        .add_context_transformer(project_context_transformer)
+        # .add_context_transformer(team_context_transformer)
+        .add_context_transformer(user_context_transformer)
+    )

--- a/tests/flagpole/test_evaluation_context.py
+++ b/tests/flagpole/test_evaluation_context.py
@@ -1,0 +1,56 @@
+from typing import Any
+
+from flagpole.evaluation_context import ContextBuilder
+
+
+class TestEvaluationContext:
+    pass
+
+
+class TestContextBuilder:
+    def test_empty_context_builder(self):
+        context_builder = ContextBuilder()
+        context = context_builder.build()
+
+        assert context.size() == 0
+
+    def test_static_transformer(self):
+        def static_transformer(_data: dict[str, Any]) -> dict[str, Any]:
+            return dict(foo="bar", baz=1)
+
+        eval_context = ContextBuilder().add_context_transformer(static_transformer).build()
+
+        assert eval_context.size() == 2
+        assert eval_context.get("foo") == "bar"
+        assert eval_context.get("baz") == 1
+
+    def test_transformer_with_data(self):
+        def transformer_with_data(data: dict[str, Any]) -> dict[str, Any]:
+            return dict(foo="bar", baz=data.get("baz"))
+
+        eval_context = (
+            ContextBuilder().add_context_transformer(transformer_with_data).build({"baz": 2})
+        )
+
+        assert eval_context.size() == 2
+        assert eval_context.get("foo") == "bar"
+        assert eval_context.get("baz") == 2
+
+    def test_multiple_context_transformers(self):
+        def transformer_one(data: dict[str, Any]) -> dict[str, Any]:
+            return dict(foo="overwrite_me", baz=2, buzz=data.get("buzz"))
+
+        def transformer_two(_data: dict[str, Any]) -> dict[str, Any]:
+            return dict(foo="bar")
+
+        eval_context = (
+            ContextBuilder()
+            .add_context_transformer(transformer_one)
+            .add_context_transformer(transformer_two)
+            .build({"foo": "bar", "buzz": {1, 2, 3}})
+        )
+
+        assert eval_context.size() == 3
+        assert eval_context.get("foo") == "bar"
+        assert eval_context.get("baz") == 2
+        assert eval_context.get("buzz") == {1, 2, 3}

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -33,6 +33,8 @@ class TestParseFeatureConfig:
         assert feature.owner == "test-owner"
         assert feature.segments == []
 
+        assert not feature.match(dict())
+
     def test_valid_with_all_nesting(self):
         feature = Feature.from_feature_config_json(
             "foobar",
@@ -42,7 +44,7 @@ class TestParseFeatureConfig:
                 "owner": "test-owner",
                 "segments": [{
                     "name": "segment1",
-                    "rollout": 42,
+                    "rollout": 100,
                     "conditions": [{
                         "name": "condition1",
                         "property": "test_property",
@@ -58,7 +60,7 @@ class TestParseFeatureConfig:
         assert feature.name == "foobar"
         assert len(feature.segments) == 1
         assert feature.segments[0].name == "segment1"
-        assert feature.segments[0].rollout == 42
+        assert feature.segments[0].rollout == 100
         assert len(feature.segments[0].conditions) == 1
 
         condition = feature.segments[0].conditions[0]
@@ -67,6 +69,9 @@ class TestParseFeatureConfig:
         assert condition.operator
         assert condition.operator.kind == OperatorKind.IN
         assert condition.operator.value == ["foobar"]
+
+        assert feature.match(dict(test_property="foobar"))
+        assert not feature.match(dict(test_property="barfoo"))
 
     def test_invalid_json(self):
         with pytest.raises(InvalidFeatureFlagConfiguration):

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from flagpole import ContextBuilder, Feature, InvalidFeatureFlagConfiguration
+from flagpole import ContextBuilder, EvaluationContext, Feature, InvalidFeatureFlagConfiguration
 from flagpole.operators import OperatorKind
 
 
@@ -33,7 +33,7 @@ class TestParseFeatureConfig:
         assert feature.owner == "test-owner"
         assert feature.segments == []
 
-        assert not feature.match(dict())
+        assert not feature.match(EvaluationContext(dict()))
 
     def test_valid_with_all_nesting(self):
         feature = Feature.from_feature_config_json(
@@ -68,8 +68,8 @@ class TestParseFeatureConfig:
         assert condition.operator.kind == OperatorKind.IN
         assert condition.operator.value == ["foobar"]
 
-        assert feature.match(dict(test_property="foobar"))
-        assert not feature.match(dict(test_property="barfoo"))
+        assert feature.match(EvaluationContext(dict(test_property="foobar")))
+        assert not feature.match(EvaluationContext(dict(test_property="barfoo")))
 
     def test_invalid_json(self):
         with pytest.raises(InvalidFeatureFlagConfiguration):
@@ -105,10 +105,10 @@ class TestParseFeatureConfig:
                 }]
             }
             """,
-            self.get_is_true_context_builder(is_true_value=True),
         )
 
-        assert feature.match(context_data=dict())
+        context_builder = self.get_is_true_context_builder(is_true_value=True)
+        assert feature.match(context_builder.build())
 
     def test_disabled_feature(self):
         feature = Feature.from_feature_config_json(
@@ -131,7 +131,7 @@ class TestParseFeatureConfig:
                 }]
             }
             """,
-            self.get_is_true_context_builder(is_true_value=True),
         )
 
-        assert not feature.match(context_data=dict())
+        context_builder = self.get_is_true_context_builder(is_true_value=True)
+        assert not feature.match(context_builder.build())

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from flagpole import Feature, InvalidFeatureFlagConfiguration
+from flagpole.operators import OperatorKind
+
+
+class TestParseFeatureConfig:
+    def test_valid_without_created_at(self):
+        feature = Feature.parse_feature_config_json("foo", '{"owner": "test", "segments":[]}')
+        assert feature.name == "foo"
+        assert isinstance(feature.created_at, datetime)
+        assert feature.segments == []
+
+    def test_feature_with_empty_segments(self):
+        feature = Feature.parse_feature_config_json(
+            "foobar",
+            """
+            {
+                "created_at": "2023-10-12T00:00:00.000Z",
+                "owner": "test-owner",
+                "segments": []
+            }
+            """,
+        )
+
+        assert feature.name == "foobar"
+        assert feature.created_at == datetime(2023, 10, 12, tzinfo=timezone.utc)
+        assert feature.owner == "test-owner"
+        assert feature.segments == []
+
+    def test_valid_with_all_nesting(self):
+        feature = Feature.parse_feature_config_json(
+            "foobar",
+            """
+            {
+                "created_at": "2023-10-12T00:00:00.000Z",
+                "owner": "test-owner",
+                "segments": [{
+                    "name": "segment1",
+                    "rollout": 42,
+                    "conditions": [{
+                        "name": "condition1",
+                        "property": "test_property",
+                        "operator": {
+                            "kind": "in",
+                            "value": ["foobar"]
+                        }
+                    }]
+                }]
+            }
+            """,
+        )
+        assert feature.name == "foobar"
+        assert len(feature.segments) == 1
+        assert feature.segments[0].name == "segment1"
+        assert feature.segments[0].rollout == 42
+        assert len(feature.segments[0].conditions) == 1
+
+        condition = feature.segments[0].conditions[0]
+        assert condition.name == "condition1"
+        assert condition.property == "test_property"
+        assert condition.operator
+        assert condition.operator.kind == OperatorKind.IN
+        assert condition.operator.value == ["foobar"]
+
+    def test_invalid_json(self):
+        with pytest.raises(InvalidFeatureFlagConfiguration):
+            Feature.parse_feature_config_json("foobar", "{")
+
+    def test_empty_string_name(self):
+        with pytest.raises(InvalidFeatureFlagConfiguration) as exception:
+            Feature.parse_feature_config_json("", '{"segments":[]}')
+        assert "Provided JSON is not a valid feature" in str(exception)
+
+    def test_missing_segments(self):
+        with pytest.raises(InvalidFeatureFlagConfiguration) as exception:
+            Feature.parse_feature_config_json("foo", "{}")
+        assert "Provided JSON is not a valid feature" in str(exception)

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -46,7 +46,6 @@ class TestParseFeatureConfig:
                     "name": "segment1",
                     "rollout": 100,
                     "conditions": [{
-                        "name": "condition1",
                         "property": "test_property",
                         "operator": {
                             "kind": "in",
@@ -64,7 +63,6 @@ class TestParseFeatureConfig:
         assert len(feature.segments[0].conditions) == 1
 
         condition = feature.segments[0].conditions[0]
-        assert condition.name == "condition1"
         assert condition.property == "test_property"
         assert condition.operator
         assert condition.operator.kind == OperatorKind.IN

--- a/tests/flagpole/test_operators.py
+++ b/tests/flagpole/test_operators.py
@@ -1,0 +1,156 @@
+import pytest
+from pydantic import ValidationError
+
+from flagpole.operators import (
+    ConditionTypeMismatchException,
+    ContainsOperator,
+    EqualsOperator,
+    InOperator,
+    NotContainsOperator,
+    NotEqualsOperator,
+    NotInOperator,
+    OperatorKind,
+    create_case_insensitive_set_from_list,
+)
+from sentry.testutils.cases import TestCase
+
+
+class TestCreateCaseInsensitiveSetFromList(TestCase):
+    def test_empty_set(self):
+        assert create_case_insensitive_set_from_list([]) == set()
+
+    def test_returns_int_set(self):
+        assert create_case_insensitive_set_from_list([1, 2, 3]) == {1, 2, 3}
+
+    def test_returns_float_set(self):
+        assert create_case_insensitive_set_from_list([1.1, 2.2, 3.3]) == {1.1, 2.2, 3.3}
+
+    def test_returns_lowercase_string_set(self):
+        assert create_case_insensitive_set_from_list(["AbC", "DEF"]) == {"abc", "def"}
+
+
+class TestInOperators(TestCase):
+    def test_invalid_values(self):
+        with pytest.raises(ValidationError):
+            InOperator(value="bar")
+
+        with pytest.raises(ValidationError):
+            InOperator(value=1234)
+
+    def test_is_in(self):
+        values = ["bar", "baz"]
+        operator = InOperator(kind=OperatorKind.IN, value=values)
+        assert operator.match(condition_property="bar", segment_name="test")
+
+        not_operator = NotInOperator(kind=OperatorKind.NOT_IN, value=values)
+        assert not not_operator.match(condition_property="bar", segment_name="test")
+
+        int_values = [1, 2]
+        operator = InOperator(kind=OperatorKind.IN, value=int_values)
+        # Validation check to ensure no type coercion occurs
+        assert operator.value == int_values
+        assert operator.match(condition_property=2, segment_name="test")
+        assert not operator.match(condition_property=3, segment_name="test")
+
+    def test_is_in_numeric_string(self):
+        values = ["123", "456"]
+        operator = InOperator(kind=OperatorKind.IN, value=values)
+        assert operator.value == values
+        assert not operator.match(condition_property=123, segment_name="test")
+        assert operator.match(condition_property="123", segment_name="test")
+
+    def test_is_not_in(self):
+        values = ["bar", "baz"]
+        operator = InOperator(kind=OperatorKind.IN, value=values)
+        assert not operator.match(condition_property="foo", segment_name="test")
+
+        not_operator = NotInOperator(kind=OperatorKind.NOT_IN, value=values)
+        assert not_operator.match(condition_property="foo", segment_name="test")
+
+    def test_is_in_case_insensitivity(self):
+        values = ["bAr", "baz"]
+        operator = InOperator(kind=OperatorKind.IN, value=values)
+        assert operator.match(condition_property="BaR", segment_name="test")
+
+        not_operator = NotInOperator(kind=OperatorKind.NOT_IN, value=values)
+        assert not not_operator.match(condition_property="BaR", segment_name="test")
+
+    def test_invalid_property_value(self):
+        values = ["bar", "baz"]
+        operator = InOperator(kind=OperatorKind.IN, value=values)
+
+        with pytest.raises(ConditionTypeMismatchException):
+            operator.match(condition_property=[], segment_name="test")
+
+        not_operator = NotInOperator(kind=OperatorKind.NOT_IN, value=values)
+        with pytest.raises(ConditionTypeMismatchException):
+            not_operator.match(condition_property=[], segment_name="test")
+
+
+class TestContainsOperators(TestCase):
+    def test_does_contain(self):
+        operator = ContainsOperator(kind=OperatorKind.CONTAINS, value="bar")
+        assert operator.match(condition_property=["foo", "bar"], segment_name="test")
+
+        not_operator = NotContainsOperator(kind=OperatorKind.NOT_CONTAINS, value="bar")
+        assert not not_operator.match(condition_property=["foo", "bar"], segment_name="test")
+
+        operator = ContainsOperator(kind=OperatorKind.CONTAINS, value=1)
+        assert operator.match(condition_property=[1, 2], segment_name="test")
+        assert not operator.match(condition_property=[3, 4], segment_name="test")
+
+    def test_does_not_contain(self):
+        values = "baz"
+        operator = ContainsOperator(kind=OperatorKind.CONTAINS, value=values)
+        assert not operator.match(condition_property=["foo", "bar"], segment_name="test")
+
+        not_operator = NotContainsOperator(kind=OperatorKind.NOT_CONTAINS, value=values)
+        assert not_operator.match(condition_property=["foo", "bar"], segment_name="test")
+
+    def test_invalid_property_provided(self):
+        values = "baz"
+
+        with pytest.raises(ConditionTypeMismatchException):
+            operator = ContainsOperator(kind=OperatorKind.CONTAINS, value=values)
+            assert not operator.match(condition_property="oops", segment_name="test")
+
+        with pytest.raises(ConditionTypeMismatchException):
+            not_operator = NotContainsOperator(kind=OperatorKind.NOT_CONTAINS, value=values)
+            assert not_operator.match(condition_property="oops", segment_name="test")
+
+
+class TestEqualsOperators(TestCase):
+    def test_is_equal_string(self):
+        value = "foo"
+        operator = EqualsOperator(kind=OperatorKind.EQUALS, value=value)
+        assert operator.match(condition_property="foo", segment_name="test")
+
+        not_operator = NotEqualsOperator(kind=OperatorKind.NOT_EQUALS, value=value)
+        assert not not_operator.match(condition_property="foo", segment_name="test")
+
+    def test_is_not_equals(self):
+        values = "bar"
+        operator = EqualsOperator(kind=OperatorKind.EQUALS, value=values)
+        assert not operator.match(condition_property="foo", segment_name="test")
+
+        not_operator = NotEqualsOperator(kind=OperatorKind.NOT_EQUALS, value=values)
+        assert not_operator.match(condition_property="foo", segment_name="test")
+
+    def test_is_equal_case_insensitive(self):
+        values = "bAr"
+        operator = EqualsOperator(kind=OperatorKind.EQUALS, value=values)
+        assert operator.match(condition_property="BaR", segment_name="test")
+
+        not_operator = NotEqualsOperator(kind=OperatorKind.NOT_EQUALS, value=values)
+        assert not not_operator.match(condition_property="BaR", segment_name="test")
+
+    def test_equality_type_mismatch_strings(self):
+        values = ["foo", "bar"]
+        operator = EqualsOperator(kind=OperatorKind.EQUALS, value=values)
+
+        with pytest.raises(ConditionTypeMismatchException):
+            operator.match(condition_property="foo", segment_name="test")
+
+        not_operator = NotEqualsOperator(kind=OperatorKind.NOT_EQUALS, value=values)
+        with pytest.raises(ConditionTypeMismatchException):
+            not_operator.match(condition_property="foo", segment_name="test")

--- a/tests/flagpole/test_operators.py
+++ b/tests/flagpole/test_operators.py
@@ -33,20 +33,20 @@ class TestCreateCaseInsensitiveSetFromList(TestCase):
         assert create_case_insensitive_set_from_list(["AbC", "DEF"]) == {"abc", "def"}
 
 
-def assert_valid_types(operator: type[Operator], expected_types: Any):
+def assert_valid_types(operator: type[Operator], expected_types: list[Any]):
     for value in expected_types:
         operator_dict = dict(value=value)
         json_operator = json.dumps(operator_dict)
         try:
-            operator = operator.parse_raw(json_operator)
+            parsed_operator = operator.parse_raw(json_operator)
         except ValidationError as exc:
             raise AssertionError(
                 f"Expected value `{value}` to be a valid value for operator '{operator}'"
             ) from exc
-        assert operator.value == value
+        assert parsed_operator.value == value
 
 
-def assert_invalid_types(operator: type[Operator], invalid_types: Any):
+def assert_invalid_types(operator: type[Operator], invalid_types: list[Any]):
     for value in invalid_types:
         json_dict = dict(value=value)
         operator_json = json.dumps(json_dict)
@@ -165,7 +165,7 @@ class TestContainsOperators(TestCase):
         assert_valid_types(operator=NotContainsOperator, expected_types=values)
 
     def test_invalid_value_type_parsing(self):
-        values = [
+        values: list[Any] = [
             None,
             [],
             dict(foo="bar"),

--- a/tests/flagpole/test_sentry_flagpole_context.py
+++ b/tests/flagpole/test_sentry_flagpole_context.py
@@ -1,0 +1,163 @@
+import pytest
+
+from flagpole.sentry_flagpole_context import (
+    InvalidContextDataException,
+    get_sentry_flagpole_context_builder,
+    organization_context_transformer,
+    project_context_transformer,
+    user_context_transformer,
+)
+from sentry.models.useremail import UserEmail
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+class TestSentryFlagpoleContext(TestCase):
+    def test_sentry_flagpole_context_builder(self):
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        sentry_flagpole_builder = get_sentry_flagpole_context_builder()
+
+        sentry_context = sentry_flagpole_builder.build(dict(organization=org, project=project))
+
+        assert sentry_context.get("organization_slug") == org.slug
+        assert sentry_context.get("organization_slug") == org.slug
+        assert sentry_context.get("project_slug") == project.slug
+        assert sentry_context.get("project_id") == project.id
+
+
+class TestSentryOrganizationContextTransformer(TestCase):
+    def test_without_organization_passed(self):
+        context_data = organization_context_transformer(dict())
+        assert context_data == dict()
+
+    def test_with_invalid_organization(self):
+        with pytest.raises(InvalidContextDataException):
+            organization_context_transformer(dict(organization=1234))
+
+        with pytest.raises(InvalidContextDataException):
+            organization_context_transformer(dict(organization=self.create_project()))
+
+    def test_with_valid_organization(self):
+        org = self.create_organization(slug="foobar", name="Foo Bar")
+        org.flags.early_adopter = True
+        org.save()
+        assert bool(org.flags.early_adopter) is True
+
+        context_data = organization_context_transformer(dict(organization=org))
+
+        assert context_data == {
+            "organization_slug": "foobar",
+            "organization_id": org.id,
+            "organization_name": "Foo Bar",
+            "organization_is-early-adopter": True,
+        }
+
+
+class TestProjectContextTransformer(TestCase):
+    def test_without_project_passed(self):
+        context_data = project_context_transformer(dict())
+        assert context_data == dict()
+
+    def test_with_invalid_project_passed(self):
+        with pytest.raises(InvalidContextDataException):
+            project_context_transformer(dict(project=123))
+
+        with pytest.raises(InvalidContextDataException):
+            project_context_transformer(dict(project=self.create_organization()))
+
+    def test_with_valid_project(self):
+        project = self.create_project(slug="foobar", name="Foo Bar")
+
+        context_data = project_context_transformer(dict(project=project))
+        assert context_data == {
+            "project_slug": "foobar",
+            "project_name": "Foo Bar",
+            "project_id": project.id,
+        }
+
+
+@control_silo_test
+class TestUserContextTransformer(TestCase):
+    def test_without_user_passed(self):
+        context_data = project_context_transformer(dict())
+        assert context_data == dict()
+
+    def test_with_invalid_user_passed(self):
+        with pytest.raises(InvalidContextDataException):
+            user_context_transformer(dict(actor=123))
+
+        with pytest.raises(InvalidContextDataException):
+            user_context_transformer(dict(actor=self.create_organization()))
+
+    def test_with_valid_user(self):
+        user = self.create_user(email="foobar@example.com")
+        # Create a new, unverified email to ensure we don't list it
+        self.create_useremail(user=user, email="unverified_email@example.com")
+
+        context_data = user_context_transformer(dict(actor=user))
+        assert context_data == {
+            "user_email": "foobar@example.com",
+            "user_domain": "example.com",
+            "user_id": user.id,
+            "user_is-superuser": False,
+            "user_is-staff": False,
+        }
+
+    def test_with_only_unverified_emails(self):
+        user = self.create_user(email="foobar@example.com")
+        user_email = UserEmail.objects.filter(user_id=user.id).get()
+        user_email.is_verified = False
+        user_email.save()
+
+        context_data = user_context_transformer(dict(actor=user))
+        assert context_data == {
+            "user_id": user.id,
+            "user_is-superuser": False,
+            "user_is-staff": False,
+        }
+
+    def test_with_super_user_and_staff(self):
+        user = self.create_user(email="super_user_admin_person@sentry.io", is_superuser=True)
+        context_data = user_context_transformer(dict(actor=user))
+        assert context_data == {
+            "user_email": "super_user_admin_person@sentry.io",
+            "user_domain": "sentry.io",
+            "user_id": user.id,
+            "user_is-superuser": True,
+            "user_is-staff": False,
+        }
+
+        user.is_staff = True
+        user.is_superuser = False
+        user.save()
+        context_data = user_context_transformer(dict(actor=user))
+        assert context_data == {
+            "user_email": "super_user_admin_person@sentry.io",
+            "user_domain": "sentry.io",
+            "user_id": user.id,
+            "user_is-superuser": False,
+            "user_is-staff": True,
+        }
+
+
+class TestTeamContextTransformer(TestCase):
+    pass
+    # def test_with_missing_team(self):
+    #     context_data = team_context_transformer(dict())
+    #     assert context_data == dict()
+    #
+    # def test_with_invalid_team(self):
+    #     with pytest.raises(InvalidContextDataException):
+    #         team_context_transformer(dict(team="invalid"))
+    #
+    #     with pytest.raises(InvalidContextDataException):
+    #         team_context_transformer(dict(team=self.create_organization()))
+    #
+    # def test_with_valid_team(self):
+    #     team = self.create_team(organization=self.create_organization())
+    #
+    #     context_data = team_context_transformer(dict(team=team))
+    #     assert context_data == {
+    #         "team_id": team.id
+    #     }


### PR DESCRIPTION
<!-- Describe your PR here. -->
# Flagpole Data Model
This PR adds the core data model for Flagpole, plus some of the initial sentry feature context generation code as well.

Flagpole is intended to be an options-backed feature flagging utility that operates against a generated evaluation context to decide whether a feature is enabled or not.

For more information, please refer to the [Technical Spec](https://www.notion.so/sentry/Flagpole-Spec-95238403e37a442f8af659a69e079e3d?pvs=4)

## Notable changes from the hackweek prototype
- `ContextBuilder` class that composes a sequence of transformers that take some contextual data and flatten it into a format usable by Flagpole's feature evaluation predicates.
- `sentry_flagpole_context` module that generates a `ContextBuilder` including User, Organization, and Project data
- A revised, pydantic backed data model for easy JSON schema generation and data validation


