### PR TITLE
chore(api): RateLimit with keyword instead of positional args

### DIFF
--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -306,9 +306,9 @@ class EventAiSuggestedFixEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
         },
     }
 

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -42,9 +42,9 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "POST": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
         }
     }
 

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -64,19 +64,19 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
         },
         "PUT": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
         },
         "DELETE": {
-            RateLimitCategory.IP: RateLimit(5, 5),
-            RateLimitCategory.USER: RateLimit(5, 5),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 5),
+            RateLimitCategory.IP: RateLimit(limit=5, window=5),
+            RateLimitCategory.USER: RateLimit(limit=5, window=5),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=5),
         },
     }
 

--- a/src/sentry/api/endpoints/group_event_details.py
+++ b/src/sentry/api/endpoints/group_event_details.py
@@ -105,9 +105,9 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(15, 1),
-            RateLimitCategory.USER: RateLimit(15, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(15, 1),
+            RateLimitCategory.IP: RateLimit(limit=15, window=1),
+            RateLimitCategory.USER: RateLimit(limit=15, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=15, window=1),
         }
     }
 

--- a/src/sentry/api/endpoints/group_first_last_release.py
+++ b/src/sentry/api/endpoints/group_first_last_release.py
@@ -16,9 +16,9 @@ class GroupFirstLastReleaseEndpoint(GroupEndpoint, EnvironmentMixin):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
         }
     }
 

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -22,9 +22,9 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(1, 1),
-            RateLimitCategory.USER: RateLimit(1, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(1, 1),
+            RateLimitCategory.IP: RateLimit(limit=1, window=1),
+            RateLimitCategory.USER: RateLimit(limit=1, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=1, window=1),
         }
     }
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -28,9 +28,9 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEndpoint):
 
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(10, 1),
-            RateLimitCategory.USER: RateLimit(10, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(10, 1),
+            RateLimitCategory.IP: RateLimit(limit=10, window=1),
+            RateLimitCategory.USER: RateLimit(limit=10, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=1),
         }
     }
 

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -31,9 +31,9 @@ class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(10, 1),
-            RateLimitCategory.USER: RateLimit(10, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(10, 1),
+            RateLimitCategory.IP: RateLimit(limit=10, window=1),
+            RateLimitCategory.USER: RateLimit(limit=10, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=1),
         }
     }
 

--- a/src/sentry/api/endpoints/organization_member/requests/join.py
+++ b/src/sentry/api/endpoints/organization_member/requests/join.py
@@ -59,9 +59,9 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
 
     rate_limits = {
         "POST": {
-            RateLimitCategory.IP: RateLimit(5, 86400),
-            RateLimitCategory.USER: RateLimit(5, 86400),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 86400),
+            RateLimitCategory.IP: RateLimit(limit=5, window=86400),
+            RateLimitCategory.USER: RateLimit(limit=5, window=86400),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=86400),
         }
     }
 

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -282,7 +282,7 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
     """
 
     # still 40 req/s but allows for bursts of 200 up to req/s for dashboard loading
-    default_rate_limit = RateLimit(200, 5)
+    default_rate_limit = RateLimit(limit=200, window=5)
 
     rate_limits = {
         "GET": {
@@ -361,7 +361,7 @@ class OrganizationMetricsQueryEndpoint(OrganizationEndpoint):
     """
 
     # still 40 req/s but allows for bursts of 200 up to req/s for dashboard loading
