### PR TITLE
ref(search): dont parse token values

### DIFF
--- a/fixtures/search-syntax/aggregate_duration_filter.json
+++ b/fixtures/search-syntax/aggregate_duration_filter.json
@@ -27,7 +27,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueDuration", "value": 500, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "500", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/aggregate_duration_filter_overrides_numeric_shorthand.json
+++ b/fixtures/search-syntax/aggregate_duration_filter_overrides_numeric_shorthand.json
@@ -28,7 +28,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueDuration", "value": 2, "unit": "m"}
+        "value": {"type": "valueDuration", "value": "2", "unit": "m"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/aggregate_rel_time_filter.json
+++ b/fixtures/search-syntax/aggregate_rel_time_filter.json
@@ -15,7 +15,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "",
-        "value": {"type": "valueRelativeDate", "value": 7, "sign": "+", "unit": "d"}
+        "value": {"type": "valueRelativeDate", "value": "7", "sign": "+", "unit": "d"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -36,7 +36,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "",
-        "value": {"type": "valueRelativeDate", "value": 2, "sign": "-", "unit": "w"}
+        "value": {"type": "valueRelativeDate", "value": "2", "sign": "-", "unit": "w"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/boolean_filter.json
+++ b/fixtures/search-syntax/boolean_filter.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueBoolean", "value": true}
+        "value": {"type": "valueBoolean", "value": "true"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +24,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueBoolean", "value": true}
+        "value": {"type": "valueBoolean", "value": "TRUE"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -39,7 +39,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueBoolean", "value": true}
+        "value": {"type": "valueBoolean", "value": "1"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +54,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueBoolean", "value": false}
+        "value": {"type": "valueBoolean", "value": "false"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -69,7 +69,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueBoolean", "value": false}
+        "value": {"type": "valueBoolean", "value": "FALSE"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -84,7 +84,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueBoolean", "value": false}
+        "value": {"type": "valueBoolean", "value": "0"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -99,7 +99,7 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueBoolean", "value": false}
+        "value": {"type": "valueBoolean", "value": "false"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/boolean_filter_passthrough.json
+++ b/fixtures/search-syntax/boolean_filter_passthrough.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "project_id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueNumber", "value": "1",  "unit": null}
+        "value": {"type": "valueNumber", "value": "1", "unit": null}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/boolean_filter_passthrough.json
+++ b/fixtures/search-syntax/boolean_filter_passthrough.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "project_id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueNumber", "value": "1", "rawValue": 1, "unit": null}
+        "value": {"type": "valueNumber", "value": "1",  "unit": null}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/duration_aggregate_measurements_filter.json
+++ b/fixtures/search-syntax/duration_aggregate_measurements_filter.json
@@ -31,7 +31,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "",
-        "value": {"type": "valueDuration", "value": 3.3, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "3.3", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -68,7 +68,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueDuration", "value": 3.3, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "3.3", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -105,7 +105,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "<",
-        "value": {"type": "valueDuration", "value": 3.3, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "3.3", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/duration_aggregate_op_breakdowns_filter.json
+++ b/fixtures/search-syntax/duration_aggregate_op_breakdowns_filter.json
@@ -31,7 +31,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "",
-        "value": {"type": "valueDuration", "value": 3.3, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "3.3", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -68,7 +68,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueDuration", "value": 3.3, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "3.3", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -105,7 +105,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "<",
-        "value": {"type": "valueDuration", "value": 3.3, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "3.3", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/duration_filter.json
+++ b/fixtures/search-syntax/duration_filter.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "transaction.duration", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueDuration", "value": 500, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "500", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +24,7 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "transaction.duration", "quoted": false},
         "operator": "",
-        "value": {"type": "valueDuration", "value": 500, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "500", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/duration_filter_overrides_numeric_shorthand.json
+++ b/fixtures/search-syntax/duration_filter_overrides_numeric_shorthand.json
@@ -10,7 +10,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "transaction.duration", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueDuration", "value": 2, "unit": "m"}
+        "value": {"type": "valueDuration", "value": "2", "unit": "m"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/duration_measurements_filter.json
+++ b/fixtures/search-syntax/duration_measurements_filter.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "measurements.fp", "quoted": false},
         "operator": "",
-        "value": {"type": "valueDuration", "value": 1.5, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "1.5", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +24,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "measurements.fp", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueDuration", "value": 1.5, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "1.5", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -39,7 +39,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "measurements.fp", "quoted": false},
         "operator": "<",
-        "value": {"type": "valueDuration", "value": 1.5, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "1.5", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/duration_op_breakdowns_filter.json
+++ b/fixtures/search-syntax/duration_op_breakdowns_filter.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "spans.browser", "quoted": false},
         "operator": "",
-        "value": {"type": "valueDuration", "value": 1.5, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "1.5", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +24,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "spans.browser", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueDuration", "value": 1.5, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "1.5", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -39,7 +39,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "spans.browser", "quoted": false},
         "operator": "<",
-        "value": {"type": "valueDuration", "value": 1.5, "unit": "s"}
+        "value": {"type": "valueDuration", "value": "1.5", "unit": "s"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_aggregate_measurements_filter.json
+++ b/fixtures/search-syntax/numeric_aggregate_measurements_filter.json
@@ -141,7 +141,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "<",
-        "value": {"type": "valueNumber", "value": "3",  "unit": "k"}
+        "value": {"type": "valueNumber", "value": "3", "unit": "k"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -174,7 +174,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "",
-        "value": {"type": "valueNumber", "value": "2",  "unit": "m"}
+        "value": {"type": "valueNumber", "value": "2", "unit": "m"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_aggregate_measurements_filter.json
+++ b/fixtures/search-syntax/numeric_aggregate_measurements_filter.json
@@ -30,7 +30,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },
@@ -68,7 +67,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },
@@ -106,7 +104,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },

--- a/fixtures/search-syntax/numeric_aggregate_measurements_filter.json
+++ b/fixtures/search-syntax/numeric_aggregate_measurements_filter.json
@@ -30,7 +30,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },
@@ -68,7 +68,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },
@@ -106,7 +106,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },
@@ -141,7 +141,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "<",
-        "value": {"type": "valueNumber", "value": "3", "rawValue": 3000, "unit": "k"}
+        "value": {"type": "valueNumber", "value": "3",  "unit": "k"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -174,7 +174,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": "",
-        "value": {"type": "valueNumber", "value": "2", "rawValue": 2000000, "unit": "m"}
+        "value": {"type": "valueNumber", "value": "2",  "unit": "m"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_aggregate_op_breakdowns_filter.json
+++ b/fixtures/search-syntax/numeric_aggregate_op_breakdowns_filter.json
@@ -43,7 +43,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },
@@ -97,7 +96,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },
@@ -151,7 +149,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },
@@ -205,7 +202,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3",
-
           "unit": "k"
         }
       },

--- a/fixtures/search-syntax/numeric_aggregate_op_breakdowns_filter.json
+++ b/fixtures/search-syntax/numeric_aggregate_op_breakdowns_filter.json
@@ -259,7 +259,7 @@
         "operator": "",
         "value": {
           "type": "valueDuration",
-          "value": 2,
+          "value": "2",
           "unit": "m"
         }
       },

--- a/fixtures/search-syntax/numeric_aggregate_op_breakdowns_filter.json
+++ b/fixtures/search-syntax/numeric_aggregate_op_breakdowns_filter.json
@@ -43,7 +43,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },
@@ -97,7 +97,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },
@@ -151,7 +151,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },
@@ -205,7 +205,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3",
-          "rawValue": 3000,
+
           "unit": "k"
         }
       },

--- a/fixtures/search-syntax/numeric_filter.json
+++ b/fixtures/search-syntax/numeric_filter.json
@@ -56,7 +56,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "project_id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueNumber", "value": "-500",  "unit": null}
+        "value": {"type": "valueNumber", "value": "-500", "unit": null}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -71,7 +71,7 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "issue.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueNumber", "value": "500",  "unit": null}
+        "value": {"type": "valueNumber", "value": "500", "unit": null}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -86,7 +86,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "issue.id", "quoted": false},
         "operator": "<",
