### PR TITLE
deps(ui): Upgrade react-lazyload

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/react": "18.2.55",
     "@types/react-date-range": "^1.4.4",
     "@types/react-dom": "18.2.19",
+    "@types/react-lazyload": "3.2.3",
     "@types/react-grid-layout": "^1.3.2",
     "@types/react-mentions": "4.1.6",
     "@types/react-router": "^3.0.22",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "react-date-range": "^1.4.0",
     "react-dom": "18.2.0",
     "react-grid-layout": "^1.3.4",
-    "react-lazyload": "^2.3.0",
+    "react-lazyload": "^3.2.1",
     "react-mentions": "4.4.2",
     "react-popper": "^2.3.0",
     "react-router": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10253,10 +10253,10 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-lazyload@^2.3.0:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/react-lazyload/-/react-lazyload-2.6.5.tgz#7a5ac001f0f8aeddc10c30e4ce318c10f13aa723"
-  integrity sha512-C/juO9l7dGS7jEARBLjM3oG7F1lL5bqajz/55sk3GFc0Ippd9vnSkdRxdiaE6gf5si3YxIow8dSJ+YuB2D/3vg==
+react-lazyload@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/react-lazyload/-/react-lazyload-3.2.1.tgz#320087741ee6aaf693369b67690799423ed4d7a3"
+  integrity sha512-oDLlLOI/rRLY0fUh/HYFCy4CqCe7zdJXv6oTl2pC30tN3ezWxvwcdHYfD/ZkrGOMOOT5pO7hNLSvg7WsmAij1w==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3596,6 +3596,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-lazyload@3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@types/react-lazyload/-/react-lazyload-3.2.3.tgz#42129b6e11353bfe8ed2ba5e1b964676ee23668b"
+  integrity sha512-s03gWlHXiFqZr7TEFDTx8Lkl+ZEYrwTkXP9MNZ3Z3blzsPrnkYjgeSK2tjfzVv/TYVCnDk6TZwNRDHQlHy/1Ug==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-mentions@4.1.6":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/react-mentions/-/react-mentions-4.1.6.tgz#0ecdb61785c22edbf9c7d6718505d4814ad3a65c"


### PR DESCRIPTION
Silences warning about react 18 peer dependency.
I think the breaking major version is an extra div wrapper.





> 3.0.0 fixes the findDomNode warning through usage of React ref, and the following are the changes you need to be aware of
> Now we have an extra div wrapping the lazy loaded component for the React ref to work
We can understand that it is an extra DOM node, and we are working to optimize that if possible
It might break your UI or snapshot tests based on your usage
To customize the styling to the extra div please refer [here](https://github.com/twobin/react-lazyload#classNamePrefix)
Found any other problem, please feel free to leave a comment over https://github.com/twobin/react-lazyload/issues/310


the types are pretty simple https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-lazyload/index.d.ts