### PR TITLE
ref(rules): Create apply_delayed processor

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -260,6 +260,36 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
         return result
 
+    def get_rate_bulk(
+        self,
+        duration: timedelta,
+        comparison_interval: timedelta,
+        group_ids: set[int],
+        environment_id: int,
+        comparison_type: str,
+    ) -> dict[int, int]:
+        start, end = self.get_comparison_start_end(timedelta(), duration)
+        with self.get_option_override(duration):
+            result = self.batch_query(
+                group_ids=group_ids,
+                start=start,
+                end=end,
+                environment_id=environment_id,
+            )
+        if comparison_type == ComparisonType.PERCENT:
+            start, comparison_end = self.get_comparison_start_end(comparison_interval, duration)
+            comparison_result = self.batch_query(
+                group_ids=group_ids,
+                start=start,
+                end=comparison_end,
+                environment_id=environment_id,
+            )
+            result = {
+                group_id: percent_increase(result[group_id], comparison_result[group_id])
+                for group_id in group_ids
+            }
+        return result
+
     def get_snuba_query_result(
         self,
         tsdb_function: Callable[..., Any],

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -1,16 +1,41 @@
+import contextlib
 import logging
-from collections.abc import Mapping
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import DefaultDict, NamedTuple
 
 from sentry.buffer.redis import BufferHookEvent, RedisBuffer, redis_buffer_registry
 from sentry.models.project import Project
+from sentry.models.rule import Rule
+from sentry.rules.conditions.base import EventCondition
+from sentry.rules.conditions.event_frequency import (
+    BaseEventFrequencyCondition,
+    ComparisonType,
+    EventFrequencyConditionData,
+    percent_increase,
+)
+from sentry.rules.processing.processor import is_condition_slow, split_conditions_and_filters
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.query import RangeQuerySetWrapper
-from sentry.utils.safe import safe_execute
+from sentry.utils.snuba import options_override
 
 logger = logging.getLogger("sentry.rules.delayed_processing")
 
 
 PROJECT_ID_BUFFER_LIST_KEY = "project_id_buffer_list"
+
+
+def get_slow_conditions(rule: Rule) -> list[EventFrequencyConditionData]:
+    """
+    Returns the slow conditions of a rule model instance.
+    """
+    conditions_and_filters = rule.data.get("conditions", ())
+    conditions, _ = split_conditions_and_filters(conditions_and_filters)
+    slow_conditions = [cond for cond in conditions if is_condition_slow(cond)]
+
+    return slow_conditions
 
 
 @redis_buffer_registry.add_handler(BufferHookEvent.FLUSH)
@@ -19,18 +44,164 @@ def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
         project_ids = buffer.get_set(PROJECT_ID_BUFFER_LIST_KEY)
 
         for project in RangeQuerySetWrapper(Project.objects.filter(id__in=project_ids)):
-            rulegroup_event_mapping = buffer.get_hash(
-                model=Project, field={"project_id": project.id}
-            )
 
             with metrics.timer("delayed_processing.process_project.duration"):
-                safe_execute(
-                    apply_delayed,
-                    project,
-                    rulegroup_event_mapping,
-                    _with_transaction=False,
+                apply_delayed.delay(project=project, buffer=buffer)
+
+
+@instrumented_task(
+    name="sentry.delayed_processing.tasks.apply_delayed",
+    queue="dynamicsampling",
+    default_retry_delay=5,
+    max_retries=5,
+    soft_time_limit=50,
+    time_limit=60,  # 1 minute
+    silo_mode=SiloMode.REGION,
+)
+def apply_delayed(project: Project, buffer: RedisBuffer) -> None:
+    """ """
+
+    # XXX(schew2381): This is from
+    # https://github.com/getsentry/sentry/blob/fbfd6800cf067f171840c427df7d5c2864b91fb0/src/sentry/rules/processor.py#L209-L212
+    # Do we need to check this before we start the steps (ask dan, I think the
+    # answer is now b/c we check it before triggering actions))
+
+    # frequency = rule.data.get("frequency") or Rule.DEFAULT_FREQUENCY
+    # now = datetime.now()
+    # freq_offset = now - timedelta(minutes=frequency)
+    # if status.last_active and status.last_active > freq_offset:
+    #     return
+
+    # STEP 1: Fetch the rulegroup_to_event mapping for the project from redis
+
+    # The mapping looks like: {rule.id}:{group.id} -> {event.id}
+    # TODO: Updating return type of get_hash
+    rulegroup_to_event = buffer.get_hash(model=Project, field={"id": project.id})
+
+    # STEP 2: Map each rule to the groups that must be checked for that rule.
+    rules_to_groups: DefaultDict[int, set[int]] = defaultdict(set)
+    for rule_group in rulegroup_to_event.keys():
+        rule_id, group_id = rule_group.split(":")
+        rules_to_groups[int(rule_id)].add(int(group_id))
+
+    # STEP 3: Fetch the Rule models we need to check
+    rules = Rule.objects.filter(id__in=list(rules_to_groups.keys()))
+
+    # STEP 4: Create a map of unique conditions to a tuple containing the JSON
+    # information needed to instantiate that condition class and the group_ids that
+    # must be checked for that condition. We don't query per rule condition because
+    # condition of the same class, interval, and environment can share a single scan.
+
+    # Map unique conditions to the group IDs that need to checked for that
+    # condition. We also store a pointer to that condition's JSON so we can
+    # instantiate the class later
+    class UniqueCondition(NamedTuple):
+        cls_id: str
+        interval: str
+        environment_id: int
+
+    class DataAndGroups(NamedTuple):
+        data: EventFrequencyConditionData
+        group_ids: set[int]
+
+    condition_groups: dict[UniqueCondition, DataAndGroups] = {}
+
+    for rule in rules:
+        # We only want to a rule's fast conditions because rules are only added
+        # to the buffer if we've already checked their fast conditions.
+        slow_conditions = get_slow_conditions(rule)
+        for condition_data in slow_conditions:
+            unique_condition = UniqueCondition(
+                condition_data["id"], condition_data["interval"], rule.environment_id
+            )
+
+            # Add to set the set of group_ids if there are already group_ids for
+            # that apply to the unique condition
+            if data_and_groups := condition_groups.get(unique_condition):
+                data_and_groups.group_ids.update(rules_to_groups[rule.id])
+            # Otherwise, create the tuple containing the condition data and the
+            # set of group_ids that apply to the unique condition
+            else:
+                condition_groups[unique_condition] = DataAndGroups(
+                    condition_data, rules_to_groups[rule.id]
                 )
 
+    # Step 5: Instantiate each unique condition, and evaluate the relevant
+    # group_ids that apply for that condition
 
-def apply_delayed(project: Project, rule_group_pairs: Mapping[str, str]) -> None:
-    pass
+    # XXX: Probably want to safe execute somewhere in this step before making
+    # the query
+    condition_group_results: dict[UniqueCondition, dict[int, int]] = {}
+    for unique_condition, (condition_data, group_ids) in condition_groups.items():
+        condition_cls = rules.get(unique_condition.cls_id)
+
+        if condition_cls is None:
+            logger.warning("Unregistered condition %r", condition_data["id"])
+            return None
+
+        condition_inst: BaseEventFrequencyCondition = condition_cls(
+            project=project, data=condition_data, rule=rule
+        )
+        if not isinstance(condition_inst, EventCondition):
+            logger.warning("Unregistered condition %r", condition_data["id"])
+            return None
+
+        _, duration = condition_inst.intervals[unique_condition.interval]
+        end = datetime.now()
+        # For conditions with interval >= 1 hour we don't need to worry about read your writes
+        # consistency. Disable it so that we can scale to more nodes.
+        option_override_cm: contextlib.AbstractContextManager[object] = contextlib.nullcontext()
+        if duration >= timedelta(hours=1):
+            option_override_cm = options_override({"consistent": False})
+
+        with option_override_cm:
+            results = condition_inst.batch_query(
+                group_ids, end - duration, end, environment_id=unique_condition.environment_id
+            )
+
+            # If the condition is a percent comparison, we need to query the
+            # previous interval to compare against the current interval
+            comparison_type = condition_data.get("comparisonType", ComparisonType.COUNT)
+            if comparison_type == ComparisonType.PERCENT:
+                comparison_interval = condition_inst.intervals[unique_condition.interval][1]
+                comparison_end = end - comparison_interval
+
+                comparison_results = condition_inst.batch_query(
+                    group_ids,
+                    comparison_end - duration,
+                    comparison_end,
+                    environment_id=unique_condition.environment_id,
+                )
+
+                results = {
+                    group_id: percent_increase(results[group_id], comparison_results[group_id])
+                    for group_id in group_ids
+                }
+
+        condition_group_results[unique_condition] = results
+
+    # Step 6: For each rule and group applying to that rule, check if the group
+    # meets the conditions of the rule (basically doing BaseEventFrequencyCondition.passes)
+    for rule in rules:
+        # don't know why mypy is complaining : (expression has type "int", variable has type "str")
+        for group_id in rules_to_groups[rule.id]:  # type: ignore[assignment]
+            pass
+
+            # get:
+            # 1. rule conditions + result of condition check in results dict
+            # 2. the predicate func (any, all) to iterate over for conditions
+            # 3. The interval rules value to compare the result of the query
+            #    against (e.g. # issues is > 50, 50 is the value). This is
+            #    stored in DataAndGroups.data["value"], see EventFrequencyConditionData
+
+            # Store all rule/group pairs  we need to activate
+
+    # Step 8: Bulk fetch the events of the rule/group pairs we need to trigger
+    # actions for, then trigger those actions
+
+    # Was thinking we could do something like this where we get futures,
+    # then safe execute them
+    # https://github.com/getsentry/sentry/blob/3075c03e0819dd2c974897cc3014764c43151db5/src/sentry/tasks/post_process.py#L1115-L1128
+
+    # XXX: Be sure to do this before triggering actions!
+    # https://github.com/getsentry/sentry/blob/fbfd6800cf067f171840c427df7d5c2864b91fb0/src/sentry/rules/processor.py#L247-L254

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -28,6 +28,23 @@ logger = logging.getLogger("sentry.rules.delayed_processing")
 PROJECT_ID_BUFFER_LIST_KEY = "project_id_buffer_list"
 
 
+class UniqueCondition(NamedTuple):
+    cls_id: str
+    interval: str
+    environment_id: int
+
+    def __repr__(self):
+        return f"id: {self.cls_id},\ninterval: {self.interval},\nenv id: {self.environment_id}"
+
+
+class DataAndGroups(NamedTuple):
+    data: MutableMapping[str, Any] | None
+    group_ids: set[int]
+
+    def __repr__(self):
+        return f"data: {self.data}\ngroup_ids: {self.group_ids}"
+
+
 def get_slow_conditions(rule: Rule) -> list[MutableMapping[str, str] | None]:
     """
     Returns the slow conditions of a rule model instance.
@@ -41,85 +58,41 @@ def get_slow_conditions(rule: Rule) -> list[MutableMapping[str, str] | None]:
     return slow_conditions
 
 
-@redis_buffer_registry.add_handler(BufferHookEvent.FLUSH)
-def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
-    with metrics.timer("delayed_processing.process_all_conditions.duration"):
-        project_ids = buffer.get_set(PROJECT_ID_BUFFER_LIST_KEY)
-
-        for project in RangeQuerySetWrapper(Project.objects.filter(id__in=project_ids)):
-            with metrics.timer("delayed_processing.process_project.duration"):
-                apply_delayed.delay(project=project, buffer=buffer)
-
-
-@instrumented_task(
-    name="sentry.delayed_processing.tasks.apply_delayed",
-    queue="dynamicsampling",
-    default_retry_delay=5,
-    max_retries=5,
-    soft_time_limit=50,
-    time_limit=60,  # 1 minute
-    silo_mode=SiloMode.REGION,
-)
-def apply_delayed(project: Project, buffer: RedisBuffer) -> None:
-    """ """
-
-    # XXX(schew2381): This is from
-    # https://github.com/getsentry/sentry/blob/fbfd6800cf067f171840c427df7d5c2864b91fb0/src/sentry/rules/processor.py#L209-L212
-    # Do we need to check this before we start the steps (ask dan, I think the
-    # answer is no b/c we check it before triggering actions))
-
-    # frequency = rule.data.get("frequency") or Rule.DEFAULT_FREQUENCY
-    # now = datetime.now()
-    # freq_offset = now - timedelta(minutes=frequency)
-    # if status.last_active and status.last_active > freq_offset:
-    #     return
-
-    # STEP 1: Fetch the rulegroup_to_events mapping for the project from redis
-
-    # The mapping looks like: [f'{rule.id}:{group.id}':'event.id']
-    rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": project.id})
-
-    # STEP 2: Map each rule to the groups that must be checked for that rule.
+def get_rules_to_groups(
+    rulegroup_to_events: list[dict[str, set[str]]]
+) -> DefaultDict[int, set[int]]:
     rules_to_groups: DefaultDict[int, set[int]] = defaultdict(set)
     for rulegroup_to_event in rulegroup_to_events:
         for rule_group in rulegroup_to_event.keys():
             rule_id, group_id = rule_group.split(":")
             rules_to_groups[int(rule_id)].add(int(group_id))
 
-    # STEP 3: Fetch the Rule models we need to check
-    alert_rules = Rule.objects.filter(id__in=list(rules_to_groups.keys()))
+    return rules_to_groups
 
-    # STEP 4: Create a map of unique conditions to a tuple containing the JSON
-    # information needed to instantiate that condition class and the group_ids that
-    # must be checked for that condition. We don't query per rule condition because
-    # condition of the same class, interval, and environment can share a single scan.
 
-    # Map unique conditions to the group IDs that need to checked for that
-    # condition. We also store a pointer to that condition's JSON so we can
-    # instantiate the class later
-    class UniqueCondition(NamedTuple):
-        cls_id: str
-        interval: str
-        environment_id: int
+def get_rule_to_slow_conditions(alert_rules: list[Rule]) -> DefaultDict[Rule, list[dict[str, Any]]]:
+    rule_to_slow_conditions: DefaultDict[Rule, list[dict[str, Any]]] = defaultdict(list)
+    for rule in alert_rules:
+        slow_conditions = get_slow_conditions(rule)
+        for condition_data in slow_conditions:
+            rule_to_slow_conditions[rule].append(condition_data)
 
-        def __repr__(self):
-            return f"id: {self.cls_id},\ninterval: {self.interval},\nenv id: {self.environment_id}"
+    return rule_to_slow_conditions
 
-    class DataAndGroups(NamedTuple):
-        data: MutableMapping[str, Any] | None
-        group_ids: set[int]
 
-        def __repr__(self):
-            return f"data: {self.data}\ngroup_ids: {self.group_ids}"
-
+def get_condition_groups(
+    alert_rules: list[Rule], rules_to_groups: DefaultDict[int, set[int]]
+) -> dict[UniqueCondition, DataAndGroups]:
+    """Map unique conditions to the group IDs that need to checked for that
+    condition. We also store a pointer to that condition's JSON so we can
+    instantiate the class later
+    """
     condition_groups: dict[UniqueCondition, DataAndGroups] = {}
-    rule_to_slow_conditions = defaultdict(list)
     for rule in alert_rules:
         # We only want a rule's slow conditions because alert_rules are only added
         # to the buffer if we've already checked their fast conditions.
         slow_conditions = get_slow_conditions(rule)
         for condition_data in slow_conditions:
-            rule_to_slow_conditions[rule].append(condition_data)
             if condition_data:
                 unique_condition = UniqueCondition(
                     condition_data["id"], condition_data["interval"], rule.environment_id
@@ -134,15 +107,12 @@ def apply_delayed(project: Project, buffer: RedisBuffer) -> None:
                     condition_groups[unique_condition] = DataAndGroups(
                         condition_data, rules_to_groups[rule.id]
                     )
+    return condition_groups
 
-    # XXX: CEO the only difference between UniqueCondition and DataAndGroup's data is the condition value
-    # does this still work when we have 2 of the same condition ids with different values?
-    # I made 2 EventFrequencyCondition with the same interval but different values and only see 1 shown
-    # it does properly handle same condition ids with different intervals
 
-    # Step 5: Instantiate each unique condition, and evaluate the relevant
-    # group_ids that apply for that condition
-
+def get_condition_group_results(
+    condition_groups: dict[UniqueCondition, DataAndGroups], project: Project, rule: Rule
+) -> dict[UniqueCondition, dict[int, int]]:
     # XXX: Probably want to safe execute somewhere in this step before making
     # the query
     condition_group_results: dict[UniqueCondition, dict[int, int]] = {}
@@ -199,33 +169,93 @@ def apply_delayed(project: Project, buffer: RedisBuffer) -> None:
                     }
 
         condition_group_results[unique_condition] = results
+    return condition_group_results
 
-    # Step 6: For each rule and group applying to that rule, check if the group
-    # meets the conditions of the rule (basically doing BaseEventFrequencyCondition.passes)
+
+def get_rules_to_fire(
+    condition_group_results: dict[UniqueCondition, dict[int, int]],
+    rule_to_slow_conditions: DefaultDict[Rule, list[dict[str, Any]]],
+    rules_to_groups: DefaultDict[int, set[int]],
+) -> DefaultDict[Rule, list[int]]:
+    condition_to_results = {c.cls_id: results for c, results in condition_group_results.items()}
     rules_to_fire = defaultdict(set)
     for alert_rule, slow_conditions in rule_to_slow_conditions.items():
         for slow_condition in slow_conditions:
-            for (
-                condition,
-                data,
-            ) in condition_groups.items():  # unique conditions to conditions and groups
-                if slow_condition == data.data:
-                    for (
-                        c,
-                        results,
-                    ) in condition_group_results.items():  # unique condition to results per group
-                        if c.cls_id == slow_condition["id"]:
-                            if results[int(group_id)] > int(slow_condition.get("value")):
-                                rules_to_fire[alert_rule].add(group_id)
+            condition_id = slow_condition.get("id")
+            target_value = int(slow_condition.get("value"))
+            results = condition_to_results[condition_id]
+            for group_id in rules_to_groups[alert_rule.id]:
+                if results[group_id] > target_value:
+                    rules_to_fire[alert_rule].add(group_id)
+    return rules_to_fire
 
-            # get:
-            # 1. rule conditions + result of condition check in results dict
-            # 2. the predicate func (any, all) to iterate over for conditions
-            # 3. The interval rules value to compare the result of the query
-            #    against (e.g. # issues is > 50, 50 is the value). This is
-            #    stored in DataAndGroups.data["value"], see EventFrequencyConditionData
 
-            # Store all rule/group pairs we need to activate
+@redis_buffer_registry.add_handler(BufferHookEvent.FLUSH)
+def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
+    with metrics.timer("delayed_processing.process_all_conditions.duration"):
+        project_ids = buffer.get_set(PROJECT_ID_BUFFER_LIST_KEY)
+
+        for project in RangeQuerySetWrapper(Project.objects.filter(id__in=project_ids)):
+            with metrics.timer("delayed_processing.process_project.duration"):
+                apply_delayed.delay(project=project, buffer=buffer)
+
+
+@instrumented_task(
+    name="sentry.delayed_processing.tasks.apply_delayed",
+    queue="dynamicsampling",
+    default_retry_delay=5,
+    max_retries=5,
+    soft_time_limit=50,
+    time_limit=60,  # 1 minute
+    silo_mode=SiloMode.REGION,
+)
+def apply_delayed(project: Project, buffer: RedisBuffer) -> None:
+    """ """
+
+    # XXX(schew2381): This is from
+    # https://github.com/getsentry/sentry/blob/fbfd6800cf067f171840c427df7d5c2864b91fb0/src/sentry/rules/processor.py#L209-L212
+    # Do we need to check this before we start the steps (ask dan, I think the
+    # answer is no b/c we check it before triggering actions))
+
+    # frequency = rule.data.get("frequency") or Rule.DEFAULT_FREQUENCY
+    # now = datetime.now()
+    # freq_offset = now - timedelta(minutes=frequency)
+    # if status.last_active and status.last_active > freq_offset:
+    #     return
+
+    # STEP 1: Fetch the rulegroup_to_events mapping for the project from redis
+
+    # The mapping looks like: [f'{rule.id}:{group.id}':'event.id']
+    rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": project.id})
+
+    # STEP 2: Map each rule to the groups that must be checked for that rule.
+    rules_to_groups = get_rules_to_groups(rulegroup_to_events)
+
+    # STEP 3: Fetch the Rule models we need to check
+    alert_rules = Rule.objects.filter(id__in=list(rules_to_groups.keys()))
+
+    # STEP 4: Create a map of unique conditions to a tuple containing the JSON
+    # information needed to instantiate that condition class and the group_ids that
+    # must be checked for that condition. We don't query per rule condition because
+    # condition of the same class, interval, and environment can share a single scan.
+    condition_groups = get_condition_groups(alert_rules, rules_to_groups)
+
+    # XXX: CEO the only difference between UniqueCondition and DataAndGroup's data is the condition value
+    # does this still work when we have 2 of the same condition ids with different values?
+    # I made 2 EventFrequencyCondition with the same interval but different values and only see 1 shown
+    # it does properly handle same condition ids with different intervals
+
+    # Step 5: Instantiate each unique condition, and evaluate the relevant
+    # group_ids that apply for that condition
+    condition_group_results = get_condition_group_results(condition_groups, project, alert_rules[0])
+
+    # Step 6: For each rule and group applying to that rule, check if the group
+    # meets the conditions of the rule (basically doing BaseEventFrequencyCondition.passes)
+    rule_to_slow_conditions = get_rule_to_slow_conditions(alert_rules)
+    rules_to_fire = get_rules_to_fire(
+        condition_group_results, rule_to_slow_conditions, rules_to_groups
+    )
+    return rules_to_fire
 
     # Step 7: Bulk fetch the events of the rule/group pairs we need to trigger
     # actions for, then trigger those actions

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -113,7 +113,8 @@ def get_condition_groups(
 
 
 def get_condition_group_results(
-    condition_groups: dict[UniqueCondition, DataAndGroups], project: Project, rule: Rule
+    condition_groups: dict[UniqueCondition, DataAndGroups],
+    project: Project,
 ) -> dict[UniqueCondition, dict[int, int]]:
     # XXX: Probably want to safe execute somewhere in this step before making
     # the query
@@ -126,7 +127,7 @@ def get_condition_group_results(
             return None
 
         condition_inst: BaseEventFrequencyCondition = condition_cls(
-            project=project, data=condition_data, rule=rule
+            project=project, data=condition_data
         )
         if not isinstance(condition_inst, EventCondition):
             logger.warning("Unregistered condition %r", condition_cls.id)
@@ -232,7 +233,7 @@ def apply_delayed(project: Project, buffer: RedisBuffer) -> None:
 
     # Step 5: Instantiate each unique condition, and evaluate the relevant
     # group_ids that apply for that condition
-    condition_group_results = get_condition_group_results(condition_groups, project, alert_rules[0])
+    condition_group_results = get_condition_group_results(condition_groups, project)
 
     # Step 6: For each rule and group applying to that rule, check if the group
     # meets the conditions of the rule (basically doing BaseEventFrequencyCondition.passes)

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -12,7 +12,6 @@ from sentry.rules.processing.processor import is_condition_slow, split_condition
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
-from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.safe import safe_execute
 
 logger = logging.getLogger("sentry.rules.delayed_processing")
@@ -170,9 +169,9 @@ def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
     with metrics.timer("delayed_processing.process_all_conditions.duration"):
         project_ids = buffer.get_set(PROJECT_ID_BUFFER_LIST_KEY)
 
-        for project in RangeQuerySetWrapper(Project.objects.filter(id__in=project_ids)):
+        for project_id in project_ids:
             with metrics.timer("delayed_processing.process_project.duration"):
-                apply_delayed.delay(project_id=project.id, buffer=buffer)
+                apply_delayed.delay(project_id=project_id, buffer=buffer)
 
 
 @instrumented_task(

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -54,12 +54,11 @@ def is_condition_slow(
 
 
 def split_conditions_and_filters(
-    data: Mapping[str, Any],
+    data: list[Mapping[str, Any]],
 ) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]]]:
-    conditions_and_filters = data.get("conditions", [])
     conditions = []
     filters = []
-    for condition_or_filter in conditions_and_filters:
+    for condition_or_filter in data:
         id = condition_or_filter["id"]
         rule_cls = rules.get(id)
         if rule_cls is None:

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -55,7 +55,7 @@ def is_condition_slow(
 
 def split_conditions_and_filters(
     data: list[Mapping[str, Any]],
-) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]]]:
+) -> tuple[list[MutableMapping[str, Any]], list[Mapping[str, Any]]]:
     conditions = []
     filters = []
     for condition_or_filter in data:

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -53,6 +53,26 @@ def is_condition_slow(
     return False
 
 
+def split_conditions_and_filters(
+    data: Mapping[str, Any],
+) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]]]:
+    conditions_and_filters = data.get("conditions", [])
+    conditions = []
+    filters = []
+    for condition_or_filter in conditions_and_filters:
+        id = condition_or_filter["id"]
+        rule_cls = rules.get(id)
+        if rule_cls is None:
+            logger.warning("Unregistered condition or filter %r", id)
+            continue
+
+        if rule_cls.rule_type == EventFilter.rule_type:
+            filters.append(condition_or_filter)
+        elif rule_cls.rule_type == EventCondition.rule_type:
+            conditions.append(condition_or_filter)
+    return conditions, filters
+
+
 class RuleProcessor:
     def __init__(
         self,

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -54,8 +54,8 @@ def is_condition_slow(
 
 
 def split_conditions_and_filters(
-    data: list[Mapping[str, Any]],
-) -> tuple[list[MutableMapping[str, Any]], list[Mapping[str, Any]]]:
+    data: list[MutableMapping[str, Any]],
+) -> tuple[list[MutableMapping[str, Any]], list[MutableMapping[str, Any]]]:
     conditions = []
     filters = []
     for condition_or_filter in data:

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -75,25 +75,6 @@ def split_conditions_and_filters(rule_condition_list):
     return condition_list, filter_list
 
 
-# def split_conditions_and_filters(
-#     data: list[MutableMapping[str, Any]],
-# ) -> tuple[list[MutableMapping[str, Any]], list[MutableMapping[str, Any]]]:
-#     conditions = []
-#     filters = []
-#     for condition_or_filter in data:
-#         id = condition_or_filter["id"]
-#         rule_cls = rules.get(id)
-#         if rule_cls is None:
-#             logger.warning("Unregistered condition or filter %r", id)
-#             continue
-
-#         if rule_cls.rule_type == EventFilter.rule_type:
-#             filters.append(condition_or_filter)
-#         elif rule_cls.rule_type == EventCondition.rule_type:
-#             conditions.append(condition_or_filter)
-#     return conditions, filters
-
-
 class RuleProcessor:
     def __init__(
         self,

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from sentry.db import models
 from sentry.eventstore.models import Event
 from sentry.models.project import Project
@@ -9,6 +11,8 @@ from sentry.rules.processing.delayed_processing import (
 )
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+
+pytestmark = pytest.mark.sentry_metrics
 
 
 class ProcessDelayedAlertConditionsTest(TestCase, APITestCase):

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1,14 +1,82 @@
 from unittest.mock import Mock, patch
 
 from sentry.db import models
+from sentry.eventstore.models import Event
+from sentry.models.project import Project
 from sentry.rules.processing.delayed_processing import (
     apply_delayed,
     process_delayed_alert_conditions,
 )
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
-class ProcessDelayedAlertConditionsTest(TestCase):
+class ProcessDelayedAlertConditionsTest(TestCase, APITestCase):
+    def create_event(self, project: Project) -> Event:
+        return self.store_event(
+            data={
+                "event_id": "0" * 32,
+                "environment": self.environment.name,
+                "timestamp": iso_format(before_now(days=1)),
+                "fingerprint": ["part-1"],
+                "stacktrace": {"frames": [{"filename": "flow/spice.js"}]},
+            },
+            project_id=project.id,
+        )
+
+    def setUp(self):
+        event_frequency_condition = {
+            "interval": "1h",
+            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+            "value": 666,
+            "name": "The issue is seen more than 30 times in 1m",
+        }
+        user_frequency_condition = {
+            "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition",
+            "value": 2,
+            "interval": "5m",
+        }
+        event_frequency_percent_condition = {
+            "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
+            "interval": "1h",
+            "value": "100",
+            "comparisonType": "count",
+        }
+        self.rule1 = self.create_project_rule(
+            project=self.project, condition_match=[event_frequency_condition]
+        )
+        self.rule2 = self.create_project_rule(
+            project=self.project, condition_match=[user_frequency_condition]
+        )
+        self.event1 = self.create_event(self.project)
+        self.group1 = self.event1.group
+        self.event2 = self.create_event(self.project)
+        self.group2 = self.event2.group
+        self.rulegroup_event_mapping_one = {
+            f"{self.rule1.id}:{self.group1.id}": {self.event1.event_id},
+            f"{self.rule2.id}:{self.group2.id}": {self.event2.event_id},
+        }
+
+        self.project_two = self.create_project(organization=self.organization)
+        self.rule3 = self.create_project_rule(
+            project=self.project_two, condition_match=[event_frequency_condition]
+        )
+        self.rule4 = self.create_project_rule(
+            project=self.project_two, condition_match=[event_frequency_percent_condition]
+        )
+        self.event3 = self.create_event(self.project_two)
+        self.group3 = self.event3.group
+        self.event4 = self.create_event(self.project_two)
+        self.group4 = self.event4.group
+        self.rulegroup_event_mapping_two = {
+            f"{self.rule3.id}:{self.group3.id}": {self.event3.event_id},
+            f"{self.rule4.id}:{self.group4.id}": {self.event4.event_id},
+        }
+        self.buffer_mapping = {
+            self.project.id: self.rulegroup_event_mapping_one,
+            self.project_two.id: self.rulegroup_event_mapping_two,
+        }
+
     def get_rulegroup_event_mapping_from_input(
         self, model: type[models.Model], field: dict[str, models.Model | str | int]
     ):
@@ -16,23 +84,8 @@ class ProcessDelayedAlertConditionsTest(TestCase):
         proj_id = field.popitem()[1]
         return self.buffer_mapping[proj_id]
 
-    @patch("sentry.rules.processing.delayed_processing.safe_execute")
-    def test_fetches_from_buffer_and_executes(self, mock_safe_execute):
-        project_two = self.create_project()
-
-        rulegroup_event_mapping_one = {
-            f"{self.project.id}:1": "event_1",
-            f"{project_two.id}:2": "event_2",
-        }
-        rulegroup_event_mapping_two = {
-            f"{self.project.id}:3": "event_3",
-            f"{project_two.id}:4": "event_4",
-        }
-        self.buffer_mapping = {
-            self.project.id: rulegroup_event_mapping_one,
-            project_two.id: rulegroup_event_mapping_two,
-        }
-
+    @patch("sentry.rules.processing.delayed_processing.apply_delayed")
+    def test_fetches_from_buffer_and_executes(self, mock_apply_delayed):
         mock_buffer = Mock()
         mock_buffer.get_set.return_value = self.buffer_mapping.keys()
         # To get the correct mapping, we need to return the correct
@@ -42,12 +95,17 @@ class ProcessDelayedAlertConditionsTest(TestCase):
         process_delayed_alert_conditions(mock_buffer)
 
         for project, rule_group_event_mapping in (
-            (self.project, rulegroup_event_mapping_one),
-            (project_two, rulegroup_event_mapping_two),
+            (self.project, self.rulegroup_event_mapping_one),
+            (self.project_two, self.rulegroup_event_mapping_two),
         ):
-            mock_safe_execute.assert_any_call(
-                apply_delayed,
-                project,
-                rule_group_event_mapping,
-                _with_transaction=False,
-            )
+            assert mock_apply_delayed.delay.call_count == 2
+
+    def test_apply_delayed(self):
+        mock_buffer = Mock()
+        mock_buffer.get_set.return_value = self.buffer_mapping.keys()
+        mock_buffer.get_hash.return_value = [
+            self.rulegroup_event_mapping_one,
+            self.rulegroup_event_mapping_two,
+        ]
+        for proj in [self.project, self.project_two]:
+            apply_delayed(proj, mock_buffer)

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -30,24 +30,32 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase):
 
     def setUp(self):
         event_frequency_condition = {
+            "interval": "1d",
+            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+            "value": 1,
+            "name": "The issue is seen more than 1 times in 1d",
+        }
+        event_frequency_condition2 = {
             "interval": "1h",
             "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
-            "value": 666,
-            "name": "The issue is seen more than 30 times in 1m",
+            "value": 1,
+            "name": "The issue is seen more than 1 times in 1h",
         }
         user_frequency_condition = {
             "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition",
-            "value": 2,
+            "value": 1,
             "interval": "5m",
         }
         event_frequency_percent_condition = {
             "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
             "interval": "1h",
-            "value": "100",
+            "value": "1",
             "comparisonType": "count",
         }
         self.rule1 = self.create_project_rule(
-            project=self.project, condition_match=[event_frequency_condition]
+            project=self.project,
+            condition_match=[event_frequency_condition],
+            environment_id=self.environment.id,
         )
         self.rule2 = self.create_project_rule(
             project=self.project, condition_match=[user_frequency_condition]
@@ -62,8 +70,11 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase):
         }
 
         self.project_two = self.create_project(organization=self.organization)
+        self.environment2 = self.create_environment(project=self.project_two)
         self.rule3 = self.create_project_rule(
-            project=self.project_two, condition_match=[event_frequency_condition]
+            project=self.project_two,
+            condition_match=[event_frequency_condition2],
+            environment_id=self.environment2.id,
         )
         self.rule4 = self.create_project_rule(
             project=self.project_two, condition_match=[event_frequency_percent_condition]

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -7,7 +7,6 @@ import pytest
 
 from sentry.db import models
 from sentry.eventstore.models import Event
-from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.processing.delayed_processing import (
     apply_delayed,
     process_delayed_alert_conditions,
@@ -21,7 +20,6 @@ pytestmark = pytest.mark.sentry_metrics
 
 class ProcessDelayedAlertConditionsTest(TestCase, APITestCase):
     def create_event(self, project_id, timestamp, fingerprint, environment=None) -> Event:
-        print("user: ", uuid4().hex)
         data = {
             "timestamp": iso_format(timestamp),
             "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
@@ -57,7 +55,7 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase):
             "value": 2,
             "name": "The issue is seen more than 2 times in 1d",
         }
-        event_frequency_condition3 = {
+        self.event_frequency_condition3 = {
             "interval": "1h",
             "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
             "value": 1,

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -158,13 +158,13 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         """
         self.mock_buffer.get_hash.return_value = [self.rulegroup_event_mapping_one]
 
-        rules = apply_delayed(self.project, self.mock_buffer)
+        rules = apply_delayed(self.project.id, self.mock_buffer)
         assert self.rule1 in rules
         assert self.rule2 in rules
 
         self.mock_buffer.get_hash.return_value = [self.rulegroup_event_mapping_two]
 
-        rules = apply_delayed(self.project_two, self.mock_buffer)
+        rules = apply_delayed(self.project_two.id, self.mock_buffer)
         assert self.rule3 in rules
         assert self.rule4 in rules
 
@@ -191,7 +191,7 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
             },
         ]
 
