### PR TITLE
chore(hybridcloud) Allow customized RPC cache durations

### DIFF
--- a/src/sentry/hybridcloud/rpc/services/caching/impl.py
+++ b/src/sentry/hybridcloud/rpc/services/caching/impl.py
@@ -2,6 +2,7 @@ from collections.abc import Generator, Mapping
 from typing import TypeVar
 
 from django.core.cache import cache
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
 
 from sentry.hybridcloud.models.cacheversion import (
     CacheVersionBase,
@@ -25,8 +26,12 @@ def _consume_generator(g: Generator[None, None, _V]) -> _V:
             return e.value
 
 
-def _set_cache(key: str, value: str | None, version: int) -> Generator[None, None, bool]:
-    result = cache.add(_versioned_key(key, version), value)
+def _set_cache(
+    key: str, value: str | None, version: int, timeout: int | None = None
+) -> Generator[None, None, bool]:
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+    result = cache.add(_versioned_key(key, version), value, timeout=timeout)
     yield
     return result
 

--- a/tests/sentry/hybridcloud/test_caching.py
+++ b/tests/sentry/hybridcloud/test_caching.py
@@ -97,7 +97,7 @@ def test_caching_function_none_value():
     cache.clear()
 
     @back_with_silo_cache(
-        base_key="my-test-key", silo_mode=SiloMode.CONTROL, t=RpcOrganizationSummary
+        base_key="my-test-key", silo_mode=SiloMode.CONTROL, t=RpcOrganizationSummary, timeout=900
     )
     def get_org(org_id: int) -> RpcOrganizationSummary | None:
         return organization_service.get_org_by_id(id=org_id)


### PR DESCRIPTION
I'd like to see if increasing the cache duration for users/subscriptions will help reduce RPC throughput.