### PR TITLE
replay: support banner mobile waitlist

### DIFF
--- a/static/app/components/replays/alerts/replayUnsupportedAlert.tsx
+++ b/static/app/components/replays/alerts/replayUnsupportedAlert.tsx
@@ -19,7 +19,7 @@ export default function ReplayUnsupportedAlert({projectSlug}: Props) {
         `Currently, [docsLink:Web is supported], and Mobile is being developed. Join our [waitlistLink:waitlist].`,
         {
           docsLink,
-          waitlistLink
+          waitlistLink,
         }
       )}
     </Alert>

--- a/static/app/components/replays/alerts/replayUnsupportedAlert.tsx
+++ b/static/app/components/replays/alerts/replayUnsupportedAlert.tsx
@@ -11,15 +11,16 @@ export default function ReplayUnsupportedAlert({projectSlug}: Props) {
   const docsLink = (
     <ExternalLink href="https://docs.sentry.io/product/session-replay/getting-started/#supported-sdks" />
   );
-  const waitlistLink = (
-    <ExternalLink href="https://sentry.io/lp/mobile-replay-beta/" />
-  );
+  const waitlistLink = <ExternalLink href="https://sentry.io/lp/mobile-replay-beta/" />;
   return (
     <Alert icon={<IconInfo />}>
       <strong>{t(`Session Replay isn't available for %s.`, projectSlug)}</strong>{' '}
-      {tct(`Currently, [docsLink:Web is supported], and Mobile is being developed. Join our [waitlistLink:waitlist].`, {
-        link,
-      })}
+      {tct(
+        `Currently, [docsLink:Web is supported], and Mobile is being developed. Join our [waitlistLink:waitlist].`,
+        {
+          link,
+        }
+      )}
     </Alert>
   );
 }

--- a/static/app/components/replays/alerts/replayUnsupportedAlert.tsx
+++ b/static/app/components/replays/alerts/replayUnsupportedAlert.tsx
@@ -18,7 +18,8 @@ export default function ReplayUnsupportedAlert({projectSlug}: Props) {
       {tct(
         `Currently, [docsLink:Web is supported], and Mobile is being developed. Join our [waitlistLink:waitlist].`,
         {
-          link,
+          docsLink,
+          waitlistLink
         }
       )}
     </Alert>

--- a/static/app/components/replays/alerts/replayUnsupportedAlert.tsx
+++ b/static/app/components/replays/alerts/replayUnsupportedAlert.tsx
@@ -8,13 +8,16 @@ interface Props {
 }
 
 export default function ReplayUnsupportedAlert({projectSlug}: Props) {
-  const link = (
-    <ExternalLink href="https://docs.sentry.io/product/session-replay/getting-started/" />
+  const docsLink = (
+    <ExternalLink href="https://docs.sentry.io/product/session-replay/getting-started/#supported-sdks" />
+  );
+  const waitlistLink = (
+    <ExternalLink href="https://sentry.io/lp/mobile-replay-beta/" />
   );
   return (
     <Alert icon={<IconInfo />}>
       <strong>{t(`Session Replay isn't available for %s.`, projectSlug)}</strong>{' '}
-      {tct(`To learn more about which SDKs we support, please visit our [link:docs].`, {
+      {tct(`Currently, [docsLink:Web is supported], and Mobile is being developed. Join our [waitlistLink:waitlist].`, {
         link,
       })}
     </Alert>


### PR DESCRIPTION
Mobile support is already with closed alpha customers, we're close.

Resolves: https://github.com/getsentry/sentry/issues/68816