### PR TITLE
chore(hybridcloud) Expand logging for gitlab webhooks

### DIFF
--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -147,9 +147,9 @@ class GitlabRequestParserTest(TestCase):
             HTTP_X_GITLAB_EVENT="Push Hook",
         )
         with mock.patch(
-            "sentry.middleware.integrations.parsers.base.ratelimiter.is_limited"
+            "sentry.middleware.integrations.parsers.base.ratelimiter.is_limited_with_value"
         ) as mock_is_limited:
-            mock_is_limited.return_value = True
+            mock_is_limited.return_value = (True, 3500, 360)
             parser = GitlabRequestParser(request=request, response_handler=self.get_response)
             response = parser.get_response()
 

--- a/tests/sentry/middleware/integrations/parsers/test_jira_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira_server.py
@@ -120,11 +120,11 @@ class JiraServerRequestParserTest(TestCase):
         parser = JiraServerRequestParser(request=request, response_handler=self.get_response)
 
         with mock.patch(
-            "sentry.middleware.integrations.parsers.base.ratelimiter.is_limited"
+            "sentry.middleware.integrations.parsers.base.ratelimiter.is_limited_with_value"
         ) as mock_is_limited, mock.patch(
             "sentry.middleware.integrations.parsers.jira_server.get_integration_from_token"
         ) as mock_get_token:
-            mock_is_limited.return_value = True
+            mock_is_limited.return_value = (True, 3500, 360)
             mock_get_token.return_value = self.integration
             response = parser.get_response()
         assert isinstance(response, HttpResponse)


### PR DESCRIPTION
The logs still don't make sense to me based on how many hooks we receive.