### PR TITLE
fix(tests): Sort output of default comparators test

### DIFF
--- a/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
+++ b/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
@@ -1,8 +1,180 @@
 ---
-created: '2024-04-04T03:50:03.648903+00:00'
+created: '2024-04-09T21:58:14.348228+00:00'
 creator: sentry
 source: tests/sentry/backup/test_comparators.py
 ---
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - environment
+    - organization_id
+    - project_id
+  model_name: feedback.feedback
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - apikey_id
+    - organization
+  model_name: hybridcloud.apikeyreplica
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - apitoken_id
+    - application_id
+    - organization
+    - user_id
+  model_name: hybridcloud.apitokenreplica
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - externalactor_id
+    - integration
+    - organization_id
+    - team_id
+    - user
+  model_name: hybridcloud.externalactorreplica
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization_id
+    - organization_slug_reservation_id
+    - user_id
+  model_name: hybridcloud.organizationslugreservationreplica
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - created_by_id
+    - organization
+    - orgauthtoken_id
+  model_name: hybridcloud.orgauthtokenreplica
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: hybridcloud.regioncacheversion
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: hybridcloud.webhookpayload
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: nodestore.node
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - file_id
+    - project_id
+  model_name: replays.replayrecordingsegment
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - group
+    - project
+    - user_id
+  model_name: sentry.activity
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - team
+    - user_id
+  model_name: sentry.actor
+- comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_modified
+  - class: EqualOrRemovedComparator
+    fields:
+    - owner
+    - team
+    - user_id
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields:
+    - organization
+    - owner
+    - snuba_query
+    - team
+    - user_id
+  model_name: sentry.alertrule
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - alert_rule
+  model_name: sentry.alertruleactivationcondition
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - alert_rule
+    - query_subscription
+  model_name: sentry.alertruleactivations
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - alert_rule
+    - previous_alert_rule
+    - user_id
+  model_name: sentry.alertruleactivity
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - alert_rule
+    - project
+  model_name: sentry.alertruleexcludedprojects
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - alert_rule
+    - project
+  model_name: sentry.alertruleprojects
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - alert_rule
+  model_name: sentry.alertruletrigger
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - alert_rule_trigger
+    - integration_id
+    - sentry_app_id
+  model_name: sentry.alertruletriggeraction
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - alert_rule_trigger
+    - query_subscription
+  model_name: sentry.alertruletriggerexclusion
+- comparators:
+  - class: HashObfuscatingComparator
+    fields:
+    - client_id
+    - client_secret
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields:
+    - owner
+  model_name: sentry.apiapplication
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - application
+    - user
+  model_name: sentry.apiauthorization
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - application
+    - user
+  model_name: sentry.apigrant
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization_id
+  model_name: sentry.apikey
 - comparators:
   - class: HashObfuscatingComparator
     fields:
@@ -26,464 +198,6 @@ source: tests/sentry/backup/test_comparators.py
     - user
   model_name: sentry.apitoken
 - comparators:
