### PR TITLE
feat(crons): Add broken monitor recovery event

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -9,6 +9,7 @@ from .codeowners_assignment import *  # noqa: F401,F403
 from .codeowners_created import *  # noqa: F401,F403
 from .codeowners_updated import *  # noqa: F401,F403
 from .comment_webhooks import *  # noqa: F401,F403
+from .cron_monitor_broken_status_recovery import *  # noqa: F401,F403
 from .cron_monitor_created import *  # noqa: F401,F403
 from .eventuser_endpoint_request import *  # noqa: F401,F403
 from .eventuser_equality_check import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/cron_monitor_broken_status_recovery.py
+++ b/src/sentry/analytics/events/cron_monitor_broken_status_recovery.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class CronMonitorBrokenStatusRecovery(analytics.Event):
+    type = "cron_monitor_broken_status.recovery"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("monitor_id"),
+        analytics.Attribute("monitor_env_id"),
+    )
+
+
+analytics.register(CronMonitorBrokenStatusRecovery)


### PR DESCRIPTION
Add a new analytic event that is meant to track the case in which a user received a broken cron detection and then recovered their monitor status