### PR TITLE
ref(rules): Add delete methods to Redis Buffer

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -88,6 +88,8 @@ class RedisOperation(Enum):
     SET_GET = "smembers"
     HASH_ADD = "hset"
     HASH_GET_ALL = "hgetall"
+    HASH_DELETE = "hdel"
+    DELETE = "delete"
 
 
 class PendingBuffer:
@@ -276,6 +278,18 @@ class RedisBuffer(Buffer):
 
     def get_set(self, key: str) -> list[set[int]]:
         return self._execute_redis_operation(key, RedisOperation.SET_GET)
+
+    def delete_key(self, key: str) -> None:
+        self._execute_redis_operation(key, RedisOperation.DELETE)
+
+    def delete_hash(
+        self,
+        model: type[models.Model],
+        filters: dict[str, models.Model | str | int],
+        field: str,
+    ) -> None:
+        key = self._make_key(model, filters)
+        self._execute_redis_operation(key, RedisOperation.HASH_DELETE, field)
 
     def push_to_hash(
         self,

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -258,14 +258,14 @@ class TestRedisBuffer:
     def group_rule_data_by_project_id(self, buffer, project_ids):
         project_ids_to_rule_data = defaultdict(list)
         for proj_id in project_ids[0]:
-            rule_group_pairs = buffer.get_hash(Project, {"project_id": proj_id})
+            rule_group_pairs = buffer.get_hash(Project, {"project_id": proj_id[0]})
             for pair in rule_group_pairs:
                 for k, v in pair.items():
                     if isinstance(k, bytes):
                         k = k.decode("utf-8")
                     if isinstance(v, bytes):
                         v = v.decode("utf-8")
-                    project_ids_to_rule_data[int(proj_id)].append({k: v})
+                    project_ids_to_rule_data[int(proj_id[0])].append({k: v})
         return project_ids_to_rule_data
 
     def test_enqueue(self):


### PR DESCRIPTION
We need a way to delete things we've already processed from the buffer. This PR adds `hdel` (hash delete) and `zremrangebyscore` methods to the Redis buffer that will later be used in `apply_delayed`, as well as replaces `sadd` with `zadd`, replaces `smembers` with `zrange` so we can remove project ids by the time they were added.

Closes https://github.com/getsentry/team-core-product-foundations/issues/304