### PR TITLE
ref(replays): don't show unsupported banner if mobile ff enabled

### DIFF
--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -12,7 +12,7 @@ import {useProjectCreationAccess} from 'sentry/components/projects/useProjectCre
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import ReplayUnsupportedAlert from 'sentry/components/replays/alerts/replayUnsupportedAlert';
 import {Tooltip} from 'sentry/components/tooltip';
-import {replayPlatforms} from 'sentry/data/platformCategories';
+import {mobile, replayPlatforms} from 'sentry/data/platformCategories';
 import {t, tct} from 'sentry/locale';
 import PreferencesStore from 'sentry/stores/preferencesStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
@@ -51,6 +51,11 @@ export default function ReplayOnboardingPanel() {
   const projects = useProjects();
   const organization = useOrganization();
   const {canCreateProject} = useProjectCreationAccess({organization});
+  const hasMobileReplays = organization.features.includes('session-replay-mobile-player');
+
+  const supportedPlatforms = hasMobileReplays
+    ? replayPlatforms.concat(mobile)
+    : replayPlatforms;
 
   const selectedProjects = projects.projects.filter(p =>
     pageFilters.selection.projects.includes(Number(p.id))
@@ -59,11 +64,11 @@ export default function ReplayOnboardingPanel() {
   const hasSelectedProjects = selectedProjects.length > 0;
 
   const allProjectsUnsupported = projects.projects.every(
-    p => !replayPlatforms.includes(p.platform!)
+    p => !supportedPlatforms.includes(p.platform!)
   );
 
   const allSelectedProjectsUnsupported = selectedProjects.every(
-    p => !replayPlatforms.includes(p.platform!)
+    p => !supportedPlatforms.includes(p.platform!)
   );
 
   // if all projects are unsupported we should prompt the user to create a project


### PR DESCRIPTION
- fixes https://github.com/getsentry/sentry/issues/68569
- we'll need to change instances of `replayPlatforms` in other places in the code eventually, to include the mobile platforms, but those can be changed later

<img width="1036" alt="SCR-20240409-moat" src="https://github.com/getsentry/sentry/assets/56095982/7de5ace8-4a02-4611-a436-937a72a917eb">
