### PR TITLE
chore(hybridcloud) Remove references to file_id from control avatars

### DIFF
--- a/src/sentry/models/avatars/base.py
+++ b/src/sentry/models/avatars/base.py
@@ -12,10 +12,11 @@ from PIL import Image
 
 from sentry import options
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import BoundedBigIntegerField, Model
+from sentry.db.models import Model
+from sentry.db.models.fields.bounded import BoundedBigIntegerField
+from sentry.models.files.control_file import ControlFile
 from sentry.models.files.file import File
 from sentry.silo import SiloMode
-from sentry.tasks.files import copy_file_to_control_and_update_model
 from sentry.types.region import get_local_region
 from sentry.utils.cache import cache
 from sentry.utils.db import atomic_transaction
@@ -35,8 +36,9 @@ class AvatarBase(Model):
     AVATAR_TYPES: ClassVar[tuple[tuple[int, str], ...]]
     FILE_TYPE: ClassVar[str]
 
-    file_id = BoundedBigIntegerField(unique=True, null=True)
     ident = models.CharField(max_length=32, unique=True, db_index=True)
+    # Deprecated, will be moved to OrganizationAvatar soon
+    file_id = BoundedBigIntegerField(unique=True, null=True)
 
     class Meta:
         abstract = True
@@ -49,32 +51,8 @@ class AvatarBase(Model):
         return super().save(*args, **kwargs)
 
     def get_file(self):
-        # If we're getting a file, and the preferred write file type isn't
-        # present, move data over to new storage async.
         file_id = getattr(self, self.file_write_fk(), None)
         file_class = self.file_class()
-
-        if file_id is None:
-            file_id = self.file_id
-            file_class = File
-            if file_id is None:
-                return None
-            if SiloMode.get_current_mode() == SiloMode.MONOLITH:
-                copy_file_to_control_and_update_model.apply_async(
-                    kwargs={
-                        "app_name": "sentry",
-                        "model_name": type(self).__name__,
-                        "model_id": self.id,
-                        "file_id": file_id,
-                    }
-                )
-
-        if (
-            SiloMode.get_current_mode() != SiloMode.MONOLITH
-            and SiloMode.get_current_mode() not in file_class._meta.silo_limit.modes
-        ):
-            return None
-
         try:
             return file_class.objects.get(pk=file_id)
         except ObjectDoesNotExist:
@@ -114,7 +92,7 @@ class AvatarBase(Model):
                 cache.set(cache_key, photo)
         return photo
 
-    def file_class(self):
+    def file_class(self) -> type[File] | type[ControlFile]:
         return File
 
     def file_fk(self) -> str:

--- a/src/sentry/models/avatars/control_base.py
+++ b/src/sentry/models/avatars/control_base.py
@@ -1,6 +1,6 @@
 from sentry.db.models import BoundedBigIntegerField
 from sentry.models.avatars.base import AvatarBase
-from sentry.models.files import ControlFile, File
+from sentry.models.files import ControlFile
 
 
 class ControlAvatarBase(AvatarBase):
@@ -9,24 +9,16 @@ class ControlAvatarBase(AvatarBase):
     class Meta:
         abstract = True
 
-    def file_class(self) -> type[ControlFile] | type[File]:
+    def file_class(self) -> type[ControlFile]:
         """
         Select the file class this avatar has used.
         File classes can vary by the avatar as we have migrated
         storage for saas, but self-hosted and single-tenant instances
         did not have relations and storage migrated.
         """
-        if self.control_file_id:
-            return ControlFile
-        if self.file_id:
-            return File
         return ControlFile
 
     def file_fk(self) -> str:
-        if self.control_file_id:
-            return "control_file_id"
-        if self.file_id:
-            return "file_id"
         return "control_file_id"
 
     def file_write_fk(self) -> str:
@@ -34,4 +26,4 @@ class ControlAvatarBase(AvatarBase):
         return "control_file_id"
 
     def get_file_id(self) -> int:
