### PR TITLE
fix(ppf): Fix the offsets committed by post process forwarder

### DIFF
--- a/src/sentry/consumers/synchronized.py
+++ b/src/sentry/consumers/synchronized.py
@@ -244,7 +244,7 @@ class SynchronizedConsumer(Consumer[TStrategyPayload]):
 
         # Check to make sure the message does not exceed the remote offset. If
         # it does, pause the partition and seek back to the message offset.
-        if message.offset >= remote_offset:
+        if message.offset > remote_offset:
             self.__consumer.pause([message.partition])
             self.__consumer.seek({message.partition: message.offset})
             return None

--- a/tests/sentry/consumers/test_synchronized.py
+++ b/tests/sentry/consumers/test_synchronized.py
@@ -12,14 +12,16 @@ from arroyo.backends.abstract import Consumer
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker, LocalConsumer
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
-from arroyo.commit import IMMEDIATE
+from arroyo.commit import IMMEDIATE, Commit
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import (
     CommitOffsets,
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.types import BrokerValue, Commit, Partition, Topic
+from arroyo.types import BrokerValue
+from arroyo.types import Commit as ConsumerCommit
+from arroyo.types import Partition, Topic
 
 from sentry.consumers.synchronized import SynchronizedConsumer, commit_codec
 
@@ -518,10 +520,10 @@ def test_commits_correct_offset() -> None:
 
     commit_mock = mock.Mock()
 
-    class PassthroughFactory(ProcessingStrategyFactory):
+    class PassthroughFactory(ProcessingStrategyFactory[KafkaPayload]):
         def create_with_partitions(
-            self, _commit: Commit, _partitions: Mapping[Partition, int]
-        ) -> ProcessingStrategy:
+            self, _commit: ConsumerCommit, _partitions: Mapping[Partition, int]
+        ) -> ProcessingStrategy[KafkaPayload]:
             return CommitOffsets(commit_mock)
 
     processor = StreamProcessor(synchronized_consumer, topic, PassthroughFactory(), IMMEDIATE)


### PR DESCRIPTION
The post process forwarder is committing the wrong offsets. Specifically it is committing offsets behind where it should be. It's not noticable in prod but on small deployments that receive little data this can cause issues like offsets out of range due to retention.