### PR TITLE
fix(trace-explorer): Use max limit for trace spans query

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -153,6 +153,7 @@ class OrganizationTracesEndpoint(OrganizationEventsV2EndpointBase):
                     # limit the number of segments we fetch per trace so a single
                     # large trace does not result in the rest being blank
                     limitby=("trace", int(10_000 / len(spans_by_trace))),
+                    limit=10_000,
                     config=QueryBuilderConfig(
                         functions_acl=["trace_name", "first_seen", "last_seen"],
                         transform_alias_to_input_format=True,


### PR DESCRIPTION
This was using the default of 50 and couldn't generate a good breakdown.