### PR TITLE
fix(grid-editable): adjust resizer height

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -5,7 +5,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import {space} from 'sentry/styles/space';
 
 export const GRID_HEAD_ROW_HEIGHT = 45;
-export const GRID_BODY_ROW_HEIGHT = 40;
+export const GRID_BODY_ROW_HEIGHT = 42;
 export const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
 
 /**
@@ -269,7 +269,9 @@ export const GridResizer = styled('div')<{dataRows: number}>`
 
   height: ${p => {
     const numOfRows = p.dataRows;
-    const height = GRID_HEAD_ROW_HEIGHT + numOfRows * GRID_BODY_ROW_HEIGHT;
+    // 1px for the border
+    const totalRowHeight = numOfRows * (GRID_BODY_ROW_HEIGHT + 1);
+    const height = GRID_HEAD_ROW_HEIGHT + totalRowHeight;
 
     return height;
   }}px;


### PR DESCRIPTION
Adjusts row height of GridEditable component that is used to calculate the height of the resizer

Before:
![image](https://github.com/getsentry/sentry/assets/86684834/b114fa12-1a6b-4f25-82f9-c8c9b03fadc6)

After:
![image](https://github.com/getsentry/sentry/assets/86684834/f7ae02ca-a8fc-415d-b4d0-9cd215e3dc05)

