### PR TITLE
fix(crons): Update slug in quotas when deleting monitors

### DIFF
--- a/src/sentry/monitors/endpoints/base_monitor_details.py
+++ b/src/sentry/monitors/endpoints/base_monitor_details.py
@@ -256,7 +256,9 @@ class MonitorDetailsMixin(BaseEndpointMixin):
             for monitor_object in monitor_objects_list:
                 # randomize slug on monitor deletion to prevent re-creation side effects
                 if isinstance(monitor_object, Monitor):
-                    monitor_object.update(slug=get_random_string(length=24))
+                    new_slug = get_random_string(length=24)
+                    quotas.backend.update_monitor_slug(monitor.slug, new_slug, monitor.project_id)
+                    monitor_object.update(slug=new_slug)
 
                 schedule = RegionScheduledDeletion.schedule(
                     monitor_object, days=0, actor=request.user

--- a/tests/sentry/monitors/endpoints/test_base_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_details.py
@@ -857,7 +857,8 @@ class BaseDeleteMonitorTest(MonitorTestCase):
         self.login_as(user=self.user)
         super().setUp()
 
-    def test_simple(self):
+    @patch("sentry.quotas.backend.update_monitor_slug")
+    def test_simple(self, update_monitor_slug):
         monitor = self._create_monitor()
         old_slug = monitor.slug
 
@@ -872,6 +873,7 @@ class BaseDeleteMonitorTest(MonitorTestCase):
         assert RegionScheduledDeletion.objects.filter(
             object_id=monitor.id, model_name="Monitor"
         ).exists()
+        update_monitor_slug.assert_called_once()
 
     def test_mismatched_org_slugs(self):
         monitor = self._create_monitor()


### PR DESCRIPTION
This ensures we're not changing monitor slugs without keeping them
synchronized in the quotas system.