### PR TITLE
ref: eliminate reruns for migration tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -140,8 +140,7 @@ jobs:
 
       - name: run tests
         run: |
-          # historic migrations trigger some warnings
-          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations" make test-python-ci
+          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations --reruns 0" make test-python-ci
 
       # Upload coverage data even if running the tests step fails since
       # it reduces large coverage fluctuations


### PR DESCRIPTION
if any of these fail and rerun they chew up the entire timeout budget making it very difficult to find the actual problem

<!-- Describe your PR here. -->