### PR TITLE
ref(crons): Remove footer on crons broken monitor email

### DIFF
--- a/src/sentry/templates/sentry/emails/crons/broken-monitors.html
+++ b/src/sentry/templates/sentry/emails/crons/broken-monitors.html
@@ -32,3 +32,5 @@
       Still facing issues? <a href="https://sentry.zendesk.com/hc/en-us/requests/new">Reach out to our support team</a>.
     </p>
 {% endblock %}
+
+{% block footer %}{% endblock %}


### PR DESCRIPTION
We currently don't have a setting to turn off these emails, and have decided against it since the emails are billing-related in the case we disable cron monitors.

Therefore, footer shouldn't be here since the link to notification settings doesn't offer any options to turn off this email.