-        "value": {"type": "valueNumber", "value": "500",  "unit": null}
+        "value": {"type": "valueNumber", "value": "500", "unit": null}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_filter.json
+++ b/fixtures/search-syntax/numeric_filter.json
@@ -56,7 +56,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "project_id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueNumber", "value": "-500", "rawValue": -500, "unit": null}
+        "value": {"type": "valueNumber", "value": "-500",  "unit": null}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -71,7 +71,7 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "issue.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueNumber", "value": "500", "rawValue": 500, "unit": null}
+        "value": {"type": "valueNumber", "value": "500",  "unit": null}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -86,7 +86,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "issue.id", "quoted": false},
         "operator": "<",
-        "value": {"type": "valueNumber", "value": "500", "rawValue": 500, "unit": null}
+        "value": {"type": "valueNumber", "value": "500",  "unit": null}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_filter_with_decimals.json
+++ b/fixtures/search-syntax/numeric_filter_with_decimals.json
@@ -12,7 +12,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },

--- a/fixtures/search-syntax/numeric_filter_with_decimals.json
+++ b/fixtures/search-syntax/numeric_filter_with_decimals.json
@@ -12,7 +12,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },

--- a/fixtures/search-syntax/numeric_filter_with_shorthand.json
+++ b/fixtures/search-syntax/numeric_filter_with_shorthand.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.colno", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueNumber", "value": "3", "rawValue": 3000, "unit": "k"}
+        "value": {"type": "valueNumber", "value": "3",  "unit": "k"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +24,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.colno", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueNumber", "value": "3", "rawValue": 3000000, "unit": "m"}
+        "value": {"type": "valueNumber", "value": "3",  "unit": "m"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -42,7 +42,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3",
-          "rawValue": 3000000000,
+
           "unit": "b"
         }
       },

--- a/fixtures/search-syntax/numeric_filter_with_shorthand.json
+++ b/fixtures/search-syntax/numeric_filter_with_shorthand.json
@@ -42,7 +42,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3",
-
           "unit": "b"
         }
       },

--- a/fixtures/search-syntax/numeric_filter_with_shorthand.json
+++ b/fixtures/search-syntax/numeric_filter_with_shorthand.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.colno", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueNumber", "value": "3",  "unit": "k"}
+        "value": {"type": "valueNumber", "value": "3", "unit": "k"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +24,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "stack.colno", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueNumber", "value": "3",  "unit": "m"}
+        "value": {"type": "valueNumber", "value": "3", "unit": "m"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_in_filter.json
+++ b/fixtures/search-syntax/numeric_in_filter.json
@@ -17,7 +17,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-
                 "unit": null
               }
             },
@@ -26,7 +25,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-
                 "unit": null
               }
             },
@@ -35,7 +33,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-
                 "unit": null
               }
             }
@@ -63,7 +60,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-
                 "unit": null
               }
             },
@@ -72,7 +68,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-
                 "unit": null
               }
             },
@@ -81,7 +76,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-
                 "unit": null
               }
             }
@@ -109,7 +103,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-
                 "unit": null
               }
             },
@@ -118,7 +111,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-
                 "unit": null
               }
             },
@@ -127,7 +119,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-
                 "unit": null
               }
             }
@@ -155,7 +146,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-
                 "unit": null
               }
             },
@@ -164,7 +154,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-
                 "unit": null
               }
             },
@@ -173,7 +162,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-
                 "unit": null
               }
             }
@@ -195,7 +183,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "100",
-
                 "unit": null
               }
             }
@@ -224,7 +211,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-
                 "unit": null
               }
             },
@@ -233,7 +219,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-
                 "unit": null
               }
             },
@@ -242,7 +227,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-
                 "unit": null
               }
             }
@@ -299,7 +283,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-
                 "unit": null
               }
             },
@@ -308,7 +291,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-
                 "unit": null
               }
             },
@@ -340,7 +322,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-
                 "unit": null
               }
             },
@@ -349,7 +330,6 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-
                 "unit": null
               }
             }

