### PR TITLE
ref(relocation): Minor copy improvements

### DIFF
--- a/static/app/views/relocation/encryptBackup.tsx
+++ b/static/app/views/relocation/encryptBackup.tsx
@@ -65,7 +65,7 @@ export function EncryptBackup(props: StepProps) {
           {t('encrypts the data using our public key, and ')}
           <mark>{'/sentry-admin/export.tar'}</mark>
           {t(
-            'is the name of the output tarball. This is what youll upload in the next step.'
+            "is the name of the output tarball. This is what you'll upload in the next step."
           )}
         </p>
         <p className="encrypt-note">

--- a/static/app/views/relocation/encryptBackup.tsx
+++ b/static/app/views/relocation/encryptBackup.tsx
@@ -28,8 +28,10 @@ export function EncryptBackup(props: StepProps) {
       >
         <p>
           {t(
-            'You’ll need to have the public key saved in the previous step accessible when you run the following command in your terminal. Make sure your current working directory is the root of your `self-hosted` install when you execute it.'
+            'You’ll need to have the public key saved in the previous step accessible when you run the following command in your terminal. Make sure your current working directory is the root of your '
           )}
+          <mark>self-hosted</mark>
+          {t('install when you execute it.')}
         </p>
         <RelocationCodeBlock
           dark
@@ -44,35 +46,32 @@ export function EncryptBackup(props: StepProps) {
           <b>{t('Understanding the command:')}</b>
         </p>
         <p>
-          <mark>{'SENTRY_DOCKER_IO_DIR=/path/to/key'}</mark>
-          {t('Map local directory to ')}
-          <mark>{'/sentry-admin'}</mark>
-          {t('in your Docker container.')}
-        </p>
-        <p>
-          <mark>{'./sentry-admin.sh'}</mark>
+          {t('The ')}
+          <mark>{'SENTRY_DOCKER_IO_DIR=/path/to/key/dir'}</mark>
           {t(
-            'This is a script present in your self-hosted installation containing admin tools.'
+            'environment variable maps the local directory where you saved your public key in the previous step to a '
           )}
-        </p>
-        <p>
-          <mark>{'export global'}</mark>
-          {t('Perform a global export of your entire self-hosted instance.')}
-        </p>
-        <p>
-          <mark>{'--encrypt-with /sentry-admin/key.pub'}</mark>
-          {t('Encrypts the export with the public key created in the last step.')}
-        </p>
-        <p>
-          <mark>{'/sentry-admin/file.tar'}</mark>
+          <mark>{'/sentry-admin'}</mark>
+          {t('volume in your Docker container. ')}
+          <mark>{'./sentry-admin.sh'}</mark>
+          {t('is a script included by default with your ')}
+          <mark>{'self-hosted'}</mark>
           {t(
-            'Writes the export file into the same directory where the public key file is located.'
+            'installation which contains a number of administrative tools. One of these is the'
+          )}
+          <mark>{'export global'}</mark>
+          {t('command for backing up all Sentry data. ')}
+          <mark>{'--encrypt-with /sentry-admin/key.pub'}</mark>
+          {t('encrypts the data using our public key, and ')}
+          <mark>{'/sentry-admin/export.tar'}</mark>
+          {t(
+            'is the name of the output tarball. This is what youll upload in the next step.'
           )}
         </p>
         <p className="encrypt-note">
           <i>
-            {t('Note: Depending on your configuration, you may need to use ')}
-            <mark>sudo</mark>
+            {t('Note: Depending on your system configuration, you may need to use ')}
+            <mark>sudo -E</mark>
             {t('for this command.')}
           </i>
         </p>

--- a/static/app/views/relocation/relocation.tsx
+++ b/static/app/views/relocation/relocation.tsx
@@ -323,6 +323,11 @@ const Container = styled('div')`
   padding: 120px ${space(3)};
   width: 100%;
   margin: 0 auto;
+
+  p,
+  a {
+    line-height: 1.6;
+  }
 `;
 
 const Header = styled('header')`

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -132,7 +132,7 @@ export function UploadBackup({onComplete}: StepProps) {
       >
         <p>
           {t(
-            'Nearly done! Just upload your tarball to here, and well send you an email when everything is ready to go!'
+            'Nearly done! Just upload your tarball here, and well send you an email when everything is ready to go!'
           )}
         </p>
         {file ? (

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -132,7 +132,7 @@ export function UploadBackup({onComplete}: StepProps) {
       >
         <p>
           {t(
-            'Nearly done! Just upload your tarball here, and well send you an email when everything is ready to go!'
+            "Nearly done! Just upload your tarball here, and we'll send you an email when everything is ready to go!"
           )}
         </p>
         {file ? (

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -132,7 +132,7 @@ export function UploadBackup({onComplete}: StepProps) {
       >
         <p>
           {t(
-            'Nearly done! The file is being uploaded to sentry for the relocation process. You can close this tab if you like. We will email  when complete.'
+            'Nearly done! Just upload your tarball to here, and well send you an email when everything is ready to go!'
           )}
         </p>
         {file ? (


### PR DESCRIPTION
The most relevant changes are seen in this image:

![Screenshot 2024-04-10 at 16 17 18](https://github.com/getsentry/sentry/assets/3709945/e467819c-4e7f-4f34-8c5e-0ac80b2cfb5a)

I made the "understand this command" section more paragraph based and increased the line height a bit to make it easier to read. I've also made some small copy changes to the other instructions.
