### PR TITLE
fix(proguard): Don't differentiate between no line and 0

### DIFF
--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -300,7 +300,7 @@ class JavaSourceLookupStacktraceProcessor(StacktraceProcessor):
 
         def frames_differ(a, b):
             return (
-                a.get("lineno") != b.get("lineno")
+                a.get("lineno", 0) != b.get("lineno", 0)
                 or a.get("abs_path") != b.get("abs_path")
                 or a.get("function") != b.get("function")
                 or a.get("filename") != b.get("filename")


### PR DESCRIPTION
This is a common discrepancy we're seeing in A/B tests. Since there is no essential difference between a frame having `lineno: 0` and no `lineno` at all, we'd like to ignore it.