### PR TITLE
feat: Add Activated Alert Rules to alert rule index

### DIFF
--- a/fixtures/js-stubs/metricRule.ts
+++ b/fixtures/js-stubs/metricRule.ts
@@ -7,6 +7,7 @@ export function MetricRuleFixture(
   params: Partial<SavedMetricRule> = {}
 ): SavedMetricRule {
   return {
+    activations: [],
     status: 0,
     dateCreated: '2019-07-31T23:02:02.731Z',
     dataset: Dataset.ERRORS,

--- a/static/app/components/badge/alertBadge.tsx
+++ b/static/app/components/badge/alertBadge.tsx
@@ -1,14 +1,25 @@
 import styled from '@emotion/styled';
 
 import {DiamondStatus} from 'sentry/components/diamondStatus';
-import {IconCheckmark, IconExclamation, IconFire, IconIssues} from 'sentry/icons';
+import {
+  IconCheckmark,
+  IconEllipsis,
+  IconExclamation,
+  IconFire,
+  IconHappy,
+  IconIssues,
+} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ColorOrAlias} from 'sentry/utils/theme';
-import {IncidentStatus} from 'sentry/views/alerts/types';
+import {ActivationStatus, IncidentStatus} from 'sentry/views/alerts/types';
 
 type Props = {
+  /**
+   * The rule is actively monitoring
+   */
+  activationStatus?: ActivationStatus;
   /**
    * @deprecated use withText
    */
@@ -31,7 +42,7 @@ type Props = {
  * This badge is a composition of DiamondStatus specifically used for incident
  * alerts.
  */
-function AlertBadge({status, withText, isIssue}: Props) {
+function AlertBadge({status, withText, isIssue, activationStatus}: Props) {
   let statusText = t('Resolved');
   let Icon: React.ComponentType<SVGIconProps> = IconCheckmark;
   let color: ColorOrAlias = 'successText';
@@ -48,6 +59,15 @@ function AlertBadge({status, withText, isIssue}: Props) {
     statusText = t('Warning');
     Icon = IconExclamation;
     color = 'warningText';
+  }
+
+  if (activationStatus === ActivationStatus.WAITING) {
+    statusText = t('Ready');
+    Icon = IconHappy;
+    color = 'purple300';
+  } else if (activationStatus === ActivationStatus.MONITORING) {
+    statusText = t('Monitoring');
+    Icon = IconEllipsis;
   }
 
   return (

--- a/static/app/components/badge/alertBadge.tsx
+++ b/static/app/components/badge/alertBadge.tsx
@@ -6,8 +6,8 @@ import {
   IconEllipsis,
   IconExclamation,
   IconFire,
-  IconHappy,
   IconIssues,
+  IconShow,
 } from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
@@ -63,11 +63,11 @@ function AlertBadge({status, withText, isIssue, activationStatus}: Props) {
 
   if (activationStatus === ActivationStatus.WAITING) {
     statusText = t('Ready');
-    Icon = IconHappy;
+    Icon = IconEllipsis;
     color = 'purple300';
   } else if (activationStatus === ActivationStatus.MONITORING) {
     statusText = t('Monitoring');
-    Icon = IconEllipsis;
+    Icon = IconShow;
   }
 
   return (

--- a/static/app/views/alerts/list/rules/activatedRuleRow.tsx
+++ b/static/app/views/alerts/list/rules/activatedRuleRow.tsx
@@ -18,14 +18,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
-import {
-  IconArrow,
-  IconChevron,
-  IconEllipsis,
-  IconMute,
-  IconNot,
-  IconUser,
-} from 'sentry/icons';
+import {IconArrow, IconChevron, IconEllipsis, IconMute, IconUser} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Actor, Project} from 'sentry/types';
@@ -38,9 +31,8 @@ import {
   AlertRuleTriggerType,
 } from 'sentry/views/alerts/rules/metric/types';
 
-import type {CombinedMetricIssueAlerts} from '../../types';
+import type {CombinedMetricIssueAlerts, MetricAlert} from '../../types';
 import {CombinedAlertType, IncidentStatus} from '../../types';
-import {isIssueAlert} from '../../utils';
 
 type Props = {
   hasEditAccess: boolean;
@@ -53,10 +45,10 @@ type Props = {
   orgId: string;
   projects: Project[];
   projectsLoaded: boolean;
-  rule: CombinedMetricIssueAlerts;
+  rule: MetricAlert;
 };
 
-function RuleListRow({
+function ActivatedRuleListRow({
   rule,
   projectsLoaded,
   projects,
@@ -67,42 +59,16 @@ function RuleListRow({
 }: Props) {
   const {teams: userTeams} = useUserTeams();
   const [assignee, setAssignee] = useState<string>('');
-  const activeIncident =
-    rule.latestIncident?.status !== undefined &&
-    [IncidentStatus.CRITICAL, IncidentStatus.WARNING].includes(
-      rule.latestIncident.status
-    );
 
-  function renderLastIncidentDate(): React.ReactNode {
-    if (isIssueAlert(rule)) {
-      if (!rule.lastTriggered) {
-        return t('Alert not triggered yet');
-      }
-      return (
-        <div>
-          {t('Triggered ')}
-          <TimeSince date={rule.lastTriggered} />
-        </div>
-      );
-    }
-
-    if (!rule.latestIncident) {
-      return t('Alert not triggered yet');
-    }
-
-    if (activeIncident) {
-      return (
-        <div>
-          {t('Triggered ')}
-          <TimeSince date={rule.latestIncident.dateCreated} />
-        </div>
-      );
+  function renderLatestActivation(): React.ReactNode {
+    if (!rule.activations?.length) {
+      return t('Alert not been activated yet');
     }
 
     return (
       <div>
-        {t('Resolved ')}
-        <TimeSince date={rule.latestIncident.dateClosed!} />
+        {t('Last activated ')}
+        <TimeSince date={rule.activations[0].dateCreated} />
       </div>
     );
   }
@@ -117,71 +83,50 @@ function RuleListRow({
   }
 
   function renderAlertRuleStatus(): React.ReactNode {
-    if (isIssueAlert(rule)) {
-      if (rule.status === 'disabled') {
-        return (
-          <IssueAlertStatusWrapper>
-            <IconNot size="sm" color="subText" />
-            {t('Disabled')}
-          </IssueAlertStatusWrapper>
-        );
-      }
-      if (rule.snooze) {
-        return renderSnoozeStatus();
-      }
-      return null;
-    }
+    // const isActive = !(rule.activations?.length && rule.activations[0].isComplete);
 
     if (rule.snooze) {
       return renderSnoozeStatus();
     }
 
-    const criticalTrigger = rule.triggers.find(
-      ({label}) => label === AlertRuleTriggerType.CRITICAL
-    );
-    const warningTrigger = rule.triggers.find(
-      ({label}) => label === AlertRuleTriggerType.WARNING
-    );
-    const resolvedTrigger = rule.resolveThreshold;
-
-    // NOTE: If there is no active incident, will default to a trigger
-    const trigger =
-      activeIncident && rule.latestIncident?.status === IncidentStatus.CRITICAL
-        ? criticalTrigger
-        : warningTrigger ?? criticalTrigger;
+    const isUnhealthy =
+      rule.latestIncident?.status !== undefined &&
+      [IncidentStatus.CRITICAL, IncidentStatus.WARNING].includes(
+        rule.latestIncident.status
+      );
 
     let iconColor: ColorOrAlias = 'successText';
-    let iconDirection: 'up' | 'down' | undefined;
-    // NOTE: This is incorrectly assuming that all rules have a thresholdType of ABOVE
+    let iconDirection: 'up' | 'down' =
+      rule.thresholdType === AlertRuleThresholdType.ABOVE ? 'down' : 'up';
     let thresholdTypeText =
-      activeIncident && rule.thresholdType === AlertRuleThresholdType.ABOVE
-        ? t('Above')
-        : t('Below');
-
-    if (activeIncident) {
+      rule.thresholdType === AlertRuleThresholdType.ABOVE ? t('Below') : t('Above');
+    if (isUnhealthy) {
       iconColor =
-        trigger?.label === AlertRuleTriggerType.CRITICAL
+        rule.latestIncident?.status === IncidentStatus.CRITICAL
           ? 'errorText'
-          : trigger?.label === AlertRuleTriggerType.WARNING
-            ? 'warningText'
-            : 'successText';
+          : 'warningText';
+      // if unhealthy, swap icon direction
       iconDirection = rule.thresholdType === AlertRuleThresholdType.ABOVE ? 'up' : 'down';
-    } else {
-      // Use the Resolved threshold type, which is opposite of Critical
-      iconDirection = rule.thresholdType === AlertRuleThresholdType.ABOVE ? 'down' : 'up';
       thresholdTypeText =
-        rule.thresholdType === AlertRuleThresholdType.ABOVE ? t('Below') : t('Above');
+        rule.thresholdType === AlertRuleThresholdType.ABOVE ? t('Above') : t('Below');
+    }
+
+    let threshold = rule.triggers.find(
+      ({label}) => label === AlertRuleTriggerType.CRITICAL
+    )?.alertThreshold;
+    if (isUnhealthy && rule.latestIncident?.status === IncidentStatus.WARNING) {
+      threshold = rule.triggers.find(
+        ({label}) => label === AlertRuleTriggerType.WARNING
+      )?.alertThreshold;
+    } else if (!isUnhealthy && rule.latestIncident && rule.resolveThreshold) {
+      threshold = rule.resolveThreshold;
     }
 
     return (
       <FlexCenter>
         <IconArrow color={iconColor} direction={iconDirection} />
         <TriggerText>
-          {`${thresholdTypeText} ${
-            rule.latestIncident || (!rule.latestIncident && !resolvedTrigger)
-              ? trigger?.alertThreshold?.toLocaleString()
-              : resolvedTrigger?.toLocaleString()
-          }`}
+          {`${thresholdTypeText} ${threshold}`}
           {getThresholdUnits(
             rule.aggregate,
             rule.comparisonDelta
@@ -194,9 +139,7 @@ function RuleListRow({
   }
 
   const slug = rule.projects[0];
-  const editLink = `/organizations/${orgId}/alerts/${
-    isIssueAlert(rule) ? 'rules' : 'metric-rules'
-  }/${slug}/${rule.id}/`;
+  const editLink = `/organizations/${orgId}/alerts/metric-rules/${slug}/${rule.id}/`;
 
   const duplicateLink = {
     pathname: `/organizations/${orgId}/alerts/new/${
@@ -317,39 +260,24 @@ function RuleListRow({
 
   return (
     <ErrorBoundary>
-      <AlertNameWrapper isIssueAlert={isIssueAlert(rule)}>
+      <AlertNameWrapper>
         <FlexCenter>
           <Tooltip
-            title={
-              isIssueAlert(rule)
-                ? t('Issue Alert')
-                : tct('Metric Alert Status: [status]', {
-                    status:
-                      IssueStatusText[
-                        rule?.latestIncident?.status ?? IncidentStatus.CLOSED
-                      ],
-                  })
-            }
+            title={tct('Metric Alert Status: [status]', {
+              status:
+                IssueStatusText[rule?.latestIncident?.status ?? IncidentStatus.CLOSED],
+            })}
           >
-            <AlertBadge
-              status={rule?.latestIncident?.status}
-              isIssue={isIssueAlert(rule)}
-            />
+            <AlertBadge status={rule?.latestIncident?.status} />
           </Tooltip>
         </FlexCenter>
         <AlertNameAndStatus>
           <AlertName>
-            <Link
-              to={
-                isIssueAlert(rule)
-                  ? `/organizations/${orgId}/alerts/rules/${rule.projects[0]}/${rule.id}/details/`
-                  : `/organizations/${orgId}/alerts/rules/details/${rule.id}/`
-              }
-            >
+            <Link to={`/organizations/${orgId}/alerts/rules/details/${rule.id}/`}>
               {rule.name}
             </Link>
           </AlertName>
-          <AlertIncidentDate>{renderLastIncidentDate()}</AlertIncidentDate>
+          <AlertActivationDate>{renderLatestActivation()}</AlertActivationDate>
         </AlertNameAndStatus>
       </AlertNameWrapper>
       <FlexCenter>{renderAlertRuleStatus()}</FlexCenter>
@@ -453,7 +381,7 @@ const AlertName = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
 `;
 
-const AlertIncidentDate = styled('div')`
+const AlertActivationDate = styled('div')`
   color: ${p => p.theme.gray300};
 `;
 
@@ -521,4 +449,4 @@ const Label = styled(TextOverflow)`
   margin-left: 6px;
 `;
 
-export default RuleListRow;
+export default ActivatedRuleListRow;

--- a/static/app/views/alerts/list/rules/activatedRuleRow.tsx
+++ b/static/app/views/alerts/list/rules/activatedRuleRow.tsx
@@ -67,7 +67,7 @@ function ActivatedRuleListRow({
 
   function renderLatestActivation(): React.ReactNode {
     if (!rule.activations?.length) {
-      return t('Alert not been activated yet');
+      return t('Alert has not been activated yet');
     }
 
     return (

--- a/static/app/views/alerts/list/rules/activatedRuleRow.tsx
+++ b/static/app/views/alerts/list/rules/activatedRuleRow.tsx
@@ -258,6 +258,16 @@ function ActivatedRuleListRow({
   return (
     <ErrorBoundary>
       <AlertNameWrapper>
+        <AlertNameAndStatus>
+          <AlertName>
+            <Link to={`/organizations/${orgId}/alerts/rules/details/${rule.id}/`}>
+              {rule.name}
+            </Link>
+          </AlertName>
+          <AlertActivationDate>{renderLatestActivation()}</AlertActivationDate>
+        </AlertNameAndStatus>
+      </AlertNameWrapper>
+      <FlexCenter>
         <FlexCenter>
           <Tooltip
             title={tct('Metric Alert Status: [status]', {
@@ -272,16 +282,8 @@ function ActivatedRuleListRow({
             />
           </Tooltip>
         </FlexCenter>
-        <AlertNameAndStatus>
-          <AlertName>
-            <Link to={`/organizations/${orgId}/alerts/rules/details/${rule.id}/`}>
-              {rule.name}
-            </Link>
-          </AlertName>
-          <AlertActivationDate>{renderLatestActivation()}</AlertActivationDate>
-        </AlertNameAndStatus>
-      </AlertNameWrapper>
-      <FlexCenter>{renderAlertRuleStatus()}</FlexCenter>
+        <MarginLeft>{renderAlertRuleStatus()}</MarginLeft>
+      </FlexCenter>
       <FlexCenter>
         <ProjectBadgeContainer>
           <ProjectBadge
@@ -448,6 +450,10 @@ const MenuItemWrapper = styled('div')`
 
 const Label = styled(TextOverflow)`
   margin-left: 6px;
+`;
+
+const MarginLeft = styled('div')`
+  margin-left: ${space(1)};
 `;
 
 export default ActivatedRuleListRow;

--- a/static/app/views/alerts/list/rules/activatedRuleRow.tsx
+++ b/static/app/views/alerts/list/rules/activatedRuleRow.tsx
@@ -258,9 +258,7 @@ function ActivatedRuleListRow({
     <ErrorBoundary>
       <AlertNameWrapper>
         <AlertNameAndStatus>
-          <AlertName>
-            <div>{rule.name}</div>
-          </AlertName>
+          <AlertName>{rule.name}</AlertName>
           <AlertActivationDate>{renderLatestActivation()}</AlertActivationDate>
         </AlertNameAndStatus>
       </AlertNameWrapper>
@@ -295,12 +293,7 @@ function ActivatedRuleListRow({
           <ActorAvatar actor={teamActor} size={24} />
         ) : (
           <AssigneeWrapper>
-            {!projectsLoaded && (
-              <LoadingIndicator
-                mini
-                style={{height: '24px', margin: 0, marginRight: 11}}
-              />
-            )}
+            {!projectsLoaded && <StyledLoadingIndicator mini />}
             {projectsLoaded && (
               <DropdownAutoComplete
                 data-test-id="alert-row-assignee"
@@ -351,6 +344,7 @@ function ActivatedRuleListRow({
   );
 }
 
+// TODO: see static/app/components/profiling/flex.tsx and utilize the FlexContainer styled component
 const FlexCenter = styled('div')`
   display: flex;
   align-items: center;
@@ -434,23 +428,29 @@ const IconContainer = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: ${p => p.theme.iconSizes.lg};
+  height: ${p => p.theme.iconSizes.lg};
   flex-shrink: 0;
 `;
 
 const MenuItemWrapper = styled('div')`
   display: flex;
   align-items: center;
-  font-size: 13px;
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const Label = styled(TextOverflow)`
-  margin-left: 6px;
+  margin-left: ${space(0.75)};
 `;
 
 const MarginLeft = styled('div')`
   margin-left: ${space(1)};
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  height: 24px;
+  margin: 0;
+  margin-right: ${space(1.5)};
 `;
 
 export default ActivatedRuleListRow;

--- a/static/app/views/alerts/list/rules/activatedRuleRow.tsx
+++ b/static/app/views/alerts/list/rules/activatedRuleRow.tsx
@@ -13,7 +13,6 @@ import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import IdBadge from 'sentry/components/idBadge';
-import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
@@ -260,9 +259,7 @@ function ActivatedRuleListRow({
       <AlertNameWrapper>
         <AlertNameAndStatus>
           <AlertName>
-            <Link to={`/organizations/${orgId}/alerts/rules/details/${rule.id}/`}>
-              {rule.name}
-            </Link>
+            <div>{rule.name}</div>
           </AlertName>
           <AlertActivationDate>{renderLatestActivation()}</AlertActivationDate>
         </AlertNameAndStatus>

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -333,8 +333,55 @@ describe('AlertRulesList', () => {
     expect(rules[0]).toBeInTheDocument();
 
     expect(screen.getByText('Triggered')).toBeInTheDocument();
-    expect(screen.getByText('Above 70')).toBeInTheDocument();
-    expect(screen.getByText('Below 36')).toBeInTheDocument();
+    expect(screen.getByText('Above 70')).toBeInTheDocument(); // the fixture trigger threshold
+    expect(screen.getByText('Below 36')).toBeInTheDocument(); // the fixture resolved threshold
+    expect(screen.getAllByTestId('alert-badge')[0]).toBeInTheDocument();
+  });
+
+  it('displays activated metric alert status', async () => {
+    rulesMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/combined-rules/',
+      headers: {Link: pageLinks},
+      body: [
+        MetricRuleFixture({
+          id: '1',
+          projects: ['earth'],
+          name: 'Active Activated Alert',
+          monitorType: 1,
+          activationCondition: 0,
+          activations: [
+            {
+              alertRuleId: '1',
+              dateCreated: '2021-08-01T00:00:00Z',
+              finishedAt: '',
+              id: '1',
+              isComplete: false,
+              querySubscriptionId: '1',
+            },
+          ],
+          latestIncident: IncidentFixture({
+            status: IncidentStatus.CRITICAL,
+          }),
+        }),
+        MetricRuleFixture({
+          id: '2',
+          projects: ['earth'],
+          name: 'Ready Activated Alert',
+          monitorType: 1,
+          activationCondition: 0,
+        }),
+      ],
+    });
+    const {routerContext, organization} = initializeOrg({organization: defaultOrg});
+    render(<AlertRulesList />, {context: routerContext, organization});
+
+    expect(await screen.findByText('Active Activated Alert')).toBeInTheDocument();
+    expect(await screen.findByText('Ready Activated Alert')).toBeInTheDocument();
+
+    expect(screen.getByText('Last activated')).toBeInTheDocument();
+    expect(screen.getByText('Alert has not been activated yet')).toBeInTheDocument();
+    expect(screen.getByText('Above 70')).toBeInTheDocument(); // the fixture trigger threshold
+    expect(screen.getByText('Below 70')).toBeInTheDocument(); // Alert has never fired, so no resolved threshold
     expect(screen.getAllByTestId('alert-badge')[0]).toBeInTheDocument();
   });
 

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -449,7 +449,7 @@ describe('AlertRulesList', () => {
     );
   });
 
-  it('does not display ACTIVATED Metric Alerts', async () => {
+  it('renders ACTIVATED Metric Alerts', async () => {
     rulesMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/combined-rules/',
       headers: {Link: pageLinks},
@@ -463,7 +463,7 @@ describe('AlertRulesList', () => {
         MetricRuleFixture({
           id: '345',
           projects: ['earth'],
-          name: 'Omitted Test Metric Alert',
+          name: 'activated Test Metric Alert',
           monitorType: 1,
           latestIncident: IncidentFixture({
             status: IncidentStatus.CRITICAL,
@@ -484,7 +484,6 @@ describe('AlertRulesList', () => {
 
     expect(await screen.findByText('Test Metric Alert 2')).toBeInTheDocument();
     expect(await screen.findByText('First Issue Alert')).toBeInTheDocument();
-
-    expect(screen.queryByText('Omitted Test Metric Alert')).not.toBeInTheDocument();
+    expect(await screen.findByText('activated Test Metric Alert')).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -423,7 +423,6 @@ describe('AlertRulesList', () => {
       expect.objectContaining({
         query: {
           expand: ['latestIncident', 'lastTriggered'],
-          monitor_type: '0',
           sort: ['incident_status', 'date_triggered'],
           team: ['myteams', 'unassigned'],
         },

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -39,6 +39,7 @@ import {AlertRuleType} from '../../types';
 import {getTeamParams, isIssueAlert} from '../../utils';
 import AlertHeader from '../header';
 
+import ActivatedRuleRow from './activatedRuleRow';
 import RuleListRow from './row';
 
 type SortField = 'date_added' | 'name' | ['incident_status', 'date_triggered'];
@@ -48,7 +49,6 @@ function getAlertListQueryKey(orgSlug: string, query: Location['query']): ApiQue
   const queryParams = {...query};
   queryParams.expand = ['latestIncident', 'lastTriggered'];
   queryParams.team = getTeamParams(queryParams.team!);
-  queryParams.monitor_type = MonitorType.CONTINUOUS.toString();
 
   if (!queryParams.sort) {
     queryParams.sort = defaultSort;
@@ -76,6 +76,7 @@ function AlertRulesList() {
       : location.query.sort,
   });
 
+  // Fetch alert rules
   const {
     data: ruleListResponse = [],
     refetch,
@@ -254,7 +255,19 @@ function AlertRulesList() {
                         !isIssueAlertInstance &&
                         rule.monitorType === MonitorType.ACTIVATED
                       ) {
-                        return null;
+                        return (
+                          <ActivatedRuleRow
+                            // Metric and issue alerts can have the same id
+                            key={`${keyPrefix}-${rule.id}`}
+                            projectsLoaded={initiallyLoaded}
+                            projects={projects as Project[]}
+                            rule={rule}
+                            orgId={organization.slug}
+                            onOwnerChange={handleOwnerChange}
+                            onDelete={handleDeleteRule}
+                            hasEditAccess={hasEditAccess}
+                          />
+                        );
                       }
 
                       return (

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -367,12 +367,7 @@ function RuleListRow({
           <ActorAvatar actor={teamActor} size={24} />
         ) : (
           <AssigneeWrapper>
-            {!projectsLoaded && (
-              <LoadingIndicator
-                mini
-                style={{height: '24px', margin: 0, marginRight: 11}}
-              />
-            )}
+            {!projectsLoaded && <StyledLoadingIndicator mini />}
             {projectsLoaded && (
               <DropdownAutoComplete
                 data-test-id="alert-row-assignee"
@@ -423,6 +418,7 @@ function RuleListRow({
   );
 }
 
+// TODO: see static/app/components/profiling/flex.tsx and utilize the FlexContainer styled component
 const FlexCenter = styled('div')`
   display: flex;
   align-items: center;
@@ -506,23 +502,29 @@ const IconContainer = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: ${p => p.theme.iconSizes.lg};
+  height: ${p => p.theme.iconSizes.lg};
   flex-shrink: 0;
 `;
 
 const MenuItemWrapper = styled('div')`
   display: flex;
   align-items: center;
-  font-size: 13px;
+  font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const Label = styled(TextOverflow)`
-  margin-left: 6px;
+  margin-left: ${space(0.75)};
 `;
 
 const MarginLeft = styled('div')`
   margin-left: ${space(1)};
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  height: 24px;
+  margin: 0;
+  margin-right: ${space(1.5)};
 `;
 
 export default RuleListRow;

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -144,7 +144,6 @@ function RuleListRow({
     );
     const resolvedTrigger = rule.resolveThreshold;
 
-    // NOTE: If there is no active incident, will default to a trigger
     const trigger =
       activeIncident && rule.latestIncident?.status === IncidentStatus.CRITICAL
         ? criticalTrigger
@@ -152,7 +151,6 @@ function RuleListRow({
 
     let iconColor: ColorOrAlias = 'successText';
     let iconDirection: 'up' | 'down' | undefined;
-    // NOTE: This is incorrectly assuming that all rules have a thresholdType of ABOVE
     let thresholdTypeText =
       activeIncident && rule.thresholdType === AlertRuleThresholdType.ABOVE
         ? t('Above')
@@ -318,6 +316,22 @@ function RuleListRow({
   return (
     <ErrorBoundary>
       <AlertNameWrapper isIssueAlert={isIssueAlert(rule)}>
+        <AlertNameAndStatus>
+          <AlertName>
+            <Link
+              to={
+                isIssueAlert(rule)
+                  ? `/organizations/${orgId}/alerts/rules/${rule.projects[0]}/${rule.id}/details/`
+                  : `/organizations/${orgId}/alerts/rules/details/${rule.id}/`
+              }
+            >
+              {rule.name}
+            </Link>
+          </AlertName>
+          <AlertIncidentDate>{renderLastIncidentDate()}</AlertIncidentDate>
+        </AlertNameAndStatus>
+      </AlertNameWrapper>
+      <FlexCenter>
         <FlexCenter>
           <Tooltip
             title={
@@ -337,22 +351,8 @@ function RuleListRow({
             />
           </Tooltip>
         </FlexCenter>
-        <AlertNameAndStatus>
-          <AlertName>
-            <Link
-              to={
-                isIssueAlert(rule)
-                  ? `/organizations/${orgId}/alerts/rules/${rule.projects[0]}/${rule.id}/details/`
-                  : `/organizations/${orgId}/alerts/rules/details/${rule.id}/`
-              }
-            >
-              {rule.name}
-            </Link>
-          </AlertName>
-          <AlertIncidentDate>{renderLastIncidentDate()}</AlertIncidentDate>
-        </AlertNameAndStatus>
-      </AlertNameWrapper>
-      <FlexCenter>{renderAlertRuleStatus()}</FlexCenter>
+        <MarginLeft>{renderAlertRuleStatus()}</MarginLeft>
+      </FlexCenter>
       <FlexCenter>
         <ProjectBadgeContainer>
           <ProjectBadge
@@ -519,6 +519,10 @@ const MenuItemWrapper = styled('div')`
 
 const Label = styled(TextOverflow)`
   margin-left: 6px;
+`;
+
+const MarginLeft = styled('div')`
+  margin-left: ${space(1)};
 `;
 
 export default RuleListRow;

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -85,6 +85,21 @@ export type SavedTrigger = Omit<UnsavedTrigger, 'actions'> & {
 
 export type Trigger = Partial<SavedTrigger> & UnsavedTrigger;
 
+export type AlertRuleActivation = {
+  alertRuleId: string;
+  dateCreated: string;
+  finishedAt: string;
+  id: string;
+  isComplete: boolean;
+  querySubscriptionId: string;
+  metricValue?: number;
+};
+
+export enum ActivationCondition {
+  RELEASE_CONDITION = 0,
+  DEPLOY_CONDITION = 1,
+}
+
 // Form values for creating a new metric alert rule
 export type UnsavedMetricRule = {
   aggregate: string;
@@ -108,6 +123,7 @@ export type UnsavedMetricRule = {
 
 // Form values for updating a metric alert rule
 export interface SavedMetricRule extends UnsavedMetricRule {
+  activations: AlertRuleActivation[];
   dateCreated: string;
   dateModified: string;
   id: string;

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -70,6 +70,11 @@ export enum IncidentStatus {
   CRITICAL = 20,
 }
 
+export enum ActivationStatus {
+  WAITING = 0,
+  MONITORING = 1,
+}
+
 export enum IncidentStatusMethod {
   MANUAL = 1,
   RULE_UPDATED = 2,

--- a/static/app/views/alerts/types.tsx
+++ b/static/app/views/alerts/types.tsx
@@ -92,9 +92,8 @@ interface IssueAlert extends IssueAlertRule {
   latestIncident?: Incident | null;
 }
 
-interface MetricAlert extends MetricRule {
+export interface MetricAlert extends MetricRule {
   type: CombinedAlertType.METRIC;
-  latestIncident?: Incident | null;
 }
 
 export type CombinedMetricIssueAlerts = IssueAlert | MetricAlert;


### PR DESCRIPTION
Duplicates the AlertRuleRow component to enable Activated Alert Rule rows.

<img width="1418" alt="Screenshot 2024-04-17 at 11 24 44 AM" src="https://github.com/getsentry/sentry/assets/6186377/3d07f663-84a2-412c-bc98-602b794b15cc">

Moves Alert Badge next to the rule status
Introduces a new "active state" to determine whether we are "ready to monitor" or "actively monitoring" states
cleans up the status logic