### PR TITLE
fix(discover): Cannot add max(timestamp) when timestamp exists

### DIFF
--- a/static/app/views/discover/table/index.tsx
+++ b/static/app/views/discover/table/index.tsx
@@ -123,13 +123,13 @@ class Table extends PureComponent<TableProps, TableState> {
     if (
       eventView.hasAggregateField() &&
       apiPayload.field.includes('trace') &&
-      !apiPayload.field.includes('max(timestamp)')
+      !apiPayload.field.includes('max(timestamp)') &&
+      !apiPayload.field.includes('timestamp')
     ) {
       apiPayload.field.push('max(timestamp)');
     } else if (
       apiPayload.field.includes('trace') &&
-      !apiPayload.field.includes('timestamp') &&
-      !apiPayload.field.includes('max(timestamp)')
+      !apiPayload.field.includes('timestamp')
     ) {
       apiPayload.field.push('timestamp');
     }

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -341,7 +341,7 @@ function TableView(props: TableViewProps) {
       );
     } else if (columnKey === 'trace') {
       const timestamp = getTimeStampFromTableDateField(
-        eventView.hasAggregateField() ? dataRow['max(timestamp)'] : dataRow.timestamp
+        dataRow['max(timestamp)'] ?? dataRow.timestamp
       );
       const dateSelection = eventView.normalizeDateSelection(location);
       if (dataRow.trace) {


### PR DESCRIPTION
When there are aggregates, we just want either `timestamp` or `max(timestamp)`. Having both leads to an error.