### PR TITLE
feat(new-trace): Removing project selection when routing to issues from trace view

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -201,6 +201,8 @@ function IssueListHeader({node}: {node: TraceTreeNode<TraceTree.NodeValue>}) {
                       start: dateSelection.start,
                       end: dateSelection.end,
                       statsPeriod: dateSelection.statsPeriod,
+                      // If we don't pass the project param, the issues page will filter by the last selected project.
+                      // Traces can have multiple projects, so we query issues by all projects and rely on our search query to filter the results.
                       project: -1,
                     },
                   }}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -201,6 +201,7 @@ function IssueListHeader({node}: {node: TraceTreeNode<TraceTree.NodeValue>}) {
                       start: dateSelection.start,
                       end: dateSelection.end,
                       statsPeriod: dateSelection.statsPeriod,
+                      project: -1,
                     },
                   }}
                 >


### PR DESCRIPTION
Trace can have multiple projects and issues landing page pushes the project last selected when no project param is passed. 