### PR TITLE
feat(platform): Adding a new native platform

### DIFF
--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -31,6 +31,7 @@ class EventAppleCrashReportEndpoint(ProjectEndpoint):
         if event is None:
             raise ResourceDoesNotExist
 
+        # TODO @athena: remove comment before merging
         if event.platform not in ("cocoa", "native"):
             return HttpResponse(
                 {"message": "Only cocoa events can return an apple crash report"}, status=403

--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -33,6 +33,7 @@ from sentry.utils import json
 
 
 class LayoutSerializer(serializers.Serializer):
+    # TODO @athena: remove comment before merging
     """
     Layout settings for the source. This is required for HTTP, GCS, and S3 sources and invalid for AppStoreConnect sources.
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -35,7 +35,9 @@ MAX_SQL_FORMAT_LENGTH = 1500
 
 
 def get_crash_files(events):
-    event_ids = [x.event_id for x in events if x.platform == "native"]
+    event_ids = [
+        x.event_id for x in events if (x.platform == "native" or x.platform == "nintendo-switch")
+    ]
     if event_ids:
         return [
             ea

--- a/src/sentry/culprit.py
+++ b/src/sentry/culprit.py
@@ -62,7 +62,7 @@ def get_frame_culprit(frame, platform):
     # was passed in (as that one comes from the exception which might
     # not necessarily be the same platform).
     platform = frame.get("platform") or platform
-    if platform in ("objc", "cocoa", "native"):
+    if platform in ("objc", "cocoa", "native", "nintendo-switch"):
         return frame.get("function") or "?"
     fileloc = frame.get("module") or frame.get("filename")
     if not fileloc:

--- a/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass
 # The aforementioned query has been simplified for the scope of this comment. In order to get more in-depth
 # explanations a research document has been written on Notion at:
 # https://www.notion.so/sentry/Exploration-of-Static-Time-to-Adoption-bbd98781ecb94c33be15108b0200db8e
+
+# TODO @athena: remove this comment before merging
 LATEST_RELEASE_TTAS = {
     "android": 43747,
     "apple": 1423869,

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -98,6 +98,7 @@ class ErrorEvent(BaseEvent):
             "dart-flutter",
             "unity",
             "dotnet-xamarin",
+            "nintendo-switch",
         )
 
         return rv

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -112,7 +112,7 @@ def get_basename(string: str) -> str:
 
 
 def get_package_component(package: str, platform: str | None) -> GroupingComponent:
-    if package is None or platform != "native":
+    if package is None or (platform != "native" and platform != "nintendo-switch"):
         return GroupingComponent(id="package")
 
     package = get_basename(package).lower()
@@ -382,6 +382,7 @@ def frame(
         context_line_component.update(tree_label=function_component.tree_label)
         values.append(context_line_component)
 
+    # TODO @athena: delete comment before merging
     if (
         context["discard_native_filename"]
         and get_behavior_family_for_platform(platform) == "native"

--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -175,6 +175,7 @@ def _handles_frame(frame, data):
         return False
 
     # Skip "native" frames
+    # TODO @athena: remove comment before merging
     if _is_native_frame(abs_path):
         return False
 

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -40,6 +40,7 @@ MINIDUMP_ATTACHMENT_TYPE = "event.minidump"
 APPLECRASHREPORT_ATTACHMENT_TYPE = "event.applecrashreport"
 
 
+# TODO @athena: remove this comment before merging
 def _merge_frame(new_frame, symbolicated, platform="native"):
     # il2cpp events which have the "csharp" platform have good (C#) names
     # coming from the SDK, we do not want to override those with bad (mangled) C++ names.

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -17,7 +17,7 @@ WINDOWS_PATH_RE = re.compile(r"^([a-z]:\\|\\\\)", re.IGNORECASE)
 # "csharp" events are also considered "native" as they are processed by symbolicator.
 # This includes il2cpp events that are symbolicated using native debug files,
 # as well as .NET with Portable PDB files which are handled by symbolicator.
-NATIVE_PLATFORMS = ("objc", "cocoa", "swift", "native", "c", "csharp")
+NATIVE_PLATFORMS = ("objc", "cocoa", "swift", "native", "c", "csharp", "nintendo-switch")
 
 # Debug image types that can be handled by the symbolicator
 NATIVE_IMAGE_TYPES = (

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -110,7 +110,7 @@ GETTING_STARTED_DOCS_PLATFORMS = [
     "minidump",
     "native",
     "native-qt",
-    "nintendo",
+    "nintendo-switch",
     "node",
     "node-awslambda",
     "node-azurefunctions",

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -506,6 +506,7 @@ def run_symbolicate(
     if platform in SHOULD_SYMBOLICATE_JS:
         symbolicator_platform = SymbolicatorPlatform.js
     else:
+        # TODO @athena: remove comment before merging
         symbolicator_platform = SymbolicatorPlatform.native
     symbolicator = Symbolicator(
         task_kind=SymbolicatorTaskKind(platform=symbolicator_platform),

--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -107,6 +107,7 @@ def trim_function_name(function, platform, normalize_lambdas=True):
     """
     if platform == "csharp":
         return trim_csharp_function_name(function)
+    # TODO @athena: remove this comment before merging
     if get_behavior_family_for_platform(platform) == "native":
         return trim_native_function_name(function, platform, normalize_lambdas=normalize_lambdas)
     return function

--- a/src/sentry/stacktraces/platform.py
+++ b/src/sentry/stacktraces/platform.py
@@ -1,4 +1,4 @@
-NATIVE_PLATFORMS = frozenset(("objc", "cocoa", "swift", "native", "c"))
+NATIVE_PLATFORMS = frozenset(("objc", "cocoa", "swift", "native", "c", "nintendo-switch"))
 JAVASCRIPT_PLATFORMS = frozenset(("javascript", "node"))
 
 

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -122,6 +122,7 @@ def get_symbolication_platforms(
         platforms.append(SymbolicatorPlatform.jvm)
     if is_js_event(data, stacktraces):
         platforms.append(SymbolicatorPlatform.js)
+    # TODO @athena: remove comment before merging
     if get_native_symbolication_function(data, stacktraces) is not None:
         platforms.append(SymbolicatorPlatform.native)
 
@@ -161,6 +162,7 @@ def _do_symbolicate_event(
 
     # Backwards compatibility: If the current platform is JS, we may need to do
     # native afterwards. Otherwise we don't do anything.
+    # TODO @athena: remove comment before merge
     if symbolicate_platforms is None:
         if (
             task_kind.platform == SymbolicatorPlatform.js

--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -145,7 +145,7 @@ DESKTOP = [
 
 # TODO: @athena Remove this
 # This is only temporary since we decide the right category. Don't add anything here or your frontend experience will be broken
-TEMPORARY = ["nintendo"]
+TEMPORARY = ["nintendo-switch"]
 
 CATEGORY_LIST = [
     {id: "browser", "name": _("Browser"), "platforms": FRONTEND},

--- a/src/sentry/utils/rust.py
+++ b/src/sentry/utils/rust.py
@@ -225,6 +225,7 @@ def merge_rust_info_frames(event, hint):
         return event
 
     # Update the platform
+    # TODO @athena: Remove the comment before merging
     event["platform"] = "native"
     for frame in stacktrace:
         frame["platform"] = "python"

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -201,6 +201,7 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
         )
         configs.append(java_config)
 
+    # TODO @athena: remove comment before merging
     native_options = _get_options(sdk_name=SdkName.Native, has_organization_allowlist=True)
 
     if native_options:

--- a/src/sentry/utils/tag_normalization.py
+++ b/src/sentry/utils/tag_normalization.py
@@ -87,7 +87,7 @@ def normalize_sdk_tag(tag: str) -> str:
         return "other"
 
     # collapse tags other than JavaScript / Native to their top-level SDK
-
+    # TODO @athena: Remove comment before merging
     if not tag.split(".")[1] in {"javascript", "native"}:
         tag = ".".join(tag.split(".", 2)[0:2])
 


### PR DESCRIPTION
**This PR is up only to ask questions. Please check my comments and help with your domain.**

I'm adding a new platform which has a custom sdk built for. Right now the sdk is using "native" as platform but they're moving towards using "nintendo-switch" instead. So my goal is to make sure after that change in the SDK nothing breaks. I already covered frontend and UI changes. This my attempt for the backend.

The reason we're creating a new platform is that a lot of product features are platform specific. For example if we use native sdk instead it comes with support for performance and product will be full of performance related onboarding material. We like to create a separate platform to be able to say this platform doesn't support performance, replay or user feedback.