### PR TITLE
feat(perf): Adjust HTTP sample table column widths

### DIFF
--- a/static/app/views/performance/http/spanSamplesTable.tsx
+++ b/static/app/views/performance/http/spanSamplesTable.tsx
@@ -39,12 +39,12 @@ const COLUMN_ORDER: Column[] = [
   {
     key: SpanIndexedField.ID,
     name: t('Span ID'),
-    width: COL_WIDTH_UNDEFINED,
+    width: 150,
   },
   {
     key: SpanIndexedField.RESPONSE_CODE,
     name: t('Status'),
-    width: COL_WIDTH_UNDEFINED,
+    width: 50,
   },
   {
     key: SpanIndexedField.SPAN_DESCRIPTION,


### PR DESCRIPTION
Both the span ID and status code have known widths, since their lengths are fixed.
