### PR TITLE
chore(slack): remove more non-block kit

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 from sentry.eventstore.models import Event, GroupEvent
-from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackAttachment, SlackBody
+from sentry.integrations.slack.message_builder import SlackBody
 from sentry.models.group import Group
 from sentry.notifications.utils.actions import MessageAction
-from sentry.utils.assets import get_asset_url
-from sentry.utils.http import absolute_uri
 
 
 def get_slack_button(action: MessageAction) -> Mapping[str, Any]:
@@ -49,46 +47,3 @@ class SlackMessageBuilder(ABC):
         Returns True if we need to escape the text in the message.
         """
         return False
-
-    def _build(
-        self,
-        text: str,
-        title: str | None = None,
-        title_link: str | None = None,
-        footer: str | None = None,
-        color: str | None = None,
-        actions: Sequence[MessageAction] | None = None,
-        **kwargs: Any,
-    ) -> SlackAttachment:
-        """
-        Helper to DRY up Slack specific fields.
-
-        :param string text: Body text.
-        :param [string] title: Title text.
-        :param [string] title_link: Optional URL attached to the title.
-        :param [string] footer: Footer text.
-        :param [string] color: The key in the Slack palate table, NOT hex. Default: "info".
-        :param [list[MessageAction]] actions: List of actions displayed alongside the message.
-        :param kwargs: Everything else.
-        """
-        # If `footer` string is passed, automatically attach a `footer_icon`.
-        if footer:
-            kwargs["footer"] = footer
-            kwargs["footer_icon"] = str(
-                absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
-            )
-
-        if title:
-            kwargs["title"] = title
-            if title_link:
-                kwargs["title_link"] = title_link
-
-        if actions is not None:
-            kwargs["actions"] = [get_slack_button(action) for action in actions]
-
-        return {
-            "text": text,
-            "mrkdwn_in": ["text"],
-            "color": LEVEL_TO_COLOR[color or "info"],
-            **kwargs,
-        }

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -28,7 +28,6 @@ from sentry.integrations.slack.message_builder import (
     CATEGORY_TO_EMOJI,
     LEVEL_TO_EMOJI,
     SLACK_URL_FORMAT,
-    SlackAttachment,
     SlackBlock,
 )
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
@@ -506,7 +505,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         """
         return True
 
-    def build(self, notification_uuid: str | None = None) -> SlackBlock | SlackAttachment:
+    def build(self, notification_uuid: str | None = None) -> SlackBlock:
         # XXX(dcramer): options are limited to 100 choices, even when nested
         text = build_attachment_text(self.group, self.event) or ""
         text = text.strip(" \n")

--- a/src/sentry/integrations/slack/message_builder/notifications/base.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from sentry import features
 from sentry.integrations.slack.message_builder import SlackAttachment, SlackBlock
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
@@ -35,15 +34,6 @@ class SlackNotificationsMessageBuilder(BlockSlackMessageBuilder):
         )
         actions = self.notification.get_message_actions(self.recipient, ExternalProviders.SLACK)
         callback_id = json.dumps(callback_id_raw) if callback_id_raw else None
-        if not features.has("organizations:slack-block-kit", self.notification.organization):
-            return self._build(
-                title=title,
-                title_link=title_link,
-                text=text,
-                footer=footer,
-                actions=actions,
-                callback_id=callback_id,
-            )
 
         first_block_text = ""
         if title_link:

--- a/src/sentry/integrations/slack/message_builder/notifications/base.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.integrations.slack.message_builder import SlackAttachment, SlackBlock
+from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.notifications.notifications.base import BaseNotification
@@ -24,7 +24,7 @@ class SlackNotificationsMessageBuilder(BlockSlackMessageBuilder):
         self.context = context
         self.recipient = recipient
 
-    def build(self) -> SlackAttachment | SlackBlock:
+    def build(self) -> SlackBlock:
         callback_id_raw = self.notification.get_callback_data()
         title = self.notification.build_attachment_title(self.recipient)
         title_link = self.notification.get_title_link(self.recipient, ExternalProviders.SLACK)

--- a/src/sentry/integrations/slack/message_builder/notifications/digest.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/digest.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from sentry.digests import Digest
 from sentry.digests.utils import get_groups
-from sentry.integrations.slack.message_builder import SlackAttachment, SlackBlock
+from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.notifications.notifications.digest import DigestNotification
 from sentry.services.hybrid_cloud.actor import RpcActor
