### PR TITLE
fix(metrics): add metric button alignment

### DIFF
--- a/static/app/components/modals/metricWidgetViewerModal/queries.tsx
+++ b/static/app/components/modals/metricWidgetViewerModal/queries.tsx
@@ -324,13 +324,12 @@ const StyledEquationSymbol = styled(EquationSymbol)<{isClickable: boolean}>`
 const ButtonBar = styled('div')<{addQuerySymbolSpacing: boolean}>`
   align-items: center;
   display: flex;
-  padding-top: ${space(0.5)};
   gap: ${space(2)};
 
   ${p =>
     p.addQuerySymbolSpacing &&
     `
     padding-left: ${space(1)};
-    margin-left: ${space(2)};
+    margin-left: 38px;
   `}
 `;

--- a/static/app/views/metrics/queries.tsx
+++ b/static/app/views/metrics/queries.tsx
@@ -364,14 +364,13 @@ const ButtonBar = styled('div')<{addQuerySymbolSpacing: boolean}>`
   align-items: center;
   display: flex;
   padding-bottom: ${space(2)};
-  padding-top: ${space(1)};
   gap: ${space(2)};
 
   ${p =>
     p.addQuerySymbolSpacing &&
     `
     padding-left: ${space(1)};
-    margin-left: ${space(2)};
+    margin-left: 38px;
   `}
 `;
 


### PR DESCRIPTION
Before: 
<img width="549" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/20c300fa-f5d0-4e3b-93c6-49e11fabbce2">

After: 
<img width="549" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/4541afca-ffdb-44c8-a320-2bf7170dc471">
