### PR TITLE
Use last forwarded IP

### DIFF
--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -29,7 +29,7 @@ class SetRemoteAddrFromForwardedFor(MiddlewareMixin):
             pass
         else:
             # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
-            # Take just the first one.
-            real_ip = real_ip.split(",")[0].strip()
+            # Take the last one, from the last trusted forwarder.
+            real_ip = real_ip.split(",")[-1].strip()
             real_ip = self._remove_port_number(real_ip)
             request.META["REMOTE_ADDR"] = real_ip

--- a/tests/sentry/middleware/test_proxy.py
+++ b/tests/sentry/middleware/test_proxy.py
@@ -18,9 +18,9 @@ class SetRemoteAddrFromForwardedForTestCase(TestCase):
 
     def test_ipv4(self):
         request = HttpRequest()
-        request.META["HTTP_X_FORWARDED_FOR"] = "8.8.8.8:80,8.8.4.4"
+        request.META["HTTP_X_FORWARDED_FOR"] = "8.8.8.8,8.8.4.4:80"
         self.middleware.process_request(request)
-        assert request.META["REMOTE_ADDR"] == "8.8.8.8"
+        assert request.META["REMOTE_ADDR"] == "8.8.4.4"
 
     def test_ipv4_whitespace(self):
         request = HttpRequest()
@@ -32,7 +32,7 @@ class SetRemoteAddrFromForwardedForTestCase(TestCase):
         request = HttpRequest()
         request.META["HTTP_X_FORWARDED_FOR"] = "2001:4860:4860::8888,2001:4860:4860::8844"
         self.middleware.process_request(request)
-        assert request.META["REMOTE_ADDR"] == "2001:4860:4860::8888"
+        assert request.META["REMOTE_ADDR"] == "2001:4860:4860::8844"
 
 
 test_region = Region(


### PR DESCRIPTION
Well-behaved forwarders will append the IP they're forwarding for to an existing list. In the most typical case, this means that only the last one is trustworthy from a spoofing request-maker.

And all this is assuming that the proxy itself is trusted.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#security_and_privacy_concerns

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
