### PR TITLE
feat(traces): Auto tag completion

### DIFF
--- a/static/app/views/performance/traces/tracesSearchBar.tsx
+++ b/static/app/views/performance/traces/tracesSearchBar.tsx
@@ -1,6 +1,7 @@
+import SearchBar from 'sentry/components/events/searchBar';
 import type {SmartSearchBarProps} from 'sentry/components/smartSearchBar';
-import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface TracesSearchBarProps {
   handleSearch: SmartSearchBarProps['onSearch'];
@@ -9,11 +10,13 @@ interface TracesSearchBarProps {
 
 export function TracesSearchBar({query, handleSearch}: TracesSearchBarProps) {
   // TODO: load tags for autocompletion
+  const organization = useOrganization();
   return (
-    <SmartSearchBar
+    <SearchBar
       query={query}
       onSearch={handleSearch}
       placeholder={t('Filter by tags')}
+      organization={organization}
     />
   );
 }


### PR DESCRIPTION
### Summary
This swaps the smart search bar for the discover search bar as it already has recent searches and tag keys built-in, we can replace this once we get a better implementation of tag key lookup for spans.
