### PR TITLE
feat(dynamic-sampling): Add new patterns to match health checks

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -705,7 +705,7 @@ HEALTH_CHECK_GLOBS = [
     "*/health",
     "*/healthy",
     "*/healthz",
-    "*/[_health]",
+    r"*/\[_health\]",
     "*/live",
     "*/livez",
     "*/ready",

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -705,6 +705,7 @@ HEALTH_CHECK_GLOBS = [
     "*/health",
     "*/healthy",
     "*/healthz",
+    "*/_health",
     r"*/\[_health\]",
     "*/live",
     "*/livez",

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -705,6 +705,7 @@ HEALTH_CHECK_GLOBS = [
     "*/health",
     "*/healthy",
     "*/healthz",
+    "*/[_health]",
     "*/live",
     "*/livez",
     "*/ready",

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -92,6 +92,7 @@ config:
       - '*/health'
       - '*/healthy'
       - '*/healthz'
+      - '*/\[_health\]'
       - '*/live'
       - '*/livez'
       - '*/ready'

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -92,6 +92,7 @@ config:
       - '*/health'
       - '*/healthy'
       - '*/healthz'
+      - '*/_health'
       - '*/\[_health\]'
       - '*/live'
       - '*/livez'

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -93,6 +93,7 @@ config:
       - '*/health'
       - '*/healthy'
       - '*/healthz'
+      - '*/\[_health\]'
       - '*/live'
       - '*/livez'
       - '*/ready'

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -93,6 +93,7 @@ config:
       - '*/health'
       - '*/healthy'
       - '*/healthz'
+      - '*/_health'
       - '*/\[_health\]'
       - '*/live'
       - '*/livez'


### PR DESCRIPTION
This PR adds a new pattern for matching health checks. The new pattern is `*/[_health]`.

Closes: https://github.com/getsentry/sentry/issues/68869