### PR TITLE
chore(slack): default message builder to block kit attempt 2

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -267,21 +267,6 @@ def get_context(group: Group) -> str:
     return context_text.rstrip()
 
 
-def get_option_groups(group: Group) -> Sequence[Mapping[str, Any]]:
-    all_members = group.project.get_members_as_rpc_users()
-    members = list({m.id: m for m in all_members}.values())
-    teams = group.project.teams.all()
-
-    option_groups = []
-    if teams:
-        option_groups.append({"text": "Teams", "options": format_actor_options(teams)})
-
-    if members:
-        option_groups.append({"text": "People", "options": format_actor_options(members)})
-
-    return option_groups
-
-
 def get_option_groups_block_kit(group: Group) -> Sequence[Mapping[str, Any]]:
     all_members = group.project.get_members_as_rpc_users()
     members = list({m.id: m for m in all_members}.values())
@@ -289,13 +274,13 @@ def get_option_groups_block_kit(group: Group) -> Sequence[Mapping[str, Any]]:
 
     option_groups = []
     if teams:
-        team_options = format_actor_options(teams)
+        team_options = format_actor_options(teams, True)
         option_groups.append(
             {"label": {"type": "plain_text", "text": "Teams"}, "options": team_options}
         )
 
     if members:
-        member_options = format_actor_options(members)
+        member_options = format_actor_options(members, True)
         option_groups.append(
             {"label": {"type": "plain_text", "text": "People"}, "options": member_options}
         )
@@ -460,7 +445,7 @@ def build_actions(
             name="assign",
             label="Select Assignee...",
             type="select",
-            selected_options=format_actor_options([assignee]) if assignee else [],
+            selected_options=format_actor_options([assignee], True) if assignee else [],
             option_groups=get_option_groups_block_kit(group),
         )
         return assign_button
@@ -633,7 +618,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             elif action.name == "assign":
                 actions.append(
                     self.get_external_select_action(
-                        action, format_actor_option(assignee) if assignee else None
+                        action, format_actor_option(assignee, True) if assignee else None
                     )
                 )
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -10,7 +10,7 @@ from django.utils.timesince import timesince
 from django.utils.translation import gettext as _
 from sentry_relay.processing import parse_release
 
-from sentry import features, tagstore
+from sentry import tagstore
 from sentry.api.endpoints.group_details import get_group_global_count
 from sentry.constants import LOG_LEVELS_MAP
 from sentry.eventstore.models import GroupEvent