-  - class: HashObfuscatingComparator
-    fields:
-    - client_id
-    - client_secret
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - owner
-  model_name: sentry.apiapplication
-- comparators:
-  - class: HashObfuscatingComparator
-    fields:
-    - ident
-    - token
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-    - last_synced
-    - last_verified
-  - class: ForeignKeyComparator
-    fields:
-    - auth_provider
-    - user
-  model_name: sentry.authidentity
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_modified
-  - class: EqualOrRemovedComparator
-    fields:
-    - owner
-    - team
-    - user_id
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - organization
-    - owner
-    - snuba_query
-    - team
-    - user_id
-  model_name: sentry.alertrule
-- comparators:
-  - class: UUID4Comparator
-    fields:
-    - detection_uuid
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-    - date_closed
-    - date_detected
-    - date_started
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule
-    - organization
-  model_name: sentry.incident
-- comparators:
-  - class: UUID4Comparator
-    fields:
-    - notification_uuid
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - incident
-    - user_id
-  model_name: sentry.incidentactivity
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_modified
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule_trigger
-    - incident
-  model_name: sentry.incidenttrigger
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_updated
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.integration
-- comparators:
-  - class: UUID4Comparator
-    fields:
-    - guid
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - organization_id
-    - project_id
-  model_name: sentry.monitor
-- comparators:
-  - class: HashObfuscatingComparator
-    fields:
-    - token_hashed
-    - token_last_characters
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-    - date_deactivated
-    - date_last_used
-  - class: ForeignKeyComparator
-    fields:
-    - created_by
-    - organization_id
-    - project_last_used_id
-  model_name: sentry.orgauthtoken
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_modified
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - dashboard_widget_query
-  model_name: sentry.dashboardwidgetqueryondemand
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_modified
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - widget
-  model_name: sentry.dashboardwidgetquery
-- comparators:
-  - class: AutoSuffixComparator
-    fields:
-    - slug
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.organization
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_updated
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-    - grace_period_end
-  - class: ForeignKeyComparator
-    fields:
-    - integration
-    - organization_id
-  model_name: sentry.organizationintegration
-- comparators:
-  - class: HashObfuscatingComparator
-    fields:
-    - token
-  - class: EqualOrRemovedComparator
-    fields:
-    - inviter_id
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-    - token_expires_at
-  - class: EmailObfuscatingComparator
-    fields:
-    - email
-  - class: ForeignKeyComparator
-    fields:
-    - inviter_id
-    - organization
-    - user_id
-  model_name: sentry.organizationmember
-- comparators:
-  - class: HashObfuscatingComparator
-    fields:
-    - public_key
-    - secret_key
-  - class: SecretHexComparator
-    fields:
-    - public_key
-    - secret_key
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - project
-  model_name: sentry.projectkey
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_updated
-  - class: SubscriptionIDComparator
-    fields:
-    - subscription_id
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - project
-    - snuba_query
-  model_name: sentry.querysubscription
-- comparators:
-  - class: HashObfuscatingComparator
-    fields:
-    - public_key
-    - relay_id
-  - class: DatetimeEqualityComparator
-    fields:
-    - first_seen
-    - last_seen
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.relay
-- comparators:
-  - class: HashObfuscatingComparator
-    fields:
-    - public_key
-    - relay_id
-  - class: DatetimeEqualityComparator
-    fields:
-    - first_seen
-    - last_seen
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.relayusage
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_updated
-  - class: EmailObfuscatingComparator
-    fields:
-    - creator_label
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-    - date_deleted
-    - date_published
-  - class: ForeignKeyComparator
-    fields:
-    - application
-    - creator_user
-    - owner_id
-    - proxy_user
-  model_name: sentry.sentryapp
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_updated
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-    - date_deleted
-  - class: ForeignKeyComparator
-    fields:
-    - api_grant
-    - api_token
-    - organization_id
-    - sentry_app
-  model_name: sentry.sentryappinstallation
-- comparators:
-  - class: HashObfuscatingComparator
-    fields:
-    - secret
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - application_id
-    - installation_id
-    - organization_id
-    - project_id
-  model_name: sentry.servicehook
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - actor
-    - organization
-  - class: IgnoredComparator
-    fields:
-    - org_role
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - organization
-  model_name: sentry.team
-- comparators:
-  - class: AutoSuffixComparator
-    fields:
-    - username
-  - class: DateUpdatedComparator
-    fields:
-    - last_active
-  - class: IgnoredComparator
-    fields:
-    - is_password_expired
-    - is_unclaimed
-    - last_password_change
-  - class: UserPasswordObfuscatingComparator
-    fields:
-    - password
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_joined
-    - last_login
-  - class: EmailObfuscatingComparator
-    fields:
-    - email
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.user
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_hash_added
-  - class: IgnoredComparator
-    fields:
-    - is_verified
-    - validation_hash
-  - class: EmailObfuscatingComparator
-    fields:
-    - email
-  - class: ForeignKeyComparator
-    fields:
-    - user
-  model_name: sentry.useremail
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - first_seen
-    - last_seen
-  - class: IgnoredComparator
-    fields:
-    - country_code
-    - region_code
-  - class: ForeignKeyComparator
-    fields:
-    - user
-  model_name: sentry.userip
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_updated
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.userrole
-- comparators:
-  - class: DateUpdatedComparator
-    fields:
-    - date_updated
-  - class: DatetimeEqualityComparator
-    fields:
-    - date_added
-  - class: ForeignKeyComparator
-    fields:
-    - role
-    - user
-  model_name: sentry.userroleuser
-- comparators:
-  - class: EmailObfuscatingComparator
-    fields:
-    - email
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.email
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - group
-    - project
-    - user_id
-  model_name: sentry.activity
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.regionoutbox
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.controloutbox
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.option
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.controloption
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization
-  model_name: sentry.organizationoption
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - project
-  model_name: sentry.projectoption
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization_id
-    - project_id
-    - user
-  model_name: sentry.useroption
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - team
-    - user_id
-  model_name: sentry.actor
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - application
-    - user
-  model_name: sentry.apiauthorization
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - application
-    - user
-  model_name: sentry.apigrant
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization_id
-    - user_id
-  model_name: sentry.organizationslugreservation
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization_id
-  model_name: sentry.apikey
-- comparators:
   - class: ForeignKeyComparator
     fields:
     - project
