### PR TITLE
feat(trace-explorer): Add trace breakdowns to trace response

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -1,11 +1,13 @@
 from collections import defaultdict
 from collections.abc import Mapping
 from datetime import datetime, timedelta
-from typing import Any, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast
 
+import sentry_sdk
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
+from snuba_sdk import Column, Condition, Op
 
 from sentry import options
 from sentry.api.api_owners import ApiOwner
@@ -19,6 +21,14 @@ from sentry.search.events.builder import SpansIndexedQueryBuilder
 from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
+from sentry.utils.snuba import bulk_snql_query
+
+
+class TraceInterval(TypedDict):
+    project: str | None
+    start: int
+    end: int
+    kind: Literal["project", "missing", "unknown"]
 
 
 class TraceResult(TypedDict):
@@ -26,6 +36,9 @@ class TraceResult(TypedDict):
     numSpans: int
     name: str | None
     duration: int
+    start: int
+    end: int
+    breakdowns: list[TraceInterval]
     spans: list[Mapping[str, Any]]
 
 
@@ -118,34 +131,90 @@ class OrganizationTracesEndpoint(OrganizationEventsV2EndpointBase):
             snuba_params.start = min_timestamp - buffer
             snuba_params.end = max_timestamp + buffer
 
+            trace_condition = f"trace:[{', '.join(spans_by_trace.keys())}]"
+
             with handle_query_errors():
-                builder = SpansIndexedQueryBuilder(
+                breakdowns_query = SpansIndexedQueryBuilder(
                     Dataset.SpansIndexed,
                     cast(ParamsType, params),
                     snuba_params=snuba_params,
-                    query=f"trace:[{', '.join(spans_by_trace.keys())}]",
-                    selected_columns=["trace", "count()", "trace_name()", "elapsed()"],
-                    limit=len(spans_by_trace),
+                    query=f"{trace_condition}",
+                    selected_columns=[
+                        "trace",
+                        "project",
+                        "transaction",
+                        "first_seen()",
+                        "last_seen()",
+                    ],
+                    orderby=["first_seen()", "last_seen()"],
+                    # limit the number of segments we fetch per trace so a single
+                    # large trace does not result in the rest being blank
+                    limitby=("trace", int(10_000 / len(spans_by_trace))),
                     config=QueryBuilderConfig(
-                        functions_acl=["trace_name", "elapsed"],
+                        functions_acl=["trace_name", "first_seen", "last_seen"],
                         transform_alias_to_input_format=True,
                     ),
                 )
-                trace_results = builder.run_query(Referrer.API_TRACE_EXPLORER_TRACES_META.value)
-                trace_results = builder.process_results(trace_results)
+                # TODO: this should be `is_transaction:1` but there's some
+                # boolean mapping that's not working for this field
+                breakdowns_query.add_conditions(
+                    [
+                        Condition(Column("is_segment"), Op.EQ, 1),
+                    ]
+                )
+
+            with handle_query_errors():
+                traces_meta_query = SpansIndexedQueryBuilder(
+                    Dataset.SpansIndexed,
+                    cast(ParamsType, params),
+                    snuba_params=snuba_params,
+                    query=trace_condition,
+                    selected_columns=[
+                        "trace",
+                        "count()",
+                        "trace_name()",
+                        "first_seen()",
+                        "last_seen()",
+                    ],
+                    limit=len(spans_by_trace),
+                    config=QueryBuilderConfig(
+                        functions_acl=["trace_name", "first_seen", "last_seen"],
+                        transform_alias_to_input_format=True,
+                    ),
+                )
+
+            with handle_query_errors():
+                results = bulk_snql_query(
+                    [
+                        breakdowns_query.get_snql_query(),
+                        traces_meta_query.get_snql_query(),
+                    ],
+                    Referrer.API_TRACE_EXPLORER_TRACES_META.value,
+                )
+                breakdowns_results = breakdowns_query.process_results(results[0])
+                traces_meta_results = traces_meta_query.process_results(results[1])
+
+            try:
+                breakdowns = process_breakdowns(breakdowns_results["data"])
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
+                breakdowns = defaultdict(list)
 
             traces: list[TraceResult] = [
                 {
                     "trace": row["trace"],
                     "numSpans": row["count()"],
                     "name": row["trace_name()"],
-                    "duration": row["elapsed()"],
+                    "duration": row["last_seen()"] - row["first_seen()"],
+                    "start": row["first_seen()"],
+                    "end": row["last_seen()"],
+                    "breakdowns": breakdowns[row["trace"]],
                     "spans": [
                         {field: span[field] for field in serialized["field"]}
                         for span in spans_by_trace[row["trace"]]
                     ],
                 }
-                for row in trace_results["data"]
+                for row in traces_meta_results["data"]
             ]
 
             return {"data": traces, "meta": meta}
@@ -162,3 +231,105 @@ class OrganizationTracesEndpoint(OrganizationEventsV2EndpointBase):
                 dataset=Dataset.SpansIndexed,
             ),
         )
