### PR TITLE
fix(ddm): Return consistent empty results from metrics API

### DIFF
--- a/src/sentry/sentry_metrics/querying/data/execution.py
+++ b/src/sentry/sentry_metrics/querying/data/execution.py
@@ -372,8 +372,8 @@ class QueryResult:
             series_query=series_query,
             totals_query=totals_query,
             result={
-                "series": {"data": {}, "meta": {}},
-                "totals": {"data": {}, "meta": {}},
+                "series": {"data": [], "meta": []},
+                "totals": {"data": [], "meta": []},
                 # We want to honor the date ranges of the supplied query.
                 "modified_start": scheduled_query.metrics_query.start,
                 "modified_end": scheduled_query.metrics_query.end,

--- a/src/sentry/sentry_metrics/querying/data/transformation/metrics_api.py
+++ b/src/sentry/sentry_metrics/querying/data/transformation/metrics_api.py
@@ -159,7 +159,11 @@ class MetricsAPIQueryResultsTransformer(QueryResultsTransformer[Mapping[str, Any
             group_bys: list[str],
             query_groups: OrderedDict[GroupKey, GroupValue],
             add_to_group: Callable[[Mapping[str, Any], GroupValue], None],
-        ):
+        ) -> None:
+            if not rows:
+                query_groups.setdefault(tuple(), GroupValue.empty())
+                return
+
             for row in rows:
                 grouped_values = []
                 for group_by in group_bys:
@@ -168,6 +172,7 @@ class MetricsAPIQueryResultsTransformer(QueryResultsTransformer[Mapping[str, Any
 
                 group_value = query_groups.setdefault(tuple(grouped_values), GroupValue.empty())
                 add_to_group(row, group_value)
+            return
 
         for query_result in query_results:
             # All queries must have the same timerange, so under this assumption we take the first occurrence of each.

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -1087,7 +1087,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         )
         data = results["data"]
         assert len(data) == 1
-        assert len(data[0]) == 0
+        assert data[0][0]["series"] == [None, None, None]
+        assert data[0][0]["totals"] is None
 
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     def test_query_with_two_metrics_and_one_blocked_for_a_project(self):
@@ -1126,7 +1127,9 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         )
         data = results["data"]
         assert len(data) == 2
-        assert len(data[0]) == 0
+        assert len(data[0][0]["series"]) == 3
+        assert data[0][0]["series"] == [None, None, None]
+        assert data[0][0]["totals"] is None
         assert data[1][0]["by"] == {}
         assert data[1][0]["series"] == [None, self.to_reference_unit(10.0), None]
         assert data[1][0]["totals"] == self.to_reference_unit(10.0)
@@ -1929,3 +1932,29 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             self.to_reference_unit(5.0),
         ]
         assert data[1]["totals"] == self.to_reference_unit(4.0)
+
+    @with_feature("organizations:ddm-metrics-api-unit-normalization")
+    def test_groupby_project_and_filter_by_unknown_project_id(self) -> None:
+        self.empty_project = self.create_project(name="empty project")
+
+        mql = self.mql(
+            "avg",
+            TransactionMRI.DURATION.value,
+            group_by="project",
+        )
+        query = MQLQuery(mql)
+
+        results = self.run_query(
+            mql_queries=[query],
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.empty_project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"][0]
+        assert len(data) == 1
+        assert data[0]["series"] == [None, None, None]
+        assert data[0]["totals"] is None


### PR DESCRIPTION
Until now, different empty queries returned different kinds of empty results from Snuba, and therefore inconsistent results in the API. This commit makes all those consistent after some things were changed on the Snuba side.