### PR TITLE
ref(rules): Add batch_query_hook to EventFrequencyCondition

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -249,12 +249,12 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
     def get_sums(
         self,
         keys: list[int],
-        group: GroupEvent,
+        group: Group,
         start: datetime,
         end: datetime,
-        environment_id: int,
+        environment_id: str,
         referrer_suffix: str,
-    ) -> dict[int, int]:
+    ) -> Mapping[int, int]:
         sums: Mapping[int, int] = self.tsdb.get_sums(
             model=get_issue_tsdb_group_model(group.issue_category),
             keys=keys,
@@ -325,7 +325,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         return batch_sums
 
     def batch_query_hook(
-        self, group_ids: list[int], start: datetime, end: datetime, environment_id: str
+        self, group_ids: Sequence[int], start: datetime, end: datetime, environment_id: str
     ) -> dict[int, int]:
         batch_sums: dict[int, int] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids)

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -315,10 +315,9 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
     ) -> dict[int, int]:
         batch_sums: dict[int, int] = defaultdict(int)
         for group_chunk in chunked(groups, SNUBA_LIMIT):
-            keys = [group.id for group in groups]
             group = groups[0]
             sums = self.get_sums(
-                keys=keys,
+                keys=[group.id for group in groups],
                 group=group,
                 model=get_issue_tsdb_group_model(group.issue_category),
                 start=start,

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -305,54 +305,41 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         )
         return sums[event.group_id]
 
-    def get_chunked_sums(
-        self,
-        groups: list[Group],
-        start: datetime,
-        end: datetime,
-        environment_id: str,
-        referrer_suffix: str,
-    ) -> dict[int, int]:
-        batch_sums: dict[int, int] = defaultdict(int)
-        for group_chunk in chunked(groups, SNUBA_LIMIT):
-            group = groups[0]
-            sums = self.get_sums(
-                keys=[group.id for group in groups],
-                group=group,
-                model=get_issue_tsdb_group_model(group.issue_category),
-                start=start,
-                end=end,
-                environment_id=environment_id,
-                referrer_suffix="alert_event_frequency",
-            )
-            batch_sums.update(sums)
-        return batch_sums
-
     def batch_query_hook(
         self, group_ids: Sequence[int], start: datetime, end: datetime, environment_id: str
     ) -> dict[int, int]:
+        def get_chunked_sums(
+            groups: list[Group],
+        ) -> dict[int, int]:
+            batch_sums: dict[int, int] = defaultdict(int)
+            for group_chunk in chunked(groups, SNUBA_LIMIT):
+                group = groups[0]
+                sums = self.get_sums(
+                    keys=[group.id for group in groups],
+                    group=group,
+                    model=get_issue_tsdb_group_model(group.issue_category),
+                    start=start,
+                    end=end,
+                    environment_id=environment_id,
+                    referrer_suffix="alert_event_frequency",
+                )
+                batch_sums.update(sums)
+            return batch_sums
+
         batch_sums: dict[int, int] = defaultdict(int)
         groups = Group.objects.filter(id__in=group_ids)
         error_issues = [group for group in groups if group.issue_category == GroupCategory.ERROR]
         generic_issues = [group for group in groups if group.issue_category != GroupCategory.ERROR]
 
         if error_issues:
