### PR TITLE
fix(security): delete grant once used

### DIFF
--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -90,9 +90,10 @@ class ApiToken(ReplicatedControlModel, HasApiScopes):
                 application=grant.application, user=grant.user, scope_list=grant.get_scopes()
             )
 
-            # remove the ApiGrant from the database to prevent reuse of the same
-            # authorization code
-            grant.delete()
+            with transaction.atomic(router.db_for_write(ApiGrant)):
+                # remove the ApiGrant from the database to prevent reuse of the same
+                # authorization code
+                grant.delete()
 
             return api_token
 

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -5,7 +5,7 @@ from collections.abc import Collection
 from datetime import timedelta
 from typing import Any, ClassVar
 
-from django.db import models, router, transaction
+from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 from django.utils.encoding import force_str
 
@@ -90,12 +90,18 @@ class ApiToken(ReplicatedControlModel, HasApiScopes):
                 application=grant.application, user=grant.user, scope_list=grant.get_scopes()
             )
 
+        try:
             with transaction.atomic(router.db_for_write(ApiGrant)):
                 # remove the ApiGrant from the database to prevent reuse of the same
                 # authorization code
                 grant.delete()
+        except IntegrityError as e:
+            # If we cannot delete the ApiGrant, then we should also
+            # delete the token that was created
+            api_token.delete()
+            raise IntegrityError("unable to delete ApiGrant") from e
 
-            return api_token
+        return api_token
 
     def is_expired(self):
         if not self.expires_at:

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -176,6 +176,33 @@ class OAuthTokenCodeTest(TestCase):
         assert resp.status_code == 400
         assert json.loads(resp.content) == {"error": "invalid_grant"}
 
+    def test_one_time_use_grant(self):
+        self.login_as(self.user)
+        resp = self.client.post(
+            self.path,
+            {
+                "grant_type": "authorization_code",
+                "redirect_uri": self.application.get_default_redirect_uri(),
+                "code": self.grant.code,
+                "client_id": self.application.client_id,
+                "client_secret": self.client_secret,
+            },
+        )
+        assert resp.status_code == 200
+
+        # attempt to re-use the same grant code
+        resp = self.client.post(
+            self.path,
+            {
+                "grant_type": "authorization_code",
+                "redirect_uri": self.application.get_default_redirect_uri(),
+                "code": self.grant.code,
+                "client_id": self.application.client_id,
+                "client_secret": self.client_secret,
+            },
+        )
+        assert resp.status_code == 400
+
     def test_invalid_redirect_uri(self):
         self.login_as(self.user)
 


### PR DESCRIPTION
When an `ApiToken` is created from an `ApiGrant` we should delete that specific grant from the database in order prevent reuse of the same code for token exchanges.

Note, we already do this in the "grant exchanger". This particular code path does not use the generic `GrantExchanger`. I'm not sure why, but that's something we can come back to refactor. 
https://github.com/getsentry/sentry/blob/80f9de5890cac1a7d70252f7f4818baaf2155dd9/src/sentry/mediators/token_exchange/grant_exchanger.py#L37-L39
