### PR TITLE
fix(spans): Dont lower span description searches

### DIFF
--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -42,9 +42,6 @@ class SpansIndexedDatasetConfig(DatasetConfig):
             constants.SPAN_OP: lambda search_filter: filter_aliases.lowercase_search(
                 self.builder, search_filter
             ),
-            constants.SPAN_DESCRIPTION: lambda search_filter: filter_aliases.lowercase_search(
-                self.builder, search_filter
-            ),
         }
 
     @property


### PR DESCRIPTION
- Only span ops are lowered, descriptions are untouched, so we shouldn't be lowering description in the filter