### PR TITLE
feat(sdk-crash): Keep sdk frame path for native

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event_native.py
+++ b/fixtures/sdk_crash_detection/crash_event_native.py
@@ -3,7 +3,9 @@ from collections.abc import Mapping, MutableMapping, Sequence
 
 
 def get_frames(
-    sdk_frame_function: str, system_frame_package: str
+    sdk_frame_function: str,
+    sdk_frame_package: str,
+    system_frame_package: str,
 ) -> Sequence[MutableMapping[str, str]]:
     frames = [
         {
@@ -24,7 +26,7 @@ def get_frames(
         {
             "function": sdk_frame_function,
             "symbol": sdk_frame_function,
-            "package": "E:\\Sentry\\Sentaurs\\Game\\Sentaurs.exe",
+            "package": sdk_frame_package,
         },
         {
             "function": "boost::serialization::singleton<T>::singleton<T>",
@@ -37,11 +39,12 @@ def get_frames(
 
 def get_crash_event(
     sdk_frame_function="sentry_value_to_msgpack",
+    sdk_frame_package="E:\\Sentry\\Sentaurs\\Game\\Sentaurs.exe",
     system_frame_package="C:\\Windows\\System32\\DriverStore\\FileRepository\\u0398226.inf_amd64_c5d9587384e4b5ff\\B398182\\amdxx64.dll",
     **kwargs,
 ) -> dict[str, object]:
     return get_crash_event_with_frames(
-        get_frames(sdk_frame_function, system_frame_package),
+        get_frames(sdk_frame_function, sdk_frame_package, system_frame_package),
         **kwargs,
     )
 

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -244,11 +244,13 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
                     r"sentry__*",  # module level interface
                     r"Java_io_sentry_android_ndk_*",  # JNI interface
                 },
-                # The native SDK usually has the same path as the application binary.
-                # Therefore, we can't rely on it. We set a fixed path of Sentry for
-                # the SDK frames are so it's not empty.
                 path_patterns=set(),
-                path_replacer=FixedPathReplacer(path="sentry"),
+                path_replacer=KeepAfterPatternMatchPathReplacer(
+                    patterns={
+                        r"sentry_.*",
+                    },
+                    fallback_path="sentry",
+                ),
             ),
             sdk_crash_ignore_functions_matchers=set(),
         )

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_native.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_native.py
@@ -174,6 +174,62 @@ def test_sdk_crash_is_reported_with_native_paths(
         assert mock_sdk_crash_reporter.report.call_count == 0
 
 
+@pytest.mark.parametrize(
+    ["sdk_frame_function", "sdk_frame_package", "expected_sdk_frame_package"],
+    [
+        (
+            "sentry_sync",
+            "C:\\GitLab-Runner\\builds\\WEFASW\\0\\3rdParty\\Sentry\\upstream\\src\\sentry_sync.h",
+            "sentry_sync.h",
+        ),
+        (
+            "sentry_value_to_msgpack",
+            "sentry._sentry.h",
+            "sentry",
+        ),
+        (
+            "sentry_value_to_msgpack",
+            "some_weird_path/sentry__.h",
+            "sentry__.h",
+        ),
+    ],
+)
+@decorators
+def test_sdk_crash_sentry_native_keeps_sentry_package_paths(
+    mock_sdk_crash_reporter,
+    mock_random,
+    store_event,
+    configs,
+    sdk_frame_function,
+    sdk_frame_package,
+    expected_sdk_frame_package,
+):
+    event = store_event(
+        data=get_crash_event(
+            sdk_frame_function=sdk_frame_function, sdk_frame_package=sdk_frame_package
+        )
+    )
+
+    configs[1].organization_allowlist = [event.project.organization_id]
+
+    sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
+
+    assert mock_sdk_crash_reporter.report.call_count == 1
+    reported_event_data = mock_sdk_crash_reporter.report.call_args.args[0]
+
+    stripped_frames = get_path(
+        reported_event_data, "exception", "values", -1, "stacktrace", "frames"
+    )
+
+    assert len(stripped_frames) == 4
+
+    sdk_frame = stripped_frames[2]
+    assert sdk_frame["function"] == sdk_frame_function
+    assert sdk_frame["symbol"] == sdk_frame_function
+    assert sdk_frame["package"] == expected_sdk_frame_package
+    assert sdk_frame["in_app"] is True
+
+
 @decorators
 def test_beta_sdk_version_detected(mock_sdk_crash_reporter, mock_random, store_event, configs):
     event_data = get_crash_event()


### PR DESCRIPTION
Keep the SDK frame path for native without keeping application-related path information.
