### PR TITLE
feat(perf): Add sample table to Response Code HTTP sample panel

### DIFF
--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -320,7 +320,7 @@ describe('HTTPSamplesPanel', () => {
             firstBound: expect.closeTo(333.3333),
             secondBound: expect.closeTo(666.6666),
             upperBound: 1000,
-            referrer: 'api.starfish.http-module-samples-panel-samples',
+            referrer: 'api.starfish.http-module-samples-panel-duration-samples',
             statsPeriod: '10d',
           }),
         })

--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -99,7 +99,7 @@ describe('HTTPSamplesPanel', () => {
   });
 
   describe('status panel', () => {
-    let chartRequestMock;
+    let chartRequestMock, samplesRequestMock;
 
     beforeEach(() => {
       jest.mocked(useLocation).mockReturnValue({
@@ -142,6 +142,30 @@ describe('HTTPSamplesPanel', () => {
           },
         },
       });
+    });
+
+    samplesRequestMock = MockApiClient.addMockResponse({
+      url: `/api/0/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
+          referrer: 'api.starfish.http-module-samples-panel-response-code-samples',
+        }),
+      ],
+      body: {
+        data: [
+          {
+            span_id: 'b1bf1acde131623a',
+            'span.description':
+              'GET https://sentry.io/api/0/organizations/sentry/info/?projectId=1',
+            project: 'javascript',
+            timestamp: '2024-03-25T20:31:36+00:00',
+            'span.status_code': '200',
+            'transaction.id': '11c910c9c10b3ec4ecf8f209b8c6ce48',
+            'span.self_time': 320.300102,
+          },
+        ],
+      },
     });
 
     it('fetches panel data', async () => {
@@ -197,6 +221,22 @@ describe('HTTPSamplesPanel', () => {
             topEvents: '5',
             yAxis: 'count()',
           },
+        })
+      );
+
+      expect(samplesRequestMock).toHaveBeenNthCalledWith(
+        1,
+        `/api/0/organizations/${organization.slug}/events/`,
+        expect.objectContaining({
+          method: 'GET',
+          query: expect.objectContaining({
+            query:
+              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308]',
+            project: [],
+            field: ['transaction.id', 'span.description', 'span.status_code'],
+            referrer: 'api.starfish.http-module-samples-panel-duration-samples',
+            statsPeriod: '10d',
+          }),
         })
       );
 

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -189,7 +189,7 @@ export function HTTPSamplesPanel() {
     ],
     min: 0,
     max: durationAxisMax,
-    enabled: query.panel === 'duration' && durationAxisMax > 0,
+    enabled: isPanelOpen && query.panel === 'duration' && durationAxisMax > 0,
     referrer: 'api.starfish.http-module-samples-panel-duration-samples',
   });
 
@@ -209,7 +209,7 @@ export function HTTPSamplesPanel() {
     ],
     sorts: [SPAN_SAMPLES_SORT],
     limit: SPAN_SAMPLE_LIMIT,
-    enabled: query.panel === 'status',
+    enabled: isPanelOpen && query.panel === 'status',
     referrer: 'api.starfish.http-module-samples-panel-response-code-samples',
   });
 

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -175,10 +175,10 @@ export function HTTPSamplesPanel() {
   const durationAxisMax = computeAxisMax([durationData?.[`avg(span.self_time)`]]);
 
   const {
-    data: samplesData,
-    isFetching: isSamplesDataFetching,
-    error: samplesDataError,
-    refetch: refetchSpanSamples,
+    data: durationSamplesData,
+    isFetching: isDurationSamplesDataFetching,
+    error: durationSamplesDataError,
+    refetch: refetchDurationSpanSamples,
   } = useSpanSamples({
     search,
     fields: [
@@ -189,17 +189,17 @@ export function HTTPSamplesPanel() {
     min: 0,
     max: durationAxisMax,
     enabled: query.panel === 'duration' && durationAxisMax > 0,
-    referrer: 'api.starfish.http-module-samples-panel-samples',
+    referrer: 'api.starfish.http-module-samples-panel-duration-samples',
   });
 
   const sampledSpanDataSeries = useSampleScatterPlotSeries(
-    samplesData,
+    durationSamplesData,
     domainTransactionMetrics?.[0]?.['avg(span.self_time)'],
     highlightedSpanId
   );
 
   const findSampleFromDataPoint = (dataPoint: {name: string | number; value: number}) => {
-    return samplesData.find(
+    return durationSamplesData.find(
       s => s.timestamp === dataPoint.name && s['span.self_time'] === dataPoint.value
     );
   };
@@ -368,12 +368,12 @@ export function HTTPSamplesPanel() {
 
               <ModuleLayout.Full>
                 <SpanSamplesTable
-                  data={samplesData}
-                  isLoading={isDurationDataFetching || isSamplesDataFetching}
+                  data={durationSamplesData}
+                  isLoading={isDurationDataFetching || isDurationSamplesDataFetching}
                   highlightedSpanId={highlightedSpanId}
                   onSampleMouseOver={sample => setHighlightedSpanId(sample.span_id)}
                   onSampleMouseOut={() => setHighlightedSpanId(undefined)}
-                  error={samplesDataError}
+                  error={durationSamplesDataError}
                   // TODO: The samples endpoint doesn't provide its own meta, so we need to create it manually
                   meta={{
                     fields: {
@@ -397,7 +397,7 @@ export function HTTPSamplesPanel() {
           )}
 
           <ModuleLayout.Full>
-            <Button onClick={() => refetchSpanSamples()}>
+            <Button onClick={() => refetchDurationSpanSamples()}>
               {t('Try Different Samples')}
             </Button>
           </ModuleLayout.Full>

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -201,9 +201,11 @@ export function HTTPSamplesPanel() {
   } = useIndexedSpans({
     filters,
     fields: [
+      SpanIndexedField.PROJECT,
       SpanIndexedField.TRANSACTION_ID,
       SpanIndexedField.SPAN_DESCRIPTION,
       SpanIndexedField.RESPONSE_CODE,
+      SpanIndexedField.ID,
     ],
     sorts: [SPAN_SAMPLES_SORT],
     limit: SPAN_SAMPLE_LIMIT,


### PR DESCRIPTION
The "Duration" panel had a samples table, and now the "Response Code" one does, too! This one doesn't use the `spans-samples` endpoint because we don't need a time-dispered duration-banded set of samples, we just need some random spans.