-        rules = apply_delayed(self.project, self.mock_buffer)
+        rules = apply_delayed(self.project.id, self.mock_buffer)
         assert self.rule1 in rules
         assert rule5 in rules
 
@@ -217,7 +217,7 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
             },
         ]
 
-        rules = apply_delayed(self.project, self.mock_buffer)
+        rules = apply_delayed(self.project.id, self.mock_buffer)
         assert self.rule1 in rules
         assert diff_interval_rule in rules
 
@@ -244,7 +244,7 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
             },
         ]
 
-        rules = apply_delayed(self.project, self.mock_buffer)
+        rules = apply_delayed(self.project.id, self.mock_buffer)
         assert self.rule1 in rules
         assert diff_env_rule in rules
 
@@ -276,6 +276,6 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
             },
         ]
 
-        rules = apply_delayed(self.project, self.mock_buffer)
+        rules = apply_delayed(self.project.id, self.mock_buffer)
         assert self.rule1 in rules
         assert no_fire_rule not in rules

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -43,37 +43,29 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
             assert_no_errors=False,
         )
 
+    def create_event_frequency_condition(
+        self,
+        interval="1d",
+        id="EventFrequencyCondition",
+        value=1,
+    ):
+        condition_id = f"sentry.rules.conditions.event_frequency.{id}"
+        return {"interval": interval, "id": condition_id, "value": value}
+
     def setUp(self):
         super().setUp()
