### PR TITLE
feat(metrics): Refetch metrics on opening selector

### DIFF
--- a/static/app/components/comboBox/index.tsx
+++ b/static/app/components/comboBox/index.tsx
@@ -46,6 +46,7 @@ interface ComboBoxProps<Value extends string>
   className?: string;
   disabled?: boolean;
   isLoading?: boolean;
+  loadingMessage?: string;
   menuSize?: FormSize;
   menuWidth?: string;
   size?: FormSize;
@@ -60,6 +61,7 @@ function ComboBox<Value extends string>({
   placeholder,
   disabled,
   isLoading,
+  loadingMessage,
   sizeLimitMessage,
   menuTrigger = 'focus',
   menuWidth,
@@ -100,7 +102,7 @@ function ComboBox<Value extends string>({
 
   // Make popover width constant while it is open
   useEffect(() => {
-    if (popoverRef.current && state.isOpen) {
+    if (!menuWidth && popoverRef.current && state.isOpen) {
       const popoverElement = popoverRef.current;
       popoverElement.style.width = `${popoverElement.offsetWidth + 4}px`;
       return () => {
@@ -108,7 +110,7 @@ function ComboBox<Value extends string>({
       };
     }
     return () => {};
-  }, [state.isOpen]);
+  }, [menuWidth, state.isOpen]);
 
   const selectContext = useContext(SelectContext);
 
@@ -160,7 +162,7 @@ function ComboBox<Value extends string>({
           <StyledOverlay ref={popoverRef} width={menuWidth}>
             {isLoading && (
               <MenuHeader size={menuSize ?? size}>
-                <MenuTitle>{t('Loading...')}</MenuTitle>
+                <MenuTitle>{loadingMessage ?? t('Loading...')}</MenuTitle>
                 <MenuHeaderTrailingItems>
                   {isLoading && <StyledLoadingIndicator size={12} mini />}
                 </MenuHeaderTrailingItems>
@@ -196,6 +198,7 @@ function ControlledComboBox<Value extends string>({
   options,
   sizeLimit,
   value,
+  onOpenChange,
   ...props
 }: Omit<ComboBoxProps<Value>, 'items' | 'defaultItems' | 'children'> & {
   options: ComboBoxOptionOrSection<Value>[];
@@ -264,12 +267,16 @@ function ControlledComboBox<Value extends string>({
     setInputValue(newInputValue);
   }, []);
 
-  const handleOpenChange = useCallback((isOpen: boolean) => {
-    // Disable filtering right after the dropdown is opened
-    if (isOpen) {
-      setIsFiltering(false);
-    }
-  }, []);
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      // Disable filtering right after the dropdown is opened
+      if (isOpen) {
+        setIsFiltering(false);
+      }
+      onOpenChange?.(isOpen);
+    },
+    [onOpenChange]
+  );
 
   return (
     // TODO: remove usage of SelectContext in ListBox

--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -28,7 +28,7 @@ export function useMetricsMeta(
   useCases: UseCase[] = DEFAULT_USE_CASES,
   filterBlockedMetrics = true,
   enabled: boolean = true
-): {data: MetricMeta[]; isLoading: boolean} {
+): {data: MetricMeta[]; isLoading: boolean; isRefetching: boolean; refetch: () => void} {
   const {slug} = useOrganization();
 
   const queryKeys = useMemo(() => {
@@ -37,18 +37,27 @@ export function useMetricsMeta(
 
   const results = useApiQueries<MetricMeta[]>(queryKeys, {
     enabled,
-    refetchInterval: 60000,
     staleTime: 2000, // 2 seconds to cover page load
   });
 
-  const {data, isLoading} = useMemo(() => {
+  const {data, isLoading, isRefetching, refetch} = useMemo(() => {
     const mergedResult: {
       data: MetricMeta[];
       isLoading: boolean;
-    } = {data: [], isLoading: false};
+      isRefetching: boolean;
+      refetch: () => void;
+    } = {
+      data: [],
+      isLoading: false,
+      isRefetching: false,
+      refetch: () => {
+        results.forEach(result => result.refetch());
+      },
+    };
 
     for (const useCaseResult of results) {
       mergedResult.isLoading ||= useCaseResult.isLoading;
+      mergedResult.isRefetching ||= useCaseResult.isRefetching;
       const useCaseData = useCaseResult.data ?? [];
       mergedResult.data.push(...useCaseData);
     }
@@ -61,7 +70,7 @@ export function useMetricsMeta(
   );
 
   if (!filterBlockedMetrics) {
-    return {data: meta, isLoading};
+    return {data: meta, isLoading, isRefetching, refetch};
   }
 
   return {
@@ -69,6 +78,8 @@ export function useMetricsMeta(
       return entry.blockingStatus?.every(({isBlocked}) => !isBlocked) ?? true;
     }),
     isLoading,
+    isRefetching,
+    refetch,
   };
 }
 

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -150,7 +150,7 @@ export function useApiQueries<TResponseData, TError = RequestError>(
       return {
         queryKey,
         queryFn,
-        options,
+        ...options,
       };
     }),
   });

--- a/static/app/views/metrics/queryBuilder.tsx
+++ b/static/app/views/metrics/queryBuilder.tsx
@@ -80,7 +80,12 @@ export const QueryBuilder = memo(function QueryBuilder({
   const breakpoints = useBreakpoints();
   const {projects} = useProjects();
 
-  const {data: meta, isLoading: isMetaLoading} = useMetricsMeta(pageFilters.selection);
+  const {
+    data: meta,
+    isLoading: isMetaLoading,
+    isRefetching: isMetaRefetching,
+    refetch: refetchMeta,
+  } = useMetricsMeta(pageFilters.selection);
   const mriMode = useMriMode();
 
   const shouldUseComboBox = hasMetricsExperimentalFeature(organization);
@@ -196,6 +201,15 @@ export const QueryBuilder = memo(function QueryBuilder({
     [incrementQueryMetric, onChange, organization]
   );
 
+  const handleOpenMetricsMenu = useCallback(
+    (isOpen: boolean) => {
+      if (isOpen && !isMetaLoading && !isMetaRefetching) {
+        refetchMeta();
+      }
+    },
+    [isMetaLoading, isMetaRefetching, refetchMeta]
+  );
+
   const mriOptions = useMemo(
     () =>
       displayedMetrics.map<ComboBoxOption<MRI>>(metric => ({
@@ -227,10 +241,12 @@ export const QueryBuilder = memo(function QueryBuilder({
           <MetricComboBox
             aria-label={t('Metric')}
             placeholder={t('Select a metric')}
+            loadingMessage={t('Loading metrics...')}
             sizeLimit={100}
             size="md"
             menuSize="sm"
             isLoading={isMetaLoading}
+            onOpenChange={handleOpenMetricsMenu}
             options={mriOptions}
             value={metricsQuery.mri}
             onChange={handleMRIChange}


### PR DESCRIPTION
Update / Refetch metrics on opening the selector.
Fix an issue with `useQueries` where the query options were not passed on properly.

- closes https://github.com/getsentry/sentry/issues/68516