### PR TITLE
feat(event-tags): Implement highlight tags/context backend

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -179,6 +179,8 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
     dataScrubberDefaults = serializers.BooleanField(required=False)
     sensitiveFields = ListField(child=serializers.CharField(), required=False)
     safeFields = ListField(child=serializers.CharField(), required=False)
+    highlightContext = ListField(child=serializers.CharField(), required=False)
+    highlightTags = ListField(child=serializers.CharField(), required=False)
     storeCrashReports = serializers.IntegerField(
         min_value=-1, max_value=STORE_CRASH_REPORTS_MAX, required=False, allow_null=True
     )
@@ -639,6 +641,13 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if result.get("safeFields") is not None:
             if project.update_option("sentry:safe_fields", result["safeFields"]):
                 changed_proj_settings["sentry:safe_fields"] = result["safeFields"]
+        if features.has("organizations:event-tags-tree-ui", project.organization):
+            if result.get("highlightContext") is not None:
+                if project.update_option("sentry:highlight_context", result["highlightContext"]):
+                    changed_proj_settings["sentry:highlight_context"] = result["highlightContext"]
+            if result.get("highlightTags") is not None:
+                if project.update_option("sentry:highlight_tags", result["highlightTags"]):
+                    changed_proj_settings["sentry:highlight_tags"] = result["highlightTags"]
         if result.get("storeCrashReports") is not None:
             if project.get_option("sentry:store_crash_reports") != result["storeCrashReports"]:
                 changed_proj_settings["sentry:store_crash_reports"] = result["storeCrashReports"]

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -120,6 +120,8 @@ class ProjectMemberSerializer(serializers.Serializer):
         "performanceIssueCreationRate",
         "performanceIssueCreationThroughPlatform",
         "performanceIssueSendToPlatform",
+        "highlightContext",
+        "highlightTags",
     ]
 )
 class ProjectAdminSerializer(ProjectMemberSerializer):

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -34,6 +34,7 @@ from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
 from sentry.ingest.inbound_filters import FilterTypes
+from sentry.issues.highlights import HighlightContextField
 from sentry.lang.native.sources import (
     InvalidSourcesError,
     parse_backfill_sources,
@@ -181,7 +182,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
     dataScrubberDefaults = serializers.BooleanField(required=False)
     sensitiveFields = ListField(child=serializers.CharField(), required=False)
     safeFields = ListField(child=serializers.CharField(), required=False)
-    highlightContext = ListField(child=serializers.CharField(), required=False)
+    highlightContext = HighlightContextField(required=False)
     highlightTags = ListField(child=serializers.CharField(), required=False)
     storeCrashReports = serializers.IntegerField(
         min_value=-1, max_value=STORE_CRASH_REPORTS_MAX, required=False, allow_null=True

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -24,6 +24,7 @@ from sentry.digests import backend as digests
 from sentry.eventstore.models import DEFAULT_SUBJECT_TEMPLATE
 from sentry.features.base import ProjectFeature
 from sentry.ingest.inbound_filters import FilterTypes
+from sentry.issues.highlights import get_highlight_preset_for_project
 from sentry.lang.native.sources import parse_sources, redact_source_secrets
 from sentry.lang.native.utils import convert_crashreport_count
 from sentry.models.environment import EnvironmentProject
@@ -906,6 +907,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                     "org": orgs[str(item.organization_id)],
                     "options": options_by_project[item.id],
                     "processing_issues": processing_issues_by_project.get(item.id, 0),
+                    "highlight_preset": get_highlight_preset_for_project(item),
                 }
             )
         return attrs
@@ -945,6 +947,14 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 "verifySSL": bool(attrs["options"].get("sentry:verify_ssl", False)),
                 "scrubIPAddresses": bool(attrs["options"].get("sentry:scrub_ip_address", False)),
                 "scrapeJavaScript": bool(attrs["options"].get("sentry:scrape_javascript", True)),
