### PR TITLE
feat(issue-platform): Allow assignee to be passed with the occurrence

### DIFF
--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -38,9 +38,11 @@ class IssueOccurrenceData(TypedDict):
     level: str | None
     culprit: str | None
     initial_issue_priority: NotRequired[int | None]
-    # Who to assign the issue to when creating a new issue. Has no effect on existing issues.
-    # In the format of an Actor identifier, as defined in `ActorTuple.from_actor_identifier`
     assignee: NotRequired[str | None]
+    """
+    Who to assign the issue to when creating a new issue. Has no effect on existing issues.
+    In the format of an Actor identifier, as defined in `ActorTuple.from_actor_identifier`
+    """
 
 
 @dataclass(frozen=True)

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -10,6 +11,7 @@ from django.utils.timezone import is_aware
 
 from sentry import nodestore
 from sentry.issues.grouptype import GroupType, get_group_type_by_type_id
+from sentry.utils.actor import ActorTuple
 from sentry.utils.dates import parse_timestamp
 
 DEFAULT_LEVEL = "info"
@@ -36,6 +38,9 @@ class IssueOccurrenceData(TypedDict):
     level: str | None
     culprit: str | None
     initial_issue_priority: NotRequired[int | None]
+    # Who to assign the issue to when creating a new issue. Has no effect on existing issues.
+    # In the format of an Actor identifier, as defined in `ActorTuple.from_actor_identifier`
+    assignee: NotRequired[str | None]
 
 
 @dataclass(frozen=True)
@@ -88,6 +93,7 @@ class IssueOccurrence:
     level: str
     culprit: str
     initial_issue_priority: int | None = None
+    assignee: ActorTuple | None = None
 
     def __post_init__(self) -> None:
         if not is_aware(self.detection_time):
@@ -111,10 +117,13 @@ class IssueOccurrence:
             "level": self.level,
             "culprit": self.culprit,
             "initial_issue_priority": self.initial_issue_priority,
+            "assignee": self.assignee.identifier if self.assignee else None,
         }
 
     @classmethod
     def from_dict(cls, data: IssueOccurrenceData) -> IssueOccurrence:
+        from sentry.api.serializers.rest_framework import ValidationError
+
         # Backwards compatibility - we used to not require this field, so set a default when `None`
         level = data.get("level")
         if not level:
@@ -122,6 +131,18 @@ class IssueOccurrence:
         culprit = data.get("culprit")
         if not culprit:
             culprit = ""
+
+        assignee = None
+        try:
+            # Note that this can cause IO, but in practice this will happen only the first time that
+            # the occurrence is sent to the issue platform. We then translate to the id and store
+            # that, so subsequent fetches won't cause IO.
+            assignee = ActorTuple.from_actor_identifier(data.get("assignee"))
+        except ValidationError:
+            logging.exception("Failed to parse assignee actor identifier")
+        except Exception:
+            # We never want this to cause parsing an occurrence to fail
+            logging.exception("Unexpected error parsing assignee")
         return cls(
             data["id"],
             data["project_id"],
@@ -141,6 +162,7 @@ class IssueOccurrence:
             level,
             culprit,
             data.get("initial_issue_priority"),
+            assignee,
         )
 
     @property

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -154,6 +154,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                 "type": payload["type"],
                 "detection_time": payload["detection_time"],
                 "level": payload.get("level", DEFAULT_LEVEL),
+                "assignee": payload.get("assignee"),
             }
 
             process_occurrence_data(occurrence_data)

--- a/src/sentry/utils/actor.py
+++ b/src/sentry/utils/actor.py
@@ -47,7 +47,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
             "maisey@dogsrule.com" -> look up User by primary email
         """
 
-        if actor_identifier is None:
+        if not actor_identifier:
             return None
 
         # If we have an integer, fall back to assuming it's a User

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -458,3 +458,21 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
         message["initial_issue_priority"] = PriorityLevel.HIGH
         kwargs = _get_kwargs(message)
         assert kwargs["occurrence_data"]["initial_issue_priority"] == PriorityLevel.HIGH
+
+    def test_assignee(self) -> None:
+        message = deepcopy(get_test_message(self.project.id))
+        message["assignee"] = f"user:{self.user.id}"
+        kwargs = _get_kwargs(message)
+        assert kwargs["occurrence_data"]["assignee"] == f"user:{self.user.id}"
+
+    def test_assignee_none(self) -> None:
+        kwargs = _get_kwargs(deepcopy(get_test_message(self.project.id)))
+        assert kwargs["occurrence_data"]["assignee"] is None
+        message = deepcopy(get_test_message(self.project.id))
+        message["assignee"] = None
+        kwargs = _get_kwargs(message)
+        assert kwargs["occurrence_data"]["assignee"] is None
+        message = deepcopy(get_test_message(self.project.id))
+        message["assignee"] = ""
+        kwargs = _get_kwargs(message)
+        assert kwargs["occurrence_data"]["assignee"] == ""


### PR DESCRIPTION
We want to allow issue platform customers to specify who should be assigned to the issues created from their occurrences. This assignee will only be used when creating a new issue, it won't change the assignee of an existing issue.

Assignees can be team or user. We already have a format for passing this via the API, so I'm using this here too. The Actor format (separate from the `Actor` model which is being removed) allows us to specify the assignee in a structured way. The format is defined here: https://github.com/getsentry/sentry/blob/ef66c637e6a69de97552a1fd6b200e16939afa94/src/sentry/utils/actor.py#L41-L47

<!-- Describe your PR here. -->