### PR TITLE
ref(actors): Remove uneeded get_actor_id_for_user

### DIFF
--- a/src/sentry/issues/priority.py
+++ b/src/sentry/issues/priority.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from sentry import features
 from sentry.models.activity import Activity
-from sentry.models.actor import get_actor_id_for_user
+from sentry.models.actor import get_actor_for_user
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.models.project import Project
 from sentry.models.user import User
@@ -70,7 +70,7 @@ def update_priority(
         project=project,
         new_priority=priority.to_str(),
         previous_priority=previous_priority.to_str() if previous_priority else None,
-        user_id=get_actor_id_for_user(actor) if actor else None,
+        user_id=get_actor_for_user(actor).id if actor else None,
         reason=reason.value if reason else None,
         sender=sender,
     )

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -203,10 +203,6 @@ class Actor(Model):
         return (self.pk, ImportKind.Inserted)
 
 
-def get_actor_id_for_user(user: User | RpcUser) -> int:
-    return get_actor_for_user(user).id
-
-
 def get_actor_for_user(user: int | User | RpcUser) -> Actor:
     if isinstance(user, int):
         user_id = user

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -14,7 +14,7 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
-from sentry.models.actor import get_actor_id_for_user
+from sentry.models.actor import get_actor_for_user
 from sentry.types.activity import ActivityType
 from sentry.types.group import GROUP_SUBSTATUS_TO_GROUP_HISTORY_STATUS
 
