### PR TITLE
fix(api): Project Endpoint Redirect Logic

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -139,13 +139,14 @@ class ProjectEndpoint(Endpoint):
         except Project.DoesNotExist:
             try:
                 # Project may have been renamed
+                # This will only happen if the passed in project_slug is a slug and not an id
                 redirect = ProjectRedirect.objects.select_related("project")
                 if id_or_slug_path_params_enabled(
                     self.convert_args.__qualname__, str(organization_slug)
                 ):
                     redirect = redirect.get(
                         organization__slug__id_or_slug=organization_slug,
-                        redirect_slug__id_or_slug=project_slug,
+                        redirect_slug=project_slug,
                     )
                 else:
                     redirect = redirect.get(

--- a/tests/sentry/api/path_params/resources/test_project_slug.py
+++ b/tests/sentry/api/path_params/resources/test_project_slug.py
@@ -23,6 +23,19 @@ class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
 
         self.assert_conversion(endpoint_class, converted_slugs, converted_ids)
 
+        # rename the project_slug
+        from sentry.models.projectredirect import ProjectRedirect
+
+        old_slug = self.project.slug
+
+        self.project.slug = "new-slug"
+        ProjectRedirect.record(self.project, old_slug)
+        slug_kwargs["project_slug"] = old_slug
+
+        _, converted_slugs = endpoint_class().convert_args(request=request, **slug_kwargs)
+
+        self.project.slug = old_slug
+
     def project_alert_rule_endpoint_test(self, endpoint_class, slug_params, *args):
         slug_kwargs = {param: self.slug_mappings[param].slug for param in slug_params}
         id_kwargs = {param: self.slug_mappings[param].id for param in slug_params}

--- a/tests/sentry/api/path_params/resources/test_project_slug.py
+++ b/tests/sentry/api/path_params/resources/test_project_slug.py
@@ -34,6 +34,8 @@ class ProjectSlugTests(TestCase, APIIdOrSlugTestMixin):
 
         _, converted_slugs = endpoint_class().convert_args(request=request, **slug_kwargs)
 
+        self.assert_conversion(endpoint_class, converted_slugs, converted_ids)
+
         self.project.slug = old_slug
 
     def project_alert_rule_endpoint_test(self, endpoint_class, slug_params, *args):


### PR DESCRIPTION
There was a subtle issue with how I added `id` support in the Project Endpoint.

The `ProjectRedirect` model uses `SlugField` not `SentrySlugField` as the type for `redirect_slug`, meaning the lookup I made will error out. 

However, the bigger issue is that a project's id will __never__ be changed. This means we should not even try to look for both id or slug. If the Project doesn't exist, we should only check the ProjectRedirect model for a change in slug.

I also wrote a test to enforce this logic.