### PR TITLE
Downgrade SDK because rc4 introduced a bug with Celery instrumentation.

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,7 +67,7 @@ sentry-kafka-schemas>=0.1.68
 sentry-ophio==0.2.6
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.56
-sentry-sdk>=2.0.0rc5
+sentry-sdk>=2.0.0rc3
 snuba-sdk>=2.0.32
 simplejson>=3.17.6
 sqlparse>=0.4.4

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,7 +67,7 @@ sentry-kafka-schemas>=0.1.68
 sentry-ophio==0.2.6
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.56
-sentry-sdk>=2.0.0rc3
+sentry-sdk==2.0.0rc3
 snuba-sdk>=2.0.32
 simplejson>=3.17.6
 sqlparse>=0.4.4

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -184,7 +184,7 @@ sentry-kafka-schemas==0.1.68
 sentry-ophio==0.2.6
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.56
-sentry-sdk==2.0.0rc5
+sentry-sdk==2.0.0rc3
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -124,7 +124,7 @@ sentry-kafka-schemas==0.1.68
 sentry-ophio==0.2.6
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.56
-sentry-sdk==2.0.0rc5
+sentry-sdk==2.0.0rc3
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Literal, NotRequired, TypedDict
 
-from sentry_sdk.types import Event, Hint
+Event = Any
+Hint = Any
 
 
 class SdkConfig(TypedDict):

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -100,7 +100,7 @@ def patch_sentry_sdk():
     MetricsAggregator._emit = patched_emit  # type: ignore[method-assign]
 
 
-def before_emit_metric(key: str, value: int | float | str, unit: str, tags: dict[str, Any]) -> bool:
+def before_emit_metric(key: str, tags: dict[str, Any]) -> bool:
     if not options.get("delightful_metrics.enable_common_tags"):
         tags.pop("transaction", None)
         tags.pop("release", None)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -28,7 +28,7 @@ from sentry.utils.rust import RustInfoIntegration
 
 # Can't import models in utils because utils should be the bottom of the food chain
 if TYPE_CHECKING:
-    from sentry_sdk.types import Event, Hint
+    from sentry_sdk._types import Event, Hint
 
     from sentry.models.organization import Organization
     from sentry.services.hybrid_cloud.organization import RpcOrganization


### PR DESCRIPTION
We introduces a bug in Celery instrumentation in the version 2.0.0rc4, so we will downgrade to rc3