### PR TITLE
fix(ddm): Use `replace` instead of `re.sub`

### DIFF
--- a/src/sentry/sentry_metrics/querying/data/query.py
+++ b/src/sentry/sentry_metrics/querying/data/query.py
@@ -61,8 +61,10 @@ class MQLQuery:
         # We sort query names by length and content with the goal of trying to always match the longest queries first.
         sorted_query_names = sorted(sub_queries.keys(), key=lambda q: (len(q), q), reverse=True)
         for query_name in sorted_query_names:
+            # We pass a lambda to the sub, because of how escaping is handled by `re.sub`. More information
+            # can be found at https://stackoverflow.com/questions/280435/escaping-regex-string.
             replaced_mql_formula = re.sub(
-                rf"\${query_name}", sub_queries[query_name].mql, replaced_mql_formula
+                rf"\${query_name}", lambda _: sub_queries[query_name].mql, replaced_mql_formula
             )
 
         return MQLQuery(mql=replaced_mql_formula, order=self.order, limit=self.limit)

--- a/src/sentry/sentry_metrics/querying/data/query.py
+++ b/src/sentry/sentry_metrics/querying/data/query.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, cast
@@ -61,10 +60,8 @@ class MQLQuery:
         # We sort query names by length and content with the goal of trying to always match the longest queries first.
         sorted_query_names = sorted(sub_queries.keys(), key=lambda q: (len(q), q), reverse=True)
         for query_name in sorted_query_names:
-            # We pass a lambda to the sub, because of how escaping is handled by `re.sub`. More information
-            # can be found at https://stackoverflow.com/questions/280435/escaping-regex-string.
-            replaced_mql_formula = re.sub(
-                rf"\${query_name}", lambda _: sub_queries[query_name].mql, replaced_mql_formula
+            replaced_mql_formula = replaced_mql_formula.replace(
+                f"${query_name}", sub_queries[query_name].mql
             )
 
         return MQLQuery(mql=replaced_mql_formula, order=self.order, limit=self.limit)

--- a/tests/sentry/sentry_metrics/querying/data/test_query.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_query.py
@@ -14,6 +14,11 @@ from sentry.sentry_metrics.querying.errors import InvalidMetricsQueryError
             {"a": "query_1", "b": "query_2", "aa": "query_3", "ab": "query_4"},
             "query_1 / query_3 + query_4 * query_2",
         ),
+        (
+            "$a * 2",
+            {"a": r'sum(my_metric){endpoint:"\organizations\metrics\api"}'},
+            r'sum(my_metric){endpoint:"\organizations\metrics\api"} * 2',
+        ),
     ],
 )
 def test_compile_mql_query(formula, queries, expected_formula):


### PR DESCRIPTION
This PR fixes escaping of `re.sub` when compiling an `MQLQuery` by just using the `replace` function of Python.

Closes: https://github.com/getsentry/sentry/issues/68597