--- a/fixtures/search-syntax/numeric_in_filter.json
+++ b/fixtures/search-syntax/numeric_in_filter.json
@@ -17,7 +17,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-                "rawValue": 500,
+
                 "unit": null
               }
             },
@@ -26,7 +26,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-                "rawValue": 501,
+
                 "unit": null
               }
             },
@@ -35,7 +35,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-                "rawValue": 502,
+
                 "unit": null
               }
             }
@@ -63,7 +63,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-                "rawValue": 500,
+
                 "unit": null
               }
             },
@@ -72,7 +72,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-                "rawValue": 501,
+
                 "unit": null
               }
             },
@@ -81,7 +81,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-                "rawValue": 502,
+
                 "unit": null
               }
             }
@@ -109,7 +109,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-                "rawValue": 500,
+
                 "unit": null
               }
             },
@@ -118,7 +118,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-                "rawValue": 501,
+
                 "unit": null
               }
             },
@@ -127,7 +127,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-                "rawValue": 502,
+
                 "unit": null
               }
             }
@@ -155,7 +155,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-                "rawValue": 500,
+
                 "unit": null
               }
             },
@@ -164,7 +164,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-                "rawValue": 501,
+
                 "unit": null
               }
             },
@@ -173,7 +173,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-                "rawValue": 502,
+
                 "unit": null
               }
             }
@@ -195,7 +195,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "100",
-                "rawValue": 100,
+
                 "unit": null
               }
             }
@@ -224,7 +224,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-                "rawValue": 500,
+
                 "unit": null
               }
             },
@@ -233,7 +233,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-                "rawValue": 501,
+
                 "unit": null
               }
             },
@@ -242,7 +242,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "502",
-                "rawValue": 502,
+
                 "unit": null
               }
             }
@@ -299,7 +299,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-                "rawValue": 500,
+
                 "unit": null
               }
             },
@@ -308,7 +308,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-                "rawValue": 501,
+
                 "unit": null
               }
             },
@@ -340,7 +340,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "500",
-                "rawValue": 500,
+
                 "unit": null
               }
             },
@@ -349,7 +349,7 @@
               "value": {
                 "type": "valueNumber",
                 "value": "501",
-                "rawValue": 501,
+
                 "unit": null
               }
             }

--- a/fixtures/search-syntax/numeric_measurements_filter.json
+++ b/fixtures/search-syntax/numeric_measurements_filter.json
@@ -12,7 +12,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },
@@ -32,7 +32,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },
@@ -52,7 +52,7 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-          "rawValue": 3.1415,
+
           "unit": null
         }
       },

--- a/fixtures/search-syntax/numeric_measurements_filter.json
+++ b/fixtures/search-syntax/numeric_measurements_filter.json
@@ -12,7 +12,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },
@@ -32,7 +31,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },
@@ -52,7 +50,6 @@
         "value": {
           "type": "valueNumber",
           "value": "3.1415",
-
           "unit": null
         }
       },

