### PR TITLE
feat(crons): Disallow teams not part of project to be selected for notifications

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
@@ -1,8 +1,9 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
 import MemberListStore from 'sentry/stores/memberListStore';
@@ -103,5 +104,37 @@ describe('SentryMemberTeamSelectorField', () => {
 
     await userEvent.click(screen.getByLabelText('Clear choices'));
     expect(mock).toHaveBeenCalledWith([], expect.anything());
+  });
+
+  it('disables teams not associated with project', async () => {
+    const project = ProjectFixture();
+    const teamWithProject = TeamFixture({projects: [project], slug: 'my-team'});
+    const teamWithoutProject = TeamFixture({id: '2', slug: 'disabled-team'});
+    TeamStore.init();
+    TeamStore.loadInitialData([teamWithProject, teamWithoutProject]);
+
+    const mock = jest.fn();
+    render(
+      <SentryMemberTeamSelectorField
+        label="Select Owner"
+        onChange={mock}
+        memberOfProjectSlug={project.slug}
+        name="team-or-member"
+        multiple
+      />
+    );
+
+    await selectEvent.openMenu(screen.getByRole('textbox', {name: 'Select Owner'}));
+    expect(
+      within(
+        (await screen.findByText('My Teams')).parentElement as HTMLElement
+      ).getByText('#my-team')
+    ).toBeInTheDocument();
+
+    expect(
+      within(
+        (await screen.findByText('Disabled Teams')).parentElement as HTMLElement
+      ).getByText('#disabled-team')
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -504,13 +504,18 @@ function MonitorForm({
                   {t('Customize this monitors notification configuration in Alerts')}
                 </AlertLink>
               )}
-              <SentryMemberTeamSelectorField
-                label={t('Notify')}
-                help={t('Send notifications to a member or team.')}
-                name="alertRule.targets"
-                multiple
-                menuPlacement="auto"
-              />
+              <Observer>
+                {() => (
+                  <SentryMemberTeamSelectorField
+                    label={t('Notify')}
+                    help={t('Send notifications to a member or team.')}
+                    name="alertRule.targets"
+                    memberOfProjectSlug={form.current.getValue('project')?.toString()}
+                    multiple
+                    menuPlacement="auto"
+                  />
+                )}
+              </Observer>
               <Observer>
                 {() => {
                   const selectedAssignee = form.current.getValue('alertRule.targets');


### PR DESCRIPTION
Adds a new `memberOfProjectSlug` prop to the sentryMemberTeamSelectorField to restrict selectable teams to only be the ones that are associated with the provided project slug

<img width="582" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/432ba671-91e9-4d35-8975-dec29709646c">


related to: https://github.com/getsentry/sentry/issues/63814