### PR TITLE
fix(api-idorslug): Make Project Endpoint use Lookup for all control paths

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -144,7 +144,7 @@ class ProjectEndpoint(Endpoint):
                     self.convert_args.__qualname__, str(organization_slug)
                 ):
                     redirect = redirect.get(
-                        organization__id=organization_slug,
+                        organization__slug__id_or_slug=organization_slug,
                         redirect_slug__id_or_slug=project_slug,
                     )
                 else:


### PR DESCRIPTION
I missed a control path that needs to use the lookup. It caused 
https://sentry.sentry.io/issues/5178612789/?project=1&referrer=github-pr-bot
