### PR TITLE
fix(celery): Expose task correctly so it gets picked up

### DIFF
--- a/src/sentry/integrations/slack/tasks/__init__.py
+++ b/src/sentry/integrations/slack/tasks/__init__.py
@@ -1,3 +1,3 @@
-from sentry.integrations.slack.tasks.send_notifications_on_activity import (  # noqa
-    send_activity_notifications_to_slack_threads,
-)
+from .send_notifications_on_activity import send_activity_notifications_to_slack_threads
+
+__all__ = ("send_activity_notifications_to_slack_threads",)

--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -47,8 +47,6 @@ def send_activity_notifications_to_slack_threads(activity_id) -> None:
                 sample_rate=1.0,
             )
 
-    _default_logger.info("task completed", extra={"activity_id": activity_id})
-
 
 @receiver(post_save, sender=Activity)
 def activity_created_receiver(instance, created, **kwargs):


### PR DESCRIPTION
We were not correctly exposing the celery task, which led to a key error

Resolves: https://sentry.sentry.io/issues/4271076192/?project=1&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+send_activity_notifications_to_slack_threads&referrer=issue-stream&statsPeriod=14d&stream_index=0