### PR TITLE
chore(alerts): move weekly summary Monday -> Saturday

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1108,7 +1108,7 @@ CELERYBEAT_SCHEDULE_REGION = {
     "schedule-weekly-organization-reports-new": {
         "task": "sentry.tasks.summaries.weekly_reports.schedule_organizations",
         # 05:00 PDT, 09:00 EDT, 12:00 UTC
-        "schedule": crontab(minute="0", hour="12", day_of_week="monday"),
+        "schedule": crontab(minute="0", hour="12", day_of_week="saturday"),
         "options": {"expires": 60 * 60 * 3},
     },
     "schedule-daily-organization-reports": {


### PR DESCRIPTION
Moving weekly summary schedule as agreed in [ClickHouse capacity DACI action items](https://www.notion.so/sentry/DACI-How-do-we-get-more-headroom-on-errors-abb2f34c5abf4b7b8368512325fc9d0f?pvs=4#b0394538de184c7291ea1348a65352aa).

I've validated that the report dates in title are generated dynamically, with [end date](https://github.com/getsentry/sentry/blob/7a29224de8550bdf31dc763a7e72920024f986f0/src/sentry/tasks/summaries/weekly_reports.py#L68) being `floor_to_utc_day(timezone.now())`  and [start date](https://github.com/getsentry/sentry/blob/7a29224de8550bdf31dc763a7e72920024f986f0/src/sentry/tasks/summaries/utils.py#L41) being end - 7 days. 