### PR TITLE
feat(autofix): Update backend endpoints to match updated seer apis

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -144,9 +144,12 @@ class GroupAutofixEndpoint(GroupEndpoint):
         if event_id is None:
             event = group.get_recommended_event_for_environments()
             if not event:
+                event = group.get_latest_event()
+
+            if not event:
                 return Response(
                     {
-                        "detail": "Could not find recommended event for issue, please try providing an event_id"
+                        "detail": "Could not find an event for the issue, please try providing an event_id"
                     },
                     status=400,
                 )

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -31,7 +31,7 @@ TIMEOUT_SECONDS = 60 * 30  # 30 minutes
 
 
 @region_silo_endpoint
-class GroupAiAutofixEndpoint(GroupEndpoint):
+class GroupAutofixEndpoint(GroupEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
         "GET": ApiPublishStatus.EXPERIMENTAL,

--- a/src/sentry/api/endpoints/group_ai_autofix_update.py
+++ b/src/sentry/api/endpoints/group_ai_autofix_update.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+
+import requests
+from django.conf import settings
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.group import GroupEndpoint
+from sentry.models.group import Group
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+logger = logging.getLogger(__name__)
+
+from rest_framework.request import Request
+
+
+@region_silo_endpoint
+class GroupAiAutofixUpdateEndpoint(GroupEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    # go away
+    private = True
+    enforce_rate_limit = True
+    rate_limits = {
+        "POST": {
+            RateLimitCategory.IP: RateLimit(5, 1),
+            RateLimitCategory.USER: RateLimit(5, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+        }
+    }
+
+    def post(self, request: Request, group: Group) -> Response:
+        """
+        Select a root cause for autofix
+
+        :pparam int run_id: the ID of the run to select the root cause for
+        :pparam int | None cause_id: the ID of the root cause to select
+        :pparam int | None fix_id: the ID of the fix to select
+        :pparam string | None custom_root_cause: the custom root cause to select
+        """
+        response = requests.post(
+            f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update",
+            data=request.body,
+            headers={"content-type": "application/json;charset=utf-8"},
+        )
+
+        response.raise_for_status()
+
+        return Response(
+            status=202,
+        )

--- a/src/sentry/api/endpoints/group_autofix_update.py
+++ b/src/sentry/api/endpoints/group_autofix_update.py
@@ -11,7 +11,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.models.group import Group
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
 
@@ -19,21 +18,12 @@ from rest_framework.request import Request
 
 
 @region_silo_endpoint
-class GroupAiAutofixUpdateEndpoint(GroupEndpoint):
+class GroupAutofixUpdateEndpoint(GroupEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
-    # go away
     private = True
-    enforce_rate_limit = True
-    rate_limits = {
-        "POST": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
-        }
-    }
 
     def post(self, request: Request, group: Group) -> Response:
         """

--- a/src/sentry/api/endpoints/group_autofix_update.py
+++ b/src/sentry/api/endpoints/group_autofix_update.py
@@ -27,16 +27,14 @@ class GroupAutofixUpdateEndpoint(GroupEndpoint):
 
     def post(self, request: Request, group: Group) -> Response:
         """
-        Select a root cause for autofix
-
-        :pparam int run_id: the ID of the run to select the root cause for
-        :pparam int | None cause_id: the ID of the root cause to select
-        :pparam int | None fix_id: the ID of the fix to select
-        :pparam string | None custom_root_cause: the custom root cause to select
+        Send an update event to autofix for a given group.
         """
+        if not request.data:
+            return Response(status=400, data={"error": "Need a body with a run_id and payload"})
+
         response = requests.post(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update",
-            data=request.body,
+            data=request.data,
             headers={"content-type": "application/json;charset=utf-8"},
         )
 

--- a/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
+++ b/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+
+import requests
+from django.conf import settings
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.helpers.repos import get_repos_from_project_code_mappings
+from sentry.models.project import Project
+
+logger = logging.getLogger(__name__)
+
+from rest_framework.request import Request
+
+
+@region_silo_endpoint
+class ProjectAutofixCreateCodebaseIndexEndpoint(ProjectEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    private = True
+
+    def post(self, request: Request, project: Project) -> Response:
+        """
+        Create a codebase index for for a project's repositories, uses the code mapping to determine which repositories to index
+        """
+        repos = get_repos_from_project_code_mappings(project)
+
+        for repo in repos:
+            response = requests.post(
+                f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
+                data={
+                    "organization_id": project.organization.id,
+                    "project_id": project.id,
+                    "repo": repo,
+                },
+                headers={"content-type": "application/json;charset=utf-8"},
+            )
+
+            response.raise_for_status()
+
+        return Response(
+            status=202,
+        )

--- a/src/sentry/api/helpers/repos.py
+++ b/src/sentry/api/helpers/repos.py
@@ -1,0 +1,27 @@
+from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.models.project import Project
+from sentry.models.repository import Repository
+
+
+def get_repos_from_project_code_mappings(project: Project) -> list[dict]:
+    repo_configs: list[RepositoryProjectPathConfig] = RepositoryProjectPathConfig.objects.filter(
+        project__in=[project]
+    )
+
+    repos: dict[tuple, dict] = {}
+    for repo_config in repo_configs:
+        repo: Repository = repo_config.repository
+        repo_name_sections = repo.name.split("/")
+
+        # We expect a repository name to be in the format of "owner/name" for now.
+        if len(repo_name_sections) > 1 and repo.provider:
+            repo_dict = {
+                "provider": repo.provider,
+                "owner": repo_name_sections[0],
+                "name": "/".join(repo_name_sections[1:]),
+            }
+            repo_key = (repo_dict["provider"], repo_dict["owner"], repo_dict["name"])
+
+            repos[repo_key] = repo_dict
+
+    return list(repos.values())

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -229,9 +229,9 @@ from .endpoints.event_owners import EventOwnersEndpoint
 from .endpoints.event_reprocessable import EventReprocessableEndpoint
 from .endpoints.filechange import CommitFileChangeEndpoint
 from .endpoints.group_activities import GroupActivitiesEndpoint
-from .endpoints.group_ai_autofix import GroupAiAutofixEndpoint
-from .endpoints.group_ai_autofix_update import GroupAiAutofixUpdateEndpoint
+from .endpoints.group_ai_autofix import GroupAutofixEndpoint
 from .endpoints.group_attachments import GroupAttachmentsEndpoint
+from .endpoints.group_autofix_update import GroupAutofixUpdateEndpoint
 from .endpoints.group_current_release import GroupCurrentReleaseEndpoint
 from .endpoints.group_details import GroupDetailsEndpoint
 from .endpoints.group_external_issue_details import GroupExternalIssueDetailsEndpoint
@@ -487,6 +487,9 @@ from .endpoints.project_app_store_connect_credentials import (
 )
 from .endpoints.project_artifact_bundle_file_details import ProjectArtifactBundleFileDetailsEndpoint
 from .endpoints.project_artifact_bundle_files import ProjectArtifactBundleFilesEndpoint
+from .endpoints.project_autofix_create_codebase_index import (
+    ProjectAutofixCreateCodebaseIndexEndpoint,
+)
 from .endpoints.project_commits import ProjectCommitsEndpoint
 from .endpoints.project_create_sample import ProjectCreateSampleEndpoint
 from .endpoints.project_create_sample_transaction import ProjectCreateSampleTransactionEndpoint
@@ -766,12 +769,12 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
         ),
         re_path(
             r"^(?P<issue_id>[^\/]+)/ai-autofix/$",
-            GroupAiAutofixEndpoint.as_view(),
+            GroupAutofixEndpoint.as_view(),
             name=f"{name_prefix}-group-ai-autofix",
         ),
         re_path(
             r"^(?P<issue_id>[^\/]+)/ai-autofix/update/$",
-            GroupAiAutofixUpdateEndpoint.as_view(),
+            GroupAutofixUpdateEndpoint.as_view(),
             name=f"{name_prefix}-group-ai-autofix-update",
         ),
         re_path(
@@ -2727,6 +2730,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/monitors/(?P<monitor_slug>[^\/]+)/stats/$",
         ProjectMonitorStatsEndpoint.as_view(),
         name="sentry-api-0-project-monitor-stats",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/autofix/codebase-index/create$",
+        ProjectAutofixCreateCodebaseIndexEndpoint.as_view(),
+        name="sentry-api-0-project-autofix-create-codebase-index",
     ),
 ]
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -230,6 +230,7 @@ from .endpoints.event_reprocessable import EventReprocessableEndpoint
 from .endpoints.filechange import CommitFileChangeEndpoint
 from .endpoints.group_activities import GroupActivitiesEndpoint
 from .endpoints.group_ai_autofix import GroupAiAutofixEndpoint
+from .endpoints.group_ai_autofix_update import GroupAiAutofixUpdateEndpoint
 from .endpoints.group_attachments import GroupAttachmentsEndpoint
 from .endpoints.group_current_release import GroupCurrentReleaseEndpoint
 from .endpoints.group_details import GroupDetailsEndpoint
@@ -767,6 +768,11 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
             r"^(?P<issue_id>[^\/]+)/ai-autofix/$",
             GroupAiAutofixEndpoint.as_view(),
             name=f"{name_prefix}-group-ai-autofix",
+        ),
+        re_path(
+            r"^(?P<issue_id>[^\/]+)/ai-autofix/update/$",
+            GroupAiAutofixUpdateEndpoint.as_view(),
+            name=f"{name_prefix}-group-ai-autofix-update",
         ),
         re_path(
             r"^(?P<issue_id>[^\/]+)/autofix/setup/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -768,7 +768,7 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
             name=f"{name_prefix}-group-participants",
         ),
         re_path(
-            r"^(?P<issue_id>[^\/]+)/ai-autofix/$",
+            r"^(?P<issue_id>[^\/]+)/autofix/$",
             GroupAutofixEndpoint.as_view(),
             name=f"{name_prefix}-group-autofix",
         ),
@@ -2732,7 +2732,7 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-project-monitor-stats",
     ),
     re_path(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/autofix/codebase-index/create$",
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/autofix/codebase-index/create/$",
         ProjectAutofixCreateCodebaseIndexEndpoint.as_view(),
         name="sentry-api-0-project-autofix-codebase-index-create",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -770,12 +770,12 @@ def create_group_urls(name_prefix: str) -> list[URLPattern | URLResolver]:
         re_path(
             r"^(?P<issue_id>[^\/]+)/ai-autofix/$",
             GroupAutofixEndpoint.as_view(),
-            name=f"{name_prefix}-group-ai-autofix",
+            name=f"{name_prefix}-group-autofix",
         ),
         re_path(
-            r"^(?P<issue_id>[^\/]+)/ai-autofix/update/$",
+            r"^(?P<issue_id>[^\/]+)/autofix/update/$",
             GroupAutofixUpdateEndpoint.as_view(),
-            name=f"{name_prefix}-group-ai-autofix-update",
+            name=f"{name_prefix}-group-autofix-update",
         ),
         re_path(
             r"^(?P<issue_id>[^\/]+)/autofix/setup/$",
@@ -2734,7 +2734,7 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
     re_path(
         r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/autofix/codebase-index/create$",
         ProjectAutofixCreateCodebaseIndexEndpoint.as_view(),
-        name="sentry-api-0-project-autofix-create-codebase-index",
+        name="sentry-api-0-project-autofix-codebase-index-create",
     ),
 ]
 

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -13,15 +13,12 @@ pytestmark = [requires_snuba]
 
 @apply_feature_flag_on_cls("projects:ai-autofix")
 class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
-    def test_ai_autofix_get_endpoint_with_autofix(self):
+    @patch(
+        "sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_get_autofix_state",
+        return_value={"status": "PROCESSING"},
+    )
+    def test_ai_autofix_get_endpoint_with_autofix(self, mock_autofix_state_call):
         group = self.create_group()
-        metadata = {
-            "autofix": {
-                "status": "PROCESSING",
-            }
-        }
-        group.data["metadata"] = metadata
-        group.save()
 
         self.login_as(user=self.user)
         url = f"/api/0/issues/{group.id}/ai-autofix/"
@@ -31,13 +28,15 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["autofix"] is not None
         assert response.data["autofix"]["status"] == "PROCESSING"
 
-    def test_ai_autofix_get_endpoint_without_autofix(self):
+        mock_autofix_state_call.assert_called_once()
+        mock_autofix_state_call.assert_called_with(group.id)
+
+    @patch(
+        "sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_get_autofix_state",
+        return_value=None,
+    )
+    def test_ai_autofix_get_endpoint_without_autofix(self, mock_autofix_state_call):
         group = self.create_group()
-        metadata = {
-            "autofix": None,
-        }
-        group.data["metadata"] = metadata
-        group.save()
 
         self.login_as(user=self.user)
         url = f"/api/0/issues/{group.id}/ai-autofix/"
@@ -45,6 +44,9 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200
         assert response.data["autofix"] is None
+
+        mock_autofix_state_call.assert_called_once()
+        mock_autofix_state_call.assert_called_with(group.id)
 
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     def test_ai_autofix_post_endpoint(self, mock_call):
@@ -99,12 +101,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert any(
             [entry.get("type") == "exception" for entry in serialized_event_arg.get("entries", [])]
         )
-
-        group = Group.objects.get(id=group.id)
-
         assert response.status_code == 202
-        assert "autofix" in group.data["metadata"]
-        assert group.data["metadata"]["autofix"]["status"] == "PROCESSING"
 
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     def test_ai_autofix_post_without_event_id(self, mock_call):
@@ -157,12 +154,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert any(
             [entry.get("type") == "exception" for entry in serialized_event_arg.get("entries", [])]
         )
-
-        group = Group.objects.get(id=group.id)
-
         assert response.status_code == 202
-        assert "autofix" in group.data["metadata"]
-        assert group.data["metadata"]["autofix"]["status"] == "PROCESSING"
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
@@ -194,68 +186,13 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         url = f"/api/0/issues/{group.id}/ai-autofix/"
         self.login_as(user=self.user)
         response = self.client.post(url, data={"instruction": "Yes"}, format="json")
-        mock_call.assert_called_with(
-            ANY,
-            group,
-            [
-                {
-                    "provider": "integrations:github",
-                    "owner": "getsentry",
-                    "name": "sentry",
-                }
-            ],
-            ANY,
-            "Yes",
-            TIMEOUT_SECONDS,
-        )
 
-        actual_group_arg = mock_call.call_args[0][1]
-        assert actual_group_arg.id == group.id
-
-        serialized_event_arg = mock_call.call_args[0][3]
-        assert any(
-            [entry.get("type") == "exception" for entry in serialized_event_arg.get("entries", [])]
-        )
-
-        group = Group.objects.get(id=group.id)
-
-        assert response.status_code == 202
-        assert "autofix" in group.data["metadata"]
-        assert group.data["metadata"]["autofix"]["status"] == "PROCESSING"
-
-    @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
-    @patch("sentry.models.Group.get_latest_event", return_value=None)
-    def test_ai_autofix_post_without_event_id_error(
-        self, mock_latest_event, mock_recommended_event
-    ):
-        release = self.create_release(project=self.project, version="1.0.0")
-
-        repo = self.create_repo(
-            project=self.project,
-            name="getsentry/sentry",
-            provider="integrations:github",
-        )
-        self.create_code_mapping(project=self.project, repo=repo)
-
-        data = load_data("python", timestamp=before_now(minutes=1))
-        event = self.store_event(
-            data={
-                **data,
-                "release": release.version,
-                "exception": {"values": [{"type": "exception", "data": {"values": []}}]},
-            },
-            project_id=self.project.id,
-        )
-
-        group = event.group
-
-        assert group is not None
-        group.save()
-
-        url = f"/api/0/issues/{group.id}/ai-autofix/"
-        self.login_as(user=self.user)
-        response = self.client.post(url, data={"instruction": "Yes"}, format="json")
         assert response.status_code == 400
+        assert (
+            response.data["detail"]
+            == "Could not find recommended event for issue, please try providing an event_id"
+        )
+        mock_call.assert_not_called()
 
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     def test_ai_autofix_without_code_mapping(self, mock_call):
@@ -293,11 +230,6 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 400  # Expecting a Bad Request response for invalid repo
         assert response.data["detail"] == error_msg
-
-        assert "autofix" in group.data["metadata"]
-        assert group.data["metadata"]["autofix"]["status"] == "ERROR"
-        assert group.data["metadata"]["autofix"]["error_message"] == error_msg
-        assert group.data["metadata"]["autofix"]["steps"] == []
 
     @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     def test_ai_autofix_without_stacktrace(self, mock_call):
@@ -342,71 +274,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400  # Expecting a Bad Request response for invalid repo
         assert response.data["detail"] == error_msg
 
-        assert "autofix" in group.data["metadata"]
-        assert group.data["metadata"]["autofix"]["status"] == "ERROR"
-        assert group.data["metadata"]["autofix"]["error_message"] == error_msg
-        assert group.data["metadata"]["autofix"]["steps"] == []
-
     def test_get_repos_from_code_mapping_no_repos(self):
         group = self.create_group(project=self.project)
         repos = GroupAutofixEndpoint._get_repos_from_code_mapping(group)
         assert len(repos) == 0, "Expected no repositories to be returned when none are linked"
-
-    def test_get_repos_from_code_mapping_with_repos(self):
-        group = self.create_group(project=self.project)
-
-        # Creating a repository and linking it to the project
-        repo1 = self.create_repo(
-            project=self.project, name="getsentry/sentry", provider="integrations:github"
-        )
-        self.create_code_mapping(repo=repo1, stack_root="app")
-
-        repo2 = self.create_repo(
-            project=self.project, name="getsentry/sentry-cli", provider="integrations:github"
-        )
-        self.create_code_mapping(repo=repo2, stack_root="src")
-
-        repos = GroupAutofixEndpoint._get_repos_from_code_mapping(group)
-        assert len(repos) == 2, "Expected two repositories to be returned"
-        assert {
-            "provider": "integrations:github",
-            "owner": "getsentry",
-            "name": "sentry",
-        } in repos, "Expected repo1 to be in the returned list"
-        assert {
-            "provider": "integrations:github",
-            "owner": "getsentry",
-            "name": "sentry-cli",
-        } in repos, "Expected repo2 to be in the returned list"
-
-    def test_get_repos_from_code_mapping_with_duplicate_repos(self):
-        group = self.create_group(project=self.project)
-
-        # Creating a repository and linking it to the project
-        repo1 = self.create_repo(
-            project=self.project, name="getsentry/sentry", provider="integrations:github"
-        )
-        self.create_code_mapping(repo=repo1, stack_root="app")
-
-        repo2 = self.create_repo(
-            project=self.project, name="getsentry/sentry", provider="integrations:github"
-        )
-        self.create_code_mapping(repo=repo2, stack_root="src")
-
-        repos = GroupAutofixEndpoint._get_repos_from_code_mapping(group)
-        assert len(repos) == 1, "Expected one repository to be returned"
-        assert {
-            "provider": "integrations:github",
-            "owner": "getsentry",
-            "name": "sentry",
-        } in repos
-
-    def test_get_repos_from_code_mapping_with_invalid_provider(self):
-        group = self.create_group(project=self.project)
-
-        # Creating a repository and linking it to the project
-        repo1 = self.create_repo(project=self.project, name="getsentry/sentry", provider=None)
-        self.create_code_mapping(repo=repo1, stack_root="app")
-
-        repos = GroupAutofixEndpoint._get_repos_from_code_mapping(group)
-        assert len(repos) == 0

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -1,6 +1,6 @@
 from unittest.mock import ANY, patch
 
-from sentry.api.endpoints.group_ai_autofix import TIMEOUT_SECONDS, GroupAiAutofixEndpoint
+from sentry.api.endpoints.group_ai_autofix import TIMEOUT_SECONDS, GroupAutofixEndpoint
 from sentry.models.group import Group
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -46,7 +46,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.data["autofix"] is None
 
-    @patch("sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix")
+    @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     def test_ai_autofix_post_endpoint(self, mock_call):
         release = self.create_release(project=self.project, version="1.0.0")
 
@@ -106,7 +106,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert "autofix" in group.data["metadata"]
         assert group.data["metadata"]["autofix"]["status"] == "PROCESSING"
 
-    @patch("sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix")
+    @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     def test_ai_autofix_post_without_event_id(self, mock_call):
         release = self.create_release(project=self.project, version="1.0.0")
 
@@ -165,7 +165,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert group.data["metadata"]["autofix"]["status"] == "PROCESSING"
 
     @patch("sentry.models.Group.get_recommended_event_for_environments", return_value=None)
-    @patch("sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix")
+    @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     def test_ai_autofix_post_without_event_id_no_recommended_event(self, mock_call, mock_event):
         release = self.create_release(project=self.project, version="1.0.0")
 
@@ -257,7 +257,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.post(url, data={"instruction": "Yes"}, format="json")
         assert response.status_code == 400
 
-    @patch("sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix")
+    @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     def test_ai_autofix_without_code_mapping(self, mock_call):
         release = self.create_release(project=self.project, version="1.0.0")
 
@@ -299,7 +299,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert group.data["metadata"]["autofix"]["error_message"] == error_msg
         assert group.data["metadata"]["autofix"]["steps"] == []
 
-    @patch("sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix")
+    @patch("sentry.api.endpoints.group_ai_autofix.GroupAutofixEndpoint._call_autofix")
     def test_ai_autofix_without_stacktrace(self, mock_call):
         release = self.create_release(project=self.project, version="1.0.0")
 
@@ -349,7 +349,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
 
     def test_get_repos_from_code_mapping_no_repos(self):
         group = self.create_group(project=self.project)
-        repos = GroupAiAutofixEndpoint._get_repos_from_code_mapping(group)
+        repos = GroupAutofixEndpoint._get_repos_from_code_mapping(group)
         assert len(repos) == 0, "Expected no repositories to be returned when none are linked"
 
     def test_get_repos_from_code_mapping_with_repos(self):
@@ -366,7 +366,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
         self.create_code_mapping(repo=repo2, stack_root="src")
 
-        repos = GroupAiAutofixEndpoint._get_repos_from_code_mapping(group)
+        repos = GroupAutofixEndpoint._get_repos_from_code_mapping(group)
         assert len(repos) == 2, "Expected two repositories to be returned"
         assert {
             "provider": "integrations:github",
@@ -393,7 +393,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
         self.create_code_mapping(repo=repo2, stack_root="src")
 
-        repos = GroupAiAutofixEndpoint._get_repos_from_code_mapping(group)
+        repos = GroupAutofixEndpoint._get_repos_from_code_mapping(group)
         assert len(repos) == 1, "Expected one repository to be returned"
         assert {
             "provider": "integrations:github",
@@ -408,5 +408,5 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
         repo1 = self.create_repo(project=self.project, name="getsentry/sentry", provider=None)
         self.create_code_mapping(repo=repo1, stack_root="app")
 
-        repos = GroupAiAutofixEndpoint._get_repos_from_code_mapping(group)
+        repos = GroupAutofixEndpoint._get_repos_from_code_mapping(group)
         assert len(repos) == 0

--- a/tests/sentry/api/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_update.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+from django.conf import settings
+from rest_framework import status
+
+from sentry.testutils.cases import APITestCase
+
+
+class TestGroupAutofixUpdate(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.group = self.create_group()
+        self.url = f"/api/0/issues/{self.group.id}/autofix/update/"
+
+    @patch("sentry.api.endpoints.group_autofix_update.requests.post")
+    def test_autofix_update_successful(self, mock_post):
+        mock_post.return_value.status_code = 202
+        mock_post.return_value.json.return_value = {}
+
+        response = self.client.post(
+            self.url,
+            data={
+                "run_id": 123,
+                "payload": {
+                    "type": "select_root_cause",
+                    "cause_id": 456,
+                    "fix_id": 789,
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        mock_post.assert_called_once_with(
+            f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update",
+            data={
+                "run_id": 123,
+                "payload": {
+                    "type": "select_root_cause",
+                    "cause_id": 456,
+                    "fix_id": 789,
+                },
+            },
+            headers={"content-type": "application/json;charset=utf-8"},
+        )
+
+    @patch("sentry.api.endpoints.group_autofix_update.requests.post")
+    def test_autofix_update_failure(self, mock_post):
+        mock_post.return_value.raise_for_status.side_effect = Exception("Failed to update")
+
+        response = self.client.post(
+            self.url,
+            data={
+                "run_id": 123,
+                "payload": {
+                    "type": "select_root_cause",
+                    "cause_id": 456,
+                    "fix_id": 789,
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    def test_autofix_update_missing_parameters(self):
+        response = self.client.post(self.url, data={}, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/sentry/api/endpoints/test_project_autofix_create_codebase_index.py
+++ b/tests/sentry/api/endpoints/test_project_autofix_create_codebase_index.py
@@ -1,0 +1,104 @@
+from unittest.mock import call, patch
+
+from django.conf import settings
+from django.urls import reverse
+from rest_framework import status
+
+from sentry.testutils.cases import APITestCase
+
+
+class TestProjectAutofixCodebaseIndexCreate(APITestCase):
+    endpoint = "sentry-api-0-project-autofix-codebase-index-create"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.project = self.create_project()
+        self.url = reverse(
+            self.endpoint,
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+            },
+        )
+
+    @patch("sentry.api.endpoints.project_autofix_create_codebase_index.requests.post")
+    def test_autofix_create_successful(self, mock_post):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {}
+
+        repo = self.create_repo(name="getsentry/sentry", provider="integrations:github")
+        self.create_code_mapping(project=self.project, repo=repo)
+
+        response = self.client.post(
+            self.url,
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        mock_post.assert_called_once_with(
+            f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
+            data={
+                "organization_id": self.project.organization.id,
+                "project_id": self.project.id,
+                "repo": {
+                    "provider": "integrations:github",
+                    "owner": "getsentry",
+                    "name": "sentry",
+                },
+            },
+            headers={"content-type": "application/json;charset=utf-8"},
+        )
+
+    @patch("sentry.api.endpoints.project_autofix_create_codebase_index.requests.post")
+    def test_autofix_create_multiple_repos_successful(self, mock_post):
+        # Setup multiple repositories
+        repo1 = self.create_repo(name="getsentry/sentry", provider="integrations:github")
+        repo2 = self.create_repo(name="getsentry/relay", provider="integrations:github")
+        self.create_code_mapping(project=self.project, repo=repo1, stack_root="/path1")
+        self.create_code_mapping(project=self.project, repo=repo2, stack_root="/path2")
+
+        # Mock the POST request to return successful status
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {}
+
+        # Perform the POST request
+        response = self.client.post(
+            self.url,
+            format="json",
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert (
+            mock_post.call_count == 2
+        )  # Ensure that the endpoint was called twice, once for each repo
+        calls = [
+            call(
+                f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
+                data={
+                    "organization_id": self.project.organization.id,
+                    "project_id": self.project.id,
+                    "repo": {
+                        "provider": "integrations:github",
+                        "owner": "getsentry",
+                        "name": "sentry",
+                    },
+                },
+                headers={"content-type": "application/json;charset=utf-8"},
+            ),
+            call(
+                f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
+                data={
+                    "organization_id": self.project.organization.id,
+                    "project_id": self.project.id,
+                    "repo": {
+                        "provider": "integrations:github",
+                        "owner": "getsentry",
+                        "name": "relay",
+                    },
+                },
+                headers={"content-type": "application/json;charset=utf-8"},
+            ),
+        ]
+        mock_post.assert_has_calls(calls, any_order=True)

--- a/tests/sentry/api/helpers/test_repos.py
+++ b/tests/sentry/api/helpers/test_repos.py
@@ -1,0 +1,17 @@
+from sentry.api.helpers.repos import get_repos_from_project_code_mappings
+from sentry.testutils.cases import TestCase
+
+
+class TestGetRepoFromCodeMappings(TestCase):
+    def test_get_repos_from_project_code_mappings_empty(self):
+        project = self.create_project()
+        repos = get_repos_from_project_code_mappings(project)
+        self.assertEqual(repos, [])
+
+    def test_get_repos_from_project_code_mappings_with_data(self):
+        project = self.create_project()
+        repo = self.create_repo(name="getsentry/sentry", provider="github")
+        self.create_code_mapping(project=project, repo=repo)
+        repos = get_repos_from_project_code_mappings(project)
+        expected_repos = [{"provider": repo.provider, "owner": "getsentry", "name": "sentry"}]
+        self.assertEqual(repos, expected_repos)


### PR DESCRIPTION
This PR updates the the backend apis for Autofix to match the new re-architectured apis on seer.

We will no longer be storing the state of Autofix in the group metadata. Seer is now the source of truth and any requests for the Autofix state occur in a request to Seer.

- Update endpoint: `/api/0/{issues|group}/<issue_id>/autofix/update/`
- Create codebase index project-level endpoint: `/api/0/projects/<organization_slug>/<project_slug>/autofix/codebase-index/create/`
- Removes storing autofix in group metadata
- Renames all uses of ai-autofix to just autofix
  - Now `/api/0/{issues|group}/<issue_id>/autofix/`
  - Another PR will be followed up to rename the file
- Moves code mapping helper to its own file to be used in codebase indexing & autofix initial run

### Prereq:
Merge the [seer pr](https://github.com/getsentry/seer/pull/606) to be merged before merging this.
