### PR TITLE
fix(ddm): Add message to the block metric confirm modal

### DIFF
--- a/static/app/views/settings/projectMetrics/projectMetricsDetails.tsx
+++ b/static/app/views/settings/projectMetrics/projectMetricsDetails.tsx
@@ -136,6 +136,13 @@ function ProjectMetricsDetails({project, params, organization}: Props) {
               isBlocked={isBlockedMetric}
               onConfirm={handleMetricBlockToggle}
               aria-label={t('Block Metric')}
+              message={
+                isBlockedMetric
+                  ? t('Are you sure you want to unblock this metric?')
+                  : t(
+                      'Are you sure you want to block this metric? It will no longer be ingested, and will not be available for use in Metrics, Alerts, or Dashboards.'
+                    )
+              }
             />
             <LinkButton
               to={getMetricsUrl(organization.slug, {


### PR DESCRIPTION
I've noticed this when responding to this issue: https://github.com/getsentry/sentry/issues/63922
![image](https://github.com/getsentry/sentry/assets/9060071/17de7105-cd49-4ba0-9315-a618a1d9356c)
