### PR TITLE
fix(replay): Print non-console breadcrumb messages

### DIFF
--- a/static/app/views/replays/detail/console/messageFormatter.spec.tsx
+++ b/static/app/views/replays/detail/console/messageFormatter.spec.tsx
@@ -249,4 +249,23 @@ describe('MessageFormatter', () => {
 
     expect(screen.getByText('Placeholder myPlaceholder with 100%')).toBeInTheDocument();
   });
+
+  it('should print non-console breadcrumbs', () => {
+    const [frame] = hydrateBreadcrumbs(
+      ReplayRecordFixture(),
+      [
+        {
+          category: 'cypress',
+          message: 'custom breadcrumb',
+          timestamp: new Date('2022-06-22T20:00:39.959Z').getTime(),
+          type: 'info',
+        },
+      ],
+      mockRRWebFrames
+    );
+
+    render(<MessageFormatter frame={frame} />);
+
+    expect(screen.getByText('cypress custom breadcrumb')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/replays/detail/console/messageFormatter.tsx
+++ b/static/app/views/replays/detail/console/messageFormatter.tsx
@@ -1,6 +1,5 @@
-import {memo} from 'react';
-
 import type {OnExpandCallback} from 'sentry/components/objectInspector';
+import {defined} from 'sentry/utils';
 import type {BreadcrumbFrame, ConsoleFrame} from 'sentry/utils/replays/types';
 import {isConsoleFrame} from 'sentry/utils/replays/types';
 import Format from 'sentry/views/replays/detail/console/format';
@@ -32,13 +31,13 @@ function isSerializedError(frame: ConsoleFrame) {
 /**
  * Attempt to emulate the browser console as much as possible
  */
-function UnmemoizedMessageFormatter({frame, expandPaths, onExpand}: Props) {
+export default function MessageFormatter({frame, expandPaths, onExpand}: Props) {
   if (!isConsoleFrame(frame)) {
     return (
       <Format
         expandPaths={expandPaths}
         onExpand={onExpand}
-        args={[frame.category, frame.data]}
+        args={[frame.category, frame.message, frame.data].filter(defined)}
       />
     );
   }
@@ -83,6 +82,3 @@ function UnmemoizedMessageFormatter({frame, expandPaths, onExpand}: Props) {
     />
   );
 }
-
-const MessageFormatter = memo(UnmemoizedMessageFormatter);
-export default MessageFormatter;


### PR DESCRIPTION
**Before:**
<img width="390" alt="before" src="https://github.com/getsentry/sentry/assets/187460/d16b8ea6-209d-4740-a4be-8485513a9445">

**After:**
<img width="452" alt="after" src="https://github.com/getsentry/sentry/assets/187460/1de24780-2c2d-4007-a6cd-957a77b08af3">




Fixes https://github.com/getsentry/sentry/issues/63798