### PR TITLE
fix(performance): Add trailing slash to links

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -329,7 +329,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={t('App Starts')}
-                  to={`/organizations/${organization.slug}/performance/mobile/app-startup`}
+                  to={`/organizations/${organization.slug}/performance/mobile/app-startup/`}
                   id="performance-mobile-app-startup"
                   icon={<SubitemDot collapsed />}
                   isNew
@@ -339,7 +339,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
-                  to={`/organizations/${organization.slug}/performance/browser/resources`}
+                  to={`/organizations/${organization.slug}/performance/browser/resources/`}
                   id="performance-browser-resources"
                   icon={<SubitemDot collapsed />}
                 />
@@ -348,7 +348,7 @@ function Sidebar() {
                 <SidebarItem
                   {...sidebarItemProps}
                   label={<GuideAnchor target="traces">{t('Traces')}</GuideAnchor>}
-                  to={`/organizations/${organization.slug}/performance/traces`}
+                  to={`/organizations/${organization.slug}/performance/traces/`}
                   id="performance-trace-explorer"
                   icon={<SubitemDot collapsed />}
                 />

--- a/static/app/views/starfish/components/spanDescriptionLink.tsx
+++ b/static/app/views/starfish/components/spanDescriptionLink.tsx
@@ -47,7 +47,7 @@ export function SpanDescriptionLink({
           to={normalizeUrl(
             `/organizations/${organization.slug}${routingContext.baseURL}/${
               extractRoute(location) ?? 'spans'
-            }/span/${group}?${qs.stringify(queryString)}`
+            }/span/${group}/?${qs.stringify(queryString)}`
           )}
         >
           {description}


### PR DESCRIPTION
Fixes the flashing when changing routes, possibly because the redirect takes you out of the view with the sidebar? Forcing it to destroy the sidebar and add it back? Not totally sure.