### PR TITLE
chore(snuba): Pass referrer to get_groups_user_counts

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -101,7 +101,9 @@ def get_approx_start_time(group: Group):
 # pull things out into their own functions
 SUPPORTED_CONTEXT_DATA = {
     "Events": lambda group: get_group_global_count(group),
-    "Users Affected": lambda group: group.count_users_seen(),
+    "Users Affected": lambda group: group.count_users_seen(
+        referrer="tagstore.get_groups_user_counts.slack_issue_notification"
+    ),
     "State": lambda group: SUBSTATUS_TO_STR.get(group.substatus, "").replace("_", " ").title(),
     "First Seen": lambda group: time_since(group.first_seen),
     "Approx. Start Time": get_approx_start_time,

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -56,6 +56,7 @@ from sentry.notifications.utils.participants import (
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.services.hybrid_cloud.identity import RpcIdentity, identity_service
 from sentry.services.hybrid_cloud.user.model import RpcUser
+from sentry.snuba.referrer import Referrer
 from sentry.types.group import SUBSTATUS_TO_STR
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -102,7 +103,7 @@ def get_approx_start_time(group: Group):
 SUPPORTED_CONTEXT_DATA = {
     "Events": lambda group: get_group_global_count(group),
     "Users Affected": lambda group: group.count_users_seen(
-        referrer="tagstore.get_groups_user_counts.slack_issue_notification"
+        referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_SLACK_ISSUE_NOTIFICATION.value
     ),
     "State": lambda group: SUBSTATUS_TO_STR.get(group.substatus, "").replace("_", " ").title(),
     "First Seen": lambda group: time_since(group.first_seen),

--- a/src/sentry/issues/ignored.py
+++ b/src/sentry/issues/ignored.py
@@ -19,6 +19,7 @@ from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.serial import serialize_generic_user
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.signals import issue_archived
+from sentry.snuba.referrer import Referrer
 from sentry.types.group import GroupSubStatus
 from sentry.utils import metrics
 
@@ -112,7 +113,7 @@ def handle_ignored(
                 state["times_seen"] = group.times_seen
             if ignore_user_count and not ignore_user_window:
                 state["users_seen"] = group.count_users_seen(
-                    referrer="tagstore.get_groups_user_counts.ignored"
+                    referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_IGNORED.value
                 )
             GroupSnooze.objects.create_or_update(
                 group=group,

--- a/src/sentry/issues/ignored.py
+++ b/src/sentry/issues/ignored.py
@@ -111,7 +111,9 @@ def handle_ignored(
             if ignore_count and not ignore_window:
                 state["times_seen"] = group.times_seen
             if ignore_user_count and not ignore_user_window:
-                state["users_seen"] = group.count_users_seen()
+                state["users_seen"] = group.count_users_seen(
+                    referrer="tagstore.get_groups_user_counts.ignored"
+                )
             GroupSnooze.objects.create_or_update(
                 group=group,
                 values={

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -47,6 +47,7 @@ from sentry.models.grouphistory import record_group_history, record_group_histor
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.referrer import Referrer
 from sentry.types.activity import ActivityType
 from sentry.types.group import (
     IGNORED_SUBSTATUS_CHOICES,
@@ -872,7 +873,7 @@ class Group(Model):
     def get_email_subject(self):
         return f"{self.qualified_short_id} - {self.title}"
 
-    def count_users_seen(self, referrer="tagstore.get_groups_user_counts"):
+    def count_users_seen(self, referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS.value):
         return tagstore.backend.get_groups_user_counts(
             [self.project_id],
             [self.id],

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -872,13 +872,14 @@ class Group(Model):
     def get_email_subject(self):
         return f"{self.qualified_short_id} - {self.title}"
 
-    def count_users_seen(self):
+    def count_users_seen(self, referrer="tagstore.get_groups_user_counts"):
         return tagstore.backend.get_groups_user_counts(
             [self.project_id],
             [self.id],
             environment_ids=None,
             start=self.first_seen,
             tenant_ids={"organization_id": self.project.organization_id},
+            referrer=referrer,
         )[self.id]
 
     @classmethod

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -87,7 +87,11 @@ class GroupSnooze(Model):
             if self.user_window:
                 if not self.test_user_rates():
                     return False
-            elif self.user_count <= group.count_users_seen() - self.state["users_seen"]:
+            elif (
+                self.user_count
+                <= group.count_users_seen(referrer="tagstore.get_groups_user_counts.groupsnooze")
+                - self.state["users_seen"]
+            ):
                 return False
         return True
 

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -18,6 +18,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.issues.constants import get_issue_tsdb_group_model, get_issue_tsdb_user_group_model
+from sentry.snuba.referrer import Referrer
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
@@ -89,7 +90,9 @@ class GroupSnooze(Model):
                     return False
             elif (
                 self.user_count
-                <= group.count_users_seen(referrer="tagstore.get_groups_user_counts.groupsnooze")
+                <= group.count_users_seen(
+                    referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_GROUP_SNOOZE.value
+                )
                 - self.state["users_seen"]
             ):
                 return False

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -689,6 +689,14 @@ class Referrer(Enum):
     TAGSTORE_GET_GROUP_LIST_TAG_VALUE = "tagstore.get_group_list_tag_value"
     TAGSTORE_GET_GROUP_TAG_VALUE_ITER = "tagstore.get_group_tag_value_iter"
     TAGSTORE_GET_GROUPS_USER_COUNTS = "tagstore.get_groups_user_counts"
+    TAGSTORE_GET_GROUPS_USER_COUNTS_OPEN_PR_COMMENT = (
+        "tagstore.get_groups_user_counts.open_pr_comment"
+    )
+    TAGSTORE_GET_GROUPS_USER_COUNTS_GROUP_SNOOZE = "tagstore.get_groups_user_counts.groupsnooze"
+    TAGSTORE_GET_GROUPS_USER_COUNTS_IGNORED = "tagstore.get_groups_user_counts.ignored"
+    TAGSTORE_GET_GROUPS_USER_COUNTS_SLACK_ISSUE_NOTIFICATION = (
+        "tagstore.get_groups_user_counts.slack_issue_notification"
+    )
     TAGSTORE_GET_GENERIC_GROUP_LIST_TAG_VALUE = "tagstore.get_generic_group_list_tag_value"
     TAGSTORE_GET_GENERIC_GROUPS_USER_COUNTS = "tagstore.get_generic_groups_user_counts"
     TAGSTORE_GET_RELEASE_TAGS = "tagstore.get_release_tags"

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -256,7 +256,14 @@ class TagStorage(Service):
         raise NotImplementedError
 
     def get_groups_user_counts(
-        self, project_ids, group_ids, environment_ids, start=None, end=None, tenant_ids=None
+        self,
+        project_ids,
+        group_ids,
+        environment_ids,
+        start=None,
+        end=None,
+        tenant_ids=None,
+        referrer=None,
     ):
         """
         >>> get_groups_user_counts([1, 2], [2, 3], [4, 5])

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -888,7 +888,14 @@ class SnubaTagStorage(TagStorage):
         return defaultdict(int, {k: v for k, v in result.items() if v})
 
     def get_groups_user_counts(
-        self, project_ids, group_ids, environment_ids, start=None, end=None, tenant_ids=None
+        self,
+        project_ids,
+        group_ids,
+        environment_ids,
+        start=None,
+        end=None,
+        tenant_ids=None,
+        referrer="tagstore.get_groups_user_counts",
     ):
         return self.__get_groups_user_counts(
             project_ids,
@@ -898,7 +905,7 @@ class SnubaTagStorage(TagStorage):
             end,
             Dataset.Events,
             [],
-            "tagstore.get_groups_user_counts",
+            referrer,
             tenant_ids=tenant_ids,
         )
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -33,6 +33,7 @@ from sentry.search.events.constants import (
 from sentry.search.events.fields import FIELD_ALIASES
 from sentry.search.events.filter import _flip_field_sort
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.referrer import Referrer
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT, TagKeyStatus, TagStorage
 from sentry.tagstore.exceptions import (
     GroupTagKeyNotFound,
@@ -861,7 +862,7 @@ class SnubaTagStorage(TagStorage):
         end=None,
         dataset=Dataset.Events,
         extra_aggregations=None,
-        referrer="tagstore.__get_groups_user_counts",
+        referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS.value,
         tenant_ids=None,
     ):
         filters = {"project_id": project_ids, "group_id": group_ids}

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -149,7 +149,9 @@ def get_issue_table_contents(issue_list: list[dict[str, Any]]) -> list[PullReque
             title=issue.title,
             subtitle=issue.culprit,
             url=issue.get_absolute_url(),
-            affected_users=issue.count_users_seen(),
+            affected_users=issue.count_users_seen(
+                referrer="tagstore.get_groups_user_counts.open_pr_comment"
+            ),
             event_count=group_id_to_info[issue.id]["event_count"],
             function_name=group_id_to_info[issue.id]["function_name"],
         )

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -150,7 +150,7 @@ def get_issue_table_contents(issue_list: list[dict[str, Any]]) -> list[PullReque
             subtitle=issue.culprit,
             url=issue.get_absolute_url(),
             affected_users=issue.count_users_seen(
-                referrer="tagstore.get_groups_user_counts.open_pr_comment"
+                referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_OPEN_PR_COMMENT.value
             ),
             event_count=group_id_to_info[issue.id]["event_count"],
             function_name=group_id_to_info[issue.id]["function_name"],


### PR DESCRIPTION
The group model's method `count_users_seen` is called by a few different features but `get_groups_user_counts` hard codes the referrer so we can't tell who is actually calling it. This PR passes the referrer in with a description of where it's coming from. 