### PR TITLE
build: Remove "sentry-" from codecov bundle name

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -778,7 +778,7 @@ if (CODECOV_TOKEN && ENABLE_CODECOV_BA) {
   appConfig.plugins?.push(
     codecovWebpackPlugin({
       enableBundleAnalysis: true,
-      bundleName: 'sentry-webpack-bundle',
+      bundleName: 'app-webpack-bundle',
       uploadToken: CODECOV_TOKEN,
       debug: true,
     })


### PR DESCRIPTION
Previously we named the bundle we uploaded for codecov bundle analysis `sentry-webpack-bundle`. This has the unfortunate side effect of being prepended with `sentry-`, which made the Sentry/GitHub integration automatically link to Sentry when it was rendered as a comment on the PR.

https://github.com/getsentry/sentry/pull/68985#issuecomment-2059233966 is an example comment.

To get around this, rename the bundle name to `app-webpack-bundle`.