### PR TITLE
ref(spans): Remove span module aliases as they are unused

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -112,7 +112,6 @@ SPAN_COLUMN_MAP = {
     "description": "description",
     "domain": "domain",
     "group": "group",
-    "module": "module",
     "id": "span_id",
     "parent_span": "parent_span_id",
     "platform": "platform",
@@ -123,7 +122,6 @@ SPAN_COLUMN_MAP = {
     # DO NOT directly expose span.duration, we should always use the alias
     # "span.duration": "duration",
     "span.group": "group",
-    "span.module": "module",
     "span.op": "op",
     "span.self_time": "exclusive_time",
     "span.status": "span_status",
@@ -837,7 +835,8 @@ SnubaQuery = Union[Request, MutableMapping[str, Any]]
 Translator = Callable[[Any], Any]
 RequestQueryBody = tuple[Request, Translator, Translator]
 LegacyQueryBody = tuple[MutableMapping[str, Any], Translator, Translator]
-ResultSet = list[Mapping[str, Any]]  # TODO: Would be nice to make this a concrete structure
+# TODO: Would be nice to make this a concrete structure
+ResultSet = list[Mapping[str, Any]]
 
 
 def raw_snql_query(
@@ -1503,9 +1502,14 @@ def get_snuba_translators(filter_keys, is_grouprelease=False):
     """
 
     # Helper lambdas to compose translator functions
-    identity = lambda x: x
-    compose = lambda f, g: lambda x: f(g(x))
-    replace = lambda d, key, val: d.update({key: val}) or d
+    def identity(x):
+        return x
+
+    def compose(f, g):
+        return lambda x: f(g(x))
+
+    def replace(d, key, val):
+        return d.update({key: val}) or d
 
     forward = identity
     reverse = identity


### PR DESCRIPTION
`module` is unused and the column in Snuba will be deleted.

`span.module` is computed with https://github.com/getsentry/sentry/blob/7a44b756da14e601f0389418f69bd6cae25d0587/src/sentry/search/events/datasets/field_aliases.py#L87C5-L124 so the alias in that map is not used.

Both can be removed.