### PR TITLE
fix serializer alert rule projects

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -23,7 +23,6 @@ from sentry.incidents.models.alert_rule import (
 from sentry.incidents.models.alert_rule_activations import AlertRuleActivations
 from sentry.incidents.models.incident import Incident
 from sentry.models.actor import ACTOR_TYPES, Actor, actor_type_to_string
-from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.models.user import User
@@ -149,11 +148,9 @@ class AlertRuleSerializer(Serializer):
 
         alert_rule_projects = set()
         for alert_rule in alert_rules.values():
-            try:
-                if alert_rule.projects.get().slug:
-                    alert_rule_projects.add((alert_rule.id, alert_rule.projects.get().slug))
-            except Project.DoesNotExist:
-                pass
+            if alert_rule.projects.exists():
+                for project in alert_rule.projects.all():
+                    alert_rule_projects.add((alert_rule.id, project.slug))
 
         # TODO - Cleanup Subscription Project Mapping
         snuba_alert_rule_projects = AlertRule.objects.filter(

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -157,7 +157,9 @@ class AlertRuleSerializer(Serializer):
             id__in=[item.id for item in item_list]
         ).values_list("id", "snuba_query__subscriptions__project__slug")
 
-        alert_rule_projects.update([tup for tup in snuba_alert_rule_projects if tup[1]])
+        alert_rule_projects.update(
+            [(id, project_slug) for id, project_slug in snuba_alert_rule_projects if project_slug]
+        )
 
         for alert_rule_id, project_slug in alert_rule_projects:
             rule_result = result[alert_rules[alert_rule_id]].setdefault("projects", [])


### PR DESCRIPTION
Serializer was incorrectly serializing projects for alert rules.

- we were improperly attempting to add an iterable to a set
- we were improperly catchign an exception IF the `.get()` of a model failed and passing
- We had no tests to validate the serialization