-        self.event_frequency_condition = {
-            "interval": "1d",
-            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
-            "value": 1,
-            "name": "The issue is seen more than 1 times in 1d",
-        }
-        self.event_frequency_condition2 = {
-            "interval": "1d",
-            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
-            "value": 2,
-            "name": "The issue is seen more than 2 times in 1d",
-        }
-        self.event_frequency_condition3 = {
-            "interval": "1h",
-            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
-            "value": 1,
-            "name": "The issue is seen more than 1 times in 1h",
-        }
-        user_frequency_condition = {
-            "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition",
-            "value": 1,
-            "interval": "1m",
-        }
-        event_frequency_percent_condition = {
-            "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
-            "interval": "5m",
-            "value": "1",
-            "comparisonType": "count",
-        }
+        self.event_frequency_condition = self.create_event_frequency_condition()
+        self.event_frequency_condition2 = self.create_event_frequency_condition(value=2)
+        self.event_frequency_condition3 = self.create_event_frequency_condition(
+            interval="1h", value=1
+        )
+        user_frequency_condition = self.create_event_frequency_condition(
+            interval="1m",
+            id="EventUniqueUserFrequencyCondition",
+        )
+        event_frequency_percent_condition = self.create_event_frequency_condition(
+            interval="5m", id="EventFrequencyPercentCondition"
+        )
         self.now = datetime.now(UTC)
 
         self.rule1 = self.create_project_rule(
@@ -136,9 +128,6 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         }
 
         self.mock_buffer = Mock()
