### PR TITLE
feat(metric-stats): Add cardinality.{limit,scope} tags to strings indexer

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -198,6 +198,8 @@ SHARED_TAG_STRINGS = {
     "outcome.id": PREFIX + 276,
     "outcome.reason": PREFIX + 277,
     "cardinality.window": PREFIX + 278,
+    "cardinality.limit": PREFIX + 279,
+    "cardinality.scope": PREFIX + 280,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }

--- a/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
+++ b/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
@@ -1,7 +1,7 @@
 from hashlib import sha256
 
 LOCKED_FILE = "src/sentry/sentry_metrics/indexer/strings.py"
-LOCKED_DIGEST = "609a019a93229c352ec38c2be6a0620bfd2964e00315258c32f1502b4bc14add"
+LOCKED_DIGEST = "890c15103cfd9315583cfd72e4488a310e67e0c5acaddae7780cebb6e586dc70"
 MESSAGE = f"""{LOCKED_FILE} is locked.
 
 * We have detected you made changes to this file.


### PR DESCRIPTION
Epic: https://github.com/getsentry/relay/issues/3147

Adds `cardinality.scope` and `cardinality.limit` tags to strings indexer, to allow manual queries via cardinality analyzer spanning multiple/all orgs with a fixed metric id/tag id.

The tag is unused in all indexer tables.