### PR TITLE
feat(feedback): apply denylist during create_user_report

### DIFF
--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -32,7 +32,8 @@ def save_userreport(
     start_time=None,
 ):
     with metrics.timer("sentry.ingest.userreport.save_userreport"):
-
+        if is_org_in_denylist(project.organization):
+            return
         if should_filter_user_report(report["comments"]):
             return
 
@@ -129,4 +130,11 @@ def should_filter_user_report(comments: str):
         )
         return True
 
+    return False
+
+
+def is_org_in_denylist(organization):
+    if organization.slug in options.get("feedback.organizations.slug-denylist"):
+        metrics.incr("user_report.create_user_report.filtered", tags={"reason": "org.denylist"})
+        return True
     return False

--- a/tests/sentry/ingest/test_userreport.py
+++ b/tests/sentry/ingest/test_userreport.py
@@ -1,5 +1,6 @@
 from sentry.feedback.usecases.create_feedback import UNREAL_FEEDBACK_UNATTENDED_MESSAGE
-from sentry.ingest.userreport import should_filter_user_report
+from sentry.ingest.userreport import is_org_in_denylist, save_userreport, should_filter_user_report
+from sentry.models.userreport import UserReport
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -19,3 +20,61 @@ def test_unreal_unattended_message_without_option(set_sentry_option):
 def test_empty_message(set_sentry_option):
     with set_sentry_option("feedback.filter_garbage_messages", True):
         assert should_filter_user_report("") is True
+
+
+@django_db_all
+def test_org_denylist(set_sentry_option, default_project):
+    with set_sentry_option(
+        "feedback.organizations.slug-denylist", [default_project.organization.slug]
+    ):
+        assert is_org_in_denylist(default_project.organization) is True
+
+
+@django_db_all
+def test_org_denylist_not_in_list(set_sentry_option, default_project):
+    with set_sentry_option("feedback.organizations.slug-denylist", ["not-in-list"]):
+        assert is_org_in_denylist(default_project.organization) is False
+
+
+@django_db_all
+def test_save_user_report_returns_instance(set_sentry_option, default_project, monkeypatch):
+    # Mocking dependencies and setting up test data
+    monkeypatch.setattr("sentry.ingest.userreport.is_org_in_denylist", lambda org: False)
+    monkeypatch.setattr("sentry.ingest.userreport.should_filter_user_report", lambda message: False)
+    monkeypatch.setattr(
+        "sentry.ingest.userreport.UserReport.objects.create", lambda **kwargs: UserReport()
+    )
+    monkeypatch.setattr(
+        "sentry.eventstore.backend.get_event_by_id", lambda project_id, event_id: None
+    )
+
+    # Test data
+    report = {
+        "event_id": "123456",
+        "name": "Test User",
+        "email": "test@example.com",
+        "comments": "This is a test feedback",
+        "project_id": default_project.id,
+    }
+
+    # Call the function
+    result = save_userreport(default_project, report, "api")
+
+    # Assert the result is an instance of UserReport
+    assert isinstance(result, UserReport)
+
+
+@django_db_all
+def test_save_user_report_denylist(set_sentry_option, default_project, monkeypatch):
+    monkeypatch.setattr("sentry.ingest.userreport.is_org_in_denylist", lambda org: True)
+    report = {
+        "event_id": "123456",
+        "name": "Test User",
+        "email": "test@example.com",
+        "comments": "This is a test feedback",
+        "project_id": default_project.id,
+    }
+
+    result = save_userreport(default_project, report, "api")
+
+    assert result is None


### PR DESCRIPTION
During the development of user feedback we identified a bunch of orgs that are sending spam/garbage through user feedbacks, which ends up being a majority of the traffic. lets apply that denylist here so we can keep the system healthier 