### PR TITLE
fix(relocation): Add CSRF token to 'Resend Claim Acct' button

### DIFF
--- a/src/sentry/templates/sentry/account/relocate/failure.html
+++ b/src/sentry/templates/sentry/account/relocate/failure.html
@@ -10,6 +10,13 @@
 	<p>{% blocktrans %}This link has expired. Request a new claim account email to set your account
 	  password and claim your account.{% endblocktrans %}</p>
   <form method="POST" action="{% url 'sentry-account-relocate-reclaim' user_id %}">
+    {% csrf_token %}
+    {{ form|as_crispy_errors }}
+
+    {% for field in form %}
+      {{ field|as_crispy_field }}
+    {% endfor %}
+
     <fieldset class="form-actions">
       <button type="submit" class="btn btn-primary">{% trans "Resend Email" %}</button>
     </fieldset>


### PR DESCRIPTION
Fixes CSRF token failures seen on prod when trying to resent an expired "Claim Account" email.