### PR TITLE
feat(perf): Split "projects" into a separate column on Domains list

### DIFF
--- a/static/app/views/performance/http/domainCell.tsx
+++ b/static/app/views/performance/http/domainCell.tsx
@@ -2,11 +2,9 @@ import {Link} from 'react-router';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
-import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {NULL_DOMAIN_DESCRIPTION} from 'sentry/views/performance/http/settings';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
@@ -19,9 +17,6 @@ interface Props {
 export function DomainCell({projectId, domain}: Props) {
   const location = useLocation();
   const organization = useOrganization();
-  const {projects} = useProjects();
-
-  const project = projects.find(p => projectId === p.id);
 
   const queryString = {
     ...location.query,
@@ -32,8 +27,6 @@ export function DomainCell({projectId, domain}: Props) {
 
   return (
     <DomainDescription>
-      {project && <ProjectAvatar project={project} />}
-
       <OverflowEllipsisTextContainer>
         <Link
           to={normalizeUrl(

--- a/static/app/views/performance/http/domainsTable.tsx
+++ b/static/app/views/performance/http/domainsTable.tsx
@@ -128,6 +128,7 @@ export function DomainsTable({response, sort}: Props) {
       isLoading={isLoading}
     >
       <GridEditable
+        aria-label={t('Domains')}
         isLoading={isLoading}
         error={response.error}
         data={data}

--- a/static/app/views/performance/http/domainsTable.tsx
+++ b/static/app/views/performance/http/domainsTable.tsx
@@ -15,6 +15,7 @@ import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DomainCell} from 'sentry/views/performance/http/domainCell';
+import {ProjectIdCell} from 'sentry/views/performance/http/projectIdCell';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import type {MetricsResponse} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -35,6 +36,7 @@ type Row = Pick<
 
 type Column = GridColumnHeader<
   | 'span.domain'
+  | 'project.id'
   | 'spm()'
   | 'http_response_rate(3)'
   | 'http_response_rate(4)'
@@ -47,6 +49,11 @@ const COLUMN_ORDER: Column[] = [
   {
     key: 'span.domain',
     name: t('Domain'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: 'project.id',
+    name: t('Project'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
@@ -168,6 +175,11 @@ function renderBodyCell(
     return (
       <DomainCell projectId={row['project.id']?.toString()} domain={row['span.domain']} />
     );
+  }
+
+  // TODO: Integrate this into `fieldRenderers`
+  if (column.key === 'project.id') {
+    return <ProjectIdCell projectId={row['project.id']?.toString()} />;
   }
 
   if (!meta?.fields) {

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -257,6 +257,7 @@ describe('HTTPLandingPage', function () {
     expect(screen.getByRole('table', {name: 'Domains'})).toBeInTheDocument();
 
     expect(screen.getByRole('columnheader', {name: 'Domain'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Project'})).toBeInTheDocument();
     expect(
       screen.getByRole('columnheader', {name: 'Requests Per Minute'})
     ).toBeInTheDocument();
@@ -271,9 +272,10 @@ describe('HTTPLandingPage', function () {
       'href',
       '/organizations/org-slug/performance/http/domains/?domain=%2A.sentry.io&project=1&statsPeriod=10d'
     );
-    expect(screen.getByRole('link', {name: '*.github.com'})).toHaveAttribute(
+    expect(screen.getByRole('cell', {name: 'backend'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'backend'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/performance/http/domains/?domain=%2A.github.com&statsPeriod=10d'
+      '/organizations/org-slug/projects/backend/?project=1'
     );
     expect(screen.getByRole('cell', {name: '40.8K/s'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '0.04%'})).toBeInTheDocument();

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -1,15 +1,18 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
 import {HTTPLandingPage} from 'sentry/views/performance/http/httpLandingPage';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useOrganization');
+jest.mock('sentry/utils/useProjects');
 
 describe('HTTPLandingPage', function () {
   const organization = OrganizationFixture();
@@ -36,7 +39,7 @@ describe('HTTPLandingPage', function () {
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',
     search: '',
-    query: {statsPeriod: '10d', 'span.domain': 'git'},
+    query: {statsPeriod: '10d', 'span.domain': 'git', project: '1'},
     hash: '',
     state: undefined,
     action: 'PUSH',
@@ -44,6 +47,24 @@ describe('HTTPLandingPage', function () {
   });
 
   jest.mocked(useOrganization).mockReturnValue(organization);
+
+  jest.mocked(useProjects).mockReturnValue({
+    projects: [
+      ProjectFixture({
+        id: '1',
+        name: 'Backend',
+        slug: 'backend',
+        firstTransactionEvent: true,
+        platform: 'javascript',
+      }),
+    ],
+    onSearch: jest.fn(),
+    placeholders: [],
+    fetching: false,
+    hasMore: null,
+    fetchError: null,
+    initiallyLoaded: false,
+  });
 
   beforeEach(function () {
     jest.clearAllMocks();

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -80,12 +80,41 @@ describe('HTTPLandingPage', function () {
       body: {
         data: [
           {
-            'span.domain': '*.sentry.io',
+            'span.domain': ['*.sentry.io'],
+            'project.id': 1,
+            'sum(span.self_time)': 815833579.659315,
+            'spm()': 40767.0,
+            'time_spent_percentage()': 0.33634048399458855,
+            'http_response_rate(3)': 0.00035567983908553485,
+            'http_response_rate(4)': 0.3931893443226139,
+            'http_response_rate(5)': 0.0037624385736829626,
+            'avg(span.self_time)': 333.53512222275975,
           },
           {
-            'span.domain': '*.github.com',
+            'span.domain': ['*.github.com'],
+            'project.id': 2,
+            'sum(span.self_time)': 473552338.9970339,
+            'spm()': 29912.133333333335,
+            'time_spent_percentage()': 0.19522955032268177,
+            'http_response_rate(3)': 0.0,
+            'http_response_rate(4)': 0.0012324987407562593,
+            'http_response_rate(5)': 0.004054096219594279,
+            'avg(span.self_time)': 263.857441905979,
           },
         ],
+        meta: {
+          fields: {
+            'project.id': 'integer',
+            'span.domain': 'array',
+            'sum(span.self_time)': 'duration',
+            'http_response_rate(3)': 'percentage',
+            'spm()': 'rate',
+            'time_spent_percentage()': 'percentage',
+            'http_response_rate(4)': 'percentage',
+            'http_response_rate(5)': 'percentage',
+            'avg(span.self_time)': 'duration',
+          },
+        },
       },
     });
 
@@ -225,13 +254,32 @@ describe('HTTPLandingPage', function () {
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
+    expect(screen.getByRole('table', {name: 'Domains'})).toBeInTheDocument();
+
+    expect(screen.getByRole('columnheader', {name: 'Domain'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: 'Requests Per Minute'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: '3XXs'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: '4XXs'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: '5XXs'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Avg Duration'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Time Spent'})).toBeInTheDocument();
+
+    expect(screen.getByRole('cell', {name: '*.sentry.io'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: '*.sentry.io'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/performance/http/domains/?domain=%2A.sentry.io&statsPeriod=10d'
+      '/organizations/org-slug/performance/http/domains/?domain=%2A.sentry.io&project=1&statsPeriod=10d'
     );
     expect(screen.getByRole('link', {name: '*.github.com'})).toHaveAttribute(
       'href',
       '/organizations/org-slug/performance/http/domains/?domain=%2A.github.com&statsPeriod=10d'
     );
+    expect(screen.getByRole('cell', {name: '40.8K/s'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '0.04%'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '39.32%'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '0.38%'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '333.54ms'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '1.35wk'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/performance/http/projectIdCell.tsx
+++ b/static/app/views/performance/http/projectIdCell.tsx
@@ -1,0 +1,16 @@
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import useProjects from 'sentry/utils/useProjects';
+
+interface Props {
+  domain?: string[];
+  projectId?: string;
+}
+
+// TODO: Move this into `SPECIAL_FIELDS` and let the field renderer pipeline render it. To do so, we'll need `project` as an alias to `project.id` in the span metrics dataset.
+export function ProjectIdCell({projectId}: Props) {
+  const {projects} = useProjects();
+
+  const project = projects.find(p => projectId === p.id);
+
+  return project ? <ProjectBadge project={project} /> : projectId;
+}


### PR DESCRIPTION
Putting the project icon into the domain is confusing. Better to have a separate column! This is how we handle this in other parts of the UI. Also adds some needed specs for the domains table while I'm there.

**Before:**
<img width="218" alt="Screenshot 2024-04-15 at 4 14 48 PM" src="https://github.com/getsentry/sentry/assets/989898/af86a53c-fdab-41d0-a33b-cd0e47da93cc">

**After:**
<img width="314" alt="Screenshot 2024-04-15 at 4 15 02 PM" src="https://github.com/getsentry/sentry/assets/989898/4b4ff633-3a26-4945-adcd-fd5393e14dc0">
