### PR TITLE
ref(uI): Cleanup unused ts-ignore after update

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -613,7 +613,6 @@ export class TokenConverter {
    * [0]:https://pegjs.org/documentation
    */
   predicateFilter = <T extends FilterType>(type: T, key: FilterMap[T]['key']) => {
-    // @ts-ignore TODO(scttcper): Remove after typescript 5.4 update
     const keyName = getKeyName(key);
     const aggregateKey = key as ReturnType<TokenConverter['tokenKeyAggregate']>;
 

--- a/static/app/utils/useHotkeys.spec.tsx
+++ b/static/app/utils/useHotkeys.spec.tsx
@@ -19,7 +19,6 @@ describe('useHotkeys', function () {
     events = {};
 
     // Define the addEventListener method with a Jest mock function
-    // @ts-ignore TODO(scttcper): Remove after typescript 5.4 update
     document.addEventListener = jest.fn((event: string, callback: () => any) => {
       events[event] = callback;
     });


### PR DESCRIPTION
Couldn't remove these until getsentry had been updated as well
