### PR TITLE
feat(perf): Add HTTP module domain search

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -6,7 +6,7 @@ describe('utils/tokenizeSearch', function () {
       [{transaction: '/index'}, 'transaction:/index'],
       [{transaction: '/index', has: 'span.domain'}, 'transaction:/index has:span.domain'],
       [{transaction: '/index', 'span.domain': undefined}, 'transaction:/index'],
-      [{'span.domain': '*hello*'}, 'span.domain:"\\*hello\\*"'],
+      [{'span.domain': '*hello*'}, 'span.domain:*hello*'],
       [{'span.description': '*hello*'}, 'span.description:*hello*'],
       [{transaction: '(empty)'}, '!has:transaction'],
     ])('converts %s to search string', (query, result) => {

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -1,6 +1,10 @@
 import {escapeDoubleQuotes} from 'sentry/utils';
 
-const ALLOWED_WILDCARD_FIELDS = ['span.description', 'span.domain', 'span.status_code'];
+export const ALLOWED_WILDCARD_FIELDS = [
+  'span.description',
+  'span.domain',
+  'span.status_code',
+];
 export const EMPTY_OPTION_VALUE = '(empty)' as const;
 
 export enum TokenType {

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -1,6 +1,6 @@
 import {escapeDoubleQuotes} from 'sentry/utils';
 
-const ALLOWED_WILDCARD_FIELDS = ['span.description', 'span.status_code'];
+const ALLOWED_WILDCARD_FIELDS = ['span.description', 'span.domain', 'span.status_code'];
 export const EMPTY_OPTION_VALUE = '(empty)' as const;
 
 export enum TokenType {

--- a/static/app/views/performance/http/domainCell.tsx
+++ b/static/app/views/performance/http/domainCell.tsx
@@ -29,6 +29,7 @@ export function DomainCell({projectId, domain}: Props) {
 
   const queryString = {
     ...location.query,
+    'span.domain': undefined,
     domain,
   };
 

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -14,7 +14,7 @@ import {space} from 'sentry/styles/space';
 import {fromSorts} from 'sentry/utils/discover/eventView';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {escapeFilterValue, MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -68,7 +68,7 @@ export function HTTPDomainSummaryPage() {
 
   const filters: SpanMetricsQueryFilters = {
     'span.module': ModuleName.HTTP,
-    'span.domain': domain,
+    'span.domain': escapeFilterValue(domain),
   };
 
   const cursor = decodeScalar(location.query?.[QueryParameterNames.TRANSACTIONS_CURSOR]);

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -36,7 +36,7 @@ describe('HTTPLandingPage', function () {
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',
     search: '',
-    query: {statsPeriod: '10d'},
+    query: {statsPeriod: '10d', 'span.domain': 'git'},
     hash: '',
     state: undefined,
     action: 'PUSH',
@@ -188,7 +188,7 @@ describe('HTTPLandingPage', function () {
           ],
           per_page: 10,
           project: [],
-          query: 'span.module:http has:span.domain',
+          query: 'span.module:http span.domain:*git* has:span.domain',
           referrer: 'api.starfish.http-module-landing-domains-list',
           sort: '-time_spent_percentage()',
           statsPeriod: '10d',

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -12,7 +12,7 @@ import {space} from 'sentry/styles/space';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {escapeFilterValue, MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -107,14 +107,14 @@ export function HTTPSamplesPanel() {
   // The ribbon is above the data selectors, and not affected by them. So, it has its own filters.
   const ribbonFilters: SpanMetricsQueryFilters = {
     'span.module': ModuleName.HTTP,
-    'span.domain': query.domain,
+    'span.domain': escapeFilterValue(query.domain), // Exact match on domains with asterisks
     transaction: query.transaction,
   };
 
   // These filters are for the charts and samples tables
   const filters: SpanMetricsQueryFilters = {
     'span.module': ModuleName.HTTP,
-    'span.domain': query.domain,
+    'span.domain': escapeFilterValue(query.domain), // Exact match on domains with asterisks
     transaction: query.transaction,
   };
 

--- a/static/app/views/starfish/queries/useIndexedSpans.tsx
+++ b/static/app/views/starfish/queries/useIndexedSpans.tsx
@@ -3,7 +3,7 @@ import type {Location} from 'history';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {ALLOWED_WILDCARD_FIELDS, MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {SpanIndexedField, SpanIndexedFieldTypes} from 'sentry/views/starfish/types';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
@@ -48,15 +48,17 @@ function getEventView(
   fields: SpanIndexedField[],
   sorts?: Sort[]
 ) {
-  // TODO: Add a `MutableSearch` constructor that accept a key-value mapping
+  // TODO: Use `MutableSearch.fromQueryObject` instead
   const search = new MutableSearch([]);
 
   for (const filterName in filters) {
+    const shouldEscape = !ALLOWED_WILDCARD_FIELDS.includes(filterName);
     const filter = filters[filterName];
+
     if (Array.isArray(filter)) {
-      search.addFilterValues(filterName, filter);
+      search.addFilterValues(filterName, filter, shouldEscape);
     } else {
-      search.addFilterValue(filterName, filter);
+      search.addFilterValue(filterName, filter, shouldEscape);
     }
   }
 


### PR DESCRIPTION
**e.g.,**
<img width="352" alt="Screenshot 2024-04-12 at 11 27 23 AM" src="https://github.com/getsentry/sentry/assets/989898/749131dd-8fe2-43b6-8581-0829172ba5ce">

- Allow wildcards in domain searches
- Add domain search input