@@ -503,25 +217,6 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - artifact_bundle
-    - organization_id
-  model_name: sentry.releaseartifactbundle
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - artifact_bundle
-    - organization_id
-  model_name: sentry.debugidartifactbundle
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - artifact_bundle
-    - organization_id
-    - project_id
-  model_name: sentry.projectartifactbundle
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
     - user
   model_name: sentry.assistantactivity
 - comparators:
@@ -538,6 +233,21 @@ source: tests/sentry/backup/test_comparators.py
     - user
   model_name: sentry.authenticator
 - comparators:
+  - class: HashObfuscatingComparator
+    fields:
+    - ident
+    - token
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+    - last_synced
+    - last_verified
+  - class: ForeignKeyComparator
+    fields:
+    - auth_provider
+    - user
+  model_name: sentry.authidentity
+- comparators:
   - class: ForeignKeyComparator
     fields:
     - auth_identity_id
@@ -547,108 +257,20 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - organization_id
+  model_name: sentry.authprovider
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
     - authprovider_id
     - team_id
   model_name: sentry.authproviderdefaultteams
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - organization_id
-  model_name: sentry.authprovider
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
     - auth_provider_id
     - organization
   model_name: sentry.authproviderreplica
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - blob
-    - organization_id
-  model_name: sentry.controlfileblobowner
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.scheduleddeletion
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.regionscheduleddeletion
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.controlfileblob
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - blob
-    - file
-  model_name: sentry.controlfileblobindex
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.controlfile
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - blob
-    - organization_id
-  model_name: sentry.fileblobowner
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.fileblob
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - blob
-    - file
-  model_name: sentry.fileblobindex
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - blob
-  model_name: sentry.file
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - control_file_id
-    - doc_integration
-    - file_id
-  model_name: sentry.docintegrationavatar
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - file_id
-    - organization
-  model_name: sentry.organizationavatar
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - file_id
-    - project
-  model_name: sentry.projectavatar
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - control_file_id
-    - file_id
-    - sentry_app
-  model_name: sentry.sentryappavatar
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - file_id
-    - team
-  model_name: sentry.teamavatar
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - control_file_id
-    - file_id
-    - user
-  model_name: sentry.useravatar
 - comparators:
   - class: ForeignKeyComparator
     fields: []
@@ -679,21 +301,73 @@ source: tests/sentry/backup/test_comparators.py
   model_name: sentry.commitfilechange
 - comparators:
   - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.controlfile
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.controlfileblob
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - blob
+    - file
+  model_name: sentry.controlfileblobindex
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - blob
+    - organization_id
+  model_name: sentry.controlfileblobowner
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.controlimportchunk
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.controlimportchunkreplica
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.controloption
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.controloutbox
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.controltombstone
+- comparators:
+  - class: ForeignKeyComparator
     fields:
     - project
   model_name: sentry.counter
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - dashboard
+    - created_by_id
+    - organization
+  model_name: sentry.customdynamicsamplingrule
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - custom_dynamic_sampling_rule
     - project
-  model_name: sentry.dashboardproject
+  model_name: sentry.customdynamicsamplingruleproject
 - comparators:
   - class: ForeignKeyComparator
     fields:
     - created_by_id
     - organization
   model_name: sentry.dashboard
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - dashboard
+    - project
+  model_name: sentry.dashboardproject
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -705,18 +379,33 @@ source: tests/sentry/backup/test_comparators.py
     - dashboard
   model_name: sentry.dashboardwidget
 - comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_modified
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
   - class: ForeignKeyComparator
     fields:
-    - file
-    - project_id
-  model_name: sentry.projectdebugfile
+    - widget
+  model_name: sentry.dashboardwidgetquery
+- comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_modified
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields:
+    - dashboard_widget_query
+  model_name: sentry.dashboardwidgetqueryondemand
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - artifact_bundle
     - organization_id
