### PR TITLE
feat(perf): Add HTTP code breakdown chart to sample panel

### DIFF
--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -1,6 +1,6 @@
 import {escapeDoubleQuotes} from 'sentry/utils';
 
-const ALLOWED_WILDCARD_FIELDS = ['span.description'];
+const ALLOWED_WILDCARD_FIELDS = ['span.description', 'span.status_code'];
 export const EMPTY_OPTION_VALUE = '(empty)' as const;
 
 export enum TokenType {

--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -111,6 +111,7 @@ describe('HTTPSamplesPanel', () => {
           transaction: '/api/0/users',
           transactionMethod: 'GET',
           panel: 'status',
+          responseCodeClass: '3',
         },
         hash: '',
         state: undefined,
@@ -127,10 +128,16 @@ describe('HTTPSamplesPanel', () => {
           }),
         ],
         body: {
-          'spm()': {
+          '301': {
             data: [
               [1699907700, [{count: 7810.2}]],
               [1699908000, [{count: 1216.8}]],
+            ],
+          },
+          '304': {
+            data: [
+              [1699907700, [{count: 2701.5}]],
+              [1699908000, [{count: 78.12}]],
             ],
           },
         },
@@ -160,7 +167,7 @@ describe('HTTPSamplesPanel', () => {
             per_page: 50,
             project: [],
             query:
-              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
+              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users span.status_code:3*',
             referrer: 'api.starfish.http-module-samples-panel-metrics-ribbon',
             statsPeriod: '10d',
           },
@@ -177,22 +184,18 @@ describe('HTTPSamplesPanel', () => {
             dataset: 'spansMetrics',
             environment: [],
             excludeOther: 0,
-            field: [],
+            field: ['span.status_code', 'count()'],
             interval: '30m',
             orderby: undefined,
             partial: 1,
             per_page: 50,
             project: [],
             query:
-              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
+              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users span.status_code:3*',
             referrer: 'api.starfish.http-module-samples-panel-response-code-chart',
             statsPeriod: '10d',
-            topEvents: undefined,
-            yAxis: [
-              'http_response_rate(3)',
-              'http_response_rate(4)',
-              'http_response_rate(5)',
-            ],
+            topEvents: '5',
+            yAxis: 'count()',
           },
         })
       );

--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -191,7 +191,7 @@ describe('HTTPSamplesPanel', () => {
             per_page: 50,
             project: [],
             query:
-              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users span.status_code:3*',
+              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308]',
             referrer: 'api.starfish.http-module-samples-panel-response-code-chart',
             statsPeriod: '10d',
             topEvents: '5',

--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -167,7 +167,7 @@ describe('HTTPSamplesPanel', () => {
             per_page: 50,
             project: [],
             query:
-              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users span.status_code:3*',
+              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
             referrer: 'api.starfish.http-module-samples-panel-metrics-ribbon',
             statsPeriod: '10d',
           },

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -102,6 +102,14 @@ export function HTTPSamplesPanel() {
 
   const isPanelOpen = Boolean(detailKey);
 
+  // The ribbon is above the data selectors, and not affected by them. So, it has its own filters.
+  const ribbonFilters: SpanMetricsQueryFilters = {
+    'span.module': ModuleName.HTTP,
+    'span.domain': query.domain,
+    transaction: query.transaction,
+  };
+
+  // These filters are for the charts and samples tables
   const filters: SpanMetricsQueryFilters = {
     'span.module': ModuleName.HTTP,
     'span.domain': query.domain,
@@ -118,7 +126,7 @@ export function HTTPSamplesPanel() {
     data: domainTransactionMetrics,
     isFetching: areDomainTransactionMetricsFetching,
   } = useSpanMetrics({
-    search,
+    search: MutableSearch.fromQueryObject(ribbonFilters),
     fields: [
       `${SpanFunction.SPM}()`,
       `avg(${SpanMetricsField.SPAN_SELF_TIME})`,

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -20,6 +20,7 @@ import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {AverageValueMarkLine} from 'sentry/views/performance/charts/averageValueMarkLine';
+import {HTTP_RESPONSE_STATUS_CODES} from 'sentry/views/performance/http/definitions';
 import {DurationChart} from 'sentry/views/performance/http/durationChart';
 import decodePanel from 'sentry/views/performance/http/queryParameterDecoders/panel';
 import decodeResponseCodeClass from 'sentry/views/performance/http/queryParameterDecoders/responseCodeClass';
@@ -116,8 +117,15 @@ export function HTTPSamplesPanel() {
     transaction: query.transaction,
   };
 
-  if (query.responseCodeClass) {
-    filters['span.status_code'] = `${query.responseCodeClass}*`;
+  const responseCodeInRange = query.responseCodeClass
+    ? Object.keys(HTTP_RESPONSE_STATUS_CODES).filter(code =>
+        code.startsWith(query.responseCodeClass)
+      )
+    : [];
+
+  if (responseCodeInRange.length > 0) {
+    // TODO: Allow automatic array parameter concatenation
+    filters['span.status_code'] = `[${responseCodeInRange.join(',')}]`;
   }
 
   const search = MutableSearch.fromQueryObject(filters);

--- a/static/app/views/performance/http/queryParameterDecoders/responseCodeClass.tsx
+++ b/static/app/views/performance/http/queryParameterDecoders/responseCodeClass.tsx
@@ -1,0 +1,23 @@
+import {decodeScalar} from 'sentry/utils/queryString';
+
+const OPTIONS = ['' as const, '2' as const, '3' as const, '4' as const, '5' as const];
+const DEFAULT = '';
+
+type ResponseCodeClass = (typeof OPTIONS)[number];
+
+export default function decode(
+  value: string | string[] | undefined | null
+): ResponseCodeClass {
+  const decodedValue = decodeScalar(value, DEFAULT);
+
+  if (isAValidOption(decodedValue)) {
+    return decodedValue;
+  }
+
+  return DEFAULT;
+}
+
+function isAValidOption(maybeOption: string): maybeOption is ResponseCodeClass {
+  // Manually widen  to allow the comparison to string
+  return (OPTIONS as unknown as string[]).includes(maybeOption as ResponseCodeClass);
+}

--- a/static/app/views/performance/http/responseCodeCountChart.tsx
+++ b/static/app/views/performance/http/responseCodeCountChart.tsx
@@ -1,0 +1,33 @@
+import {t} from 'sentry/locale';
+import type {Series} from 'sentry/types/echarts';
+import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
+import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+
+interface Props {
+  isLoading: boolean;
+  series: Series[];
+  error?: Error | null;
+}
+
+export function ResponseCodeCountChart({series, isLoading, error}: Props) {
+  return (
+    <ChartPanel title={t('Response Codes')}>
+      <Chart
+        showLegend
+        height={CHART_HEIGHT}
+        grid={{
+          left: '4px',
+          right: '0',
+          top: '8px',
+          bottom: '0',
+        }}
+        data={series}
+        loading={isLoading}
+        error={error}
+        type={ChartType.LINE}
+        aggregateOutputFormat="number"
+      />
+    </ChartPanel>
+  );
+}


### PR DESCRIPTION
Fancy new chart, fancy new selector. See a full breakdown of _all_ HTTP codes within the selected range!

**e.g.,**

<img width="784" alt="Screenshot 2024-04-10 at 4 05 09 PM" src="https://github.com/getsentry/sentry/assets/989898/d9c04170-f2bc-457e-9f97-556afa3e9842">
