### PR TITLE
feat(ui): Support single select in SentryMemberTeamSelectorField

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
 import MemberListStore from 'sentry/stores/memberListStore';
@@ -39,18 +39,74 @@ describe('SentryMemberTeamSelectorField', () => {
     });
   });
 
-  it('can change values', async () => {
+  it('can select a team', async () => {
     const mock = jest.fn();
     render(
       <SentryMemberTeamSelectorField
+        label="Select Owner"
         onChange={mock}
         name="team-or-member"
         projects={mockProjects}
       />
     );
 
-    await selectEvent.select(screen.getByText(/Choose Teams and Members/i), '#team-slug');
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Select Owner'}),
+      `#${mockTeams[0].slug}`
+    );
 
     expect(mock).toHaveBeenCalledWith('team:1', expect.anything());
+
+    await userEvent.click(screen.getByLabelText('Clear choices'));
+    expect(mock).toHaveBeenCalledWith(null, expect.anything());
+  });
+
+  it('can select a member', async () => {
+    const mock = jest.fn();
+    render(
+      <SentryMemberTeamSelectorField
+        label="Select Owner"
+        onChange={mock}
+        name="team-or-member"
+        projects={mockProjects}
+      />
+    );
+
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Select Owner'}),
+      mockUsers[0].name
+    );
+
+    expect(mock).toHaveBeenCalledWith('user:1', expect.anything());
+
+    await userEvent.click(screen.getByLabelText('Clear choices'));
+    expect(mock).toHaveBeenCalledWith(null, expect.anything());
+  });
+
+  it('can multiselect a member', async () => {
+    const mock = jest.fn();
+    render(
+      <SentryMemberTeamSelectorField
+        label="Select Owner"
+        onChange={mock}
+        name="team-or-member"
+        projects={mockProjects}
+        multiple
+      />
+    );
+
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Select Owner'}),
+      mockUsers[0].name
+    );
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Select Owner'}),
+      `#${mockTeams[0].slug}`
+    );
+
+    expect(mock).toHaveBeenCalledWith(['user:1', 'team:1'], expect.anything());
+
+    await userEvent.click(screen.getByLabelText('Clear choices'));
+    expect(mock).toHaveBeenCalledWith([], expect.anything());
   });
 });

--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -30,13 +30,21 @@ function SentryMemberTeamSelectorField({
   ...props
 }: RenderFieldProps) {
   const {form} = useContext(FormContext);
-  const currentItems = form?.getValue<string[]>(props.name, []);
+  const {multiple} = props;
+  const fieldValue = form?.getValue<string[] | null>(props.name, multiple ? [] : null);
+
+  // Coerce value to always be a list of items
+  const currentValue = useMemo(
+    () =>
+      Array.isArray(fieldValue) ? fieldValue : fieldValue ? [fieldValue] : undefined,
+    [fieldValue]
+  );
 
   // Ensure the current value of the fields members is loaded
   const ensureUserIds = useMemo(
     () =>
-      currentItems?.filter(item => item.startsWith('user:')).map(user => user.slice(7)),
-    [currentItems]
+      currentValue?.filter(item => item.startsWith('user:')).map(user => user.slice(7)),
+    [currentValue]
   );
   useMembers({ids: ensureUserIds});
 
@@ -59,8 +67,8 @@ function SentryMemberTeamSelectorField({
   // Ensure the current value of the fields teams is loaded
   const ensureTeamIds = useMemo(
     () =>
-      currentItems?.filter(item => item.startsWith('team:')).map(user => user.slice(5)),
-    [currentItems]
+      currentValue?.filter(item => item.startsWith('team:')).map(user => user.slice(5)),
+    [currentValue]
   );
   useTeamsById({ids: ensureTeamIds});
 


### PR DESCRIPTION
Before this change the field would only correctly work when the `multiple` prop was set.