### PR TITLE
(chore)issues: clean up "organizations:discover-events-rate-limit" flag

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -94,13 +94,9 @@ ALLOWED_EVENTS_REFERRERS = {
 
 API_TOKEN_REFERRER = Referrer.API_AUTH_TOKEN_EVENTS.value
 
-RATE_LIMIT = 30
-RATE_LIMIT_WINDOW = 1
-CONCURRENT_RATE_LIMIT = 15
-
-DEFAULT_RATE_LIMIT = 50
+DEFAULT_RATE_LIMIT = 30
 DEFAULT_RATE_LIMIT_WINDOW = 1
-DEFAULT_CONCURRENT_RATE_LIMIT = 50
+DEFAULT_CONCURRENT_RATE_LIMIT = 15
 
 DEFAULT_EVENTS_RATE_LIMIT_CONFIG = {
     "GET": {
@@ -118,25 +114,7 @@ DEFAULT_EVENTS_RATE_LIMIT_CONFIG = {
 
 
 def rate_limit_events(request: Request, organization_slug=None, *args, **kwargs) -> RateLimitConfig:
-    try:
-        organization = Organization.objects.get_from_cache(slug=organization_slug)
-    except Organization.DoesNotExist:
-        return DEFAULT_EVENTS_RATE_LIMIT_CONFIG
-    # Check for feature flag to enforce rate limit otherwise use default rate limit
-    if features.has("organizations:discover-events-rate-limit", organization, actor=request.user):
-        return {
-            "GET": {
-                RateLimitCategory.IP: RateLimit(
-                    RATE_LIMIT, RATE_LIMIT_WINDOW, CONCURRENT_RATE_LIMIT
-                ),
-                RateLimitCategory.USER: RateLimit(
-                    RATE_LIMIT, RATE_LIMIT_WINDOW, CONCURRENT_RATE_LIMIT
-                ),
-                RateLimitCategory.ORGANIZATION: RateLimit(
-                    RATE_LIMIT, RATE_LIMIT_WINDOW, CONCURRENT_RATE_LIMIT
-                ),
-            }
-        }
+    # TODO: keeping this function for future use, as we'll add more rate limits soon
     return DEFAULT_EVENTS_RATE_LIMIT_CONFIG
 
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1548,8 +1548,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:discover": False,
     # Enable discover 2 basic functions
     "organizations:discover-basic": True,
-    # Enables events endpoint rate limit
-    "organizations:discover-events-rate-limit": False,
     # Enable discover 2 custom queries and saved queries
     "organizations:discover-query": True,
     # Enable the org recalibration

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -69,7 +69,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:device-class-synthesis", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:device-classification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    manager.add("organizations:discover-events-rate-limit", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:ds-org-recalibration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:enterprise-data-secrecy", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:escalating-issues-msteams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -165,8 +165,6 @@ class OrganizationEventsEndpointTest(APITestCase):
         }
         with freeze_time("2000-01-01"):
             for _ in range(RATE_LIMIT):
-                self.do_request(query, features={"organizations:discover-events-rate-limit": True})
-            response = self.do_request(
-                query, features={"organizations:discover-events-rate-limit": True}
-            )
+                self.do_request(query)
+            response = self.do_request(query)
             assert response.status_code == 429, response.content

--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -3,7 +3,7 @@ from unittest import mock
 from django.test import override_settings
 from django.urls import reverse
 
-from sentry.api.endpoints.organization_events import RATE_LIMIT
+from sentry.api.endpoints.organization_events import DEFAULT_RATE_LIMIT
 from sentry.search.events import constants
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
@@ -164,7 +164,7 @@ class OrganizationEventsEndpointTest(APITestCase):
             "project": [self.project.id],
         }
         with freeze_time("2000-01-01"):
-            for _ in range(RATE_LIMIT):
+            for _ in range(DEFAULT_RATE_LIMIT):
                 self.do_request(query)
             response = self.do_request(query)
             assert response.status_code == 429, response.content


### PR DESCRIPTION
Clean up ["organizations:discover-events-rate-limit" flag](https://flagr.getsentry.net/#/flags/211), which has been globally "on" since 2022, making its values the new default. 


