### PR TITLE
fix(discover): Use legacy project event redirect for discover error l…

### DIFF
--- a/static/app/views/discover/table/index.tsx
+++ b/static/app/views/discover/table/index.tsx
@@ -138,7 +138,6 @@ class Table extends PureComponent<TableProps, TableState> {
     // Note: Event ID or 'id' is added to the fields in the API payload response by default for all non-aggregate queries.
     if (!eventView.hasAggregateField()) {
       apiPayload.field.push('trace');
-      apiPayload.field.push('issue');
       apiPayload.field.push('event.type');
     }
 

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -207,8 +207,11 @@ function TableView(props: TableViewProps) {
           );
         }
 
+        const project = dataRow.project || dataRow['project.name'];
+
         target = {
-          pathname: `/organizations/${organization.slug}/issues/${dataRow['issue.id']}/events/${dataRow.id}/?referrer=discover-events-table`,
+          // NOTE: This uses a legacy redirect for project event to the issue group event link
+          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/?referrer=discover-events-table`,
           query: location.query,
         };
       }
@@ -330,8 +333,11 @@ function TableView(props: TableViewProps) {
           );
         }
 
+        const project = dataRow.project || dataRow['project.name'];
+
         target = {
-          pathname: `/organizations/${organization.slug}/issues/${dataRow['issue.id']}/events/${dataRow.id}/?referrer=discover-events-table`,
+          // NOTE: This uses a legacy redirect for project event to the issue group event link
+          pathname: `/${organization.slug}/${project}/events/${dataRow.id}/?referrer=discover-events-table`,
           query: location.query,
         };
       }


### PR DESCRIPTION
…inks

This uses the legacy ProjectEventRedirect component that is still in use to redirect an error event without a trace id to the issue details page.

Quering for the issue forces discover to use the errors table by default unless another condition uses the transactions table.