-    - project_debug_file
-    - project_id
-  model_name: sentry.proguardartifactrelease
+  model_name: sentry.debugidartifactbundle
 - comparators:
   - class: ForeignKeyComparator
     fields: []
@@ -741,32 +430,50 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - created_by_id
+    - organization
+  model_name: sentry.discoversavedquery
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - discover_saved_query
+    - project
+  model_name: sentry.discoversavedqueryproject
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
     - organization_id
     - release
   model_name: sentry.distribution
 - comparators:
   - class: ForeignKeyComparator
-    fields:
-    - custom_dynamic_sampling_rule
-    - project
-  model_name: sentry.customdynamicsamplingruleproject
+    fields: []
+  model_name: sentry.docintegration
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - created_by_id
-    - organization
-  model_name: sentry.customdynamicsamplingrule
+    - control_file_id
+    - doc_integration
+    - file_id
+  model_name: sentry.docintegrationavatar
+- comparators:
+  - class: EmailObfuscatingComparator
+    fields:
+    - email
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.email
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization_id
+  model_name: sentry.environment
 - comparators:
   - class: ForeignKeyComparator
     fields:
     - environment
     - project
   model_name: sentry.environmentproject
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization_id
-  model_name: sentry.environment
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -777,85 +484,67 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - processing_issue
+    - raw_event
+  model_name: sentry.eventprocessingissue
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - file_id
+    - organization
+    - user_id
+  model_name: sentry.exporteddata
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - data_export
+  model_name: sentry.exporteddatablob
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - integration_id
+    - organization
+    - team
+    - user_id
+  model_name: sentry.externalactor
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - integration_id
+    - organization
+  model_name: sentry.externalissue
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
     - organization
   model_name: sentry.featureadoption
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - actor
-    - group
-    - organization
-    - project
-    - release
-  model_name: sentry.grouphistory
+    - blob
+  model_name: sentry.file
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.fileblob
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - group
-    - project
-  model_name: sentry.grouplink
+    - blob
+    - file
+  model_name: sentry.fileblobindex
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - environment
-  model_name: sentry.snubaquery
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - snuba_query
-  model_name: sentry.snubaqueryeventtype
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - project
-    - team
-  model_name: sentry.projectteam
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization
-  model_name: sentry.project
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - user
-  model_name: sentry.lostpasswordhash
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
+    - blob
     - organization_id
-  model_name: sentry.organizationmapping
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - inviter
-    - organization_id
-    - organizationmember_id
-    - user
-  model_name: sentry.organizationmembermapping
+  model_name: sentry.fileblobowner
 - comparators:
   - class: ForeignKeyComparator
     fields:
     - first_release
     - project
   model_name: sentry.group
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - group
-    - organization
-    - project
-    - team
-    - user_id
-  model_name: sentry.groupowner
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - group
-    - project
-    - team
-    - user_id
-  model_name: sentry.groupsubscription
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -900,6 +589,15 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - actor
+    - group
+    - organization
+    - project
+    - release
+  model_name: sentry.grouphistory
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
     - group
     - organization
     - project
@@ -908,7 +606,22 @@ source: tests/sentry/backup/test_comparators.py
   - class: ForeignKeyComparator
     fields:
     - group
+    - project
+  model_name: sentry.grouplink
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - group
   model_name: sentry.groupmeta
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - group
+    - organization
+    - project
+    - team
+    - user_id
+  model_name: sentry.groupowner
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -922,19 +635,6 @@ source: tests/sentry/backup/test_comparators.py
     - project_id
     - release_id
   model_name: sentry.grouprelease
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - project
-    - release
-  model_name: sentry.releaseproject
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization
-    - owner_id
-    - project_id
-  model_name: sentry.release
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -970,12 +670,16 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - group
     - project
-  model_name: sentry.grouptombstone
+    - team
+    - user_id
+  model_name: sentry.groupsubscription
 - comparators:
   - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.identityprovider
+    fields:
+    - project
+  model_name: sentry.grouptombstone
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -985,33 +689,80 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields: []
-  model_name: sentry.regionimportchunk
+  model_name: sentry.identityprovider
 - comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.controlimportchunk
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.controlimportchunkreplica
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.docintegration
-- comparators:
+  - class: UUID4Comparator
+    fields:
+    - detection_uuid
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+    - date_closed
+    - date_detected
+    - date_started
   - class: ForeignKeyComparator
     fields:
