### PR TITLE
chore(code-mappings): Unregister go automatic code mapping feature flag 

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1538,8 +1538,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:default-high-priority-alerts": False,
     # Enables automatically deriving of code mappings
     "organizations:derive-code-mappings": True,
-    # Enables automatically deriving of code mappings for Go Projects
-    "organizations:derive-code-mappings-go": False,
     # Enable device.class as a selectable column
     "organizations:device-classification": False,
     # Enables synthesis of device.class in ingest

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -65,7 +65,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ddm-ui", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:default-high-priority-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:derive-code-mappings", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    manager.add("organizations:derive-code-mappings-go", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:device-class-synthesis", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:device-classification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -102,11 +102,6 @@ def derive_code_mappings(
         logger.info("Event should not be processed.", extra=extra)
         return
 
-    if data["platform"].startswith("go") and not features.has(
-        "organizations:derive-code-mappings-go", org
-    ):
-        return
-
     stacktrace_paths: list[str] = identify_stacktrace_paths(data)
     if not stacktrace_paths:
         logger.info("No stacktrace paths found.", extra=extra)

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -459,7 +459,6 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
         )
 
     @responses.activate
-    @with_feature({"organizations:derive-code-mappings-go": True})
     def test_derive_code_mappings_go_abs_filename(self):
         repo_name = "go_repo"
         with patch(
@@ -475,7 +474,6 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    @with_feature({"organizations:derive-code-mappings-go": True})
     def test_derive_code_mappings_go_long_abs_filename(self):
         repo_name = "go_repo"
         with patch(
@@ -491,7 +489,6 @@ class TestGoDeriveCodeMappings(BaseDeriveCodeMappings):
             assert code_mapping.repository.name == repo_name
 
     @responses.activate
-    @with_feature({"organizations:derive-code-mappings-go": True})
     def test_derive_code_mappings_similar_but_incorrect_file(self):
         repo_name = "go_repo"
         with patch(


### PR DESCRIPTION
Title

Order of operations: 
- [Remove flag checks in sentry](https://github.com/getsentry/sentry/pull/69049)
- [Remove feature from options automator](https://github.com/getsentry/sentry-options-automator/pull/1144)
- [Unregister feature in getSentry](https://github.com/getsentry/getsentry/pull/13670)
- This PR 
