### PR TITLE
fix(crons): Temporarily increase frequency of the broken monitor task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1041,7 +1041,7 @@ CELERYBEAT_SCHEDULE_REGION = {
     "monitors-detect-broken-monitor-envs": {
         "task": "sentry.monitors.tasks.detect_broken_monitor_envs",
         # 8:00 PDT, 11:00 EDT, 15:00 UTC
-        "schedule": crontab(minute="0", hour="15", day_of_week="mon-fri"),
+        "schedule": crontab(minute="*/30"),
         "options": {"expires": 15 * 60},
     },
     "clear-expired-snoozes": {


### PR DESCRIPTION
We want to capture profiles for this task to see what's up with performance.