-    - integration_id
+    - alert_rule
     - organization
-    - team
+  model_name: sentry.incident
+- comparators:
+  - class: UUID4Comparator
+    fields:
+    - notification_uuid
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields:
+    - incident
     - user_id
-  model_name: sentry.externalactor
+  model_name: sentry.incidentactivity
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - integration_id
-    - organization
-  model_name: sentry.externalissue
+    - incident
+    - project
+  model_name: sentry.incidentproject
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - incident
+    - user_id
+  model_name: sentry.incidentseen
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - event_stats_snapshot
+    - incident
+  model_name: sentry.incidentsnapshot
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - incident
+    - user_id
+  model_name: sentry.incidentsubscription
+- comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_modified
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields:
+    - alert_rule_trigger
+    - incident
+  model_name: sentry.incidenttrigger
+- comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_updated
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.integration
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1021,38 +772,6 @@ source: tests/sentry/backup/test_comparators.py
   - class: ForeignKeyComparator
     fields: []
   model_name: sentry.integrationfeature
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - integration_id
-    - project
-  model_name: sentry.projectintegration
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - integration_id
-    - organization_id
-    - organization_integration_id
-    - project
-    - repository
-  model_name: sentry.repositoryprojectpathconfig
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - sentry_app
-  model_name: sentry.sentryappcomponent
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization_id
-    - sentry_app_installation
-  model_name: sentry.sentryappinstallationforprovider
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - api_token
-    - sentry_app_installation
-  model_name: sentry.sentryappinstallationtoken
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1067,6 +786,77 @@ source: tests/sentry/backup/test_comparators.py
     - release_id
     - repository_id
   model_name: sentry.latestreporeleaseenvironment
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - user
+  model_name: sentry.lostpasswordhash
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.metricskeyindexer
+- comparators:
+  - class: UUID4Comparator
+    fields:
+    - guid
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields:
+    - organization_id
+    - project_id
+  model_name: sentry.monitor
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - location
+    - monitor
+    - monitor_environment
+    - project_id
+  model_name: sentry.monitorcheckin
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - monitor_incident
+  model_name: sentry.monitorenvbrokendetection
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - environment_id
+    - monitor
+  model_name: sentry.monitorenvironment
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - monitor
+    - monitor_environment
+    - resolving_checkin
+    - starting_checkin
+  model_name: sentry.monitorincident
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.monitorlocation
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization
+    - rule
+  model_name: sentry.neglectedrule
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - integration_id
+    - organization
+    - sentry_app_id
+  model_name: sentry.notificationaction
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - action
+    - project
+  model_name: sentry.notificationactionproject
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1088,11 +878,77 @@ source: tests/sentry/backup/test_comparators.py
   model_name: sentry.notificationsettingprovider
 - comparators:
   - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.option
+- comparators:
+  - class: AutoSuffixComparator
+    fields:
+    - slug
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.organization
+- comparators:
+  - class: ForeignKeyComparator
     fields:
     - member
     - requester_id
     - team
   model_name: sentry.organizationaccessrequest
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - file_id
+    - organization
+  model_name: sentry.organizationavatar
+- comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_updated
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+    - grace_period_end
+  - class: ForeignKeyComparator
+    fields:
+    - integration
+    - organization_id
+  model_name: sentry.organizationintegration
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization_id
+  model_name: sentry.organizationmapping
+- comparators:
+  - class: HashObfuscatingComparator
+    fields:
+    - token
+  - class: EqualOrRemovedComparator
+    fields:
+    - inviter_id
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+    - token_expires_at
+  - class: EmailObfuscatingComparator
+    fields:
+    - email
+  - class: ForeignKeyComparator
+    fields:
+    - inviter_id
+    - organization
+    - user_id
+  model_name: sentry.organizationmember
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - inviter
+    - organization_id
+    - organizationmember_id
+    - user
+  model_name: sentry.organizationmembermapping
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1117,6 +973,43 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - organization
+  model_name: sentry.organizationoption
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization_id
+    - user_id
+  model_name: sentry.organizationslugreservation
+- comparators:
+  - class: HashObfuscatingComparator
+    fields:
+    - token_hashed
+    - token_last_characters
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+    - date_deactivated
+    - date_last_used
+  - class: ForeignKeyComparator
+    fields:
+    - created_by
+    - organization_id
+    - project_last_used_id
+  model_name: sentry.orgauthtoken
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - incident
+  model_name: sentry.pendingincidentsnapshot
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization_id
+  model_name: sentry.perfstringindexer
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
     - group
     - project
   model_name: sentry.platformexternalissue
