### PR TITLE
ref(ui): Split `My Teams` and `Other Teams` in rules team filter

### DIFF
--- a/static/app/views/alerts/list/rules/teamFilter.tsx
+++ b/static/app/views/alerts/list/rules/teamFilter.tsx
@@ -9,7 +9,7 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {Team} from 'sentry/types';
+import type {Team} from 'sentry/types';
 import {useTeams} from 'sentry/utils/useTeams';
 
 interface Props {

--- a/static/app/views/alerts/list/rules/teamFilter.tsx
+++ b/static/app/views/alerts/list/rules/teamFilter.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
+import partition from 'lodash/partition';
 
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import Badge from 'sentry/components/badge/badge';
@@ -8,6 +9,7 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {Team} from 'sentry/types';
 import {useTeams} from 'sentry/utils/useTeams';
 
 interface Props {
@@ -38,6 +40,12 @@ const suggestedOptions = [
   },
 ];
 
+const makeTeamOption = (team: Team) => ({
+  value: team.id,
+  label: `#${team.slug}`,
+  leadingItems: <TeamAvatar team={team} size={18} />,
+});
+
 function TeamFilter({
   selectedTeams,
   handleChangeFilter,
@@ -47,15 +55,9 @@ function TeamFilter({
 }: Props) {
   const {teams, onSearch, fetching} = useTeams({provideUserTeams: showIsMemberTeams});
 
-  const teamOptions = useMemo(
-    () =>
-      teams.map(team => ({
-        value: team.id,
-        label: `#${team.slug}`,
-        leadingItems: <TeamAvatar team={team} size={18} />,
-      })),
-    [teams]
-  );
+  const [myTeams, otherTeams] = partition(teams, team => team.isMember);
+  const myTeamOptions = myTeams.map(makeTeamOption);
+  const otherTeamOptions = otherTeams.map(makeTeamOption);
 
   const [triggerIcon, triggerLabel] = useMemo(() => {
     const firstSelectedSuggestion =
@@ -88,14 +90,13 @@ function TeamFilter({
       searchable
       loading={fetching}
       menuTitle={t('Filter teams')}
-      options={
-        showSuggestedOptions
-          ? [
-              {value: '_suggested', label: t('Suggested'), options: suggestedOptions},
-              {value: '_teams', label: t('Teams'), options: teamOptions},
-            ]
-          : teamOptions
-      }
+      options={[
+        ...(showSuggestedOptions
+          ? [{value: '_suggested', label: t('Suggested'), options: suggestedOptions}]
+          : []),
+        {value: '_my_teams', label: t('My Teams'), options: myTeamOptions},
+        {value: '_teams', label: t('Other Teams'), options: otherTeamOptions},
+      ]}
       value={selectedTeams}
       onSearch={debounce(val => void onSearch(val), DEFAULT_DEBOUNCE_DURATION)}
       onChange={opts => {


### PR DESCRIPTION
Before

<img width="320" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/45d0070b-b80a-4d7f-9dd3-bba8e0e6e3c1">


After

<img width="297" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/cc933688-dcf7-4544-ba00-2d0f49cbb60b">
