### PR TITLE
ref(code-mappings): Make file matching logic stricter, fix minor issue with find_roots

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -322,7 +322,7 @@ class CodeMappingTreesHelper:
             num_relevant_items = max(1, len(src_file_items) - 1)
             relevant_items = frame_items[(len(frame_items) - num_relevant_items) :]
             # relevant_path = "/".join(relevant_items)
-            return src_file_items.endswith(relevant_items)
+            return _list_endswith(src_file_items, relevant_items)
             # return src_file.endswith(relevant_path)
         else:  # exact match
             return src_file == frame_filename

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -80,6 +80,7 @@ class FrameFilename:
             raise UnsupportedFrameFilename("It needs an extension.")
 
         start_at_index = self._get_straight_path_prefix_end_index(frame_file_path)
+        self.straight_path_prefix = frame_file_path[:start_at_index]
         if start_at_index == 0:
             self.root = frame_file_path.split("/")[0]
         else:
@@ -325,7 +326,7 @@ class CodeMappingTreesHelper:
             return _list_endswith(src_file_items, relevant_items)
             # return src_file.endswith(relevant_path)
         else:  # exact match
-            return src_file == frame_filename
+            return src_file == frame_filename.full_path
 
     def _matches_existing_code_mappings(self, src_file: str) -> bool:
         """Check if the source file is already covered by an existing code mapping"""

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -285,7 +285,6 @@ class CodeMappingTreesHelper:
         source code. Use existing code mappings to exclude some source files
         """
 
-        # l1 shoudl be longer
         def _list_endswith(l1: list[str], l2: list[str]) -> bool:
             if len(l2) > len(l1):
                 l1, l2 = l2, l1

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -132,15 +132,15 @@ class TestFrameFilename:
     @pytest.mark.parametrize(
         "files,prefixes",
         [
-            ("FrameFilename('app:///utils/something.py').straight_path_prefix", "'app:///'"),
-            ("FrameFilename('./app/utils/something.py').straight_path_prefix", "'./'"),
+            ("FrameFilename('app:///utils/something.py').straight_path_prefix", "app:///"),
+            ("FrameFilename('./app/utils/something.py').straight_path_prefix", "./"),
             (
                 "FrameFilename('../../../../../../packages/something.py').straight_path_prefix",
-                "'../../../../../../'",
+                "../../../../../../",
             ),
             (
                 "FrameFilename('app:///../services/something.py').straight_path_prefix",
-                "'app:///../'",
+                "app:///../",
             ),
         ],
     )

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -132,13 +132,16 @@ class TestFrameFilename:
     @pytest.mark.parametrize(
         "files,prefixes",
         [
-            ("FrameFilename(app:///utils/something.py).straight_path_prefix", "app:///"),
-            ("FrameFilename(./app/utils/something.py).straight_path_prefix", "./"),
+            ("FrameFilename('app:///utils/something.py').straight_path_prefix", "'app:///'"),
+            ("FrameFilename('./app/utils/something.py').straight_path_prefix", "'./'"),
             (
-                "FrameFilename(../../../../../../packages/something.py).straight_path_prefix",
-                "../../../../../../",
+                "FrameFilename('../../../../../../packages/something.py').straight_path_prefix",
+                "'../../../../../../'",
             ),
-            ("FrameFilename(app:///../services/something.py).straight_path_prefix", "app:///../"),
+            (
+                "FrameFilename('app:///../services/something.py').straight_path_prefix",
+                "'app:///../'",
+            ),
         ],
     )
     def test_straight_path_prefix(self, files, prefixes):

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -132,10 +132,13 @@ class TestFrameFilename:
     @pytest.mark.parametrize(
         "files,prefixes",
         [
-            ("FrameFilename(app:///utils/something.py).straight_path_prefix"),
-            ("FrameFilename(./app/utils/something.py).straight_path_prefix"),
-            ("FrameFilename(../../../../../../packages/something.py).straight_path_prefix"),
-            ("FrameFilename(app:///../services/something.py).straight_path_prefix"),
+            ("FrameFilename(app:///utils/something.py).straight_path_prefix", "app:///"),
+            ("FrameFilename(./app/utils/something.py).straight_path_prefix", "./"),
+            (
+                "FrameFilename(../../../../../../packages/something.py).straight_path_prefix",
+                "../../../../../../",
+            ),
+            ("FrameFilename(app:///../services/something.py).straight_path_prefix", "app:///../"),
         ],
     )
     def test_straight_path_prefix(self, files, prefixes):

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -129,6 +129,17 @@ class TestFrameFilename:
             with pytest.raises(UnsupportedFrameFilename):
                 FrameFilename(filepath)
 
+    def test_straight_path_prefix(self):
+        app_path = "app:///utils/something.py"
+        dot_slash_path = "./app/utils/something.py"
+        dot_dot_slash_path = "../../../../../../packages/something.py"
+        combo_path = "app:///../services/something.py"
+
+        assert FrameFilename(app_path).straight_path_prefix == "app:///"
+        assert FrameFilename(dot_slash_path).straight_path_prefix == "./"
+        assert FrameFilename(dot_dot_slash_path).straight_path_prefix == "../../../../../../"
+        assert FrameFilename(combo_path).straight_path_prefix == "app:///../"
+
 
 class TestDerivedCodeMappings(TestCase):
     @pytest.fixture(autouse=True)

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -129,16 +129,17 @@ class TestFrameFilename:
             with pytest.raises(UnsupportedFrameFilename):
                 FrameFilename(filepath)
 
-    def test_straight_path_prefix(self):
-        app_path = "app:///utils/something.py"
-        dot_slash_path = "./app/utils/something.py"
-        dot_dot_slash_path = "../../../../../../packages/something.py"
-        combo_path = "app:///../services/something.py"
-
-        assert FrameFilename(app_path).straight_path_prefix == "app:///"
-        assert FrameFilename(dot_slash_path).straight_path_prefix == "./"
-        assert FrameFilename(dot_dot_slash_path).straight_path_prefix == "../../../../../../"
-        assert FrameFilename(combo_path).straight_path_prefix == "app:///../"
+    @pytest.mark.parametrize(
+        "files,prefixes",
+        [
+            ("FrameFilename(app:///utils/something.py).straight_path_prefix"),
+            ("FrameFilename(./app/utils/something.py).straight_path_prefix"),
+            ("FrameFilename(../../../../../../packages/something.py).straight_path_prefix"),
+            ("FrameFilename(app:///../services/something.py).straight_path_prefix"),
+        ],
+    )
+    def test_straight_path_prefix(self, files, prefixes):
+        assert eval(files) == prefixes
 
 
 class TestDerivedCodeMappings(TestCase):


### PR DESCRIPTION
This PR does two things:
1. It makes the logic that matches a file in a github repository to a stack trace file stricter in certain cases, and more accurate in general
2. It fixes a minor edge case with find_roots that caused a correct mapping to fail the safety check 

These fixes are in response to the logs captured by the safety checks added in the previous refactor. These safety checks ensured that these issue did not result in erroneous code mappings, thankfully. 