### PR TITLE
feat(feedback): Add logging whenever a feedback item is loaded/rendered

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
@@ -21,8 +21,10 @@ export default function FeedbackItemLoader() {
   useSentryAppComponentsData({projectId: projectSlug});
 
   useEffect(() => {
-    trackAnalytics('feedback.feedback-item-rendered', {organization});
-  }, [organization]);
+    if (issueData) {
+      trackAnalytics('feedback.feedback-item-rendered', {organization});
+    }
+  }, [organization, issueData]);
 
   // There is a case where we are done loading, but we're fetching updates
   // This happens when the user has seen a feedback, clicks around a bit, then

--- a/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
@@ -1,3 +1,5 @@
+import {useEffect} from 'react';
+
 import FeedbackEmptyDetails from 'sentry/components/feedback/details/feedbackEmptyDetails';
 import FeedbackErrorDetails from 'sentry/components/feedback/details/feedbackErrorDetails';
 import FeedbackItem from 'sentry/components/feedback/feedbackItem/feedbackItem';
@@ -7,13 +9,20 @@ import useFetchFeedbackData from 'sentry/components/feedback/useFetchFeedbackDat
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import useSentryAppComponentsData from 'sentry/stores/useSentryAppComponentsData';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export default function FeedbackItemLoader() {
+  const organization = useOrganization();
   const feedbackId = useCurrentFeedbackId();
   const {issueResult, issueData, tags, eventData} = useFetchFeedbackData({feedbackId});
 
   const projectSlug = useCurrentFeedbackProject();
   useSentryAppComponentsData({projectId: projectSlug});
+
+  useEffect(() => {
+    trackAnalytics('feedback.feedback-item-rendered', {organization});
+  }, [organization]);
 
   // There is a case where we are done loading, but we're fetching updates
   // This happens when the user has seen a feedback, clicks around a bit, then

--- a/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
@@ -14,7 +14,7 @@ export type FeedbackEventParameters = {
 export type FeedbackEventKey = keyof FeedbackEventParameters;
 
 export const feedbackEventMap: Record<FeedbackEventKey, string | null> = {
-  'feedback.feedback-item-rendered': 'Loaded and rendered a feedback items',
+  'feedback.feedback-item-rendered': 'Loaded and rendered a feedback item',
   'feedback.index-setup-viewed': 'Viewed Feedback Onboarding Setup',
   'feedback.list-item-selected': 'Selected Item in Feedback List',
   'feedback.details-integration-issue-clicked':

--- a/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/feedbackAnalyticsEvents.tsx
@@ -2,6 +2,7 @@ export type FeedbackEventParameters = {
   'feedback.details-integration-issue-clicked': {
     integration_key: string;
   };
+  'feedback.feedback-item-rendered': {};
   'feedback.index-setup-viewed': {};
   'feedback.list-item-selected': {};
   'feedback.list-view-setup-sidebar': {platform: string};
@@ -13,6 +14,7 @@ export type FeedbackEventParameters = {
 export type FeedbackEventKey = keyof FeedbackEventParameters;
 
 export const feedbackEventMap: Record<FeedbackEventKey, string | null> = {
+  'feedback.feedback-item-rendered': 'Loaded and rendered a feedback items',
   'feedback.index-setup-viewed': 'Viewed Feedback Onboarding Setup',
   'feedback.list-item-selected': 'Selected Item in Feedback List',
   'feedback.details-integration-issue-clicked':


### PR DESCRIPTION
This is distinct from and in addition to the existing logging we have. We have:
- `feedback.list-item-selected` for when an item in the list is rendered
- regular pageview logging for when the page is loaded (which may or may not have a feedback_id in the url)

So this new logging will tell us how many feedbacks are actually shown onto the screen. The same issue can be shown and counted over and over again.