### PR TITLE
ref(ui): Drop MenuListItem.displayName mutation

### DIFF
--- a/static/app/components/forms/controls/selectOption.tsx
+++ b/static/app/components/forms/controls/selectOption.tsx
@@ -9,13 +9,6 @@ import {defined} from 'sentry/utils';
 
 type Props = React.ComponentProps<typeof selectComponents.Option>;
 
-// FIXME(epurkhiser): This is actually mutating the MenuListItem component, and
-// is probably not something we should be doing.
-//
-// We still have some tests that find select options by the display name
-// "Option".
-MenuListItem.displayName = 'Option';
-
 function SelectOption(props: Props) {
   const {
     label,


### PR DESCRIPTION
Since we're fully on RTL this should be OK to drop