@@ -22,7 +22,6 @@ from sentry.integrations.message_builder import (
     format_actor_option,
     format_actor_options,
     get_color,
-    get_timestamp,
     get_title_link,
 )
 from sentry.integrations.slack.message_builder import (
@@ -287,17 +286,16 @@ def get_option_groups_block_kit(group: Group) -> Sequence[Mapping[str, Any]]:
     all_members = group.project.get_members_as_rpc_users()
     members = list({m.id: m for m in all_members}.values())
     teams = group.project.teams.all()
-    use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
 
     option_groups = []
     if teams:
-        team_options = format_actor_options(teams, use_block_kit)
+        team_options = format_actor_options(teams)
         option_groups.append(
             {"label": {"type": "plain_text", "text": "Teams"}, "options": team_options}
         )
 
     if members:
-        member_options = format_actor_options(members, use_block_kit)
+        member_options = format_actor_options(members)
         option_groups.append(
             {"label": {"type": "plain_text", "text": "People"}, "options": member_options}
         )
@@ -428,91 +426,51 @@ def build_actions(
     identity: RpcIdentity | None = None,
 ) -> tuple[Sequence[MessageAction], str, str]:
     """Having actions means a button will be shown on the Slack message e.g. ignore, resolve, assign."""
-    use_block_kit = features.has("organizations:slack-block-kit", project.organization)
-
     if actions and identity:
         text = get_action_text(text, actions, identity)
         return [], text, "_actioned_issue"
 
     status = group.get_status()
 
-    def _ignore_button(use_block_kit) -> MessageAction | None:
+    def _ignore_button() -> MessageAction | None:
         if group.issue_category == GroupCategory.FEEDBACK:
             return None
-        if use_block_kit:
-            if status == GroupStatus.IGNORED:
-                return MessageAction(
-                    name="status", label="Mark as Ongoing", value="unresolved:ongoing"
-                )
-            return MessageAction(name="status", label="Archive", value="archive_dialog")
-
         if status == GroupStatus.IGNORED:
+            return MessageAction(name="status", label="Mark as Ongoing", value="unresolved:ongoing")
+
+        return MessageAction(name="status", label="Archive", value="archive_dialog")
+
+    def _resolve_button() -> MessageAction:
+        if status == GroupStatus.RESOLVED:
             return MessageAction(
-                name="status",
-                label="Mark as Ongoing",
-                value="unresolved:ongoing",
+                name="unresolved:ongoing", label="Unresolve", value="unresolved:ongoing"
             )
+        if not project.flags.has_releases:
+            return MessageAction(name="status", label="Resolve", value="resolved")
 
         return MessageAction(
             name="status",
-            label="Archive",
-            value="ignored:until_escalating",
-        )
-
-    def _resolve_button(use_block_kit) -> MessageAction:
-        if use_block_kit:
-            if status == GroupStatus.RESOLVED:
-                return MessageAction(
-                    name="unresolved:ongoing", label="Unresolve", value="unresolved:ongoing"
-                )
-            if not project.flags.has_releases:
-                return MessageAction(name="status", label="Resolve", value="resolved")
-            return MessageAction(
-                name="status",
-                label="Resolve",
-                value="resolve_dialog",
-            )
-
-        if status == GroupStatus.RESOLVED:
-            return MessageAction(
-                name="status",
-                label="Unresolve",
-                value="unresolved:ongoing",
-            )
-
-        if not project.flags.has_releases:
-            return MessageAction(
-                name="status",
-                label="Resolve",
-                value="resolved",
-            )
-        return MessageAction(
-            name="resolve_dialog",
-            label="Resolve...",
+            label="Resolve",
             value="resolve_dialog",
         )
 
-    def _assign_button(use_block_kit) -> MessageAction:
+    def _assign_button() -> MessageAction:
         assignee = group.get_assignee()
         assign_button = MessageAction(
             name="assign",
             label="Select Assignee...",
             type="select",
             selected_options=format_actor_options([assignee]) if assignee else [],
-            option_groups=(
-                get_option_groups(group)
-                if not use_block_kit
-                else get_option_groups_block_kit(group)
-            ),
+            option_groups=get_option_groups_block_kit(group),
         )
         return assign_button
 
     action_list = [
         a
         for a in [
-            _resolve_button(use_block_kit),
-            _ignore_button(use_block_kit),
-            _assign_button(use_block_kit),
+            _resolve_button(),
+            _ignore_button(),
+            _assign_button(),
         ]
         if a is not None
     ]
@@ -555,9 +513,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.skip_fallback = skip_fallback
         self.notes = notes
         self.commits = commits
-        self.use_block_kit = features.has(
-            "organizations:slack-block-kit", group.project.organization
-        )
 
     @property
     def escape_text(self) -> bool:
@@ -571,14 +526,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         text = build_attachment_text(self.group, self.event) or ""
         text = text.strip(" \n")
 
-        if self.use_block_kit:
-            text = escape_slack_markdown_text(text)
-        if not self.use_block_kit and self.escape_text:
-            text = escape_slack_text(text)
-            # XXX(scefali): Not sure why we actually need to do this just for unfurled messages.
-            # If we figure out why this is required we should note it here because it's quite strange
-            if self.is_unfurl:
-                text = escape_slack_text(text)
+        text = escape_slack_markdown_text(text)
 
         # This link does not contain user input (it's a static label and a url), must not escape it.
         replay_link = build_attachment_replay_link(self.group, self.event)
@@ -587,7 +535,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         # If an event is unspecified, use the tags of the latest event (if one exists).
         event_for_tags = self.event or self.group.get_latest_event()
         color = get_color(event_for_tags, self.notification, self.group)
-        fields = build_tag_fields(event_for_tags, self.tags)
         footer = (
             self.notification.build_notification_footer(self.recipient, ExternalProviders.SLACK)
             if self.notification and self.recipient
@@ -620,25 +567,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             notification_uuid=notification_uuid,
         )
         title = build_attachment_title(obj)
-
-        if not features.has("organizations:slack-block-kit", self.group.project.organization):
-            if replay_link:
-                text += f"\n\n{replay_link}"
-            if action_text and self.identity:
-                text += "\n" + action_text
-
-            return self._build(
-                actions=payload_actions,
-                callback_id=json.dumps({"issue": self.group.id}),
-                color=color,
-                fallback=self.build_fallback_text(obj, project.slug),
-                fields=fields,
-                footer=footer,
-                text=text,
-                title=title,
-                title_link=title_link,
-                ts=get_timestamp(self.group, self.event) if not self.issue_details else None,
-            )
 
         # build up the blocks for newer issue alert formatting #
 
@@ -705,7 +633,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             elif action.name == "assign":
                 actions.append(
                     self.get_external_select_action(
-                        action, format_actor_option(assignee, True) if assignee else None
+                        action, format_actor_option(assignee) if assignee else None
                     )
                 )
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2799,7 +2799,6 @@ class ActivityTestCase(TestCase):
 
     def get_notification_uuid(self, text: str) -> str:
         # Allow notification\\_uuid and notification_uuid
-        text = text.split("|")[0]
         result = re.search("notification.*_uuid=([a-zA-Z0-9-]+)", text)
         assert result is not None
         return result[1]

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -647,16 +647,21 @@ class PerformanceIssueTestCase(BaseTestCase):
                     perf_problem.fingerprint = fingerprint
             return perf_problems
 
-        with mock.patch(
-            "sentry.issues.ingest.send_issue_occurrence_to_eventstream",
-            side_effect=send_issue_occurrence_to_eventstream,
-        ) as mock_eventstream, mock.patch(
-            "sentry.event_manager.detect_performance_problems",
-            side_effect=detect_performance_problems_interceptor,
-        ), mock.patch.object(
-            issue_type, "noise_config", new=NoiseConfig(noise_limit, timedelta(minutes=1))
-        ), override_options(
-            {"performance.issues.all.problem-detection": 1.0, detector_option: 1.0}
+        with (
+            mock.patch(
+                "sentry.issues.ingest.send_issue_occurrence_to_eventstream",
+                side_effect=send_issue_occurrence_to_eventstream,
+            ) as mock_eventstream,
+            mock.patch(
+                "sentry.event_manager.detect_performance_problems",
+                side_effect=detect_performance_problems_interceptor,
+            ),
+            mock.patch.object(
+                issue_type, "noise_config", new=NoiseConfig(noise_limit, timedelta(minutes=1))
+            ),
+            override_options(
+                {"performance.issues.all.problem-detection": 1.0, detector_option: 1.0}
+            ),
         ):
             event = perf_event_manager.save(project_id)
             if mock_eventstream.call_args:
@@ -2794,6 +2799,7 @@ class ActivityTestCase(TestCase):
 
     def get_notification_uuid(self, text: str) -> str:
         # Allow notification\\_uuid and notification_uuid
+        text = text.split("|")[0]
         result = re.search("notification.*_uuid=([a-zA-Z0-9-]+)", text)
         assert result is not None
         return result[1]
@@ -2847,14 +2853,15 @@ class SlackActivityNotificationTest(ActivityTestCase):
     def assert_performance_issue_attachments(
         self, attachment, project_slug, referrer, alert_type="workflow"
     ):
-        assert attachment["title"] == "N+1 Query"
+        assert "N+1 Query" in attachment["text"]
         assert (
-            attachment["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+            "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+            in attachment["blocks"][1]["text"]["text"]
         )
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
+        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]
+        notification_uuid = self.get_notification_uuid(title_link)
         assert (
-            attachment["footer"]
+            attachment["blocks"][-2]["elements"][0]["text"]
             == f"{project_slug} | production | <http://testserver/settings/account/notifications/{alert_type}/?referrer={referrer}&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -8,7 +8,7 @@ from sentry.notifications.notifications.activity.assigned import AssignedActivit
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
@@ -112,23 +112,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert channel == self.identity.external_id
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_assignment(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue is assigned
-        """
-        with self.tasks():
-            self.create_notification(self.group, AssignedActivityNotification).send()
-        attachment, text = get_attachment()
-        assert text == f"Issue assigned to {self.name} by themselves"
-        assert attachment["title"] == self.group.title
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
     @with_feature("organizations:slack-block-kit")
     def test_assignment_block(self):
         """
@@ -148,30 +131,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_assignment_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type is assigned
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-
-        with self.tasks():
-            self.create_notification(group_event.group, AssignedActivityNotification).send()
-        attachment, text = get_attachment()
-        assert text == f"Issue assigned to {self.name} by themselves"
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "assigned_activity-slack-user"
         )
 
     @responses.activate
@@ -202,27 +161,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             group_event.project.slug,
             group_event.group,
             "assigned_activity-slack",
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_assignment_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue is assigned
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group, AssignedActivityNotification).send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue assigned to {self.name} by themselves"
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "assigned_activity-slack-user"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -65,38 +65,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_issue_alert_user(self):
-        """Test that issue alerts are sent to a Slack user."""
-
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
-        notification_uuid = str(uuid.uuid4())
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=self.rule),
-            ActionTargetType.MEMBER,
-            self.user.id,
-            notification_uuid=notification_uuid,
-        )
-
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-
-        assert attachment["title"] == "Hello world"
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-        assert event.group
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue"
-        )
-
-    @responses.activate
     @with_feature("organizations:slack-block-kit")
     def test_issue_alert_user_block(self):
         """
@@ -244,31 +212,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_generic_issue_alert_user(self, occurrence):
-        """Test that generic issue alerts are sent to a Slack user."""
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-
-        notification = AlertRuleNotification(
-            Notification(event=group_event, rule=self.rule), ActionTargetType.MEMBER, self.user.id
-        )
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "issue_alert-slack-user", "alerts"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
     @with_feature("organizations:slack-block-kit")
     def test_generic_issue_alert_user_block(self, occurrence):
         """
