### PR TITLE
feat(profiling): add frame-level platform info

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1124,11 +1124,10 @@ def _calculate_duration_for_android_format(profile: Profile) -> int:
 
 
 def _set_frames_platform(profile: Profile):
-    if "version" in profile:
-        platform = profile["platform"]
-        for i, f in enumerate(profile["profile"]["frames"]):
-            if f.get("platform", "") == "":
-                profile["profile"]["frames"][i]["platform"] = platform
-    elif profile["platform"] == "android":
-        for i, _ in enumerate(profile["profile"]["methods"]):
-            profile["profile"]["methods"][i]["platform"] = "android"
+    platform = profile["platform"]
+    frames = (
+        profile["profile"]["methods"] if platform == "android" else profile["profile"]["frames"]
+    )
+    for f in frames:
+        if "platform" not in f:
+            f["platform"] = platform

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1126,12 +1126,9 @@ def _calculate_duration_for_android_format(profile: Profile) -> int:
 def _set_frames_platform(profile: Profile):
     if "version" in profile:
         platform = profile["platform"]
-        if platform in ["javascript", "node", "cocoa"]:
-            # bail early because it was already set
-            return
-        for i, _ in enumerate(profile["profile"]["frames"]):
-            profile["profile"]["frames"][i]["platform"] = platform
-        return
+        for i, f in enumerate(profile["profile"]["frames"]):
+            if f.get("platform", "") == "":
+                profile["profile"]["frames"][i]["platform"] = platform
     elif profile["platform"] == "android":
         for i, _ in enumerate(profile["profile"]["methods"]):
             profile["profile"]["methods"][i]["platform"] = "android"

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -148,6 +148,10 @@ def process_profile_task(
     if not _normalize_profile(profile, organization, project):
         return
 
+    # set platform information at frame-level
+    # only for those platforms that didn't go through symbolication
+    _set_frames_platform(profile)
+
     if "version" in profile:
         set_measurement("profile.samples.processed", len(profile["profile"]["samples"]))
         set_measurement("profile.stacks.processed", len(profile["profile"]["stacks"]))
@@ -637,7 +641,9 @@ def _process_symbolicator_results_for_sample(
             # This works since symbolicated_frames are in the same order
             # as raw_frames (except some frames are not sent).
             for frame_idx in symbolicated_frames_dict[symbolicated_frame_idx]:
-                new_frames.append(symbolicated_frames[frame_idx])
+                f = symbolicated_frames[frame_idx]
+                f["platform"] = platform
+                new_frames.append(f)
 
             # go to the next symbolicated frame result
             symbolicated_frame_idx += 1
@@ -1115,3 +1121,17 @@ def _calculate_duration_for_sample_format_v2(profile: Profile) -> int:
 
 def _calculate_duration_for_android_format(profile: Profile) -> int:
     return int(profile["duration_ns"] * 1e-6)
+
+
+def _set_frames_platform(profile: Profile):
+    if "version" in profile:
+        platform = profile["platform"]
+        if platform in ["javascript", "node", "cocoa"]:
+            # bail early because it was already set
+            return
+        for i, _ in enumerate(profile["profile"]["frames"]):
+            profile["profile"]["frames"][i]["platform"] = platform
+        return
+    elif profile["platform"] == "android":
+        for i, _ in enumerate(profile["profile"]["methods"]):
+            profile["profile"]["methods"][i]["platform"] = "android"

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -22,6 +22,7 @@ from sentry.profiles.task import (
     _deobfuscate_using_symbolicator,
     _normalize,
     _process_symbolicator_results_for_sample,
+    _set_frames_platform,
     _symbolicate_profile,
 )
 from sentry.testutils.cases import TransactionTestCase
@@ -865,3 +866,36 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
 
         _symbolicate_profile(js_profile, self.project)
         assert js_profile["profile"]["frames"][0].get("data", {}).get("symbolicated", False)
+
+
+def test_set_frames_platform_sample():
+    python_prof = {
+        "version": "1",
+        "platform": "python",
+        "profile": {
+            "frames": [
+                {"function": "a"},
+                {"function": "b"},
+            ]
+        },
+    }
+    _set_frames_platform(python_prof)
+
+    platforms = [f["platform"] for f in python_prof["profile"]["frames"]]
+    assert platforms == ["python", "python"]
+
+
+def test_set_frames_platform_android():
+    android_prof = {
+        "platform": "android",
+        "profile": {
+            "methods": [
+                {"name": "a"},
+                {"name": "b"},
+            ]
+        },
+    }
+    _set_frames_platform(android_prof)
+
+    platforms = [m["platform"] for m in android_prof["profile"]["methods"]]
+    assert platforms == ["android", "android"]

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -869,20 +869,21 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
 
 
 def test_set_frames_platform_sample():
-    python_prof = {
+    js_prof = {
         "version": "1",
-        "platform": "python",
+        "platform": "javascript",
         "profile": {
             "frames": [
                 {"function": "a"},
-                {"function": "b"},
+                {"function": "b", "platform": "cocoa"},
+                {"function": "c"},
             ]
         },
     }
-    _set_frames_platform(python_prof)
+    _set_frames_platform(js_prof)
 
-    platforms = [f["platform"] for f in python_prof["profile"]["frames"]]
-    assert platforms == ["python", "python"]
+    platforms = [f["platform"] for f in js_prof["profile"]["frames"]]
+    assert platforms == ["javascript", "cocoa", "javascript"]
 
 
 def test_set_frames_platform_android():

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -16,6 +16,7 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releasefile import ReleaseFile
 from sentry.profiles.task import (
+    Profile,
     _calculate_profile_duration_ms,
     _deobfuscate,
     _deobfuscate_locally,
@@ -869,7 +870,7 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
 
 
 def test_set_frames_platform_sample():
-    js_prof = {
+    js_prof: Profile = {
         "version": "1",
         "platform": "javascript",
         "profile": {
@@ -887,7 +888,7 @@ def test_set_frames_platform_sample():
 
 
 def test_set_frames_platform_android():
-    android_prof = {
+    android_prof: Profile = {
         "platform": "android",
         "profile": {
             "methods": [


### PR DESCRIPTION
Way back we added [frame-level](https://github.com/getsentry/vroom/blob/main/internal/frame/frame.go#L42) platform information in `vroom`, but we're not passing this information down from `sentry`.

This will also help us to distinguish between `js` and `cocoa` frames in mixed stack traces scenarios (such as for react-native).