### PR TITLE
fix(dashboards): disable metric chart zoom

### DIFF
--- a/static/app/views/dashboards/metrics/chart.tsx
+++ b/static/app/views/dashboards/metrics/chart.tsx
@@ -49,7 +49,7 @@ export function MetricChartContainer({
           displayType={displayType}
           group={DASHBOARD_CHART_GROUP}
           height={chartHeight}
-          enableZoom
+          enableZoom={false}
         />
       </TransitionChart>
     </MetricWidgetChartWrapper>


### PR DESCRIPTION
Temporarily disabling chart zoom for metric charts as it has a severe negative impact on the dashboards with large amount of metric widgets