### PR TITLE
fix(replay): Remove duplicate nav events from the Replay>Breadcrumbs list

### DIFF
--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -200,8 +200,7 @@ describe('ReplayReader', () => {
         expected: [
           expect.objectContaining({category: 'replay.init'}),
           expect.objectContaining({category: 'ui.slowClickDetected'}),
-          expect.objectContaining({category: 'navigation'}),
-          expect.objectContaining({op: 'navigation.navigate'}),
+          expect.objectContaining({op: 'navigation.navigate'}), // prefer the nav span over the breadcrumb
           expect.objectContaining({category: 'ui.click'}),
           expect.objectContaining({category: 'ui.click'}),
         ],


### PR DESCRIPTION
Replay frames include SpanFrame and CrumbFrames, which each have the similar concept of 'navigation', but each with some different properties: 
![SCR-20240416-mtyp](https://github.com/getsentry/sentry/assets/187460/b94f3f14-73d1-4c80-a35a-314f6eee8558)

The trouble is that these two things have the same or similar timestamps, so they render right next to each other, and mostly look the same (except that spans can have more unique titles...):

**Before:**
![before](https://github.com/getsentry/sentry/assets/187460/0820aa35-e766-4902-a19a-488e464b6f14)

**After:**
![after](https://github.com/getsentry/sentry/assets/187460/8a948e62-af31-4891-a0a1-94e1d22cfda6)

This change de-duplicates these breadcrumb types, so in most cases you'll only see one "Navigation" row. 