### PR TITLE
chore(hybrid-cloud): remove logging from release registry

### DIFF
--- a/src/sentry/tasks/release_registry.py
+++ b/src/sentry/tasks/release_registry.py
@@ -47,10 +47,6 @@ def fetch_release_registry_data(**kwargs):
 
     More details about the registry: https://github.com/getsentry/sentry-release-registry/
     """
-    logger.info(
-        "release_registry.fetch.starting",
-        extra={"release_registry_baseurl": str(settings.SENTRY_RELEASE_REGISTRY_BASEURL)},
-    )
     if not settings.SENTRY_RELEASE_REGISTRY_BASEURL:
         logger.warning("Release registry URL is not specified, skipping the task.")
         return
@@ -65,8 +61,4 @@ def fetch_release_registry_data(**kwargs):
 
     # AWS Layers
     layer_data = _fetch_registry_url("/aws-lambda-layers")
-    logger.info(
-        "release_registry.fetch.aws-lambda-layers",
-        extra={"layer_data": layer_data},
-    )
     cache.set(LAYER_INDEX_CACHE_KEY, layer_data, CACHE_TTL)


### PR DESCRIPTION
SENTRY-2JN5 is a noisy issue that is supposed to inform us whether we are fetching the AWS layer from cache. Yes, we are, so we can remove `capture_exception` now :)

Similarly, the logs being removed are showing up too.

This PR undoes https://github.com/getsentry/sentry/pull/62007