### PR TITLE
fix(replay): Fix Breadcrumb filters to properly render hydration errors

### DIFF
--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -231,6 +231,7 @@ export const BreadcrumbCategories = [
   'navigation',
   'replay.init',
   'replay.mutations',
+  'replay.hydrate-error',
   'ui.blur',
   'ui.click',
   'ui.focus',

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -43,6 +43,7 @@ const TYPE_TO_LABEL: Record<string, string> = {
   action: 'User Action',
   rageOrMulti: 'Rage & Multi Click',
   rageOrDead: 'Rage & Dead Click',
+  hydrateError: 'Hydration Error',
   lcp: 'LCP',
   click: 'User Click',
   keydown: 'KeyDown',
@@ -65,6 +66,7 @@ const OPORCATEGORY_TO_TYPE: Record<string, keyof typeof TYPE_TO_LABEL> = {
   'ui.focus': 'action',
   'ui.multiClick': 'rageOrMulti',
   'ui.slowClickDetected': 'rageOrDead',
+  'replay.hydrate-error': 'hydrateError',
   'largest-contentful-paint': 'lcp',
   'ui.click': 'click',
   'ui.keyDown': 'keydown',
@@ -73,7 +75,11 @@ const OPORCATEGORY_TO_TYPE: Record<string, keyof typeof TYPE_TO_LABEL> = {
 };
 
 function typeToLabel(val: string): string {
-  return TYPE_TO_LABEL[val] ?? 'Unknown';
+  if (TYPE_TO_LABEL[val]) {
+    return TYPE_TO_LABEL[val];
+  }
+  Sentry.captureException('Unknown breadcrumb filter type');
+  return 'Unknown';
 }
 
 const FILTERS = {

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -1,5 +1,6 @@
 import type {RefObject} from 'react';
 import {useCallback, useMemo, useRef} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {uniq} from 'sentry/utils/array/uniq';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';


### PR DESCRIPTION
Now the Breadcrumb Filter dropdown correctly says "Hydration Error" and allows filtering for those items if they exist
<img width="341" alt="SCR-20240410-mgmg" src="https://github.com/getsentry/sentry/assets/187460/f8847a36-b885-40dc-a96b-5ed6961d9ccb">



Fixes https://github.com/getsentry/sentry/issues/68555