@@ -23,7 +23,7 @@ class DigestNotificationMessageBuilder(SlackNotificationsMessageBuilder):
         super().__init__(notification, context, recipient)
         self.notification: DigestNotification = notification
 
-    def build(self) -> SlackAttachment | SlackBlock:
+    def build(self) -> SlackBlock:
         """
         It's currently impossible in mypy to have recursive types so we need a
         hack to get this to return a SlackBody.

--- a/src/sentry/integrations/slack/message_builder/notifications/digest.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/digest.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from sentry import features
 from sentry.digests import Digest
 from sentry.digests.utils import get_groups
 from sentry.integrations.slack.message_builder import SlackAttachment, SlackBlock
@@ -31,18 +30,6 @@ class DigestNotificationMessageBuilder(SlackNotificationsMessageBuilder):
         """
         digest: Digest = self.context.get("digest", {})
         digest_groups = get_groups(digest)
-        if not features.has("organizations:slack-block-kit", self.notification.organization):
-            return [
-                SlackIssuesMessageBuilder(
-                    group=group,
-                    event=event,
-                    rules=[rule],
-                    issue_details=True,
-                    notification=self.notification,
-                    recipient=self.recipient,
-                ).build()
-                for rule, group, event in digest_groups
-            ]
         blocks = []
         for rule, group, event in digest_groups:
             alert_as_blocks = SlackIssuesMessageBuilder(

--- a/src/sentry/integrations/slack/message_builder/notifications/issues.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/issues.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.integrations.slack.message_builder import SlackAttachment, SlackBlock
+from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.services.hybrid_cloud.actor import RpcActor
@@ -21,7 +21,7 @@ class IssueNotificationMessageBuilder(SlackNotificationsMessageBuilder):
         super().__init__(notification, context, recipient)
         self.notification: ProjectNotification = notification
 
-    def build(self) -> SlackAttachment | SlackBlock:
+    def build(self) -> SlackBlock:
         group = getattr(self.notification, "group", None)
         return SlackIssuesMessageBuilder(
             group=group,

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -6,7 +6,6 @@ from urllib.parse import urlencode
 
 from sentry_relay.processing import parse_release
 
-from sentry import features
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.commitfilechange import CommitFileChange
@@ -160,9 +159,7 @@ class ReleaseActivityNotification(ActivityNotification):
                 return [
                     MessageAction(
                         name=project.slug,
-                        label=project.slug
-                        if features.has("organizations:slack-block-kit", self.project.organization)
-                        else None,
+                        label=project.slug,
                         url=self.organization.absolute_url(
                             f"/organizations/{project.organization.slug}/releases/{release.version}/",
                             query=f"project={project.id}&unselectedSeries=Healthy&referrer={self.metrics_key}&notification_uuid={self.notification_uuid}",

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -5,7 +5,6 @@ import random
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from typing import TYPE_CHECKING, Any
 
-from sentry import features
 from sentry.db.models import Model
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.utils.actions import MessageAction
@@ -85,9 +84,7 @@ class IntegrationNudgeNotification(BaseNotification):
         return [
             MessageAction(
                 name="Turn on personal notifications",
-                label="Turn on personal notifications"
-                if features.has("organizations:slack-block-kit", self.organization)
-                else None,
+                label="Turn on personal notifications",
                 action_id="enable_notifications",
                 value="all_slack",
             )

--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 
 from django.urls import reverse
 
-from sentry import features
 from sentry.models.organizationmember import OrganizationMember
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
 from sentry.notifications.notifications.strategies.member_write_role_recipient_strategy import (
@@ -71,22 +70,14 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification, abc.ABC
                 style="primary",
                 action_id="approve_request",
                 value="approve_member",
-                label=(
-                    "Approve"
-                    if features.has("organizations:slack-block-kit", self.organization)
-                    else None
-                ),
+                label="Approve",
             ),
             MessageAction(
                 name="Reject",
                 style="danger",
                 action_id="approve_request",
                 value="reject_member",
-                label=(
-                    "Reject"
-                    if features.has("organizations:slack-block-kit", self.organization)
-                    else None
-                ),
+                label="Reject",
             ),
             MessageAction(
                 name="See Members & Requests",

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -175,7 +175,6 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
         assert self.organization.absolute_url("/settings/members/") in mail.outbox[0].body
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_request_to_join_slack(self):
         with self.tasks():
             self.get_success_response(self.organization.slug, email=self.email, status_code=204)

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -6,7 +6,6 @@ import responses
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.assigned import AssignedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
@@ -112,7 +111,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert channel == self.identity.external_id
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_assignment_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is assigned
@@ -139,7 +137,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_assignment_generic_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type is assigned
@@ -169,7 +166,6 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_assignment_performance_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is assigned

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -5,7 +5,6 @@ import responses
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.regression import RegressionActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
@@ -27,7 +26,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_regression_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue regresses
@@ -48,7 +46,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_regression_with_release_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue regresses
@@ -77,7 +74,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_regression_performance_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue regresses
@@ -104,7 +100,6 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_regression_generic_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type regresses

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -5,7 +5,6 @@ import responses
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.resolved import ResolvedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
@@ -27,7 +26,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_resolved_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is resolved
@@ -61,7 +59,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_resolved_performance_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is resolved
@@ -92,7 +89,6 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_resolved_generic_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type is resolved

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -7,7 +7,6 @@ from sentry.notifications.notifications.activity.resolved_in_release import (
     ResolvedInReleaseActivityNotification,
 )
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
@@ -31,7 +30,6 @@ class SlackResolvedInReleaseNotificationTest(
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_resolved_in_release_block(self):
         notification = self.create_notification(self.group)
         with self.tasks():
@@ -57,7 +55,6 @@ class SlackResolvedInReleaseNotificationTest(
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_resolved_in_release_performance_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is resolved in a release
@@ -86,7 +83,6 @@ class SlackResolvedInReleaseNotificationTest(
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_resolved_in_release_generic_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type is resolved in a release
@@ -113,7 +109,6 @@ class SlackResolvedInReleaseNotificationTest(
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_resolved_in_release_parsed_version_block(self):
         """
         Test that the release version is formatted to the short version when block kit is enabled.

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -5,7 +5,6 @@ import responses
 from sentry.models.activity import Activity
 from sentry.notifications.notifications.activity.unassigned import UnassignedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
@@ -27,7 +26,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_unassignment_block(self):
         """
         Test that a Slack message is sent with the expected payload when an issue is unassigned
@@ -54,7 +52,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_PERF_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_unassignment_performance_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a performance issue is unassigned
@@ -81,7 +78,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         return_value=TEST_ISSUE_OCCURRENCE,
         new_callable=mock.PropertyMock,
     )
-    @with_feature("organizations:slack-block-kit")
     def test_unassignment_generic_issue_block(self, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type is unassigned

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -15,7 +15,6 @@ from sentry.models.rule import Rule
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -156,7 +155,6 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
 
 class DigestSlackNotification(SlackActivityNotificationTest):
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     @mock.patch.object(sentry, "digests")
     def test_slack_digest_notification_block(self, digests):
         """

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -27,7 +27,6 @@ from sentry.tasks.post_process import post_process_group
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -146,9 +145,7 @@ class ActivityNotificationTest(APITestCase):
         self.short_id = self.group.qualified_short_id
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_sends_note_notification(self):
-        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when a comment is created on an issue.
@@ -185,9 +182,7 @@ class ActivityNotificationTest(APITestCase):
         )
 
     @responses.activate
-    @with_feature("organizations:slack-block-kit")
     def test_sends_unassignment_notification(self):
-        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is unassigned.
@@ -254,9 +249,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature("organizations:slack-block-kit")
     def test_sends_resolution_notification(self, record_analytics):
-        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is resolved.
@@ -309,9 +302,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature("organizations:slack-block-kit")
     def test_sends_deployment_notification(self, record_analytics):
-        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when a release is deployed.
@@ -375,9 +366,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature("organizations:slack-block-kit")
     def test_sends_regression_notification(self, record_analytics):
-        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue regresses.
@@ -442,9 +431,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature("organizations:slack-block-kit")
     def test_sends_resolved_in_release_notification(self, record_analytics):
-        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue is resolved by a release.
@@ -511,9 +498,7 @@ class ActivityNotificationTest(APITestCase):
 
     @responses.activate
     @patch("sentry.analytics.record")
-    @with_feature("organizations:slack-block-kit")
     def test_sends_issue_notification(self, record_analytics):
-        # TODO: make this a block kit test
         """
         Test that an email AND Slack notification are sent with
         the expected values when an issue comes in that triggers an alert rule.


### PR DESCRIPTION
Fixes typing (all SlackMessageBuilders should return SlackBlock), defaults all message builders to use block kit, and removes some straggling uses of the flag. Last up will be to default the webhook handlers to rely on block kit logic.