### PR TITLE
fix(replays): Shorten storage policy retry cadence

### DIFF
--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -403,6 +403,6 @@ class GoogleCloudStorageWithReplayUploadPolicy(GoogleCloudStorage):
             """Retry gateway timeout exceptions up to the limit."""
             return attempt <= GCS_RETRIES and isinstance(e, GCS_RETRYABLE_ERRORS)
 
-        # Retry cadence: 0.25, 0.5, 1, 2, 4, 8
-        policy = ConditionalRetryPolicy(should_retry, exponential_delay(0.5))
+        # Retry cadence: 0.05, 0.1, 0.2, 0.4, 0.8, 1.6 => ~3 seconds
+        policy = ConditionalRetryPolicy(should_retry, exponential_delay(0.1))
         policy(callable)

--- a/src/sentry/filestore/gcs.py
+++ b/src/sentry/filestore/gcs.py
@@ -403,6 +403,6 @@ class GoogleCloudStorageWithReplayUploadPolicy(GoogleCloudStorage):
             """Retry gateway timeout exceptions up to the limit."""
             return attempt <= GCS_RETRIES and isinstance(e, GCS_RETRYABLE_ERRORS)
 
-        # Retry cadence: 0.05, 0.1, 0.2, 0.4, 0.8, 1.6 => ~3 seconds
-        policy = ConditionalRetryPolicy(should_retry, exponential_delay(0.1))
+        # Retry cadence: 0.025, 0.05, 0.1, 0.2, 0.4, 0.8 => ~1.7 seconds
+        policy = ConditionalRetryPolicy(should_retry, exponential_delay(0.05))
         policy(callable)


### PR DESCRIPTION
Shortens the storage policy retry length from 17 seconds to 1.7 seconds.  Currently we wait 250 milliseconds after the first failure.  This is probably too long.  A 10x decrease in the wait time is roughly the amount of time it takes to upload a file in the first place.  Waiting one upload interval and checking the service provider again seems reasonable.  We also don't want to block the process for 17 seconds.  Let's block for ~1.7 and if it hasn't fixed it self do our normal crash and retry cycle.

The goal is to not allow random or intermittent failures to significantly lower throughput when we could immediately retry.