### PR TITLE
chore(actor): Move ActorTuple to its own file so that it's not tied to models during import

### DIFF
--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -8,9 +8,9 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer
-from sentry.models.actor import ActorTuple
 from sentry.models.projectownership import ProjectOwnership
 from sentry.models.team import Team
+from sentry.utils.actor import ActorTuple
 
 
 @region_silo_endpoint

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -4,10 +4,10 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from sentry.models.actor import ActorTuple
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.models.user import User
+from sentry.utils.actor import ActorTuple
 
 
 @extend_schema_field(field=OpenApiTypes.STR)

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -27,7 +27,7 @@ from sentry.issues.priority import update_priority
 from sentry.issues.status_change import handle_status_update
 from sentry.issues.update_inbox import update_inbox
 from sentry.models.activity import Activity, ActivityIntegration
-from sentry.models.actor import Actor, ActorTuple
+from sentry.models.actor import Actor
 from sentry.models.group import STATUS_UPDATE_CHOICES, Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupbookmark import GroupBookmark
@@ -56,6 +56,7 @@ from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.types.activity import ActivityType
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus, PriorityLevel
 from sentry.utils import metrics
+from sentry.utils.actor import ActorTuple
 
 from . import ACTIVITIES_COUNT, BULK_MUTATION_LIMIT, SearchFunction, delete_group_list
 from .validators import GroupValidator, ValidationError

--- a/src/sentry/api/serializers/rest_framework/mentions.py
+++ b/src/sentry/api/serializers/rest_framework/mentions.py
@@ -4,13 +4,13 @@ from collections.abc import Sequence
 
 from rest_framework import serializers
 
-from sentry.models.actor import ActorTuple
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.util import region_silo_function
+from sentry.utils.actor import ActorTuple
 
 
 @region_silo_function

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -38,7 +38,6 @@ from sentry.issues.grouptype import (
     PerformanceP95EndpointRegressionGroupType,
     ProfileFunctionRegressionType,
 )
