### PR TITLE
feat(crons): Add project slug to broken/muted cron emails

### DIFF
--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -88,6 +88,7 @@ def generate_monitor_email_context(
     return [
         (
             monitor_entry["slug"],
+            monitor_entry["project_slug"],
             generate_monitor_detail_url(
                 organization,
                 monitor_entry["project_slug"],

--- a/src/sentry/templates/sentry/emails/crons/broken-monitors.html
+++ b/src/sentry/templates/sentry/emails/crons/broken-monitors.html
@@ -18,9 +18,10 @@
       We've noticed the cron monitors below have not processed a successful check-in for multiple days:
     </p>
       <ul>
-        {% for monitor_name, monitor_url, earliest_incident_start_date in broken_monitors %}
+        {% for monitor_name, project_slug, monitor_url, earliest_incident_start_date in broken_monitors %}
           <li>
-            <a href="{{monitor_url}}">{{monitor_name}}</a> <br /> Failing since {{earliest_incident_start_date|date:"N j, Y, g:i:s a e"}}
+            <a href="{{monitor_url}}">{{monitor_name}}</a> | <strong>{{project_slug}}</strong>
+            <br /> Failing since {{earliest_incident_start_date|date:"N j, Y, g:i:s a e"}}
           </li>
         {% endfor %}
       </ul>

--- a/src/sentry/templates/sentry/emails/crons/broken-monitors.txt
+++ b/src/sentry/templates/sentry/emails/crons/broken-monitors.txt
@@ -1,8 +1,9 @@
 Your Cron Monitors Aren't Working
 
 We've noticed the cron monitors below have not processed a successful check-in for multiple days:
-{% for monitor_name, monitor_url, earliest_incident_start_date in broken_monitors %}
-* {{monitor_name}} {{monitor_url}} | Failing since {{earliest_incident_start_date|date:"N j, Y, g:i:s a e"}}
+{% for monitor_name, project_slug, monitor_url, earliest_incident_start_date in broken_monitors %}
+* {{monitor_name}}
+{{project_slug}} {{monitor_url}} | Failing since {{earliest_incident_start_date|date:"N j, Y, g:i:s a e"}}
 {% endfor %}
 
 To bring your monitors back to a healthy status, we recommend checking out our troubleshooting guide and our FAQs: "https://docs.sentry.io/product/crons/troubleshooting/". Otherwise, we'll automatically mute or disable them for you in a few days.

--- a/src/sentry/templates/sentry/emails/crons/muted-monitors.html
+++ b/src/sentry/templates/sentry/emails/crons/muted-monitors.html
@@ -18,9 +18,10 @@
       The Cron Monitors below have not processed a successful check-in for multiple weeks. We have automatically muted the failing environments for these monitors:
     </p>
       <ul>
-        {% for monitor_name, monitor_url, earliest_incident_start_date in muted_monitors %}
+        {% for monitor_name, project_slug, monitor_url, earliest_incident_start_date in muted_monitors %}
           <li>
-            <a href="{{monitor_url}}">{{monitor_name}}</a> <br /> Failing since {{earliest_incident_start_date|date:"N j, Y, g:i:s a e"}}
+            <a href="{{monitor_url}}">{{monitor_name}}</a> | <strong>{{project_slug}}</strong>
+            <br /> Failing since {{earliest_incident_start_date|date:"N j, Y, g:i:s a e"}}
           </li>
         {% endfor %}
       </ul>

--- a/src/sentry/templates/sentry/emails/crons/muted-monitors.txt
+++ b/src/sentry/templates/sentry/emails/crons/muted-monitors.txt
@@ -1,8 +1,9 @@
 Your Cron Monitors Have Been Muted
 
 The Cron Monitors below have not processed a successful check-in for multiple weeks. We have automatically muted the failing environments for these monitors:
-{% for monitor_name, monitor_url, earliest_incident_start_date in muted_monitors %}
-* {{monitor_name}} {{monitor_url}} | Failing since {{earliest_incident_start_date|date:"N j, Y, g:i:s a e"}}
+{% for monitor_name, project_slug, monitor_url, earliest_incident_start_date in muted_monitors %}
+* {{monitor_name}}
+{{project_slug}} {{monitor_url}} | Failing since {{earliest_incident_start_date|date:"N j, Y, g:i:s a e"}}
 {% endfor %}
 
 To unmute your monitors, please head over to Crons and manually unmute your monitors.

--- a/src/sentry/web/frontend/debug/debug_cron_broken_monitor_email.py
+++ b/src/sentry/web/frontend/debug/debug_cron_broken_monitor_email.py
@@ -9,7 +9,10 @@ from .mail import MailPreview
 def get_context():
     date = datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.UTC)
     return {
-        "broken_monitors": [("Dummy Cron Monitor", "#", date), ("Example Cron Monitor", "#", date)],
+        "broken_monitors": [
+            ("Dummy Cron Monitor", "project-slug", "#", date),
+            ("Example Cron Monitor", "project-slug", "#", date),
+        ],
         "view_monitors_link": "#",
     }
 

--- a/src/sentry/web/frontend/debug/debug_cron_muted_monitor_email.py
+++ b/src/sentry/web/frontend/debug/debug_cron_muted_monitor_email.py
@@ -9,7 +9,10 @@ from .mail import MailPreview
 def get_context():
     date = datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.UTC)
     return {
-        "muted_monitors": [("Dummy Cron Monitor", "#", date), ("Example Cron Monitor", "#", date)],
+        "muted_monitors": [
+            ("Dummy Cron Monitor", "project-slug", "#", date),
+            ("Example Cron Monitor", "project-slug", "#", date),
+        ],
         "view_monitors_link": "#",
     }
 

--- a/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
+++ b/tests/sentry/monitors/tasks/test_detect_broken_monitor_envs.py
@@ -234,6 +234,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 "broken_monitors": [
                     (
                         monitor.slug,
+                        self.project.slug,
                         f"http://testserver/organizations/{self.organization.slug}/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
                         timezone.now() - timedelta(days=14),
                     )
@@ -244,11 +245,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 "broken_monitors": [
                     (
                         second_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
@@ -259,11 +262,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 "broken_monitors": [
                     (
                         second_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
@@ -369,6 +374,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 "muted_monitors": [
                     (
                         monitor.slug,
+                        self.project.slug,
                         f"http://testserver/organizations/{self.organization.slug}/crons/{self.project.slug}/{monitor.slug}/?environment={self.environment.name}",
                         timezone.now() - timedelta(days=14),
                     )
@@ -379,11 +385,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 "muted_monitors": [
                     (
                         second_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
@@ -394,11 +402,13 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 "muted_monitors": [
                     (
                         second_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
                     (
                         third_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{third_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     ),
@@ -486,6 +496,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 "muted_monitors": [
                     (
                         second_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     )
@@ -496,6 +507,7 @@ class MonitorDetectBrokenMonitorEnvTaskTest(TestCase):
                 "muted_monitors": [
                     (
                         second_monitor.slug,
+                        second_project.slug,
                         f"http://testserver/organizations/{second_org.slug}/crons/{second_project.slug}/{second_monitor.slug}/?environment={second_env.name}",
                         timezone.now() - timedelta(days=14),
                     )


### PR DESCRIPTION
New emails:

<img width="716" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/264ace4b-1b3f-4e62-93f2-1981afbb6867">
<img width="1512" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/d48e90f2-4bfd-4e72-a8b6-aea8c25e6571">
<img width="708" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/1e2269e3-acc5-4bf6-b70a-fd3da64d9949">
<img width="1512" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/4f2276dd-7809-4cb6-bc8d-daa2c20e4495">
