### PR TITLE
feat(stacktrace): Use new chevron button for exapanding frames

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -225,7 +225,6 @@ export class DeprecatedLine extends Component<Props, State> {
 
     return (
       <ToggleContextButton
-        className="btn-toggle"
         data-test-id={`toggle-button-${isExpanded ? 'expanded' : 'collapsed'}`}
         size="zero"
         aria-label={t('Toggle Context')}
@@ -536,11 +535,8 @@ const DefaultLineTagWrapper = styled('div')`
   gap: ${space(1)};
 `;
 
-// the Button's label has the padding of 3px because the button size has to be 16x16 px.
 const ToggleContextButton = styled(Button)`
-  span:first-child {
-    padding: 3px;
-  }
+  color: ${p => p.theme.subText};
 `;
 
 const StyledLi = styled('li')`

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -5,6 +5,7 @@ import scrollToElement from 'scroll-to-element';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
+import {Chevron} from 'sentry/components/chevron';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {analyzeFrameForRootCause} from 'sentry/components/events/interfaces/analyzeFrames';
 import LeadHint from 'sentry/components/events/interfaces/frame/line/leadHint';
@@ -14,7 +15,7 @@ import {SourceMapsDebuggerModal} from 'sentry/components/events/interfaces/sourc
 import {getThreadById} from 'sentry/components/events/interfaces/utils';
 import StrictClick from 'sentry/components/strictClick';
 import {Tag} from 'sentry/components/tag';
-import {IconChevron, IconFix, IconRefresh} from 'sentry/icons';
+import {IconFix, IconRefresh} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
@@ -229,8 +230,9 @@ export class DeprecatedLine extends Component<Props, State> {
         size="zero"
         aria-label={t('Toggle Context')}
         onClick={this.toggleContext}
+        borderless
       >
-        <IconChevron direction={isExpanded ? 'up' : 'down'} legacySize="8px" />
+        <Chevron direction={isExpanded ? 'up' : 'down'} size="medium" />
       </ToggleContextButton>
     );
   }

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -472,8 +472,7 @@ const ExpandCell = styled('div')`
 
 const ToggleButton = styled(Button)`
   display: block;
-  width: 16px;
-  height: 16px;
+  color: ${p => p.theme.subText};
 `;
 
 const Registers = styled(Context)`

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import scrollToElement from 'scroll-to-element';
 
 import {Button} from 'sentry/components/button';
+import {Chevron} from 'sentry/components/chevron';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {OpenInContextLine} from 'sentry/components/events/interfaces/frame/openInContextLine';
 import {StacktraceLink} from 'sentry/components/events/interfaces/frame/stacktraceLink';
@@ -23,7 +24,6 @@ import StrictClick from 'sentry/components/strictClick';
 import {Tag} from 'sentry/components/tag';
 import {Tooltip} from 'sentry/components/tooltip';
 import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
-import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconFileBroken} from 'sentry/icons/iconFileBroken';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
 import {IconWarning} from 'sentry/icons/iconWarning';
@@ -400,11 +400,10 @@ function NativeFrame({
             {expandable && (
               <ToggleButton
                 size="zero"
+                borderless
                 aria-label={t('Toggle Context')}
                 tooltipProps={isHoverPreviewed ? {delay: SLOW_TOOLTIP_DELAY} : undefined}
-                icon={
-                  <IconChevron legacySize="8px" direction={expanded ? 'up' : 'down'} />
-                }
+                icon={<Chevron size="medium" direction={expanded ? 'up' : 'down'} />}
               />
             )}
           </ExpandCell>
@@ -472,6 +471,7 @@ const ExpandCell = styled('div')`
 `;
 
 const ToggleButton = styled(Button)`
+  display: block;
   width: 16px;
   height: 16px;
 `;


### PR DESCRIPTION
Before:

![CleanShot 2024-04-10 at 12 48 42](https://github.com/getsentry/sentry/assets/10888943/49a0466e-fb88-44ac-9f88-8aad9dbe0cba)

After:

![CleanShot 2024-04-10 at 13 47 09@2x](https://github.com/getsentry/sentry/assets/10888943/d9dc1f16-7889-496f-a84d-66f8288b9e12)
