### PR TITLE
feat(stacktrace): Add InteractionStateLayer to stack trace frames

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -72,9 +72,6 @@ describe('StackTrace', function () {
     const stackTraceContent = screen.getByTestId('stack-trace-content');
     expect(stackTraceContent).toBeInTheDocument();
 
-    // stack trace content has to have a platform icon and a frame list
-    expect(stackTraceContent.children).toHaveLength(2);
-
     // platform icon
     expect(screen.getByTestId('platform-icon-python')).toBeInTheDocument();
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -298,20 +298,27 @@ function Content({
   const platformIcon = stackTracePlatformIcon(platform, data.frames ?? []);
 
   return (
-    <Wrapper className={wrapperClassName} data-test-id="stack-trace-content">
+    <Wrapper>
       {!hideIcon && <StacktracePlatformIcon platform={platformIcon} />}
-      <GuideAnchor target="stack_trace">
-        <StyledList data-test-id="frames">
-          {!newestFirst ? convertedFrames : [...convertedFrames].reverse()}
-        </StyledList>
-      </GuideAnchor>
+      <ContentPanel className={wrapperClassName} data-test-id="stack-trace-content">
+        <GuideAnchor target="stack_trace">
+          <StyledList data-test-id="frames">
+            {!newestFirst ? convertedFrames : [...convertedFrames].reverse()}
+          </StyledList>
+        </GuideAnchor>
+      </ContentPanel>
     </Wrapper>
   );
 }
 
-const Wrapper = styled(Panel)`
+const Wrapper = styled('div')`
+  position: relative;
+`;
+
+const ContentPanel = styled(Panel)`
   position: relative;
   border-top-left-radius: 0;
+  overflow: hidden;
 `;
 
 const StyledList = styled('ul')`

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -269,23 +269,32 @@ export function NativeContent({
   }
 
   return (
-    <Wrapper className={wrapperClassName} data-test-id="native-stack-trace-content">
+    <Wrapper>
       {hideIcon ? null : (
         <StacktracePlatformIcon
           platform={stackTracePlatformIcon(platform, data.frames ?? [])}
         />
       )}
-
-      <Frames data-test-id="stack-trace">
-        {!newestFirst ? convertedFrames : [...convertedFrames].reverse()}
-      </Frames>
+      <ContentPanel
+        className={wrapperClassName}
+        data-test-id="native-stack-trace-content"
+      >
+        <Frames data-test-id="stack-trace">
+          {!newestFirst ? convertedFrames : [...convertedFrames].reverse()}
+        </Frames>
+      </ContentPanel>
     </Wrapper>
   );
 }
 
-const Wrapper = styled(Panel)`
+const Wrapper = styled('div')`
+  position: relative;
+`;
+
+const ContentPanel = styled(Panel)`
   position: relative;
   border-top-left-radius: 0;
+  overflow: hidden;
 `;
 
 export const Frames = styled('ul')`

--- a/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
@@ -18,7 +18,7 @@ function StacktracePlatformIcon({platform}: Props) {
 
 const StyledPlatformIcon = styled(PlatformIcon)`
   position: absolute;
-  top: -1px;
+  top: 0;
   left: -20px;
   border-radius: 3px 0 0 3px;
 

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -13,6 +13,7 @@ import {StacktraceLink} from 'sentry/components/events/interfaces/frame/stacktra
 import type {FrameSourceMapDebuggerData} from 'sentry/components/events/interfaces/sourceMapsDebuggerModal';
 import {SourceMapsDebuggerModal} from 'sentry/components/events/interfaces/sourceMapsDebuggerModal';
 import {getThreadById} from 'sentry/components/events/interfaces/utils';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import StrictClick from 'sentry/components/strictClick';
 import {Tag} from 'sentry/components/tag';
 import {IconFix, IconRefresh} from 'sentry/icons';
@@ -301,16 +302,8 @@ export class DeprecatedLine extends Component<Props, State> {
   }
 
   renderDefaultLine() {
-    const {
-      isHoverPreviewed,
-      data,
-      isANR,
-      threadId,
-      lockAddress,
-      isSubFrame,
-      hiddenFrameCount,
-      event,
-    } = this.props;
+    const {isHoverPreviewed, data, isANR, threadId, lockAddress, isSubFrame, event} =
+      this.props;
     const {isHovering, isExpanded} = this.state;
     const organization = this.props.organization;
     const anrCulprit =
@@ -356,13 +349,14 @@ export class DeprecatedLine extends Component<Props, State> {
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : undefined}>
         <DefaultLine
-          className="title"
           data-test-id="title"
           isSubFrame={!!isSubFrame}
-          hasToggle={!!hiddenFrameCount}
           onMouseEnter={() => this.handleMouseEnter()}
           onMouseLeave={() => this.handleMouseLeave()}
+          isExpanded={this.state.isExpanded ?? false}
+          isExpandable={this.isExpandable()}
         >
+          {this.isExpandable() ? <InteractionStateLayer /> : null}
           <DefaultLineTitleWrapper isInAppFrame={data.inApp}>
             <LeftLineTitle>
               <div>
@@ -516,13 +510,24 @@ const RepeatedContent = styled(LeftLineTitle)`
 `;
 
 const DefaultLine = styled('div')<{
-  hasToggle: boolean;
+  isExpandable: boolean;
+  isExpanded: boolean;
   isSubFrame: boolean;
 }>`
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: ${p => (p.isSubFrame ? `${p.theme.surface100}` : '')};
+  background: ${p => (p.isSubFrame ? `${p.theme.surface100}` : `${p.theme.surface200}`)};
+  min-height: 32px;
+  word-break: break-word;
+  padding: ${space(0.75)} ${space(1.5)};
+  font-size: ${p => p.theme.fontSizeSmall};
+  line-height: 16px;
+  cursor: ${p => (p.isExpandable ? 'pointer' : 'default')};
+  code {
+    font-family: ${p => p.theme.text.family};
+  }
 `;
 
 const StyledIconRefresh = styled(IconRefresh)`

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -20,6 +20,7 @@ import {
 import {formatAddress, parseAddress} from 'sentry/components/events/interfaces/utils';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {TraceEventDataSectionContext} from 'sentry/components/events/traceEventDataSection';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import StrictClick from 'sentry/components/strictClick';
 import {Tag} from 'sentry/components/tag';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -268,6 +269,7 @@ function NativeFrame({
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
+          {expandable ? <InteractionStateLayer /> : null}
           <SymbolicatorIcon>
             {status === 'error' ? (
               <Tooltip
@@ -505,6 +507,7 @@ const RowHeader = styled('span')<{
   isInAppFrame: boolean;
   isSubFrame: boolean;
 }>`
+  position: relative;
   display: grid;
   grid-template-columns: repeat(2, auto) 1fr repeat(2, auto) ${space(2)};
   grid-template-rows: repeat(2, auto);
@@ -532,19 +535,6 @@ const StackTraceFrame = styled('li')`
   :not(:last-child) {
     ${RowHeader} {
       border-bottom: 1px solid ${p => p.theme.border};
-    }
-  }
-
-  &:last-child {
-    ${RowHeader} {
-      border-bottom-right-radius: 5px;
-      border-bottom-left-radius: 5px;
-    }
-  }
-
-  &:first-child {
-    ${RowHeader} {
-      border-top-right-radius: 5px;
     }
   }
 `;


### PR DESCRIPTION
Adding this makes it more obvious that you can click the whole frame to expand (and makes the click much more satisfying):

https://github.com/getsentry/sentry/assets/10888943/24257c7a-51c6-44f0-a934-6abf88f0e9c1