-
-    def tearDown(self):
-        super().tearDown()
 
     def get_rulegroup_event_mapping_from_input(
         self, model: type[models.Model], field: dict[str, models.Model | str | int]

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -85,6 +85,7 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         self.create_event(self.project.id, self.now, "group-1", self.environment.name)
 
         self.group1 = self.event1.group
+        assert self.group1
 
         self.rule2 = self.create_project_rule(
             project=self.project, condition_match=[user_frequency_condition]
@@ -92,6 +93,7 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         self.event2 = self.create_event(self.project, self.now, "group-2", self.environment.name)
         self.create_event(self.project, self.now, "group-2", self.environment.name)
         self.group2 = self.event2.group
+        assert self.group2
 
         self.rulegroup_event_mapping_one = {
             f"{self.rule1.id}:{self.group1.id}": {self.event1.event_id},
@@ -113,6 +115,7 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         self.create_event(self.project_two, self.now, "group-3", self.environment2.name)
         self.create_event(self.project_two, self.now, "group-3", self.environment2.name)
         self.group3 = self.event3.group
+        assert self.group3
 
         self.rule4 = self.create_project_rule(
             project=self.project_two, condition_match=[event_frequency_percent_condition]
@@ -121,6 +124,7 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         self.create_event(self.project_two, self.now, "group-4")
         self._make_sessions(60, project=self.project_two)
         self.group4 = self.event4.group
+        assert self.group4
 
         self.rulegroup_event_mapping_two = {
             f"{self.rule3.id}:{self.group3.id}": {self.event3.event_id},
@@ -187,12 +191,14 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         event5 = self.create_event(self.project_two, self.now, "group-5", self.environment.name)
         self.create_event(self.project_two, self.now, "group-5", self.environment.name)
         self.create_event(self.project_two, self.now, "group-5", self.environment.name)
-        self.group5 = event5.group
+        group5 = event5.group
+        assert group5
+        assert self.group1
 
         self.mock_buffer.get_hash.return_value = [
             {
                 f"{self.rule1.id}:{self.group1.id}": {self.event1.event_id},
-                f"{rule5.id}:{self.group5.id}": {event5.event_id},
+                f"{rule5.id}:{group5.id}": {event5.event_id},
             },
         ]
 
@@ -212,6 +218,8 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         event5 = self.create_event(self.project.id, self.now, "group-5", self.environment.name)
         self.create_event(self.project.id, self.now, "group-5", self.environment.name)
         group5 = event5.group
+        assert group5
+        assert self.group1
 
         self.mock_buffer.get_hash.return_value = [
             {
@@ -237,6 +245,8 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         event5 = self.create_event(self.project.id, self.now, "group-5", environment3.name)
         self.create_event(self.project.id, self.now, "group-5", environment3.name)
         group5 = event5.group
+        assert group5
+        assert self.group1
 
         self.mock_buffer.get_hash.return_value = [
             {
@@ -267,6 +277,8 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         event5 = self.create_event(self.project.id, self.now, "group-5", self.environment.name)
         self.create_event(self.project.id, self.now, "group-5", self.environment.name)
         group5 = event5.group
+        assert group5
+        assert self.group1
 
         self.mock_buffer.get_hash.return_value = [
             {

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -8,6 +8,7 @@ import pytest
 from django.utils import timezone
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
+from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.rules.conditions.event_frequency import (
     EventFrequencyCondition,
@@ -29,15 +30,17 @@ pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
 
 class BaseEventFrequencyPercentTest(BaseMetricsTestCase):
-    def _make_sessions(self, num: int, environment_name: str | None = None):
+    def _make_sessions(
+        self, num: int, environment_name: str | None = None, project: Project | None = None
+    ):
         received = time.time()
 
         def make_session(i):
             return dict(
                 distinct_id=uuid4().hex,
                 session_id=uuid4().hex,
-                org_id=self.project.organization_id,
-                project_id=self.project.id,
+                org_id=project.organization_id if project else self.project.organization_id,
+                project_id=project.id if project else self.project.id,
                 status="ok",
                 seq=0,
                 release="foo@1.0.0",


### PR DESCRIPTION
Adds a processor for rules with "slow" conditions that are evaluated up to a minute after the event comes in. This PR _only_ goes as far as getting the rules that we need to fire, the actual firing will happen in a follow up PR.

Addresses part of https://github.com/getsentry/team-core-product-foundations/issues/242