### PR TITLE
chore(slack): remove non block kit part 2

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -190,13 +190,8 @@ def build_footer(
         # If this notification is triggered via the "Send Test Notification"
         # button then the label is not defined, but the url works.
         text = rules[0].label if rules[0].label else "Test Alert"
-        footer += f" via {url_format.format(text=text, url=rule_url)}"
 
-        if (
-            features.has("organizations:slack-block-kit", project.organization)
-            and url_format == SLACK_URL_FORMAT
-        ):
-            footer = url_format.format(text=text, url=rule_url)
+        footer = url_format.format(text=text, url=rule_url)
 
         if len(rules) > 1:
             footer += f" (+{len(rules) - 1} other)"

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -190,8 +190,10 @@ def build_footer(
         # If this notification is triggered via the "Send Test Notification"
         # button then the label is not defined, but the url works.
         text = rules[0].label if rules[0].label else "Test Alert"
+        footer += f" via {url_format.format(text=text, url=rule_url)}"
 
-        footer = url_format.format(text=text, url=rule_url)
+        if url_format == SLACK_URL_FORMAT:
+            footer = url_format.format(text=text, url=rule_url)
 
         if len(rules) > 1:
             footer += f" (+{len(rules) - 1} other)"

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -45,9 +45,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         # XXX(CEO): when removing the feature flag, put `label` back up as a class var
-        self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"  # type: ignore[misc]
-        if features.has("organizations:slack-block-kit", self.project.organization):
-            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and notes {notes} in notification"  # type: ignore[misc]
+        self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and notes {notes} in notification"  # type: ignore[misc]
         self.form_fields = {
             "workspace": {
                 "type": "choice",
@@ -57,11 +55,10 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             "channel_id": {"type": "string", "placeholder": "e.g., CA2FRA079 or UA1J9RTE1"},
             "tags": {"type": "string", "placeholder": "e.g., environment,user,my_tag"},
         }
-        if features.has("organizations:slack-block-kit", self.project.organization):
-            self.form_fields["notes"] = {
-                "type": "string",
-                "placeholder": "e.g. @jane, @on-call-team",
-            }
+        self.form_fields["notes"] = {
+            "type": "string",
+            "placeholder": "e.g. @jane, @on-call-team",
+        }
 
         self._repository: IssueAlertNotificationMessageRepository = (
             get_default_issue_alert_repository()
@@ -86,45 +83,25 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             additional_attachment = get_additional_attachment(
                 integration, self.project.organization
             )
-            payload = {}
-            if features.has("organizations:slack-block-kit", event.group.project.organization):
-                blocks = SlackIssuesMessageBuilder(
-                    group=event.group,
-                    event=event,
-                    tags=tags,
-                    rules=rules,
-                    notes=self.get_option("notes", ""),
-                ).build(notification_uuid=notification_uuid)
+            blocks = SlackIssuesMessageBuilder(
+                group=event.group,
+                event=event,
+                tags=tags,
+                rules=rules,
+                notes=self.get_option("notes", ""),
+            ).build(notification_uuid=notification_uuid)
 
-                if additional_attachment:
-                    for block in additional_attachment:
-                        blocks["blocks"].append(block)
+            if additional_attachment:
+                for block in additional_attachment:
+                    blocks["blocks"].append(block)
 
-                if blocks.get("blocks"):
-                    payload = {
-                        "text": blocks.get("text"),
-                        "blocks": json.dumps(blocks.get("blocks")),
-                        "channel": channel,
-                        "unfurl_links": False,
-                        "unfurl_media": False,
-                    }
-            else:
-                attachments = [
-                    SlackIssuesMessageBuilder(
-                        group=event.group,
-                        event=event,
-                        tags=tags,
-                        rules=rules,
-                    ).build(notification_uuid=notification_uuid)
-                ]
-                # getsentry might add a billing related attachment
-                if additional_attachment:
-                    attachments.append(additional_attachment)
-
+            if blocks.get("blocks"):
                 payload = {
+                    "text": blocks.get("text"),
+                    "blocks": json.dumps(blocks.get("blocks")),
                     "channel": channel,
-                    "link_names": 1,
-                    "attachments": json.dumps(attachments),
+                    "unfurl_links": False,
+                    "unfurl_media": False,
                 }
                 self.logger.info(
                     "rule.slack_post.attachments",
@@ -203,9 +180,8 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     "event_id": event.event_id,
                     "channel_name": self.get_option("channel"),
                 }
-                if features.has("organizations:slack-block-kit", event.group.project.organization):
-                    # temporarily log the payload so we can debug message failures
-                    log_params["payload"] = json.dumps(payload)
+                # temporarily log the payload so we can debug message failures
+                log_params["payload"] = json.dumps(payload)
 
                 self.logger.info(
                     "rule.fail.slack_post",
@@ -297,20 +273,12 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     def render_label(self) -> str:
         tags = self.get_tags_list()
 
-        if features.has("organizations:slack-block-kit", self.project.organization):
-            return self.label.format(
-                workspace=self.get_integration_name(),
-                channel=self.get_option("channel"),
-                channel_id=self.get_option("channel_id"),
-                tags="[{}]".format(", ".join(tags)),
-                notes=self.get_option("notes", ""),
-            )
-
         return self.label.format(
             workspace=self.get_integration_name(),
             channel=self.get_option("channel"),
             channel_id=self.get_option("channel_id"),
             tags="[{}]".format(", ".join(tags)),
+            notes=self.get_option("notes", ""),
         )
 
     def get_tags_list(self) -> Sequence[str]:

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -41,11 +41,10 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     prompt = "Send a Slack notification"
     provider = "slack"
     integration_key = "workspace"
+    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and notes {notes} in notification"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        # XXX(CEO): when removing the feature flag, put `label` back up as a class var
-        self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and notes {notes} in notification"  # type: ignore[misc]
         self.form_fields = {
             "workspace": {
                 "type": "choice",
@@ -95,10 +94,10 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 for block in additional_attachment:
                     blocks["blocks"].append(block)
 
-            if blocks.get("blocks"):
+            if payload_blocks := blocks.get("blocks"):
                 payload = {
                     "text": blocks.get("text"),
-                    "blocks": json.dumps(blocks.get("blocks")),
+                    "blocks": json.dumps(payload_blocks),
                     "channel": channel,
                     "unfurl_links": False,
                     "unfurl_media": False,

--- a/src/sentry/integrations/slack/message_builder/notifications/base.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/base.py
@@ -65,11 +65,7 @@ class SlackNotificationsMessageBuilder(BlockSlackMessageBuilder):
 
         actions_block = []
         for action in actions:
-            if (
-                action.label in ["Turn on personal notifications", "Approve", "Reject"]
-                or action.url
-            ):
-                actions_block.append(self.get_button_action(action))
+            actions_block.append(self.get_button_action(action))
 
         if actions_block:
             blocks.append({"type": "actions", "elements": [action for action in actions_block]})

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -9,7 +9,7 @@ import sentry_sdk
 
 from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.notifications import get_context, get_integrations_by_channel_by_recipient
-from sentry.integrations.slack.message_builder import SlackAttachment, SlackBlock
+from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder.notifications import get_message_builder
 from sentry.models.integrations.integration import Integration
@@ -46,7 +46,7 @@ def _get_attachments(
     recipient: RpcActor,
     shared_context: Mapping[str, Any],
     extra_context_by_actor: Mapping[RpcActor, Mapping[str, Any]] | None,
-) -> list[SlackAttachment] | SlackBlock:
+) -> SlackBlock:
     extra_context = (
         extra_context_by_actor[recipient] if extra_context_by_actor and recipient else {}
     )
@@ -59,7 +59,7 @@ def _get_attachments(
 def _notify_recipient(
     notification: BaseNotification,
     recipient: RpcActor,
-    attachments: list[SlackAttachment] | SlackBlock,
+    attachments: SlackBlock,
     channel: str,
     integration: Integration,
     shared_context: Mapping[str, Any],

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import sentry_sdk
 
-from sentry import features
 from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.notifications import get_context, get_integrations_by_channel_by_recipient
 from sentry.integrations.slack.message_builder import SlackAttachment, SlackBlock
@@ -54,11 +53,7 @@ def _get_attachments(
     context = get_context(notification, recipient, shared_context, extra_context)
     cls = get_message_builder(notification.message_builder)
     attachments = cls(notification, context, recipient).build()
-    if isinstance(attachments, list) or features.has(
-        "organizations:slack-block-kit", notification.organization
-    ):
-        return attachments
-    return [attachments]
+    return attachments
 
 
 def _notify_recipient(
@@ -75,69 +70,39 @@ def _notify_recipient(
 
         text = notification.get_notification_title(ExternalProviders.SLACK, shared_context)
 
-        # NOTE(isabella): we check that attachments consists of blocks in case the flag is turned on
-        # while a notification with the legacy format is being sent
-        if features.has("organizations:slack-block-kit", notification.organization) and isinstance(
-            local_attachments, dict
-        ):
-            blocks = []
-            if text:
-                # NOTE(isabella): with legacy attachments, the notification title was
-                # automatically rendered based on the `text` field in the payload; in the block
-                # system, that payload field is used strictly as preview/fallback text, so we need
-                # to add this block to render the title in the notification ie. "Issue marked as
-                # regression", "New comment by <user>"
-                blocks.append(BlockSlackMessageBuilder.get_markdown_block(text))
-            attachment_blocks = local_attachments.get("blocks")
-            if attachment_blocks:
-                for attachment in attachment_blocks:
-                    blocks.append(attachment)
-            if len(blocks) >= 2 and blocks[1].get("block_id"):
-                # block id needs to be in the first block
-                blocks[0]["block_id"] = blocks[1]["block_id"]
-                del blocks[1]["block_id"]
-            additional_attachment = get_additional_attachment(
-                integration, notification.organization
-            )
-            if additional_attachment:
-                for block in additional_attachment:
-                    blocks.append(block)
-            if (
-                not text
-            ):  # if there isn't a notification title, try using message description as fallback
-                text = notification.get_message_description(recipient, ExternalProviders.SLACK)
-            payload = {
-                "channel": channel,
-                "unfurl_links": False,
-                "unfurl_media": False,
-                "text": text if text else "",
-                "blocks": json.dumps(blocks),
-            }
-            callback_id = local_attachments.get("callback_id")
-            if callback_id:
-                # callback_id is now at the same level as blocks, rather than within attachments
-                if isinstance(callback_id, str):
-                    payload["callback_id"] = callback_id
-                else:
-                    payload["callback_id"] = json.dumps(local_attachments.get("callback_id"))
-        else:
-            # Add optional billing related attachment.
-            additional_attachment = get_additional_attachment(
-                integration, notification.organization
-            )
-            if additional_attachment:
-                local_attachments.append(additional_attachment)
-
-            # unfurl_links and unfurl_media are needed to preserve the intended message format
-            # and prevent the app from replying with help text to the unfurl
-            payload = {
-                "channel": channel,
-                "link_names": 1,
-                "unfurl_links": False,
-                "unfurl_media": False,
-                "text": text,
-                "attachments": json.dumps(local_attachments),
-            }
+        blocks = []
+        if text:
+            blocks.append(BlockSlackMessageBuilder.get_markdown_block(text))
+        attachment_blocks = local_attachments.get("blocks")
+        if attachment_blocks:
+            for attachment in attachment_blocks:
+                blocks.append(attachment)
+        if len(blocks) >= 2 and blocks[1].get("block_id"):
+            # block id needs to be in the first block
+            blocks[0]["block_id"] = blocks[1]["block_id"]
+            del blocks[1]["block_id"]
+        additional_attachment = get_additional_attachment(integration, notification.organization)
+        if additional_attachment:
+            for block in additional_attachment:
+                blocks.append(block)
+        if (
+            not text
+        ):  # if there isn't a notification title, try using message description as fallback
+            text = notification.get_message_description(recipient, ExternalProviders.SLACK)
+        payload = {
+            "channel": channel,
+            "unfurl_links": False,
+            "unfurl_media": False,
+            "text": text if text else "",
+            "blocks": json.dumps(blocks),
+        }
+        callback_id = local_attachments.get("callback_id")
+        if callback_id:
+            # callback_id is now at the same level as blocks, rather than within attachments
+            if isinstance(callback_id, str):
+                payload["callback_id"] = callback_id
+            else:
+                payload["callback_id"] = json.dumps(local_attachments.get("callback_id"))
 
         post_message_task = post_message
         if SiloMode.get_current_mode() == SiloMode.CONTROL:

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -9,8 +9,7 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.testutils.cases import APITestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import get_attachment_no_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.utils import json
@@ -188,9 +187,7 @@ class OrganizationInviteRequestCreateTest(
         assert "eric@localhost" in mail.outbox[0].body
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
     def test_request_to_invite_slack(self):
-        # TODO: make this a block kit test
         with self.tasks():
             self.get_success_response(
                 self.organization.slug,
@@ -200,44 +197,44 @@ class OrganizationInviteRequestCreateTest(
                 status_code=201,
             )
 
-        attachment = get_attachment_no_text()
+        blocks, fallback_text = get_blocks_and_fallback_text()
         assert (
-            attachment["text"]
+            fallback_text
             == f"foo@localhost is requesting to invite eric@localhost into {self.organization.name}"
         )
-        notification_uuid = parse_qs(urlparse(attachment["actions"][2]["url"]).query)[
-            "notification_uuid"
-        ][0]
-        assert attachment["actions"] == [
+        query_params = parse_qs(urlparse(blocks[1]["elements"][0]["text"]).query)
+        notification_uuid = query_params["notification_uuid"][0]
+        notification_uuid = notification_uuid.split("|")[
+            0
+        ]  # remove method of hyperlinking in slack
+        assert blocks[2]["elements"] == [
             {
-                "text": "Approve",
-                "name": "Approve",
-                "style": "primary",
                 "type": "button",
+                "text": {"type": "plain_text", "text": "Approve"},
+                "action_id": "approve_request",
                 "value": "approve_member",
-                "action_id": "approve_request",
             },
             {
-                "text": "Reject",
-                "name": "Reject",
-                "style": "danger",
                 "type": "button",
+                "text": {"type": "plain_text", "text": "Reject"},
+                "action_id": "approve_request",
                 "value": "reject_member",
-                "action_id": "approve_request",
             },
             {
-                "text": "See Members & Requests",
-                "name": "See Members & Requests",
-                "url": f"http://testserver/settings/{self.organization.slug}/members/?referrer=invite_request-slack-user&notification_uuid={notification_uuid}",
                 "type": "button",
+                "text": {"type": "plain_text", "text": "See Members & Requests"},
+                "url": f"http://testserver/settings/{self.organization.slug}/members/?referrer=invite_request-slack-user&notification_uuid={notification_uuid}",
+                "value": "link_clicked",
             },
         ]
+        footer = blocks[1]["elements"][0]["text"]
         assert (
-            attachment["footer"]
+            footer
             == f"You are receiving this notification because you have the scope member:write | <http://testserver/settings/account/notifications/approval/?referrer=invite_request-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         member = OrganizationMember.objects.get(email="eric@localhost")
-        assert json.loads(attachment["callback_id"]) == {
+        data = parse_qs(responses.calls[0].request.body)
+        assert json.loads(data["callback_id"][0]) == {
             "member_id": member.id,
             "member_email": "eric@localhost",
         }

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1002,9 +1002,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
 
     @responses.activate
     @with_feature("organizations:rule-create-edit-confirm-notification")
-    @with_feature({"organizations:slack-block-kit": False})
     def test_slack_confirmation_notification_contents(self):
-        # TODO: make this a block kit test
         conditions = [
             {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
         ]
@@ -1093,7 +1091,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert rendered_blocks[0]["text"]["text"] == message
         changes = "*Changes*\n"
         changes += "• Added condition 'The issue's category is equal to Performance'\n"
-        changes += "• Changed action from *Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] in notification* to *Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] in notification*\n"
+        changes += "• Changed action from *Send a notification to the Awesome Team Slack workspace to #old_channel_name (optionally, an ID: old_channel_id) and show tags [] and notes  in notification* to *Send a notification to the Awesome Team Slack workspace to new_channel_name (optionally, an ID: new_channel_id) and show tags [] and notes  in notification*\n"
         changes += "• Changed frequency from *5 minutes* to *3 hours*\n"
         changes += f"• Added *{staging_env.name}* environment\n"
         changes += "• Changed rule name from *my rule* to *new rule*\n"

--- a/tests/sentry/integrations/slack/notifications/test_deploy.py
+++ b/tests/sentry/integrations/slack/notifications/test_deploy.py
@@ -3,77 +3,14 @@ from django.utils import timezone
 
 from sentry.models.activity import Activity
 from sentry.models.deploy import Deploy
-from sentry.models.release import Release
 from sentry.notifications.notifications.activity.release import ReleaseActivityNotification
 from sentry.testutils.cases import SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.types.activity import ActivityType
 
 
 class SlackDeployNotificationTest(SlackActivityNotificationTest):
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_deploy(self):
-        """
-        Test that a Slack message is sent with the expected payload when a deploy happens.
-        """
-        release = Release.objects.create(
-            version="meow" * 10,
-            organization_id=self.project.organization_id,
-            date_released=timezone.now(),
-        )
-
-        # The projects can appear out of order.
-        projects = (self.project, self.create_project(name="battlesnake"))
-        SLUGS_TO_PROJECT = {project.slug: project for project in projects}
-
-        for project in projects:
-            release.add_project(project)
-
-        deploy = Deploy.objects.create(
-            release=release,
-            organization_id=self.organization.id,
-            environment_id=self.environment.id,
-        )
-        notification = ReleaseActivityNotification(
-            Activity(
-                project=self.project,
-                user_id=self.user.id,
-                type=ActivityType.RELEASE.value,
-                data={"version": release.version, "deploy_id": deploy.id},
-            )
-        )
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        assert (
-            text
-            == f"Release {release.version} was deployed to {self.environment.name} for these projects"
-        )
-
-        first_project = None
-        notification_uuid = self.get_notification_uuid(attachment["actions"][0]["url"])
-        for i in range(len(projects)):
-            project = SLUGS_TO_PROJECT[attachment["actions"][i]["text"]]
-            if not first_project:
-                first_project = project
-            assert (
-                attachment["actions"][i]["url"]
-                == f"http://testserver/organizations/{self.organization.slug}/releases/"
-                f"{release.version}/?project={project.id}&unselectedSeries=Healthy&referrer=release_activity&notification_uuid={notification_uuid}"
-            )
-        assert first_project is not None
-
-        assert (
-            attachment["footer"]
-            == f"{first_project.slug} | <http://testserver/settings/account/notifications/"
-            f"deploy/?referrer=release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_deploy_block(self):
         """
         Test that a Slack message is sent with the expected payload when a deploy happens.

--- a/tests/sentry/integrations/slack/notifications/test_escalating.py
+++ b/tests/sentry/integrations/slack/notifications/test_escalating.py
@@ -5,9 +5,8 @@ import responses
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.escalating import EscalatingActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -27,29 +26,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_escalating(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue escalates
-        """
-        with self.tasks():
-            self.create_notification(self.group).send()
-
-        attachment, text = get_attachment()
-        assert text == "Issue marked as escalating"
-        assert attachment["title"] == "こんにちは"
-        assert (
-            attachment["text"]
-            == "Sentry flagged this issue as escalating because over 100 events happened in an hour."
-        )
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=escalating_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_escalating_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue escalates
@@ -77,39 +53,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_escalating_performance_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a performance issue escalates
-        """
-        event = self.create_performance_issue()
-        with self.tasks():
-            self.create_notification(event.group).send()
-
-        attachment, text = get_attachment()
-        assert text == "Issue marked as escalating"
-        assert attachment["title"] == "N+1 Query"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}"
-        )
-        assert (
-            attachment["text"]
-            == "Sentry flagged this issue as escalating because over 100 events happened in an hour."
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=escalating_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature("organizations:slack-block-kit")
     def test_escalating_performance_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue escalates
@@ -138,43 +81,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_escalating_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a generic issue type escalates
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-
-        with self.tasks():
-            self.create_notification(group_event.group).send()
-
-        attachment, text = get_attachment()
-        assert text == "Issue marked as escalating"
-        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{group_event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}"
-        )
-        assert (
-            attachment["text"]
-            == "Sentry flagged this issue as escalating because over 100 events happened in an hour."
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=escalating_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature("organizations:slack-block-kit")
     def test_escalating_generic_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type escalates

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -29,9 +29,8 @@ from sentry.plugins.base import Notification
 from sentry.silo import SiloMode
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.integrations import ExternalProviders
@@ -65,7 +64,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_issue_alert_user_block(self):
         """
         Test that issues alert are sent to a Slack user with the proper payload when block kit is
@@ -102,36 +100,12 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_PERF_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_performance_issue_alert_user(self, occurrence):
-        """Test that performance issue alerts are sent to a Slack user."""
-
-        event = self.create_performance_issue()
-
-        notification = AlertRuleNotification(
-            Notification(event=event, rule=self.rule), ActionTargetType.MEMBER, self.user.id
-        )
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        self.assert_performance_issue_attachments(
-            attachment, self.project.slug, "issue_alert-slack-user", "alerts"
-        )
-
-    @responses.activate
     @mock.patch("sentry.integrations.slack.message_builder.issues.get_tags", new=fake_get_tags)
     @mock.patch(
         "sentry.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_performance_issue_alert_user_block(self, occurrence):
         """
         Test that performance issue alerts are sent to a Slack user with the proper payload when
@@ -164,7 +138,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
     @mock.patch("sentry.integrations.slack.message_builder.issues.get_tags", new=fake_get_tags)
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_crons_issue_alert_user_block(self):
         orig_event = self.store_event(
             data={"message": "Hello world", "level": "error"}, project_id=self.project.id
@@ -212,7 +185,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_generic_issue_alert_user_block(self, occurrence):
         """
         Test that generic issue alerts are sent to a Slack user with the proper payload when
@@ -267,7 +239,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert len(responses.calls) == 0
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_issue_alert_issue_owners_block(self):
         """
         Test that issue alerts are sent to issue owners in Slack with the proper payload when block
@@ -320,7 +291,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_issue_alert_issue_owners_environment_block(self):
         """
         Test that issue alerts are sent to issue owners in Slack with the environment in the query
@@ -381,7 +351,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_issue_alert_team_issue_owners_block(self):
         """
         Test that issue alerts are sent to a team in Slack via an Issue Owners rule action with the
@@ -538,7 +507,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
     @responses.activate
     @patch.object(sentry, "digests")
-    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_team_issue_owners_user_settings_off_digests(self, digests):
         """Test that issue alerts are sent to a team in Slack via an Issue Owners rule action
         even when the users' issue alert notification settings are off and digests are triggered."""
@@ -629,19 +597,17 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         # check that the team got a notification
         data = parse_qs(responses.calls[0].request.body)
         assert data["channel"] == ["CXXXXXXX2"]
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-        assert len(attachments) == 1
-        assert "Hello world" in attachments[0]["text"]
-        title_link = attachments[0]["blocks"][0]["text"]["text"][13:][1:-1]
+        assert "blocks" in data
+        blocks = json.loads(data["blocks"][0])
+        assert "Hello world" in blocks[1]["text"]["text"]
+        title_link = blocks[1]["text"]["text"][13:][1:-1]
         notification_uuid = self.get_notification_uuid(title_link)
         assert (
-            attachments[0]["blocks"][-2]["elements"][0]["text"]
+            blocks[-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_issue_alert_team_block(self):
         """Test that issue alerts are sent to a team in Slack when block kit is enabled."""
         # add a second organization
@@ -733,7 +699,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_team_new_project(self):
         """Test that issue alerts are sent to a team in Slack when the team has added a new project"""
 
@@ -801,14 +766,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         # check that the team got a notification
         data = parse_qs(responses.calls[0].request.body)
         assert data["channel"] == ["CXXXXXXX2"]
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-        assert len(attachments) == 1
-        assert "Hello world" in attachments[0]["text"]
-        title_link = attachments[0]["blocks"][0]["text"]["text"][13:][1:-1]
+        assert "blocks" in data
+        blocks = json.loads(data["blocks"][0])
+        assert "Hello world" in blocks[1]["text"]["text"]
+        title_link = blocks[1]["text"]["text"][13:][1:-1]
         notification_uuid = self.get_notification_uuid(title_link)
         assert (
-            attachments[0]["blocks"][-2]["elements"][0]["text"]
+            blocks[-2]["elements"][0]["text"]
             == f"{project2.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -861,7 +825,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert len(responses.calls) == 0
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
     def test_issue_alert_team_fallback(self):
         """Test that issue alerts are sent to each member of a team in Slack."""
 
@@ -908,31 +871,28 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         data2 = call2 if call2["channel"] == ["UXXXXXXX2"] else call1
 
         assert data["channel"] == ["UXXXXXXX1"]
-        assert "attachments" in data
-        attachments = json.loads(data["attachments"][0])
-        assert len(attachments) == 1
-        assert "Hello world" in attachments[0]["text"]
-        title_link = attachments[0]["blocks"][0]["text"]["text"][13:][1:-1]
+        assert "blocks" in data
+        blocks = json.loads(data["blocks"][0])
+        assert "Hello world" in blocks[1]["text"]["text"]
+        title_link = blocks[1]["text"]["text"]
         notification_uuid = self.get_notification_uuid(title_link)
         assert (
-            attachments[0]["blocks"][-2]["elements"][0]["text"]
+            blocks[-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
         # check that user2 got a notification as well
         assert data2["channel"] == ["UXXXXXXX2"]
-        assert "attachments" in data2
-        attachments = json.loads(data2["attachments"][0])
-        assert len(attachments) == 1
-        assert "Hello world" in attachments[0]["text"]
+        assert "blocks" in data2
+        blocks = json.loads(data2["blocks"][0])
+        assert "Hello world" in blocks[1]["text"]["text"]
         assert (
-            attachments[0]["blocks"][-2]["elements"][0]["text"]
+            blocks[-2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
     @patch.object(sentry, "digests")
-    @with_feature("organizations:slack-block-kit")
     def test_digest_enabled_block(self, digests):
         """
         Test that with digests enabled, but Slack notification settings

--- a/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
+++ b/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
@@ -6,50 +6,13 @@ from sentry.notifications.notifications.activity.new_processing_issues import (
 )
 from sentry.testutils.cases import SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.types.activity import ActivityType
 from sentry.web.frontend.debug.debug_new_processing_issues_email import get_issues_data
 
 
 class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_new_processing_issue(self):
-        """
-        Test that a Slack message is sent with the expected payload when an issue is held back in reprocessing
-        """
-
-        notification = NewProcessingIssuesActivityNotification(
-            Activity(
-                project=self.project,
-                user_id=self.user.id,
-                type=ActivityType.NEW_PROCESSING_ISSUES,
-                data={
-                    "issues": get_issues_data(),
-                    "reprocessing_active": True,
-                },
-            )
-        )
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        notification_uuid = self.get_notification_uuid(text)
-        assert (
-            text
-            == f"Processing issues on <http://testserver/settings/{self.organization.slug}/projects/{self.project.slug}/processing-issues/?referrer=new_processing_issues_activity&notification_uuid={notification_uuid}|{self.project.slug}>"
-        )
-        assert (
-            attachment["text"]
-            == f"Some events failed to process in your project {self.project.slug}"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=new_processing_issues_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_new_processing_issue_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is held back in reprocessing
@@ -87,41 +50,6 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
         )
 
     @responses.activate
-    @with_feature("organizations:customer-domains")
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_new_processing_issue_customer_domains(self):
-        notification = NewProcessingIssuesActivityNotification(
-            Activity(
-                project=self.project,
-                user_id=self.user.id,
-                type=ActivityType.NEW_PROCESSING_ISSUES,
-                data={
-                    "issues": get_issues_data(),
-                    "reprocessing_active": True,
-                },
-            )
-        )
-        with self.tasks():
-            notification.send()
-
-        slug = self.organization.slug
-        attachment, text = get_attachment()
-        notification_uuid = self.get_notification_uuid(text)
-        assert (
-            text
-            == f"Processing issues on <http://{slug}.testserver/settings/projects/{self.project.slug}/processing-issues/?referrer=new_processing_issues_activity&notification_uuid={notification_uuid}|{self.project.slug}>"
-        )
-        assert (
-            attachment["text"]
-            == f"Some events failed to process in your project {self.project.slug}"
-        )
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://{slug}.testserver/settings/account/notifications/workflow/?referrer=new_processing_issues_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature("organizations:slack-block-kit")
     @with_feature("organizations:customer-domains")
     def test_new_processing_issue_customer_domains_block(self):
         notification = NewProcessingIssuesActivityNotification(

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -5,9 +5,8 @@ import responses
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.note import NoteActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
-from sentry.testutils.helpers.slack import get_attachment, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -27,32 +26,6 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         )
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_note(self):
-        """
-        Test that a Slack message is sent with the expected payload when a comment is made on an issue
-        """
-        notification = self.create_notification(self.group)
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-
-        assert text == f"New comment by {self.name}"
-        assert attachment["title"] == f"{self.group.title}"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}"
-        )
-        assert attachment["text"] == notification.activity.data["text"]
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_note_block(self):
         """
         Tests that a Slack message is sent with the expected payload when a comment is made on an issue
@@ -78,33 +51,6 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         )
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_note_performance_issue(self):
-        """
-        Test that a Slack message is sent with the expected payload when a comment is made on a performance issue
-        """
-        event = self.create_performance_issue()
-        notification = self.create_notification(event.group)
-
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        assert text == f"New comment by {self.name}"
-        assert attachment["title"] == "N+1 Query"
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}"
-        )
-        assert attachment["text"] == notification.activity.data["text"]
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_note_performance_issue_block(self):
         """
         Tests that a Slack message is sent with the expected payload when a comment is made on a performance issue
@@ -136,37 +82,6 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_note_generic_issue(self, occurrence):
-        """
-        Test that a Slack message is sent with the expected payload when a comment is made on a generic issue type
-        """
-        event = self.store_event(
-            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
-        )
-        group_event = event.for_group(event.groups[0])
-        notification = self.create_notification(group_event.group)
-
-        with self.tasks():
-            notification.send()
-
-        attachment, text = get_attachment()
-        assert text == f"New comment by {self.name}"
-        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
-        assert attachment["text"] == notification.activity.data["text"]
-        notification_uuid = self.get_notification_uuid(attachment["title_link"])
-        assert (
-            attachment["footer"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
-        )
-
-    @responses.activate
-    @mock.patch(
-        "sentry.eventstore.models.GroupEvent.occurrence",
-        return_value=TEST_ISSUE_OCCURRENCE,
-        new_callable=mock.PropertyMock,
-    )
-    @with_feature("organizations:slack-block-kit")
     def test_note_generic_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a comment is made on a generic issue type

--- a/tests/sentry/integrations/slack/notifications/test_nudge.py
+++ b/tests/sentry/integrations/slack/notifications/test_nudge.py
@@ -7,8 +7,7 @@ from sentry.notifications.notifications.integration_nudge import (
     IntegrationNudgeNotification,
 )
 from sentry.testutils.cases import SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import get_attachment_no_text, get_blocks_and_fallback_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
@@ -17,32 +16,6 @@ SEED = 0
 
 class SlackNudgeNotificationTest(SlackActivityNotificationTest):
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
-    def test_nudge(self):
-        notification = IntegrationNudgeNotification(
-            self.organization,
-            recipient=self.user,
-            provider=ExternalProviders.SLACK,
-            seed=SEED,
-        )
-
-        with self.tasks():
-            notification.send()
-
-        attachment = get_attachment_no_text()
-        assert attachment["text"] == MESSAGE_LIBRARY[SEED].format(provider="Slack")
-        assert len(attachment["actions"]) == 1
-        assert attachment["actions"][0]["action_id"] == "enable_notifications"
-        assert attachment["actions"][0]["name"] == "Turn on personal notifications"
-        assert attachment["actions"][0]["value"] == "all_slack"
-
-        # Slack requires callback_id to handle enablement
-        request_data = parse_qs(responses.calls[0].request.body)
-        request_block_payload = json.loads(request_data["attachments"][0])
-        assert request_block_payload[0]["callback_id"]
-
-    @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_nudge_block(self):
         notification = IntegrationNudgeNotification(
             self.organization,

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -46,7 +46,6 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.group import GroupSubStatus
@@ -267,7 +266,6 @@ def build_test_message(
 
 
 class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTestMixin):
-    @with_feature("organizations:slack-block-kit")
     def test_build_group_block(self):
         release = self.create_release(project=self.project)
         event = self.store_event(
@@ -354,7 +352,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
         assert SlackIssuesMessageBuilder(group).build() == test_message
 
-    @with_feature("organizations:slack-block-kit")
     def test_build_group_block_with_message(self):
         event_data = {
             "event_id": "a" * 32,
@@ -384,7 +381,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             group=group,
         )
 
-    @with_feature("organizations:slack-block-kit")
     def test_build_group_block_with_empty_string_message(self):
         event_data = {
             "event_id": "a" * 32,
@@ -414,7 +410,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             group=group,
         )
 
-    @with_feature("organizations:slack-block-kit")
     @patch(
         "sentry.integrations.slack.message_builder.issues.get_option_groups_block_kit",
         wraps=get_option_groups_block_kit,
@@ -433,7 +428,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert len(team_option_groups["options"]) == 2
         assert len(member_option_groups["options"]) == 2
 
-    @with_feature("organizations:slack-block-kit")
     def test_build_group_attachment_issue_alert(self):
         issue_alert_group = self.create_group(project=self.project)
         ret = SlackIssuesMessageBuilder(issue_alert_group, issue_details=True).build()
@@ -445,7 +439,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         "sentry.api.serializers.models.pullrequest.PullRequestSerializer._external_url",
         return_value="https://github.com/meowmeow/cats/pull/1",
     )
-    @with_feature("organizations:slack-block-kit")
     def test_issue_alert_with_suspect_commits(self, mock_external_url):
         self.login_as(user=self.user)
         self.project.flags.has_releases = True
@@ -517,7 +510,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         "sentry.api.serializers.models.pullrequest.PullRequestSerializer._external_url",
         return_value="https://unknown.com/meowmeow/cats/pull/1",
     )
-    @with_feature("organizations:slack-block-kit")
     def test_issue_alert_with_suspect_commits_unknown_provider(self, mock_external_url):
         self.login_as(user=self.user)
         self.project.flags.has_releases = True
@@ -585,7 +577,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             suggested_assignees=commit_author.email,
         )
 
-    @with_feature("organizations:slack-block-kit")
     def test_issue_alert_with_suggested_assignees(self):
         self.project.flags.has_releases = True
         self.project.save(update_fields=["flags"])
@@ -697,7 +688,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             == expected_blocks
         )
 
-    @with_feature("organizations:slack-block-kit")
     def test_team_recipient(self):
         issue_alert_group = self.create_group(project=self.project)
         ret = SlackIssuesMessageBuilder(
@@ -712,7 +702,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
         assert has_actions
 
-    @with_feature("organizations:slack-block-kit")
     def test_team_recipient_block_kit_already_assigned(self):
         issue_alert_group = self.create_group(project=self.project)
         GroupAssignee.objects.create(
@@ -728,7 +717,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
         assert ret["blocks"][2]["elements"][2]["initial_option"]["value"] == f"user:{self.user.id}"
 
-    @with_feature("organizations:slack-block-kit")
     def test_build_group_generic_issue_block(self):
         """Test that a generic issue type's Slack alert contains the expected values"""
         event = self.store_event(
@@ -755,7 +743,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             if section["type"] == "text":
                 assert ":red_circle:" in section["text"]["text"]
 
-    @with_feature("organizations:slack-block-kit")
     def test_build_group_generic_issue_block_no_escaping(self):
         """Test that a generic issue type's Slack alert contains the expected values"""
         event = self.store_event(
@@ -789,7 +776,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert blocks["blocks"][1]["text"]["text"] == f"```{escaped_text}```"
         assert blocks["text"] == f"[{self.project.slug}] {occurrence.issue_title}"
 
-    @with_feature("organizations:slack-block-kit")
     def test_build_error_issue_fallback_text(self):
         event = self.store_event(data={}, project_id=self.project.id)
         assert event.group is not None
@@ -797,7 +783,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert isinstance(blocks, dict)
         assert blocks["text"] == f"[{self.project.slug}] {event.group.title}"
 
-    @with_feature("organizations:slack-block-kit")
     def test_build_performance_issue(self):
         event = self.create_performance_issue()
         with self.feature("organizations:performance-issues"):
@@ -810,7 +795,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
         assert blocks["text"] == f"[{self.project.slug}] N+1 Query"
 
-    @with_feature("organizations:slack-block-kit")
     def test_block_kit_truncates_long_query(self):
         event = self.store_event(
             data={"message": "a" * 5000, "level": "error"}, project_id=self.project.id
@@ -847,7 +831,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         truncated_text = "a" * 1497 + "..."
         assert blocks["blocks"][1]["text"]["text"] == f"```{truncated_text}```"
 
-    @with_feature("organizations:slack-block-kit")
     def test_escape_slack_message(self):
         group = self.create_group(
             project=self.project,
@@ -859,7 +842,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
 
 class BuildGroupAttachmentReplaysTest(TestCase):
-    @with_feature("organizations:slack-block-kit")
     @patch("sentry.models.group.Group.has_replays")
     def test_build_replay_issue(self, has_replays):
         replay1_id = "46eb3948be25448abd53fe36b5891ff2"
@@ -1166,14 +1148,10 @@ class ActionsTest(TestCase):
     def test_identity_and_action(self):
         group = self.create_group(project=self.project)
         MOCKIDENTITY = Mock()
+
         assert build_actions(
             group, self.project, "test txt", "red", [MessageAction(name="TEST")], MOCKIDENTITY
         ) == ([], "", "_actioned_issue")
-
-        with self.feature("organizations:slack-block-kit"):
-            assert build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], MOCKIDENTITY
-            ) == ([], "", "_actioned_issue")
 
     def _assert_message_actions_list(self, actions, expected):
         actions_dict = [
@@ -1186,24 +1164,16 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.IGNORED
         group.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
         expected = {
             "label": "Mark as Ongoing",
             "name": "status",
             "type": "button",
             "value": "unresolved:ongoing",
         }
-        self._assert_message_actions_list(
-            res[0],
-            expected,
-        )
 
-        with self.feature("organizations:slack-block-kit"):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
         self._assert_message_actions_list(
             res[0],
             expected,
@@ -1214,30 +1184,20 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.IGNORED
         group.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
-
         expected = {
             "label": "Mark as Ongoing",
             "name": "status",
             "type": "button",
             "value": "unresolved:ongoing",
         }
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
         self._assert_message_actions_list(
             res[0],
             expected,
         )
-        with self.feature("organizations:slack-block-kit"):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-            self._assert_message_actions_list(
-                res[0],
-                expected,
-            )
 
-    @with_feature("organizations:slack-block-kit")
     def test_ignore_unresolved_no_escalating(self):
         group = self.create_group(project=self.project)
         group.status = GroupStatus.UNRESOLVED
@@ -1257,7 +1217,6 @@ class ActionsTest(TestCase):
             expected,
         )
 
-    @with_feature("organizations:slack-block-kit")
     def test_ignore_unresolved_has_escalating(self):
         group = self.create_group(project=self.project)
         group.status = GroupStatus.UNRESOLVED
@@ -1285,14 +1244,6 @@ class ActionsTest(TestCase):
         # no ignore action if feedback issue, so only assign and resolve
         assert len(res[0]) == 2
 
-        with self.feature("organizations:slack-block-kit"):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-            # no ignore action if feedback issue, so only assign and resolve
-            assert len(res[0]) == 2
-
-    @with_feature("organizations:slack-block-kit")
     def test_resolve_resolved(self):
         group = self.create_group(project=self.project)
         group.status = GroupStatus.RESOLVED
@@ -1319,34 +1270,18 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = False
         self.project.save()
 
-        with self.feature({"organizations:slack-block-kit": False}):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-
-            self._assert_message_actions_list(
-                res[0],
-                {
-                    "label": "Resolve",
-                    "name": "status",
-                    "type": "button",
-                    "value": "resolved",
-                },
-            )
-
-        with self.feature("organizations:slack-block-kit"):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-            self._assert_message_actions_list(
-                res[0],
-                {
-                    "label": "Resolve",
-                    "name": "status",
-                    "type": "button",
-                    "value": "resolved",
-                },
-            )
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
+        self._assert_message_actions_list(
+            res[0],
+            {
+                "label": "Resolve",
+                "name": "status",
+                "type": "button",
+                "value": "resolved",
+            },
+        )
 
     def test_resolve_unresolved_has_releases(self):
         group = self.create_group(project=self.project)
@@ -1383,15 +1318,6 @@ class ActionsTest(TestCase):
             res[0],
             {"label": "Select Assignee...", "name": "assign", "type": "select", "value": None},
         )
-        with self.feature("organizations:slack-block-kit"):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
-
-            self._assert_message_actions_list(
-                res[0],
-                {"label": "Select Assignee...", "name": "assign", "type": "select", "value": None},
-            )
 
 
 class SlackNotificationConfigTest(TestCase, PerformanceIssueTestCase, OccurrenceTestMixin):

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -4,8 +4,8 @@ from django.core.mail.message import EmailMultiAlternatives
 
 from sentry.models.activity import Activity
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import get_attachment, get_channel
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers import get_channel
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -24,10 +24,12 @@ class AssignedNotificationAPITest(APITestCase):
         assert html_msg in msg.alternatives[0][0]
 
     def validate_slack_message(self, msg, group, project, user_id, index=0):
-        attachment, text = get_attachment(index)
-        assert text == msg
-        assert group.title in attachment["text"]
-        assert project.slug in attachment["blocks"][-2]["elements"][0]["text"]
+        blocks, fallback_text = get_blocks_and_fallback_text(index)
+        assert fallback_text == msg
+        blocks, fallback_text = get_blocks_and_fallback_text()
+
+        assert group.title in blocks[1]["text"]["text"]
+        assert project.slug in blocks[-2]["elements"][0]["text"]
         channel = get_channel(index)
         assert channel == user_id
 
@@ -59,9 +61,7 @@ class AssignedNotificationAPITest(APITestCase):
         self.login_as(self.user)
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_assignment_notification(self):
-        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is assigned.
@@ -83,16 +83,13 @@ class AssignedNotificationAPITest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert f"{self.group.qualified_short_id}</a> to themselves</p>" in msg.alternatives[0][0]
 
-        attachment, text = get_attachment()
-
-        assert text == f"Issue assigned to {user.get_display_name()} by themselves"
-        assert self.group.title in attachment["text"]
-        assert self.project.slug in attachment["blocks"][-2]["elements"][0]["text"]
+        blocks, fallback_text = get_blocks_and_fallback_text()
+        assert fallback_text == f"Issue assigned to {user.get_display_name()} by themselves"
+        assert self.group.title in blocks[1]["text"]["text"]
+        assert self.project.slug in blocks[-2]["elements"][0]["text"]
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_reassignment_notification_user(self):
-        # TODO: make this a block kit test
         """Test that if a user is assigned to an issue and then the issue is reassigned to a different user
         that the original assignee receives an unassignment notification as well as the new assignee
         receiving an assignment notification"""
@@ -152,9 +149,7 @@ class AssignedNotificationAPITest(APITestCase):
         self.validate_slack_message(msg, self.group, self.project, user1.id, index=2)
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
     def test_sends_reassignment_notification_team(self):
-        # TODO: make this a block kit test
         """Test that if a team is assigned to an issue and then the issue is reassigned to a different team
         that the originally assigned team receives an unassignment notification as well as the new assigned
         team receiving an assignment notification"""

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -58,6 +58,35 @@ def get_attachment():
     return attachments[0], data["text"][0]
 
 
+def get_blocks():
+    assert len(responses.calls) >= 1
+    data = parse_qs(responses.calls[0].request.body)
+    assert "text" in data
+    assert "blocks" in data
+
+    blocks = json.loads(data["blocks"][0])
+
+    # title with link, text, footer
+    if blocks[1]["type"] == "context":
+        title_block = blocks[1]["elements"][0]["text"]
+    else:
+        title_block = blocks[1]["text"]["text"]
+
+    url_block = blocks[-1].get("elements")
+    if url_block:
+        url_block = url_block[0].get("url")
+
+    # assume the divider is the last element
+    footer = blocks[-2].get("elements")
+    if footer:
+        footer = footer[0].get("text")
+    # otherwise try to get footer from the last element
+    if not footer:
+        footer = blocks[-1]["elements"][0]["text"]
+
+    return title_block, data["text"][0], footer, url_block
+
+
 def get_notification_uuid(url: str):
     query_params = parse_qs(urlparse(url).query)
     notification_uuid = query_params["notification_uuid"][0].split("|")[0]
@@ -117,7 +146,7 @@ class ActivityNotificationTest(APITestCase):
         self.short_id = self.group.qualified_short_id
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
+    @with_feature("organizations:slack-block-kit")
     def test_sends_note_notification(self):
         # TODO: make this a block kit test
         """
@@ -140,23 +169,23 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert "blah blah</p></div>" in msg.alternatives[0][0]
 
-        attachment, text = get_attachment()
+        block, text, footer, url = get_blocks()
         # check the Slack version
         assert text == f"New comment by {self.name}"
-        assert attachment["title"] == f"{self.group.title}"
-        notification_uuid = get_notification_uuid(attachment["title_link"])
+        assert self.group.title in block
+        title_link = block  # removes emoji and <>
+        notification_uuid = get_notification_uuid(block)
         assert (
-            attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}"
-        )
-        assert attachment["text"] == "blah blah"
+            f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}"
+        ) in title_link
+        assert title_link.split("\n")[-1] == "blah blah"
         assert (
-            attachment["footer"]
+            footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
+    @with_feature("organizations:slack-block-kit")
     def test_sends_unassignment_notification(self):
         # TODO: make this a block kit test
         """
@@ -183,14 +212,14 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert f"{self.user.username}</strong> unassigned" in msg.alternatives[0][0]
 
-        attachment, text = get_attachment()
+        block, text, footer, url = get_blocks()
 
         assert text == f"Issue unassigned by {self.name}"
-        assert self.group.title in attachment["text"]
-        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        assert self.group.title in block
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
-            attachment["blocks"][-2]["elements"][0]["text"]
+            footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -225,7 +254,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature({"organizations:slack-block-kit": False})
+    @with_feature("organizations:slack-block-kit")
     def test_sends_resolution_notification(self, record_analytics):
         # TODO: make this a block kit test
         """
@@ -246,17 +275,17 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert f"{self.short_id}</a> as resolved</p>" in msg.alternatives[0][0]
 
-        attachment, text = get_attachment()
+        block, text, footer, url = get_blocks()
 
-        assert self.group.title in attachment["text"]
-        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        assert self.group.title in block
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
             text
             == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=activity_notification&notification_uuid={notification_uuid}|{self.short_id}> as resolved"
         )
         assert (
-            attachment["blocks"][-2]["elements"][0]["text"]
+            footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -280,7 +309,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature({"organizations:slack-block-kit": False})
+    @with_feature("organizations:slack-block-kit")
     def test_sends_deployment_notification(self, record_analytics):
         # TODO: make this a block kit test
         """
@@ -311,19 +340,19 @@ class ActivityNotificationTest(APITestCase):
             in msg.alternatives[0][0]
         )
 
-        attachment, text = get_attachment()
+        block, text, footer, url = get_blocks()
 
         assert (
             text
             == f"Release {version_parsed} was deployed to {self.environment.name} for this project"
         )
-        notification_uuid = get_notification_uuid(attachment["actions"][0]["url"])
-        assert (
-            attachment["actions"][0]["url"]
-            == f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy&referrer=release_activity&notification_uuid={notification_uuid}"
+        title_link = block[13:][1:-1]  # removes emoji and <>
+        notification_uuid = get_notification_uuid(title_link)
+        assert url == (
+            f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy&referrer=release_activity&notification_uuid={notification_uuid}"
         )
         assert (
-            attachment["footer"]
+            footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/deploy/?referrer=release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert self.analytics_called_with_args(
@@ -346,7 +375,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature({"organizations:slack-block-kit": False})
+    @with_feature("organizations:slack-block-kit")
     def test_sends_regression_notification(self, record_analytics):
         # TODO: make this a block kit test
         """
@@ -384,13 +413,13 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert f"{group.qualified_short_id}</a> as a regression</p>" in msg.alternatives[0][0]
 
-        attachment, text = get_attachment()
+        block, text, footer, url = get_blocks()
 
         assert text == "Issue marked as regression"
-        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
-            attachment["blocks"][-2]["elements"][0]["text"]
+            footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert self.analytics_called_with_args(
@@ -413,7 +442,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature({"organizations:slack-block-kit": False})
+    @with_feature("organizations:slack-block-kit")
     def test_sends_resolved_in_release_notification(self, record_analytics):
         # TODO: make this a block kit test
         """
@@ -445,13 +474,14 @@ class ActivityNotificationTest(APITestCase):
             f'text-decoration: none">{self.short_id}</a> as resolved in' in msg.alternatives[0][0]
         )
 
-        attachment, text = get_attachment()
+        block, text, footer, url = get_blocks()
+
         assert text == f"Issue marked as resolved in {parsed_version} by {self.name}"
-        assert self.group.title in attachment["text"]
-        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        assert self.group.title in block
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
-            attachment["blocks"][-2]["elements"][0]["text"]
+            footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert self.analytics_called_with_args(
@@ -481,7 +511,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature({"organizations:slack-block-kit": False})
+    @with_feature("organizations:slack-block-kit")
     def test_sends_issue_notification(self, record_analytics):
         # TODO: make this a block kit test
         """
@@ -529,13 +559,13 @@ class ActivityNotificationTest(APITestCase):
         assert isinstance(msg.alternatives[0][0], str)
         assert "Hello world</pre>" in msg.alternatives[0][0]
 
-        attachment, text = get_attachment()
+        block, text, footer, url = get_blocks()
 
-        assert "Hello world" in attachment["text"]
-        title_link = attachment["blocks"][0]["text"]["text"][13:][1:-1]  # removes emoji and <>
+        assert "Hello world" in block
+        title_link = block[13:][1:-1]  # removes emoji and <>
         notification_uuid = get_notification_uuid(title_link)
         assert (
-            attachment["blocks"][-2]["elements"][0]["text"]
+            footer
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert self.analytics_called_with_args(

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -20,7 +20,6 @@ from sentry.rules.filters.base import EventFilter
 from sentry.rules.processing.processor import RuleProcessor
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
 from sentry.utils.safe import safe_execute
@@ -674,9 +673,7 @@ class RuleProcessorTestFilters(TestCase):
         assert futures[0].kwargs == {}
 
     @patch("sentry.shared_integrations.client.base.BaseApiClient.post")
-    @with_feature({"organizations:slack-block-kit": False})
     def test_slack_title_link_notification_uuid(self, mock_post):
-        # TODO: make this a block kit test
         """Test that the slack title link includes the notification uuid from apply function"""
         integration = install_slack(self.organization)
         action_data = [
@@ -700,9 +697,7 @@ class RuleProcessorTestFilters(TestCase):
         mock_post.assert_called_once()
         assert (
             "notification_uuid"
-            in json.loads(mock_post.call_args[1]["data"]["attachments"])[0]["blocks"][0]["text"][
-                "text"
-            ]
+            in json.loads(mock_post.call_args[1]["data"]["blocks"])[0]["text"]["text"]
         )
 
     @patch("sentry.shared_integrations.client.base.BaseApiClient.post")


### PR DESCRIPTION
Defaults `SlackNotifyService` and the pure functions in `src/sentry/integrations/slack/notifications.py` to use block kit by removing the feature flag there.

14 of the files modified are tests.