### PR TITLE
chore(code-mappings): Remove check for Go automatic code mapping feature flag

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -102,11 +102,6 @@ def derive_code_mappings(
         logger.info("Event should not be processed.", extra=extra)
         return
 
-    if data["platform"].startswith("go") and not features.has(
-        "organizations:derive-code-mappings-go", org
-    ):
-        return
-
     stacktrace_paths: list[str] = identify_stacktrace_paths(data)
     if not stacktrace_paths:
         logger.info("No stacktrace paths found.", extra=extra)


### PR DESCRIPTION
Title

Order of operations: 
- This PR 
- [Remove feature from options automator](https://github.com/getsentry/sentry-options-automator/pull/1144)
- [Unregister feature in getSentry](https://github.com/getsentry/getsentry/pull/13670)
- [Unregister feature in sentry](https://github.com/getsentry/sentry/pull/69049)