### PR TITLE
ref(ch-upgrades): testing ch 23.3 DONT MERGE

### DIFF
--- a/config/clickhouse/loc_config.xml
+++ b/config/clickhouse/loc_config.xml
@@ -1,3 +1,6 @@
 <yandex>
     <max_server_memory_usage_to_ram_ratio>0.3</max_server_memory_usage_to_ram_ratio>
+    <merge_tree>
+        <old_parts_lifetime>3</old_parts_lifetime>
+    </merge_tree>
 </yandex>

--- a/config/clickhouse/loc_config.xml
+++ b/config/clickhouse/loc_config.xml
@@ -1,6 +1,6 @@
 <yandex>
     <max_server_memory_usage_to_ram_ratio>0.3</max_server_memory_usage_to_ram_ratio>
     <merge_tree>
-        <old_parts_lifetime>3</old_parts_lifetime>
+        <old_parts_lifetime>1</old_parts_lifetime>
     </merge_tree>
 </yandex>

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -40,11 +40,13 @@ _EnvTypes = Union[str, float, int, list, dict]
 
 
 @overload
-def env(key: str) -> str: ...
+def env(key: str) -> str:
+    ...
 
 
 @overload
-def env(key: str, default: _EnvTypes, type: Type | None = None) -> _EnvTypes: ...
+def env(key: str, default: _EnvTypes, type: Type | None = None) -> _EnvTypes:
+    ...
 
 
 def env(
@@ -2894,7 +2896,7 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
     ),
     "clickhouse": lambda settings, options: (
         {
-            "image": "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.3.13.7.altinitystable",
+            "image": "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.3.19.33.altinitystable",
             "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
             "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],
             # The arm image does not properly load the MAX_MEMORY_USAGE_RATIO

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -40,13 +40,11 @@ _EnvTypes = Union[str, float, int, list, dict]
 
 
 @overload
-def env(key: str) -> str:
-    ...
+def env(key: str) -> str: ...
 
 
 @overload
-def env(key: str, default: _EnvTypes, type: Type | None = None) -> _EnvTypes:
-    ...
+def env(key: str, default: _EnvTypes, type: Type | None = None) -> _EnvTypes: ...
 
 
 def env(
@@ -2896,9 +2894,7 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
     ),
     "clickhouse": lambda settings, options: (
         {
-            "image": (
-                "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:22.8.15.25.altinitystable"
-            ),
+            "image": "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.3.13.7.altinitystable",
             "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
             "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],
             # The arm image does not properly load the MAX_MEMORY_USAGE_RATIO


### PR DESCRIPTION
similar testing as https://github.com/getsentry/snuba/pull/5425 but for `23.3` - we have to upgrade to `23.3` prior to `23.8` :(


Also - in order to fix some getsentry tests, I added `old_parts_lifetime` setting to the config so that I could make it 1 seconds instead of the [default](https://clickhouse.com/docs/en/operations/settings/merge-tree-settings#old-parts-lifetime) of 480

From a practical stand point - running the tests from a clean slate works fine, its the re-run of the tests with the same data that causes problems (and not enough time to let the data be deleted, hence the forcing of that with `old_parts_lifetime`) so I feel pretty good that the deletion script works its just the testing around it need to be fixed 