### PR TITLE
fix(hc): Fixes integration proxy log pollution and host unreachable exceptions

### DIFF
--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -18,6 +18,7 @@ from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import (
     PROXY_BASE_URL_HEADER,
@@ -40,12 +41,16 @@ class InternalIntegrationProxyEndpoint(Endpoint):
     owner = ApiOwner.HYBRID_CLOUD
     authentication_classes = ()
     permission_classes = ()
-    log_extra: dict[str, str | int] = {}
+    log_extra: dict[str, str | int]
     enforce_rate_limit = False
     """
     This endpoint is used to proxy requests from region silos to the third-party
     integration on behalf of credentials stored in the control silo.
     """
+
+    def __init__(self):
+        super().__init__()
+        self.log_extra = dict()
 
     @property
     def client(self):
@@ -224,6 +229,15 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         scope: Scope | None = None,
     ) -> DRFResponse:
         if isinstance(exc, IdentityNotValid):
+            logger.warning("hybrid_cloud.integration_proxy.invalid_identity", extra=self.log_extra)
             return self.respond(status=400)
+        elif isinstance(exc, ApiHostError):
+            logger.info(
+                "hybrid_cloud.integration_proxy.host_unreachable_error", extra=self.log_extra
+            )
+            return self.respond(status=exc.code)
+        elif isinstance(exc, ApiTimeoutError):
+            logger.info("hybrid_cloud.integration_proxy.host_timeout_error", extra=self.log_extra)
+            return self.respond(status=exc.code)
 
         return super().handle_exception(request, exc, handler_context, scope)

--- a/tests/sentry/api/endpoints/internal/test_integration_proxy.py
+++ b/tests/sentry/api/endpoints/internal/test_integration_proxy.py
@@ -15,6 +15,7 @@ from sentry.integrations.example.integration import ExampleIntegration
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
+from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import (
     PROXY_BASE_PATH,
@@ -73,37 +74,41 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
             integration_id=self.integration.id
         ).first()
 
-        signature = encode_subnet_signature(
-            secret=self.secret,
-            base_url="https://example.com/api",
-            path=self.proxy_path,
-            identifier=str(self.org_integration.id),
-            request_body=b"",
-        )
-        self.valid_header_kwargs = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_BASE_URL="https://example.com/api",
-            HTTP_X_SENTRY_SUBNET_SIGNATURE=signature,
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
+        self.valid_header_kwargs = self.create_request_headers(
+            integration_id=self.org_integration.id, signature_path=self.proxy_path
         )
         self.valid_request = self.factory.get(self.path, **self.valid_header_kwargs)
+
+    def create_request_headers(
+        self,
+        signature_path,
+        integration_id: str | None = None,
+        request_body=b"",
+        base_url="https://example.com/api",
+    ):
+        signature = encode_subnet_signature(
+            secret=self.secret,
+            base_url=base_url,
+            path=signature_path,
+            identifier=str(integration_id),
+            request_body=request_body,
+        )
+
+        return SiloHttpHeaders(
+            HTTP_X_SENTRY_SUBNET_BASE_URL=base_url,
+            HTTP_X_SENTRY_SUBNET_SIGNATURE=signature,
+            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(integration_id),
+            HTTP_X_SENTRY_SUBNET_PATH=signature_path,
+        )
 
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
     @patch.object(ExampleIntegration, "get_client")
     @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
     def test_proxy(self, mock_client, mock_get_client):
         signature_path = f"/{self.proxy_path}"
-        signature = encode_subnet_signature(
-            secret=self.secret,
-            base_url="https://example.com/api",
-            path=signature_path,
-            identifier=str(self.org_integration.id),
-            request_body=b"",
-        )
-        headers = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_BASE_URL="https://example.com/api",
-            HTTP_X_SENTRY_SUBNET_SIGNATURE=signature,
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
-            HTTP_X_SENTRY_SUBNET_PATH=signature_path,
+        headers = self.create_request_headers(
+            signature_path=signature_path,
+            integration_id=self.org_integration.id,
         )
 
         mock_response = Mock(spec=Response)
@@ -142,18 +147,10 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
     @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
     def test_proxy_with_different_base_url(self, mock_client, mock_get_client):
         signature_path = f"/{self.proxy_path}"
-        signature = encode_subnet_signature(
-            secret=self.secret,
+        headers = self.create_request_headers(
+            signature_path=signature_path,
+            integration_id=self.org_integration.id,
             base_url="https://foobar.example.com/api",
-            path=signature_path,
-            identifier=str(self.org_integration.id),
-            request_body=b"",
-        )
-        headers = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_BASE_URL="https://foobar.example.com/api",
-            HTTP_X_SENTRY_SUBNET_SIGNATURE=signature,
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
-            HTTP_X_SENTRY_SUBNET_PATH=f"/{self.proxy_path}",
         )
 
         mock_response = Mock(spec=Response)
