### PR TITLE
fix(replay): guard against experimental frames in breadcrumbs

### DIFF
--- a/static/app/components/replays/breadcrumbs/selectorList.tsx
+++ b/static/app/components/replays/breadcrumbs/selectorList.tsx
@@ -13,8 +13,16 @@ export default function SelectorList({frame}: {frame: ClickFrame}) {
   const organization = useOrganization();
 
   const componentName = frame.data.node?.attributes['data-sentry-component'];
+
+  // Guard against experimental frames for mobile replays
+  // TODO: can probably remove this check when mobile replay frames are
+  // more complete
   const lastComponentIndex =
-    frame.message.lastIndexOf('>') === -1 ? 0 : frame.message.lastIndexOf('>') + 2;
+    'message' in frame
+      ? frame.message?.lastIndexOf('>') === -1
+        ? 0
+        : frame.message?.lastIndexOf('>') + 2
+      : 0;
 
   return componentName ? (
     <Fragment>


### PR DESCRIPTION
fixes JAVASCRIPT-2SJF
fixes JAVASCRIPT-2SJG

for mobile replays, we're experimenting with adding breadcrumbs, which means some of the frames we're sending in aren't complete (eg. they don't have all the properties that replay ones do).

this was leading to a problem rendering the breadcrumbs tab since we had a click frame that didn't have property `message`, and we were trying to access `frame.message`. 

we can probably delete this check after video replay breadcrumb frames are more complete/correct, but for now let's have this guard, so we don't get this error while the SDK engineers are testing breadcrumbs!

before:
<img width="1056" alt="SCR-20240416-nklp" src="https://github.com/getsentry/sentry/assets/56095982/1e56ef7b-06c9-4228-be33-619dae36e70d">


after:

<img width="738" alt="SCR-20240416-nitv" src="https://github.com/getsentry/sentry/assets/56095982/092934a8-f279-42ac-91e7-b0eee933bca8">


