### PR TITLE
ref(rules): Add batch_query_hook to EventFrequencyPercentCondition

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -514,9 +514,9 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
             cache.set(cache_key, session_count_last_hour, 600)
         return session_count_last_hour
 
-    def get_session_interval(self, session_count: int, interval: int) -> int | None:
+    def get_session_interval(self, session_count: int, interval: str) -> int | None:
         if session_count >= MIN_SESSIONS_TO_FIRE:
-            interval_in_minutes = percent_intervals[str(interval)][1].total_seconds() // 60
+            interval_in_minutes = percent_intervals[interval][1].total_seconds() // 60
             return int(session_count / (60 / interval_in_minutes))
         return None
 
@@ -526,7 +526,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         project_id = event.project_id
         session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
         avg_sessions_in_interval = self.get_session_interval(
-            session_count_last_hour, int(self.get_option("interval"))
+            session_count_last_hour, self.get_option("interval")
         )
         if avg_sessions_in_interval:
             issue_count = self.get_snuba_query_result(
@@ -563,7 +563,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         project_id = groups[0].project.id
         session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
         avg_sessions_in_interval = self.get_session_interval(
-            session_count_last_hour, int(self.get_option("interval"))
+            session_count_last_hour, self.get_option("interval")
         )
         if avg_sessions_in_interval:
             error_issues = [

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -545,7 +545,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
                         "avg_sessions_in_interval": avg_sessions_in_interval,
                     },
                 )
-            percent: int = 100 * round(issue_count / avg_sessions_in_interval, 4)
+            percent: int = int(100 * round(issue_count / avg_sessions_in_interval, 4))
             return percent
 
         return 0
@@ -577,7 +577,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
                     referrer_suffix="alert_event_frequency_percent",
                 )
                 for group_id, count in error_issue_count.items():
-                    percent: int = 100 * round(count / avg_sessions_in_interval, 4)
+                    percent: int = int(100 * round(count / avg_sessions_in_interval, 4))
                     batch_percents[group_id] = percent
         else:
             percent = 0

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -516,9 +516,8 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
 
     def get_session_interval(self, session_count: int, interval: int) -> int | None:
         if session_count >= MIN_SESSIONS_TO_FIRE:
