### PR TITLE
fix(ddm): Fix wrong base implementation of visitor

### DIFF
--- a/src/sentry/sentry_metrics/querying/visitors/base.py
+++ b/src/sentry/sentry_metrics/querying/visitors/base.py
@@ -39,7 +39,7 @@ class QueryExpressionVisitor(ABC, Generic[TVisited]):
         return formula.set_parameters(parameters)
 
     def _visit_timeseries(self, timeseries: Timeseries) -> TVisited:
-        raise timeseries
+        return timeseries
 
     def _visit_int(self, int_number: float) -> TVisited:
         return int_number  # type: ignore[return-value]


### PR DESCRIPTION
This PR fixes the wrong base implementation of the `_visit_timeseries` method which raised an object instead of returning it.