### PR TITLE
Allow Azure OpenAPI Clients

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,5 +1,3 @@
---index-url https://pypi.devinfra.sentry.io/simple
-
 beautifulsoup4>=4.7.1
 boto3>=1.34.8
 botocore>=1.34.8

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -100,7 +100,7 @@ hiredis>=2.3.2
 # sentry-plugins specific dependencies
 phabricator>=0.7.0
 
-openai==1.3.5
+openai==1.19.0
 
 # remove once there are no unmarked transitive dependencies on setuptools
 setuptools

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -104,7 +104,7 @@ mypy==1.9.0
 mypy-extensions==1.0.0
 nodeenv==1.8.0
 oauthlib==3.1.0
-openai==1.3.5
+openai==1.19.0
 openapi-core==0.18.2
 openapi-schema-validator==0.6.2
 openapi-spec-validator==0.7.1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -75,7 +75,7 @@ mistune==2.0.4
 mmh3==4.0.0
 msgpack==1.0.7
 oauthlib==3.1.0
-openai==1.3.5
+openai==1.19.0
 orjson==3.10.0
 packaging==21.3
 parsimonious==0.10.0

--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -7,7 +7,7 @@ from typing import Any
 from django.conf import settings
 from django.dispatch import Signal
 from django.http import HttpResponse, StreamingHttpResponse
-from openai import OpenAI, RateLimitError
+from openai import AzureOpenAI, OpenAI, RateLimitError
 
 from sentry import eventstore
 from sentry.api.api_owners import ApiOwner
@@ -121,7 +121,14 @@ def get_openai_client() -> OpenAI:
         return openai_client
 
     # this will raise if OPENAI_API_KEY is not set
-    openai_client = OpenAI(api_key=settings.OPENAI_API_KEY)
+    if settings.OPENAI_AZURE_API_ENDPOINT:
+        openai_client = AzureOpenAI(
+            api_key=settings.OPENAI_API_KEY,
+            azure_endpoint=settings.OPENAI_AZURE_API_ENDPOINT,
+            api_version=settings.OPENAI_AZURE_API_VERSION,
+        )
+    else:
+        openai_client = OpenAI(api_key=settings.OPENAI_API_KEY)
 
     return openai_client
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -40,13 +40,11 @@ _EnvTypes = Union[str, float, int, list, dict]
 
 
 @overload
-def env(key: str) -> str:
-    ...
+def env(key: str) -> str: ...
 
 
 @overload
-def env(key: str, default: _EnvTypes, type: Type | None = None) -> _EnvTypes:
-    ...
+def env(key: str, default: _EnvTypes, type: Type | None = None) -> _EnvTypes: ...
 
 
 def env(
@@ -2396,6 +2394,10 @@ SENTRY_MANAGED_USER_FIELDS = ()
 
 # Secret key for OpenAI
 OPENAI_API_KEY: str | None = None
+
+# Azure Specific Settings for OpenAI
+OPENAI_AZURE_API_VERSION: str | None = None
+OPENAI_AZURE_API_ENDPOINT: str | None = None
 
 # AI Suggested Fix default model
 SENTRY_AI_SUGGESTED_FIX_MODEL: str = os.getenv("SENTRY_AI_SUGGESTED_FIX_MODEL", "gpt-3.5-turbo-16k")


### PR DESCRIPTION
Azure uses a different client for OpenAI. This PR allows Azure OpenAI when needed and uses original when not.

I had to disable the custom index for PyPi for this because I can't add the latest openai package there for Python.

This is a quick edit, so this PR really serves as a jumping off point for the solution and needs more guidance from the maintainers.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