@@ -324,52 +267,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert len(responses.calls) == 0
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_issue_alert_issue_owners(self):
-        """Test that issue alerts are sent to issue owners in Slack."""
-
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
-            "targetIdentifier": "",
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-        ProjectOwnership.objects.create(project_id=self.project.id)
-
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=rule),
-            ActionTargetType.ISSUE_OWNERS,
-            self.user.id,
-            FallthroughChoiceType.ACTIVE_MEMBERS,
-        )
-
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-
-        assert attachment["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group_id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
     @with_feature("organizations:slack-block-kit")
     def test_issue_alert_issue_owners_block(self):
         """
@@ -420,60 +317,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert (
             blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_issue_alert_issue_owners_environment(self):
-        """Test that issue alerts are sent to issue owners in Slack with the environment in the query params when the alert rule filters by environment."""
-
-        environment = self.create_environment(self.project, name="production")
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error", "environment": environment.name},
-            project_id=self.project.id,
-        )
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
-            "targetIdentifier": "",
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-        rule = self.create_project_rule(
-            project=self.project,
-            action_match=[action_data],
-            name="ja rule",
-            environment_id=environment.id,
-        )
-        ProjectOwnership.objects.create(project_id=self.project.id)
-
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=rule),
-            ActionTargetType.ISSUE_OWNERS,
-            self.user.id,
-            FallthroughChoiceType.ACTIVE_MEMBERS,
-        )
-
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-
-        assert attachment["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group_id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment={environment.name}&alert_rule_id={rule.id}&alert_type=issue"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -535,94 +378,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert (
             blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_issue_alert_team_issue_owners(self):
-        """Test that issue alerts are sent to a team in Slack via an Issue Owners rule action."""
-
-        # add a second user to the team so we can be sure it's only
-        # sent once (to the team, and not to each individual user)
-        user2 = self.create_user(is_superuser=False)
-        self.create_member(teams=[self.team], user=user2, organization=self.organization)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX2")
-            self.identity = Identity.objects.create(
-                external_id="UXXXXXXX2",
-                idp=self.idp,
-                user=user2,
-                status=IdentityStatus.VALID,
-                scopes=[],
-            )
-        # update the team's notification settings
-        ExternalActor.objects.create(
-            team_id=self.team.id,
-            organization=self.organization,
-            integration_id=self.integration.id,
-            provider=ExternalProviders.SLACK.value,
-            external_name="goma",
-            external_id="CXXXXXXX2",
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            # provider is disabled by default
-            NotificationSettingProvider.objects.create(
-                team_id=self.team.id,
-                scope_type="team",
-                scope_identifier=self.team.id,
-                provider="slack",
-                type="alerts",
-                value="always",
-            )
-
-        rule = GrammarRule(Matcher("path", "*"), [Owner("team", self.team.slug)])
-        ProjectOwnership.objects.create(project_id=self.project.id, schema=dump_schema([rule]))
-
-        event = self.store_event(
-            data={
-                "message": "Hello world",
-                "level": "error",
-                "stacktrace": {"frames": [{"filename": "foo.py"}]},
-            },
-            project_id=self.project.id,
-        )
-
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "IssueOwners",
-            "targetIdentifier": "",
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=rule), ActionTargetType.ISSUE_OWNERS, self.team.id
-        )
-
-        with self.tasks():
-            notification.send()
-
-        # check that only one was sent out - more would mean each user is being notified
-        # rather than the team
-        assert len(responses.calls) == 1
-
-        # check that the team got a notification
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["channel"] == ["CXXXXXXX2"]
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-        assert len(attachments) == 1
-        assert attachments[0]["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachments[0]["title_link"])
-        assert (
-            attachments[0]["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -877,92 +632,12 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert "attachments" in data
         attachments = json.loads(data["attachments"][0])
         assert len(attachments) == 1
-        assert attachments[0]["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachments[0]["title_link"])
+        assert "Hello world" in attachments[0]["text"]
+        title_link = attachments[0]["blocks"][0]["text"]["text"][13:][1:-1]
+        notification_uuid = self.get_notification_uuid(title_link)
         assert (
-            attachments[0]["footer"]
+            attachments[0]["blocks"][-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_issue_alert_team(self):
-        """Test that issue alerts are sent to a team in Slack."""
-        # add a second organization
-        org = self.create_organization(owner=self.user)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.create_organization_integration(
-                organization_id=org.id, integration=self.integration
-            )
-
-        # add a second user to the team so we can be sure it's only
-        # sent once (to the team, and not to each individual user)
-        user2 = self.create_user(is_superuser=False)
-        self.create_member(teams=[self.team], user=user2, organization=self.organization)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX2")
-            self.identity = Identity.objects.create(
-                external_id="UXXXXXXX2",
-                idp=self.idp,
-                user=user2,
-                status=IdentityStatus.VALID,
-                scopes=[],
-            )
-        # update the team's notification settings
-        ExternalActor.objects.create(
-            team_id=self.team.id,
-            organization=self.organization,
-            integration_id=self.integration.id,
-            provider=ExternalProviders.SLACK.value,
-            external_name="goma",
-            external_id="CXXXXXXX2",
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            NotificationSettingProvider.objects.create(
-                team_id=self.team.id,
-                scope_type="team",
-                scope_identifier=self.team.id,
-                provider="slack",
-                type="alerts",
-                value="always",
-            )
-
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "Team",
-            "targetIdentifier": str(self.team.id),
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-        notification = Notification(event=event, rule=rule)
-
-        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
-            self.adapter.notify(notification, ActionTargetType.TEAM, self.team.id)
-
-        # check that only one was sent out - more would mean each user is being notified
-        # rather than the team
-        assert len(responses.calls) == 1
-
-        # check that the team got a notification
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["channel"] == ["CXXXXXXX2"]
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-        assert len(attachments) == 1
-        assert attachments[0]["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachments[0]["title_link"])
-        assert (
-            attachments[0]["footer"]
-            == f"{self.project.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -1129,10 +804,11 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert "attachments" in data
         attachments = json.loads(data["attachments"][0])
         assert len(attachments) == 1
-        assert attachments[0]["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachments[0]["title_link"])
+        assert "Hello world" in attachments[0]["text"]
+        title_link = attachments[0]["blocks"][0]["text"]["text"][13:][1:-1]
+        notification_uuid = self.get_notification_uuid(title_link)
         assert (
-            attachments[0]["footer"]
+            attachments[0]["blocks"][-2]["elements"][0]["text"]
             == f"{project2.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -1235,10 +911,11 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert "attachments" in data
         attachments = json.loads(data["attachments"][0])
         assert len(attachments) == 1
-        assert attachments[0]["title"] == "Hello world"
-        notification_uuid = self.get_notification_uuid(attachments[0]["title_link"])
+        assert "Hello world" in attachments[0]["text"]
+        title_link = attachments[0]["blocks"][0]["text"]["text"][13:][1:-1]
+        notification_uuid = self.get_notification_uuid(title_link)
         assert (
-            attachments[0]["footer"]
+            attachments[0]["blocks"][-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -1247,39 +924,11 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert "attachments" in data2
         attachments = json.loads(data2["attachments"][0])
         assert len(attachments) == 1
-        assert attachments[0]["title"] == "Hello world"
+        assert "Hello world" in attachments[0]["text"]
         assert (
-            attachments[0]["footer"]
+            attachments[0]["blocks"][-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
-
-    @responses.activate
-    @patch.object(sentry, "digests")
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_digest_enabled(self, digests):
-        """
-        Test that with digests enabled, but Slack notification settings
-        (and not email settings), we send a Slack notification
-        """
-        backend = RedisBackend()
-        digests.digest = backend.digest
-        digests.enabled.return_value = True
-
-        rule = Rule.objects.create(project=self.project, label="my rule")
-        ProjectOwnership.objects.create(project_id=self.project.id)
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
-        key = f"mail:p:{self.project.id}:IssueOwners::AllMembers"
-        backend.add(key, event_to_record(event, [rule]), increment_delay=0, maximum_delay=0)
-
-        with self.tasks():
-            deliver_digest(key)
-
-        attachment, text = get_attachment()
-
-        assert attachment["title"] == "Hello world"
-        assert attachment["text"] == ""
 
     @responses.activate
     @patch.object(sentry, "digests")

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -7,7 +7,7 @@ from sentry.notifications.notifications.activity.regression import RegressionAct
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -24,25 +24,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
                 type=ActivityType.SET_REGRESSION,
                 data=data or {},
             )
-        )
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_regression(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue regresses
-        """
-        with self.tasks():
-            self.create_notification(self.group).send()
-
-        attachment, text = get_attachment()
-        assert text == "Issue marked as regression"
-        assert attachment["title"] == "こんにちは"
-        assert attachment["text"] == ""
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -64,29 +45,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_regression_with_release(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue regresses
-        """
-        with self.tasks():
-            self.create_notification(self.group, {"version": "1.0.0"}).send()
-
-        attachment, text = get_attachment()
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            text
-            == f"Issue marked as regression in release <http://testserver/organizations/baz/releases/1.0.0/?referrer=regression_activity&notification_uuid={notification_uuid}|1.0.0>"
-        )
-        assert attachment["title"] == "こんにちは"
-        assert attachment["text"] == ""
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -119,27 +77,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_regression_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue regresses
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group).send()
-
-        attachment, text = get_attachment()
-        assert text == "Issue marked as regression"
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "regression_activity-slack-user"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
     @with_feature("organizations:slack-block-kit")
     def test_regression_performance_issue_block(self, occurrence):
         """
@@ -159,31 +96,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             event.project.slug,
             event.group,
             "regression_activity-slack",
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_regression_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type regresses
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-
-        with self.tasks():
-            self.create_notification(group_event.group).send()
-
-        attachment, text = get_attachment()
-        assert text == "Issue marked as regression"
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "regression_activity-slack-user"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -7,7 +7,7 @@ from sentry.notifications.notifications.activity.resolved import ResolvedActivit
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -24,26 +24,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
                 type=ActivityType.SET_RESOLVED,
                 data={"assignee": ""},
             )
-        )
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_resolved(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue is resolved
-        """
-        with self.tasks():
-            self.create_notification(self.group).send()
-
-        attachment, text = get_attachment()
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            text
-            == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.short_id}> as resolved"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -81,31 +61,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_resolved_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue is resolved
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group).send()
-
-        attachment, text = get_attachment()
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            text
-            == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.project.slug.upper()}-{event.group.short_id}> as resolved"
-        )
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "resolved_activity-slack-user"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
     @with_feature("organizations:slack-block-kit")
     def test_resolved_performance_issue_block(self, occurrence):
         """
@@ -129,34 +84,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             event.project.slug,
             event.group,
             "resolved_activity-slack",
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_resolved_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type is resolved
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-        with self.tasks():
-            self.create_notification(group_event.group).send()
-
-        attachment, text = get_attachment()
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            text
-            == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{group_event.group.id}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.project.slug.upper()}-{group_event.group.short_id}> as resolved"
-        )
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "resolved_activity-slack-user"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -9,7 +9,7 @@ from sentry.notifications.notifications.activity.resolved_in_release import (
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -31,25 +31,6 @@ class SlackResolvedInReleaseNotificationTest(
         )
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_resolved_in_release(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue is resolved in a release
-        """
-        notification = self.create_notification(self.group)
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        release_name = notification.activity.data["version"]
-        assert text == f"Issue marked as resolved in {release_name} by {self.name}"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
     @with_feature("organizations:slack-block-kit")
     def test_resolved_in_release_block(self):
         notification = self.create_notification(self.group)
@@ -68,29 +49,6 @@ class SlackResolvedInReleaseNotificationTest(
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_resolved_in_release_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue is resolved in a release
-        """
-        event = self.create_performance_issue()
-        notification = self.create_notification(event.group)
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        release_name = notification.activity.data["version"]
-        assert text == f"Issue marked as resolved in {release_name} by {self.name}"
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "resolved_in_release_activity-slack-user"
         )
 
     @responses.activate
@@ -128,32 +86,6 @@ class SlackResolvedInReleaseNotificationTest(
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_resolved_in_release_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type is resolved in a release
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-        notification = self.create_notification(group_event.group)
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        release_name = notification.activity.data["version"]
-        assert text == f"Issue marked as resolved in {release_name} by {self.name}"
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "resolved_in_release_activity-slack-user"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
     @with_feature("organizations:slack-block-kit")
     def test_resolved_in_release_generic_issue_block(self, occurrence):
         """
@@ -178,24 +110,6 @@ class SlackResolvedInReleaseNotificationTest(
             group_event.project.slug,
             group_event.group,
             "resolved_in_release_activity-slack",
-        )
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_resolved_in_release_parsed_version(self):
-        """
-        Test that the release version is formatted to the short version
-        """
-        notification = self.create_notification(self.group, version="frontend@1.0.0")
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue marked as resolved in 1.0.0 by {self.name}"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -7,7 +7,7 @@ from sentry.notifications.notifications.activity.unassigned import UnassignedAct
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -24,24 +24,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
                 type=ActivityType.ASSIGNED,
                 data={"assignee": ""},
             )
-        )
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_unassignment(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue is unassigned
-        """
-        with self.tasks():
-            self.create_notification(self.group).send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue unassigned by {self.name}"
-        assert attachment["title"] == self.group.title
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
@@ -72,27 +54,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_unassignment_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue is unassigned
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group).send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue unassigned by {self.name}"
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "unassigned_activity-slack-user"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
     @with_feature("organizations:slack-block-kit")
     def test_unassignment_performance_issue_block(self, occurrence):
         """
@@ -112,30 +73,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
             event.project.slug,
             event.group,
             "unassigned_activity-slack",
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_unassignment_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type is unassigned
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-        with self.tasks():
-            self.create_notification(group_event.group).send()
-
-        attachment, text = get_attachment()
-        assert text == f"Issue unassigned by {self.name}"
-        self.assert_generic_issue_attachments(
-            attachment, self.project.slug, "unassigned_activity-slack-user"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -18,7 +18,6 @@ from sentry.integrations.slack.message_builder.issues import (
     build_actions,
     format_release_tag,
     get_context,
-    get_option_groups,
     get_option_groups_block_kit,
     get_tags,
     time_since,
@@ -28,7 +27,6 @@ from sentry.issues.grouptype import (
     ErrorGroupType,
     FeedbackGroup,
     MonitorCheckInFailure,
-    PerformanceNPlusOneGroupType,
     PerformanceP95EndpointRegressionGroupType,
     ProfileFileIOGroupType,
 )
@@ -269,60 +267,6 @@ def build_test_message(
 
 
 class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTestMixin):
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_group_attachment(self):
-        group = self.create_group(project=self.project)
-        assert SlackIssuesMessageBuilder(group).build() == build_test_message(
-            teams={self.team},
-            users={self.user},
-            timestamp=group.last_seen,
-            group=group,
-        )
-
-        event = self.store_event(data={}, project_id=self.project.id)
-
-        assert SlackIssuesMessageBuilder(
-            group, event.for_group(group)
-        ).build() == build_test_message(
-            teams={self.team},
-            users={self.user},
-            timestamp=event.datetime,
-            group=group,
-            event=event,
-        )
-
-        assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), link_to_event=True
-        ).build() == build_test_message(
-            teams={self.team},
-            users={self.user},
-            timestamp=event.datetime,
-            group=group,
-            event=event,
-            link_to_event=True,
-        )
-
-        test_message = build_test_message(
-            teams={self.team},
-            users={self.user},
-            timestamp=group.last_seen,
-            group=group,
-        )
-        test_message["actions"] = [
-            (
-                action
-                if action["text"] != "Ignore"
-                else {
-                    "name": "status",
-                    "text": "Archive",
-                    "type": "button",
-                    "value": "ignored:until_escalating",
-                }
-            )
-            for action in test_message["actions"]
-        ]
-        assert SlackIssuesMessageBuilder(group).build() == test_message
-
     @with_feature("organizations:slack-block-kit")
     def test_build_group_block(self):
         release = self.create_release(project=self.project)
@@ -470,25 +414,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             group=group,
         )
 
-    @patch(
-        "sentry.integrations.slack.message_builder.issues.get_option_groups",
-        wraps=get_option_groups,
-    )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_group_attachment_prune_duplicate_assignees(self, mock_get_option_groups):
-        user2 = self.create_user()
-        self.create_member(user=user2, organization=self.organization)
-        team2 = self.create_team(organization=self.organization, members=[self.user, user2])
-        project2 = self.create_project(organization=self.organization, teams=[self.team, team2])
-        group = self.create_group(project=project2)
-
-        SlackIssuesMessageBuilder(group).build()
-        assert mock_get_option_groups.called
-
-        team_option_groups, member_option_groups = mock_get_option_groups(group)
-        assert len(team_option_groups["options"]) == 2
-        assert len(member_option_groups["options"]) == 2
-
     @with_feature("organizations:slack-block-kit")
     @patch(
         "sentry.integrations.slack.message_builder.issues.get_option_groups_block_kit",
@@ -508,15 +433,8 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert len(team_option_groups["options"]) == 2
         assert len(member_option_groups["options"]) == 2
 
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_group_attachment_issue_alert(self):
-        issue_alert_group = self.create_group(project=self.project)
-        ret = SlackIssuesMessageBuilder(issue_alert_group, issue_details=True).build()
-        assert isinstance(ret, dict)
-        assert ret["actions"] == []
-
     @with_feature("organizations:slack-block-kit")
-    def test_build_group_attachment_issue_alert_block_kit(self):
+    def test_build_group_attachment_issue_alert(self):
         issue_alert_group = self.create_group(project=self.project)
         ret = SlackIssuesMessageBuilder(issue_alert_group, issue_details=True).build()
         assert isinstance(ret, dict)
@@ -779,17 +697,8 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             == expected_blocks
         )
 
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_team_recipient(self):
-        issue_alert_group = self.create_group(project=self.project)
-        ret = SlackIssuesMessageBuilder(
-            issue_alert_group, recipient=RpcActor.from_object(self.team)
-        ).build()
-        assert isinstance(ret, dict)
-        assert ret["actions"] != []
-
     @with_feature("organizations:slack-block-kit")
-    def test_team_recipient_block_kit(self):
+    def test_team_recipient(self):
         issue_alert_group = self.create_group(project=self.project)
         ret = SlackIssuesMessageBuilder(
             issue_alert_group, recipient=RpcActor.from_object(self.team)
@@ -818,58 +727,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             == self.user.get_display_name()
         )
         assert ret["blocks"][2]["elements"][2]["initial_option"]["value"] == f"user:{self.user.id}"
-
-    # XXX(CEO): skipping replicating tests relating to color since there is no block kit equivalent
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_group_attachment_color_no_event_error_fallback(self):
-        group_with_no_events = self.create_group(project=self.project)
-        ret = SlackIssuesMessageBuilder(group_with_no_events).build()
-        assert isinstance(ret, dict)
-        assert ret["color"] == "#E03E2F"
-
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_group_attachment_color_unexpected_level_error_fallback(self):
-        unexpected_level_event = self.store_event(
-            data={"level": "trace"}, project_id=self.project.id, assert_no_errors=False
-        )
-        assert unexpected_level_event.group is not None
-        ret = SlackIssuesMessageBuilder(unexpected_level_event.group).build()
-        assert isinstance(ret, dict)
-        assert ret["color"] == "#E03E2F"
-
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_group_attachment_color_warning(self):
-        warning_event = self.store_event(data={"level": "warning"}, project_id=self.project.id)
-        assert warning_event.group is not None
-        ret1 = SlackIssuesMessageBuilder(warning_event.group).build()
-        assert isinstance(ret1, dict)
-        assert ret1["color"] == "#FFC227"
-        ret2 = SlackIssuesMessageBuilder(
-            warning_event.group, warning_event.for_group(warning_event.group)
-        ).build()
-        assert isinstance(ret2, dict)
-        assert ret2["color"] == "#FFC227"
-
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_group_generic_issue_attachment(self):
-        """Test that a generic issue type's Slack alert contains the expected values"""
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-        occurrence = self.build_occurrence(level="info")
-        occurrence.save()
-        group_event.occurrence = occurrence
-
-        group_event.group.type = ProfileFileIOGroupType.type_id
-
-        attachments = SlackIssuesMessageBuilder(group=group_event.group, event=group_event).build()
-
-        assert isinstance(attachments, dict)
-        assert attachments["title"] == occurrence.issue_title
-        assert attachments["text"] == occurrence.evidence_display[0].value
-        assert attachments["fallback"] == f"[{self.project.slug}] {occurrence.issue_title}"
-        assert attachments["color"] == "#2788CE"  # blue for info level
 
     @with_feature("organizations:slack-block-kit")
     def test_build_group_generic_issue_block(self):
@@ -932,38 +789,16 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert blocks["blocks"][1]["text"]["text"] == f"```{escaped_text}```"
         assert blocks["text"] == f"[{self.project.slug}] {occurrence.issue_title}"
 
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_error_issue_fallback_text(self):
-        event = self.store_event(data={}, project_id=self.project.id)
-        assert event.group is not None
-        attachments = SlackIssuesMessageBuilder(event.group, event.for_group(event.group)).build()
-        assert isinstance(attachments, dict)
-        assert attachments["fallback"] == f"[{self.project.slug}] {event.group.title}"
-
     @with_feature("organizations:slack-block-kit")
-    def test_build_error_issue_fallback_text_block_kit(self):
+    def test_build_error_issue_fallback_text(self):
         event = self.store_event(data={}, project_id=self.project.id)
         assert event.group is not None
         blocks = SlackIssuesMessageBuilder(event.group, event.for_group(event.group)).build()
         assert isinstance(blocks, dict)
         assert blocks["text"] == f"[{self.project.slug}] {event.group.title}"
 
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_performance_issue(self):
-        event = self.create_performance_issue()
-        with self.feature("organizations:performance-issues"):
-            attachments = SlackIssuesMessageBuilder(event.group, event).build()
-        assert isinstance(attachments, dict)
-        assert attachments["title"] == "N+1 Query"
-        assert (
-            attachments["text"]
-            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-        )
-        assert attachments["fallback"] == f"[{self.project.slug}] N+1 Query"
-        assert attachments["color"] == "#2788CE"  # blue for info level
-
     @with_feature("organizations:slack-block-kit")
-    def test_build_performance_issue_block_kit(self):
+    def test_build_performance_issue(self):
         event = self.create_performance_issue()
         with self.feature("organizations:performance-issues"):
             blocks = SlackIssuesMessageBuilder(event.group, event).build()
@@ -1012,30 +847,8 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         truncated_text = "a" * 1497 + "..."
         assert blocks["blocks"][1]["text"]["text"] == f"```{truncated_text}```"
 
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_performance_issue_color_no_event_passed(self):
-        """This test doesn't pass an event to the SlackIssuesMessageBuilder to mimic what
-        could happen in that case (it is optional). It also creates a performance group that won't
-        have a latest event attached to it to mimic a specific edge case.
-        """
-        perf_group = self.create_group(type=PerformanceNPlusOneGroupType.type_id)
-        attachments = SlackIssuesMessageBuilder(perf_group).build()
-
-        assert isinstance(attachments, dict)
-        assert attachments["color"] == "#2788CE"  # blue for info level
-
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_escape_slack_message(self):
-        group = self.create_group(
-            project=self.project,
-            data={"type": "error", "metadata": {"value": "<https://example.com/|*Click Here*>"}},
-        )
-        ret = SlackIssuesMessageBuilder(group, None).build()
-        assert isinstance(ret, dict)
-        assert ret["text"] == "&lt;https://example.com/|*Click Here*&gt;"
-
     @with_feature("organizations:slack-block-kit")
-    def test_escape_slack_message_block_kit(self):
+    def test_escape_slack_message(self):
         group = self.create_group(
             project=self.project,
             data={"type": "error", "metadata": {"value": "<https://example.com/|*Click Here*>"}},
@@ -1046,39 +859,9 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
 
 class BuildGroupAttachmentReplaysTest(TestCase):
-    @patch("sentry.models.group.Group.has_replays")
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_build_replay_issue(self, has_replays):
-        replay1_id = "46eb3948be25448abd53fe36b5891ff2"
-        self.project.flags.has_replays = True
-        self.project.save()
-
-        event = self.store_event(
-            data={
-                "message": "Hello world",
-                "level": "error",
-                "contexts": {"replay": {"replay_id": replay1_id}},
-                "timestamp": iso_format(before_now(minutes=1)),
-            },
-            project_id=self.project.id,
-        )
-        assert event.group is not None
-
-        with self.feature(
-            ["organizations:session-replay", "organizations:session-replay-slack-new-issue"]
-        ):
-            attachments = SlackIssuesMessageBuilder(
-                event.group, event.for_group(event.group)
-            ).build()
-        assert isinstance(attachments, dict)
-        assert (
-            attachments["text"]
-            == f"\n\n<http://testserver/organizations/baz/issues/{event.group.id}/replays/?referrer=slack|View Replays>"
-        )
-
     @with_feature("organizations:slack-block-kit")
     @patch("sentry.models.group.Group.has_replays")
-    def test_build_replay_issue_block_kit(self, has_replays):
+    def test_build_replay_issue(self, has_replays):
         replay1_id = "46eb3948be25448abd53fe36b5891ff2"
         self.project.flags.has_replays = True
         self.project.save()
@@ -1454,64 +1237,45 @@ class ActionsTest(TestCase):
                 expected,
             )
 
+    @with_feature("organizations:slack-block-kit")
     def test_ignore_unresolved_no_escalating(self):
         group = self.create_group(project=self.project)
         group.status = GroupStatus.UNRESOLVED
         group.save()
 
-        with self.feature({"organizations:slack-block-kit": False}):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-            expected = {
-                "label": "Archive",
-                "name": "status",
-                "type": "button",
-                "value": "ignored:until_escalating",
-            }
-            self._assert_message_actions_list(
-                res[0],
-                expected,
-            )
+        expected = {
+            "label": "Archive",
+            "name": "status",
+            "type": "button",
+            "value": "archive_dialog",
+        }
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
+        self._assert_message_actions_list(
+            res[0],
+            expected,
+        )
 
-        with self.feature("organizations:slack-block-kit"):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-            expected.update({"name": "status", "value": "archive_dialog"})
-            self._assert_message_actions_list(
-                res[0],
-                expected,
-            )
-
+    @with_feature("organizations:slack-block-kit")
     def test_ignore_unresolved_has_escalating(self):
         group = self.create_group(project=self.project)
         group.status = GroupStatus.UNRESOLVED
         group.save()
 
-        with self.feature({"organizations:slack-block-kit": False}):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-            expected = {
-                "label": "Archive",
-                "name": "status",
-                "type": "button",
-                "value": "ignored:until_escalating",
-            }
-            self._assert_message_actions_list(
-                res[0],
-                expected,
-            )
-        with self.feature("organizations:slack-block-kit"):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-            expected.update({"name": "status", "value": "archive_dialog"})
-            self._assert_message_actions_list(
-                res[0],
-                expected,
-            )
+        expected = {
+            "label": "Archive",
+            "name": "status",
+            "type": "button",
+            "value": "archive_dialog",
+        }
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
+        self._assert_message_actions_list(
+            res[0],
+            expected,
+        )
 
     def test_no_ignore_if_feedback(self):
         group = self.create_group(project=self.project, type=FeedbackGroup.type_id)
@@ -1528,40 +1292,25 @@ class ActionsTest(TestCase):
             # no ignore action if feedback issue, so only assign and resolve
             assert len(res[0]) == 2
 
+    @with_feature("organizations:slack-block-kit")
     def test_resolve_resolved(self):
         group = self.create_group(project=self.project)
         group.status = GroupStatus.RESOLVED
         group.save()
 
-        with self.feature({"organizations:slack-block-kit": False}):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-            expected = {
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
+
+        self._assert_message_actions_list(
+            res[0],
+            {
                 "label": "Unresolve",
-                "name": "status",
+                "name": "unresolved:ongoing",
                 "type": "button",
                 "value": "unresolved:ongoing",
-            }
-            self._assert_message_actions_list(
-                res[0],
-                expected,
-            )
-
-        with self.feature("organizations:slack-block-kit"):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-
-            self._assert_message_actions_list(
-                res[0],
-                {
-                    "label": "Unresolve",
-                    "name": "unresolved:ongoing",
-                    "type": "button",
-                    "value": "unresolved:ongoing",
-                },
-            )
+            },
+        )
 
     def test_resolve_unresolved_no_releases(self):
         group = self.create_group(project=self.project)
@@ -1606,34 +1355,18 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = True
         self.project.save()
 
-        with self.feature({"organizations:slack-block-kit": False}):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-
-            self._assert_message_actions_list(
-                res[0],
-                {
-                    "label": "Resolve...",
-                    "name": "resolve_dialog",
-                    "type": "button",
-                    "value": "resolve_dialog",
-                },
-            )
-
-        with self.feature("organizations:slack-block-kit"):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-            self._assert_message_actions_list(
-                res[0],
-                {
-                    "label": "Resolve",
-                    "name": "status",
-                    "type": "button",
-                    "value": "resolve_dialog",
-                },
-            )
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
+        self._assert_message_actions_list(
+            res[0],
+            {
+                "label": "Resolve",
+                "name": "status",
+                "type": "button",
+                "value": "resolve_dialog",
+            },
+        )
 
     def test_assign(self):
         group = self.create_group(project=self.project)

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -30,28 +30,6 @@ class SlackNotificationsTest(SlackActivityNotificationTest):
         self.notification = DummyNotification(self.organization)
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_additional_attachment(self):
-        with mock.patch.dict(
-            manager.attachment_generators,
-            {ExternalProviders.SLACK: additional_attachment_generator},
-        ):
-            with self.tasks():
-                send_notification_as_slack(self.notification, [self.user], {}, {})
-
-            data = parse_qs(responses.calls[0].request.body)
-
-            assert "attachments" in data
-            assert data["text"][0] == "Notification Title"
-
-            attachments = json.loads(data["attachments"][0])
-            assert len(attachments) == 2
-
-            assert attachments[0]["title"] == "My Title"
-            assert attachments[1]["title"] == self.organization.slug
-            assert attachments[1]["text"] == self.integration.id
-
-    @responses.activate
     def test_additional_attachment_block_kit(self):
         with (
             self.feature("organizations:slack-block-kit"),

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -73,7 +73,7 @@ class SlackNotifyActionTest(RuleTestCase):
         attachments = json.loads(data["attachments"][0])
 
         assert len(attachments) == 1
-        assert attachments[0]["title"] == event.title
+        assert event.title in attachments[0]["text"]
 
     @with_feature({"organizations:slack-block-kit": False})
     def test_render_label(self):
@@ -429,8 +429,8 @@ class SlackNotifyActionTest(RuleTestCase):
             attachments = json.loads(data["attachments"][0])
 
             assert len(attachments) == 2
-            assert attachments[0]["title"] == event.title
-            assert attachments[1]["title"] == self.organization.slug
+            assert event.title in attachments[0]["text"]
+            assert attachments[-1]["title"] == self.organization.slug
             assert attachments[1]["text"] == self.integration.id
             mock_record.assert_called_with(
                 "alert.sent",

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -248,9 +248,11 @@ class UnfurlTest(TestCase):
 
     @with_feature({"organizations:slack-block-kit": False})
     def test_escape_issue(self):
+        # wraps text in markdown code block
+        escape_text = "<https://example.com/|*Click Here*>"
         group = self.create_group(
             project=self.project,
-            data={"type": "error", "metadata": {"value": "<https://example.com/|*Click Here*>"}},
+            data={"type": "error", "metadata": {"value": escape_text}},
         )
 
         links = [
@@ -261,7 +263,7 @@ class UnfurlTest(TestCase):
         ]
 
         unfurls = link_handlers[LinkType.ISSUES].fn(self.request, self.integration, links)
-        assert unfurls[links[0].url]["text"] == "&amp;lt;https://example.com/|*Click Here*&amp;gt;"
+        assert unfurls[links[0].url]["blocks"][1]["text"]["text"] == "```" + escape_text + "```"
 
     def test_unfurl_metric_alert(self):
         alert_rule = self.create_alert_rule()

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -279,20 +279,8 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             "value": "ignored:archived_until_escalating",
             "type": "button",
         }
-        resp = self.post_webhook(
-            action_data=[status_action],
-            original_message=self.original_message,
-            type="interactive_message",
-            callback_id=json.dumps({"issue": self.group.id}),
-        )
-        self.group = Group.objects.get(id=self.group.id)
-
-        assert resp.status_code == 200, resp.content
-        assert self.group.get_status() == GroupStatus.IGNORED
-        assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
 
         expect_status = f"Identity not found.\n*Issue archived by <@{self.external_id}>*"
-        assert resp.data["attachments"][0]["text"] == expect_status
 
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
@@ -452,15 +440,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
         status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
 
-        resp = self.post_webhook(action_data=[status_action])
-        self.group = Group.objects.get(id=self.group.id)
-
-        assert resp.status_code == 200, resp.content
-        assert self.group.get_status() == GroupStatus.IGNORED
-        assert self.group.substatus == GroupSubStatus.FOREVER
-
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
@@ -570,13 +550,13 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])
 
