### PR TITLE
fix(new-trace): Default routing to issue details from discover for  e…

### DIFF
--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -653,9 +653,10 @@ describe('Results', function () {
         'undefined?field=title&field=event.type&field=project&field=user.display&field=timestamp&id=1&name=new&query=&sort=-project&statsPeriod=24h&topEvents=5'
       );
 
+      // NOTE: This uses a legacy redirect for project event to the issue group event link
       expect(screen.getByRole('link', {name: 'deadbeef'})).toHaveAttribute(
         'href',
-        '/organizations/org-slug/discover/project-slug:deadbeef/?field=title&field=event.type&field=project&field=user.display&field=timestamp&id=1&name=new&query=&sort=-user.display&statsPeriod=24h&topEvents=5&yAxis=count%28%29'
+        '/org-slug/project-slug/events/deadbeef/?referrer=discover-events-table?id=1&statsPeriod=24h'
       );
 
       expect(screen.getByRole('link', {name: 'user.display'})).toHaveAttribute(

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -190,7 +190,13 @@ function TableView(props: TableViewProps) {
       }
 
       let target;
-      if (dataRow.trace !== null) {
+      if (dataRow['event.type'] === 'transaction') {
+        if (dataRow.trace === null) {
+          throw new Error(
+            'Transaction event should always have a trace associated with it.'
+          );
+        }
+
         target = generateLinkToEventInTraceView({
           eventSlug: generateEventSlug(dataRow),
           dataRow,
@@ -201,12 +207,6 @@ function TableView(props: TableViewProps) {
           type: 'discover',
         });
       } else {
-        if (dataRow['event.type'] === 'transaction') {
-          throw new Error(
-            'Transaction event should always have a trace associated with it.'
-          );
-        }
-
         const project = dataRow.project || dataRow['project.name'];
 
         target = {
@@ -316,7 +316,13 @@ function TableView(props: TableViewProps) {
     if (columnKey === 'id') {
       let target;
 
-      if (dataRow.trace !== null) {
+      if (dataRow['event.type'] === 'transaction') {
+        if (dataRow.trace === null) {
+          throw new Error(
+            'Transaction event should always have a trace associated with it.'
+          );
+        }
+
         target = generateLinkToEventInTraceView({
           eventSlug: generateEventSlug(dataRow),
           dataRow,
@@ -327,12 +333,6 @@ function TableView(props: TableViewProps) {
           type: 'discover',
         });
       } else {
-        if (dataRow['event.type'] === 'transaction') {
-          throw new Error(
-            'Transaction event should always have a trace associated with it.'
-          );
-        }
-
         const project = dataRow.project || dataRow['project.name'];
 
         target = {


### PR DESCRIPTION
…rrors and default event types.

We were initially routing to issue details for rows that had no trace slug. Now we are always routing to issues for errors and default event types.
