### PR TITLE
fix(alerts): Use same key for default issue alert rule

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -860,7 +860,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         alert_rule_created.send_robust(
             user=request.user,
             project=project,
-            rule=rule,
+            rule_id=rule.id,
             rule_type="issue",
             sender=self,
             is_api_token=request.auth is not None,

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -123,7 +123,7 @@ class AlertRuleIndexMixin(Endpoint):
                     alert_rule_created.send_robust(
                         user=request.user,
                         project=sub.project,
-                        rule=alert_rule,
+                        rule_id=alert_rule.id,
                         rule_type="metric",
                         sender=self,
                         referrer=referrer,

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -12,12 +12,6 @@ from sentry.models.project import Project
 from sentry.plugins.bases.issue import IssueTrackingPlugin
 from sentry.plugins.bases.issue2 import IssueTrackingPlugin2
 from sentry.plugins.bases.notify import NotificationPlugin
-from sentry.receivers.rules import (
-    DEFAULT_RULE_DATA,
-    DEFAULT_RULE_DATA_NEW,
-    DEFAULT_RULE_LABEL,
-    DEFAULT_RULE_LABEL_NEW,
-)
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.signals import (
     advanced_search,
@@ -303,10 +297,10 @@ def record_inbound_filter_toggled(project, **kwargs):
 @alert_rule_created.connect(weak=False)
 def record_alert_rule_created(
     user,
-    project,
-    rule,
-    rule_type,
-    is_api_token,
+    project: Project,
+    rule_id: int,
+    rule_type: str,
+    is_api_token: bool,
     referrer=None,
     session_id=None,
     alert_rule_ui_component=None,
@@ -314,13 +308,6 @@ def record_alert_rule_created(
     wizard_v3=None,
     **kwargs,
 ):
-    if (
-        rule_type == "issue"
-        and rule.label in [DEFAULT_RULE_LABEL, DEFAULT_RULE_LABEL_NEW]
-        and rule.data in [DEFAULT_RULE_DATA, DEFAULT_RULE_DATA_NEW]
-    ):
-        return
-
     FeatureAdoption.objects.record(
         organization_id=project.organization_id, feature_slug="alert_rules", complete=True
     )
@@ -337,7 +324,7 @@ def record_alert_rule_created(
         default_user_id=default_user_id,
         organization_id=project.organization_id,
         project_id=project.id,
-        rule_id=rule.id,
+        rule_id=rule_id,
         rule_type=rule_type,
         referrer=referrer,
         session_id=session_id,

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -308,6 +308,8 @@ def record_alert_rule_created(
     wizard_v3=None,
     **kwargs,
 ):
+    # NOTE: This intentionally does not fire for the default issue alert rule
+    # that gets created on new project creation.
     FeatureAdoption.objects.record(
         organization_id=project.organization_id, feature_slug="alert_rules", complete=True
     )

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -555,7 +555,7 @@ def record_plugin_enabled(plugin, project, user, **kwargs):
 
 
 @alert_rule_created.connect(weak=False)
-def record_alert_rule_created(user, project, rule, rule_type, **kwargs):
+def record_alert_rule_created(user, project: Project, rule_type: str, **kwargs):
     task = OnboardingTask.METRIC_ALERT if rule_type == "metric" else OnboardingTask.ALERT_RULE
     rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
         organization_id=project.organization_id,

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -556,6 +556,8 @@ def record_plugin_enabled(plugin, project, user, **kwargs):
 
 @alert_rule_created.connect(weak=False)
 def record_alert_rule_created(user, project: Project, rule_type: str, **kwargs):
+    # NOTE: This intentionally does not fire for the default issue alert rule
+    # that gets created on new project creation.
     task = OnboardingTask.METRIC_ALERT if rule_type == "metric" else OnboardingTask.ALERT_RULE
     rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
         organization_id=project.organization_id,

--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -14,7 +14,7 @@ DEFAULT_RULE_ACTIONS = [
     }
 ]
 DEFAULT_RULE_DATA = {
-    "match": "all",
+    "action_match": "all",
     "conditions": [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}],
     "actions": DEFAULT_RULE_ACTIONS,
 }
@@ -29,7 +29,7 @@ DEFAULT_RULE_ACTIONS_NEW = [
     }
 ]
 DEFAULT_RULE_DATA_NEW = {
-    "match": "all",
+    "action_match": "all",
     "conditions": [
         {"id": "sentry.rules.conditions.high_priority_issue.HighPriorityIssueCondition"}
     ],

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -535,7 +535,7 @@ class FeatureAdoptionTest(TestCase, SnubaTestCase):
         alert_rule_created.send(
             user=self.owner,
             project=self.project,
-            rule=rule,
+            rule_id=rule.id,
             rule_type="issue",
             sender=type(self.project),
             is_api_token=False,

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -488,7 +488,7 @@ class OrganizationOnboardingTaskTest(TestCase):
             is_api_token=False,
         )
         alert_rule_created.send(
-            rule=Rule(id=1),
+            rule_id=Rule(id=1).id,
             project=self.project,
             user=self.user,
             rule_type="metric",

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -319,7 +319,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
     def test_alert_added(self):
         alert_rule_created.send(
-            rule=Rule(id=1),
+            rule_id=Rule(id=1).id,
             project=self.project,
             user=self.user,
             rule_type="issue",
@@ -383,7 +383,7 @@ class OrganizationOnboardingTaskTest(TestCase):
 
     def test_metric_added(self):
         alert_rule_created.send(
-            rule=Rule(id=1),
+            rule_id=Rule(id=1).id,
             project=self.project,
             user=self.user,
             rule_type="metric",
@@ -480,7 +480,7 @@ class OrganizationOnboardingTaskTest(TestCase):
             sender=None,
         )
         alert_rule_created.send(
-            rule=Rule(id=1),
+            rule_id=Rule(id=1).id,
             project=self.project,
             user=self.user,
             rule_type="issue",


### PR DESCRIPTION
### Summary

For the Rule model, we have the `data` field which stores conditions, filters, and actions in a generic JSON.
The `action_map` key in `data` stores the predicate to apply to conditions (e.g all/any), but in code the default issue alert rule is created with the match keyword instead.
https://github.com/getsentry/sentry/blob/31ae2c762dccf5d1101b0ccad891cdb5b7b7a0c4/src/sentry/receivers/rules.py#L16-L20


Both creating and updating an alert rule use the `action_match` key.
https://github.com/getsentry/sentry/blob/176e167c9939a4b8d0f9105b281c8209ec4f1ac5/src/sentry/api/endpoints/project_rules.py#L806
https://github.com/getsentry/sentry/blob/0c8e763bc366fe9b52b94bce3f6af3fb61b2d2c0/src/sentry/api/endpoints/project_rule_details.py#L308

So what happens is:
1. Someone creates a default alert rule by creating a new project where `match` is the key in `data` set to ALL.
2. The rule triggers, and we only check for the action_match key, [falling back to the default](https://github.com/getsentry/sentry/blob/a34ede786c38c9d507afbf1ee34c2f73c6f40276/src/sentry/rules/processing/processor.py#L198) ALL if it's not there
   - This matches the default setting of also ALL

### Confusing Data
I've confirmed this is true in [Redash](https://redash.getsentry.net/queries/5203), where the issue alert rules have `match`, `action_match`, and sometimes both. We should not use duplicate keys for the same value, where one key is not even used.

The only place where we checked `match` is when recording analytics for creating alert rules, but that signal doesn't even trigger when the default issue alert rule is created 😡
https://github.com/getsentry/sentry/blob/4022dc3b696db4abdd45cb1b12b7e0d48dcd5db3/src/sentry/receivers/features.py#L317-L322