### PR TITLE
fix(ddm): Do not block query if the tag of a metric is blocked

### DIFF
--- a/src/sentry/sentry_metrics/querying/data/execution.py
+++ b/src/sentry/sentry_metrics/querying/data/execution.py
@@ -612,9 +612,10 @@ class QueryExecutor:
             self._projects
         ).items():
             for metric_blocking in metrics_blocking_state.metrics.values():
-                blocked_metrics_for_projects.setdefault(metric_blocking.metric_mri, set()).add(
-                    project_id
-                )
+                if metric_blocking.is_blocked:
+                    blocked_metrics_for_projects.setdefault(metric_blocking.metric_mri, set()).add(
+                        project_id
+                    )
 
         return blocked_metrics_for_projects
 


### PR DESCRIPTION
This PR fixes a problem in the handling of blocked metrics in which a metric was being blocked from being queried if at least one of its tags were blocked.

Closes: https://github.com/getsentry/sentry/issues/68871
