### PR TITLE
fix(backup): Handle OrganizationMember token collisions

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -655,4 +655,10 @@ class OrganizationMember(ReplicatedRegionModel):
         ):
             self.inviter_id = None
 
+        # If there is a token collision, just wipe the token. The user can always make a new one.
+        matching_token = self.__class__.objects.filter(token=self.token).first()
+        if matching_token is not None:
+            self.token = None
+            self.token_expires_at = None
+
         return super().normalize_before_relocation_import(pk_map, scope, flags)

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -1893,13 +1893,23 @@ class CollisionTests(ImportTestCase):
         self, expected_models: list[type[Model]]
     ):
         owner = self.create_exhaustive_user(username="owner", email="importing@example.com")
-        self.create_organization("some-org", owner=owner)
+        org = self.create_organization("some-org", owner=owner)
+        old_org_membership = OrganizationMember.objects.get(organization=org)
+        old_org_membership.regenerate_token()
+        old_org_membership.save()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
             with open(tmp_path, "rb") as tmp_file:
                 owner = self.create_exhaustive_user(username="owner", email="existing@example.com")
-                self.create_organization("some-org", owner=owner)
+                org = self.create_organization("some-org", owner=owner)
+
+                # Re-insert colliding tokens, pointed at the new user and org.
+                new_org_membership = OrganizationMember.objects.get(organization=org)
+                new_org_membership.token = old_org_membership.token
+                new_org_membership.token_expires_at = old_org_membership.token_expires_at
+                new_org_membership.save()
+
                 import_in_organization_scope(
                     tmp_file,
                     flags=ImportFlags(merge_users=True),
@@ -1948,6 +1958,10 @@ class CollisionTests(ImportTestCase):
                 == 1
             )
 
+            # Expect one of the tokens to be nulled out due to collision.
+            assert OrganizationMember.objects.filter(token=old_org_membership.token).count() == 1
+            assert OrganizationMember.objects.filter(token__isnull=True).count() == 1
+
             with assume_test_silo_mode(SiloMode.CONTROL):
                 assert OrganizationMapping.objects.count() == 2
                 assert OrganizationMemberMapping.objects.count() == 2  # Same user in both orgs
@@ -1966,13 +1980,23 @@ class CollisionTests(ImportTestCase):
         self, expected_models: list[type[Model]]
     ):
         owner = self.create_exhaustive_user(username="owner", email="importing@example.com")
-        self.create_organization("some-org", owner=owner)
+        org = self.create_organization("some-org", owner=owner)
+        old_org_membership = OrganizationMember.objects.get(organization=org)
+        old_org_membership.regenerate_token()
+        old_org_membership.save()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
             with open(tmp_path, "rb") as tmp_file:
                 owner = self.create_exhaustive_user(username="owner", email="existing@example.com")
-                self.create_organization("some-org", owner=owner)
+                org = self.create_organization("some-org", owner=owner)
+
+                # Re-insert colliding tokens, pointed at the new user and org.
+                new_org_membership = OrganizationMember.objects.get(organization=org)
+                new_org_membership.token = old_org_membership.token
+                new_org_membership.token_expires_at = old_org_membership.token_expires_at
+                new_org_membership.save()
+
                 import_in_organization_scope(
                     tmp_file,
                     flags=ImportFlags(merge_users=False),
@@ -2025,6 +2049,10 @@ class CollisionTests(ImportTestCase):
                 ).count()
                 == 1
             )
+
+            # Expect one of the tokens to be nulled out due to collision.
+            assert OrganizationMember.objects.filter(token=old_org_membership.token).count() == 1
+            assert OrganizationMember.objects.filter(token__isnull=True).count() == 1
 
             with assume_test_silo_mode(SiloMode.CONTROL):
                 assert OrganizationMapping.objects.count() == 2


### PR DESCRIPTION
These were previously counted as "tested" because we cover this model in a `COLLISION_TEST`, but unfortunately did not cover this specific kind of collision. The handling and the tests are now both available.