-    default_rate_limit = RateLimit(200, 5)
+    default_rate_limit = RateLimit(limit=200, window=5)
 
     rate_limits = {
         "POST": {

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -142,9 +142,9 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(20, 1),
-            RateLimitCategory.USER: RateLimit(20, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
+            RateLimitCategory.IP: RateLimit(limit=20, window=1),
+            RateLimitCategory.USER: RateLimit(limit=20, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1),
         }
     }
     permission_classes = (OrganizationAndStaffPermission,)

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -374,9 +374,9 @@ class AppStoreConnectRefreshEndpoint(ProjectEndpoint):
         group="appconnect-refresh",
         limit_overrides={
             "POST": {
-                RateLimitCategory.IP: RateLimit(1, 20),
-                RateLimitCategory.USER: RateLimit(1, 45),
-                RateLimitCategory.ORGANIZATION: RateLimit(720, 3600),
+                RateLimitCategory.IP: RateLimit(limit=1, window=20),
+                RateLimitCategory.USER: RateLimit(limit=1, window=45),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=720, window=3600),
             }
         },
     )

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -24,9 +24,9 @@ class ProjectEventsEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(60, 60, 1),
-            RateLimitCategory.USER: RateLimit(60, 60, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(60, 60, 2),
+            RateLimitCategory.IP: RateLimit(limit=60, window=60, concurrent_limit=1),
+            RateLimitCategory.USER: RateLimit(limit=60, window=60, concurrent_limit=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=60, window=60, concurrent_limit=2),
         }
     }
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -41,9 +41,9 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
         }
     }
 

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -22,9 +22,9 @@ class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(20, 1),
-            RateLimitCategory.USER: RateLimit(20, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
+            RateLimitCategory.IP: RateLimit(limit=20, window=1),
+            RateLimitCategory.USER: RateLimit(limit=20, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1),
         }
     }
 

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -29,9 +29,9 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(20, 1),
-            RateLimitCategory.USER: RateLimit(20, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
+            RateLimitCategory.IP: RateLimit(limit=20, window=1),
+            RateLimitCategory.USER: RateLimit(limit=20, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1),
         }
     }
 

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -23,9 +23,9 @@ class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
     enforce_rate_limit = True
     rate_limits = {
         "DELETE": {
-            RateLimitCategory.IP: RateLimit(1, 1),
-            RateLimitCategory.USER: RateLimit(1, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(1, 1),
+            RateLimitCategory.IP: RateLimit(limit=1, window=1),
+            RateLimitCategory.USER: RateLimit(limit=1, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=1, window=1),
         },
     }
 

--- a/src/sentry/api/endpoints/project_users.py
+++ b/src/sentry/api/endpoints/project_users.py
@@ -19,7 +19,7 @@ class ProjectUsersEndpoint(ProjectEndpoint):
     }
     rate_limits = {
         "GET": {
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 60),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=60),
         },
     }
     permission_classes = (ProjectAndStaffPermission,)

--- a/src/sentry/api/endpoints/relay/constants.py
+++ b/src/sentry/api/endpoints/relay/constants.py
@@ -2,8 +2,8 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 RELAY_AUTH_RATE_LIMITS = {
     "default": {
-        RateLimitCategory.IP: RateLimit(200, 1),
-        RateLimitCategory.USER: RateLimit(200, 1),
-        RateLimitCategory.ORGANIZATION: RateLimit(200, 1),
+        RateLimitCategory.IP: RateLimit(limit=200, window=1),
+        RateLimitCategory.USER: RateLimit(limit=200, window=1),
+        RateLimitCategory.ORGANIZATION: RateLimit(limit=200, window=1),
     }
 }

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -41,8 +41,8 @@ class UserEmailsConfirmEndpoint(UserEndpoint):
     }
     rate_limits = {
         "POST": {
-            RateLimitCategory.USER: RateLimit(10, 60),
-            RateLimitCategory.ORGANIZATION: RateLimit(10, 60),
+            RateLimitCategory.USER: RateLimit(limit=10, window=60),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=60),
         }
     }
 

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -57,9 +57,9 @@ class OrganizationReplayCountEndpoint(OrganizationEventsV2EndpointBase):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(20, 1),
-            RateLimitCategory.USER: RateLimit(20, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
+            RateLimitCategory.IP: RateLimit(limit=20, window=1),
+            RateLimitCategory.USER: RateLimit(limit=20, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1),
         }
     }
 

--- a/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
+++ b/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
@@ -42,9 +42,9 @@ class ProjectReplayAccessibilityIssuesEndpoint(ProjectEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(5, 1),
-            RateLimitCategory.USER: RateLimit(5, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(5, 1),
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
         }
     }
 

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -84,7 +84,9 @@ class AuthLoginView(BaseView):
     enforce_rate_limit = True
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(20, 1),  # 20 GET requests per second per IP
+            RateLimitCategory.IP: RateLimit(
+                limit=20, window=1
+            ),  # 20 GET requests per second per IP
         }
     }
 

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -39,9 +39,9 @@ class RateLimitedEndpoint(Endpoint):
         group="foo",
         limit_overrides={
             "GET": {
-                RateLimitCategory.IP: RateLimit(0, 1),
-                RateLimitCategory.USER: RateLimit(0, 1),
-                RateLimitCategory.ORGANIZATION: RateLimit(0, 1),
+                RateLimitCategory.IP: RateLimit(limit=0, window=1),
+                RateLimitCategory.USER: RateLimit(limit=0, window=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=0, window=1),
             },
         },
     )