--- a/fixtures/search-syntax/other_dates.json
+++ b/fixtures/search-syntax/other_dates.json
@@ -10,7 +10,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueIso8601Date", "value": "2015-05-18T00:00:00.000Z"}
+        "value": {"type": "valueIso8601Date", "value": "2015-05-18"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -25,7 +25,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "timestamp.to_hour", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueIso8601Date", "value": "2018-01-01T05:06:07.000Z"}
+        "value": {"type": "valueIso8601Date", "value": "2018-01-01T05:06:07+00:00"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/rel_time_filter.json
+++ b/fixtures/search-syntax/rel_time_filter.json
@@ -18,7 +18,7 @@
         "operator": "",
         "value": {
           "type": "valueRelativeDate",
-          "value": 7,
+          "value": "7",
           "sign": "+",
           "unit": "d"
         }
@@ -48,7 +48,7 @@
         "operator": "",
         "value": {
           "type": "valueRelativeDate",
-          "value": 2,
+          "value": "2",
           "sign": "-",
           "unit": "w"
         }

--- a/fixtures/search-syntax/special_character_params.json
+++ b/fixtures/search-syntax/special_character_params.json
@@ -46,7 +46,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueNumber", "unit": null,  "value": "100"}
+        "value": {"type": "valueNumber", "unit": null, "value": "100"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -98,7 +98,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueNumber", "unit": null,  "value": "100"}
+        "value": {"type": "valueNumber", "unit": null, "value": "100"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -150,7 +150,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueNumber", "unit": null,  "value": "100"}
+        "value": {"type": "valueNumber", "unit": null, "value": "100"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/special_character_params.json
+++ b/fixtures/search-syntax/special_character_params.json
@@ -46,7 +46,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueNumber", "rawValue": 100, "unit": null, "value": "100"}
+        "value": {"type": "valueNumber", "unit": null,  "value": "100"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -98,7 +98,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueNumber", "rawValue": 100, "unit": null, "value": "100"}
+        "value": {"type": "valueNumber", "unit": null,  "value": "100"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -150,7 +150,7 @@
           "argsSpaceAfter": {"type": "spaces", "value": ""}
         },
         "operator": ">",
-        "value": {"type": "valueNumber", "rawValue": 100, "unit": null, "value": "100"}
+        "value": {"type": "valueNumber", "unit": null,  "value": "100"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/specific_time_filter.json
+++ b/fixtures/search-syntax/specific_time_filter.json
@@ -18,7 +18,7 @@
         "operator": "",
         "value": {
           "type": "valueIso8601Date",
-          "value": "2018-01-01T00:00:00.000Z"
+          "value": "2018-01-01"
         }
       },
       {
@@ -46,7 +46,7 @@
         "operator": "",
         "value": {
           "type": "valueIso8601Date",
-          "value": "2018-01-01T05:06:07.000Z"
+          "value": "2018-01-01T05:06:07Z"
         }
       },
       {
@@ -74,7 +74,7 @@
         "operator": "",
         "value": {
           "type": "valueIso8601Date",
-          "value": "2018-01-01T05:06:07.000Z"
+          "value": "2018-01-01T05:06:07+00:00"
         }
       },
       {

--- a/fixtures/search-syntax/supported_tags.json
+++ b/fixtures/search-syntax/supported_tags.json
@@ -72,7 +72,6 @@
         "operator": ">",
         "value": {
           "type": "valueNumber",
-
           "value": "0",
           "unit": null
         }

--- a/fixtures/search-syntax/supported_tags.json
+++ b/fixtures/search-syntax/supported_tags.json
@@ -72,7 +72,7 @@
         "operator": ">",
         "value": {
           "type": "valueNumber",
-          "rawValue": 0,
+
           "value": "0",
           "unit": null
         }

--- a/fixtures/search-syntax/timestamp.json
+++ b/fixtures/search-syntax/timestamp.json
@@ -10,7 +10,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueIso8601Date", "value": "2015-05-18T00:00:00.000Z"}
+        "value": {"type": "valueIso8601Date", "value": "2015-05-18"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -26,7 +26,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueIso8601Date", "value": "2015-05-18T10:15:01.000Z"}
+        "value": {"type": "valueIso8601Date", "value": "2015-05-18T10:15:01"}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -42,7 +42,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": ">",
-        "value": {"type": "valueIso8601Date", "value": "2015-05-18T10:15:01.103Z"}
+        "value": {"type": "valueIso8601Date", "value": "2015-05-18T10:15:01.103"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/timestamp_rollup.json
+++ b/fixtures/search-syntax/timestamp_rollup.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "timestamp.to_hour", "quoted": false},
         "operator": "",
-        "value": {"type": "valueIso8601Date", "value": "2018-01-01T05:06:07.000Z"}
+        "value": {"type": "valueIso8601Date", "value": "2018-01-01T05:06:07+00:00"}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -169,12 +169,8 @@ tz_format   = ~r"[+-]\d{2}:\d{2}"
 iso_8601_date_format = date_format time_format? ("Z" / tz_format)? &end_value
 rel_date_format      = ~r"[+-][0-9]+[wdhm]" &end_value
 duration_format      = numeric ("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w") &end_value
-size_format          = numeric (size_unit) &end_value
+size_format          = numeric ("bit"/"nb"/"bytes"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb"/"zb"/"yb"/"kib"/"mib"/"gib"/"tib"/"pib"/"eib"/"zib"/"yib") &end_value
 percentage_format    = numeric "%"
-
-size_unit = bits / bytes
-bits = ~r"bit|kib|mib|gib|tib|pib|eib|zib|yib"i
-bytes = ~r"bytes|nb|kb|mb|gb|tb|pb|eb|zb|yb"i
 
 
 # NOTE: the order in which these operators are listed matters because for

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -169,7 +169,7 @@ tz_format   = ~r"[+-]\d{2}:\d{2}"
 iso_8601_date_format = date_format time_format? ("Z" / tz_format)? &end_value
 rel_date_format      = ~r"[+-][0-9]+[wdhm]" &end_value
 duration_format      = numeric ("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w") &end_value
-size_format          = numeric size_unit &end_value
+size_format          = numeric (size_unit) &end_value
 percentage_format    = numeric "%"
 
 size_unit = bits / bytes

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -169,11 +169,12 @@ tz_format   = ~r"[+-]\d{2}:\d{2}"
 iso_8601_date_format = date_format time_format? ("Z" / tz_format)? &end_value
 rel_date_format      = ~r"[+-][0-9]+[wdhm]" &end_value
 duration_format      = numeric ("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w") &end_value
-size_format          = numeric (bits/bytes) &end_value
+size_format          = numeric (size_unit) &end_value
 percentage_format    = numeric "%"
 
-bits = ("bit" / "kib" / "mib" / "gib" / "tib" / "pib" / "eib" / "zib" / "yib")i
-bytes = ("bytes" / "nb" / "kb" / "mb" / "gb" / "tb" / "pb" / "eb" / "zb" / "yb")i
+size_unit = bits / bytes
+bits = "bit"i / "kib"i / "mib"i / "gib"i / "tib"i / "pib"i / "eib"i / "zib"i / "yib"i
+bytes = "bytes"i / "nb"i / "kb"i / "mb"i / "gb"i / "tb"i / "pb"i / "eb"i / "zb"i / "yb"i
 
 
 # NOTE: the order in which these operators are listed matters because for

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -172,7 +172,6 @@ duration_format      = numeric ("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w") 
 size_format          = numeric ("bit"/"nb"/"bytes"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb"/"zb"/"yb"/"kib"/"mib"/"gib"/"tib"/"pib"/"eib"/"zib"/"yib") &end_value
 percentage_format    = numeric "%"
 
-
 # NOTE: the order in which these operators are listed matters because for
 # example, if < comes before <= it will match that even if the operator is <=
 operator             = ">=" / "<=" / ">" / "<" / "=" / "!="

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -169,12 +169,11 @@ tz_format   = ~r"[+-]\d{2}:\d{2}"
 iso_8601_date_format = date_format time_format? ("Z" / tz_format)? &end_value
 rel_date_format      = ~r"[+-][0-9]+[wdhm]" &end_value
 duration_format      = numeric ("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w") &end_value
-size_format          = numeric (size_unit) &end_value
+size_format          = numeric (bits/bytes) &end_value
 percentage_format    = numeric "%"
 
-size_unit = bits / bytes
-bits = "bit"i / "kib"i / "mib"i / "gib"i / "tib"i / "pib"i / "eib"i / "zib"i / "yib"i
-bytes = "bytes"i / "nb"i / "kb"i / "mb"i / "gb"i / "tb"i / "pb"i / "eb"i / "zb"i / "yb"i
+bits = ("bit" / "kib" / "mib" / "gib" / "tib" / "pib" / "eib" / "zib" / "yib")i
+bytes = ("bytes" / "nb" / "kb" / "mb" / "gb" / "tb" / "pb" / "eb" / "zb" / "yb")i
 
 
 # NOTE: the order in which these operators are listed matters because for

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -173,8 +173,8 @@ size_format          = numeric (size_unit) &end_value
 percentage_format    = numeric "%"
 
 size_unit = bits / bytes
-bits = "bit"i / "kib"i / "mib"i / "gib"i / "tib"i / "pib"i / "eib"i / "zib"i / "yib"i
-bytes = "bytes"i / "nb"i / "kb"i / "mb"i / "gb"i / "tb"i / "pb"i / "eb"i / "zb"i / "yb"i
+bits = ~r"bit|kib|mib|gib|tib|pib|eib|zib|yib"i
+bytes = ~r"bytes|nb|kb|mb|gb|tb|pb|eb|zb|yb"i
 
 
 # NOTE: the order in which these operators are listed matters because for

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -169,8 +169,13 @@ tz_format   = ~r"[+-]\d{2}:\d{2}"
 iso_8601_date_format = date_format time_format? ("Z" / tz_format)? &end_value
 rel_date_format      = ~r"[+-][0-9]+[wdhm]" &end_value
 duration_format      = numeric ("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w") &end_value
-size_format          = numeric ("bit"/"nb"/"bytes"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb"/"zb"/"yb"/"kib"/"mib"/"gib"/"tib"/"pib"/"eib"/"zib"/"yib") &end_value
+size_format          = numeric size_unit &end_value
 percentage_format    = numeric "%"
+
+size_unit = bits / bytes
+bits = "bit"i / "kib"i / "mib"i / "gib"i / "tib"i / "pib"i / "eib"i / "zib"i / "yib"i
+bytes = "bytes"i / "nb"i / "kb"i / "mb"i / "gb"i / "tb"i / "pb"i / "eb"i / "zb"i / "yb"i
+
 
 # NOTE: the order in which these operators are listed matters because for
 # example, if < comes before <= it will match that even if the operator is <=

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -91,9 +91,9 @@ def parse_duration(value: str, interval: str) -> float:
 
 
 def parse_bool(value: str) -> bool:
-    if value.lower() == "true" or value == "1":
+    if value == "1" or value.lower() == "true":
         return True
-    if value.lower() == "false" or value == "0":
+    if value == "0" or value.lower() == "false":
         return False
     raise InvalidQuery(f"{value} is not a valid boolean value")
 

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -105,9 +105,6 @@ def parse_size(value: str, size: str) -> float:
     except ValueError:
         raise InvalidQuery(f"{value} is not a valid size value")
 
-    # Search grammer is case insensitive for size units
-    size = size.lower()
-
     if size == "bit":
         byte = size_value / 8
     elif size == "nb":

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -90,6 +90,14 @@ def parse_duration(value: str, interval: str) -> float:
     return delta.total_seconds() * 1000.0
 
 
+def parse_bool(value: str) -> bool:
+    if value.lower() == "true" or value == "1":
+        return True
+    if value.lower() == "false" or value == "0":
+        return False
+    raise InvalidQuery(f"{value} is not a valid boolean value")
+
+
 def parse_size(value: str, size: str) -> float:
     """Returns in total bytes"""
     try:

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -105,6 +105,9 @@ def parse_size(value: str, size: str) -> float:
     except ValueError:
         raise InvalidQuery(f"{value} is not a valid size value")
 
+    # Search grammer is case insensitive for size units
+    size = size.lower()
+
     if size == "bit":
         byte = size_value / 8
     elif size == "nb":

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -360,9 +360,9 @@ size_format
       return tc.tokenValueSize(value, unit);
     }
 
-size_unit = bytes / bits
-bytes = "bytes"i / "nb"i / "kb"i / "mb"i / "gb"i / "tb"i / "pb"i / "eb"i / "zb"i / "yb"i
+size_unit = bits / bytes
 bits = "bit"i / "kib"i / "mib"i / "gib"i / "tib"i / "pib"i / "eib"i / "zib"i / "yib"i
+bytes = "bytes"i / "nb"i / "kb"i / "mb"i / "gb"i / "tb"i / "pb"i / "eb"i / "zb"i / "yb"i
 
 percentage_format
   = value:numeric "%" {

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -346,23 +346,17 @@ rel_date_format
 
 duration_format
   = value:numeric
-    unit:(duration_unit)
+    unit:("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w")
     &end_value {
       return tc.tokenValueDuration(value, unit);
     }
 
-duration_unit = "ms" / "s" / "min" / "m" / "hr" / "h" / "day" / "d" / "wk" / "w"
-
 size_format
   = value:numeric
-    unit:(size_unit)
+    unit:("bit"/"kib"/"mib"/"gib"/"tib"/"pib"/"eib"/"zib"/"yib"/"bytes"/"nb"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb" / "zb"/"yb")
     &end_value {
       return tc.tokenValueSize(value, unit);
     }
-
-size_unit = bits / bytes
-bits = "bit"i / "kib"i / "mib"i / "gib"i / "tib"i / "pib"i / "eib"i / "zib"i / "yib"i
-bytes = "bytes"i / "nb"i / "kb"i / "mb"i / "gb"i / "tb"i / "pb"i / "eb"i / "zb"i / "yb"i
 
 percentage_format
   = value:numeric "%" {

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -283,10 +283,9 @@ search_value
   = quoted_value / value
 
 numeric_value
-  = value:("-"? numeric) unit:numeric_unit? &(end_value / comma / closed_bracket) {
+  = value:("-"? numeric) unit:[kmb]? &(end_value / comma / closed_bracket) {
       return tc.tokenValueNumber(value.join(''), unit);
     }
-numeric_unit = ("k"i / "m"i / "b"i)
 
 boolean_value
   = value:("true"i / "1" / "false"i / "0") &end_value {
@@ -353,7 +352,7 @@ duration_format
 
 size_format
   = value:numeric
-    unit:("bit"/"kib"/"mib"/"gib"/"tib"/"pib"/"eib"/"zib"/"yib"/"bytes"/"nb"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb" / "zb"/"yb")
+    unit:("bit"/"nb"/"bytes"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb"/"zb"/"yb"/"kib"/"mib"/"gib"/"tib"/"pib"/"eib"/"zib"/"yib")
     &end_value {
       return tc.tokenValueSize(value, unit);
     }

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -283,9 +283,10 @@ search_value
   = quoted_value / value
 
 numeric_value
-  = value:("-"? numeric) unit:[kmb]? &(end_value / comma / closed_bracket) {
+  = value:("-"? numeric) unit:numeric_unit? &(end_value / comma / closed_bracket) {
       return tc.tokenValueNumber(value.join(''), unit);
     }
+numeric_unit = ("k"i / "m"i / "b"i)
 
 boolean_value
   = value:("true"i / "1" / "false"i / "0") &end_value {
@@ -345,17 +346,23 @@ rel_date_format
 
 duration_format
   = value:numeric
-    unit:("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w")
+    unit:(duration_unit)
     &end_value {
       return tc.tokenValueDuration(value, unit);
     }
 
+duration_unit = "ms" / "s" / "min" / "m" / "hr" / "h" / "day" / "d" / "wk" / "w"
+
 size_format
   = value:numeric
-    unit:("bit"/"nb"/"bytes"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb"/"zb"/"yb"/"kib"/"mib"/"gib"/"tib"/"pib"/"eib"/"zib"/"yib")
+    unit:(size_unit)
     &end_value {
       return tc.tokenValueSize(value, unit);
     }
+
+size_unit = bytes / bits
+bytes = "bytes"i / "nb"i / "kb"i / "mb"i / "gb"i / "tb"i / "pb"i / "eb"i / "zb"i / "yb"i
+bits = "bit"i / "kib"i / "mib"i / "gib"i / "tib"i / "pib"i / "eib"i / "zib"i / "yib"i
 
 percentage_format
   = value:numeric "%" {

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -44,6 +44,8 @@ const normalizeResult = (tokens: TokenResult<Token>[]) =>
       delete token.text;
       // @ts-expect-error
       delete token.config;
+      // @ts-expect-error
+      delete token.parsedValue;
 
       // token warnings only exist in the FE atm
       // @ts-expect-error

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -54,11 +54,6 @@ const normalizeResult = (tokens: TokenResult<Token>[]) =>
         delete token.invalid;
       }
 
-      if (token.type === Token.VALUE_ISO_8601_DATE) {
-        // Date values are represented as ISO strings in the test case json
-        return {...token, value: token.value.toISOString()};
-      }
-
       return token;
     },
   });

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -44,8 +44,6 @@ const normalizeResult = (tokens: TokenResult<Token>[]) =>
       delete token.text;
       // @ts-expect-error
       delete token.config;
-      // @ts-expect-error
-      delete token.parsedValue;
 
       // token warnings only exist in the FE atm
       // @ts-expect-error

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -44,8 +44,6 @@ const normalizeResult = (tokens: TokenResult<Token>[]) =>
       delete token.text;
       // @ts-expect-error
       delete token.config;
-      // @ts-expect-error
-      delete token.parsed;
 
       // token warnings only exist in the FE atm
       // @ts-expect-error

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -44,6 +44,8 @@ const normalizeResult = (tokens: TokenResult<Token>[]) =>
       delete token.text;
       // @ts-expect-error
       delete token.config;
+      // @ts-expect-error
+      delete token.parsed;
 
       // token warnings only exist in the FE atm
       // @ts-expect-error

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -501,7 +501,7 @@ export class TokenConverter {
   ) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_RELATIVE_DATE as const,
-    value: Number(value),
+    value: value,
     sign,
     unit,
   });
@@ -513,7 +513,7 @@ export class TokenConverter {
     ...this.defaultTokenFields,
 
     type: Token.VALUE_DURATION as const,
-    value: Number(value),
+    value: value,
     unit,
   });
 
@@ -543,14 +543,14 @@ export class TokenConverter {
     ...this.defaultTokenFields,
 
     type: Token.VALUE_SIZE as const,
-    value: Number(value),
+    value: value,
     unit,
   });
 
   tokenValuePercentage = (value: string) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_PERCENTAGE as const,
-    value: Number(value),
+    value: value,
   });
 
   tokenValueBoolean = (value: string) => ({

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -522,7 +522,9 @@ export class TokenConverter {
 
     type: Token.VALUE_DURATION as const,
     value: value,
-    parsed: {value: parseDuration(value, unit), unit: unit?.toLowerCase()},
+    parsed: this.config.parse
+      ? {value: parseDuration(value, unit), unit: unit?.toLowerCase()}
+      : undefined,
     unit,
   });
 
@@ -554,7 +556,9 @@ export class TokenConverter {
     value: value,
     // units are case insensitive, normalize them in their parsed representation
     // so that we dont have to compare all possible permutations.
-    parsed: {value: parseSize(value, unit), unit: unit.toLowerCase()},
+    parsed: this.config.parse
+      ? {value: parseSize(value, unit), unit: unit.toLowerCase()}
+      : undefined,
     unit,
   });
 
@@ -562,14 +566,14 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.VALUE_PERCENTAGE as const,
     value: value,
-    parsed: {value: parsePercentage(value)},
+    parsed: this.config.parse ? {value: parsePercentage(value)} : undefined,
   });
 
   tokenValueBoolean = (value: string) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_BOOLEAN as const,
     value: value,
-    parsed: {value: parseBoolean(value)},
+    parsed: this.config.parse ? {value: parseBoolean(value)} : undefined,
   });
 
   tokenValueNumber = (value: string, unit: 'k' | 'm' | 'b' | 'K' | 'M' | 'B') => ({
@@ -577,7 +581,9 @@ export class TokenConverter {
     type: Token.VALUE_NUMBER as const,
     value,
     unit,
-    parsed: {value: parseNumber(value, unit), unit: unit.toLowerCase()},
+    parsed: this.config.parse
+      ? {value: parseNumber(value, unit), unit: unit.toLowerCase()}
+      : undefined,
   });
 
   tokenValueNumberList = (

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -492,7 +492,6 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.VALUE_ISO_8601_DATE as const,
     value: value,
-    parsed: this.config.parse ? {value: parseDate(value)} : undefined,
   });
 
   tokenValueRelativeDate = (
@@ -503,13 +502,6 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.VALUE_RELATIVE_DATE as const,
     value: value,
-    parsed: this.config.parse
-      ? {
-          value: parseRelativeDate(value, {unit, sign}),
-          unit: unit?.toLowerCase(),
-          sign: sign?.toLowerCase(),
-        }
-      : undefined,
     sign,
     unit,
   });
@@ -522,9 +514,6 @@ export class TokenConverter {
 
     type: Token.VALUE_DURATION as const,
     value: value,
-    parsed: this.config.parse
-      ? {value: parseDuration(value, unit), unit: unit?.toLowerCase()}
-      : undefined,
     unit,
   });
 
@@ -554,11 +543,6 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.VALUE_SIZE as const,
     value: value,
-    // units are case insensitive, normalize them in their parsed representation
-    // so that we dont have to compare all possible permutations.
-    parsed: this.config.parse
-      ? {value: parseSize(value, unit), unit: unit.toLowerCase()}
-      : undefined,
     unit,
   });
 
@@ -566,14 +550,12 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.VALUE_PERCENTAGE as const,
     value: value,
-    parsed: this.config.parse ? {value: parsePercentage(value)} : undefined,
   });
 
   tokenValueBoolean = (value: string) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_BOOLEAN as const,
     value: value,
-    parsed: this.config.parse ? {value: parseBoolean(value)} : undefined,
   });
 
   tokenValueNumber = (value: string, unit: 'k' | 'm' | 'b') => ({
@@ -581,9 +563,6 @@ export class TokenConverter {
     type: Token.VALUE_NUMBER as const,
     value,
     unit,
-    parsed: this.config.parse
-      ? {value: parseNumber(value, unit), unit: unit.toLowerCase()}
-      : undefined,
   });
 
   tokenValueNumberList = (
@@ -890,92 +869,6 @@ export class TokenConverter {
   };
 }
 
-function parseDate(input: string): Date {
-  const date = new Date(input);
-
-  if (isNaN(date.getTime())) {
-    throw new Error('Invalid date');
-  }
-
-  return date;
-}
-
-function parseRelativeDate(
-  input: string,
-  {sign, unit}: {sign: '-' | '+'; unit: string}
-): Date {
-  let date = new Date(input).getTime();
-
-  if (isNaN(date)) {
-    throw new Error('Invalid date');
-  }
-
-  let offset: number | undefined;
-  switch (unit) {
-    case 'm':
-      offset = 1000 * 60;
-      break;
-    case 'h':
-      offset = 1000 * 60 * 60;
-      break;
-    case 'd':
-      offset = 1000 * 60 * 60 * 24;
-      break;
-    case 'w':
-      offset = 1000 * 60 * 60 * 24 * 7;
-      break;
-    default:
-      throw new Error('Invalid unit');
-  }
-
-  if (offset === undefined) {
-    throw new Error('Unreachable');
-  }
-
-  date = sign === '-' ? date - offset : date + offset;
-  return new Date(date);
-}
-
-// The parser supports floats and ints, parseFloat handles both.
-function numeric(input: string) {
-  const number = parseFloat(input);
-  if (isNaN(number)) {
-    throw new Error('Invalid number');
-  }
-  return number;
-}
-function parseDuration(input: string, _unit: string): number {
-  return numeric(input);
-}
-function parseNumber(input: string, unit: 'k' | 'm' | 'b') {
-  const number = numeric(input);
-  switch (unit) {
-    case 'k':
-      return number * 1e3;
-    case 'm':
-      return number * 1e6;
-    case 'b':
-      return number * 1e9;
-    default:
-      throw new Error('Invalid unit');
-  }
-}
-function parseSize(input: string, _unit: string) {
-  return numeric(input);
-}
-function parsePercentage(input: string): number {
-  return numeric(input);
-}
-function parseBoolean(input: string): boolean {
-  if (/^true$/i.test(input) || input === '1') {
-    return true;
-  }
-  if (/^false$/i.test(input) || input === '0') {
-    return false;
-  }
-  throw new Error('Invalid boolean');
-}
-
 /**
  * Maps token conversion methods to their result types
  */
@@ -1066,10 +959,6 @@ export type SearchConfig = {
    * A function that returns a warning message for a given filter token key
    */
   getFilterTokenWarning?: (key: string) => React.ReactNode;
-  /**
-   * Determines if user input values should be parsed
-   */
-  parse?: boolean;
   /**
    * If validateKeys is set to true, tag keys that don't exist in supportedTags will be consider invalid
    */

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/react';
 import merge from 'lodash/merge';
-import moment from 'moment';
 import type {LocationRange} from 'pegjs';
 
 import {t} from 'sentry/locale';
@@ -125,12 +124,6 @@ export const interchangeableFilterOperators = {
 };
 
 const textKeys = [Token.KEY_SIMPLE, Token.KEY_EXPLICIT_TAG] as const;
-
-const numberUnits = {
-  b: 1_000_000_000,
-  m: 1_000_000,
-  k: 1_000,
-};
 
 /**
  * This constant-type configuration object declares how each filter type
@@ -498,7 +491,7 @@ export class TokenConverter {
   tokenValueIso8601Date = (value: string) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_ISO_8601_DATE as const,
-    value: moment(value),
+    value: value,
   });
 
   tokenValueRelativeDate = (
@@ -563,14 +556,13 @@ export class TokenConverter {
   tokenValueBoolean = (value: string) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_BOOLEAN as const,
-    value: ['1', 'true'].includes(value.toLowerCase()),
+    value: value,
   });
 
   tokenValueNumber = (value: string, unit: string) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_NUMBER as const,
     value,
-    rawValue: Number(value) * (numberUnits[unit] ?? 1),
     unit,
   });
 

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1064,7 +1064,6 @@ export type SearchConfig = {
    * If validateKeys is set to true, tag keys that don't exist in supportedTags will be consider invalid
    */
   supportedTags?: TagCollection;
-
   /**
    * If set to true, tag keys that don't exist in supportedTags will be consider invalid
    */

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -576,7 +576,7 @@ export class TokenConverter {
     parsed: this.config.parse ? {value: parseBoolean(value)} : undefined,
   });
 
-  tokenValueNumber = (value: string, unit: 'k' | 'm' | 'b' | 'K' | 'M' | 'B') => ({
+  tokenValueNumber = (value: string, unit: 'k' | 'm' | 'b') => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_NUMBER as const,
     value,
@@ -947,8 +947,18 @@ function numeric(input: string) {
 function parseDuration(input: string, _unit: string): number {
   return numeric(input);
 }
-function parseNumber(input: string, _unit: string) {
-  return numeric(input);
+function parseNumber(input: string, unit: 'k' | 'm' | 'b') {
+  const number = numeric(input);
+  switch (unit) {
+    case 'k':
+      return number * 1e3;
+    case 'm':
+      return number * 1e6;
+    case 'b':
+      return number * 1e9;
+    default:
+      throw new Error('Invalid unit');
+  }
 }
 function parseSize(input: string, _unit: string) {
   return numeric(input);

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -492,7 +492,7 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.VALUE_ISO_8601_DATE as const,
     value: value,
-    parsedValue: parseDate(value),
+    parsed: this.config.parse ? {value: parseDate(value)} : undefined,
   });
 
   tokenValueRelativeDate = (
@@ -503,7 +503,13 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.VALUE_RELATIVE_DATE as const,
     value: value,
-    parsedValue: parseRelativeDate(value, {unit, sign}),
+    parsed: this.config.parse
+      ? {
+          value: parseRelativeDate(value, {unit, sign}),
+          unit: unit?.toLowerCase(),
+          sign: sign?.toLowerCase(),
+        }
+      : undefined,
     sign,
     unit,
   });
@@ -516,7 +522,7 @@ export class TokenConverter {
 
     type: Token.VALUE_DURATION as const,
     value: value,
-    parsedValue: parseDuration(value, unit),
+    parsed: {value: parseDuration(value, unit), unit: unit?.toLowerCase()},
     unit,
   });
 
@@ -546,7 +552,9 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.VALUE_SIZE as const,
     value: value,
-    parsedValue: parseSize(value, unit),
+    // units are case insensitive, normalize them in their parsed representation
+    // so that we dont have to compare all possible permutations.
+    parsed: {value: parseSize(value, unit), unit: unit.toLowerCase()},
     unit,
   });
 
