### PR TITLE
ref(ingest): make dlq fields optional for consumer definition

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -509,8 +509,8 @@ def get_stream_processor(
         dlq_policy = DlqPolicy(
             KafkaDlqProducer(dlq_producer, ArroyoTopic(dlq_topic_defn["real_topic_name"])),
             DlqLimit(
-                max_invalid_ratio=consumer_definition["dlq_max_invalid_ratio"],
-                max_consecutive_count=consumer_definition["dlq_max_consecutive_count"],
+                max_invalid_ratio=consumer_definition.get("dlq_max_invalid_ratio"),
+                max_consecutive_count=consumer_definition.get("dlq_max_consecutive_count"),
             ),
             None,
         )


### PR DESCRIPTION
Based on the `kafka_definition.ConsumerDefinition` and `arroyo.dlq.DlqLimit` classes, these fields are optional for running a consumer, and None by default. However, right now, omitting these fields from a consumer definition in consumers/\_\_init\_\_.py will cause the run command to crash when using `--enable-dlq`.