### PR TITLE
ref(grouping): Split grouping info helpers into separate module

### DIFF
--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -1,96 +1,11 @@
-import logging
-from typing import Any
-
 from django.http import HttpRequest, HttpResponse
 
-from sentry import eventstore
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.eventstore.models import Event
-from sentry.grouping.api import GroupingConfigNotFound
-from sentry.grouping.variants import PerformanceProblemVariant
-from sentry.models.project import Project
-from sentry.utils import json, metrics
-from sentry.utils.performance_issues.performance_detection import EventPerformanceProblem
-
-logger = logging.getLogger(__name__)
-
-
-def get_grouping_info(config_name: str | None, project: Project, event_id: str):
-    event = eventstore.backend.get_event_by_id(project.id, event_id)
-    if event is None:
-        raise ResourceDoesNotExist
-
-    # We always fetch the stored hashes here.  The reason for this is
-    # that we want to show in the UI if the forced grouping algorithm
-    # produced hashes that would normally also appear in the event.
-    hashes = event.get_hashes()
-
-    try:
-        if event.get_event_type() == "transaction":
-            # Transactions events are grouped using performance detection. They
-            # are not subject to grouping configs, and the only relevant
-            # grouping variant is `PerformanceProblemVariant`.
-
-            problems = EventPerformanceProblem.fetch_multi([(event, h) for h in hashes.hashes])
-
-            # Create a variant for every problem associated with the event
-            # TODO: Generate more unique keys, in case this event has more than
-            # one problem of a given type
-            variants = {
-                problem.problem.type.slug: PerformanceProblemVariant(problem)
-                for problem in problems
-                if problem
-            }
-        else:
-            variants = event.get_grouping_variants(
-                force_config=config_name, normalize_stacktraces=True
-            )
-
-    except GroupingConfigNotFound:
-        raise ResourceDoesNotExist(detail="Unknown grouping config")
-
-    return get_grouping_info_from_variants(
-        event, project, variants, hashes.hashes, hashes.hierarchical_hashes
-    )
-
-
-def get_grouping_info_from_variants(
-    event: Event,
-    project: Project,
-    variants: dict[str, Any],
-    hashes: list[str],
-    hierarchical_hashes: list[str],
-) -> dict[str, dict[str, Any]]:
-    grouping_info = {}
-
-    for key, variant in variants.items():
-        variant_dict = variant.as_dict()
-        # Since the hashes are generated on the fly and might no
-        # longer match the stored ones we indicate if the hash
-        # generation caused the hash to mismatch.
-        variant_dict["hashMismatch"] = hash_mismatch = (
-            variant_dict["hash"] is not None
-            and variant_dict["hash"] not in hashes
-            and variant_dict["hash"] not in hierarchical_hashes
-        )
-
-        if hash_mismatch:
-            metrics.incr("event_grouping_info.hash_mismatch")
-            logger.error(
-                "event_grouping_info.hash_mismatch",
-                extra={"project_id": project.id, "event_id": event.event_id},
-            )
-        else:
-            metrics.incr("event_grouping_info.hash_match")
-
-        variant_dict["key"] = key
-        grouping_info[key] = variant_dict
-
-    return grouping_info
+from sentry.grouping.grouping_info import get_grouping_info
+from sentry.utils import json
 
 
 @region_silo_endpoint

--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -11,8 +11,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
-from sentry.api.endpoints.event_grouping_info import get_grouping_info
 from sentry.api.serializers import serialize
