### PR TITLE
ref(replays): add error boundaries around breadcrumb rows

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -5,6 +5,7 @@ import beautify from 'js-beautify';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import ErrorBoundary from 'sentry/components/errorBoundary';
 import Link from 'sentry/components/links/link';
 import ObjectInspector from 'sentry/components/objectInspector';
 import PanelItem from 'sentry/components/panels/panelItem';
@@ -80,71 +81,74 @@ function BreadcrumbItem({
       <IconWrapper color={color} hasOccurred>
         {icon}
       </IconWrapper>
-      <CrumbDetails>
-        <Flex column>
-          <TitleContainer>
-            {<Title>{title}</Title>}
-            {onClick ? (
-              <TimestampButton
-                startTimestampMs={startTimestampMs}
-                timestampMs={frame.timestampMs}
-              />
-            ) : null}
-          </TitleContainer>
 
-          {typeof description === 'string' ||
-          (description !== undefined && isValidElement(description)) ? (
-            <Description title={description} showOnlyOnOverflow isHoverable>
-              {description}
-            </Description>
-          ) : (
-            <InspectorWrapper>
-              <ObjectInspector
-                data={description}
-                expandPaths={expandPaths}
-                onExpand={onInspectorExpanded}
-                theme={{
-                  TREENODE_FONT_SIZE: '0.7rem',
-                  ARROW_FONT_SIZE: '0.5rem',
-                }}
-              />
-            </InspectorWrapper>
-          )}
-        </Flex>
+      <ErrorBoundary mini>
+        <CrumbDetails>
+          <Flex column>
+            <TitleContainer>
+              {<Title>{title}</Title>}
+              {onClick ? (
+                <TimestampButton
+                  startTimestampMs={startTimestampMs}
+                  timestampMs={frame.timestampMs}
+                />
+              ) : null}
+            </TitleContainer>
 
-        {'data' in frame && frame.data && 'mutations' in frame.data ? (
-          <div>
-            <OpenReplayComparisonButton
-              replay={replay}
-              leftTimestamp={frame.offsetMs}
-              rightTimestamp={
-                (frame.data.mutations.next?.timestamp ?? 0) -
-                (replay?.getReplay().started_at.getTime() ?? 0)
-              }
+            {typeof description === 'string' ||
+            (description !== undefined && isValidElement(description)) ? (
+              <Description title={description} showOnlyOnOverflow isHoverable>
+                {description}
+              </Description>
+            ) : (
+              <InspectorWrapper>
+                <ObjectInspector
+                  data={description}
+                  expandPaths={expandPaths}
+                  onExpand={onInspectorExpanded}
+                  theme={{
+                    TREENODE_FONT_SIZE: '0.7rem',
+                    ARROW_FONT_SIZE: '0.5rem',
+                  }}
+                />
+              </InspectorWrapper>
+            )}
+          </Flex>
+
+          {'data' in frame && frame.data && 'mutations' in frame.data ? (
+            <div>
+              <OpenReplayComparisonButton
+                replay={replay}
+                leftTimestamp={frame.offsetMs}
+                rightTimestamp={
+                  (frame.data.mutations.next?.timestamp ?? 0) -
+                  (replay?.getReplay().started_at.getTime() ?? 0)
+                }
+              />
+            </div>
+          ) : null}
+
+          {extraction?.html ? (
+            <CodeContainer>
+              <CodeSnippet language="html" hideCopyButton>
+                {beautify.html(extraction?.html, {indent_size: 2})}
+              </CodeSnippet>
+            </CodeContainer>
+          ) : null}
+
+          {traces?.flattenedTraces.map((flatTrace, i) => (
+            <TraceGrid
+              key={i}
+              flattenedTrace={flatTrace}
+              onDimensionChange={onDimensionChange}
             />
-          </div>
-        ) : null}
+          ))}
 
-        {extraction?.html ? (
-          <CodeContainer>
-            <CodeSnippet language="html" hideCopyButton>
-              {beautify.html(extraction?.html, {indent_size: 2})}
-            </CodeSnippet>
-          </CodeContainer>
-        ) : null}
-
-        {traces?.flattenedTraces.map((flatTrace, i) => (
-          <TraceGrid
-            key={i}
-            flattenedTrace={flatTrace}
-            onDimensionChange={onDimensionChange}
-          />
-        ))}
-
-        {isErrorFrame(frame) || isFeedbackFrame(frame) ? (
-          <CrumbErrorIssue frame={frame} />
-        ) : null}
-      </CrumbDetails>
+          {isErrorFrame(frame) || isFeedbackFrame(frame) ? (
+            <CrumbErrorIssue frame={frame} />
+          ) : null}
+        </CrumbDetails>
+      </ErrorBoundary>
     </CrumbItem>
   );
 }


### PR DESCRIPTION
better fix instead of https://github.com/getsentry/sentry/pull/69060

show an error boundary around the breadcrumb rows if the breadcrumb frame is invalid for some reason, rather than breaking the entire tab. 

<img width="482" alt="SCR-20240417-jlyi" src="https://github.com/getsentry/sentry/assets/56095982/f51669ab-3253-4993-bca8-47a21e467f82">


fixes [JAVASCRIPT-2SJF](https://sentry.io/organizations/sentry/issues/?project=11276&query=JAVASCRIPT-2SJF)
fixes [JAVASCRIPT-2SJG](https://sentry.io/organizations/sentry/issues/?project=11276&query=JAVASCRIPT-2SJG)
