### PR TITLE
chore(trace-explorer): Make sample rate optional for trace explorer

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -72,7 +72,7 @@ class OrganizationTracesEndpoint(OrganizationEventsV2EndpointBase):
                     orderby=None,
                     limit=per_page * serialized["maxSpansPerTrace"],
                     limitby=("trace", serialized["maxSpansPerTrace"]),
-                    sample_rate=options.get("traces.sample-list.sample-rate"),
+                    sample_rate=sample_rate,
                     config=QueryBuilderConfig(
                         transform_alias_to_input_format=True,
                     ),

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -57,6 +57,9 @@ class OrganizationTracesEndpoint(OrganizationEventsV2EndpointBase):
 
         def data_fn(offset: int, limit: int):
             with handle_query_errors():
+                sample_rate = options.get("traces.sample-list.sample-rate")
+                if sample_rate <= 0:
+                    sample_rate = None
                 builder = SpansIndexedQueryBuilder(
                     Dataset.SpansIndexed,
                     cast(ParamsType, params),

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2413,6 +2413,6 @@ register(
 register(
     "traces.sample-list.sample-rate",
     type=Float,
-    default=100_000.0,
+    default=0.0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
This is likely the cause of there only being 1 span per trace. Let's make it optional so we can test turning it off and see how that affects results.