### PR TITLE
feat(replay): Add `shouldRecordCanvas` to allowed tags list in Replay

### DIFF
--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -48,6 +48,7 @@ const notSearchable = [
   'sdk.networkRequestHasHeaders',
   'sdk.networkResponseHasHeaders',
   'sdk.sessionSampleRate',
+  'sdk.shouldRecordCanvas',
   'sdk.useCompression',
   'sdk.useCompressionOption',
 ];


### PR DESCRIPTION
This was previously displaying an empty value.
