### PR TITLE
debug(celery): move receiver and add logs

### DIFF
--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -1,8 +1,6 @@
 import logging
 
 from django.db import router, transaction
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 
 from sentry import features
 from sentry.integrations.slack.service import SlackService
@@ -21,39 +19,54 @@ _default_logger = logging.getLogger(__name__)
     silo_mode=SiloMode.REGION,
 )
 def send_activity_notifications_to_slack_threads(activity_id) -> None:
+    log_params = {"activity_id": activity_id}
+    _default_logger.info("async processing for activity", extra=log_params)
+
     try:
         activity = Activity.objects.get(pk=activity_id)
     except Activity.DoesNotExist:
-        _default_logger.info("Activity does not exist", extra={"activity_id": activity_id})
+        _default_logger.info("activity does not exist", extra=log_params)
         return
 
     organization = Organization.objects.get_from_cache(id=activity.project.organization_id)
-    if features.has("organizations:slack-thread-issue-alert", organization):
-        slack_service = SlackService.default()
-        try:
-            slack_service.notify_all_threads_for_activity(activity=activity)
-            metrics.incr(
-                "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications.success",
-                sample_rate=1.0,
-            )
-        except Exception as err:
-            _default_logger.info(
-                "Failed to send notifications for activity",
-                exc_info=err,
-                extra={"activity_id": activity_id},
-            )
-            metrics.incr(
-                "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications.failure",
-                sample_rate=1.0,
-            )
+    log_params["organization_id"] = organization.id
+
+    org_has_flag = features.has("organizations:slack-thread-issue-alert", organization)
+    log_params["org_has_flag"] = org_has_flag
+    if not org_has_flag:
+        _default_logger.info("org does not have flag, skipping", extra=log_params)
+        return
+
+    _default_logger.info("attempting to send notifications", extra=log_params)
+    slack_service = SlackService.default()
+    try:
+        slack_service.notify_all_threads_for_activity(activity=activity)
+        metrics.incr(
+            "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications.success",
+            sample_rate=1.0,
+        )
+    except Exception as err:
+        _default_logger.info(
+            "Failed to send notifications for activity",
+            exc_info=err,
+            extra={"activity_id": activity_id},
+        )
+        metrics.incr(
+            "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications.failure",
+            sample_rate=1.0,
+        )
+
+    _default_logger.info("task finished for sending notifications", extra=log_params)
 
 
-@receiver(post_save, sender=Activity)
-def activity_created_receiver(instance, created, **kwargs):
+def activity_created_receiver(instance, created, **kwargs) -> None:
     """
     If an activity is created for an issue, this will trigger, and we can kick off an async process
     """
+    log_params = {"activity_id": instance.id, "created": created}
+    _default_logger.info("receiver for activity event", extra=log_params)
     if not created:
+        _default_logger.info("instance is not created, skipping post processing", extra=log_params)
         return
 
     transaction.on_commit(

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -147,6 +147,16 @@ class Activity(Model):
 
         super().save(*args, **kwargs)
 
+        # The receiver for the post_save signal was not working in production, so just execute directly and safely
+        try:
+            from sentry.integrations.slack.tasks.send_notifications_on_activity import (
+                activity_created_receiver,
+            )
+
+            activity_created_receiver(self, created)
+        except Exception:
+            pass
+
         if not created:
             return
 

--- a/tests/sentry/integrations/slack/tasks/test_send_notifications_on_activity.py
+++ b/tests/sentry/integrations/slack/tasks/test_send_notifications_on_activity.py
@@ -21,7 +21,9 @@ class TestActivityCreatedReceiver(TestCase):
             "sentry.integrations.slack.tasks.send_notifications_on_activity.send_activity_notifications_to_slack_threads",
             self.mock_send_activity_notifications,
         ):
-            activity_created_receiver({}, False)
+            foo = mock.MagicMock()
+            foo.id = 123
+            activity_created_receiver(foo, False)
             self.mock_send_activity_notifications.apply_async.assert_not_called()
 
     def test_calls_async_function(self) -> None:


### PR DESCRIPTION
Add more logging to help debug why the task isn't properly getting queued. When running locally, the receiver's signal wasn't executing, so invoking the trigger manually.