### PR TITLE
feat(metrics): Add abuse quotas for all namespaces and scopes

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -17,6 +17,7 @@ from sentry.options.manager import (
     FLAG_REQUIRED,
     FLAG_SCALAR,
 )
+from sentry.quotas.base import build_metric_abuse_quotas
 from sentry.utils.types import Any, Bool, Dict, Float, Int, Sequence, String
 
 # Cache
@@ -1170,40 +1171,13 @@ register(
 )
 
 
-register(
-    "global-abuse-quota.metric-bucket-limit",
-    type=Int,
-    default=0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "global-abuse-quota.sessions-metric-bucket-limit",
-    type=Int,
-    default=0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "global-abuse-quota.transactions-metric-bucket-limit",
-    type=Int,
-    default=0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "global-abuse-quota.spans-metric-bucket-limit",
-    type=Int,
-    default=0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "global-abuse-quota.custom-metric-bucket-limit",
-    type=Int,
-    default=0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
+for mabq in build_metric_abuse_quotas():
+    register(
+        mabq.option,
+        type=Int,
+        default=0,
+        flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+    )
 
 # END ABUSE QUOTAS
 

--- a/tests/sentry/quotas/test_redis.py
+++ b/tests/sentry/quotas/test_redis.py
@@ -174,11 +174,10 @@ class RedisQuotaTest(TestCase):
             assert quota.scope_id is None
             assert quota.categories == {DataCategory.METRIC_BUCKET}
             assert quota.limit == metric_abuse_limit_by_id[id] * 10
-            assert (
-                quota.namespace == expected_use_case.value
-                if expected_use_case is not None
-                else None
-            )
+            if expected_use_case is None:
+                assert quota.namespace is None
+            else:
+                assert quota.namespace == expected_use_case.value
             assert quota.window == 10
             if expected_scope == QuotaScope.GLOBAL:
                 assert quota.reason_code == "global_abuse_limit"

--- a/tests/sentry/quotas/test_redis.py
+++ b/tests/sentry/quotas/test_redis.py
@@ -5,8 +5,9 @@ from unittest import mock
 import pytest
 
 from sentry.constants import DataCategory
-from sentry.quotas.base import QuotaConfig, QuotaScope
+from sentry.quotas.base import QuotaConfig, QuotaScope, build_metric_abuse_quotas
 from sentry.quotas.redis import RedisQuota, is_rate_limited
+from sentry.sentry_metrics.use_case_id_registry import USE_CASE_ID_CARDINALITY_LIMIT_QUOTA_OPTIONS
 from sentry.testutils.cases import TestCase
 from sentry.utils.redis import clusters
 
@@ -118,11 +119,12 @@ class RedisQuotaTest(TestCase):
         self.organization.update_option("project-abuse-quota.session-limit", 602)
         self.organization.update_option("organization-abuse-quota.metric-bucket-limit", 603)
         self.organization.update_option("organization-abuse-quota.custom-metric-bucket-limit", 604)
-        self.organization.update_option("global-abuse-quota.metric-bucket-limit", 605)
-        self.organization.update_option("global-abuse-quota.sessions-metric-bucket-limit", 606)
-        self.organization.update_option("global-abuse-quota.transactions-metric-bucket-limit", 607)
-        self.organization.update_option("global-abuse-quota.spans-metric-bucket-limit", 608)
-        self.organization.update_option("global-abuse-quota.custom-metric-bucket-limit", 609)
+
+        metric_abuse_limit_by_id = dict()
+        for i, mabq in enumerate(build_metric_abuse_quotas()):
+            self.organization.update_option(mabq.option, 700 + i)
+            metric_abuse_limit_by_id[mabq.id] = 700 + i
+
         with self.feature("organizations:transaction-metrics-extraction"):
             quotas = self.quota.get_quotas(self.project)
 
@@ -150,66 +152,34 @@ class RedisQuotaTest(TestCase):
         assert quotas[3].window == 10
         assert quotas[3].reason_code == "project_abuse_limit"
 
-        assert quotas[4].id == "oam"
-        assert quotas[4].scope == QuotaScope.ORGANIZATION
-        assert quotas[4].scope_id is None
-        assert quotas[4].categories == {DataCategory.METRIC_BUCKET}
-        assert quotas[4].limit == 6030
-        assert quotas[4].window == 10
-        assert quotas[4].reason_code == "org_abuse_limit"
+        expected_quotas = dict()
+        for scope, prefix in [
+            (QuotaScope.PROJECT, "p"),
+            (QuotaScope.ORGANIZATION, "o"),
+            (QuotaScope.GLOBAL, "g"),
+        ]:
+            expected_quotas[(scope, None)] = f"{prefix}amb"
+            for use_case in USE_CASE_ID_CARDINALITY_LIMIT_QUOTA_OPTIONS:
+                expected_quotas[(scope, use_case)] = f"{prefix}amb_{use_case.value}"
 
-        assert quotas[5].id == "oacm"
-        assert quotas[5].scope == QuotaScope.ORGANIZATION
-        assert quotas[5].scope_id is None
-        assert quotas[5].categories == {DataCategory.METRIC_BUCKET}
-        assert quotas[5].limit == 6040
-        assert quotas[5].window == 10
-        assert quotas[5].reason_code == "org_abuse_limit"
+        for ((scope, use_case), id) in expected_quotas.items():
+            quota = next(x for x in quotas if x.id == id)
+            assert quota is not None
 
-        assert quotas[6].id == "gam"
-        assert quotas[6].scope == QuotaScope.GLOBAL
-        assert quotas[6].scope_id is None
-        assert quotas[6].categories == {DataCategory.METRIC_BUCKET}
-        assert quotas[6].limit == 6050
-        assert quotas[6].window == 10
-        assert quotas[6].reason_code == "global_abuse_limit"
-        assert quotas[6].namespace is None
-
-        assert quotas[7].id == "gams"
-        assert quotas[7].scope == QuotaScope.GLOBAL
-        assert quotas[7].scope_id is None
-        assert quotas[7].categories == {DataCategory.METRIC_BUCKET}
-        assert quotas[7].limit == 6060
-        assert quotas[7].window == 10
-        assert quotas[7].reason_code == "global_abuse_limit"
-        assert quotas[7].namespace == "sessions"
-
-        assert quotas[8].id == "gamt"
-        assert quotas[8].scope == QuotaScope.GLOBAL
-        assert quotas[8].scope_id is None
-        assert quotas[8].categories == {DataCategory.METRIC_BUCKET}
-        assert quotas[8].limit == 6070
-        assert quotas[8].window == 10
-        assert quotas[8].reason_code == "global_abuse_limit"
-        assert quotas[8].namespace == "transactions"
-
-        assert quotas[9].id == "gamp"
-        assert quotas[9].scope == QuotaScope.GLOBAL
-        assert quotas[9].scope_id is None
-        assert quotas[9].categories == {DataCategory.METRIC_BUCKET}
-        assert quotas[9].limit == 6080
-        assert quotas[9].window == 10
-        assert quotas[9].reason_code == "global_abuse_limit"
-        assert quotas[9].namespace == "spans"
-
-        assert quotas[10].id == "gamc"
-        assert quotas[10].scope == QuotaScope.GLOBAL
-        assert quotas[10].scope_id is None
-        assert quotas[10].categories == {DataCategory.METRIC_BUCKET}
-        assert quotas[10].limit == 6090
-        assert quotas[10].window == 10
-        assert quotas[10].reason_code == "global_abuse_limit"
-        assert quotas[10].namespace == "custom"
+            assert quota.id == id
+            assert quota.scope == scope
+            assert quota.scope_id is None
+            assert quota.categories == {DataCategory.METRIC_BUCKET}
+            assert quota.limit == metric_abuse_limit_by_id[id] * 10
+            assert quota.window == 10
+            if scope == QuotaScope.GLOBAL:
+                assert quota.reason_code == "global_abuse_limit"
+            elif scope == QuotaScope.ORGANIZATION:
+                assert quota.reason_code == "org_abuse_limit"
+            elif scope == QuotaScope.PROJECT:
+                assert quota.reason_code == "project_abuse_limit"
+            else:
+                assert False, "invalid quota scope"
 
         # Let's set the global option for error limits.
         # Since we already have an org override for it, it shouldn't change anything.


### PR DESCRIPTION
- Renames the existing metric bucket abuse quotas to a match a more general naming schema, which allows all metric abuse quotas to be named consistently. Currently we only have an abuse quota defined for testing purposes on S4S, which is fine to break.
- Adds abuse quotas for all (missing) namespaces and for the project scope.
- Fully qualifies the namespace in the abuse quota to prevent (accidental) collisions between e.g. `sessions` and `spans`.
- Uses `mb` for `metric bucket` to keep the namespace open for a future `metric volume` etc. category.

Epic: https://github.com/getsentry/relay/issues/2716