-        # Assign to user
-        status_action = {
-            "name": "assign",
-            "selected_options": [{"value": f"user:{user2.id}"}],
-        }
+        with self.feature("organizations:slack-block-kit"):
+            # Assign to user
+            status_action = {
+                "name": "assign",
+                "selected_options": [{"value": f"user:{user2.id}"}],
+            }
 
-        with self.feature({"organizations:slack-block-kit": False}):
             resp = self.post_webhook(action_data=[status_action])
 
             assert resp.status_code == 200, resp.content
@@ -606,22 +586,6 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
             expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
 
-            assert resp.data["text"].endswith(expect_status), resp.data["text"]
-
-        with self.feature("organizations:slack-block-kit"):
-            # test backwards compatibility
-            resp = self.post_webhook(action_data=[status_action])
-
-            assert resp.status_code == 200, resp.content
-            assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
-            activity = Activity.objects.filter(group=self.group).first()
-            assert activity.data == {
-                "assignee": str(user2.id),
-                "assigneeEmail": user2.email,
-                "assigneeType": "user",
-                "integration": ActivityIntegration.SLACK.value,
-            }
-            expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
             assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
             assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
 
@@ -765,17 +729,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             "selected_options": [{"value": f"user:{user2.id}"}],
         }
 