@@ -57,9 +57,9 @@ class ConcurrentRateLimitedEndpoint(Endpoint):
         group="foo",
         limit_overrides={
             "GET": {
-                RateLimitCategory.IP: RateLimit(20, 1, 1),
-                RateLimitCategory.USER: RateLimit(20, 1, 1),
-                RateLimitCategory.ORGANIZATION: RateLimit(20, 1, 1),
+                RateLimitCategory.IP: RateLimit(limit=20, window=1, concurrent_limit=1),
+                RateLimitCategory.USER: RateLimit(limit=20, window=1, concurrent_limit=1),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=1),
             },
         },
     )

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -16,7 +16,7 @@ class RateLimitedEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
     enforce_rate_limit = True
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(0, 10)}}
+    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=0, window=10)}}
 
     def get(self):
         return Response({"ok": True})

--- a/tests/sentry/ratelimits/test_config.py
+++ b/tests/sentry/ratelimits/test_config.py
@@ -7,11 +7,13 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 class TestRateLimitConfig(TestCase):
     @mock.patch(
         "sentry.ratelimits.config._get_group_defaults",
-        return_value={"blz": {RateLimitCategory.ORGANIZATION: RateLimit(420, 69)}},
+        return_value={"blz": {RateLimitCategory.ORGANIZATION: RateLimit(limit=420, window=69)}},
     )
     def test_grouping(self, *m):
         config = RateLimitConfig(group="blz")
-        assert config.get_rate_limit("GET", RateLimitCategory.ORGANIZATION) == RateLimit(420, 69)
+        assert config.get_rate_limit("GET", RateLimitCategory.ORGANIZATION) == RateLimit(
+            limit=420, window=69
+        )
 
     def test_defaults(self):
         config = RateLimitConfig()
@@ -21,9 +23,10 @@ class TestRateLimitConfig(TestCase):
 
     def test_override(self):
         config = RateLimitConfig(
-            group="default", limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(1, 1)}}
+            group="default",
+            limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(limit=1, window=1)}},
         )
-        assert config.get_rate_limit("GET", RateLimitCategory.IP) == RateLimit(1, 1)
+        assert config.get_rate_limit("GET", RateLimitCategory.IP) == RateLimit(limit=1, window=1)
         assert config.get_rate_limit(
             "POST", RateLimitCategory.IP
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.IP)
@@ -32,7 +35,7 @@ class TestRateLimitConfig(TestCase):
         ) == get_default_rate_limits_for_group("default", RateLimitCategory.ORGANIZATION)
 
     def test_backwards_compatibility(self):