@@ -185,6 +182,36 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         assert proxy_response.reason_phrase == mock_response.reason
         assert proxy_response["Content-Type"] == mock_response.headers["Content-Type"]
         assert proxy_response["X-Arbitrary"] == mock_response.headers["X-Arbitrary"]
+        assert proxy_response.get(PROXY_SIGNATURE_HEADER) is None
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
+    def test_proxy_request_with_missing_integration_id(self, mock_client, mock_get_client):
+        signature_path = f"/{self.proxy_path}"
+        headers = self.create_request_headers(
+            signature_path=signature_path,
+            integration_id=None,
+        )
+
+        mock_response = Mock(spec=Response)
+        mock_response.content = str({"foo": "bar"}).encode("utf-8")
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "Content-Type": "application/json",
+            "X-Arbitrary": "Value",
+            PROXY_SIGNATURE_HEADER: "123",
+        }
+
+        mock_client.base_url = "https://example.com/api"
+        mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
+        mock_client.request = MagicMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        proxy_response = self.client.get(self.path, **headers)
+
+        assert proxy_response.status_code == 400
+        assert mock_client.request.call_count == 0
         assert proxy_response.get(PROXY_SIGNATURE_HEADER) is None
 
     @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
@@ -250,25 +277,15 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         assert self.endpoint_cls._validate_request(request)
 
     def raise_exception(self, exc_type: type[Exception], *args, **kwargs):
-        raise exc_type()
+        raise exc_type(*args)
 
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
     @patch.object(ExampleIntegration, "get_client")
     @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
     def test_handles_identity_not_valid(self, mock_client, mock_get_client):
         signature_path = f"/{self.proxy_path}"
-        signature = encode_subnet_signature(
-            secret=self.secret,
-            base_url="https://example.com/api",
-            path=signature_path,
-            identifier=str(self.org_integration.id),
-            request_body=b"",
-        )
-        headers = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_BASE_URL="https://example.com/api",
-            HTTP_X_SENTRY_SUBNET_SIGNATURE=signature,
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
-            HTTP_X_SENTRY_SUBNET_PATH=signature_path,
+        headers = self.create_request_headers(
+            signature_path=signature_path, integration_id=self.org_integration.id
         )
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
@@ -285,20 +302,54 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
     @patch.object(ExampleIntegration, "get_client")
     @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
+    def test_handles_api_host_errors(self, mock_client, mock_get_client):
+        signature_path = f"/{self.proxy_path}"
+        headers = self.create_request_headers(
+            signature_path=signature_path, integration_id=self.org_integration.id
+        )
+        mock_client.base_url = "https://example.com/api"
+        mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
+        mock_client.request = MagicMock(
+            side_effect=lambda *args, **kwargs: self.raise_exception(
+                ApiHostError, "API request failed"
+            )
+        )
+        mock_get_client.return_value = mock_client
+
+        proxy_response = self.client.get(self.path, **headers)
+
+        assert proxy_response.status_code == 503
+        assert proxy_response.data is None
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
+    def test_handles_api_timeout_error(self, mock_client, mock_get_client):
+        signature_path = f"/{self.proxy_path}"
+        headers = self.create_request_headers(
+            signature_path=signature_path, integration_id=self.org_integration.id
+        )
+        mock_client.base_url = "https://example.com/api"
+        mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
+        mock_client.request = MagicMock(
+            side_effect=lambda *args, **kwargs: self.raise_exception(
+                ApiTimeoutError, "API request timed out"
+            )
+        )
+        mock_get_client.return_value = mock_client
+
+        proxy_response = self.client.get(self.path, **headers)
+
+        assert proxy_response.status_code == 504
+        assert proxy_response.data is None
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
     def test_returns_500_for_unexpected_error(self, mock_client, mock_get_client):
         signature_path = f"/{self.proxy_path}"
-        signature = encode_subnet_signature(
-            secret=self.secret,
-            base_url="https://example.com/api",
-            path=signature_path,
-            identifier=str(self.org_integration.id),
-            request_body=b"",
-        )
-        headers = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_BASE_URL="https://example.com/api",
-            HTTP_X_SENTRY_SUBNET_SIGNATURE=signature,
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
-            HTTP_X_SENTRY_SUBNET_PATH=signature_path,
+        headers = self.create_request_headers(
+            signature_path=signature_path, integration_id=self.org_integration.id
         )
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)


### PR DESCRIPTION
<!-- Describe your PR here. -->

## Log Pollution:

The logging context for integration proxy was using a class variable,
resulting in a shared context between requests. Moved this to a member
variable that is instantiated with the class to ensure a clean log
context between instances.

## Updated Exception Handling:

Adds custom handling for host unreachable and timeout errors, which will
now return the correct HTTP status code to the requestor. Also adds
additional logging for debugging.


