### PR TITLE
feat(proguard): Add a jvm Symbolicator pool

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3535,7 +3535,8 @@ SYMBOLICATOR_POLL_TIMEOUT = 5
 # The `url` of the different Symbolicator pools.
 # We want to route different workloads to a different set of Symbolicator pools.
 # This can be as fine-grained as using a different pool for normal "native"
-# symbolication, `js` symbolication, and for `lpq` / `lpq-js`.
+# symbolication, `js` symbolication, `jvm` symbolication,
+# and `lpq` variants`of each of them.
 # (See `SENTRY_LPQ_OPTIONS` and related settings)
 # The keys here should match the `SymbolicatorPools` enum
 # defined in `src/sentry/lang/native/symbolicator.py`.
@@ -3545,10 +3546,12 @@ SYMBOLICATOR_POLL_TIMEOUT = 5
 # The settings here are intentionally empty and will fall back to
 # `symbolicator.options` for backwards compatibility.
 SYMBOLICATOR_POOL_URLS: dict[str, str] = {
-    # "js": "...",
     # "default": "...",
+    # "js": "...",
+    # "jvm": "...",
     # "lpq": "...",
     # "lpq_js": "...",
+    # "lpq_jvm": "...",
 }
 
 SENTRY_REQUEST_METRIC_ALLOWED_PATHS = (

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -59,8 +59,10 @@ class SymbolicatorTaskKind:
 class SymbolicatorPools(Enum):
     default = "default"
     js = "js"
+    jvm = "jvm"
     lpq = "lpq"
     lpq_js = "lpq_js"
+    lpq_jvm = "lpq_jvm"
 
 
 class Symbolicator:
@@ -73,14 +75,17 @@ class Symbolicator:
     ):
         URLS = settings.SYMBOLICATOR_POOL_URLS
         pool = SymbolicatorPools.default.value
-        # TODO: Add a pool for JVM
         if task_kind.is_low_priority:
             if task_kind.platform == SymbolicatorPlatform.js:
                 pool = SymbolicatorPools.lpq_js.value
+            elif task_kind.platform == SymbolicatorPlatform.jvm:
+                pool = SymbolicatorPools.lpq_jvm.value
             else:
                 pool = SymbolicatorPools.lpq.value
         elif task_kind.platform == SymbolicatorPlatform.js:
             pool = SymbolicatorPools.js.value
+        elif task_kind.platform == SymbolicatorPlatform.jvm:
+            pool = SymbolicatorPools.jvm.value
 
         base_url = (
             URLS.get(pool)


### PR DESCRIPTION
Note that by itself this does nothing—the URL doesn't exist yet, so we will fall back to the default pool.