### PR TITLE
fix(bug): Add Slack task module to imports

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -802,6 +802,7 @@ CELERY_IMPORTS = (
     "sentry.tasks.on_demand_metrics",
     "sentry.middleware.integrations.tasks",
     "sentry.replays.usecases.ingest.issue_creation",
+    "sentry.integrations.slack.tasks",
 )
 
 default_exchange = Exchange("default", type="direct")

--- a/src/sentry/integrations/slack/tasks/__init__.py
+++ b/src/sentry/integrations/slack/tasks/__init__.py
@@ -1,0 +1,3 @@
+from sentry.integrations.slack.tasks.send_notifications_on_activity import (  # noqa
+    send_activity_notifications_to_slack_threads,
+)

--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -16,11 +16,11 @@ _default_logger = logging.getLogger(__name__)
 
 
 @instrumented_task(
-    name="sentry.integrations.slack.tasks.send_activity_notifications",
+    name="sentry.integrations.slack.tasks.send_activity_notifications_to_slack_threads",
     queue="integrations_slack_activity_notify",
     silo_mode=SiloMode.REGION,
 )
-def send_activity_notifications(activity_id):
+def send_activity_notifications_to_slack_threads(activity_id):
     try:
         activity = Activity.objects.get(pk=activity_id)
     except Activity.DoesNotExist:
@@ -57,6 +57,8 @@ def activity_created_receiver(instance, created, **kwargs):
         return
 
     transaction.on_commit(
-        lambda: send_activity_notifications.apply_async(kwargs={"activity_id": instance.id}),
+        lambda: send_activity_notifications_to_slack_threads.apply_async(
+            kwargs={"activity_id": instance.id}
+        ),
         using=router.db_for_read(Activity),
     )

--- a/tests/sentry/integrations/slack/tasks/test_send_notifications_on_activity.py
+++ b/tests/sentry/integrations/slack/tasks/test_send_notifications_on_activity.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from sentry.integrations.slack.tasks.send_notifications_on_activity import (
     activity_created_receiver,
-    send_activity_notifications,
+    send_activity_notifications_to_slack_threads,
 )
 from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
@@ -18,7 +18,7 @@ class TestActivityCreatedReceiver(TestCase):
 
     def test_ignores_uncreated_events(self) -> None:
         with mock.patch(
-            "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications",
+            "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications_to_slack_threads",
             self.mock_send_activity_notifications,
         ):
             activity_created_receiver({}, False)
@@ -26,7 +26,7 @@ class TestActivityCreatedReceiver(TestCase):
 
     def test_calls_async_function(self) -> None:
         with mock.patch(
-            "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications",
+            "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications_to_slack_threads",
             self.mock_send_activity_notifications,
         ):
             mock_activity = mock.MagicMock()
@@ -38,7 +38,7 @@ class TestActivityCreatedReceiver(TestCase):
 
     def test_receiver_signal(self) -> None:
         with mock.patch(
-            "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications",
+            "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications_to_slack_threads",
             self.mock_send_activity_notifications,
         ):
             new_activity = Activity.objects.create(
@@ -68,7 +68,7 @@ class TestSendActivityNotifications(TestCase):
             "sentry.integrations.slack.tasks.send_notifications_on_activity.SlackService",
             self.mock_slack_service,
         ):
-            send_activity_notifications(activity_id=123)
+            send_activity_notifications_to_slack_threads(activity_id=123)
             self.mock_slack_service.notify_all_threads_for_activity.assert_not_called()
 
     @with_feature("organizations:slack-thread-issue-alert")
@@ -77,5 +77,5 @@ class TestSendActivityNotifications(TestCase):
             "sentry.integrations.slack.tasks.send_notifications_on_activity.SlackService",
             self.mock_slack_service,
         ):
-            send_activity_notifications(activity_id=self.activity.id)
+            send_activity_notifications_to_slack_threads(activity_id=self.activity.id)
             self.mock_slack_service.notify_all_threads_for_activity.assert_called()


### PR DESCRIPTION
Need to make sure task is added to the import configs, currently it's not getting picked up because it's not configured correctly. Docs describe this: https://develop.sentry.dev/services/queue/#registering-a-task. Also renamed the task to be more unique since there exists a similar named task
