### PR TITLE
chore(api-idorslug): Created FF for options backed feature handler

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1477,7 +1477,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:api-auth-provider": False,
     "organizations:api-keys": False,
     # Enable Id or slug path params support for apis
-    "organizations:api-id-or-slug-enabled": True,
+    "organizations:api-id-or-slug-enabled": False,
     # Enable multiple Apple app-store-connect sources per project.
     "organizations:app-store-connect-multiple": False,
     # Enables the cron job to auto-enable codecov integrations.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1477,7 +1477,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:api-auth-provider": False,
     "organizations:api-keys": False,
     # Enable Id or slug path params support for apis
-    "organizations:api-id-or-slug-enabled": False,
+    "organizations:api-id-or-slug-enabled": True,
     # Enable multiple Apple app-store-connect sources per project.
     "organizations:app-store-connect-multiple": False,
     # Enables the cron job to auto-enable codecov integrations.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1476,6 +1476,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable auth provider configuration through api
     "organizations:api-auth-provider": False,
     "organizations:api-keys": False,
+    # Enable Id or slug path params support for apis
+    "organizations:api-id-or-slug-enabled": False,
     # Enable multiple Apple app-store-connect sources per project.
     "organizations:app-store-connect-multiple": False,
     # Enables the cron job to auto-enable codecov integrations.

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -47,6 +47,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:anr-improvements", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:api-auth-provider", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:api-keys", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+    manager.add("organizations:api-id-or-slug-enabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:codecov-commit-sha-from-git-blame", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:crons-broken-monitor-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
We have cooked the API changes for a subset of orgs for a bit and want to now officially EA these changes. 

To make this available to all EA orgs quickly, I am creating an options backed feature handler for it, and this is the feature flag for it.

I'll make another PR after I get the option registered to modify the wrapper function I have to use this feature flag.

Part of https://github.com/getsentry/team-core-product-foundations/issues/263