@@ -1128,9 +1021,28 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - processing_issue
-    - raw_event
-  model_name: sentry.eventprocessingissue
+    - organization_id
+    - project_debug_file
+    - project_id
+  model_name: sentry.proguardartifactrelease
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization
+  model_name: sentry.project
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - artifact_bundle
+    - organization_id
+    - project_id
+  model_name: sentry.projectartifactbundle
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - file_id
+    - project
+  model_name: sentry.projectavatar
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1143,6 +1055,39 @@ source: tests/sentry/backup/test_comparators.py
     - project
     - repository_project_path_config
   model_name: sentry.projectcodeowners
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - file
+    - project_id
+  model_name: sentry.projectdebugfile
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - integration_id
+    - project
+  model_name: sentry.projectintegration
+- comparators:
+  - class: HashObfuscatingComparator
+    fields:
+    - public_key
+    - secret_key
+  - class: SecretHexComparator
+    fields:
+    - public_key
+    - secret_key
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields:
+    - project
+  model_name: sentry.projectkey
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - project
+  model_name: sentry.projectoption
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1162,6 +1107,26 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - project
+    - team
+  model_name: sentry.projectteam
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - edited_by_id
+    - organization
+    - project
+  model_name: sentry.projecttransactionthreshold
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - edited_by_id
+    - organization
+    - project
+  model_name: sentry.projecttransactionthresholdoverride
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
     - organization_id
     - project_id
     - user_id
@@ -1176,14 +1141,29 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - pull_request
+  model_name: sentry.pullrequestcomment
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
     - commit
     - pull_request
   model_name: sentry.pullrequestcommit
 - comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_updated
+  - class: SubscriptionIDComparator
+    fields:
+    - subscription_id
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
   - class: ForeignKeyComparator
     fields:
-    - pull_request
-  model_name: sentry.pullrequestcomment
+    - project
+    - snuba_query
+  model_name: sentry.querysubscription
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1197,15 +1177,67 @@ source: tests/sentry/backup/test_comparators.py
   model_name: sentry.recentsearch
 - comparators:
   - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.regionimportchunk
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.regionoutbox
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.regionscheduleddeletion
+- comparators:
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.regiontombstone
+- comparators:
+  - class: ForeignKeyComparator
     fields:
-    - environment
-    - project
-  model_name: sentry.releasethreshold
+    - project_id
+  model_name: sentry.regressiongroup
+- comparators:
+  - class: HashObfuscatingComparator
+    fields:
+    - public_key
+    - relay_id
+  - class: DatetimeEqualityComparator
+    fields:
+    - first_seen
+    - last_seen
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.relay
+- comparators:
+  - class: HashObfuscatingComparator
+    fields:
+    - public_key
+    - relay_id
+  - class: DatetimeEqualityComparator
+    fields:
+    - first_seen
+    - last_seen
+  - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.relayusage
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization
+    - owner_id
+    - project_id
+  model_name: sentry.release
 - comparators:
   - class: ForeignKeyComparator
     fields:
     - release
   model_name: sentry.releaseactivity
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - artifact_bundle
+    - organization_id
+  model_name: sentry.releaseartifactbundle
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1241,10 +1273,22 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - project
+    - release
+  model_name: sentry.releaseproject
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
     - environment
     - project
     - release
   model_name: sentry.releaseprojectenvironment
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - environment
+    - project
+  model_name: sentry.releasethreshold
 - comparators:
   - class: ForeignKeyComparator
     fields: []
@@ -1275,6 +1319,15 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
+    - integration_id
+    - organization_id
+    - organization_integration_id
+    - project
+    - repository
+  model_name: sentry.repositoryprojectpathconfig
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
     - project
   model_name: sentry.reprocessingreport
 - comparators:
@@ -1290,12 +1343,6 @@ source: tests/sentry/backup/test_comparators.py
     - rule
     - user_id
   model_name: sentry.ruleactivity
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization
-    - rule
-  model_name: sentry.neglectedrule
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1319,6 +1366,68 @@ source: tests/sentry/backup/test_comparators.py
   model_name: sentry.savedsearch
 - comparators:
   - class: ForeignKeyComparator
