### PR TITLE
chore(issues): Also log the original issue id for old groups

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -761,7 +761,14 @@ def post_process_group(
             if duration and duration > 604_800:  # 7 days (7*24*60*60)
                 logger.warning(
                     "tasks.post_process.old_time_to_post_process",
-                    extra={"group_id": group_id, "project_id": project_id, "duration": duration},
+                    extra={
+                        "group_id": group_id,
+                        "project_id": project_id,
+                        "duration": duration,
+                        "original_issue_id": get_path(
+                            event.data, "contexts", "reprocessing", "original_issue_id"
+                        ),
+                    },
                 )
 
 


### PR DESCRIPTION
The general hypothesis here is that the call to `is_reprocessed_event(event.data)` above is incorrectly returning false in some cases. Logging this original issue id will help us determine _why_ it's doing that.