### PR TITLE
fix(yarn-lock): Remove orphaned entries

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,14 +1678,14 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz#d9fae00a2d5cb40f92cfe64b47ad749fbc38f917"
   integrity sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==
 
-"@internationalized/date@^3.5.1", "@internationalized/date@^3.5.2":
+"@internationalized/date@^3.5.2":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.5.2.tgz#d760ace32bb47e869b8c607a4a786c8b208aacc2"
   integrity sha512-vo1yOMUt2hzp63IutEaTUxROdvQg1qlMRsbCvbay2AK2Gai7wIgCyK5weEX3nHkiLgo4qCXHijFNC/ILhlRpOQ==
   dependencies:
     "@swc/helpers" "^0.5.0"
 
-"@internationalized/message@^3.1.1", "@internationalized/message@^3.1.2":
+"@internationalized/message@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@internationalized/message/-/message-3.1.2.tgz#c42fcc5118b6e9c4cd2109695daf1ad126a87375"
   integrity sha512-MHAWsZWz8jf6jFPZqpTudcCM361YMtPIRu9CXkYmKjJ/0R3pQRScV5C0zS+Qi50O5UAm8ecKhkXx6mWDDcF6/g==
@@ -1700,7 +1700,7 @@
   dependencies:
     "@swc/helpers" "^0.5.0"
 
-"@internationalized/string@^3.2.0", "@internationalized/string@^3.2.1":
+"@internationalized/string@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@internationalized/string/-/string-3.2.1.tgz#9059a580956b0af882ab05409efa276a42e2d960"
   integrity sha512-vWQOvRIauvFMzOO+h7QrdsJmtN1AXAFVcaLWP9AseRN2o7iHceZ6bIXhBD4teZl8i91A3gxKnWBlGgjCwU6MFQ==
@@ -2396,7 +2396,7 @@
     "@react-types/shared" "^3.22.0"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/ssr@^3.9.1", "@react-aria/ssr@^3.9.2":
+"@react-aria/ssr@^3.9.2":
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.9.2.tgz#01b756965cd6e32b95217f968f513eb3bd6ee44b"
   integrity sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==
@@ -2527,7 +2527,7 @@
     "@react-types/numberfield" "^3.7.0"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/overlays@^3.6.4", "@react-stately/overlays@^3.6.5":
+"@react-stately/overlays@^3.6.5":
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/@react-stately/overlays/-/overlays-3.6.5.tgz#f36f2a381fddd0e5573dded857962439d4bf1aef"
   integrity sha512-U4rCFj6TPJPXLUvYXAcvh+yP/CO2W+7f0IuqP7ZZGE+Osk9qFkT+zRK5/6ayhBDFpmueNfjIEAzT9gYPQwNHFw==
@@ -2653,14 +2653,14 @@
   dependencies:
     "@react-types/shared" "^3.22.0"
 
-"@react-types/listbox@^3.4.6", "@react-types/listbox@^3.4.7":
+"@react-types/listbox@^3.4.7":
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/@react-types/listbox/-/listbox-3.4.7.tgz#3b9f10e604dfa2b407334e3c9d523f0b9ca10dd8"
   integrity sha512-68y5H9CVSPFiwO6MOFxTbry9JQMK/Lb1M9i3M8TDyq1AbJxBPpgAvJ9RaqIMCucsnqCzpY/zA3D/X417zByL1w==
   dependencies:
     "@react-types/shared" "^3.22.1"
 
-"@react-types/menu@^3.9.6", "@react-types/menu@^3.9.7":
+"@react-types/menu@^3.9.7":
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/@react-types/menu/-/menu-3.9.7.tgz#6276634c473942c44853f1f767592c401d87c059"
   integrity sha512-K6KhloJVoGsqwkdeez72fkNI9dfrmLI/sNrB4XuOKo2crDQ/eyZYWyJmzz8giz/tHME9w774k487rVoefoFh5w==
@@ -2675,7 +2675,7 @@
   dependencies:
     "@react-types/shared" "^3.22.0"
 
-"@react-types/overlays@^3.8.4", "@react-types/overlays@^3.8.5":
+"@react-types/overlays@^3.8.5":
   version "3.8.5"
   resolved "https://registry.yarnpkg.com/@react-types/overlays/-/overlays-3.8.5.tgz#2dbee3ab6e5ff87d4bd443468ef7c2c6d63b5383"
   integrity sha512-4D7EEBQigD/m8hE68Ys8eloyyZFHHduqykSIgINJ0edmo0jygRbWlTwuhWFR9USgSP4dK54duN0Mvq0m4HEVEw==
@@ -2715,7 +2715,7 @@
   dependencies:
     "@react-types/shared" "^3.22.0"
 
-"@react-types/textfield@^3.9.0", "@react-types/textfield@^3.9.1":
+"@react-types/textfield@^3.9.1":
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/@react-types/textfield/-/textfield-3.9.1.tgz#727cc4a6b370dcec8a0ea0bb6bb9c0c2f2ab8c49"
   integrity sha512-JBHY9M2CkL6xFaGSfWmUJVu3tEK09FaeB1dU3IEh6P41xxbFnPakYHSSAdnwMXBtXPoSHIVsUBickW/pjgfe5g==


### PR DESCRIPTION
Remove orphaned lock file entries that were created during the de-duplication of `@react-aria/menu` in https://github.com/getsentry/sentry/pull/68332/commits/5f17e22e32fc9f57780bc09c8580078045efd2f5