+    fields: []
+  model_name: sentry.scheduleddeletion
+- comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_updated
+  - class: EmailObfuscatingComparator
+    fields:
+    - creator_label
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+    - date_deleted
+    - date_published
+  - class: ForeignKeyComparator
+    fields:
+    - application
+    - creator_user
+    - owner_id
+    - proxy_user
+  model_name: sentry.sentryapp
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - control_file_id
+    - file_id
+    - sentry_app
+  model_name: sentry.sentryappavatar
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - sentry_app
+  model_name: sentry.sentryappcomponent
+- comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_updated
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+    - date_deleted
+  - class: ForeignKeyComparator
+    fields:
+    - api_grant
+    - api_token
+    - organization_id
+    - sentry_app
+  model_name: sentry.sentryappinstallation
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization_id
+    - sentry_app_installation
+  model_name: sentry.sentryappinstallationforprovider
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - api_token
+    - sentry_app_installation
+  model_name: sentry.sentryappinstallationtoken
+- comparators:
+  - class: ForeignKeyComparator
     fields:
     - organization
   model_name: sentry.sentryfunction
@@ -1328,6 +1437,20 @@ source: tests/sentry/backup/test_comparators.py
     - organization_id
   model_name: sentry.sentryshot
 - comparators:
+  - class: HashObfuscatingComparator
+    fields:
+    - secret
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields:
+    - application_id
+    - installation_id
+    - organization_id
+    - project_id
+  model_name: sentry.servicehook
+- comparators:
   - class: ForeignKeyComparator
     fields:
     - project_id
@@ -1336,8 +1459,45 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - project_id
-  model_name: sentry.regressiongroup
+    - environment
+  model_name: sentry.snubaquery
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - snuba_query
+  model_name: sentry.snubaqueryeventtype
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization_id
+  model_name: sentry.stringindexer
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - actor
+    - organization
+  - class: IgnoredComparator
+    fields:
+    - org_role
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
+  - class: ForeignKeyComparator
+    fields:
+    - organization
+  model_name: sentry.team
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - file_id
+    - team
+  model_name: sentry.teamavatar
+- comparators:
+  - class: ForeignKeyComparator
+    fields:
+    - organization
+    - project_team
+  model_name: sentry.teamkeytransaction
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1347,25 +1507,74 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: ForeignKeyComparator
     fields: []
-  model_name: sentry.regiontombstone
+  model_name: sentry.timeseriessnapshot
 - comparators:
+  - class: AutoSuffixComparator
+    fields:
+    - username
+  - class: DateUpdatedComparator
+    fields:
+    - last_active
+  - class: IgnoredComparator
+    fields:
+    - is_password_expired
+    - is_unclaimed
+    - last_password_change
+  - class: UserPasswordObfuscatingComparator
+    fields:
+    - password
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_joined
+    - last_login
+  - class: EmailObfuscatingComparator
+    fields:
+    - email
   - class: ForeignKeyComparator
     fields: []
-  model_name: sentry.controltombstone
+  model_name: sentry.user
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - edited_by_id
-    - organization
-    - project
-  model_name: sentry.projecttransactionthresholdoverride
+    - control_file_id
+    - file_id
+    - user
+  model_name: sentry.useravatar
+- comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_hash_added
+  - class: IgnoredComparator
+    fields:
+    - is_verified
+    - validation_hash
+  - class: EmailObfuscatingComparator
+    fields:
+    - email
+  - class: ForeignKeyComparator
+    fields:
+    - user
+  model_name: sentry.useremail
+- comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - first_seen
+    - last_seen
+  - class: IgnoredComparator
+    fields:
+    - country_code
+    - region_code
+  - class: ForeignKeyComparator
+    fields:
+    - user
+  model_name: sentry.userip
 - comparators:
   - class: ForeignKeyComparator
     fields:
-    - edited_by_id
-    - organization
-    - project
-  model_name: sentry.projecttransactionthreshold
+    - organization_id
+    - project_id
+    - user
+  model_name: sentry.useroption
 - comparators:
   - class: ForeignKeyComparator
     fields:
@@ -1379,238 +1588,29 @@ source: tests/sentry/backup/test_comparators.py
     - project_id
   model_name: sentry.userreport
 - comparators:
-  - class: ForeignKeyComparator
+  - class: DateUpdatedComparator
     fields:
-    - discover_saved_query
-    - project
-  model_name: sentry.discoversavedqueryproject
-- comparators:
-  - class: ForeignKeyComparator
+    - date_updated
+  - class: DatetimeEqualityComparator
     fields:
-    - created_by_id
-    - organization
-  model_name: sentry.discoversavedquery
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization
-    - project_team
-  model_name: sentry.teamkeytransaction
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - location
-    - monitor
-    - monitor_environment
-    - project_id
-  model_name: sentry.monitorcheckin
-- comparators:
+    - date_added
   - class: ForeignKeyComparator
     fields: []
-  model_name: sentry.monitorlocation
+  model_name: sentry.userrole
 - comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_updated
+  - class: DatetimeEqualityComparator
+    fields:
+    - date_added
   - class: ForeignKeyComparator
     fields:
-    - environment_id
-    - monitor
-  model_name: sentry.monitorenvironment
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - monitor
-    - monitor_environment
-    - resolving_checkin
-    - starting_checkin
-  model_name: sentry.monitorincident
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - monitor_incident
-  model_name: sentry.monitorenvbrokendetection
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.metricskeyindexer
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization_id
-  model_name: sentry.stringindexer
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization_id
-  model_name: sentry.perfstringindexer
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule
-  model_name: sentry.alertruleactivationcondition
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule
-    - query_subscription
-  model_name: sentry.alertruleactivations
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - incident
-    - project
-  model_name: sentry.incidentproject
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - incident
-    - user_id
-  model_name: sentry.incidentseen
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - incident
-  model_name: sentry.pendingincidentsnapshot
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - event_stats_snapshot
-    - incident
-  model_name: sentry.incidentsnapshot
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: sentry.timeseriessnapshot
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - incident
-    - user_id
-  model_name: sentry.incidentsubscription
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - action
-    - project
-  model_name: sentry.notificationactionproject
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - integration_id
-    - organization
-    - sentry_app_id
-  model_name: sentry.notificationaction
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule
-    - project
-  model_name: sentry.alertruleexcludedprojects
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule
-    - project
-  model_name: sentry.alertruleprojects
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule
-  model_name: sentry.alertruletrigger
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule_trigger
-    - query_subscription
-  model_name: sentry.alertruletriggerexclusion
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule_trigger
-    - integration_id
-    - sentry_app_id
-  model_name: sentry.alertruletriggeraction
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - alert_rule
-    - previous_alert_rule
-    - user_id
-  model_name: sentry.alertruleactivity
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - file_id
-    - organization
-    - user_id
-  model_name: sentry.exporteddata
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - data_export
-  model_name: sentry.exporteddatablob
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: nodestore.node
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - file_id
-    - project_id
-  model_name: replays.replayrecordingsegment
+    - role
+    - user
+  model_name: sentry.userroleuser
 - comparators:
   - class: ForeignKeyComparator
     fields:
     - user
   model_name: social_auth.usersocialauth
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - environment
-    - organization_id
-    - project_id
-  model_name: feedback.feedback
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - organization_id
-    - organization_slug_reservation_id
-    - user_id
-  model_name: hybridcloud.organizationslugreservationreplica
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - apikey_id
-    - organization
-  model_name: hybridcloud.apikeyreplica
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - apitoken_id
-    - application_id
-    - organization
-    - user_id
-  model_name: hybridcloud.apitokenreplica
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: hybridcloud.regioncacheversion
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - externalactor_id
-    - integration
-    - organization_id
-    - team_id
-    - user
-  model_name: hybridcloud.externalactorreplica
-- comparators:
-  - class: ForeignKeyComparator
-    fields:
-    - created_by_id
-    - organization
-    - orgauthtoken_id
-  model_name: hybridcloud.orgauthtokenreplica
-- comparators:
-  - class: ForeignKeyComparator
-    fields: []
-  model_name: hybridcloud.webhookpayload

--- a/tests/sentry/backup/test_comparators.py
+++ b/tests/sentry/backup/test_comparators.py
@@ -2149,7 +2149,7 @@ def test_good_user_password_obfuscating_comparator_scrubbed_short():
 def test_default_comparators(insta_snapshot):
     serialized = []
     defs = get_default_comparators()
-    for model_name, comparators in defs.items():
+    for model_name, comparators in sorted(defs.items()):
         serialized.append(
             {
                 "model_name": model_name,


### PR DESCRIPTION
This adds a sort to the snapshot used for the `test_default_comparators` test, so that changes elsewhere in the code which change import order don't cause the test to fail when it shouldn't.