### PR TITLE
feat: Upgrade @sentry/status-page-list to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@sentry/node": "^7.109.0",
     "@sentry/react": "^7.109.0",
     "@sentry/release-parser": "^1.3.1",
-    "@sentry/status-page-list": "^0.0.1",
+    "@sentry/status-page-list": "^0.1.0",
     "@sentry/types": "^7.109.0",
     "@sentry/utils": "^7.109.0",
     "@spotlightjs/spotlight": "^1.2.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2963,10 +2963,10 @@
     "@sentry/types" "7.109.0"
     "@sentry/utils" "7.109.0"
 
-"@sentry/status-page-list@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@sentry/status-page-list/-/status-page-list-0.0.1.tgz#fb65dc67496067798dcd9b3285589ded63f0ecd1"
-  integrity sha512-LQSBWck49vqHdnt9gGKshlwtzhHLqTCAc7H1AIOF66BMmEkpsOzXjhloE7tJ8ufbuIHnPGvBseydA2CcSzwQTQ==
+"@sentry/status-page-list@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@sentry/status-page-list/-/status-page-list-0.1.0.tgz#49e8683091de0531aba96fc95f19891970929701"
+  integrity sha512-wXWu3IihxFO0l5WQkr6V138ZJKHpL8G7fw/9l0Dl6Nl1ggWcJZOaBN/o5sXasS1e0Atvy2dL9DiPsKmBq8D4MA==
 
 "@sentry/types@7.109.0", "@sentry/types@^7.109.0":
   version "7.109.0"


### PR DESCRIPTION
https://github.com/getsentry/status-page-list/releases/tag/0.1.0

Primary thing is that treeshaking is fixed.