### PR TITLE
fix(slack): put back approve and reject buttons in invite request message

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications/base.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/base.py
@@ -65,7 +65,10 @@ class SlackNotificationsMessageBuilder(BlockSlackMessageBuilder):
 
         actions_block = []
         for action in actions:
-            if action.label == "Turn on personal notifications" or action.url:
+            if (
+                action.label in ["Turn on personal notifications", "Approve", "Reject"]
+                or action.url
+            ):
                 actions_block.append(self.get_button_action(action))
 
         if actions_block:

--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.urls import reverse
 
+from sentry import features
 from sentry.models.organizationmember import OrganizationMember
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
 from sentry.notifications.notifications.strategies.member_write_role_recipient_strategy import (
@@ -70,9 +71,22 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification, abc.ABC
                 style="primary",
                 action_id="approve_request",
                 value="approve_member",
+                label=(
+                    "Approve"
+                    if features.has("organizations:slack-block-kit", self.organization)
+                    else None
+                ),
             ),
             MessageAction(
-                name="Reject", style="danger", action_id="approve_request", value="reject_member"
+                name="Reject",
+                style="danger",
+                action_id="approve_request",
+                value="reject_member",
+                label=(
+                    "Reject"
+                    if features.has("organizations:slack-block-kit", self.organization)
+                    else None
+                ),
             ),
             MessageAction(
                 name="See Members & Requests",

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -11,7 +11,7 @@ from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.slack import get_attachment_no_text
+from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
@@ -175,44 +175,45 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
         assert self.organization.absolute_url("/settings/members/") in mail.outbox[0].body
 
     @responses.activate
-    @with_feature({"organizations:slack-block-kit": False})
+    @with_feature("organizations:slack-block-kit")
     def test_request_to_join_slack(self):
-        # TODO: convert this test to block kit
         with self.tasks():
             self.get_success_response(self.organization.slug, email=self.email, status_code=204)
 
-        attachment = get_attachment_no_text()
-        assert attachment["text"] == f"{self.email} is requesting to join {self.organization.name}"
-        query_params = parse_qs(urlparse(attachment["actions"][2]["url"]).query)
+        blocks, fallback_text = get_blocks_and_fallback_text()
+        assert fallback_text == f"{self.email} is requesting to join {self.organization.name}"
+        query_params = parse_qs(urlparse(blocks[1]["elements"][0]["text"]).query)
         notification_uuid = query_params["notification_uuid"][0]
-        assert attachment["actions"] == [
+        notification_uuid = notification_uuid.split("|")[
+            0
+        ]  # remove method of hyperlinking in slack
+        assert blocks[2]["type"] == "actions"
+        assert blocks[2]["elements"] == [
             {
-                "text": "Approve",
-                "name": "Approve",
-                "style": "primary",
                 "type": "button",
+                "text": {"type": "plain_text", "text": "Approve"},
+                "action_id": "approve_request",
                 "value": "approve_member",
-                "action_id": "approve_request",
             },
             {
-                "text": "Reject",
-                "name": "Reject",
-                "style": "danger",
                 "type": "button",
+                "text": {"type": "plain_text", "text": "Reject"},
+                "action_id": "approve_request",
                 "value": "reject_member",
-                "action_id": "approve_request",
             },
             {
-                "text": "See Members & Requests",
-                "name": "See Members & Requests",
-                "url": f"http://testserver/settings/{self.organization.slug}/members/?referrer=join_request-slack-user&notification_uuid={notification_uuid}",
                 "type": "button",
+                "text": {"type": "plain_text", "text": "See Members & Requests"},
+                "url": f"http://testserver/settings/{self.organization.slug}/members/?referrer=join_request-slack-user&notification_uuid={notification_uuid}",
+                "value": "link_clicked",
             },
         ]
 
+        data = parse_qs(responses.calls[0].request.body)
+
         with outbox_runner():
             member = OrganizationMember.objects.get(email=self.email)
-        assert json.loads(attachment["callback_id"]) == {
+        assert json.loads(data["callback_id"][0]) == {
             "member_id": member.id,
             "member_email": self.email,
         }


### PR DESCRIPTION
While removing the block kit flag, I noticed that the attachments method of sending organization join request messages in Slack expected an `Approve`, `Reject`, and `See Members & Requests` button, but the block kit logic is not rendering the buttons at the moment.

<img width="692" alt="Screenshot 2024-04-12 at 15 11 58" src="https://github.com/getsentry/sentry/assets/70817427/038bd5a8-a468-439f-8056-45a748ded0c0">

For some reason we are explicitly checking the `action.label` or the existence of an `action.url` to determine whether to render the button. I added some logic so that these buttons show up, but I'm still unsure what determines whether a `MessageAction` is rendered as a button.