### PR TITLE
fix(hc): Fixes type definition for feature has method

### DIFF
--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -6,6 +6,8 @@ import abc
 from collections.abc import Mapping, MutableSet, Sequence
 from typing import TYPE_CHECKING
 
+from sentry.services.hybrid_cloud.user import RpcUser
+
 if TYPE_CHECKING:
     from sentry.features.base import Feature
     from sentry.features.manager import FeatureCheckBatch
@@ -24,7 +26,9 @@ class FeatureHandler:
         return self.has(feature, actor)
 
     @abc.abstractmethod
-    def has(self, feature: Feature, actor: User, skip_entity: bool | None = False) -> bool | None:
+    def has(
+        self, feature: Feature, actor: User | RpcUser, skip_entity: bool | None = False
+    ) -> bool | None:
         raise NotImplementedError
 
     def has_for_batch(self, batch: FeatureCheckBatch) -> Mapping[Project, bool | None]:

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -13,6 +13,7 @@ from sentry.features.base import (
     UserFeature,
 )
 from sentry.models.user import User
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.testutils.cases import TestCase
 
 
@@ -22,7 +23,7 @@ class MockBatchHandler(features.BatchFeatureHandler):
     def has(
         self,
         feature: Feature,
-        actor: User,
+        actor: User | RpcUser,
         skip_entity: bool | None = False,
     ) -> bool:
         return True


### PR DESCRIPTION
Our feature implementations all seem to handle `actor` types of RpcUser when performing feature flag checks. This updates the type signature of the base class, with a follow-up commit in SaaS to implement this new type signature.
