### PR TITLE
feat(ui): Add grouping capability to sentryProjectSelectorField

### DIFF
--- a/static/app/components/forms/fields/sentryProjectSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryProjectSelectorField.spec.tsx
@@ -24,4 +24,37 @@ describe('SentryProjectSelectorField', () => {
 
     expect(mock).toHaveBeenCalledWith('23', expect.anything());
   });
+
+  it('can group values', async () => {
+    const mock = jest.fn();
+    const projects = [
+      ProjectFixture(),
+      ProjectFixture({
+        id: '23',
+        slug: 'my-proj',
+        name: 'My Proj',
+      }),
+      ProjectFixture({
+        id: '24',
+        slug: 'other-project',
+        name: 'My Other Project',
+      }),
+    ];
+    render(
+      <SentryProjectSelectorField
+        groupProjects={project => (project.slug === 'other-project' ? 'other' : 'main')}
+        groupLabels={{
+          main: 'Main projects',
+        }}
+        onChange={mock}
+        name="project"
+        projects={projects}
+      />
+    );
+
+    await selectEvent.openMenu(screen.getByText(/choose sentry project/i));
+
+    expect(screen.getByText('Main projects')).toBeInTheDocument();
+    expect(screen.getByText('other')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Can be used to do things like this

<img width="292" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/123a8840-8f87-474b-bf84-540e5c5a451f">