### PR TITLE
feat(dynamic-sampling): Add logging to the custom rule progress check

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
+++ b/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
@@ -104,6 +104,7 @@ def get_num_samples(rule: CustomDynamicSamplingRule) -> int:
         project_ids=[project.id for project in projects],
         rule_id=rule.id,
         samples_count=samples_count,
+        min_samples_count=MIN_SAMPLES_FOR_NOTIFICATION,
     )
 
     return samples_count

--- a/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
+++ b/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
@@ -10,6 +10,7 @@ from django.http import QueryDict
 from sentry.constants import ObjectStatus
 from sentry.dynamic_sampling.tasks.common import TimedIterator, to_context_iterator
 from sentry.dynamic_sampling.tasks.constants import MAX_TASK_SECONDS
+from sentry.dynamic_sampling.tasks.logging import log_custom_rule_progress
 from sentry.dynamic_sampling.tasks.task_context import DynamicSamplingLogState, TaskContext
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
@@ -97,7 +98,15 @@ def get_num_samples(rule: CustomDynamicSamplingRule) -> int:
         referrer="dynamic_sampling.tasks.custom_rule_notifications",
     )
 
-    return result["data"][0]["count"]
+    samples_count = result["data"][0]["count"]
+    log_custom_rule_progress(
+        org_id=rule.organization.id,
+        project_ids=[project.id for project in projects],
+        rule_id=rule.id,
+        samples_count=samples_count,
+    )
+
+    return samples_count
 
 
 def send_notification(rule: CustomDynamicSamplingRule, num_samples: int) -> None:

--- a/src/sentry/dynamic_sampling/tasks/logging.py
+++ b/src/sentry/dynamic_sampling/tasks/logging.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.utils import metrics
@@ -68,6 +69,20 @@ def log_skipped_job(org_id: int, job: str):
 
 def log_recalibrate_org_error(org_id: int, error: str) -> None:
     logger.info("dynamic_sampling.recalibrate_org_error", extra={"org_id": org_id, "error": error})
+
+
+def log_custom_rule_progress(
+    org_id: int, project_ids: Sequence[int], rule_id: int, samples_count: int
+):
+    extra = {"org_id": org_id, "rule_id": rule_id, "samples_count": samples_count}
+
+    if project_ids:
+        extra["project_ids"] = project_ids
+
+    logger.info(
+        "dynamic_sampling.custom_rule_progress",
+        extra=extra,
+    )
 
 
 def log_recalibrate_org_state(

--- a/src/sentry/dynamic_sampling/tasks/logging.py
+++ b/src/sentry/dynamic_sampling/tasks/logging.py
@@ -72,9 +72,18 @@ def log_recalibrate_org_error(org_id: int, error: str) -> None:
 
 
 def log_custom_rule_progress(
-    org_id: int, project_ids: Sequence[int], rule_id: int, samples_count: int
+    org_id: int,
+    project_ids: Sequence[int],
+    rule_id: int,
+    samples_count: int,
+    min_samples_count: int,
 ):
-    extra = {"org_id": org_id, "rule_id": rule_id, "samples_count": samples_count}
+    extra = {
+        "org_id": org_id,
+        "rule_id": rule_id,
+        "samples_count": samples_count,
+        "min_samples_count": min_samples_count,
+    }
 
     if project_ids:
         extra["project_ids"] = project_ids

--- a/src/sentry/dynamic_sampling/tasks/logging.py
+++ b/src/sentry/dynamic_sampling/tasks/logging.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Sequence
+from typing import Any
 
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.utils import metrics
@@ -78,7 +79,7 @@ def log_custom_rule_progress(
     samples_count: int,
     min_samples_count: int,
 ):
-    extra = {
+    extra: dict[str, Any] = {
         "org_id": org_id,
         "rule_id": rule_id,
         "samples_count": samples_count,


### PR DESCRIPTION
This PR adds logging when the task for checking progress of custom rules is run. The rationale behind adding logging is that we want to keep track of the progress of each rule in the system, which becomes very important when trying to debug issues.