### PR TITLE
fix(replays): default mask/block setting in project creation should be true

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -84,6 +84,7 @@ export function OnboardingLayout({
       },
       platformOptions: selectedOptions,
       newOrg,
+      replayOptions: {block: true, mask: true},
     };
 
     return {

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -46,7 +46,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
   }${
     params.isReplaySelected
       ? `
-        Sentry.replayIntegration(${getReplayConfigOptions(params.replayOptions ?? {block: true, mask: true})}),`
+        Sentry.replayIntegration(${getReplayConfigOptions(params.replayOptions)}),`
       : ''
   }
 ],${
@@ -67,6 +67,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
 }
 });
 `;
+
 const getVerifyJSSnippet = () => `
 myUndefinedFunction();`;
 

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -46,7 +46,7 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
   }${
     params.isReplaySelected
       ? `
-        Sentry.replayIntegration(${getReplayConfigOptions(params.replayOptions)}),`
+        Sentry.replayIntegration(${getReplayConfigOptions(params.replayOptions ?? {block: true, mask: true})}),`
       : ''
   }
 ],${
@@ -67,7 +67,6 @@ ${getFeedbackConfigOptions(params.feedbackOptions)}}),`
 }
 });
 `;
-
 const getVerifyJSSnippet = () => `
 myUndefinedFunction();`;
 


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/68688

for project creation, pass in a default `replayOptions` param since one isn't set:

<img width="1266" alt="SCR-20240411-hwpk" src="https://github.com/getsentry/sentry/assets/56095982/e0272c8a-ad00-4a6c-84ad-c35baea3491a">