-        return self.control_file_id or self.file_id
+        return self.control_file_id

--- a/src/sentry/models/avatars/organization_avatar.py
+++ b/src/sentry/models/avatars/organization_avatar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from django.db import models
 
 from sentry.db.models import FlexibleForeignKey, region_silo_only_model
+from sentry.db.models.fields.bounded import BoundedBigIntegerField
 
 from . import AvatarBase
 
@@ -17,6 +18,8 @@ class OrganizationAvatar(AvatarBase):
     AVATAR_TYPES = ((0, "letter_avatar"), (1, "upload"))
 
     FILE_TYPE = "avatar.file"
+
+    file_id = BoundedBigIntegerField(unique=True, null=True)
 
     organization = FlexibleForeignKey("sentry.Organization", unique=True, related_name="avatar")
     avatar_type = models.PositiveSmallIntegerField(default=0, choices=AVATAR_TYPES)

--- a/src/sentry/services/hybrid_cloud/user/serial.py
+++ b/src/sentry/services/hybrid_cloud/user/serial.py
@@ -73,7 +73,7 @@ def serialize_rpc_user(user: User) -> RpcUser:
             avatar_type_map = dict(UserAvatar.AVATAR_TYPES)
             avatar = RpcAvatar(
                 id=avatar_dict["id"],
-                file_id=avatar_dict["file_id"],
+                file_id=avatar_dict["control_file_id"],
                 ident=avatar_dict["ident"],
                 avatar_type=avatar_type_map.get(avatar_dict["avatar_type"], "letter_avatar"),
             )
@@ -101,7 +101,7 @@ def serialize_rpc_user(user: User) -> RpcUser:
 def serialize_user_avatar(avatar: UserAvatar) -> RpcAvatar:
     return RpcAvatar(
         id=avatar.id,
-        file_id=avatar.file_id,
+        file_id=avatar.control_file_id,
         ident=avatar.ident,
         avatar_type=avatar.get_avatar_type_display(),
     )

--- a/tests/sentry/models/test_avatar.py
+++ b/tests/sentry/models/test_avatar.py
@@ -4,7 +4,7 @@ from sentry.models.avatars.user_avatar import UserAvatar
 from sentry.models.files.control_file import ControlFile
 from sentry.models.files.file import File
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import control_silo_test, no_silo_test
+from sentry.testutils.silo import control_silo_test
 
 
 @control_silo_test
@@ -26,28 +26,6 @@ class UserAvatarTestCase(TestCase):
             assert avatar.get_file() is None
             assert UserAvatar.objects.get(id=avatar.id).control_file_id is None
             assert UserAvatar.objects.get(id=avatar.id).get_file() is None
-
-
-@no_silo_test  # Not siloed, this logic will be removed after data is moved.
-class AvatarMigrationTestCase(TestCase):
-    def test_transition_to_control(self):
-        user = self.create_user("foo@example.com")
-        afile = File.objects.create(name="avatar.png", type=UserAvatar.FILE_TYPE)
-        avatar = UserAvatar.objects.create(user=user, file_id=afile.id)
-
-        assert avatar.control_file_id is None
-        with self.options(
-            {
-                "filestore.control.backend": options_store.get("filestore.backend"),
-                "filestore.control.options": options_store.get("filestore.options"),
-            }
-        ):
-            with self.tasks():
-                assert isinstance(avatar.get_file(), File)
-            avatar = UserAvatar.objects.get(id=avatar.id)
-            assert avatar.control_file_id is not None
-            assert avatar.file_id is None
-            assert isinstance(avatar.get_file(), ControlFile)
 
 
 class OrganizationAvatarTestCase(TestCase):


### PR DESCRIPTION
Control Silo avatars don't use `file_id` because the relation to `File` - which is a region model - cannot exist. Instead they use `control_file_id`.

These changes remove all usage of `file_id` from control avatars and hollow out the migration task that is no longer in use. The next step of this work will be to remove `file_id` from the control avatar models.

Refs HC-712