### PR TITLE
feat(replay): Cleanup viewed-by feature flag (backend)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1875,8 +1875,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:session-replay-trace-table": False,
     # Enable core Session Replay link in the sidebar
     "organizations:session-replay-ui": True,
-    # Enable 'Viewed By' state for replay items
-    "organizations:session-replay-viewed-by-ui": False,
     # Lets organizations manage grouping configs
     "organizations:set-grouping-config": False,
     # Enable the UI for updated terms of service

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -222,7 +222,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:session-replay-slack-new-issue", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:session-replay-trace-table", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:session-replay-ui", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-    manager.add("organizations:session-replay-viewed-by-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:settings-legal-tos-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
Flag is here and released to 100% already: https://flagr.getsentry.net/#/flags/601

See also https://github.com/getsentry/sentry/pull/69152

Fixes https://github.com/getsentry/team-replay/issues/19
Fixes https://github.com/getsentry/sentry/issues/64924