-        override_dict = {"GET": {RateLimitCategory.IP: RateLimit(1, 1)}}
+        override_dict = {"GET": {RateLimitCategory.IP: RateLimit(limit=1, window=1)}}
         assert RateLimitConfig.from_rate_limit_override_dict(override_dict) == RateLimitConfig(
             group="default", limit_overrides=override_dict
         )

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -18,7 +18,7 @@ class RatelimitMiddlewareTest(TestCase):
         with freeze_time("2000-01-01"):
             expected_reset_time = int(time() + 100)
             return_val = above_rate_limit_check(
-                "foo", RateLimit(10, 100), "request_uid", self.group
+                "foo", RateLimit(limit=10, window=100), "request_uid", self.group
             )
             assert return_val == RateLimitMeta(
                 rate_limit_type=RateLimitType.NOT_LIMITED,
@@ -33,7 +33,7 @@ class RatelimitMiddlewareTest(TestCase):
             )
             for i in range(10):
                 return_val = above_rate_limit_check(
-                    "foo", RateLimit(10, 100), f"request_uid{i}", self.group
+                    "foo", RateLimit(limit=10, window=100), f"request_uid{i}", self.group
                 )
             assert return_val == RateLimitMeta(
                 rate_limit_type=RateLimitType.FIXED_WINDOW,
@@ -49,7 +49,10 @@ class RatelimitMiddlewareTest(TestCase):
 
             for i in range(10):
                 return_val = above_rate_limit_check(
-                    "bar", RateLimit(120, 100, 9), f"request_uid{i}", self.group
+                    "bar",
+                    RateLimit(limit=120, window=100, concurrent_limit=9),
+                    f"request_uid{i}",
+                    self.group,
                 )
             assert return_val == RateLimitMeta(
                 rate_limit_type=RateLimitType.CONCURRENT,
@@ -66,7 +69,9 @@ class RatelimitMiddlewareTest(TestCase):
     def test_concurrent(self):
         def do_request():
             uid = uuid.uuid4().hex
-            meta = above_rate_limit_check("foo", RateLimit(10, 1, 3), uid, self.group)
+            meta = above_rate_limit_check(
+                "foo", RateLimit(limit=10, window=1, concurrent_limit=3), uid, self.group
+            )
             sleep(0.2)
             finish_request("foo", uid)
             return meta
@@ -83,6 +88,8 @@ class RatelimitMiddlewareTest(TestCase):
     def test_window_and_concurrent_limit(self):
         """Test that if there is a window limit and a concurrent limit, the
         FIXED_WINDOW limit takes precedence"""
-        return_val = above_rate_limit_check("xar", RateLimit(0, 100, 0), "request_uid", self.group)
+        return_val = above_rate_limit_check(
+            "xar", RateLimit(limit=0, window=100, concurrent_limit=0), "request_uid", self.group
+        )
         assert return_val.rate_limit_type == RateLimitType.FIXED_WINDOW
         assert return_val.concurrent_remaining is None

--- a/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
+++ b/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
@@ -13,7 +13,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 class RateLimitTestEndpoint(Endpoint):
     permission_classes = (AllowAny,)
 
-    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(1, 100)}}
+    rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=1, window=100)}}
 
     def get(self, request):
         return Response({"ok": True})

--- a/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
+++ b/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
@@ -52,8 +52,8 @@ class TestGetRateLimitValue(TestCase):
 
         class TestEndpoint(Endpoint):
             rate_limits = {
-                "GET": {RateLimitCategory.IP: RateLimit(100, 5)},
-                "POST": {RateLimitCategory.USER: RateLimit(20, 4)},
+                "GET": {RateLimitCategory.IP: RateLimit(limit=100, window=5)},
+                "POST": {RateLimitCategory.USER: RateLimit(limit=20, window=4)},
             }
 
         _test_endpoint = TestEndpoint.as_view()
@@ -75,7 +75,8 @@ class TestGetRateLimitValue(TestCase):
     def test_inherit(self):
         class ParentEndpoint(Endpoint):
             rate_limits = RateLimitConfig(
-                group="foo", limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(100, 5)}}
+                group="foo",
+                limit_overrides={"GET": {RateLimitCategory.IP: RateLimit(limit=100, window=5)}},
             )
 
         class ChildEndpoint(ParentEndpoint):
@@ -91,11 +92,11 @@ class TestGetRateLimitValue(TestCase):
     def test_multiple_inheritance(self):
         class ParentEndpoint(Endpoint):
             rate_limits: RateLimitConfig | dict[str, dict[RateLimitCategory, RateLimit]]
-            rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(100, 5)}}
+            rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=100, window=5)}}
 
         class Mixin:
             rate_limits: RateLimitConfig | dict[str, dict[RateLimitCategory, RateLimit]]
-            rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(2, 4)}}
+            rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(limit=2, window=4)}}
 
         class ChildEndpoint(ParentEndpoint, Mixin):
             pass
@@ -114,4 +115,4 @@ class TestGetRateLimitValue(TestCase):
         )
         assert get_rate_limit_value(
             "GET", RateLimitCategory.IP, rate_limit_config_reverse
-        ) == RateLimit(2, 4)
+        ) == RateLimit(limit=2, window=4)


### PR DESCRIPTION
> _"The numbers, Mason! What do they mean?"_
> — Jason Hudson

Using keyword style of instantiating RateLimit dataclass, making it immediately obvious what is the meaning of each value:

`RateLimit(123, 45, 67)` -> `RateLimit(limit=123, window=45, concurrent_limit=67)` 