-from sentry.models.actor import ActorTuple
 from sentry.models.commit import Commit
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
@@ -60,6 +59,7 @@ from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.types.group import SUBSTATUS_TO_STR
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
+from sentry.utils.actor import ActorTuple
 
 STATUSES = {"resolved": "resolved", "ignored": "ignored", "unresolved": "re-opened"}
 SUPPORTED_COMMIT_PROVIDERS = (

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections import defaultdict, namedtuple
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, overload
 
 import sentry_sdk
@@ -9,7 +7,6 @@ from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
 from django.db.models.signals import post_save
 from django.forms import model_to_dict
-from rest_framework import serializers
 
 from sentry.backup.dependencies import ImportKind, PrimaryKeyMap
 from sentry.backup.helpers import ImportFlags
@@ -20,6 +17,7 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox, outbox_context
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.utils.actor import ActorTuple
 
 if TYPE_CHECKING:
     from sentry.models.team import Team
@@ -74,32 +72,6 @@ def fetch_actors_by_actor_ids(
         return user_service.get_many(filter={"user_ids": list(user_ids)})
     elif cls is Team:
         return Team.objects.filter(actor_id__in=actor_ids).all()
-    else:
-        raise ValueError(f"Cls {cls} is not a valid actor type.")
-
-
-@overload
-def fetch_actor_by_id(cls: type[User], id: int) -> RpcUser:
-    ...
-
-
-@overload
-def fetch_actor_by_id(cls: type[Team], id: int) -> Team:
-    ...
-
-
-def fetch_actor_by_id(cls: type[User] | type[Team], id: int) -> Team | RpcUser:
-    from sentry.models.team import Team
-    from sentry.models.user import User
-
-    if cls is Team:
-        return Team.objects.get(id=id)
-
-    elif cls is User:
-        user = user_service.get_user(id)
-        if user is None:
-            raise User.DoesNotExist()
-        return user
     else:
         raise ValueError(f"Cls {cls} is not a valid actor type.")
 
@@ -231,134 +203,6 @@ def get_actor_for_team(team: int | Team) -> Actor:
         sentry_sdk.capture_exception(err)
         actor = Actor.objects.filter(type=ACTOR_TYPES["team"], team_id=team_id).first()
     return actor
-
-
-class ActorTuple(namedtuple("Actor", "id type")):
-    """
-    This is an artifact from before we had the Actor model.
-    We want to eventually drop this model and merge functionality with Actor
-    This should happen more easily if we move GroupAssignee, GroupOwner, etc. to use the Actor model.
-    """
-
-    @property
-    def identifier(self):
-        return f"{self.type.__name__.lower()}:{self.id}"
-
-    @overload
-    @classmethod
-    def from_actor_identifier(cls, actor_identifier: None) -> None:
-        ...
-
-    @overload
-    @classmethod
-    def from_actor_identifier(cls, actor_identifier: int | str) -> ActorTuple:
-        ...
-
-    @classmethod
-    def from_actor_identifier(cls, actor_identifier: int | str | None) -> ActorTuple | None:
-        from sentry.models.team import Team
-        from sentry.models.user import User
-
-        """
-        Returns an Actor tuple corresponding to a User or Team associated with
-        the given identifier.
-
-        Forms `actor_identifier` can take:
-            1231 -> look up User by id
-            "1231" -> look up User by id
-            "user:1231" -> look up User by id
-            "team:1231" -> look up Team by id
-            "maiseythedog" -> look up User by username
-            "maisey@dogsrule.com" -> look up User by primary email
-        """
-
-        if actor_identifier is None:
-            return None
-
-        # If we have an integer, fall back to assuming it's a User
-        if isinstance(actor_identifier, int):
-            return cls(actor_identifier, User)
-
-        # If the actor_identifier is a simple integer as a string,
-        # we're also a User
-        if actor_identifier.isdigit():
-            return cls(int(actor_identifier), User)
-
-        if actor_identifier.startswith("user:"):
-            return cls(int(actor_identifier[5:]), User)
-
-        if actor_identifier.startswith("team:"):
-            return cls(int(actor_identifier[5:]), Team)
-
-        try:
-            user = user_service.get_by_username(username=actor_identifier)[0]
-            return cls(user.id, User)
-        except IndexError as e:
-            raise serializers.ValidationError(f"Unable to resolve actor identifier: {e}")
-
-    @classmethod
-    def from_id(cls, user_id: int | None, team_id: int | None) -> ActorTuple | None:
-        from sentry.models.team import Team
-        from sentry.models.user import User
-
-        if user_id and team_id:
-            raise ValueError("user_id and team_id may not both be specified")
-        if user_id and not team_id:
-            return cls(user_id, User)
-        if team_id and not user_id:
-            return cls(team_id, Team)
-
-        return None
-
-    @classmethod
-    def from_ids(cls, user_ids: Sequence[int], team_ids: Sequence[int]) -> Sequence[ActorTuple]:
-        from sentry.models.team import Team
-        from sentry.models.user import User
-
-        return [
-            *[cls(user_id, User) for user_id in user_ids],
-            *[cls(team_id, Team) for team_id in team_ids],
-        ]
-
-    def resolve(self) -> Team | RpcUser:
-        return fetch_actor_by_id(self.type, self.id)
-
-    def resolve_to_actor(self) -> Actor:
-        from sentry.models.user import User
-
-        obj = self.resolve()
-        if isinstance(obj, (User, RpcUser)):
-            return get_actor_for_user(obj)
-        # Team case. Teams have actors generated as a post_save signal
-        return Actor.objects.get(id=obj.actor_id)
-
-    @classmethod
-    def resolve_many(cls, actors: Sequence[ActorTuple]) -> Sequence[Team | RpcUser]:
-        """
-        Resolve multiple actors at the same time. Returns the result in the same order
-        as the input, minus any actors we couldn't resolve.
-        :param actors:
-        :return:
-        """
-        from sentry.models.user import User
-
-        if not actors:
-            return []
-
-        actors_by_type = defaultdict(list)
-        for actor in actors:
-            actors_by_type[actor.type].append(actor)
-
-        results = {}
-        for model_class, _actors in actors_by_type.items():
-            if model_class == User:
-                for instance in user_service.get_many(filter={"user_ids": [a.id for a in _actors]}):
-                    results[(model_class, instance.id)] = instance
-            else:
-                for instance in model_class.objects.filter(id__in=[a.id for a in _actors]):
-                    results[(model_class, instance.id)] = instance
-
-        return list(filter(None, [results.get((actor.type, actor.id)) for actor in actors]))
 
 
 def handle_team_post_save(instance, **kwargs):

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -96,7 +96,7 @@ class GroupOwner(Model):
         raise NotImplementedError("Unknown Owner")
 
     def owner(self):
-        from sentry.models.actor import ActorTuple
+        from sentry.utils.actor import ActorTuple
 
         if not self.owner_id():
             return None

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -14,12 +14,12 @@ from sentry.db.models import Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields import FlexibleForeignKey, JSONField
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.models.activity import Activity
-from sentry.models.actor import ActorTuple
 from sentry.models.group import Group
 from sentry.models.groupowner import OwnerRuleType
 from sentry.ownership.grammar import Rule, load_schema, resolve_actors
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
+from sentry.utils.actor import ActorTuple
 from sentry.utils.cache import cache
 
 if TYPE_CHECKING:

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -35,11 +35,11 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 from sentry.db.models.fields.slug import SentrySlugField
 from sentry.db.models.utils import slugify_instance
 from sentry.locks import locks
-from sentry.models.actor import ActorTuple
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleSource
 from sentry.monitors.constants import MAX_SLUG_LENGTH
 from sentry.monitors.types import CrontabSchedule, IntervalSchedule
+from sentry.utils.actor import ActorTuple
 from sentry.utils.retries import TimedRetryPolicy
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -7,12 +7,12 @@ from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import ProjectSerializerResponse, Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
-from sentry.models.actor import ActorTuple
 from sentry.models.project import Project
 from sentry.monitors.utils import fetch_associated_groups
 from sentry.monitors.validators import IntervalNames
 
 from ..models import Environment
+from ..utils.actor import ActorTuple
 from .models import (
     Monitor,
     MonitorCheckIn,

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 from django.db.models import Q
 
 from sentry import features
-from sentry.models.actor import ActorTuple
 from sentry.models.commit import Commit
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
@@ -37,6 +36,7 @@ from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.services.hybrid_cloud.user_option import get_option_from_list, user_option_service
 from sentry.types.integrations import ExternalProviders, get_provider_enum_from_string
 from sentry.utils import json, metrics
+from sentry.utils.actor import ActorTuple
 from sentry.utils.committers import AuthorCommitsSerialized, get_serialized_event_file_committers
 
 if TYPE_CHECKING:

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -11,10 +11,10 @@ from parsimonious.nodes import Node, NodeVisitor
 from rest_framework.serializers import ValidationError
 
 from sentry.eventstore.models import EventSubjectTemplateData
-from sentry.models.actor import ActorTuple
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.organizationmember import OrganizationMember
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.utils.actor import ActorTuple
 from sentry.utils.codeowners import codeowners_match
 from sentry.utils.event_frames import find_stack_frames, get_sdk_name, munged_filename_and_frames
 from sentry.utils.glob import glob_match

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -416,9 +416,9 @@ def resolve_actors(owners: Iterable[Owner], project_id: int) -> Mapping[Owner, A
     """Convert a list of Owner objects into a dictionary
     of {Owner: Actor} pairs. Actors not identified are returned
     as None."""
-    from sentry.models.actor import ActorTuple
     from sentry.models.team import Team
     from sentry.models.user import User
+    from sentry.utils.actor import ActorTuple
 
     if not owners:
         return {}

--- a/src/sentry/utils/actor.py
+++ b/src/sentry/utils/actor.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from collections import defaultdict, namedtuple
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, overload
+
+from rest_framework import serializers
+
+from sentry.services.hybrid_cloud.user.service import user_service
+
+if TYPE_CHECKING:
+    from sentry.models.actor import Actor
+    from sentry.models.team import Team
+    from sentry.models.user import User
+    from sentry.services.hybrid_cloud.user import RpcUser
+
+
+class ActorTuple(namedtuple("Actor", "id type")):
+    """
+    This is an artifact from before we had the Actor model.
+    We want to eventually drop this model and merge functionality with Actor
+    This should happen more easily if we move GroupAssignee, GroupOwner, etc. to use the Actor model.
+    """
+
+    @property
+    def identifier(self):
+        return f"{self.type.__name__.lower()}:{self.id}"
+
+    @overload
+    @classmethod
+    def from_actor_identifier(cls, actor_identifier: None) -> None:
+        ...
+
+    @overload
+    @classmethod
+    def from_actor_identifier(cls, actor_identifier: int | str) -> ActorTuple:
+        ...
+
+    @classmethod
+    def from_actor_identifier(cls, actor_identifier: int | str | None) -> ActorTuple | None:
+        from sentry.models.team import Team
+        from sentry.models.user import User
+
+        """
+        Returns an Actor tuple corresponding to a User or Team associated with
+        the given identifier.
+
+        Forms `actor_identifier` can take:
+            1231 -> look up User by id
+            "1231" -> look up User by id
+            "user:1231" -> look up User by id
+            "team:1231" -> look up Team by id
+            "maiseythedog" -> look up User by username
+            "maisey@dogsrule.com" -> look up User by primary email
+        """
+
+        if actor_identifier is None:
+            return None
+
+        # If we have an integer, fall back to assuming it's a User
+        if isinstance(actor_identifier, int):
+            return cls(actor_identifier, User)
+
+        # If the actor_identifier is a simple integer as a string,
+        # we're also a User
+        if actor_identifier.isdigit():
+            return cls(int(actor_identifier), User)
+
+        if actor_identifier.startswith("user:"):
+            return cls(int(actor_identifier[5:]), User)
+
+        if actor_identifier.startswith("team:"):
+            return cls(int(actor_identifier[5:]), Team)
+
+        try:
+            user = user_service.get_by_username(username=actor_identifier)[0]
+            return cls(user.id, User)
+        except IndexError as e:
+            raise serializers.ValidationError(f"Unable to resolve actor identifier: {e}")
+
+    @classmethod
+    def from_id(cls, user_id: int | None, team_id: int | None) -> ActorTuple | None:
+        from sentry.models.team import Team
+        from sentry.models.user import User
+
+        if user_id and team_id:
+            raise ValueError("user_id and team_id may not both be specified")
+        if user_id and not team_id:
+            return cls(user_id, User)
+        if team_id and not user_id:
+            return cls(team_id, Team)
+
+        return None
+
+    @classmethod
+    def from_ids(cls, user_ids: Sequence[int], team_ids: Sequence[int]) -> Sequence[ActorTuple]:
+        from sentry.models.team import Team
+        from sentry.models.user import User
+
+        return [
+            *[cls(user_id, User) for user_id in user_ids],
+            *[cls(team_id, Team) for team_id in team_ids],
+        ]
+
+    def resolve(self) -> Team | RpcUser:
+        return fetch_actor_by_id(self.type, self.id)
+
+    def resolve_to_actor(self) -> Actor:
+        from sentry.models.actor import Actor, get_actor_for_user
+        from sentry.models.user import User
+
+        obj = self.resolve()
+        if isinstance(obj, (User, RpcUser)):
+            return get_actor_for_user(obj)
+        # Team case. Teams have actors generated as a post_save signal
+        return Actor.objects.get(id=obj.actor_id)
+
+    @classmethod
+    def resolve_many(cls, actors: Sequence[ActorTuple]) -> Sequence[Team | RpcUser]:
+        """
+        Resolve multiple actors at the same time. Returns the result in the same order
+        as the input, minus any actors we couldn't resolve.
+        :param actors:
+        :return:
+        """
+        from sentry.models.user import User
+
+        if not actors:
+            return []
+
+        actors_by_type = defaultdict(list)
+        for actor in actors:
+            actors_by_type[actor.type].append(actor)
+
+        results = {}
+        for model_class, _actors in actors_by_type.items():
+            if model_class == User:
+                for instance in user_service.get_many(filter={"user_ids": [a.id for a in _actors]}):
+                    results[(model_class, instance.id)] = instance
+            else:
+                for instance in model_class.objects.filter(id__in=[a.id for a in _actors]):
+                    results[(model_class, instance.id)] = instance
+
+        return list(filter(None, [results.get((actor.type, actor.id)) for actor in actors]))
+
+
+@overload
+def fetch_actor_by_id(cls: type[User], id: int) -> RpcUser:
+    ...
+
+
+@overload
+def fetch_actor_by_id(cls: type[Team], id: int) -> Team:
+    ...
+
+
+def fetch_actor_by_id(cls: type[User] | type[Team], id: int) -> Team | RpcUser:
+    from sentry.models.team import Team
+    from sentry.models.user import User
+
+    if cls is Team:
+        return Team.objects.get(id=id)
+
+    elif cls is User:
+        user = user_service.get_user(id)
+        if user is None:
+            raise User.DoesNotExist()
+        return user
+    else:
+        raise ValueError(f"Cls {cls} is not a valid actor type.")

--- a/src/sentry/utils/actor.py
+++ b/src/sentry/utils/actor.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, overload
 
 from rest_framework import serializers
 
-from sentry.services.hybrid_cloud.user.service import user_service
-
 if TYPE_CHECKING:
     from sentry.models.actor import Actor
     from sentry.models.team import Team
@@ -40,6 +38,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
     def from_actor_identifier(cls, actor_identifier: int | str | None) -> ActorTuple | None:
         from sentry.models.team import Team
         from sentry.models.user import User
+        from sentry.services.hybrid_cloud.user.service import user_service
 
         """
         Returns an Actor tuple corresponding to a User or Team associated with
@@ -124,6 +123,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
         :return:
         """
         from sentry.models.user import User
+        from sentry.services.hybrid_cloud.user.service import user_service
 
         if not actors:
             return []
@@ -157,6 +157,7 @@ def fetch_actor_by_id(cls: type[Team], id: int) -> Team:
 def fetch_actor_by_id(cls: type[User] | type[Team], id: int) -> Team | RpcUser:
     from sentry.models.team import Team
     from sentry.models.user import User
+    from sentry.services.hybrid_cloud.user.service import user_service
 
     if cls is Team:
         return Team.objects.get(id=id)

--- a/src/sentry/utils/actor.py
+++ b/src/sentry/utils/actor.py
@@ -14,12 +14,6 @@ if TYPE_CHECKING:
 
 
 class ActorTuple(namedtuple("Actor", "id type")):
-    """
-    This is an artifact from before we had the Actor model.
-    We want to eventually drop this model and merge functionality with Actor
-    This should happen more easily if we move GroupAssignee, GroupOwner, etc. to use the Actor model.
-    """
-
     @property
     def identifier(self):
         return f"{self.type.__name__.lower()}:{self.id}"

--- a/src/sentry/utils/actor.py
+++ b/src/sentry/utils/actor.py
@@ -101,6 +101,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
     def resolve_to_actor(self) -> Actor:
         from sentry.models.actor import Actor, get_actor_for_user
         from sentry.models.user import User
+        from sentry.services.hybrid_cloud.user import RpcUser
 
         obj = self.resolve()
         if isinstance(obj, (User, RpcUser)):

--- a/tests/sentry/api/endpoints/test_rule_snooze.py
+++ b/tests/sentry/api/endpoints/test_rule_snooze.py
@@ -4,12 +4,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from sentry import audit_log
-from sentry.models.actor import ActorTuple
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.services.hybrid_cloud.log.service import log_rpc_service
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
+from sentry.utils.actor import ActorTuple
 
 
 class BaseRuleSnoozeTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_team_alerts_triggered.py
+++ b/tests/sentry/api/endpoints/test_team_alerts_triggered.py
@@ -5,9 +5,9 @@ from sentry.incidents.models.incident import (
     IncidentActivityType,
     IncidentStatus,
 )
-from sentry.models.actor import ActorTuple
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.utils.actor import ActorTuple
 
 
 @freeze_time()

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -15,7 +15,6 @@ from sentry.api.helpers.group_index.update import (
 from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.issue_search import parse_search_query
 from sentry.models.activity import Activity
-from sentry.models.actor import ActorTuple
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupbookmark import GroupBookmark
@@ -30,6 +29,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
+from sentry.utils.actor import ActorTuple
 
 pytestmark = [requires_snuba]
 

--- a/tests/sentry/api/serializers/rest_framework/test_mentions.py
+++ b/tests/sentry/api/serializers/rest_framework/test_mentions.py
@@ -1,8 +1,8 @@
 from sentry.api.serializers.rest_framework.mentions import extract_user_ids_from_mentions
-from sentry.models.actor import ActorTuple
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.testutils.cases import TestCase
+from sentry.utils.actor import ActorTuple
 
 
 class ExtractUserIdsFromMentionsTest(TestCase):

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -2,7 +2,6 @@ from uuid import uuid4
 
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
-from sentry.models.actor import ActorTuple
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.dashboard import Dashboard
@@ -30,6 +29,7 @@ from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
+from sentry.utils.actor import ActorTuple
 
 
 class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -75,7 +75,7 @@ from sentry.incidents.models.incident import (
 from sentry.incidents.utils.types import AlertRuleActivationConditionType
 from sentry.integrations.discord.utils.channel import ChannelType
 from sentry.integrations.pagerduty.utils import add_service
-from sentry.models.actor import ActorTuple, get_actor_for_user
+from sentry.models.actor import get_actor_for_user
 from sentry.models.group import GroupStatus
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.integration.serial import serialize_integration
@@ -90,6 +90,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
 from sentry.utils import json
+from sentry.utils.actor import ActorTuple
 
 pytestmark = [pytest.mark.sentry_metrics]
 

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from unittest.mock import patch
 
-from sentry.models.actor import ActorTuple, get_actor_for_user
+from sentry.models.actor import get_actor_for_user
 from sentry.models.environment import Environment, EnvironmentProject
 from sentry.models.grouplink import GroupLink
 from sentry.models.integrations.external_issue import ExternalIssue
@@ -30,6 +30,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.integrations import ExternalProviders
+from sentry.utils.actor import ActorTuple
 
 
 class ProjectTest(APITestCase, TestCase):

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-from sentry.models.actor import ActorTuple
 from sentry.models.avatars.user_avatar import UserAvatar
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupowner import GroupOwner, GroupOwnerType, OwnerRuleType
@@ -14,6 +13,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
+from sentry.utils.actor import ActorTuple
 
 pytestmark = requires_snuba
 


### PR DESCRIPTION
We want to use `ActorTuple` in the issue platform, but it causes a lot of import loops currently. Moving this to a separate place so it can more easily be imported