### PR TITLE
fix(perf): Link Response module domains to a specific project

### DIFF
--- a/static/app/views/performance/http/domainCell.tsx
+++ b/static/app/views/performance/http/domainCell.tsx
@@ -25,6 +25,7 @@ export function DomainCell({projectId, domain}: Props) {
 
   const queryString = {
     ...location.query,
+    project: projectId,
     'span.domain': undefined,
     domain,
   };


### PR DESCRIPTION
The table is broken down by project, but the link to the domain summary wasn't actually linking to a specific project! That is _incorrect_.
