### PR TITLE
ref(ui): Use `user` over `member` in SentryMemberTeamSelectorField

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -35,7 +35,7 @@ function SentryMemberTeamSelectorField({
   // Ensure the current value of the fields members is loaded
   const ensureUserIds = useMemo(
     () =>
-      currentItems?.filter(item => item.startsWith('member:')).map(user => user.slice(7)),
+      currentItems?.filter(item => item.startsWith('user:')).map(user => user.slice(7)),
     [currentItems]
   );
   useMembers({ids: ensureUserIds});
@@ -51,7 +51,7 @@ function SentryMemberTeamSelectorField({
   // frustratingly that is difficult likely because we're recreating this
   // object on every re-render.
   const memberOptions = members?.map(member => ({
-    value: `member:${member.id}`,
+    value: `user:${member.id}`,
     label: member.name,
     leadingItems: <Avatar user={member} size={avatarSize} />,
   }));

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -48,8 +48,8 @@ export const DEFAULT_CRONTAB = '0 0 * * *';
 //
 // XXX(epurkhiser): For whatever reason the rules API wants the team and member
 // to be capitalized.
-const RULE_TARGET_MAP = {team: 'Team', member: 'Member'} as const;
-const RULES_SELECTOR_MAP = {Team: 'team', Member: 'member'} as const;
+const RULE_TARGET_MAP = {team: 'Team', user: 'Member'} as const;
+const RULES_SELECTOR_MAP = {Team: 'team', Member: 'user'} as const;
 
 // In minutes
 export const DEFAULT_MAX_RUNTIME = 30;


### PR DESCRIPTION
This allows this field to work with the backend ActorField

Adjusts the only usage of it to correctly map