### PR TITLE
fix(replays): Use project event permission class in viewed-by resource

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_viewed_by.py
+++ b/src/sentry/replays/endpoints/project_replay_viewed_by.py
@@ -9,7 +9,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.replay_examples import ReplayExamples
 from sentry.apidocs.parameters import GlobalParams, ReplayParams
@@ -34,6 +34,7 @@ class ReplayViewedByResponse(TypedDict):
 class ProjectReplayViewedByEndpoint(ProjectEndpoint):
     owner = ApiOwner.REPLAY
     publish_status = {"GET": ApiPublishStatus.PUBLIC, "POST": ApiPublishStatus.PRIVATE}
+    permission_classes = (ProjectEventPermission,)
 
     @extend_schema(
         operation_id="Get list of user who have viewed a replay",


### PR DESCRIPTION
Fixes the 403 errors we're seeing.