### PR TITLE
fix(relocation): Stop comparing hashed tokens

### DIFF
--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -793,10 +793,11 @@ def get_default_comparators() -> dict[str, list[JSONScrubbingComparator]]:
         list,
         {
             "sentry.apitoken": [
-                HashObfuscatingComparator(
-                    "refresh_token", "token", "hashed_token", "hashed_refresh_token"
-                ),
-                IgnoredComparator("token_last_characters"),
+                HashObfuscatingComparator("refresh_token", "token"),
+                # TODO: when we get rid of token/refresh_token for their hashed versions, and are
+                # sure that none of the originals are left, we can compare these above. Until then,
+                # just ignore them.
+                IgnoredComparator("hashed_token", "hashed_refresh_token", "token_last_characters"),
                 UnorderedListComparator("scope_list"),
             ],
             "sentry.apiapplication": [HashObfuscatingComparator("client_id", "client_secret")],

--- a/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
+++ b/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-04-15T19:02:42.654156+00:00'
+created: '2024-04-18T18:27:17.605949+00:00'
 creator: sentry
 source: tests/sentry/backup/test_comparators.py
 ---
@@ -182,12 +182,12 @@ source: tests/sentry/backup/test_comparators.py
 - comparators:
   - class: HashObfuscatingComparator
     fields:
-    - hashed_refresh_token
-    - hashed_token
     - refresh_token
     - token
   - class: IgnoredComparator
     fields:
+    - hashed_refresh_token
+    - hashed_token
     - token_last_characters
   - class: UnorderedListComparator
     fields:


### PR DESCRIPTION
These values are auto-generated at import time, but have not yet been auto-generated for all existing entries in the database. This causes export-then-import tests during relocation validation to fail. We can undo this change once we're sure that both of these kinds of tokens always have a hashed counterpart in the prod DB.
