### PR TITLE
feat(sdk-crash): Keep more exception fields

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event_cocoa.py
+++ b/fixtures/sdk_crash_detection/crash_event_cocoa.py
@@ -127,6 +127,7 @@ def get_crash_event_with_frames(
                     "mechanism": {
                         "handled": handled,
                         "type": "mach",
+                        "synthetic": False,
                         "meta": {
                             "signal": {
                                 "number": 11,
@@ -139,6 +140,10 @@ def get_crash_event_with_frames(
                                 "code": 1,
                                 "subcode": 0,
                                 "name": "EXC_BAD_ACCESS",
+                            },
+                            "errno": {
+                                "number": 10,
+                                "name": "EACCES",
                             },
                         },
                     },

--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -61,6 +61,7 @@ EVENT_DATA_ALLOWLIST = {
             "type": Allow.SIMPLE_TYPE,
             "mechanism": {
                 "handled": Allow.SIMPLE_TYPE,
+                "synthetic": Allow.SIMPLE_TYPE,
                 "type": Allow.SIMPLE_TYPE,
                 "meta": {
                     "signal": {
@@ -73,6 +74,10 @@ EVENT_DATA_ALLOWLIST = {
                         "exception": Allow.SIMPLE_TYPE,
                         "code": Allow.SIMPLE_TYPE,
                         "subcode": Allow.SIMPLE_TYPE,
+                        "name": Allow.SIMPLE_TYPE,
+                    },
+                    "errno": {
+                        "number": Allow.SIMPLE_TYPE,
                         "name": Allow.SIMPLE_TYPE,
                     },
                 },

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -170,6 +170,7 @@ def test_strip_event_data_keeps_exception_mechanism(store_event, configs):
 
     assert mechanism == {
         "handled": False,
+        "synthetic": False,
         "type": "mach",
         "meta": {
             "signal": {"number": 11, "code": 0, "name": "SIGSEGV", "code_name": "SEGV_NOOP"},
@@ -178,6 +179,10 @@ def test_strip_event_data_keeps_exception_mechanism(store_event, configs):
                 "code": 1,
                 "subcode": 0,
                 "name": "EXC_BAD_ACCESS",
+            },
+            "errno": {
+                "number": 10,
+                "name": "EACCES",
             },
         },
     }


### PR DESCRIPTION
Keep non PII related fields: synthetic and errno with number and name.

We need to keep the synthetic field for grouping because otherwise we group by exception type, which contains memory addresses, see:

| Without synthetic | With Synthetic |
|--------|--------|
| ![CleanShot 2024-04-11 at 11 19 33@2x](https://github.com/getsentry/sentry/assets/2443292/8a0a6b2c-f51b-4deb-aa92-748cbcc1a614) | ![CleanShot 2024-04-11 at 11 19 11@2x](https://github.com/getsentry/sentry/assets/2443292/15f53480-6fb8-496a-8eb2-a8985615cc91)| 

I also added errno with number and name because they don't contain PII, and can be useful.





