### PR TITLE
chore(issues): Add additional logging for time to post process metric

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -758,15 +758,20 @@ def post_process_group(
             # We see occasional metrics being recorded with very old data,
             # temporarily log some information about these groups to help
             # investigate.
-            if duration and duration > 604_800:  # 7 days (7*24*60*60)
+            if duration and duration > 432_000:  # 5 days (5*24*60*60)
                 logger.warning(
                     "tasks.post_process.old_time_to_post_process",
                     extra={
                         "group_id": group_id,
                         "project_id": project_id,
                         "duration": duration,
-                        "original_issue_id": get_path(
-                            event.data, "contexts", "reprocessing", "original_issue_id"
+                        "received": event.data["received"],
+                        "platform": event.data["platform"],
+                        "reprocessing": json.dumps(
+                            get_path(event.data, "contexts", "reprocessing")
+                        ),
+                        "original_issue_id": json.dumps(
+                            get_path(event.data, "contexts", "reprocessing", "original_issue_id")
                         ),
                     },
                 )


### PR DESCRIPTION
The previous logging was not enough to debug this issue, this adds additional logging to hopefully help identify why these metrics are being recorded for old events.

A quick rundown of the changes here:
- We'll capture logs for events which are now 5 days old instead of 7 days
- We'll capture `received` and `platform` values, these are both retrieved above so guaranteed to exist once we reach this log line
- We'll also capture the `contexts.reprocessing` data, this should have only the `original_issue_id` and `original_primary_hash` fields in it.
- Finally, continue capturing the `context.reprocessing.original_issue_id` for sanity but the JSON value this time since it seems like `None`s might be getting not logged.