### PR TITLE
feat(trace): Add an additional query that gets timestamps and projects

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -466,6 +466,10 @@ def update_params_with_trace_timestamp_projects(
 
         project_id_set.add(row["project.id"])
 
+    # Do not modify the params if anything comes back empty
+    if len(project_id_set) == 0 or min_timestamp is None or max_timestamp is None:
+        return
+
     project_ids = list(project_id_set)
     # Reusing this option for now
     time_buffer = options.get("performance.traces.span_query_timebuffer_hours")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1728,6 +1728,12 @@ register(
     default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )  # hours
+register(
+    "performance.traces.query_timestamp_projects",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Dynamic Sampling system-wide options
 # Size of the sliding window used for dynamic sampling. It is defaulted to 24 hours.

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -443,6 +443,7 @@ class Referrer(Enum):
     API_SERIALIZER_CHECKINS_TRACE_IDS = "api.serializer.checkins.trace-ids"
     API_STARFISH_PROFILE_FLAMEGRAPH = "api.starfish.profile-flamegraph"
     API_TRACE_VIEW_ERRORS_VIEW = "api.trace-view.errors-view"
+    API_TRACE_VIEW_GET_TIMESTAMP_PROJECTS = "api.trace-view.get-timestamp-projects"
     API_TRACE_VIEW_GET_EVENTS = "api.trace-view.get-events"
     API_TRACE_VIEW_GET_META = "api.trace-view.get-meta"
     API_TRACE_VIEW_HOVER_CARD = "api.trace-view.hover-card"


### PR DESCRIPTION
- This adds a new query to the trace view where we'll first query for the min and max timestamps and the list of projects
- This should mean that all the subsequent queries will be significantly faster since we're only querying the timestamps and projects we care about
- You can read more about the data used to determine this in the private notion doc [here](https://www.notion.so/sentry/Trace-Queries-64a39d3854e24a738dfb1dc503a57f6b)
- Should be very low risk, everything new is behind an option:
  - Turning it on here: https://github.com/getsentry/sentry-options-automator/pull/1097
  - Turning it off here: https://github.com/getsentry/sentry-options-automator/pull/1098