### PR TITLE
feat(traces): Add a timestamp param to facets

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -9,7 +9,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.api.utils import handle_query_errors
+from sentry.api.utils import handle_query_errors, update_snuba_params_with_timestamp
 from sentry.search.utils import DEVICE_CLASS
 from sentry.snuba import discover
 
@@ -28,6 +28,8 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
             params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response([])
+
+        update_snuba_params_with_timestamp(request, params, timestamp_key="traceTimestamp")
 
         def data_fn(offset, limit):
             with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -6,7 +6,7 @@ import re
 import sys
 import time
 import traceback
-from collections.abc import Generator, Mapping
+from collections.abc import Generator, Mapping, MutableMapping
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import Any, Literal, overload
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 import sentry_sdk
 from django.conf import settings
-from django.http import HttpResponseNotAllowed
+from django.http import HttpRequest, HttpResponseNotAllowed
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.exceptions import APIException, ParseError
@@ -502,3 +502,25 @@ def id_or_slug_path_params_enabled(
         return True
 
     return False
+
+
+def update_snuba_params_with_timestamp(
+    request: HttpRequest, params: MutableMapping[str, Any], timestamp_key: str = "timestamp"
+) -> None:
+    """In some views we only want to query snuba data around a single event or trace. In these cases the frontend can
+    send the timestamp of something in that event or trace and we'll query data near that event only which should be
+    faster than the default 7d or 14d queries"""
+    # during the transition this is optional but it will become required
+    sentry_sdk.set_tag("trace_view.used_timestamp", "timestamp" in request.GET)
+    if timestamp_key in request.GET and "start" in params and "end" in params:
+        example_timestamp = parse_datetime_string(request.GET[timestamp_key])
+        # While possible, the majority of traces shouldn't take more than a week
+        # Starting with 3d for now, but potentially something we can increase if this becomes a problem
+        time_buffer = options.get("performance.traces.transaction_query_timebuffer_days")
+        sentry_sdk.set_measurement("trace_view.transactions.time_buffer", time_buffer)
+        example_start = example_timestamp - timedelta(days=time_buffer)
+        example_end = example_timestamp + timedelta(days=time_buffer)
+        # If timestamp is being passed it should always overwrite the statsperiod or start & end
+        # the client should just not pass a timestamp if we need to overwrite this logic for any reason
+        params["start"] = max(params["start"], example_start)
+        params["end"] = min(params["end"], example_end)


### PR DESCRIPTION
- This adds a traceTimestamp param to facets that the frontend can send so that we're querying far less data
  - It's currently querying 14d of data, but only for a given trace but cause they need to do projects=-1 its resulting in the facets endpoint timing out for larger organizations