### PR TITLE
chore(hybridcloud) Shift logging around for gitlab

### DIFF
--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -239,16 +239,6 @@ class BaseRequestParser(abc.ABC):
         # 100 is arbitrary but we can't leave it unbounded.
         bucket_number = mailbox_bucket_id % 100
 
-        if extra_logging:
-            logger.info(
-                "integrations.parser.bucket_choice",
-                extra={
-                    "provider": self.provider,
-                    "integration_id": integration.id,
-                    "bucket": bucket_number,
-                },
-            )
-
         return f"{integration.id}:{bucket_number}"
 
     def mailbox_bucket_id(self, data: Mapping[str, Any]) -> int | None:

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -81,13 +81,20 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
 
         try:
             data = json.loads(self.request.body)
-        except ValueError as e:
-            logger.info("gitlab.body.parse_error", extra={"error": str(e)})
+        except ValueError:
             data = {}
 
+        identifier = self.get_mailbox_identifier(integration, data)
+        logger.info(
+            "gitlab.webhookpayload.save",
+            extra={
+                "identifier": identifier,
+                "integration_id": integration.id,
+            },
+        )
         return self.get_response_from_webhookpayload(
             regions=regions,
-            identifier=self.get_mailbox_identifier(integration, data),
+            identifier=identifier,
             integration_id=integration.id,
         )
 


### PR DESCRIPTION
The most recent log volumes are not matching up with recorded hooks. I'd like to be able to correlate each webhook being saved with the identifier logging added earlier.