+                "highlightTags": attrs["options"].get(
+                    "sentry:highlight_tags",
+                    attrs["highlight_preset"].get("tags", []),
+                ),
+                "highlightContext": attrs["options"].get(
+                    "sentry:highlight_context",
+                    attrs["highlight_preset"].get("context", []),
+                ),
                 "groupingConfig": self.get_value_with_default(attrs, "sentry:grouping_config"),
                 "groupingEnhancements": self.get_value_with_default(
                     attrs, "sentry:grouping_enhancements"

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -953,7 +953,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 ),
                 "highlightContext": attrs["options"].get(
                     "sentry:highlight_context",
-                    attrs["highlight_preset"].get("context", []),
+                    attrs["highlight_preset"].get("context", {}),
                 ),
                 "groupingConfig": self.get_value_with_default(attrs, "sentry:grouping_config"),
                 "groupingEnhancements": self.get_value_with_default(

--- a/src/sentry/issues/highlights.py
+++ b/src/sentry/issues/highlights.py
@@ -54,7 +54,7 @@ MOBILE_HIGHLIGHTS: HighlightPreset = {
     "context": {"profile": ["profile_id"], "app": ["name"], "device": ["family"]},
 }
 
-FALLBACK_HIGLIGHTS: HighlightPreset = {
+FALLBACK_HIGHLIGHTS: HighlightPreset = {
     "tags": SENTRY_TAGS,
     "context": {"user": ["email"], "trace": ["trace_id"]},
 }

--- a/src/sentry/issues/highlights.py
+++ b/src/sentry/issues/highlights.py
@@ -14,7 +14,7 @@ class HighlightContextField(serializers.Field):
             raise serializers.ValidationError("Expected a dictionary.")
 
         for key, value in data.items():
-            if not re.match(r"^.*$", key):
+            if not re.match(r"^.+$", key):
                 raise serializers.ValidationError(f"Key '{key}' is invalid.")
             if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
                 raise serializers.ValidationError(f"Value for '{key}' must be a list of strings.")

--- a/src/sentry/issues/highlights.py
+++ b/src/sentry/issues/highlights.py
@@ -55,11 +55,11 @@ FALLBACK_HIGHLIGHTS: HighlightPreset = {
 
 def get_highlight_preset_for_project(project: Project) -> HighlightPreset:
     if not project.platform or project.platform == "other":
-        return FALLBACK_HIGLIGHTS
+        return FALLBACK_HIGHLIGHTS
     elif project.platform in FRONTEND_SET:
         return FRONTEND_HIGHLIGHTS
     elif project.platform in BACKEND_SET:
         return BACKEND_HIGHLIGHTS
     elif project.platform in MOBILE_SET:
         return MOBILE_HIGHLIGHTS
-    return FALLBACK_HIGLIGHTS
+    return FALLBACK_HIGHLIGHTS

--- a/src/sentry/issues/highlights.py
+++ b/src/sentry/issues/highlights.py
@@ -1,0 +1,39 @@
+from typing import TypedDict
+
+from sentry.models.project import Project
+from sentry.utils.platform_categories import BACKEND, FRONTEND, MOBILE
+
+
+class HighlightPreset(TypedDict):
+    tags: list[str]
+    context: list[str]
+
+
+SENTRY_TAGS = ["handled", "level", "release", "environment"]
+
+BACKEND_HIGHLIGHTS: HighlightPreset = {
+    "tags": SENTRY_TAGS + ["url", "transaction", "status_code"],
+    "context": ["trace", "runtime"],
+}
+FRONTEND_HIGHLIGHTS: HighlightPreset = {
+    "tags": SENTRY_TAGS + ["url", "transaction", "browser", "replayId", "user"],
+    "context": ["browser", "state"],
+}
+MOBILE_HIGHLIGHTS: HighlightPreset = {
+    "tags": SENTRY_TAGS + ["mobile", "main_thread"],
+    "context": ["profile", "app", "device"],
+}
+
+FALLBACK_HIGLIGHTS: HighlightPreset = {"tags": SENTRY_TAGS, "context": ["user", "trace"]}
+
+
+def get_highlight_preset_for_project(project: Project) -> HighlightPreset:
+    if not project.platform or project.platform == "other":
+        return FALLBACK_HIGLIGHTS
+    elif project.platform in FRONTEND:
+        return FRONTEND_HIGHLIGHTS
+    elif project.platform in BACKEND:
+        return BACKEND_HIGHLIGHTS
+    elif project.platform in MOBILE:
+        return MOBILE_HIGHLIGHTS
+    return FALLBACK_HIGLIGHTS

--- a/src/sentry/issues/highlights.py
+++ b/src/sentry/issues/highlights.py
@@ -5,7 +5,7 @@ from typing import TypedDict
 from rest_framework import serializers
 
 from sentry.models.project import Project
-from sentry.utils.platform_categories import BACKEND_SET, FRONTEND_SET, MOBILE_SET
+from sentry.utils.platform_categories import BACKEND, FRONTEND, MOBILE
 
 
 class HighlightContextField(serializers.Field):
@@ -56,10 +56,10 @@ FALLBACK_HIGHLIGHTS: HighlightPreset = {
 def get_highlight_preset_for_project(project: Project) -> HighlightPreset:
     if not project.platform or project.platform == "other":
         return FALLBACK_HIGHLIGHTS
-    elif project.platform in FRONTEND_SET:
+    elif project.platform in FRONTEND:
         return FRONTEND_HIGHLIGHTS
-    elif project.platform in BACKEND_SET:
+    elif project.platform in BACKEND:
         return BACKEND_HIGHLIGHTS
-    elif project.platform in MOBILE_SET:
+    elif project.platform in MOBILE:
         return MOBILE_HIGHLIGHTS
     return FALLBACK_HIGHLIGHTS

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -30,6 +30,8 @@ OPTION_KEYS = frozenset(
         "sentry:builtin_symbol_sources",
         "sentry:symbol_sources",
         "sentry:sensitive_fields",
+        "sentry:highlight_tags",
+        "sentry:highlight_context",
         "sentry:csp_ignored_sources_defaults",
         "sentry:csp_ignored_sources",
         "sentry:default_environment",

--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -19,6 +19,7 @@ FRONTEND = [
     "javascript-astro",
     "unity",
 ]
+FRONTEND_SET = set(FRONTEND)
 
 # Mirrors `const mobile` in sentry/static/app/data/platformCategories.tsx
 # When changing this file, make sure to keep sentry/static/app/data/platformCategories.tsx in sync.
@@ -42,6 +43,7 @@ MOBILE = [
     "cocoa-objc",
     "cocoa-swift",
 ]
+MOBILE_SET = set(MOBILE)
 
 # Mirrors `const backend` in sentry/static/app/data/platformCategories.tsx
 # When changing this file, make sure to keep sentry/static/app/data/platformCategories.tsx in sync.
@@ -108,6 +110,7 @@ BACKEND = [
     "ruby-rails",
     "rust",
 ]
+BACKEND_SET = set(BACKEND)
 
 # Mirrors `const serverless` in sentry/static/app/data/platformCategories.tsx
 # When changing this file, make sure to keep sentry/static/app/data/platformCategories.tsx in sync.

--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 # Mirrors `const frontend` in sentry/static/app/data/platformCategories.tsx
 # When changing this file, make sure to keep sentry/static/app/data/platformCategories.tsx in sync.
-FRONTEND = [
+FRONTEND = {
     "dart",
     "javascript",
     "javascript-react",
@@ -18,12 +18,11 @@ FRONTEND = [
     "javascript-sveltekit",
     "javascript-astro",
     "unity",
-]
-FRONTEND_SET = set(FRONTEND)
+}
 
 # Mirrors `const mobile` in sentry/static/app/data/platformCategories.tsx
 # When changing this file, make sure to keep sentry/static/app/data/platformCategories.tsx in sync.
-MOBILE = [
+MOBILE = {
     "android",
     "apple-ios",
     "cordova",
@@ -42,12 +41,11 @@ MOBILE = [
     "java-android",
     "cocoa-objc",
     "cocoa-swift",
-]
-MOBILE_SET = set(MOBILE)
+}
 
 # Mirrors `const backend` in sentry/static/app/data/platformCategories.tsx
 # When changing this file, make sure to keep sentry/static/app/data/platformCategories.tsx in sync.
-BACKEND = [
+BACKEND = {
     "bun",
     "deno",
     "dotnet",
@@ -109,12 +107,11 @@ BACKEND = [
     "ruby-rack",
     "ruby-rails",
     "rust",
-]
-BACKEND_SET = set(BACKEND)
+}
 
 # Mirrors `const serverless` in sentry/static/app/data/platformCategories.tsx
 # When changing this file, make sure to keep sentry/static/app/data/platformCategories.tsx in sync.
-SERVERLESS = [
+SERVERLESS = {
     "dotnet-awslambda",
     "dotnet-gcpfunctions",
     "node-awslambda",
@@ -124,11 +121,11 @@ SERVERLESS = [
     "python-azurefunctions",
     "python-gcpfunctions",
     "python-serverless",
-]
+}
 
 # Mirrors `const desktop` in sentry/static/app/data/platformCategories.tsx
 # When changing this file, make sure to keep sentry/static/app/data/platformCategories.tsx in sync.
-DESKTOP = [
+DESKTOP = {
     "apple-macos",
     "dotnet",
     "dotnet-maui",
@@ -147,11 +144,11 @@ DESKTOP = [
     "native-qt",
     "unity",
     "unreal",
-]
+}
 
 # TODO: @athena Remove this
 # This is only temporary since we decide the right category. Don't add anything here or your frontend experience will be broken
-TEMPORARY = ["nintendo"]
+TEMPORARY = {"nintendo"}
 
 CATEGORY_LIST = [
     {id: "browser", "name": _("Browser"), "platforms": FRONTEND},

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -849,7 +849,6 @@ class ProjectUpdateTest(APITestCase):
         assert self.project.get_option("sentry:highlight_tags") is None
 
         preset = get_highlight_preset_for_project(self.project)
-        assert resp.data["highlightContext"] == preset["context"]
         assert resp.data["highlightTags"] == preset["tags"]
 
         with self.feature("organizations:event-tags-tree-ui"):
@@ -913,7 +912,19 @@ class ProjectUpdateTest(APITestCase):
             assert self.project.get_option("sentry:highlight_context") == {}
             assert resp.data["highlightContext"] == {}
 
-            # Checking schema validation
+            # Checking validation
+            resp = self.get_error_response(
+                self.org_slug,
+                self.proj_slug,
+                highlightContext=["bird-words", ["red", "blue"]],
+            )
+            assert "Expected a dictionary" in resp.data["highlightContext"][0]
+            resp = self.get_error_response(
+                self.org_slug,
+                self.proj_slug,
+                highlightContext={"": ["empty", "context", "type"]},
+            )
+            assert "Key '' is invalid" in resp.data["highlightContext"][0]
             resp = self.get_error_response(
                 self.org_slug,
                 self.proj_slug,


### PR DESCRIPTION
This PR will allow an organization with the `event-tags-tree-ui` flag to create project options for highlights.

They are stored as simple lists of strings in the ProjectOptions table, with `sentry:highlight_context` and `sentry:highlight_tags`  keys. 

When unset, they will default to a preset depending on the project platform. When set, the new values will be respected, even if set to empty (`[]`).

**Update**: it looks like we only want to pick out specific keys from context items so I'll have to make some edits

**todo**
- [x] Add tests 
- [x] Update with schema validation for specific context keys (rather than whole context items)