### PR TITLE
ref(rules): Update Redis buffer key

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -19,7 +19,9 @@ def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
         project_ids = buffer.get_set(PROJECT_ID_BUFFER_LIST_KEY)
 
         for project in RangeQuerySetWrapper(Project.objects.filter(id__in=project_ids)):
-            rulegroup_event_mapping = buffer.get_hash(model=Project, field={"id": project.id})
+            rulegroup_event_mapping = buffer.get_hash(
+                model=Project, field={"project_id": project.id}
+            )
 
             with metrics.timer("delayed_processing.process_project.duration"):
                 safe_execute(


### PR DESCRIPTION
Update the Redis buffer key to be "project_id" instead of "id" to avoid collision with the incrementing buffer.