### PR TITLE
feat(integrations): add endpoint for rotating client secret of Internal/Public integrations

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/__init__.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/__init__.py
@@ -15,6 +15,7 @@ from .internal_app_token.index import SentryInternalAppTokensEndpoint
 from .organization_sentry_apps import OrganizationSentryAppsEndpoint
 from .publish_request import SentryAppPublishRequestEndpoint
 from .requests import SentryAppRequestsEndpoint
+from .rotate_secret import SentryAppRotateSecretEndpoint
 from .stats.details import SentryAppStatsEndpoint
 from .stats.index import SentryAppsStatsEndpoint
 
@@ -34,6 +35,7 @@ __all__ = (
     "SentryAppInteractionEndpoint",
     "SentryAppPublishRequestEndpoint",
     "SentryAppRequestsEndpoint",
+    "SentryAppRotateSecretEndpoint",
     "SentryAppsEndpoint",
     "SentryAppsStatsEndpoint",
     "SentryAppStatsEndpoint",

--- a/src/sentry/api/endpoints/integrations/sentry_apps/rotate_secret.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/rotate_secret.py
@@ -10,7 +10,7 @@ from sentry.api.permissions import SentryPermission
 from sentry.api.serializers import serialize
 from sentry.models.apiapplication import generate_token
 from sentry.models.integrations.sentry_app import SentryApp
-from sentry.models.organization import Organization
+from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.user.service import user_service
 
 
@@ -21,7 +21,7 @@ class SentryAppRotateSecretPermission(SentryPermission):
 
     def has_object_permission(self, request: Request, view: object, sentry_app: SentryApp):
         # organization that owns an integration
-        organization = Organization.objects.get(id=sentry_app.owner_id)
+        organization = organization_service.get_org_by_id(id=sentry_app.owner_id)
 
         # if user is not a member of an organization owning an integration,
         # return 404 to avoid leaking integration slug

--- a/src/sentry/api/endpoints/integrations/sentry_apps/rotate_secret.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/rotate_secret.py
@@ -58,7 +58,7 @@ class SentryAppRotateSecretEndpoint(SentryAppBaseEndpoint):
 
     def post(self, request: Request, sentry_app: SentryApp) -> Response:
         if sentry_app.application is None:
-            return Response(status=404)
+            return Response({"detail": "Corresponding application was not found."}, status=404)
 
         new_token = generate_token()
         sentry_app.application.update(client_secret=new_token)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -282,6 +282,7 @@ from .endpoints.integrations.sentry_apps import (
     SentryAppInteractionEndpoint,
     SentryAppPublishRequestEndpoint,
     SentryAppRequestsEndpoint,
+    SentryAppRotateSecretEndpoint,
     SentryAppsEndpoint,
     SentryAppsStatsEndpoint,
     SentryAppStatsEndpoint,
@@ -2837,6 +2838,11 @@ SENTRY_APP_URLS = [
         r"^(?P<sentry_app_slug>[^\/]+)/api-tokens/(?P<api_token_id>[^\/]+)/$",
         SentryInternalAppTokenDetailsEndpoint.as_view(),
         name="sentry-api-0-sentry-internal-app-token-details",
+    ),
+    re_path(
+        r"^(?P<sentry_app_slug>[^\/]+)/rotate-secret/$",
+        SentryAppRotateSecretEndpoint.as_view(),
+        name="sentry-api-0-sentry-app-rotate-secret",
     ),
     re_path(
         r"^(?P<sentry_app_slug>[^\/]+)/stats/$",

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -94,6 +94,7 @@ const patterns: RegExp[] = [
   new RegExp('^api/0/sentry-apps/[^/]+/avatar/$'),
   new RegExp('^api/0/sentry-apps/[^/]+/api-tokens/$'),
   new RegExp('^api/0/sentry-apps/[^/]+/api-tokens/[^/]+/$'),
+  new RegExp('^api/0/sentry-apps/[^/]+/rotate-secret/$'),
   new RegExp('^api/0/sentry-apps/[^/]+/stats/$'),
   new RegExp('^api/0/sentry-apps/[^/]+/publish-request/$'),
   new RegExp('^api/0/sentry-app-installations/[^/]+/$'),

--- a/tests/sentry/api/endpoints/test_sentry_app_rotate_secret.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_rotate_secret.py
@@ -1,0 +1,62 @@
+from django.urls import reverse
+
+from sentry.models.apiapplication import ApiApplication
+from sentry.models.integrations.sentry_app import SentryApp
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class SentryAppRotateSecretTest(APITestCase):
+    def setUp(self):
+        self.application = ApiApplication.objects.create(owner=self.user)
+        self.sentry_app = SentryApp.objects.create(
+            application=self.application, owner_id=self.organization.id, name="a", slug="a"
+        )
+        self.url = reverse("sentry-api-0-sentry-app-rotate-secret", args=[self.sentry_app.slug])
+
+    def test_unauthenticated_call(self):
+        response = self.client.post(self.url)
+        assert response.status_code == 401
+
+    def test_member_call(self):
+        """
+        Tests that a low privileged user from the same org cannot rotate a secret.
+        """
+        other_user = self.create_user()
+        other_member = self.create_member(
+            user=other_user, organization=self.organization, role="member"
+        )
+        self.login_as(other_member)
+        response = self.client.post(self.url)
+        assert response.status_code == 403
+
+    def test_non_owner_call(self):
+        """
+        Tests that an authenticated user cannot rotate the secret for an app from other org.
+        """
+        self.login_as(self.user)
+        other_user = self.create_user()
+        other_org = self.create_organization(owner=other_user)
+        other_app = ApiApplication.objects.create(owner=other_user, name="b")
+        other_sentry_app = SentryApp.objects.create(
+            application=other_app, owner_id=other_org.id, name="b", slug="b"
+        )
+        response = self.client.post(
+            reverse("sentry-api-0-sentry-app-rotate-secret", args=[other_sentry_app.slug])
+        )
+        assert response.status_code == 404
+
+    def test_invalid_app_id(self):
+        self.login_as(self.user)
+        path_with_invalid_id = reverse("sentry-api-0-sentry-app-rotate-secret", args=["invalid"])
+        response = self.client.post(path_with_invalid_id)
+        assert response.status_code == 404
+
+    def test_valid_call(self):
+        self.login_as(self.user)
+        old_secret = self.sentry_app.application.client_secret
+        response = self.client.post(self.url)
+        new_secret = response.data["clientSecret"]
+        assert len(new_secret) == len(old_secret)
+        assert new_secret != old_secret

--- a/tests/sentry/api/endpoints/test_sentry_app_rotate_secret.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_rotate_secret.py
@@ -69,3 +69,14 @@ class SentryAppRotateSecretTest(APITestCase):
         new_secret = response.data["clientSecret"]
         assert len(new_secret) == len(old_secret)
         assert new_secret != old_secret
+
+    def test_no_corresponding_application_found(self):
+        self.login_as(self.user)
+        other_sentry_app = SentryApp.objects.create(
+            application=None, owner_id=self.organization.id, name="c", slug="c"
+        )
+        response = self.client.post(
+            reverse("sentry-api-0-sentry-app-rotate-secret", args=[other_sentry_app.slug])
+        )
+        assert response.status_code == 404
+        assert "Corresponding application was not found." in response.data["detail"]

--- a/tests/sentry/api/endpoints/test_sentry_app_rotate_secret.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_rotate_secret.py
@@ -60,3 +60,12 @@ class SentryAppRotateSecretTest(APITestCase):
         new_secret = response.data["clientSecret"]
         assert len(new_secret) == len(old_secret)
         assert new_secret != old_secret
+
+    def test_superuser_has_access(self):
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(user=superuser, superuser=True)
+        old_secret = self.sentry_app.application.client_secret
+        response = self.client.post(self.url)
+        new_secret = response.data["clientSecret"]
+        assert len(new_secret) == len(old_secret)
+        assert new_secret != old_secret


### PR DESCRIPTION
Adding an endpoint that allows to rotate `clientSecret` of Internal/Public integrations.
Inspired by https://github.com/getsentry/sentry/pull/53124