### PR TITLE
feat(app-start): Add cold/warm start widgets to mobile tab

### DIFF
--- a/static/app/views/performance/landing/views/mobileView.tsx
+++ b/static/app/views/performance/landing/views/mobileView.tsx
@@ -43,6 +43,13 @@ export function MobileView(props: BasePerformanceViewProps) {
   if (organization.features.includes('performance-screens-view')) {
     doubleRowAllowedCharts[0] = PerformanceWidgetSetting.SLOW_SCREENS_BY_TTID;
   }
+  if (organization.features.includes('starfish-mobile-appstart')) {
+    doubleRowAllowedCharts.push(
+      PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START,
+      PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START
+    );
+  }
+
   if (
     organization.features.includes('performance-new-trends') &&
     canUseMetricsData(props.organization)

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -22,8 +22,8 @@ import {usePerformanceDisplayType} from 'sentry/utils/performance/contexts/perfo
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
+import MobileReleaseComparisonListWidget from 'sentry/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget';
 import {PerformanceScoreListWidget} from 'sentry/views/performance/landing/widgets/widgets/performanceScoreListWidget';
-import SlowScreens from 'sentry/views/performance/landing/widgets/widgets/slowScreens';
 
 import {GenericPerformanceWidgetDataType} from '../types';
 import {_setChartSetting, filterAllowedChartsMetrics, getChartSetting} from '../utils';
@@ -205,7 +205,9 @@ function _WidgetContainer(props: Props) {
     case GenericPerformanceWidgetDataType.PERFORMANCE_SCORE:
       return <PerformanceScoreWidget {...passedProps} {...widgetProps} />;
     case GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_TTID:
-      return <SlowScreens {...passedProps} {...widgetProps} />;
+    case GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_COLD_START:
+    case GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_WARM_START:
+      return <MobileReleaseComparisonListWidget {...passedProps} {...widgetProps} />;
     default:
       throw new Error(`Widget type "${widgetProps.dataType}" has no implementation.`);
   }

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -26,6 +26,8 @@ export enum GenericPerformanceWidgetDataType {
   PERFORMANCE_SCORE = 'performance_score',
   SLOW_SCREENS_BY_TTID = 'slow_screens_by_ttid',
   PERFORMANCE_SCORE_LIST = 'performance_score_list',
+  SLOW_SCREENS_BY_COLD_START = 'slow_screens_by_cold_start',
+  SLOW_SCREENS_BY_WARM_START = 'slow_screens_by_warm_start',
 }
 
 export type PerformanceWidgetProps = {

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -399,14 +399,14 @@ export const WIDGET_DEFINITIONS: ({
     dataType: GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_TTID,
   },
   [PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START]: {
-    title: t('Slow Screens by Cold Start'),
+    title: t('Average Cold Start'),
     titleTooltip: '',
     subTitle: t('Top screens by count'),
     fields: ['avg(measurements.app_start_cold)'],
     dataType: GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_COLD_START,
   },
   [PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START]: {
-    title: t('Slow Screens by Warm Start'),
+    title: t('Average Warm Start'),
     titleTooltip: '',
     subTitle: t('Top screens by count'),
     fields: ['avg(measurements.app_start_warm)'],

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -67,6 +67,8 @@ export enum PerformanceWidgetSetting {
   OVERALL_PERFORMANCE_SCORE = 'overall_performance_score',
   MOST_TIME_CONSUMING_RESOURCES = 'most_time_consuming_resources',
   SLOW_SCREENS_BY_TTID = 'slow_screens_by_ttid',
+  SLOW_SCREENS_BY_COLD_START = 'slow_screens_by_cold_start',
+  SLOW_SCREENS_BY_WARM_START = 'slow_screens_by_warm_start',
 }
 
 const WIDGET_PALETTE = CHART_PALETTE[5];
@@ -395,5 +397,19 @@ export const WIDGET_DEFINITIONS: ({
     subTitle: t('Top screens by count'),
     fields: ['avg(measurements.time_to_initial_display)'],
     dataType: GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_TTID,
+  },
+  [PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START]: {
+    title: t('Slow Screens by Cold Start'),
+    titleTooltip: '',
+    subTitle: t('Top screens by count'),
+    fields: ['avg(measurements.app_start_cold)'],
+    dataType: GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_COLD_START,
+  },
+  [PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START]: {
+    title: t('Slow Screens by Warm Start'),
+    titleTooltip: '',
+    subTitle: t('Top screens by count'),
+    fields: ['avg(measurements.app_start_warm)'],
+    dataType: GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_WARM_START,
   },
 });

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -401,14 +401,14 @@ export const WIDGET_DEFINITIONS: ({
   [PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START]: {
     title: t('Average Cold Start'),
     titleTooltip: '',
-    subTitle: t('Top screens by count'),
+    subTitle: t('Top screens by start count'),
     fields: ['avg(measurements.app_start_cold)'],
     dataType: GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_COLD_START,
   },
   [PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START]: {
     title: t('Average Warm Start'),
     titleTooltip: '',
-    subTitle: t('Top screens by count'),
+    subTitle: t('Top screens by start count'),
     fields: ['avg(measurements.app_start_warm)'],
     dataType: GenericPerformanceWidgetDataType.SLOW_SCREENS_BY_WARM_START,
   },

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -119,10 +119,17 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
         let extraQueryParams = getMEPParamsIfApplicable(mepSetting, props.chartSetting);
 
         // Set fields
-        eventView.fields = [{field: 'transaction'}, {field}, {field: 'count()'}];
+        const sortField = {
+          [PerformanceWidgetSetting.SLOW_SCREENS_BY_TTID]: 'count()',
+          [PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START]:
+            'count_starts(measurements.app_start_cold)',
+          [PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START]:
+            'count_starts(measurements.app_start_warm)',
+        }[props.chartSetting];
+        eventView.fields = [{field: 'transaction'}, {field}, {field: sortField}];
         eventView.sorts = [
           {
-            field: 'count()',
+            field: sortField,
             kind: 'desc',
           },
         ];

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -48,6 +48,7 @@ import {
   QUERY_LIMIT_PARAM,
   TOTAL_EXPANDABLE_ROWS_HEIGHT,
 } from 'sentry/views/performance/landing/widgets/utils';
+import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets/widgetDefinitions';
 import {Subtitle} from 'sentry/views/profiling/landing/styles';
 import {RightAlignedCell} from 'sentry/views/replays/deadRageClick/deadRageSelectorCards';
 import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
@@ -313,6 +314,21 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
       );
     };
 
+  const isAppStartup = [
+    PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START,
+    PerformanceWidgetSetting.SLOW_SCREENS_BY_WARM_START,
+  ].includes(props.chartSetting);
+  const targetPathname = isAppStartup
+    ? '/performance/mobile/app-startup/spans/'
+    : '/performance/mobile/screens/spans/';
+  const targetQueryParams = isAppStartup
+    ? {
+        app_start_type:
+          props.chartSetting === PerformanceWidgetSetting.SLOW_SCREENS_BY_COLD_START
+            ? 'cold'
+            : 'warm',
+      }
+    : {};
   const getItems = provided =>
     provided.widgetData.list.data.map(
       listItem =>
@@ -323,13 +339,14 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
             <Fragment>
               <GrowLink
                 to={normalizeUrl({
-                  pathname: `/performance/mobile/screens/spans/`,
+                  pathname: targetPathname,
                   query: {
                     project: listItem['project.id'],
                     transaction,
                     primaryRelease,
                     secondaryRelease,
                     ...normalizeDateTimeParams(location.query),
+                    ...targetQueryParams,
                   },
                 })}
               >

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -90,7 +90,7 @@ export function transformEventsChartRequest<T extends WidgetDataConstraint>(
   return childData;
 }
 
-function SlowScreensByTTID(props: PerformanceWidgetProps) {
+function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
   const api = useApi();
   const pageFilter = usePageFilters();
   const mepSetting = useMEPSettingContext();
@@ -374,6 +374,7 @@ function SlowScreensByTTID(props: PerformanceWidgetProps) {
       HeaderActions={() => (
         <LinkButton
           to={normalizeUrl({
+            // TODO(nar): Needs to switch to app starts route
             pathname: `/organizations/${organization.slug}/performance/mobile/screens/`,
             query: {
               ...normalizeDateTimeParams(pageFilter),
@@ -404,7 +405,7 @@ function SlowScreensByTTID(props: PerformanceWidgetProps) {
   );
 }
 
-export default SlowScreensByTTID;
+export default MobileReleaseComparisonListWidget;
 
 const StyledDurationWrapper = styled('div')`
   padding: 0 ${space(1)};

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -55,7 +55,6 @@ import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
-import {OUTPUT_TYPE, YAxis} from 'sentry/views/starfish/views/screens';
 
 type DataType = {
   chart: WidgetDataResult & ReturnType<typeof transformEventsRequestToArea>;
@@ -302,10 +301,10 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
             bottom: '0',
           }}
           type={ChartType.LINE}
-          aggregateOutputFormat={OUTPUT_TYPE[YAxis.TTID]}
+          aggregateOutputFormat="duration"
           tooltipFormatterOptions={{
             valueFormatter: value =>
-              tooltipFormatterUsingAggregateOutputType(value, OUTPUT_TYPE[YAxis.TTID]),
+              tooltipFormatterUsingAggregateOutputType(value, 'duration'),
           }}
           error={provided.widgetData.chart.error}
           disableXAxis

--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -338,7 +338,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
             <Fragment>
               <GrowLink
                 to={normalizeUrl({
-                  pathname: `${targetModulePath}/spans/`,
+                  pathname: `${targetModulePath}spans/`,
                   query: {
                     project: listItem['project.id'],
                     transaction,


### PR DESCRIPTION
Adds cold and warm start widgets to the mobile tab that serve as entrypoints into the app starts module. These widgets use the same component as the Average TTID widget because they need the release comparison.

There were some hardcoded values in there that I needed to remove to make more flexible.

<img width="726" alt="Screenshot 2024-04-17 at 12 27 59 PM" src="https://github.com/getsentry/sentry/assets/22846452/f6263d40-bec3-4f88-9613-20170161fe91">
