### PR TITLE
Revert "Revert "fix(crons): Temporarily increase frequency of the broken monitor task (#68632)""

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1042,7 +1042,7 @@ CELERYBEAT_SCHEDULE_REGION = {
     "monitors-detect-broken-monitor-envs": {
         "task": "sentry.monitors.tasks.detect_broken_monitor_envs",
         # 8:00 PDT, 11:00 EDT, 15:00 UTC
-        "schedule": crontab(minute="0", hour="15", day_of_week="mon-fri"),
+        "schedule": crontab(minute="*/30"),
         "options": {"expires": 15 * 60},
     },
     "clear-expired-snoozes": {


### PR DESCRIPTION
This reverts commit 1c7d2b444abd2720f4eb1728b3b1138286111fd5.

We've disabled this feature flag for now. I want to get this running frequently again so that I can perform some tests.
