### PR TITLE
ref(badges): Remove shim files for badges that were not in components/badges/*

### DIFF
--- a/static/app/components/badge.tsx
+++ b/static/app/components/badge.tsx
@@ -1,8 +1,0 @@
-import Badge from 'sentry/components/badge/badge';
-
-/**
- * @deprecated Import from `sentry/components/badge/badge` instead
- *
- * TODO(ryan953): remove this shim once getsentry imports are updated
- */
-export default Badge;

--- a/static/app/components/badge/deployBadge.tsx
+++ b/static/app/components/badge/deployBadge.tsx
@@ -1,5 +1,5 @@
+import Tag from 'sentry/components/badge/tag';
 import Link from 'sentry/components/links/link';
-import {Tag} from 'sentry/components/tag';
 import {t} from 'sentry/locale';
 import type {Deploy} from 'sentry/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';

--- a/static/app/components/featureBadge.tsx
+++ b/static/app/components/featureBadge.tsx
@@ -1,8 +1,0 @@
-import FeatureBadge from 'sentry/components/badge/featureBadge';
-
-/**
- * @deprecated Import from `sentry/components/badge/featureBadge` instead
- *
- * TODO(ryan953): remove this shim once getsentry imports are updated
- */
-export default FeatureBadge;

--- a/static/app/components/tag.tsx
+++ b/static/app/components/tag.tsx
@@ -1,8 +1,0 @@
-import Tag from 'sentry/components/badge/tag';
-
-/**
- * @deprecated Import from `sentry/components/badge/tag` instead
- *
- * TODO(ryan953): remove this shim once getsentry imports are updated
- */
-export {Tag};


### PR DESCRIPTION
In #68843 we moved a bunch of files around, and then getsentry/getsentry#13646 needed to follow suit. 
This cleans up the leftover stubs which we needed so build don't break along the way.

Follows: https://github.com/getsentry/sentry/pull/68843
Depends on https://github.com/getsentry/getsentry/pull/13646