+
+
+def process_breakdowns(data):
+    trace_stacks: Mapping[str, list[TraceInterval]] = defaultdict(list)
+    breakdowns_by_trace: Mapping[str, list[TraceInterval]] = defaultdict(list)
+
+    def breakdown_append(breakdown, interval):
+        breakdown.append(interval)
+
+    def stack_pop(stack):
+        interval = stack.pop()
+        if stack:
+            # when popping an interval off the stack, it means that we've
+            # consumed up to this point in time, so we update the transaction
+            # above it to the remaining interval
+            stack[-1]["start"] = interval["end"]
+        return interval
+
+    def stack_clear(breakdown, stack, until=None):
+        interval = None
+        while stack:
+            if until is not None and stack[-1]["end"] > until:
+                break
+
+            item = stack_pop(stack)
+
+            # While popping the stack, we adjust the start
+            # of the intervals in the stack, so it's possible
+            # we produce an invalid interval. Make sure to
+            # filter them out here
+            if item["start"] <= item["end"]:
+                interval = item
+                breakdown_append(breakdown, interval)
+        return interval
+
+    for row in data:
+        stack = trace_stacks[row["trace"]]
+        cur: TraceInterval = {
+            "project": row["project"],
+            "start": row["first_seen()"],
+            "end": row["last_seen()"],
+            "kind": "project",
+        }
+
+        # nothing on the stack yet, so directly push onto
+        # stack and wait for next item to come so an
+        # interval can be determined
+        if not stack:
+            stack.append(cur)
+            continue
+
+        breakdown = breakdowns_by_trace[row["trace"]]
+        prev = stack[-1]
+        if prev["end"] <= cur["start"]:
+            # This implies there's no overlap between this transaction
+            # and the previous transaction. So we're done with the whole stack
+
+            last = stack_clear(breakdown, stack, until=cur["start"])
+
+            # if there's a gap between prev end and cur start
+            if not stack or stack[-1]["end"] < cur["start"]:
+                if last is not None and last["end"] < cur["start"]:
+                    breakdown_append(
+                        breakdown,
+                        {
+                            "project": None,
+                            "start": prev["end"],
+                            "end": cur["start"],
+                            "kind": "missing",
+                        },
+                    )
+        elif prev["project"] == cur["project"]:
+            # If the intervals are in the same project,
+            # we need to merge them into the same interval.
+            new_end = max(prev["end"], cur["end"])
+            prev["end"] = new_end
+            continue
+        else:
+            # This imples that there is some overlap between this transaction
+            # and the previous transaction. So we need push the interval up to
+            # the current item to the breakdown.
+
+            breakdown_append(
+                breakdown,
+                {
+                    "project": prev["project"],
+                    "start": prev["start"],
+                    "end": cur["start"],
+                    "kind": "project",
+                },
+            )
+
+            if prev["end"] <= cur["end"]:
+                stack_pop(stack)
+
+        stack.append(cur)
+
+    for trace, stack in trace_stacks.items():
+        breakdown = breakdowns_by_trace[trace]
+        stack_clear(breakdown, stack)
+
+    return breakdowns_by_trace

