### PR TITLE
fix(hybridcloud) Only store one webhook per region

### DIFF
--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -23,7 +23,7 @@ from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
 from sentry.silo import SiloLimit, SiloMode
 from sentry.silo.client import RegionSiloClient, SiloClientError
-from sentry.types.region import Region, get_region_for_organization
+from sentry.types.region import Region, find_regions_for_orgs, get_region_by_name
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -320,8 +320,8 @@ class BaseRequestParser(abc.ABC):
         if not organizations:
             organizations = self.get_organizations_from_integration()
 
-        regions = [get_region_for_organization(organization.slug) for organization in organizations]
-        return sorted(regions, key=lambda r: r.name)
+        region_names = find_regions_for_orgs([org.id for org in organizations])
+        return sorted([get_region_by_name(name) for name in region_names], key=lambda r: r.name)
 
     def get_default_missing_integration_response(self) -> HttpResponse:
         return HttpResponse(status=400)

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -134,6 +134,34 @@ class GitlabRequestParserTest(TestCase):
             region_names=[region.name],
         )
 
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    @responses.activate
+    def test_routing_webhook_properly_with_multiple_orgs(self):
+        integration = self.get_integration()
+        other_org = self.create_organization(owner=self.user)
+        integration.add_organization(other_org)
+
+        request = self.factory.post(
+            self.path,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
+        parser = GitlabRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 202
+        assert response.content == b""
+        assert len(responses.calls) == 0
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"gitlab:{integration.id}",
+            region_names=[region.name],
+        )
+
     @override_regions(region_config)
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @responses.activate


### PR DESCRIPTION
When an integration is shared by many organizations we only need to forward one webhook to the region, not one webhook *per* organization.