-            # interval_in_minutes = percent_intervals[interval][1].total_seconds()
-            interval_in_minutes = percent_intervals[interval][1].total_seconds() // 60
-            return session_count / (60 / interval_in_minutes)
+            interval_in_minutes = percent_intervals[str(interval)][1].total_seconds() // 60
+            return int(session_count / (60 / interval_in_minutes))
         return None
 
     def query_hook(
@@ -527,7 +526,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         project_id = event.project_id
         session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
         avg_sessions_in_interval = self.get_session_interval(
-            session_count_last_hour, self.get_option("interval")
+            session_count_last_hour, int(self.get_option("interval"))
         )
         if avg_sessions_in_interval:
             issue_count = self.get_snuba_query_result(
@@ -564,7 +563,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         project_id = groups[0].project.id
         session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
         avg_sessions_in_interval = self.get_session_interval(
-            session_count_last_hour, self.get_option("interval")
+            session_count_last_hour, int(self.get_option("interval"))
         )
         if avg_sessions_in_interval:
             error_issues = [

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -496,10 +496,9 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
             ],
         }
 
-    def query_hook(
-        self, event: GroupEvent, start: datetime, end: datetime, environment_id: str
+    def get_session_count(
+        self, project_id: int, environment_id: str, start: datetime, end: datetime
     ) -> int:
-        project_id = event.project_id
         cache_key = f"r.c.spc:{project_id}-{environment_id}"
         session_count_last_hour = cache.get(cache_key)
         if session_count_last_hour is None:
@@ -513,7 +512,13 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
                 )
 
             cache.set(cache_key, session_count_last_hour, 600)
+        return session_count_last_hour
 
+    def query_hook(
+        self, event: GroupEvent, start: datetime, end: datetime, environment_id: str
+    ) -> int:
+        project_id = event.project_id
+        session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
         if session_count_last_hour >= MIN_SESSIONS_TO_FIRE:
             interval_in_minutes = (
                 percent_intervals[self.get_option("interval")][1].total_seconds() // 60
@@ -544,6 +549,42 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
             return percent
 
         return 0
+
+    def batch_query_hook(
+        self, group_ids: Sequence[int], start: datetime, end: datetime, environment_id: str
+    ) -> dict[int, int]:
+        batch_percents: dict[int, int] = defaultdict(int)
+        groups = Group.objects.filter(id__in=group_ids)
+        project_id = groups[0].project.id
+        session_count_last_hour = self.get_session_count(project_id, environment_id, start, end)
+
+        if session_count_last_hour >= MIN_SESSIONS_TO_FIRE:
+            interval_in_minutes = (
+                percent_intervals[self.get_option("interval")][1].total_seconds() // 60
+            )
+            avg_sessions_in_interval = session_count_last_hour / (60 / interval_in_minutes)
+            error_issues = [
+                group for group in groups if group.issue_category == GroupCategory.ERROR
+            ]
+            if error_issues:
+                error_issue_count = self.get_chunked_result(
+                    tsdb_function=self.tsdb.get_sums,
+                    model=get_issue_tsdb_group_model(error_issues[0].issue_category),
+                    groups=error_issues,
+                    start=start,
+                    end=end,
+                    environment_id=environment_id,
+                    referrer_suffix="alert_event_frequency_percent",
+                )
+                for group_id, count in error_issue_count.items():
+                    percent: int = 100 * round(count / avg_sessions_in_interval, 4)
+                    batch_percents[group_id] = percent
+        else:
+            percent = 0
+            for group in groups:
+                batch_percents[group.id] = percent
+
+        return batch_percents
 
     def passes_activity_frequency(
         self, activity: ConditionActivity, buckets: dict[datetime, int]

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -114,7 +114,12 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
     rule_cls = EventFrequencyCondition
 
     def test_batch_query(self):
-        condition_inst = self.rule_cls(self.event.group.project)
+        data = {"interval": "1m", "value": 6}
+        condition_inst = self.get_rule(
+            data=data,
+            project=self.event.group.project,
+            rule=Rule(environment_id=self.environment.id),
+        )
         batch_query = condition_inst.batch_query_hook(
             group_ids=[self.event.group_id, self.event2.group_id, self.perf_event.group_id],
             start=self.start,
@@ -126,6 +131,11 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
             self.event2.group_id: 1,
             self.perf_event.group_id: 1,
         }
+        condition_inst = self.get_rule(
+            data=data,
+            project=self.event.group.project,
+            rule=Rule(environment_id=self.environment2.id),
+        )
 
         batch_query = condition_inst.batch_query_hook(
             group_ids=[self.event3.group_id],
@@ -140,7 +150,12 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
     rule_cls = EventUniqueUserFrequencyCondition
 
     def test_batch_query_user(self):
-        condition_inst = self.rule_cls(self.event.group.project)
+        data = {"interval": "1m", "value": 6}
+        condition_inst = self.get_rule(
+            data=data,
+            project=self.event.group.project,
+            rule=Rule(environment_id=self.environment.id),
+        )
         batch_query = condition_inst.batch_query_hook(
             group_ids=[self.event.group_id, self.event2.group_id, self.perf_event.group_id],
             start=self.start,
@@ -152,6 +167,11 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
             self.event2.group_id: 1,
             self.perf_event.group_id: 1,
         }
+        condition_inst = self.get_rule(
+            data=data,
+            project=self.event.group.project,
+            rule=Rule(environment_id=self.environment2.id),
+        )
 
         batch_query = condition_inst.batch_query_hook(
             group_ids=[self.event3.group_id],
@@ -168,9 +188,14 @@ class EventFrequencyPercentConditionQueryTest(
     rule_cls = EventFrequencyPercentCondition
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
-    @patch("sentry.rules.base.RuleBase.get_option", return_value="10m")
-    def test_batch_query_percent(self, mock_get_option):
-        condition_inst = self.rule_cls(self.event.group.project)
+    def test_batch_query_percent(self):
+        data = {"interval": "5m", "value": 30}
+        condition_inst = self.get_rule(
+            data=data,
+            project=self.event.group.project,
+            rule=Rule(environment_id=self.environment.id),
+        )
+
         self._make_sessions(60, self.environment2.name)
         self._make_sessions(60, self.environment.name)
         batch_query = condition_inst.batch_query_hook(
@@ -180,9 +205,14 @@ class EventFrequencyPercentConditionQueryTest(
             environment_id=self.environment.id,
         )
         assert batch_query == {
-            self.event.group_id: 10,
-            self.event2.group_id: 10,
+            self.event.group_id: 20,
+            self.event2.group_id: 20,
         }
+        condition_inst = self.get_rule(
+            data=data,
+            project=self.event.group.project,
+            rule=Rule(environment_id=self.environment2.id),
+        )
 
         batch_query = condition_inst.batch_query_hook(
             group_ids=[self.event3.group_id],
@@ -190,7 +220,7 @@ class EventFrequencyPercentConditionQueryTest(
             end=self.end,
             environment_id=self.environment2.id,
         )
-        assert batch_query == {self.event3.group_id: 10}
+        assert batch_query == {self.event3.group_id: 20}
 
 
 class ErrorEventMixin(SnubaTestCase):

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -28,6 +28,31 @@ from sentry.utils.samples import load_data
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
 
+class BaseEventFrequencyPercentTest(BaseMetricsTestCase):
+    def _make_sessions(self, num: int, environment_name: str | None):
+        received = time.time()
+
+        def make_session(i):
+            return dict(
+                distinct_id=uuid4().hex,
+                session_id=uuid4().hex,
+                org_id=self.project.organization_id,
+                project_id=self.project.id,
+                status="ok",
+                seq=0,
+                release="foo@1.0.0",
+                environment=environment_name if environment_name else "prod",
+                retention_days=90,
+                duration=None,
+                errors=0,
+                # The line below is crucial to spread sessions throughout the time period.
+                started=received - i - 1,
+                received=received,
+            )
+
+        self.bulk_store_sessions([make_session(i) for i in range(num)])
+
+
 class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTestCase):
     def setUp(self):
         super().setUp()
@@ -135,6 +160,37 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
             environment_id=self.environment2.id,
         )
         assert batch_query == {self.event3.group_id: 1}
+
+
+class EventFrequencyPercentConditionQueryTest(
+    EventFrequencyQueryTestBase, BaseEventFrequencyPercentTest
+):
+    rule_cls = EventFrequencyPercentCondition
+
+    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
+    @patch("sentry.rules.base.RuleBase.get_option", return_value="10m")
+    def test_batch_query_percent(self, mock_get_option):
+        condition_inst = self.rule_cls(self.event.group.project)
+        self._make_sessions(60, self.environment2.name)
+        self._make_sessions(60, self.environment.name)
+        batch_query = condition_inst.batch_query_hook(
+            group_ids=[self.event.group_id, self.event2.group_id, self.perf_event.group_id],
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment.id,
+        )
+        assert batch_query == {
+            self.event.group_id: 10.0,
+            self.event2.group_id: 10.0,
+        }
+
+        batch_query = condition_inst.batch_query_hook(
+            group_ids=[self.event3.group_id],
+            start=self.start,
+            end=self.end,
+            environment_id=self.environment2.id,
+        )
+        assert batch_query == {self.event3.group_id: 10.0}
 
 
 class ErrorEventMixin(SnubaTestCase):
@@ -395,36 +451,13 @@ class EventUniqueUserFrequencyConditionTestCase(StandardIntervalTestBase):
             )
 
 
-class EventFrequencyPercentConditionTestCase(BaseMetricsTestCase, RuleTestCase):
+class EventFrequencyPercentConditionTestCase(BaseEventFrequencyPercentTest, RuleTestCase):
     __test__ = Abstract(__module__, __qualname__)
 
     rule_cls = EventFrequencyPercentCondition
 
     def add_event(self, data, project_id, timestamp):
         raise NotImplementedError
-
-    def _make_sessions(self, num):
-        received = time.time()
-
-        def make_session(i):
-            return dict(
-                distinct_id=uuid4().hex,
-                session_id=uuid4().hex,
-                org_id=self.project.organization_id,
-                project_id=self.project.id,
-                status="ok",
-                seq=0,
-                release="foo@1.0.0",
-                environment="prod",
-                retention_days=90,
-                duration=None,
-                errors=0,
-                # The line below is crucial to spread sessions throughout the time period.
-                started=received - i - 1,
-                received=received,
-            )
-
-        self.bulk_store_sessions([make_session(i) for i in range(num)])
 
     def _run_test(self, minutes, data, passes, add_events=False):
         if not self.environment or self.environment.name != "prod":

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -29,7 +29,7 @@ pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
 
 class BaseEventFrequencyPercentTest(BaseMetricsTestCase):
-    def _make_sessions(self, num: int, environment_name: str | None):
+    def _make_sessions(self, num: int, environment_name: str | None = None):
         received = time.time()
 
         def make_session(i):
@@ -180,8 +180,8 @@ class EventFrequencyPercentConditionQueryTest(
             environment_id=self.environment.id,
         )
         assert batch_query == {
-            self.event.group_id: 10.0,
-            self.event2.group_id: 10.0,
+            self.event.group_id: 10,
+            self.event2.group_id: 10,
         }
 
         batch_query = condition_inst.batch_query_hook(
@@ -190,7 +190,7 @@ class EventFrequencyPercentConditionQueryTest(
             end=self.end,
             environment_id=self.environment2.id,
         )
-        assert batch_query == {self.event3.group_id: 10.0}
+        assert batch_query == {self.event3.group_id: 10}
 
 
 class ErrorEventMixin(SnubaTestCase):


### PR DESCRIPTION
Another follow up to https://github.com/getsentry/sentry/pull/68672 and a part 3 of https://github.com/getsentry/team-core-product-foundations/issues/239 to add a batch_query_hook function for the EventFrequencyPercentCondition.