### PR TITLE
fix(perf): Allow searching for domain-less HTTP samples

### DIFF
--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -106,7 +106,6 @@ describe('HTTPSamplesPanel', () => {
         pathname: '',
         search: '',
         query: {
-          domain: '*.sentry.dev',
           statsPeriod: '10d',
           transaction: '/api/0/users',
           transactionMethod: 'GET',
@@ -192,8 +191,7 @@ describe('HTTPSamplesPanel', () => {
             ],
             per_page: 50,
             project: [],
-            query:
-              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
+            query: 'span.module:http !has:span.domain transaction:/api/0/users',
             referrer: 'api.starfish.http-module-samples-panel-metrics-ribbon',
             statsPeriod: '10d',
           },
@@ -217,7 +215,7 @@ describe('HTTPSamplesPanel', () => {
             per_page: 50,
             project: [],
             query:
-              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308]',
+              'span.module:http !has:span.domain transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308]',
             referrer: 'api.starfish.http-module-samples-panel-response-code-chart',
             statsPeriod: '10d',
             topEvents: '5',
@@ -234,7 +232,7 @@ describe('HTTPSamplesPanel', () => {
           query: expect.objectContaining({
             dataset: 'spansIndexed',
             query:
-              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308]',
+              'span.module:http transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308] ( !has:span.domain OR span.domain:[""] )',
             project: [],
             field: [
               'project',
@@ -366,7 +364,7 @@ describe('HTTPSamplesPanel', () => {
           method: 'GET',
           query: expect.objectContaining({
             query:
-              'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
+              'span.module:http transaction:/api/0/users span.domain:"\\*.sentry.dev"',
             project: [],
             additionalFields: [
               'trace',

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -176,6 +176,22 @@ export function HTTPSamplesPanel() {
     referrer: 'api.starfish.http-module-samples-panel-response-code-chart',
   });
 
+  // NOTE: Due to some data confusion, the `domain` column in the spans table can either be `null` or `""`. Searches like `"!has:span.domain"` are turned into the ClickHouse clause `isNull(domain)`, and do not match the empty string. We need a query that matches empty strings _and_ null_ which is `(!has:domain OR domain:[""])`. This hack can be removed in August 2024, once https://github.com/getsentry/snuba/pull/5780 has been deployed for 90 days and all `""` domains have fallen out of the data retention window. Also, `null` domains will become more rare as people upgrade the JS SDK to versions that populate the `server.address` span attribute
+  const sampleSpansSearch = MutableSearch.fromQueryObject({
+    ...filters,
+    'span.domain': undefined,
+  });
+
+  if (query.domain === '') {
+    sampleSpansSearch.addOp('(');
+    sampleSpansSearch.addFilterValue('!has', 'span.domain');
+    sampleSpansSearch.addOp('OR');
+    // HACK: Use `addOp` to add the condition `'span.domain:[""]'` and avoid escaping the double quotes. Ideally there'd be a way to specify this explicitly, but this whole thing is a hack anyway. Once a plain `!has:span.domain` condition works, this is not necessary
+    sampleSpansSearch.addOp('span.domain:[""]');
+    sampleSpansSearch.addOp(')');
+  } else {
+    sampleSpansSearch.addFilterValue('span.domain', query.domain);
+  }
   const durationAxisMax = computeAxisMax([durationData?.[`avg(span.self_time)`]]);
 
   const {
@@ -184,7 +200,7 @@ export function HTTPSamplesPanel() {
     error: durationSamplesDataError,
     refetch: refetchDurationSpanSamples,
   } = useSpanSamples({
-    search,
+    search: sampleSpansSearch,
     fields: [
       SpanIndexedField.TRACE,
       SpanIndexedField.TRANSACTION_ID,
@@ -203,7 +219,7 @@ export function HTTPSamplesPanel() {
     error: responseCodeSamplesDataError,
     refetch: refetchResponseCodeSpanSamples,
   } = useIndexedSpans({
-    search: MutableSearch.fromQueryObject(filters),
+    search: sampleSpansSearch,
     fields: [
       SpanIndexedField.PROJECT,
       SpanIndexedField.TRACE,


### PR DESCRIPTION
This one's tricky. Anyone who tries to find samples for an "Unknown Domain" (i.e., no `span.domain` tag) won't see any samples, because the query we run (`!has:span.domain`) doesn't work! The domain isn't _null_, it's _an empty string_. Similarly, `span.domain:""` doesn't work. The only workaround is `span.domain:[""]`. There's an outgoing Relay PR that will ensure that `span.domain` is correctly _null_, but in the meantime we need to make sure we handle both `null` and `""` entries!

Hence, the hack. If the domain is empty, create the correct query, using some hackery. By default, it incorrectly escapes `""` in the query, which is not acceptable here. In the meantime, we're also working on eliminating this edge case altogether.
