### PR TITLE
fix(project-txn-threshold): Use update_or_create to prevent race conditions

### DIFF
--- a/src/sentry/api/endpoints/project_transaction_threshold.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold.py
@@ -89,19 +89,21 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
 
         data = serializer.validated_data
 
+        defaults = {"edited_by_id": request.user.id}
+        if data.get("threshold") is not None:
+            defaults["threshold"] = data.get("threshold")
+        if data.get("metric") is not None:
+            defaults["metric"] = data.get("metric")
+
         project_threshold, created = ProjectTransactionThreshold.objects.update_or_create(
             project=project,
             organization=project.organization,
-            defaults={
+            create_defaults={
                 "threshold": data.get("threshold", 300),
                 "metric": data.get("metric", TransactionMetric.DURATION.value),
                 "edited_by_id": request.user.id,
             },
-            create_defaults={
-                "threshold": data.get("threshold"),
-                "metric": data.get("metric"),
-                "edited_by_id": request.user.id,
-            },
+            defaults=defaults,
         )
 
         return Response(

--- a/src/sentry/api/endpoints/project_transaction_threshold.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold.py
@@ -1,4 +1,3 @@
-from django.db import router, transaction
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -90,29 +89,15 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
 
         data = serializer.validated_data
 
-        with transaction.atomic(router.db_for_write(ProjectTransactionThreshold)):
-            try:
-                project_threshold = ProjectTransactionThreshold.objects.get(
-                    project=project,
-                    organization=project.organization,
-                )
-                project_threshold.threshold = data.get("threshold") or project_threshold.threshold
-                project_threshold.metric = data.get("metric") or project_threshold.metric
-                project_threshold.edited_by_id = request.user.id
-                project_threshold.save()
-
-                created = False
-
-            except ProjectTransactionThreshold.DoesNotExist:
-                project_threshold = ProjectTransactionThreshold.objects.create(
-                    project=project,
-                    organization=project.organization,
-                    threshold=data.get("threshold", 300),
-                    metric=data.get("metric", TransactionMetric.DURATION.value),
-                    edited_by_id=request.user.id,
-                )
-
-                created = True
+        project_threshold, created = ProjectTransactionThreshold.objects.update_or_create(
+            project=project,
+            organization=project.organization,
+            defaults={
+                "threshold": data["threshold"],
+                "metric": data.get("metric", TransactionMetric.DURATION.value),
+                "edited_by_id": request.user.id,
+            },
+        )
 
         return Response(
             serialize(

--- a/src/sentry/api/endpoints/project_transaction_threshold.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold.py
@@ -93,7 +93,7 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
             project=project,
             organization=project.organization,
             defaults={
-                "threshold": data["threshold"],
+                "threshold": data.get("threshold", 300),
                 "metric": data.get("metric", TransactionMetric.DURATION.value),
                 "edited_by_id": request.user.id,
             },

--- a/src/sentry/api/endpoints/project_transaction_threshold.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold.py
@@ -97,6 +97,11 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
                 "metric": data.get("metric", TransactionMetric.DURATION.value),
                 "edited_by_id": request.user.id,
             },
+            create_defaults={
+                "threshold": data.get("threshold"),
+                "metric": data.get("metric"),
+                "edited_by_id": request.user.id,
+            },
         )
 
         return Response(

--- a/tests/sentry/api/endpoints/test_project_transaction_threshold.py
+++ b/tests/sentry/api/endpoints/test_project_transaction_threshold.py
@@ -75,6 +75,32 @@ class ProjectTransactionThresholdTest(APITestCase):
             project=self.project, organization=self.project.organization
         ).exists()
 
+    def test_update_single_field_project_threshold(self):
+        with self.feature(self.feature_name):
+            response = self.client.post(
+                self.url,
+                data={
+                    "metric": "lcp",
+                    "threshold": "300",
+                },
+            )
+
+        assert response.status_code == 201, response.content
+        assert response.data["threshold"] == "300"
+        assert response.data["metric"] == "duralcption"
+
+        with self.feature(self.feature_name):
+            response = self.client.post(
+                self.url,
+                data={
+                    "threshold": "400",
+                },
+            )
+
+        assert response.status_code == 201, response.content
+        assert response.data["threshold"] == "400"
+        assert response.data["metric"] == "lcp"
+
     def test_project_threshold_permissions(self):
         user = self.create_user()
         # user without project-write permissions

--- a/tests/sentry/api/endpoints/test_project_transaction_threshold.py
+++ b/tests/sentry/api/endpoints/test_project_transaction_threshold.py
@@ -87,7 +87,7 @@ class ProjectTransactionThresholdTest(APITestCase):
 
         assert response.status_code == 201, response.content
         assert response.data["threshold"] == "300"
-        assert response.data["metric"] == "duralcption"
+        assert response.data["metric"] == "lcp"
 
         with self.feature(self.feature_name):
             response = self.client.post(
@@ -97,7 +97,7 @@ class ProjectTransactionThresholdTest(APITestCase):
                 },
             )
 
-        assert response.status_code == 201, response.content
+        assert response.status_code == 200, response.content
         assert response.data["threshold"] == "400"
         assert response.data["metric"] == "lcp"
 


### PR DESCRIPTION
ProjectTransactionThresholdOverride endpoint already uses this pattern
fixes https://github.com/getsentry/sentry/issues/68678