### PR TITLE
chore(open-pr-comments): Logging to Debug Snuba Errors

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -398,7 +398,9 @@ def get_top_5_issues_by_count_for_file(
     try:
         return raw_snql_query(request, referrer=Referrer.GITHUB_PR_COMMENT_BOT.value)["data"]
     except Exception:
-        logger.exception("github.open_pr_comment.snuba_query_error", extra={"query": query})
+        logger.exception(
+            "github.open_pr_comment.snuba_query_error", extra={"query": request.print()}
+        )
         return []
 
 

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -399,7 +399,7 @@ def get_top_5_issues_by_count_for_file(
         return raw_snql_query(request, referrer=Referrer.GITHUB_PR_COMMENT_BOT.value)["data"]
     except Exception:
         logger.exception(
-            "github.open_pr_comment.snuba_query_error", extra={"query": request.print()}
+            "github.open_pr_comment.snuba_query_error", extra={"query": request.to_dict()["query"]}
         )
         return []
 

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -360,39 +360,46 @@ def get_top_5_issues_by_count_for_file(
 
     # filter on the subquery to squash group_ids with the same title and culprit
     # return the group_id with the greatest count of events
+    query = (
+        Query(subquery)
+        .set_select(
+            [
+                Column("function_name"),
+                Function(
+                    "arrayElement",
+                    (Function("groupArray", [Column("group_id")]), 1),
+                    "group_id",
+                ),
+                Function(
+                    "arrayElement",
+                    (Function("groupArray", [Column("event_count")]), 1),
+                    "event_count",
+                ),
+            ]
+        )
+        .set_groupby(
+            [
+                Column("title"),
+                Column("culprit"),
+                Column("function_name"),
+            ]
+        )
+        .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])
+        .set_limit(5)
+    )
+
     request = SnubaRequest(
         dataset=Dataset.Events.value,
         app_id="default",
         tenant_ids={"organization_id": projects[0].organization_id},
-        query=(
-            Query(subquery)
-            .set_select(
-                [
-                    Column("function_name"),
-                    Function(
-                        "arrayElement",
-                        (Function("groupArray", [Column("group_id")]), 1),
-                        "group_id",
-                    ),
-                    Function(
-                        "arrayElement",
-                        (Function("groupArray", [Column("event_count")]), 1),
-                        "event_count",
-                    ),
-                ]
-            )
-            .set_groupby(
-                [
-                    Column("title"),
-                    Column("culprit"),
-                    Column("function_name"),
-                ]
-            )
-            .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])
-            .set_limit(5)
-        ),
+        query=query,
     )
-    return raw_snql_query(request, referrer=Referrer.GITHUB_PR_COMMENT_BOT.value)["data"]
+
+    try:
+        return raw_snql_query(request, referrer=Referrer.GITHUB_PR_COMMENT_BOT.value)["data"]
+    except Exception:
+        logger.exception("github.open_pr_comment.snuba_query_error", extra={"query": query})
+        return []
 
 
 @instrumented_task(


### PR DESCRIPTION
* Getting a couple Snuba errors because of our query. Sometimes the queries are too long, so Sentry doesn't show all of it, so we are going to log it

Part of: https://github.com/getsentry/team-core-product-foundations/issues/268