### PR TITLE
ref: use actual `__init__` for initializing performance detectors

### DIFF
--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -92,11 +92,6 @@ class PerformanceDetector(ABC):
     def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
         self.settings = settings[self.settings_key]
         self._event = event
-        self.init()
-
-    @abstractmethod
-    def init(self):
-        raise NotImplementedError
 
     def find_span_prefix(self, settings, span_op: str):
         allowed_span_ops = settings.get("allowed_span_ops", [])

--- a/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_db_detector.py
@@ -64,7 +64,9 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
     type = DetectorType.CONSECUTIVE_DB_OP
     settings_key = DetectorType.CONSECUTIVE_DB_OP
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.stored_problems: dict[str, PerformanceProblem] = {}
         self.consecutive_db_spans: list[Span] = []
         self.independent_db_spans: list[Span] = []

--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from sentry import features
 from sentry.issues.grouptype import PerformanceConsecutiveHTTPQueriesGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -32,7 +34,9 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
     type = DetectorType.CONSECUTIVE_HTTP_OP
     settings_key = DetectorType.CONSECUTIVE_HTTP_OP
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.stored_problems: dict[str, PerformanceProblem] = {}
         self.consecutive_http_spans: list[Span] = []
         self.lcp = None

--- a/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 from collections import defaultdict
+from typing import Any
 
 import sentry_sdk
 
@@ -31,7 +32,9 @@ from ..types import Span
 class BaseIOMainThreadDetector(PerformanceDetector):
     __slots__ = ("spans_involved", "stored_problems")
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.spans_involved = {}
         self.most_recent_start_time = {}
         self.most_recent_hash = {}
@@ -206,7 +209,9 @@ class DBMainThreadDetector(BaseIOMainThreadDetector):
     settings_key = DetectorType.DB_MAIN_THREAD
     group_type = PerformanceDBMainThreadGroupType
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.spans_involved = {}
         self.most_recent_start_time = {}
         self.most_recent_hash = {}

--- a/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/large_payload_detector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import timedelta
+from typing import Any
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceLargeHTTPPayloadGroupType
@@ -33,7 +34,9 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
     type = DetectorType.LARGE_HTTP_PAYLOAD
     settings_key = DetectorType.LARGE_HTTP_PAYLOAD
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.stored_problems: dict[str, PerformanceProblem] = {}
         self.consecutive_http_spans: list[Span] = []
 

--- a/src/sentry/utils/performance_issues/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/mn_plus_one_db_span_detector.py
@@ -260,7 +260,9 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
     type = DetectorType.M_N_PLUS_ONE_DB
     settings_key = DetectorType.M_N_PLUS_ONE_DB
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.stored_problems = {}
         self.state = SearchingForMNPlusOne(self.settings, self.event())
 

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_api_calls_detector.py
@@ -5,6 +5,7 @@ import os
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from django.utils.encoding import force_bytes
@@ -48,7 +49,9 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
 
     HOST_DENYLIST: list[str] = []
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         # TODO: Only store the span IDs and timestamps instead of entire span objects
         self.stored_problems: PerformanceProblemsMap = {}
         self.spans: list[Span] = []

--- a/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/n_plus_one_db_span_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from typing import Any
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -58,7 +59,9 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
     type = DetectorType.N_PLUS_ONE_DB_QUERIES
     settings_key = DetectorType.N_PLUS_ONE_DB_QUERIES
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.stored_problems = {}
         self.potential_parents = {}
         self.n_hash = None

--- a/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/render_blocking_asset_span_detector.py
@@ -30,7 +30,9 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
 
     MAX_SIZE_BYTES = 1_000_000_000  # 1GB
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.stored_problems = {}
         self.transaction_start = timedelta(seconds=self.event().get("start_timestamp", 0))
         self.fcp = None

--- a/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/slow_db_query_detector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from datetime import timedelta
+from typing import Any
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
@@ -37,7 +38,9 @@ class SlowDBQueryDetector(PerformanceDetector):
     type = DetectorType.SLOW_DB_QUERY
     settings_key = DetectorType.SLOW_DB_QUERY
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.stored_problems = {}
 
     def visit_span(self, span: Span):

--- a/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/uncompressed_asset_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from sentry import features
 from sentry.issues.grouptype import PerformanceUncompressedAssetsGroupType
@@ -33,7 +34,9 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
     settings_key = DetectorType.UNCOMPRESSED_ASSETS
     type = DetectorType.UNCOMPRESSED_ASSETS
 
-    def init(self):
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
         self.stored_problems = {}
         self.any_compression = False
 


### PR DESCRIPTION
the type checker can then understand what the actual values are, otherwise it is in the dark

<!-- Describe your PR here. -->