### PR TITLE
feat(sdk-crashes): Add JNI to native

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -242,6 +242,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                 function_patterns={
                     r"sentry_*",  # public interface
                     r"sentry__*",  # module level interface
+                    r"Java_io_sentry_android_ndk_*",  # JNI interface
                 },
                 # The native SDK usually has the same path as the application binary.
                 # Therefore, we can't rely on it. We set a fixed path of Sentry for

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_native.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_native.py
@@ -112,6 +112,11 @@ def configs() -> Sequence[SDKCrashDetectionConfig]:
             "/apex/com.android.placeholder/liA/yes/yes",
             False,
         ),
+        (
+            "Java_io_sentry_android_ndk_NativeScope_nativeAddBreadcrumb",
+            "/apex/com.android.placeholder/libA/yes/yes",
+            True,
+        ),
     ],
 )
 @decorators


### PR DESCRIPTION
The SDK crash detection can keep methods starting with Java_io_sentry_android_ndk_.