-        with self.feature({"organizations:slack-block-kit": False}):
-            resp = self.post_webhook(action_data=[status_action])
-
-            assert resp.status_code == 200, resp.content
-            assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
-
-            expect_status = (
-                f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
-            )
-
-            assert resp.data["text"].endswith(expect_status), resp.data["text"]
+        expect_status = (
+            f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
+        )
 
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
@@ -843,18 +799,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             "selected_options": [{"value": f"user:{self.user.id}"}],
         }
 
-        with self.feature({"organizations:slack-block-kit": False}):
-            resp = self.post_webhook(action_data=[status_action])
-
-            assert resp.status_code == 200, resp.content
-            assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
-
-            expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
-                assignee=self.external_id
-            )
-
-            assert resp.data["text"].endswith(expect_status), resp.data["text"]
-
+        expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
+            assignee=self.external_id
+        )
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility
             resp = self.post_webhook(action_data=[status_action])
@@ -911,59 +858,6 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         )
         assert self.notification_text in resp.data["blocks"][1]["text"]["text"]
         assert resp.data["blocks"][2]["text"]["text"].endswith(expect_status), resp.data["text"]
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_resolve_issue(self):
-        status_action = {"name": "resolve_dialog", "value": "resolve_dialog"}
-
-        # Expect request to open dialog on slack
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/dialog.open",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-
-        resp = self.post_webhook(action_data=[status_action])
-        assert resp.status_code == 200, resp.content
-
-        # Opening dialog should *not* cause the current message to be updated
-        assert resp.content == b""
-
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["trigger_id"][0] == self.trigger_id
-        assert "dialog" in data
-
-        dialog = json.loads(data["dialog"][0])
-        callback_data = json.loads(dialog["callback_id"])
-        assert int(callback_data["issue"]) == self.group.id
-        assert callback_data["orig_response_url"] == self.response_url
-
-        # Completing the dialog will update the message
-        responses.add(
-            method=responses.POST,
-            url=self.response_url,
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-
-        resp = self.post_webhook(
-            type="dialog_submission",
-            callback_id=dialog["callback_id"],
-            data={"submission": {"resolve_type": "resolved"}},
-        )
-        self.group = Group.objects.get(id=self.group.id)
-
-        assert resp.status_code == 200, resp.content
-        assert self.group.get_status() == GroupStatus.RESOLVED
-
-        update_data = json.loads(responses.calls[1].request.body)
-
-        expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert update_data["text"].endswith(expect_status)
 
     @responses.activate
     def test_resolve_issue_backwards_compat_block_kit(self):
@@ -1052,65 +946,6 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert self.notification_text in update_data["blocks"][1]["text"]["text"]
         assert update_data["blocks"][2]["text"]["text"] == expect_status
-
-    @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_resolve_issue_in_next_release(self):
-        status_action = {"name": "resolve_dialog", "value": "resolve_dialog"}
-
-        release = Release.objects.create(
-            organization_id=self.organization.id,
-            version="1.0",
-        )
-        release.add_project(self.project)
-
-        # Expect request to open dialog on slack
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/dialog.open",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-
-        resp = self.post_webhook(action_data=[status_action])
-        assert resp.status_code == 200, resp.content
-
-        # Opening dialog should *not* cause the current message to be updated
-        assert resp.content == b""
-
-        data = parse_qs(responses.calls[0].request.body)
-        assert data["trigger_id"][0] == self.trigger_id
-        assert "dialog" in data
-
-        dialog = json.loads(data["dialog"][0])
-        callback_data = json.loads(dialog["callback_id"])
-        assert int(callback_data["issue"]) == self.group.id
-        assert callback_data["orig_response_url"] == self.response_url
-
-        # Completing the dialog will update the message
-        responses.add(
-            method=responses.POST,
-            url=self.response_url,
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-
-        resp = self.post_webhook(
-            type="dialog_submission",
-            callback_id=dialog["callback_id"],
-            data={"submission": {"resolve_type": "resolved:inNextRelease"}},
-        )
-        self.group = Group.objects.get(id=self.group.id)
-
-        assert resp.status_code == 200, resp.content
-        assert self.group.get_status() == GroupStatus.RESOLVED
-
-        update_data = json.loads(responses.calls[1].request.body)
-
-        expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert update_data["text"].endswith(expect_status)
 
     @responses.activate
     def test_resolve_issue_in_next_release_backwards_compat_block_kit(self):
@@ -1269,16 +1104,6 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
     def test_response_differs_on_bot_message(self):
         status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
         original_message = {"type": "message"}
-
-        with self.feature({"organizations:slack-block-kit": False}):
-            resp = self.post_webhook(action_data=[status_action], original_message=original_message)
-            self.group = Group.objects.get(id=self.group.id)
-
-            assert self.group.get_status() == GroupStatus.IGNORED
-            assert self.group.substatus == GroupSubStatus.FOREVER
-            assert resp.status_code == 200, resp.content
-            assert "attachments" in resp.data
-            assert resp.data["attachments"][0]["title"] in self.group.title
 
         with self.feature("organizations:slack-block-kit"):
             # test backwards compatibility

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -26,8 +26,8 @@ class AssignedNotificationAPITest(APITestCase):
     def validate_slack_message(self, msg, group, project, user_id, index=0):
         attachment, text = get_attachment(index)
         assert text == msg
-        assert attachment["title"] == group.title
-        assert project.slug in attachment["footer"]
+        assert group.title in attachment["text"]
+        assert project.slug in attachment["blocks"][-2]["elements"][0]["text"]
         channel = get_channel(index)
         assert channel == user_id
 
@@ -86,8 +86,8 @@ class AssignedNotificationAPITest(APITestCase):
         attachment, text = get_attachment()
 
         assert text == f"Issue assigned to {user.get_display_name()} by themselves"
-        assert attachment["title"] == self.group.title
-        assert self.project.slug in attachment["footer"]
+        assert self.group.title in attachment["text"]
+        assert self.project.slug in attachment["blocks"][-2]["elements"][0]["text"]
 
     @responses.activate
     @with_feature({"organizations:slack-block-kit": False})

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -1,7 +1,6 @@
 import uuid
 from unittest import mock
 from unittest.mock import ANY, patch
-from urllib.parse import parse_qs
 
 import responses
 from django.core import mail
@@ -19,7 +18,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
-from sentry.utils import json
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 pytestmark = [requires_snuba]
@@ -157,71 +155,6 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
 
 
 class DigestSlackNotification(SlackActivityNotificationTest):
-    @responses.activate
-    @mock.patch.object(sentry, "digests")
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_slack_digest_notification(self, digests):
-        """
-        Test that with digests enabled, but Slack notification settings
-        (and not email settings), we send a Slack notification
-        """
-        ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
-        backend = RedisBackend()
-        digests.digest = backend.digest
-        digests.enabled.return_value = True
-        timestamp_raw = before_now(days=1)
-        timestamp_secs = int(timestamp_raw.timestamp())
-        timestamp = iso_format(timestamp_raw)
-        key = f"slack:p:{self.project.id}:IssueOwners::AllMembers"
-        rule = Rule.objects.create(project=self.project, label="my rule")
-        event = self.store_event(
-            data={
-                "timestamp": timestamp,
-                "message": "Hello world",
-                "level": "error",
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        )
-
-        event2 = self.store_event(
-            data={
-                "timestamp": timestamp,
-                "message": "Goodbye world",
-                "level": "error",
-                "fingerprint": ["group-2"],
-            },
-            project_id=self.project.id,
-        )
-        notification_uuid = str(uuid.uuid4())
-        backend.add(
-            key,
-            event_to_record(event, [rule], notification_uuid),
-            increment_delay=0,
-            maximum_delay=0,
-        )
-        backend.add(
-            key,
-            event_to_record(event2, [rule], notification_uuid),
-            increment_delay=0,
-            maximum_delay=0,
-        )
-        with self.tasks():
-            deliver_digest(key)
-
-        assert len(responses.calls) >= 1
-        data = parse_qs(responses.calls[0].request.body)
-        assert "text" in data
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-        assert (
-            data["text"][0]
-            == f"<!date^{timestamp_secs}^2 issues detected {{date_pretty}} in| Digest Report for> <http://testserver/organizations/{self.organization.slug}/projects/{self.project.slug}/|{self.project.name}>"
-        )
-        assert len(attachments) == 2
-        assert "notification_uuid" in attachments[0]["title_link"]
-        assert "notification_uuid" in attachments[1]["title_link"]
-
     @responses.activate
     @with_feature("organizations:slack-block-kit")
     @mock.patch.object(sentry, "digests")

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -60,7 +60,7 @@ def get_attachment():
 
 def get_notification_uuid(url: str):
     query_params = parse_qs(urlparse(url).query)
-    notification_uuid = query_params["notification_uuid"][0]
+    notification_uuid = query_params["notification_uuid"][0].split("|")[0]
     assert len(notification_uuid) > 1
     return notification_uuid
 
@@ -186,10 +186,11 @@ class ActivityNotificationTest(APITestCase):
         attachment, text = get_attachment()
 
         assert text == f"Issue unassigned by {self.name}"
-        assert attachment["title"] == self.group.title
-        notification_uuid = get_notification_uuid(attachment["title_link"])
+        assert self.group.title in attachment["text"]
+        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        notification_uuid = get_notification_uuid(title_link)
         assert (
-            attachment["footer"]
+            attachment["blocks"][-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -247,16 +248,18 @@ class ActivityNotificationTest(APITestCase):
 
         attachment, text = get_attachment()
 
-        notification_uuid = get_notification_uuid(attachment["title_link"])
+        assert self.group.title in attachment["text"]
+        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        notification_uuid = get_notification_uuid(title_link)
         assert (
             text
             == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.short_id}> as resolved"
         )
-        assert attachment["title"] == self.group.title
         assert (
-            attachment["footer"]
+            attachment["blocks"][-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
+
         assert self.analytics_called_with_args(
             record_analytics,
             "integrations.email.notification_sent",
@@ -384,9 +387,10 @@ class ActivityNotificationTest(APITestCase):
         attachment, text = get_attachment()
 
         assert text == "Issue marked as regression"
-        notification_uuid = get_notification_uuid(attachment["title_link"])
+        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        notification_uuid = get_notification_uuid(title_link)
         assert (
-            attachment["footer"]
+            attachment["blocks"][-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert self.analytics_called_with_args(
@@ -443,10 +447,11 @@ class ActivityNotificationTest(APITestCase):
 
         attachment, text = get_attachment()
         assert text == f"Issue marked as resolved in {parsed_version} by {self.name}"
-        assert attachment["title"] == self.group.title
-        notification_uuid = get_notification_uuid(attachment["title_link"])
+        assert self.group.title in attachment["text"]
+        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        notification_uuid = get_notification_uuid(title_link)
         assert (
-            attachment["footer"]
+            attachment["blocks"][-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert self.analytics_called_with_args(
@@ -526,10 +531,11 @@ class ActivityNotificationTest(APITestCase):
 
         attachment, text = get_attachment()
 
-        assert attachment["title"] == "Hello world"
-        notification_uuid = get_notification_uuid(attachment["title_link"])
+        assert "Hello world" in attachment["text"]
+        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        notification_uuid = get_notification_uuid(title_link)
         assert (
-            attachment["footer"]
+            attachment["blocks"][-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert self.analytics_called_with_args(

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -700,7 +700,9 @@ class RuleProcessorTestFilters(TestCase):
         mock_post.assert_called_once()
         assert (
             "notification_uuid"
-            in json.loads(mock_post.call_args[1]["data"]["attachments"])[0]["title_link"]
+            in json.loads(mock_post.call_args[1]["data"]["attachments"])[0]["blocks"][0]["text"][
+                "text"
+            ]
         )
 
     @patch("sentry.shared_integrations.client.base.BaseApiClient.post")


### PR DESCRIPTION
The same PR as https://github.com/getsentry/sentry/pull/68016, except we are 100% sure the flag is GA'd now.

Defaults the Slack message builder to use block kit. This touches a lot of file paths so a ton of tests needed to be deleted (if they were testing non-block kit) or slightly refactored.

The only non-test file changed is `src/sentry/integrations/slack/message_builder/issues.py`