### PR TITLE
metrics(indexer): Add metrics around join time for chained processing strategies

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/common.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/common.py
@@ -146,13 +146,13 @@ class BatchMessages(ProcessingStep[KafkaPayload]):
         self.__closed = True
 
     def join(self, timeout: float | None = None) -> None:
-        if self.__batch:
-            last = self.__batch.messages[-1]
-            logger.debug(
-                "Abandoning batch of %s messages...latest offset: %s",
-                len(self.__batch),
-                last.committable,
-            )
-
-        self.__next_step.close()
-        self.__next_step.join(timeout)
+        with metrics.timer("metrics_consumer.join_time.batch_messages"):
+            if self.__batch:
+                last = self.__batch.messages[-1]
+                logger.debug(
+                    "Abandoning batch of %s messages...latest offset: %s",
+                    len(self.__batch),
+                    last.committable,
+                )
+            self.__next_step.close()
+            self.__next_step.join(timeout)


### PR DESCRIPTION
Currently, we have a total shutdown time for the indexer; however, we don't have a better breakdown to understand which strategies make up this shutdown time and how much. 
