### PR TITLE
feat(scraping): Pass `verify_ssl` to Symbolicator

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -268,6 +268,7 @@ def get_scraping_config(project: Project) -> dict[str, Any]:
     allow_scraping_org_level = project.organization.get_option("sentry:scrape_javascript", True)
     allow_scraping_project_level = project.get_option("sentry:scrape_javascript", True)
     allow_scraping = allow_scraping_org_level and allow_scraping_project_level
+    verify_ssl = project.get_option("sentry:verify_ssl", True)
 
     allowed_origins = []
     scraping_headers = {}
@@ -283,6 +284,7 @@ def get_scraping_config(project: Project) -> dict[str, Any]:
         "enabled": allow_scraping,
         "headers": scraping_headers,
         "allowed_origins": allowed_origins,
+        "verify_ssl": verify_ssl,
     }
 
 


### PR DESCRIPTION
Companion PR to https://github.com/getsentry/symbolicator/pull/1435.

This passes the "Verify TLS/SSL" project setting to Symbolicator through the `scraping_config`. If it's unset, we default to `True` for security, although I'm not sure if it's ever unset. Still, better safe than sorry.