### PR TITLE
feat(user_report): filter out garbage user reports

### DIFF
--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -6,9 +6,12 @@ from datetime import timedelta
 from django.db import IntegrityError, router
 from django.utils import timezone
 
-from sentry import eventstore, features
+from sentry import eventstore, features, options
 from sentry.eventstore.models import Event
-from sentry.feedback.usecases.create_feedback import shim_to_feedback
+from sentry.feedback.usecases.create_feedback import (
+    UNREAL_FEEDBACK_UNATTENDED_MESSAGE,
+    shim_to_feedback,
+)
 from sentry.models.userreport import UserReport
 from sentry.signals import user_feedback_received
 from sentry.utils import metrics
@@ -29,6 +32,10 @@ def save_userreport(
     start_time=None,
 ):
     with metrics.timer("sentry.ingest.userreport.save_userreport"):
+
+        if should_filter_user_report(report["comments"]):
+            return
+
         if start_time is None:
             start_time = timezone.now()
 
@@ -101,3 +108,25 @@ def find_event_user(event: Event):
         return None
     eventuser = EventUser.from_event(event)
     return eventuser
+
+
+def should_filter_user_report(comments: str):
+    """
+    We don't care about empty user reports, or ones that
+    the unreal SDKs send.
+    """
+
+    if not options.get("feedback.filter_garbage_messages"):
+        return False
+
+    if not comments:
+        metrics.incr("user_report.create_user_report.filtered", tags={"reason": "empty"})
+        return True
+
+    if comments == UNREAL_FEEDBACK_UNATTENDED_MESSAGE:
+        metrics.incr(
+            "user_report.create_user_report.filtered", tags={"reason": "unreal.unattended"}
+        )
+        return True
+
+    return False

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2419,3 +2419,11 @@ register(
     default=0.0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+
+register(
+    "feedback.filter_garbage_messages",
+    type=Bool,
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/ingest/test_userreport.py
+++ b/tests/sentry/ingest/test_userreport.py
@@ -1,0 +1,21 @@
+from sentry.feedback.usecases.create_feedback import UNREAL_FEEDBACK_UNATTENDED_MESSAGE
+from sentry.ingest.userreport import should_filter_user_report
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@django_db_all
+def test_unreal_unattended_message_with_option(set_sentry_option):
+    with set_sentry_option("feedback.filter_garbage_messages", True):
+        assert should_filter_user_report(UNREAL_FEEDBACK_UNATTENDED_MESSAGE) is True
+
+
+@django_db_all
+def test_unreal_unattended_message_without_option(set_sentry_option):
+    with set_sentry_option("feedback.filter_garbage_messages", False):
+        assert should_filter_user_report(UNREAL_FEEDBACK_UNATTENDED_MESSAGE) is False
+
+
+@django_db_all
+def test_empty_message(set_sentry_option):
+    with set_sentry_option("feedback.filter_garbage_messages", True):
+        assert should_filter_user_report("") is True


### PR DESCRIPTION
Throughout the development of user feedback project, we noticed a lion's share of user reports are either empty, or are an autogenerated feedback from the unreal engine SDK. this PR will filter these out so that they are not created, and don't clog up our systems. 

We should follow up with kill switches for organizations that spam feedbacks to us.