### PR TITLE
fix: require email to be verified before making it primary

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -26,6 +26,7 @@ from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.user import User
+from sentry.models.useremail import UserEmail
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.organization.model import RpcOrganizationDeleteState
 from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
@@ -92,6 +93,11 @@ class BaseUserSerializer(CamelSnakeModelSerializer):
             .exclude(id=self.instance.id if hasattr(self.instance, "id") else 0).exists()
         ):
             raise serializers.ValidationError("That username is already in use.")
+        verified_email_found = UserEmail.objects.filter(
+            user=self.instance, email=value, is_verified=True
+        )
+        if not verified_email_found:
+            raise serializers.ValidationError("Verified email address is not found.")
         return value
 
     def validate(self, attrs):

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -166,6 +166,7 @@ class UserDetailsUpdateTest(UserDetailsTest):
         user = self.create_user(email="c@example.com", username="diff@example.com")
         self.login_as(user=user, superuser=False)
 
+        self.create_useremail(user, "new@example.com", is_verified=True)
         self.get_success_response("me", username="new@example.com")
 
         user = User.objects.get(id=user.id)
@@ -179,12 +180,26 @@ class UserDetailsUpdateTest(UserDetailsTest):
         user = self.create_user(email="c@example.com", username="c@example.com")
         self.login_as(user=user)
 
+        self.create_useremail(user, "new@example.com", is_verified=True)
         self.get_success_response("me", username="new@example.com")
 
         user = User.objects.get(id=user.id)
 
         assert user.email == "new@example.com"
         assert user.username == "new@example.com"
+
+    def test_cannot_change_username_to_non_verified(self):
+        user = self.create_user(email="c@example.com", username="c@example.com")
+        self.login_as(user=user)
+
+        self.create_useremail(user, "new@example.com", is_verified=False)
+        resp = self.get_error_response("me", username="new@example.com", status_code=400)
+        assert resp.data["username"][0] == "Verified email address is not found."
+
+        user = User.objects.get(id=user.id)
+
+        assert user.email == "c@example.com"
+        assert user.username == "c@example.com"
 
 
 @control_silo_test

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -194,7 +194,7 @@ class UserDetailsUpdateTest(UserDetailsTest):
 
         self.create_useremail(user, "new@example.com", is_verified=False)
         resp = self.get_error_response("me", username="new@example.com", status_code=400)
-        assert resp.data["username"][0] == "Verified email address is not found."
+        assert resp.data["detail"] == "Verified email address is not found."
 
         user = User.objects.get(id=user.id)
 


### PR DESCRIPTION
Make sure the `username` is verified before making it a primary email.