### PR TITLE
fix(dropdownmenu): Fix bug where an empty string key can't be selected

### DIFF
--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -12,6 +12,7 @@ import MenuListItem, {
   InnerWrap as MenuListItemInnerWrap,
 } from 'sentry/components/menuListItem';
 import {IconChevron} from 'sentry/icons';
+import {defined} from 'sentry/utils';
 import mergeRefs from 'sentry/utils/mergeRefs';
 import usePrevious from 'sentry/utils/usePrevious';
 
@@ -127,7 +128,7 @@ function BaseDropdownMenuItem(
       state.selectionManager.toggleSelection(node.key);
       return;
     }
-    key && onAction?.(key);
+    defined(key) && onAction?.(key);
   };
 
   // Open submenu on hover


### PR DESCRIPTION
Noticed that if you have a key that's an empty string, selecting it wouldn't trigger the callback.