### PR TITLE
ref(replays): hide console tab for mobile replays

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -25,6 +25,11 @@ function getReplayTabs({
   // The new trace table inside Breadcrumb items:
   const hasTraceTable = organization.features.includes('session-replay-trace-table');
 
+  // For video replays, we hide the console, a11y, trace, and memory tabs
+  // The console tab isn't useful for video replays; most of the useful logging
+  // context will come from breadcrumbs
+  // A11y, trace, and memory aren't applicable for mobile
+
   return {
     [TabKey.BREADCRUMBS]: t('Breadcrumbs'),
     [TabKey.CONSOLE]: isVideoReplay ? null : t('Console'),

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -27,7 +27,7 @@ function getReplayTabs({
 
   return {
     [TabKey.BREADCRUMBS]: t('Breadcrumbs'),
-    [TabKey.CONSOLE]: t('Console'),
+    [TabKey.CONSOLE]: isVideoReplay ? null : t('Console'),
     [TabKey.NETWORK]: t('Network'),
     [TabKey.ERRORS]: t('Errors'),
     [TabKey.TRACE]: hasTraceTable || isVideoReplay ? null : t('Trace'),


### PR DESCRIPTION
hiding because we decided the console tab isn't useful for video replays; most useful logging context will come from breadcrumbs instead

<img width="1046" alt="SCR-20240416-kdcu" src="https://github.com/getsentry/sentry/assets/56095982/b7f41cd2-54a0-4c52-8515-6b2ada4968d1">
