### PR TITLE
fix(dashboards): disable add widget button if limit is reached

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -177,6 +177,7 @@ function Controls({
                     aria-label="Add Widget"
                     priority="primary"
                     data-test-id="add-widget-library"
+                    disabled={widgetLimitReached}
                   />
                 ) : (
                   <Button


### PR DESCRIPTION
- fixes #68868 
<img width="361" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/b80bfa49-c667-4d5c-9db9-98a4634b6b1b">