### PR TITLE
fix(backup): Improper filtering on empty pk map

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -183,9 +183,7 @@ class BaseModel(models.Model):
             foreign_field_model_name = get_model_name(foreign_field.model)
             matched_fks = set(pk_map.get_pks(foreign_field_model_name))
             matched_fks_query = dict()
-            if len(matched_fks) > 0:
-                matched_fks_query[field_name + "__in"] = matched_fks
-
+            matched_fks_query[field_name + "__in"] = matched_fks
             if foreign_field.nullable:
                 match_on_null_query = dict()
                 match_on_null_query[field_name + "__isnull"] = True


### PR DESCRIPTION
We use pk maps to filter dependent queries when exporting. For example, if we want to get all user emails associated with a user with id `2`, we would submit a pk map containing the key `2` to ensure that it is included in the filter when Django constructs the SQL query to pull down the emails, such they they will contain a clause equivalent to `WHERE user_id IN (2, ...)`.

This all works fine, except that we had an erroneous condition that removed this filtering for cases where the pk map was empty. So instead of something like `WHERE used_ID IN ()`, which would produce no results very quickly, we eliminated the clause entirely, causing us to pull down the entire table verrrrrrry sloooooooowly. This was, unsurprisingly, causing RPC timeouts.