--- a/src/sentry/search/events/datasets/spans_indexed.py
+++ b/src/sentry/search/events/datasets/spans_indexed.py
@@ -254,19 +254,20 @@ class SpansIndexedDatasetConfig(DatasetConfig):
                     private=True,
                 ),
                 SnQLFunction(
-                    "elapsed",
+                    "first_seen",
                     snql_aggregate=lambda args, alias: Function(
-                        "minus",
-                        [
-                            Function(
-                                "max",
-                                [self._resolve_timestamp_with_ms("end_timestamp", "end_ms")],
-                            ),
-                            Function(
-                                "min",
-                                [self._resolve_timestamp_with_ms("start_timestamp", "start_ms")],
-                            ),
-                        ],
+                        "min",
+                        [self._resolve_timestamp_with_ms("start_timestamp", "start_ms")],
+                        alias,
+                    ),
+                    default_result_type="duration",
+                    private=True,
+                ),
+                SnQLFunction(
+                    "last_seen",
+                    snql_aggregate=lambda args, alias: Function(
+                        "max",
+                        [self._resolve_timestamp_with_ms("end_timestamp", "end_ms")],
                         alias,
                     ),
                     default_result_type="duration",

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -1,8 +1,10 @@
 from uuid import uuid4
 
+import pytest
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
+from sentry.api.endpoints.organization_traces import process_breakdowns
 from sentry.testutils.cases import APITestCase, BaseSpansTestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -191,7 +193,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             "project": [self.project.id],
             "field": ["id", "parent_span"],
             "query": "foo:bar",
-            "maxSpansPerTrace": 3,
+            "maxSpansPerTrace": 2,
         }
 
         response = self.do_request(query)
@@ -224,6 +226,9 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     "numSpans": 4,
                     "name": "foo",
                     "duration": 60_100,
