### PR TITLE
fix(crons): Fix infinite loop in broken monitor detector

### DIFF
--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -170,7 +170,6 @@ def detect_broken_monitor_envs_for_org(org_id: int):
     # Query for all the broken incidents within the current org we are processing
     for open_incident in RangeQuerySetWrapper(
         orgs_open_incidents,
-        order_by="starting_timestamp",
         step=1000,
     ):
         # Record how long it takes to process this org's incident


### PR DESCRIPTION
This fixes an infinite loop that occurs in the broken monitor detector when we have two rows that have the same `starting_timestamp`. The `RangeQuerySetWrapper` ends up looping forever if the last two rows in the query have an identical `order_by` key.

We fetch the duplicate rows here: https://github.com/getsentry/sentry/blob/4454c16924b310d03584a1f85e4b2114ff53070b/src/sentry/utils/query.py#L146 These are fetched in a deterministic order most likely, which is the same each time. So then we pass the checkk here https://github.com/getsentry/sentry/blob/4454c16924b310d03584a1f85e4b2114ff53070b/src/sentry/utils/query.py#L154-L163 and increment `num`. Now, since `num > start`, we start the loop again and iterate forever.
