### PR TITLE
ref(traces): Make min size for breakdown slices

### DIFF
--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -117,7 +117,14 @@ export function SpanBreakdownSliceRenderer({
   const relativeSliceStart = sliceStart - trace.start;
   const sliceOffset = toPercent(relativeSliceStart / traceDuration);
   return (
-    <div style={{width: slicePercent, left: sliceOffset, position: 'absolute'}}>
+    <div
+      style={{
+        width: `max(2px, ${slicePercent})`,
+        left: sliceOffset,
+        position: 'absolute',
+        ...(sliceName ? {} : {zIndex: -1}),
+      }}
+    >
       <Tooltip
         title={
           <div>


### PR DESCRIPTION
### Summary
Also hides missing so it doesn't overlap the min 2px slices.
