### PR TITLE
fix(gridEditable): Fix story so the row at index 0 can be highlighted

### DIFF
--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -125,7 +125,7 @@ export default storyBook(GridEditable, story => {
 
   story('Row Mouse Events', () => {
     const [activeRowKey, setActiveRowKey] = useState<number | undefined>(undefined);
-    const activeRow = activeRowKey ? data[activeRowKey] : undefined;
+    const activeRow = activeRowKey !== undefined ? data[activeRowKey] : undefined;
 
     return (
       <Fragment>


### PR DESCRIPTION
Before: you can hover the 1st row, but "Hovered Row" is blank
<img width="813" alt="SCR-20240412-jdvf" src="https://github.com/getsentry/sentry/assets/187460/ca69ad53-afc9-452a-8b1f-3a3587649013">

After:
<img width="586" alt="SCR-20240412-jeqq" src="https://github.com/getsentry/sentry/assets/187460/5b3ec499-233d-4d17-990f-4d27858d66a6">
