### PR TITLE
fix(profiling): keep frame-level platform information when available in mixed stack traces

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -148,6 +148,10 @@ def process_profile_task(
     if not _normalize_profile(profile, organization, project):
         return
 
+    # set platform information at frame-level
+    # only for those platforms that didn't go through symbolication
+    _set_frames_platform(profile)
+
     if "version" in profile:
         set_measurement("profile.samples.processed", len(profile["profile"]["samples"]))
         set_measurement("profile.stacks.processed", len(profile["profile"]["stacks"]))
@@ -1117,3 +1121,14 @@ def _calculate_duration_for_sample_format_v2(profile: Profile) -> int:
 
 def _calculate_duration_for_android_format(profile: Profile) -> int:
     return int(profile["duration_ns"] * 1e-6)
+
+
+def _set_frames_platform(profile: Profile):
+    if "version" not in profile:
+        return
+    platform = profile.get("platform", "")
+    if platform in ["javascript", "node", "cocoa", ""]:
+        # bail early because it was already set
+        return
+    for i, _ in enumerate(profile["profile"]["frames"]):
+        profile["profile"]["frames"]["platform"] = platform

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -629,7 +629,10 @@ def _process_symbolicator_results_for_sample(
         for idx in range(len(raw_frames)):
             # If we didn't send the frame to symbolicator, add the raw frame.
             if idx not in frames_sent:
-                new_frames.append(raw_frames[idx])
+                f = raw_frames[idx]
+                if profile["platform"] != platform:
+                    f["platform"] = platform
+                new_frames.append(f)
                 continue
 
             # If we sent it to symbolicator, add the current symbolicated frame
@@ -637,7 +640,10 @@ def _process_symbolicator_results_for_sample(
             # This works since symbolicated_frames are in the same order
             # as raw_frames (except some frames are not sent).
             for frame_idx in symbolicated_frames_dict[symbolicated_frame_idx]:
-                new_frames.append(symbolicated_frames[frame_idx])
+                f = symbolicated_frames[frame_idx]
+                if profile["platform"] != platform:
+                    f["platform"] = platform
+                new_frames.append(f)
 
             # go to the next symbolicated frame result
             symbolicated_frame_idx += 1

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1130,8 +1130,7 @@ def _set_frames_platform(profile: Profile):
             # bail early because it was already set
             return
         for i, frame in enumerate(profile["profile"]["frames"]):
-            if frame.get("platform", "") == "":
-                profile["profile"]["frames"]["platform"] = platform
+            profile["profile"]["frames"]["platform"] = platform
         return
     elif profile["platform"] == "android":
         for i, _ in enumerate(profile["profile"]["methods"]):

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1129,7 +1129,7 @@ def _set_frames_platform(profile: Profile):
         if platform in ["javascript", "node", "cocoa"]:
             # bail early because it was already set
             return
-        for i, frame in enumerate(profile["profile"]["frames"]):
+        for i, _ in enumerate(profile["profile"]["frames"]):
             profile["profile"]["frames"]["platform"] = platform
         return
     elif profile["platform"] == "android":

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -629,10 +629,7 @@ def _process_symbolicator_results_for_sample(
         for idx in range(len(raw_frames)):
             # If we didn't send the frame to symbolicator, add the raw frame.
             if idx not in frames_sent:
-                f = raw_frames[idx]
-                if profile["platform"] != platform:
-                    f["platform"] = platform
-                new_frames.append(f)
+                new_frames.append(raw_frames[idx])
                 continue
 
             # If we sent it to symbolicator, add the current symbolicated frame

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1130,5 +1130,6 @@ def _set_frames_platform(profile: Profile):
     if platform in ["javascript", "node", "cocoa"]:
         # bail early because it was already set
         return
-    for i, _ in enumerate(profile["profile"]["frames"]):
-        profile["profile"]["frames"]["platform"] = platform
+    for i, frame in enumerate(profile["profile"]["frames"]):
+        if frame.get("platform", "") == "":
+            profile["profile"]["frames"]["platform"] = platform

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -638,8 +638,7 @@ def _process_symbolicator_results_for_sample(
             # as raw_frames (except some frames are not sent).
             for frame_idx in symbolicated_frames_dict[symbolicated_frame_idx]:
                 f = symbolicated_frames[frame_idx]
-                if profile["platform"] != platform:
-                    f["platform"] = platform
+                f["platform"] = platform
                 new_frames.append(f)
 
             # go to the next symbolicated frame result

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1126,8 +1126,8 @@ def _calculate_duration_for_android_format(profile: Profile) -> int:
 def _set_frames_platform(profile: Profile):
     if "version" not in profile:
         return
-    platform = profile.get("platform", "")
-    if platform in ["javascript", "node", "cocoa", ""]:
+    platform = profile["platform"]
+    if platform in ["javascript", "node", "cocoa"]:
         # bail early because it was already set
         return
     for i, _ in enumerate(profile["profile"]["frames"]):

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1124,12 +1124,15 @@ def _calculate_duration_for_android_format(profile: Profile) -> int:
 
 
 def _set_frames_platform(profile: Profile):
-    if "version" not in profile:
+    if "version" in profile:
+        platform = profile["platform"]
+        if platform in ["javascript", "node", "cocoa"]:
+            # bail early because it was already set
+            return
+        for i, frame in enumerate(profile["profile"]["frames"]):
+            if frame.get("platform", "") == "":
+                profile["profile"]["frames"]["platform"] = platform
         return
-    platform = profile["platform"]
-    if platform in ["javascript", "node", "cocoa"]:
-        # bail early because it was already set
-        return
-    for i, frame in enumerate(profile["profile"]["frames"]):
-        if frame.get("platform", "") == "":
-            profile["profile"]["frames"]["platform"] = platform
+    elif profile["platform"] == "android":
+        for i, _ in enumerate(profile["profile"]["methods"]):
+            profile["profile"]["methods"][i] = "android"


### PR DESCRIPTION
Way back we added [frame-level](https://github.com/getsentry/vroom/blob/main/internal/frame/frame.go#L42) platform information in `vroom`, but we're not passing this information down from `sentry`.

This will help us to distinguish between `js` and `cocoa` frames in mixed stack traces scenarios (such as for react-native).