### PR TITLE
fix(replay): Filter empty querystring params from replay list api call

### DIFF
--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -40,7 +40,7 @@ export const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
 //      [0]: https://tanstack.com/query/v4/docs/guides/query-cancellation#default-behavior
 const PERSIST_IN_FLIGHT = true;
 
-type QueryKeyEndpointOptions<
+export type QueryKeyEndpointOptions<
   Headers = Record<string, string>,
   Query = Record<string, any>,
   Data = Record<string, any>,

--- a/static/app/utils/replays/hooks/useFetchReplayList.ts
+++ b/static/app/utils/replays/hooks/useFetchReplayList.ts
@@ -3,7 +3,11 @@ import {useMemo} from 'react';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import type {Organization} from 'sentry/types';
 import {uniq} from 'sentry/utils/array/uniq';
-import {type ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
+import {
+  type ApiQueryKey,
+  type QueryKeyEndpointOptions,
+  useApiQuery,
+} from 'sentry/utils/queryClient';
 import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
 import {
   REPLAY_LIST_FIELDS,
@@ -11,8 +15,20 @@ import {
   type ReplayListRecord,
 } from 'sentry/views/replays/types';
 
+interface QueryOptions {
+  cursor?: string;
+  end?: string;
+  environment?: string[];
+  project?: string[];
+  query?: string;
+  sort?: string;
+  start?: string;
+  statsPeriod?: string;
+  utc?: string;
+}
+
 type Options = {
-  options: ApiQueryKey[1];
+  options: QueryKeyEndpointOptions<Record<string, string>, QueryOptions, never>;
   organization: Organization;
   queryReferrer: ReplayListQueryReferrer;
 };
@@ -40,13 +56,17 @@ export default function useFetchReplayList({
       queryReferrer === 'issueReplays' || queryReferrer === 'transactionReplays'
         ? ALL_ACCESS_PROJECTS
         : originalProject;
+
+    const query = Object.fromEntries(
+      Object.entries(options.query).filter(([_key, val]) => val !== '')
+    );
     return [
       url,
       {
         ...options,
         query: {
           per_page: 50,
-          ...options.query,
+          ...query,
           fields,
           project,
           queryReferrer,

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -24,12 +24,20 @@ function ReplaysList() {
   const query = useLocationQuery({
     fields: {
       cursor: decodeScalar,
+      end: decodeScalar,
+      environment: decodeList,
       project: decodeList,
       query: decodeScalar,
       sort: value => decodeScalar(value, '-started_at'),
+      start: decodeScalar,
       statsPeriod: decodeScalar,
+      utc: decodeScalar,
     },
   });
+  const filteredQuery = useMemo(
+    () => Object.fromEntries(Object.entries(query).filter(([_key, val]) => val !== '')),
+    [query]
+  );
 
   const {
     data: replays,
@@ -37,7 +45,7 @@ function ReplaysList() {
     isLoading,
     error,
   } = useFetchReplayList({
-    options: {query},
+    options: {query: filteredQuery},
     organization,
     queryReferrer: 'replayList',
   });

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -34,10 +34,6 @@ function ReplaysList() {
       utc: decodeScalar,
     },
   });
-  const filteredQuery = useMemo(
-    () => Object.fromEntries(Object.entries(query).filter(([_key, val]) => val !== '')),
-    [query]
-  );
 
   const {
     data: replays,
@@ -45,7 +41,7 @@ function ReplaysList() {
     isLoading,
     error,
   } = useFetchReplayList({
-    options: {query: filteredQuery},
+    options: {query},
     organization,
     queryReferrer: 'replayList',
   });


### PR DESCRIPTION
Following up on https://github.com/getsentry/sentry/pull/68849

This filters empty query params, which don't need to be sent to the server. Also in #68849 i missed a few important fields in the list.