@@ -554,22 +562,22 @@ export class TokenConverter {
     ...this.defaultTokenFields,
     type: Token.VALUE_PERCENTAGE as const,
     value: value,
-    parsedValue: parsePercentage(value),
+    parsed: {value: parsePercentage(value)},
   });
 
   tokenValueBoolean = (value: string) => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_BOOLEAN as const,
     value: value,
-    parsedValue: parseBoolean(value),
+    parsed: {value: parseBoolean(value)},
   });
 
-  tokenValueNumber = (value: string, unit: string) => ({
+  tokenValueNumber = (value: string, unit: 'k' | 'm' | 'b' | 'K' | 'M' | 'B') => ({
     ...this.defaultTokenFields,
     type: Token.VALUE_NUMBER as const,
     value,
     unit,
-    parsedValue: parseNumber(value, unit),
+    parsed: {value: parseNumber(value, unit), unit: unit.toLowerCase()},
   });
 
   tokenValueNumberList = (
@@ -918,7 +926,7 @@ function parseRelativeDate(
     throw new Error('Unreachable');
   }
 
-  date = sign === '+' ? date + offset : date - offset;
+  date = sign === '-' ? date - offset : date + offset;
   return new Date(date);
 }
 
@@ -1043,9 +1051,14 @@ export type SearchConfig = {
    */
   getFilterTokenWarning?: (key: string) => React.ReactNode;
   /**
+   * Determines if user input values should be parsed
+   */
+  parse?: boolean;
+  /**
    * If validateKeys is set to true, tag keys that don't exist in supportedTags will be consider invalid
    */
   supportedTags?: TagCollection;
+
   /**
    * If set to true, tag keys that don't exist in supportedTags will be consider invalid
    */

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -2060,7 +2060,6 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
 
         {this.shouldShowDatePicker && (
           <SearchBarDatePicker
-            date={this.cursorValueIsoDate?.value}
             dateString={this.cursorValueIsoDate?.text}
             handleSelectDateTime={this.onAutoCompleteIsoDate}
           />

--- a/static/app/components/smartSearchBar/searchBarDatePicker.tsx
+++ b/static/app/components/smartSearchBar/searchBarDatePicker.tsx
@@ -1,7 +1,6 @@
 import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import format from 'date-fns/format';
-import type {Moment} from 'moment';
 
 import {DatePicker} from 'sentry/components/calendar';
 import Checkbox from 'sentry/components/checkbox';
@@ -12,7 +11,6 @@ import {DEFAULT_DAY_START_TIME, setDateToTime} from 'sentry/utils/dates';
 
 type SearchBarDatePickerProps = {
   handleSelectDateTime: (value: string) => void;
-  date?: Moment;
   dateString?: string;
 };
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -111,7 +111,12 @@ def result_transformer(result):
             return SearchValue(raw_value=[item["value"]["value"] for item in token["items"]])
 
         if token["type"] == "valueNumberList":
-            return SearchValue(raw_value=[item["value"]["rawValue"] for item in token["items"]])
+            return SearchValue(
+                raw_value=[
+                    parse_numeric_value(item["value"]["value"], item["value"]["unit"])
+                    for item in token["items"]
+                ]
+            )
 
         if token["type"] == "valueIso8601Date":
             return SearchValue(raw_value=parse_datetime_string(token["value"]))

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -18,7 +18,12 @@ from sentry.api.event_search import (
 )
 from sentry.constants import MODULE_ROOT
 from sentry.exceptions import InvalidSearchQuery
-from sentry.search.utils import parse_datetime_string, parse_duration, parse_numeric_value
+from sentry.search.utils import (
+    parse_bool,
+    parse_datetime_string,
+    parse_duration,
+    parse_numeric_value,
+)
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
 
@@ -128,7 +133,7 @@ def result_transformer(result):
             return SearchValue(raw_value=parse_duration(token["value"], token["unit"]))
 
         if token["type"] == "valueBoolean":
-            return SearchValue(raw_value=int(token["value"]))
+            return SearchValue(raw_value=int(parse_bool(token["value"])))
 
         if token["type"] == "freeText":
             if token["quoted"]:


### PR DESCRIPTION
remove rawValue in favor of parsed and make sure we parse values correctly for tokens like relative date. I also noticed that the grammar for size units only recognizes lowercase inputs, so I'm making those case insensitive.

I've made parsing a config option as most parts of the app will not require it.