### PR TITLE
fix(shared-issue): Remove 'loaded images' section from shared issue view

### DIFF
--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -109,6 +109,10 @@ function EventEntryContent({
       );
 
     case EntryType.DEBUGMETA:
+      if (isShare) {
+        return null;
+      }
+
       return (
         <DebugMeta
           event={event}


### PR DESCRIPTION
Fixes JAVASCRIPT-2S7G

The `DebugMeta` component has a subcomponent which has `useOrganization` and that breaks the page. We could pass down the shared organization object which has many fewer keys, but there are multiple subcomponents which check for `organization.features` so that would be a bit cumbersome.

IMO the share view shouldn't even show this component since it isn't very useful, especially to someone without full access to the issue. So I just added a few lines to hide it which should solve the issue.