### PR TITLE
fix(starfish): map cache.hit to sentry_tags

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -136,6 +136,7 @@ SPAN_COLUMN_MAP = {
     "user": "user",
     "profile_id": "profile_id",  # deprecated in favour of `profile.id`
     "profile.id": "profile_id",
+    "cache.hit": "sentry_tags[cache.hit]",
     "transaction.method": "sentry_tags[transaction.method]",
     "system": "sentry_tags[system]",
     "raw_domain": "sentry_tags[raw_domain]",


### PR DESCRIPTION
In order for us to query for `cache.hit` field in discover api, we should map the sentry_tag value back to `cache.hit`