### PR TITLE
feat(traces): Update UI for sub-span table, breakdown, issues.

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -282,7 +282,7 @@ function BaseButton({
   );
 
   const hasChildren = Array.isArray(children)
-    ? children.some(child => !!child)
+    ? children.some(child => child?.type !== null)
     : !!children;
 
   // Buttons come in 4 flavors: <Link>, <ExternalLink>, <a>, and <button>.

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -38,7 +38,9 @@ function getMetaQueryParams(
   };
 }
 
-export function useTraceMeta(): UseApiQueryResult<TraceMeta | null, any> {
+export function useTraceMeta(
+  traceSlug?: string
+): UseApiQueryResult<TraceMeta | null, any> {
   const filters = usePageFilters();
   const organization = useOrganization();
   const params = useParams<{traceSlug?: string}>();
@@ -49,14 +51,16 @@ export function useTraceMeta(): UseApiQueryResult<TraceMeta | null, any> {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const trace = traceSlug ?? params.traceSlug;
+
   return useApiQuery(
     [
-      `/organizations/${organization.slug}/events-trace-meta/${params.traceSlug ?? ''}/`,
+      `/organizations/${organization.slug}/events-trace-meta/${trace ?? ''}/`,
       {query: queryParams},
     ],
     {
       staleTime: Infinity,
-      enabled: !!params.traceSlug && !!organization.slug,
+      enabled: !!trace && !!organization.slug,
     }
   );
 }

--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -208,7 +208,7 @@ function SpanTable({
 function SpanRow({span, traceId}: {span: SpanResult<Field>; traceId: string}) {
   return (
     <Fragment>
-      <StyledPanelItem align="right">
+      <StyledSpanPanelItem align="right">
         <SpanIdRenderer
           projectSlug={span.project}
           transactionId={span['transaction.id']}
@@ -216,24 +216,24 @@ function SpanRow({span, traceId}: {span: SpanResult<Field>; traceId: string}) {
           traceId={traceId}
           timestamp={span.timestamp}
         />
-      </StyledPanelItem>
-      <StyledPanelItem align="left">
+      </StyledSpanPanelItem>
+      <StyledSpanPanelItem align="left">
         <Description>
           <ProjectRenderer projectSlug={span.project} hideName />
           <strong>{span['span.op']}</strong>
           <em>{'\u2014'}</em>
           {span['span.description']}
         </Description>
-      </StyledPanelItem>
-      <StyledPanelItem align="right">
+      </StyledSpanPanelItem>
+      <StyledSpanPanelItem align="right">
         <EmptyValueContainer>{'\u2014'}</EmptyValueContainer>
-      </StyledPanelItem>
-      <StyledPanelItem align="right">
+      </StyledSpanPanelItem>
+      <StyledSpanPanelItem align="right">
         <PerformanceDuration milliseconds={span['span.duration']} abbreviation />
-      </StyledPanelItem>
-      <StyledPanelItem align="right">
+      </StyledSpanPanelItem>
+      <StyledSpanPanelItem align="right">
         <EmptyValueContainer>{'\u2014'}</EmptyValueContainer>
-      </StyledPanelItem>
+      </StyledSpanPanelItem>
     </Fragment>
   );
 }
@@ -343,6 +343,16 @@ const StyledPanelItem = styled(PanelItem)<{
         ? `text-align: ${p.align};`
         : undefined}
   ${p => p.span && `grid-column: auto / span ${p.span}`}
+`;
+
+const StyledSpanPanelItem = styled(StyledPanelItem)`
+  &:nth-child(10n + 1),
+  &:nth-child(10n + 2),
+  &:nth-child(10n + 3),
+  &:nth-child(10n + 4),
+  &:nth-child(10n + 5) {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
 `;
 
 const SpanTablePanelItem = styled(StyledPanelItem)`

--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -163,35 +163,45 @@ function TraceRow({trace}: {trace: TraceResult<Field>}) {
       <StyledPanelItem align="right">
         <EmptyValueContainer>{'\u2014'}</EmptyValueContainer>
       </StyledPanelItem>
-      {expanded && (
-        <StyledPanelItem span={6}>
-          <StyledPanel>
-            <SpanPanelContent>
-              <StyledPanelHeader align="left" lightText>
-                {t('Span ID')}
-              </StyledPanelHeader>
-              <StyledPanelHeader align="left" lightText>
-                {t('Span Description')}
-              </StyledPanelHeader>
-              <StyledPanelHeader align="right" lightText />
-              <StyledPanelHeader align="right" lightText>
-                {t('Span Duration')}
-              </StyledPanelHeader>
-              <StyledPanelHeader align="right" lightText>
-                {t('Issues')}
-              </StyledPanelHeader>
-              {trace.spans.map(span => (
-                <SpanRow key={span.id} span={span} trace={trace.trace} />
-              ))}
-            </SpanPanelContent>
-          </StyledPanel>
-        </StyledPanelItem>
-      )}
+      {expanded && <SpanTable spans={trace.spans} trace={trace} />}
     </Fragment>
   );
 }
 
-function SpanRow({span, trace}: {span: SpanResult<Field>; trace: string}) {
+function SpanTable({
+  spans,
+  trace,
+}: {
+  spans: SpanResult<Field>[];
+  trace: TraceResult<Field>;
+}) {
+  return (
+    <SpanTablePanelItem span={6}>
+      <StyledPanel>
+        <SpanPanelContent>
+          <StyledPanelHeader align="left" lightText>
+            {t('Span ID')}
+          </StyledPanelHeader>
+          <StyledPanelHeader align="left" lightText>
+            {t('Span Description')}
+          </StyledPanelHeader>
+          <StyledPanelHeader align="right" lightText />
+          <StyledPanelHeader align="right" lightText>
+            {t('Span Duration')}
+          </StyledPanelHeader>
+          <StyledPanelHeader align="right" lightText>
+            {t('Issues')}
+          </StyledPanelHeader>
+          {spans.map(span => (
+            <SpanRow key={span.id} span={span} traceId={trace.trace} />
+          ))}
+        </SpanPanelContent>
+      </StyledPanel>
+    </SpanTablePanelItem>
+  );
+}
+
+function SpanRow({span, traceId}: {span: SpanResult<Field>; traceId: string}) {
   return (
     <Fragment>
       <StyledPanelItem align="right">
@@ -199,7 +209,7 @@ function SpanRow({span, trace}: {span: SpanResult<Field>; trace: string}) {
           projectSlug={span.project}
           transactionId={span['transaction.id']}
           spanId={span.id}
-          trace={trace}
+          traceId={traceId}
           timestamp={span.timestamp}
         />
       </StyledPanelItem>
@@ -329,6 +339,10 @@ const StyledPanelItem = styled(PanelItem)<{
         ? `text-align: ${p.align};`
         : undefined}
   ${p => p.span && `grid-column: auto / span ${p.span}`}
+`;
+
+const SpanTablePanelItem = styled(StyledPanelItem)`
+  background-color: ${p => p.theme.gray100};
 `;
 
 const EmptyValueContainer = styled('span')`

--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -29,6 +29,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 
 import {ProjectRenderer, SpanIdRenderer, TraceIdRenderer} from './fieldRenderers';
 import {TracesSearchBar} from './tracesSearchBar';
+import {normalizeTraces} from './utils';
 
 const DEFAULT_PER_PAGE = 20;
 
@@ -77,7 +78,7 @@ export function Content() {
   const isLoading = traces.isFetching;
   const isError = !isLoading && traces.isError;
   const isEmpty = !isLoading && !isError && (traces?.data?.data?.length ?? 0) === 0;
-  const data = !isLoading && !isError ? traces?.data?.data : undefined;
+  const data = normalizeTraces(!isLoading && !isError ? traces?.data?.data : undefined);
 
   return (
     <LayoutMain fullWidth>
@@ -236,7 +237,7 @@ function SpanRow({span, traceId}: {span: SpanResult<Field>; traceId: string}) {
 
 type SpanResult<F extends string> = Record<F, any>;
 
-interface TraceResult<F extends string> {
+export interface TraceResult<F extends string> {
   duration: number;
   name: string | null;
   numSpans: number;

--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -108,18 +108,19 @@ export function Content() {
           <StyledPanelHeader align="right" lightText>
             {t('Issues')}
           </StyledPanelHeader>
+          <StyledPanelHeader align="right" lightText style={{padding: '5px'}} />
           {isLoading && (
-            <StyledPanelItem span={6}>
+            <StyledPanelItem span={7}>
               <LoadingIndicator />
             </StyledPanelItem>
           )}
           {isError && ( // TODO: need an error state
-            <StyledPanelItem span={6}>
+            <StyledPanelItem span={7}>
               <EmptyStateWarning withIcon />
             </StyledPanelItem>
           )}
           {isEmpty && (
-            <StyledPanelItem span={6}>
+            <StyledPanelItem span={7}>
               <EmptyStateWarning withIcon />
             </StyledPanelItem>
           )}
@@ -164,6 +165,7 @@ function TraceRow({trace}: {trace: TraceResult<Field>}) {
       <StyledPanelItem align="right">
         <EmptyValueContainer>{'\u2014'}</EmptyValueContainer>
       </StyledPanelItem>
+      <StyledPanelItem style={{padding: '5px'}} />
       {expanded && <SpanTable spans={trace.spans} trace={trace} />}
     </Fragment>
   );
@@ -177,7 +179,7 @@ function SpanTable({
   trace: TraceResult<Field>;
 }) {
   return (
-    <SpanTablePanelItem span={6}>
+    <SpanTablePanelItem span={7}>
       <StyledPanel>
         <SpanPanelContent>
           <StyledPanelHeader align="left" lightText>
@@ -193,6 +195,7 @@ function SpanTable({
           <StyledPanelHeader align="right" lightText>
             {t('Issues')}
           </StyledPanelHeader>
+
           {spans.map(span => (
             <SpanRow key={span.id} span={span} traceId={trace.trace} />
           ))}
@@ -303,13 +306,13 @@ const StyledPanel = styled(Panel)`
 const TracePanelContent = styled('div')`
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(1, min-content) auto repeat(4, min-content);
+  grid-template-columns: repeat(1, min-content) auto repeat(2, min-content) 120px 60px 10px;
 `;
 
 const SpanPanelContent = styled('div')`
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(1, min-content) auto repeat(3, min-content);
+  grid-template-columns: repeat(1, min-content) auto repeat(1, min-content) 120px 60px;
 `;
 
 const StyledPanelHeader = styled(PanelHeader)<{align: 'left' | 'right'}>`

--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -35,6 +35,7 @@ import {
   TraceBreakdownContainer,
   TraceBreakdownRenderer,
   TraceIdRenderer,
+  TraceIssuesRenderer,
 } from './fieldRenderers';
 import {TracesSearchBar} from './tracesSearchBar';
 import {normalizeTraces} from './utils';
@@ -173,7 +174,7 @@ function TraceRow({trace}: {trace: TraceResult<Field>}) {
         <PerformanceDuration milliseconds={trace.duration} abbreviation />
       </StyledPanelItem>
       <StyledPanelItem align="right">
-        <EmptyValueContainer>{'\u2014'}</EmptyValueContainer>
+        <TraceIssuesRenderer trace={trace} />
       </StyledPanelItem>
       <StyledPanelItem style={{padding: '5px'}} />
       {expanded && <SpanTable spans={trace.spans} trace={trace} />}
@@ -345,13 +346,13 @@ const StyledPanel = styled(Panel)`
 const TracePanelContent = styled('div')`
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(1, min-content) auto repeat(2, min-content) 120px 60px 10px;
+  grid-template-columns: repeat(1, min-content) auto repeat(2, min-content) 120px 66px 10px;
 `;
 
 const SpanPanelContent = styled('div')`
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(1, min-content) auto repeat(1, min-content) 120px 60px;
+  grid-template-columns: repeat(1, min-content) auto repeat(1, min-content) 120px 66px;
 `;
 
 const StyledPanelHeader = styled(PanelHeader)<{align: 'left' | 'right'}>`

--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -27,7 +27,12 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-import {ProjectRenderer, SpanIdRenderer, TraceIdRenderer} from './fieldRenderers';
+import {
+  ProjectRenderer,
+  SpanIdRenderer,
+  TraceBreakdownRenderer,
+  TraceIdRenderer,
+} from './fieldRenderers';
 import {TracesSearchBar} from './tracesSearchBar';
 import {normalizeTraces} from './utils';
 
@@ -157,7 +162,7 @@ function TraceRow({trace}: {trace: TraceResult<Field>}) {
         <Count value={trace.numSpans} />
       </StyledPanelItem>
       <StyledPanelItem align="right">
-        <EmptyValueContainer>{'\u2014'}</EmptyValueContainer>
+        <TraceBreakdownRenderer trace={trace} />
       </StyledPanelItem>
       <StyledPanelItem align="right">
         <PerformanceDuration milliseconds={trace.duration} abbreviation />

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -43,7 +43,7 @@ interface SpanIdRendererProps {
   projectSlug: string;
   spanId: string;
   timestamp: string;
-  trace: string;
+  traceId: string;
   transactionId: string;
 }
 
@@ -51,7 +51,7 @@ export function SpanIdRenderer({
   projectSlug,
   spanId,
   timestamp,
-  trace,
+  traceId,
   transactionId,
 }: SpanIdRendererProps) {
   const location = useLocation();
@@ -67,7 +67,7 @@ export function SpanIdRenderer({
     eventView: EventView.fromLocation(location),
     dataRow: {
       id: transactionId,
-      trace,
+      trace: traceId,
       timestamp,
     },
     spanId,

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -2,13 +2,13 @@ import {type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/button';
-import Duration from 'sentry/components/duration';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {ROW_HEIGHT, ROW_PADDING} from 'sentry/components/performance/waterfall/constants';
 import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
+import PerformanceDuration from 'sentry/components/performanceDuration';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconIssues} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -123,7 +123,7 @@ export function SpanBreakdownSliceRenderer({
           <div>
             <div>{sliceName}</div>
             <div>
-              <Duration seconds={sliceDuration / 1000} fixedDigits={2} abbreviation />
+              <PerformanceDuration milliseconds={sliceDuration} abbreviation />
             </div>
           </div>
         }

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -79,7 +79,7 @@ export function TraceBreakdownRenderer({trace}: {trace: TraceResult<Field>}) {
       {trace.breakdowns.map(breakdown => {
         return (
           <SpanBreakdownSliceRenderer
-            key={breakdown.start + (breakdown.project ?? t('missing'))}
+            key={breakdown.start + (breakdown.project ?? t('missing instrumentation'))}
             sliceName={breakdown.project}
             sliceStart={breakdown.start}
             sliceEnd={breakdown.end}

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -1,5 +1,11 @@
+import styled from '@emotion/styled';
+
+import Duration from 'sentry/components/duration';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
+import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
+import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
+import {Tooltip} from 'sentry/components/tooltip';
 import type {DateString} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {
@@ -7,6 +13,7 @@ import {
   generateLinkToEventInTraceView,
 } from 'sentry/utils/discover/urls';
 import {getShortEventId} from 'sentry/utils/events';
+import toPercent from 'sentry/utils/number/toPercent';
 import Projects from 'sentry/utils/projects';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -36,6 +43,47 @@ export function ProjectRenderer({projectSlug, hideName}: ProjectRendererProps) {
         );
       }}
     </Projects>
+  );
+}
+
+const RelativeOpsBreakdown = styled('div')`
+  position: relative;
+  display: flex;
+  min-width: 150px;
+`;
+
+const RectangleRelativeOpsBreakdown = styled(RowRectangle)`
+  position: relative;
+  width: 100%;
+`;
+
+export function TraceBreakdownRenderer({trace}: {trace: TraceResult<Field>}) {
+  const widthPercentage = 1.0;
+  const operationName = 'trace';
+  const spanOpDuration = 1000;
+  return (
+    <RelativeOpsBreakdown data-test-id="relative-ops-breakdown">
+      <div key={operationName} style={{width: toPercent(widthPercentage || 0)}}>
+        <Tooltip
+          title={
+            <div>
+              <div>{operationName}</div>
+              <div>
+                <Duration seconds={spanOpDuration / 1000} fixedDigits={2} abbreviation />
+              </div>
+            </div>
+          }
+          containerDisplayMode="block"
+        >
+          <RectangleRelativeOpsBreakdown
+            style={{
+              backgroundColor: pickBarColor(operationName),
+            }}
+            onClick={_ => {}}
+          />
+        </Tooltip>
+      </div>
+    </RelativeOpsBreakdown>
   );
 }
 

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -1,13 +1,16 @@
 import {type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {LinkButton} from 'sentry/components/button';
 import Duration from 'sentry/components/duration';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {ROW_HEIGHT, ROW_PADDING} from 'sentry/components/performance/waterfall/constants';
 import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {Tooltip} from 'sentry/components/tooltip';
+import {IconIssues} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {DateString} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
@@ -22,8 +25,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
+
+import {useTraceMeta} from '../newTraceDetails/traceApi/useTraceMeta';
 
 import type {TraceResult} from './content';
 import type {Field} from './data';
@@ -227,4 +233,37 @@ export function TransactionRenderer({
   });
 
   return <Link to={target}>{transaction}</Link>;
+}
+
+export function TraceIssuesRenderer({trace}: {trace: TraceResult<Field>}) {
+  const traceMeta = useTraceMeta(trace.trace);
+  const organization = useOrganization();
+
+  const issueCount = !traceMeta.data
+    ? undefined
+    : traceMeta.data.errors + traceMeta.data.performance_issues;
+
+  return (
+    <LinkButton
+      to={normalizeUrl({
+        pathname: `/organizations/${organization.slug}/issues`,
+        query: {
+          query: `is:unresolved trace:"${trace.trace}"`,
+        },
+      })}
+      size="xs"
+      icon={<IconIssues size="xs" />}
+    >
+      {issueCount !== undefined ? (
+        issueCount
+      ) : (
+        <LoadingIndicator
+          size={12}
+          mini
+          style={{height: '12px', width: '12px', margin: 0, marginRight: 0}}
+        />
+      )}
+      {issueCount === 100 && '+'}
+    </LinkButton>
+  );
 }

--- a/static/app/views/performance/traces/utils.tsx
+++ b/static/app/views/performance/traces/utils.tsx
@@ -1,0 +1,11 @@
+import type {TraceResult} from './content';
+
+export function normalizeTraces(traces: TraceResult<string>[] | undefined) {
+  if (!traces) {
+    return traces;
+  }
+  return traces.sort(
+    // Only sort name == null to the end, the rest leave in the original order.
+    (t1, t2) => (t1.name ? '0' : '1').localeCompare(t2.name ? '0' : '1')
+  );
+}


### PR DESCRIPTION
### Summary

Adds:
- Trace breakdown
- Issues count / link
- Better span subtable styling
- Row ordering styling for sub-span table

#### Other:
- Shifted all the 'null' trace names to the bottom since these aren't that useful to read without clicking in, the rest of the ordering is untouched and remains in the order provided from the api call.
- Had to fix the `hasChildren` in the button component since it was doing a truthy check for children, if the value is `0` it returns false and remove margin...

#### Screenshots
![Screenshot 2024-04-17 at 3 22 04 PM](https://github.com/getsentry/sentry/assets/6111995/98956560-c456-4091-8e57-529f41dcf29b)