### PR TITLE
feat(dashboards): Allow removing of wrapper in lazyrender

### DIFF
--- a/static/app/components/lazyRender.tsx
+++ b/static/app/components/lazyRender.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 
 function maybeCleanupObserver(
   observerRef: React.MutableRefObject<IntersectionObserver | null>
@@ -84,7 +84,7 @@ export function LazyRender(props: LazyRenderProps) {
   );
 
   if (visible && props.withoutWrapper) {
-    return <Fragment>{props.children}</Fragment>;
+    return props.children;
   }
 
   return <div ref={onRefNode}>{visible ? props.children : null}</div>;

--- a/static/app/components/lazyRender.tsx
+++ b/static/app/components/lazyRender.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useRef, useState} from 'react';
+import {Fragment, useCallback, useRef, useState} from 'react';
 
 function maybeCleanupObserver(
   observerRef: React.MutableRefObject<IntersectionObserver | null>
@@ -25,6 +25,10 @@ export interface LazyRenderProps {
   children: React.ReactNode;
   containerHeight?: number;
   observerOptions?: Partial<IntersectionObserverInit>;
+  /**
+   * Removes the wrapping div once rendered
+   */
+  removeWrapper?: boolean;
 }
 
 /**
@@ -78,6 +82,10 @@ export function LazyRender(props: LazyRenderProps) {
     },
     [visible, props.observerOptions, props.containerHeight]
   );
+
+  if (visible && props.removeWrapper) {
+    return <Fragment>{props.children}</Fragment>;
+  }
 
   return <div ref={onRefNode}>{visible ? props.children : null}</div>;
 }

--- a/static/app/components/lazyRender.tsx
+++ b/static/app/components/lazyRender.tsx
@@ -28,7 +28,7 @@ export interface LazyRenderProps {
   /**
    * Removes the wrapping div once rendered
    */
-  removeWrapper?: boolean;
+  withoutWrapper?: boolean;
 }
 
 /**
@@ -83,7 +83,7 @@ export function LazyRender(props: LazyRenderProps) {
     [visible, props.observerOptions, props.containerHeight]
   );
 
-  if (visible && props.removeWrapper) {
+  if (visible && props.withoutWrapper) {
     return <Fragment>{props.children}</Fragment>;
   }
 

--- a/static/app/components/lazyRender.tsx
+++ b/static/app/components/lazyRender.tsx
@@ -26,7 +26,7 @@ export interface LazyRenderProps {
   containerHeight?: number;
   observerOptions?: Partial<IntersectionObserverInit>;
   /**
-   * Removes the wrapping div once rendered
+   * Removes the wrapping div once visible
    */
   withoutWrapper?: boolean;
 }