-            error_sums = self.get_chunked_sums(
+            error_sums = get_chunked_sums(
                 groups=error_issues,
-                start=start,
-                end=end,
-                environment_id=environment_id,
-                referrer_suffix="alert_event_frequency",
             )
             batch_sums.update(error_sums)
 
         if generic_issues:
-            generic_sums = self.get_chunked_sums(
+            generic_sums = get_chunked_sums(
                 groups=generic_issues,
-                start=start,
-                end=end,
-                environment_id=environment_id,
-                referrer_suffix="alert_event_frequency",
             )
             batch_sums.update(generic_sums)
 

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -313,7 +313,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         batch_sums: dict[int, int] = defaultdict(int)
         for group_chunk in chunked(groups, SNUBA_LIMIT):
             keys = [group.id for group in groups]
-            error_sums = self.get_sums(
+            sums = self.get_sums(
                 keys=keys,
                 group=groups[0],
                 start=start,
@@ -321,7 +321,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
                 environment_id=environment_id,
                 referrer_suffix="alert_event_frequency",
             )
-            batch_sums.update(error_sums)
+            batch_sums.update(sums)
         return batch_sums
 
     def batch_query_hook(

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -317,11 +317,10 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         for group_chunk in chunked(groups, SNUBA_LIMIT):
             keys = [group.id for group in groups]
             group = groups[0]
-            model = get_issue_tsdb_group_model(group.issue_category)
             sums = self.get_sums(
                 keys=keys,
                 group=group,
-                model=model,
+                model=get_issue_tsdb_group_model(group.issue_category),
                 start=start,
                 end=end,
                 environment_id=environment_id,

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -28,6 +28,58 @@ from sentry.utils.samples import load_data
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
 
+class EventFrequencyQueryTest(SnubaTestCase, RuleTestCase, PerformanceIssueTestCase):
+    rule_cls = EventFrequencyCondition
+
+    def test_batch_query(self):
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "environment": self.environment.name,
+                "timestamp": iso_format(before_now(seconds=30)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        event2 = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "environment": self.environment.name,
+                "timestamp": iso_format(before_now(seconds=12)),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        )
+
+        fingerprint = f"{PerformanceNPlusOneGroupType.type_id}-something_random"
+        event_data = load_data(
+            "transaction-n-plus-one",
+            timestamp=before_now(seconds=12),
+            start_timestamp=before_now(seconds=12),
+            fingerprint=[fingerprint],
+        )
+        event_data["user"] = {"id": uuid4().hex}
+        event_data["environment"] = self.environment.name
+
+        # Store a performance event
+        perf_event = self.create_performance_issue(
+            event_data=event_data,
+            project_id=self.project.id,
+            fingerprint=fingerprint,
+        )
+        start = before_now(minutes=1)
+        end = timezone.now()
+
+        condition_inst = self.rule_cls(event.group.project)
+        batch_query = condition_inst.batch_query_hook(
+            group_ids=[event.group_id, event2.group_id, perf_event.group_id],
+            start=start,
+            end=end,
+            environment_id=self.environment.id,
+        )
+        assert batch_query == {event.group_id: 1, event2.group_id: 1, perf_event.group_id: 1}
+
+
 class ErrorEventMixin(SnubaTestCase):
     def add_event(self, data, project_id, timestamp):
         data["timestamp"] = iso_format(timestamp)
@@ -263,40 +315,6 @@ class EventFrequencyConditionTestCase(StandardIntervalTestBase):
                 project_id=self.project.id,
                 timestamp=timestamp,
             )
-
-    def test_batch_query(self):
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "environment": "production",
-                "timestamp": iso_format(before_now(seconds=30)),
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        )
-        event2 = self.store_event(
-            data={
-                "event_id": "b" * 32,
-                "environment": "production",
-                "timestamp": iso_format(before_now(seconds=12)),
-                "fingerprint": ["group-2"],
-            },
-            project_id=self.project.id,
-        )
-        perf_event = self.create_performance_issue(
-            fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group-3"
-        )
-        start = before_now(minutes=1)
-        end = timezone.now()
-
-        condition_inst = self.rule_cls(event.group.project)
-        batch_query = condition_inst.batch_query_hook(
-            group_ids=[event.group.id, event2.group.id, perf_event.group_id],
-            start=start,
-            end=end,
-            environment_id=self.environment.id,
-        )
-        assert batch_query == {event.group.id: 1, event2.group.id: 1, perf_event.group_id: 1}
 
 
 class EventUniqueUserFrequencyConditionTestCase(StandardIntervalTestBase):


### PR DESCRIPTION
Add a `batch_query_hook` to the `EventFrequencyCondition` so that when we process "slow" rule conditions we can batch the queries by group ids. 

Partially closes https://github.com/getsentry/team-core-product-foundations/issues/239