### PR TITLE
feat: Consumer defaults to auto.offset.reset earliest

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -300,7 +300,7 @@ def cron(**options: Any) -> None:
 @click.option(
     "--auto-offset-reset",
     "auto_offset_reset",
-    default="latest",
+    default="earliest",
     type=click.Choice(["earliest", "latest", "error"]),
     help="Position in the commit log topic to begin reading from when no prior offset has been recorded.",
 )


### PR DESCRIPTION
Earliest is a safer default than latest. For example if we increase partition count in production, we need to start new partitions from the earliest point otherwise we run the risk of skipping messages.

We will apply this default for all sentry consumers including the snuba ones: https://github.com/getsentry/snuba/pull/5753

After this is merged, we can remove all the manually passed values in ops and use this default