### PR TITLE
ref(crons): Notify user that monitor will be disabled after broken

### DIFF
--- a/src/sentry/templates/sentry/emails/crons/broken-monitors.html
+++ b/src/sentry/templates/sentry/emails/crons/broken-monitors.html
@@ -25,7 +25,7 @@
         {% endfor %}
       </ul>
     <p>
-      To bring your monitors back to a healthy status, we recommend checking out our <a href="https://docs.sentry.io/product/crons/troubleshooting/">troubleshooting guide and our FAQs</a>.
+      To bring your monitors back to a healthy status, we recommend checking out our <a href="https://docs.sentry.io/product/crons/troubleshooting/">troubleshooting guide and our FAQs</a>. Otherwise, we'll automatically mute or disable them for you in a few days.
     </p>
     <p><a href="{{ view_monitors_link }}" class="btn">View Monitors</a></p>
     <p>

--- a/src/sentry/templates/sentry/emails/crons/broken-monitors.txt
+++ b/src/sentry/templates/sentry/emails/crons/broken-monitors.txt
@@ -5,7 +5,7 @@ We've noticed the cron monitors below have not processed a successful check-in f
 * {{monitor_name}} {{monitor_url}} | Failing since {{earliest_incident_start_date|date:"N j, Y, g:i:s a e"}}
 {% endfor %}
 
-To bring your monitors back to a healthy status, we recommend checking out our troubleshooting guide and our FAQs: "https://docs.sentry.io/product/crons/troubleshooting/".
+To bring your monitors back to a healthy status, we recommend checking out our troubleshooting guide and our FAQs: "https://docs.sentry.io/product/crons/troubleshooting/". Otherwise, we'll automatically mute or disable them for you in a few days.
 
 View Monitors: {{ view_monitors_link }}
 


### PR DESCRIPTION
Adds this bit of text to notify user that their monitors will eventually be disabled

<img width="724" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/40248fa6-2ca2-4d8f-9a10-5e973dfaf6b4">