+from sentry.grouping.grouping_info import get_grouping_info
 from sentry.models.group import Group
 from sentry.models.user import User
 from sentry.seer.utils import (

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -1,0 +1,89 @@
+import logging
+from typing import Any
+
+from sentry import eventstore
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.eventstore.models import Event
+from sentry.grouping.api import GroupingConfigNotFound
+from sentry.grouping.variants import BaseVariant, PerformanceProblemVariant
+from sentry.models.project import Project
+from sentry.utils import metrics
+from sentry.utils.performance_issues.performance_detection import EventPerformanceProblem
+
+logger = logging.getLogger(__name__)
+
+
+def get_grouping_info(
+    config_name: str | None, project: Project, event_id: str
+) -> dict[str, dict[str, Any]]:
+    event = eventstore.backend.get_event_by_id(project.id, event_id)
+    if event is None:
+        raise ResourceDoesNotExist
+
+    # We always fetch the stored hashes here.  The reason for this is
+    # that we want to show in the UI if the forced grouping algorithm
+    # produced hashes that would normally also appear in the event.
+    hashes = event.get_hashes()
+
+    try:
+        if event.get_event_type() == "transaction":
+            # Transactions events are grouped using performance detection. They
+            # are not subject to grouping configs, and the only relevant
+            # grouping variant is `PerformanceProblemVariant`.
+
+            problems = EventPerformanceProblem.fetch_multi([(event, h) for h in hashes.hashes])
+
+            # Create a variant for every problem associated with the event
+            # TODO: Generate more unique keys, in case this event has more than
+            # one problem of a given type
+            variants: dict[str, BaseVariant] = {
+                problem.problem.type.slug: PerformanceProblemVariant(problem)
+                for problem in problems
+                if problem
+            }
+        else:
+            variants = event.get_grouping_variants(
+                force_config=config_name, normalize_stacktraces=True
+            )
+
+    except GroupingConfigNotFound:
+        raise ResourceDoesNotExist(detail="Unknown grouping config")
+
+    return get_grouping_info_from_variants(
+        event, project, variants, hashes.hashes, hashes.hierarchical_hashes
+    )
+
+
+def get_grouping_info_from_variants(
+    event: Event,
+    project: Project,
+    variants: dict[str, Any],
+    hashes: list[str],
+    hierarchical_hashes: list[str],
+) -> dict[str, dict[str, Any]]:
+    grouping_info = {}
+
+    for key, variant in variants.items():
+        variant_dict = variant.as_dict()
+        # Since the hashes are generated on the fly and might no
+        # longer match the stored ones we indicate if the hash
+        # generation caused the hash to mismatch.
+        variant_dict["hashMismatch"] = hash_mismatch = (
+            variant_dict["hash"] is not None
+            and variant_dict["hash"] not in hashes
+            and variant_dict["hash"] not in hierarchical_hashes
+        )
+
+        if hash_mismatch:
+            metrics.incr("event_grouping_info.hash_mismatch")
+            logger.error(
+                "event_grouping_info.hash_mismatch",
+                extra={"project_id": project.id, "event_id": event.event_id},
+            )
+        else:
+            metrics.incr("event_grouping_info.hash_match")
+
+        variant_dict["key"] = key
+        grouping_info[key] = variant_dict
+
+    return grouping_info

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -97,9 +97,9 @@ def _write_tree_labels(tree_labels: Sequence[TreeLabel | None], event_data: Node
 
 @dataclass(frozen=True)
 class CalculatedHashes:
-    hashes: Sequence[str]
-    hierarchical_hashes: Sequence[str]
-    tree_labels: Sequence[TreeLabel | None]
+    hashes: list[str]
+    hierarchical_hashes: list[str]
+    tree_labels: list[TreeLabel | None]
     variants: KeyedVariants | None = None
 
     def write_to_event(self, event_data: NodeData) -> None:

--- a/tests/sentry/api/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/api/endpoints/test_event_grouping_info.py
@@ -3,8 +3,8 @@ from unittest import mock
 import pytest
 from django.urls import reverse
 
-from sentry.api.endpoints.event_grouping_info import get_grouping_info
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.grouping.grouping_info import get_grouping_info
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
@@ -107,8 +107,8 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
         with pytest.raises(ResourceDoesNotExist):
             get_grouping_info("fake-config", self.project, event.event_id)
 
-    @mock.patch("sentry.api.endpoints.event_grouping_info.logger")
-    @mock.patch("sentry.api.endpoints.event_grouping_info.metrics")
+    @mock.patch("sentry.grouping.grouping_info.logger")
+    @mock.patch("sentry.grouping.grouping_info.metrics")
     def test_get_grouping_info_hash_mismatch(self, mock_metrics, mock_logger):
         # Make a Python event
         data = load_data(platform="python")


### PR DESCRIPTION
When originally written, the `get_grouping_info` helper was only used to provide data to `EventGroupingInfoEndpoint.get`, so it made sense to have it in the same file. We've since come to use it elsewhere as well, so it makes sense for it to switch to living in a neutral location. This therefore moves it into a new `grouping.grouping_info` module, and - in preparation for using just the variants part of it in a new spot - splits that bit out into its own function as well.  