@@ -272,7 +272,7 @@ def record_group_history(
     actor_id = None
     if actor:
         if isinstance(actor, RpcUser) or isinstance(actor, User):
-            actor_id = get_actor_id_for_user(actor)
+            actor_id = get_actor_for_user(actor).id
         elif isinstance(actor, Team):
             actor_id = actor.actor_id
         else:
@@ -307,7 +307,7 @@ def bulk_record_group_history(
     actor_id = None
     if actor:
         if isinstance(actor, RpcUser) or isinstance(actor, User):
-            actor_id = get_actor_id_for_user(actor)
+            actor_id = get_actor_for_user(actor).id
         elif isinstance(actor, Team):
             actor_id = actor.actor_id
         else:

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable, MutableMapping
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Union
 
-from sentry.models.actor import ACTOR_TYPES, get_actor_id_for_user
+from sentry.models.actor import ACTOR_TYPES, get_actor_for_user
 from sentry.services.hybrid_cloud import RpcModel
 from sentry.services.hybrid_cloud.organization import RpcTeam
 from sentry.services.hybrid_cloud.user import RpcUser
@@ -133,7 +133,7 @@ class RpcActor(RpcModel):
     def from_rpc_user(cls, user: RpcUser, fetch_actor: bool = True) -> "RpcActor":
         actor_id = None
         if fetch_actor:
-            actor_id = get_actor_id_for_user(user)
+            actor_id = get_actor_for_user(user).id
         return cls(
             id=user.id,
             actor_id=actor_id,

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -12,7 +12,7 @@ from sentry.eventstore.models import Event
 from sentry.incidents.models.alert_rule import AlertRuleMonitorType
 from sentry.incidents.models.incident import IncidentActivityType
 from sentry.models.activity import Activity
-from sentry.models.actor import Actor, get_actor_id_for_user
+from sentry.models.actor import Actor, get_actor_for_user
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.identity import Identity, IdentityProvider
 from sentry.models.integrations.integration import Integration
@@ -553,7 +553,7 @@ class Fixtures:
 
     def create_group_history(self, *args, **kwargs):
         if "actor" not in kwargs:
-            kwargs["actor"] = Actor.objects.get(id=get_actor_id_for_user(self.user))
+            kwargs["actor"] = Actor.objects.get(id=get_actor_for_user(self.user).id)
         return Factories.create_group_history(*args, **kwargs)
 
     def create_comment(self, *args, **kwargs):

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -15,7 +15,7 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.slack.message_builder.notifications.rule_save_edit import (
     SlackRuleSaveEditMessageBuilder,
 )
-from sentry.models.actor import get_actor_for_user, get_actor_id_for_user
+from sentry.models.actor import get_actor_for_user
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.models.user import User
@@ -739,7 +739,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         payload["actions"][0].pop("name")
         kwargs = {
             "name": payload["name"],
-            "owner": get_actor_id_for_user(self.user),
+            "owner": get_actor_for_user(self.user).id,
             "environment": payload.get("environment"),
             "action_match": payload["actionMatch"],
             "filter_match": payload.get("filterMatch"),

--- a/tests/sentry/api/serializers/test_external_actor.py
+++ b/tests/sentry/api/serializers/test_external_actor.py
@@ -4,7 +4,7 @@ from sentry.api.bases.external_actor import (
     ExternalUserSerializer,
 )
 from sentry.api.serializers import serialize
-from sentry.models.actor import Actor, get_actor_id_for_user
+from sentry.models.actor import Actor, get_actor_for_user
 from sentry.models.integrations.external_actor import ExternalActor
 from sentry.testutils.cases import TestCase
 from sentry.types.integrations import ExternalProviders, get_provider_name
@@ -27,11 +27,11 @@ class ExternalActorSerializerTest(TestCase):
         )
 
     def test_idempotent_actor(self):
-        actor_id = get_actor_id_for_user(self.user)
-        other_actor_id = get_actor_id_for_user(self.user)
+        actor_id = get_actor_for_user(self.user).id
+        other_actor_id = get_actor_for_user(self.user).id
         assert other_actor_id == actor_id
 
-        get_actor_id_for_user(self.user)
+        get_actor_for_user(self.user).id
         assert Actor.objects.filter(user_id=self.user.id).count() == 1
 
     def test_user(self):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -75,7 +75,7 @@ from sentry.incidents.models.incident import (
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.integrations.discord.utils.channel import ChannelType
 from sentry.integrations.pagerduty.utils import add_service
-from sentry.models.actor import ActorTuple, get_actor_for_user, get_actor_id_for_user
+from sentry.models.actor import ActorTuple, get_actor_for_user
 from sentry.models.group import GroupStatus
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.integration.serial import serialize_integration
@@ -668,7 +668,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             1,
             owner=ActorTuple.from_actor_identifier(self.user.id),
         )
-        assert alert_rule_1.owner.id == get_actor_id_for_user(self.user)
+        assert alert_rule_1.owner.id == get_actor_for_user(self.user).id
         alert_rule_2 = create_alert_rule(
             self.organization,
             [self.project],
@@ -992,7 +992,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             1,
             owner=ActorTuple.from_actor_identifier(self.user.id),
         )
-        assert alert_rule.owner.id == get_actor_id_for_user(self.user)
+        assert alert_rule.owner.id == get_actor_for_user(self.user).id
         update_alert_rule(
             alert_rule=alert_rule,
             owner=ActorTuple.from_actor_identifier(f"team:{self.team.id}"),
@@ -1002,17 +1002,17 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             alert_rule=alert_rule,
             owner=ActorTuple.from_actor_identifier(f"user:{self.user.id}"),
         )
-        assert alert_rule.owner.id == get_actor_id_for_user(self.user)
+        assert alert_rule.owner.id == get_actor_for_user(self.user).id
         update_alert_rule(
             alert_rule=alert_rule,
             owner=ActorTuple.from_actor_identifier(self.user.id),
         )
-        assert alert_rule.owner.id == get_actor_id_for_user(self.user)
+        assert alert_rule.owner.id == get_actor_for_user(self.user).id
         update_alert_rule(
             alert_rule=alert_rule,
             name="not updating owner",
         )
-        assert alert_rule.owner.id == get_actor_id_for_user(self.user)
+        assert alert_rule.owner.id == get_actor_for_user(self.user).id
 
         update_alert_rule(
             alert_rule=alert_rule,

--- a/tests/sentry/mediators/project_rules/test_creator.py
+++ b/tests/sentry/mediators/project_rules/test_creator.py
@@ -1,5 +1,5 @@
 from sentry.mediators.project_rules.creator import Creator
-from sentry.models.actor import get_actor_for_user, get_actor_id_for_user
+from sentry.models.actor import get_actor_for_user
 from sentry.models.rule import Rule
 from sentry.models.user import User
 from sentry.testutils.cases import TestCase
@@ -18,7 +18,7 @@ class TestCreator(TestCase):
             self.user = User.objects.get(id=self.user.id)
         self.creator = Creator(
             name="New Cool Rule",
-            owner=get_actor_id_for_user(self.user),
+            owner=get_actor_for_user(self.user).id,
             project=self.project,
             action_match="all",
             filter_match="any",

--- a/tests/sentry/mediators/project_rules/test_updater.py
+++ b/tests/sentry/mediators/project_rules/test_updater.py
@@ -1,5 +1,5 @@
 from sentry.mediators.project_rules.updater import Updater
-from sentry.models.actor import get_actor_for_user, get_actor_id_for_user
+from sentry.models.actor import get_actor_for_user
 from sentry.models.user import User
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
@@ -21,7 +21,7 @@ class TestUpdater(TestCase):
         assert self.rule.label == "Cool New Rule"
 
     def test_update_owner(self):
-        self.updater.owner = get_actor_id_for_user(self.user)
+        self.updater.owner = get_actor_for_user(self.user).id
         self.updater.call()
         with assume_test_silo_mode_of(User):
             self.user = User.objects.get(id=self.user.id)


### PR DESCRIPTION
This was just an alias that is slightly less clear than just inlining
what this function was doing.