+                    "start": int(timestamps[0].timestamp() * 1000),
+                    "end": int(timestamps[0].timestamp() * 1000) + 60_100,
+                    "breakdown": [],
                     "spans": sorted(
                         [
                             # span_ids[1] does not match
@@ -238,6 +243,9 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     "numSpans": 3,
                     "name": "bar",
                     "duration": 90_123,
+                    "start": int(timestamps[4].timestamp() * 1000),
+                    "end": int(timestamps[4].timestamp() * 1000) + 90_123,
+                    "breakdown": [],
                     "spans": sorted(
                         [
                             {"id": span_ids[5], "parent_span": span_ids[4]},
@@ -249,3 +257,478 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             ],
             key=lambda trace: trace["trace"],  # type: ignore[arg-type, return-value]
         )
+        assert 0
+
+
+@pytest.mark.parametrize(
+    ["data", "expected"],
+    [
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 100,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 100,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="single transaction",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 100,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "bar",
+                    "transaction": "bar1",
+                    "first_seen()": 25,
+                    "last_seen()": 75,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 25,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "bar",
+                        "start": 25,
+                        "end": 75,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "foo",
+                        "start": 75,
+                        "end": 100,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="two transactions different project nested",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 75,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "bar",
+                    "transaction": "bar1",
+                    "first_seen()": 25,
+                    "last_seen()": 100,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 25,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "bar",
+                        "start": 25,
+                        "end": 100,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="two transactions different project overlapping",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 25,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "bar",
+                    "transaction": "bar1",
+                    "first_seen()": 50,
+                    "last_seen()": 75,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 25,
+                        "kind": "project",
+                    },
+                    {
+                        "project": None,
+                        "start": 25,
+                        "end": 50,
+                        "kind": "missing",
+                    },
+                    {
+                        "project": "bar",
+                        "start": 50,
+                        "end": 75,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="two transactions different project non overlapping",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 100,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo2",
+                    "first_seen()": 25,
+                    "last_seen()": 75,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 100,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="two transactions same project nested",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 75,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo2",
+                    "first_seen()": 25,
+                    "last_seen()": 100,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 100,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="two transactions same project overlapping",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 25,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo2",
+                    "first_seen()": 50,
+                    "last_seen()": 75,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 25,
+                        "kind": "project",
+                    },
+                    {
+                        "project": None,
+                        "start": 25,
+                        "end": 50,
+                        "kind": "missing",
+                    },
+                    {
+                        "project": "foo",
+                        "start": 50,
+                        "end": 75,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="two transactions same project non overlapping",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 100,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "bar",
+                    "transaction": "bar1",
+                    "first_seen()": 20,
+                    "last_seen()": 80,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "baz",
+                    "transaction": "baz1",
+                    "first_seen()": 40,
+                    "last_seen()": 60,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 20,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "bar",
+                        "start": 20,
+                        "end": 40,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "baz",
+                        "start": 40,
+                        "end": 60,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "bar",
+                        "start": 60,
+                        "end": 80,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "foo",
+                        "start": 80,
+                        "end": 100,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="three transactions different project nested",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 100,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "bar",
+                    "transaction": "bar1",
+                    "first_seen()": 25,
+                    "last_seen()": 50,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "baz",
+                    "transaction": "baz1",
+                    "first_seen()": 50,
+                    "last_seen()": 75,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 25,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "bar",
+                        "start": 25,
+                        "end": 50,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "baz",
+                        "start": 50,
+                        "end": 75,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "foo",
+                        "start": 75,
+                        "end": 100,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="three transactions different project 2 overlap the first",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 50,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "bar",
+                    "transaction": "bar1",
+                    "first_seen()": 20,
+                    "last_seen()": 30,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "baz",
+                    "transaction": "baz1",
+                    "first_seen()": 50,
+                    "last_seen()": 75,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 20,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "bar",
+                        "start": 20,
+                        "end": 30,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "foo",
+                        "start": 30,
+                        "end": 50,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "baz",
+                        "start": 50,
+                        "end": 75,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="three transactions different project 1 overlap the first and other non overlap",
+        ),
+        pytest.param(
+            [
+                {
+                    "trace": "a" * 32,
+                    "project": "foo",
+                    "transaction": "foo1",
+                    "first_seen()": 0,
+                    "last_seen()": 50,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "bar",
+                    "transaction": "bar1",
+                    "first_seen()": 20,
+                    "last_seen()": 30,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "baz",
+                    "transaction": "baz1",
+                    "first_seen()": 40,
+                    "last_seen()": 60,
+                },
+            ],
+            {
+                "a"
+                * 32: [
+                    {
+                        "project": "foo",
+                        "start": 0,
+                        "end": 20,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "bar",
+                        "start": 20,
+                        "end": 30,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "baz",
+                        "start": 40,
+                        "end": 60,
+                        "kind": "project",
+                    },
+                ],
+            },
+            id="three transactions different project 2 overlap and second extend past parent",
+        ),
+    ],
+)
+def test_process_breakdowns(data, expected):
+    assert process_breakdowns(data) == expected

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -228,7 +228,14 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     "duration": 60_100,
                     "start": int(timestamps[0].timestamp() * 1000),
                     "end": int(timestamps[0].timestamp() * 1000) + 60_100,
-                    "breakdown": [],
+                    "breakdowns": [
+                        {
+                            "project": self.project.slug,
+                            "start": int(timestamps[0].timestamp() * 1000),
+                            "end": int(timestamps[0].timestamp() * 1000) + 60_100,
+                            "kind": "project",
+                        },
+                    ],
                     "spans": sorted(
                         [
                             # span_ids[1] does not match
@@ -245,7 +252,14 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     "duration": 90_123,
                     "start": int(timestamps[4].timestamp() * 1000),
                     "end": int(timestamps[4].timestamp() * 1000) + 90_123,
-                    "breakdown": [],
+                    "breakdowns": [
+                        {
+                            "project": self.project.slug,
+                            "start": int(timestamps[4].timestamp() * 1000),
+                            "end": int(timestamps[4].timestamp() * 1000) + 90_123,
+                            "kind": "project",
+                        },
+                    ],
                     "spans": sorted(
                         [
                             {"id": span_ids[5], "parent_span": span_ids[4]},
@@ -257,7 +271,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             ],
             key=lambda trace: trace["trace"],  # type: ignore[arg-type, return-value]
         )
-        assert 0
 
 
 @pytest.mark.parametrize(
@@ -335,13 +348,20 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     "project": "foo",
                     "transaction": "foo1",
                     "first_seen()": 0,
-                    "last_seen()": 75,
+                    "last_seen()": 50,
                 },
                 {
                     "trace": "a" * 32,
                     "project": "bar",
                     "transaction": "bar1",
                     "first_seen()": 25,
+                    "last_seen()": 75,
+                },
+                {
+                    "trace": "a" * 32,
+                    "project": "baz",
+                    "transaction": "baz1",
+                    "first_seen()": 50,
                     "last_seen()": 100,
                 },
             ],
@@ -357,12 +377,18 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                     {
                         "project": "bar",
                         "start": 25,
+                        "end": 50,
+                        "kind": "project",
+                    },
+                    {
+                        "project": "baz",
+                        "start": 50,
                         "end": 100,
                         "kind": "project",
                     },
                 ],
             },
-            id="two transactions different project overlapping",
+            id="three transactions different project overlapping",
         ),
         pytest.param(
             [


### PR DESCRIPTION
To give an overview where a trace is spending it's time, this adds a breakdown of the trace by project.