--- a/static/app/components/lazyRender.tsx
+++ b/static/app/components/lazyRender.tsx
@@ -28,7 +28,7 @@ export interface LazyRenderProps {
   /**
    * Removes the wrapping div once visible
    */
-  withoutWrapper?: boolean;
+  withoutContainer?: boolean;
 }
 
 /**
@@ -83,7 +83,7 @@ export function LazyRender(props: LazyRenderProps) {
     [visible, props.observerOptions, props.containerHeight]
   );
 
-  if (visible && props.withoutWrapper) {
+  if (visible && props.withoutContainer) {
     return props.children;
   }
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -11,6 +11,10 @@ import {DashboardWidgetSource, DisplayType} from 'sentry/views/dashboards/types'
 
 const stubEl = (props: {children?: React.ReactNode}) => <div>{props.children}</div>;
 
+jest.mock('sentry/components/lazyRender', () => ({
+  LazyRender: ({children}: {children: React.ReactNode}) => children,
+}));
+
 const mockWidgetAsQueryParams = {
   defaultTableColumns: ['field1', 'field2'],
   defaultTitle: 'Default title',

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -22,6 +22,9 @@ import ReleaseWidgetQueries from 'sentry/views/dashboards/widgetCard/releaseWidg
 
 jest.mock('sentry/components/charts/simpleTableChart', () => jest.fn(() => <div />));
 jest.mock('sentry/views/dashboards/widgetCard/releaseWidgetQueries');
+jest.mock('sentry/components/lazyRender', () => ({
+  LazyRender: ({children}: {children: React.ReactNode}) => children,
+}));
 
 describe('Dashboards > WidgetCard', function () {
   const {router, organization, routerContext} = initializeOrg({

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -1,5 +1,5 @@
 import {Component, Fragment} from 'react';
-// import LazyLoad from 'react-lazyload';
+import LazyLoad from 'react-lazyload';
 import type {WithRouterProps} from 'react-router';
 import type {useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
@@ -226,7 +226,7 @@ class WidgetCard extends Component<Props, State> {
       renderErrorMessage,
       tableItemLimit,
       windowWidth,
-      // noLazyLoad,
+      noLazyLoad,
       showStoredAlert,
       noDashboardsMEPProvider,
       dashboardFilters,
@@ -349,8 +349,7 @@ class WidgetCard extends Component<Props, State> {
                       <IconWarning color="gray500" size="lg" />
                     </StyledErrorPanel>
                   </Fragment>
-                ) : (
-                  // noLazyLoad ?
+                ) : noLazyLoad ? (
                   <WidgetCardChartContainer
                     location={location}
                     api={api}
@@ -365,28 +364,23 @@ class WidgetCard extends Component<Props, State> {
                     dashboardFilters={dashboardFilters}
                     chartGroup={DASHBOARD_CHART_GROUP}
                   />
-                  // )
-                  // : (
-                  //   <LazyLoad
-                  //     once
-                  //     resize
-                  //     height={200}
-                  //   >
-                  //     <WidgetCardChartContainer
-                  //       location={location}
-                  //       api={api}
-                  //       organization={organization}
-                  //       selection={selection}
-                  //       widget={widget}
-                  //       isMobile={isMobile}
-                  //       renderErrorMessage={renderErrorMessage}
-                  //       tableItemLimit={tableItemLimit}
-                  //       windowWidth={windowWidth}
-                  //       onDataFetched={this.setData}
-                  //       dashboardFilters={dashboardFilters}
-                  //       chartGroup={DASHBOARD_CHART_GROUP}
-                  //     />
-                  //   </LazyLoad>
+                ) : (
+                  <LazyLoad once resize height={200}>
+                    <WidgetCardChartContainer
+                      location={location}
+                      api={api}
+                      organization={organization}
+                      selection={selection}
+                      widget={widget}
+                      isMobile={isMobile}
+                      renderErrorMessage={renderErrorMessage}
+                      tableItemLimit={tableItemLimit}
+                      windowWidth={windowWidth}
+                      onDataFetched={this.setData}
+                      dashboardFilters={dashboardFilters}
+                      chartGroup={DASHBOARD_CHART_GROUP}
+                    />
+                  </LazyLoad>
                 )}
                 {this.renderToolbar()}
               </WidgetCardPanel>

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -1,5 +1,4 @@
 import {Component, Fragment} from 'react';
-import LazyLoad from 'react-lazyload';
 import type {WithRouterProps} from 'react-router';
 import type {useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
@@ -10,6 +9,7 @@ import {Alert} from 'sentry/components/alert';
 import ErrorPanel from 'sentry/components/charts/errorPanel';
 import {HeaderTitle} from 'sentry/components/charts/styles';
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import {LazyRender} from 'sentry/components/lazyRender';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Panel from 'sentry/components/panels/panel';
 import PanelAlert from 'sentry/components/panels/panelAlert';
@@ -365,7 +365,7 @@ class WidgetCard extends Component<Props, State> {
                     chartGroup={DASHBOARD_CHART_GROUP}
                   />
                 ) : (
-                  <LazyLoad once resize height={200}>
+                  <LazyRender containerHeight={200} removeWrapper>
                     <WidgetCardChartContainer
                       location={location}
                       api={api}
@@ -380,7 +380,7 @@ class WidgetCard extends Component<Props, State> {
                       dashboardFilters={dashboardFilters}
                       chartGroup={DASHBOARD_CHART_GROUP}
                     />
-                  </LazyLoad>
+                  </LazyRender>
                 )}
                 {this.renderToolbar()}
               </WidgetCardPanel>

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -365,7 +365,7 @@ class WidgetCard extends Component<Props, State> {
                     chartGroup={DASHBOARD_CHART_GROUP}
                   />
                 ) : (
-                  <LazyRender containerHeight={200} removeWrapper>
+                  <LazyRender containerHeight={200} withoutWrapper>
                     <WidgetCardChartContainer
                       location={location}
                       api={api}

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -365,7 +365,7 @@ class WidgetCard extends Component<Props, State> {
                     chartGroup={DASHBOARD_CHART_GROUP}
                   />
                 ) : (
-                  <LazyRender containerHeight={200} withoutWrapper>
+                  <LazyRender containerHeight={200} withoutContainer>
                     <WidgetCardChartContainer
                       location={location}
                       api={api}


### PR DESCRIPTION
This reverts commit be24d67

Updating react-lazyload added an additional div wrapper to use as the visible ref. Dashboard styles rely on lots of overflow and full height styles and a wrapping div breaks them since you want the overflow scrollbars to be on that element.

This adds the ability for our lazy render to remove the wrapper once the component is on the screen.


[good test dashboard](https://sentry.sentry.io/dashboard/51993/?project=-1&statsPeriod=1h)