### PR TITLE
fix(open-pr-comments): Refactored `get_top_5_issues_by_count_for_file` to Prevent Snuba Errors

### DIFF
--- a/src/sentry/tasks/integrations/github/constants.py
+++ b/src/sentry/tasks/integrations/github/constants.py
@@ -3,4 +3,5 @@ ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
 RATE_LIMITED_MESSAGE = "API rate limit exceeded"
 
 # Number of stackframes to check for filename + function combo, starting from the top
-STACKFRAME_COUNT = 4
+DEFAULT_STACKFRAME_COUNT = 4
+REDUCED_STACKFRAME_COUNT = 2

--- a/src/sentry/tasks/integrations/github/language_parsers.py
+++ b/src/sentry/tasks/integrations/github/language_parsers.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from snuba_sdk import BooleanCondition, BooleanOp, Column, Condition, Function, Op
 
-from sentry.tasks.integrations.github.constants import STACKFRAME_COUNT
+from sentry.tasks.integrations.github.constants import DEFAULT_STACKFRAME_COUNT
 
 stackframe_function_name = lambda i: Function(
     "arrayElement",
@@ -26,12 +26,14 @@ class SimpleLanguageParser(ABC):
         return functions
 
     @classmethod
-    def generate_multi_if(cls, function_names: list[str]) -> list[Function]:
+    def generate_multi_if(
+        cls, function_names: list[str], stackframe_count=DEFAULT_STACKFRAME_COUNT
+    ) -> list[Function]:
         """
         Fetch the function name from the stackframe that matches a name within the list of function names.
         """
         multi_if = []
-        for i in range(-STACKFRAME_COUNT, 0):
+        for i in range(-stackframe_count, 0):
             # if, then conditions
             multi_if.extend(
                 [
@@ -133,12 +135,14 @@ class LanguageParser(ABC):
         return function_name_conditions
 
     @classmethod
-    def generate_multi_if(cls, function_names: list[str]) -> list[Function]:
+    def generate_multi_if(
+        cls, function_names: list[str], stackframe_count=DEFAULT_STACKFRAME_COUNT
+    ) -> list[Function]:
         """
         Fetch the function name from the stackframe that matches a name within the list of function names.
         """
         multi_if = []
-        for i in range(-STACKFRAME_COUNT, 0):
+        for i in range(-stackframe_count, 0):
             # if, then conditions
             stackframe_function_name_conditions = cls._get_function_name_functions(
                 i, function_names

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -5,6 +5,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import sentry_sdk
 from django.db.models import Value
 from django.db.models.functions import StrIndex
 from snuba_sdk import (
@@ -397,6 +398,7 @@ def get_top_5_issues_by_count_for_file(
             return raw_snql_query(request, referrer=Referrer.GITHUB_PR_COMMENT_BOT.value)["data"]
         except Exception as e:
             logger.exception("github.open_pr_comment.snuba_query_error", extra={"error": str(e)})
+            sentry_sdk.capture_exception(e)
 
     return []
 


### PR DESCRIPTION
We had Snuba errors because our queries were too long or took up too much memory. To prevent this, we now try the original query, but if it fails, we try a smaller query which will take up less memory by only looking for function names up to 2 level down in the stack.

The diff for the function looks weird, but I only moved the logic in to a try-catch block.

Fixes: https://github.com/getsentry/team-core-product-foundations/issues/268