### PR TITLE
feat(ui): Align keyValueTable keys to the center

### DIFF
--- a/static/app/components/keyValueTable.tsx
+++ b/static/app/components/keyValueTable.tsx
@@ -46,6 +46,8 @@ const commonStyles = ({theme, type}: {type: Props['type']} & {theme: Theme}) => 
 
 const Key = styled('dt')<{type: Props['type']}>`
   ${commonStyles};
+  display: flex;
+  align-items: center;
   color: ${p => p.theme.textColor};
 `;
 


### PR DESCRIPTION
Not 100% sure we want this, but it fixes things like this

Before:
<img alt="clipboard.png" width="335" src="https://i.imgur.com/YMlu7Mg.png" />

After:
<img alt="clipboard.png" width="334" src="https://i.imgur.com/W6bD4IJ.png" />