### PR TITLE
feat(menu-list-item): Details overlay

### DIFF
--- a/static/app/components/comboBox/comboBox.stories.tsx
+++ b/static/app/components/comboBox/comboBox.stories.tsx
@@ -1,16 +1,41 @@
 import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
 
 import type {ComboBoxOptionOrSection} from 'sentry/components/comboBox/types';
+import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
 import Matrix from 'sentry/components/stories/matrix';
 import SizingWindow from 'sentry/components/stories/sizingWindow';
 import storyBook from 'sentry/stories/storyBook';
+import {space} from 'sentry/styles/space';
 
 import {ComboBox} from './';
 
+const Divider = styled('hr')`
+  margin: ${space(1)} 0;
+  border: none;
+  border-top: 1px solid ${p => p.theme.innerBorder};
+`;
+
 const options: ComboBoxOptionOrSection<string>[] = [
   {label: 'Option One', value: 'opt_one'},
-  {label: 'Option Two', value: 'opt_two'},
-  {label: 'Option Three', value: 'opt_three'},
+  {label: 'Option Two', value: 'opt_two', details: 'This is a description'},
+  {
+    label: 'Option Three',
+    value: 'opt_three',
+    details: (
+      <Fragment>
+        <strong>{'Option Three (deprecated)'}</strong>
+        <Divider />
+        This is a description using JSX.
+        <Divider />
+        <KeyValueTable>
+          <KeyValueTableRow keyName="Coffee" value="Black hot drink" />
+          <KeyValueTableRow keyName="Milk" value="White cold drink" />
+        </KeyValueTable>
+      </Fragment>
+    ),
+    showDetailsInOverlay: true,
+  },
   {label: 'Disabled', value: 'opt_dis', disabled: true},
   {label: 'Option Four', textValue: 'included in search', value: 'opt_four'},
   {

--- a/static/app/components/compactSelect/listBox/option.tsx
+++ b/static/app/components/compactSelect/listBox/option.tsx
@@ -33,6 +33,7 @@ export function ListBoxOption({item, listState, size}: ListBoxOptionProps) {
     tooltip,
     tooltipOptions,
     selectionMode,
+    showDetailsInOverlay,
   } = item.props;
   const multiple = selectionMode
     ? selectionMode === 'multiple'
@@ -97,6 +98,7 @@ export function ListBoxOption({item, listState, size}: ListBoxOptionProps) {
       labelProps={labelPropsMemo}
       leadingItems={leadingItemsMemo}
       trailingItems={trailingItems}
+      showDetailsInOverlay={showDetailsInOverlay}
       tooltip={tooltip}
       tooltipOptions={tooltipOptions}
       data-test-id={item.key}

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -1,11 +1,4 @@
-import {
-  forwardRef as reactForwardRef,
-  Fragment,
-  memo,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {forwardRef as reactForwardRef, memo, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {usePopper} from 'react-popper';
 import isPropValid from '@emotion/is-prop-valid';
@@ -141,81 +134,79 @@ function BaseMenuListItem({
   const detailId = useMemo(() => domId('menuitem-details-'), []);
 
   return (
-    <Fragment>
-      <MenuItemWrap
-        role="menuitem"
-        aria-disabled={disabled}
-        aria-labelledby={labelId}
-        aria-describedby={detailId}
-        as={as}
-        ref={mergeRefs([forwardRef, itemRef])}
-        {...props}
-      >
-        <Tooltip skipWrapper title={tooltip} {...tooltipOptions}>
-          <InnerWrap
-            isFocused={isFocused}
-            disabled={disabled}
-            priority={priority}
-            size={size}
-            {...innerWrapProps}
-          >
-            <StyledInteractionStateLayer
-              isHovered={isFocused}
-              isPressed={isPressed}
-              higherOpacity={priority !== 'default'}
-            />
-            {leadingItems && (
-              <LeadingItems
-                disabled={disabled}
-                spanFullHeight={leadingItemsSpanFullHeight}
-                size={size}
+    <MenuItemWrap
+      role="menuitem"
+      aria-disabled={disabled}
+      aria-labelledby={labelId}
+      aria-describedby={detailId}
+      as={as}
+      ref={mergeRefs([forwardRef, itemRef])}
+      {...props}
+    >
+      <Tooltip skipWrapper title={tooltip} {...tooltipOptions}>
+        <InnerWrap
+          isFocused={isFocused}
+          disabled={disabled}
+          priority={priority}
+          size={size}
+          {...innerWrapProps}
+        >
+          <StyledInteractionStateLayer
+            isHovered={isFocused}
+            isPressed={isPressed}
+            higherOpacity={priority !== 'default'}
+          />
+          {leadingItems && (
+            <LeadingItems
+              disabled={disabled}
+              spanFullHeight={leadingItemsSpanFullHeight}
+              size={size}
+            >
+              {typeof leadingItems === 'function'
+                ? leadingItems({disabled, isFocused, isSelected})
+                : leadingItems}
+            </LeadingItems>
+          )}
+          <ContentWrap isFocused={isFocused} showDivider={showDivider} size={size}>
+            <LabelWrap>
+              <Label
+                id={labelId}
+                data-test-id="menu-list-item-label"
+                aria-hidden="true"
+                {...labelProps}
               >
-                {typeof leadingItems === 'function'
-                  ? leadingItems({disabled, isFocused, isSelected})
-                  : leadingItems}
-              </LeadingItems>
-            )}
-            <ContentWrap isFocused={isFocused} showDivider={showDivider} size={size}>
-              <LabelWrap>
-                <Label
-                  id={labelId}
-                  data-test-id="menu-list-item-label"
-                  aria-hidden="true"
-                  {...labelProps}
-                >
-                  {label}
-                </Label>
-                {!showDetailsInOverlay && details && (
-                  <Details
-                    id={detailId}
-                    disabled={disabled}
-                    priority={priority}
-                    {...detailsProps}
-                  >
-                    {details}
-                  </Details>
-                )}
-                {showDetailsInOverlay && details && isFocused && (
-                  <DetailsOverlay size={size} id={detailId} itemRef={itemRef}>
-                    {details}
-                  </DetailsOverlay>
-                )}
-              </LabelWrap>
-              {trailingItems && (
-                <TrailingItems
+                {label}
+              </Label>
+              {!showDetailsInOverlay && details && (
+                <Details
+                  id={detailId}
                   disabled={disabled}
-                  spanFullHeight={trailingItemsSpanFullHeight}
+                  priority={priority}
+                  {...detailsProps}
                 >
-                  {typeof trailingItems === 'function'
-                    ? trailingItems({disabled, isFocused, isSelected})
-                    : trailingItems}
-                </TrailingItems>
+                  {details}
+                </Details>
               )}
-            </ContentWrap>
-          </InnerWrap>
-        </Tooltip>
-      </MenuItemWrap>
-    </Fragment>
+              {showDetailsInOverlay && details && isFocused && (
+                <DetailsOverlay size={size} id={detailId} itemRef={itemRef}>
+                  {details}
+                </DetailsOverlay>
+              )}
+            </LabelWrap>
+            {trailingItems && (
+              <TrailingItems
+                disabled={disabled}
+                spanFullHeight={trailingItemsSpanFullHeight}
+              >
+                {typeof trailingItems === 'function'
+                  ? trailingItems({disabled, isFocused, isSelected})
+                  : trailingItems}
+              </TrailingItems>
+            )}
+          </ContentWrap>
+        </InnerWrap>
+      </Tooltip>
+    </MenuItemWrap>
   );
 }
 

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -244,7 +244,7 @@ function DetailsOverlay({
   });
 
   return createPortal(
-    <PositionWrapper
+    <StyledPositionWrapper
       {...popper.attributes.popper}
       ref={setOverlayElement}
       zIndex={theme.zIndex.tooltip}
@@ -253,15 +253,22 @@ function DetailsOverlay({
       <StyledOverlay id={id} placement="right-start" size={size}>
         {children}
       </StyledOverlay>
-    </PositionWrapper>,
+    </StyledPositionWrapper>,
     document.body
   );
 }
 
+const StyledPositionWrapper = styled(PositionWrapper)`
+  &[data-popper-reference-hidden='true'] {
+    opacity: 0;
+    pointer-events: none;
+  }
+`;
+
 const StyledOverlay = styled(Overlay)<{
   size: Props['size'];
 }>`
-  padding: ${p => getVerticalPadding(p.size)} ${space(1)};
+  padding: ${p => getVerticalPadding(p.size)};
   font-size: ${p => p.theme.form[p.size ?? 'md'].fontSize};
   cursor: auto;
   user-select: text;

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -359,7 +359,7 @@ const StyledInteractionStateLayer = styled(InteractionStateLayer)`
  * Returns the appropriate vertical padding based on the size prop. To be used
  * as top/bottom padding/margin in ContentWrap and LeadingItems.
  */
-export const getVerticalPadding = (size: Props['size']) => {
+const getVerticalPadding = (size: Props['size']) => {
   switch (size) {
     case 'xs':
       return space(0.5);


### PR DESCRIPTION
Allow showing item details inside an overlay (`showDetailsInOverlay`) in case we want to show more detailed information than just one line of text.

![image](https://github.com/getsentry/sentry/assets/7033940/fbc4d619-b7d8-489a-8a1c-463e6778c8de)

![image](https://github.com/getsentry/sentry/assets/7033940/14732429-8ebe-4c64-b190-b9fbb874c8f5)

- closes https://github.com/getsentry/sentry/issues/68514