### PR TITLE
feat(crons): Group projects by supported platforms

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -35,6 +35,8 @@ import {crontabAsText} from 'sentry/views/monitors/utils/crontabAsText';
 import type {IntervalConfig, Monitor, MonitorConfig, MonitorType} from '../types';
 import {ScheduleType} from '../types';
 
+import {platformsWithGuides} from './monitorQuickStartGuide';
+
 const SCHEDULE_OPTIONS: SelectValue<string>[] = [
   {value: ScheduleType.CRONTAB, label: t('Crontab')},
   {value: ScheduleType.INTERVAL, label: t('Interval')},
@@ -286,6 +288,13 @@ function MonitorForm({
           <StyledSentryProjectSelectorField
             name="project"
             aria-label={t('Project')}
+            groupProjects={project =>
+              platformsWithGuides.includes(project.platform) ? 'suggested' : 'other'
+            }
+            groupLabels={{
+              suggested: t('Suggested Projects'),
+              other: t('Other Projects'),
+            }}
             projects={filteredProjects}
             placeholder={t('Choose Project')}
             disabled={!!monitor}

--- a/static/app/views/monitors/components/monitorQuickStartGuide.tsx
+++ b/static/app/views/monitors/components/monitorQuickStartGuide.tsx
@@ -127,6 +127,16 @@ const onboardingGuides: Record<string, OnboardingGuide> = {
   },
 };
 
+/**
+ * The platforms that are well supported for crons
+ */
+export const platformsWithGuides = Array.from(
+  Object.values(onboardingGuides).reduce((combinedPlatforms, guide) => {
+    guide.platforms?.forEach(platform => combinedPlatforms.add(platform));
+    return combinedPlatforms;
+  }, new Set())
+);
+
 const guideToSelectOption = ({key, label}) => ({label, value: key});
 
 export default function MonitorQuickStartGuide({monitor}: Props) {


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry/issues/69040

When creating / editing a monitor, the project field will now group the
projects depending on if we have a guide configured for that project
platform.

<img width="334" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/593804aa-4c3e-4186-94d8-7ca8b17712db">
