### PR TITLE
feat(chartcuterie): endpoint regression backend

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from concurrent.futures import ThreadPoolExecutor
 
 import sentry_sdk
@@ -22,6 +21,7 @@ from sentry.snuba.metrics_performance import query as metrics_query
 from sentry.snuba.referrer import Referrer
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.iterators import chunked
+from sentry.utils.performance_issues.detectors.utils import escape_transaction
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger(__name__)
@@ -381,9 +381,3 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 default_per_page=5,
                 max_per_page=5,
             )
-
-
-def escape_transaction(transaction: str) -> str:
-    transaction = re.sub(r'"', r"\"", transaction)
-    transaction = re.sub(r"\*", r"\*", transaction)
-    return transaction

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1886,6 +1886,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:slack-block-kit": True,
     # Send Slack notifications to threads for Issue Alerts
     "organizations:slack-thread-issue-alert": False,
+    # Add regression chart as image to slack message
+    "organizations:slack-endpoint-regression-image": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -224,6 +224,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:slack-thread-issue-alert", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:slack-endpoint-regression-image", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:sourcemaps-bundle-flat-file-indexing", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:sourcemaps-upload-release-as-artifact-bundle", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:stacktrace-processing-caching", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/integrations/slack/message_builder/image_block_builder.py
+++ b/src/sentry/integrations/slack/message_builder/image_block_builder.py
@@ -1,0 +1,93 @@
+import logging
+
+import sentry_sdk
+
+from sentry import features
+from sentry.api import client
+from sentry.charts import backend as charts
+from sentry.charts.types import ChartType
+from sentry.integrations.slack.message_builder import SlackBlock
+from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
+from sentry.integrations.slack.message_builder.time_utils import (
+    get_approx_start_time,
+    get_relative_time,
+)
+from sentry.issues.grouptype import PerformanceP95EndpointRegressionGroupType
+from sentry.models.apikey import ApiKey
+from sentry.models.group import Group
+from sentry.snuba.referrer import Referrer
+from sentry.utils.performance_issues.detectors.utils import escape_transaction
+
+logger = logging.getLogger("sentry.integrations.slack")
+
+
+class ImageBlockBuilder(BlockSlackMessageBuilder):
+    def __init__(self, group: Group) -> None:
+        super().__init__()
+        self.group = group
+        self.event = group.get_latest_event_for_environments()
+
+    def build_image_block(self) -> SlackBlock | None:
+        if (
+            features.has("organizations:slack-endpoint-regression-image", self.group.organization)
+            and self.group.issue_type == PerformanceP95EndpointRegressionGroupType
+        ):
+            return self._build_endpoint_regression_image_block()
+
+        # TODO: Add support for other issue alerts
+        logger.warning("build_issue_alert_image.not_supported")
+        return None
+
+    def _build_endpoint_regression_image_block(self) -> SlackBlock | None:
+        logger.info(
+            "build_endpoint_regression_image.attempt",
+            extra={
+                "group_id": self.group.id,
+            },
+        )
+
+        organization = self.group.organization
+        if self.event is None or self.event.transaction is None or self.event.occurrence is None:
+            return None
+        transaction_name = escape_transaction(self.event.transaction)
+        period = get_relative_time(anchor=get_approx_start_time(self.group), relative_days=14)
+
+        try:
+            resp = client.get(
+                auth=ApiKey(organization_id=organization.id, scope_list=["org:read"]),
+                user=None,
+                path=f"/organizations/{organization.slug}/events-stats/",
+                data={
+                    "yAxis": ["count()", "p95(transaction.duration)"],
+                    "referrer": Referrer.API_ALERTS_CHARTCUTERIE,
+                    "query": f"event.type:transaction transaction:{transaction_name}",
+                    "project": self.group.project.id,
+                    "start": period["start"].strftime("%Y-%m-%d %H:%M:%S"),
+                    "end": period["end"].strftime("%Y-%m-%d %H:%M:%S"),
+                    "dataset": "metrics",
+                },
+            )
+
+            url = charts.generate_chart(
+                ChartType.SLACK_PERFORMANCE_ENDPOINT_REGRESSION,
+                data={
+                    "evidenceData": self.event.occurrence.evidence_data,
+                    "percentileData": resp.data["p95(transaction.duration)"]["data"],
+                },
+            )
+
+            return self.get_image_block(
+                url=url,
+                title=self.group.title,
+                alt="P95(transaction.duration)",
+            )
+
+        except Exception as e:
+            logger.exception(
+                "build_endpoint_regression_image.failed",
+                extra={
+                    "exception": e,
+                },
+            )
+            sentry_sdk.capture_exception()
+            return None

--- a/src/sentry/integrations/slack/message_builder/image_block_builder.py
+++ b/src/sentry/integrations/slack/message_builder/image_block_builder.py
@@ -35,7 +35,6 @@ class ImageBlockBuilder(BlockSlackMessageBuilder):
             return self._build_endpoint_regression_image_block()
 
         # TODO: Add support for other issue alerts
-        logger.warning("build_issue_alert_image.not_supported")
         return None
 
     def _build_endpoint_regression_image_block(self) -> SlackBlock | None:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -106,7 +106,11 @@ SUPPORTED_CONTEXT_DATA = {
     ),
     "State": lambda group: SUBSTATUS_TO_STR.get(group.substatus, "").replace("_", " ").title(),
     "First Seen": lambda group: time_since(group.first_seen),
-    "Approx. Start Time": get_approx_start_time,
+    "Approx. Start Time": lambda group: datetime.fromtimestamp(
+        get_approx_start_time(group=group)
+    ).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    ),  # format moment into YYYY-mm-dd h:m:s
 }
 
 

--- a/src/sentry/integrations/slack/message_builder/time_utils.py
+++ b/src/sentry/integrations/slack/message_builder/time_utils.py
@@ -41,15 +41,16 @@ def time_since(value: datetime):
 
 def get_relative_time(
     anchor: int, relative_days: int, retention_days: int = 90
-) -> Mapping[str, int]:
+) -> Mapping[str, datetime]:
     max_time = time.time()
     min_time = max_time - retention_days * DAY_IN_SEC
     before_time = anchor - relative_days * DAY_IN_SEC
     before_datetime = (
         datetime.fromtimestamp(before_time)
         if before_time >= min_time
-        else datetime.fromtimestamp(before_time)
+        else datetime.fromtimestamp(min_time)
     )
+
     after_time = anchor + relative_days * DAY_IN_SEC
     after_datetime = (
         datetime.fromtimestamp(after_time)

--- a/src/sentry/integrations/slack/message_builder/time_utils.py
+++ b/src/sentry/integrations/slack/message_builder/time_utils.py
@@ -1,0 +1,62 @@
+import time
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+
+from django.utils import timezone
+from django.utils.timesince import timesince
+from django.utils.translation import gettext as _
+
+from sentry.models.group import Group
+
+DAY_IN_SEC = 24 * 60 * 60
+
+
+def get_approx_start_time(group: Group):
+    event = group.get_recommended_event_for_environments()
+    if event is None:
+        return None
+
+    occurrence = event.occurrence
+    if occurrence is None:
+        return None
+
+    regression_time = occurrence.evidence_data.get("breakpoint", None)
+    return regression_time
+
+
+def time_since(value: datetime):
+    """
+    Display the relative time
+    """
+    now = timezone.now()
+    if value < (now - timedelta(days=5)):
+        return value.date()
+    diff = timesince(value, now)
+    if diff == timesince(now, now):
+        return "Just now"
+    if diff == "1 day":
+        return _("Yesterday")
+    return f"{diff} ago"
+
+
+def get_relative_time(
+    anchor: int, relative_days: int, retention_days: int = 90
+) -> Mapping[str, int]:
+    max_time = time.time()
+    min_time = max_time - retention_days * DAY_IN_SEC
+    before_time = anchor - relative_days * DAY_IN_SEC
+    before_datetime = (
+        datetime.fromtimestamp(before_time)
+        if before_time >= min_time
+        else datetime.fromtimestamp(before_time)
+    )
+    after_time = anchor + relative_days * DAY_IN_SEC
+    after_datetime = (
+        datetime.fromtimestamp(after_time)
+        if after_time <= max_time
+        else datetime.fromtimestamp(max_time)
+    )
+    return {
+        "start": before_datetime,
+        "end": after_datetime,
+    }

--- a/src/sentry/utils/performance_issues/detectors/utils.py
+++ b/src/sentry/utils/performance_issues/detectors/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from sentry.utils.performance_issues.base import get_span_duration
 
 from ..types import Span
@@ -14,3 +16,9 @@ def get_total_span_duration(spans: list[Span]) -> float:
 def get_max_span_duration(spans: list[Span]) -> float:
     "Given a list of spans, return the duration of the longest span in milliseconds"
     return max([get_span_duration(span).total_seconds() * 1000 for span in spans])
+
+
+def escape_transaction(transaction: str) -> str:
+    transaction = re.sub(r'"', r"\"", transaction)
+    transaction = re.sub(r"\*", r"\*", transaction)
+    return transaction

--- a/tests/acceptance/chartcuterie/test_image_block_builder.py
+++ b/tests/acceptance/chartcuterie/test_image_block_builder.py
@@ -5,7 +5,7 @@ import pytest
 from sentry.integrations.slack.message_builder.image_block_builder import ImageBlockBuilder
 from sentry.issues.grouptype import PerformanceP95EndpointRegressionGroupType
 from sentry.models.group import Group
-from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
+from sentry.testutils.cases import AcceptanceTestCase, MetricsEnhancedPerformanceTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -13,7 +13,9 @@ from tests.sentry.issues.test_utils import OccurrenceTestMixin
 pytestmark = pytest.mark.sentry_metrics
 
 
-class TestSlackImageBlockBuilder(MetricsEnhancedPerformanceTestCase, OccurrenceTestMixin):
+class TestSlackImageBlockBuilder(
+    AcceptanceTestCase, MetricsEnhancedPerformanceTestCase, OccurrenceTestMixin
+):
     def setUp(self):
         super().setUp()
         self.features = {

--- a/tests/sentry/integrations/slack/test_image_block_builder.py
+++ b/tests/sentry/integrations/slack/test_image_block_builder.py
@@ -1,0 +1,55 @@
+import uuid
+
+import pytest
+
+from sentry.integrations.slack.message_builder.image_block_builder import ImageBlockBuilder
+from sentry.issues.grouptype import PerformanceP95EndpointRegressionGroupType
+from sentry.models.group import Group
+from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import with_feature
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+class TestSlackImageBlockBuilder(MetricsEnhancedPerformanceTestCase, OccurrenceTestMixin):
+    def setUp(self):
+        super().setUp()
+        self.features = {
+            "organizations:performance-use-metrics": True,
+            "organizations:slack-endpoint-regression-image": True,
+        }
+
+    @with_feature("organizations:slack-endpoint-regression-image")
+    def test_image_block(self):
+        for i in range(10):
+            event_id = uuid.uuid4().hex
+            _ = self.process_occurrence(
+                project_id=self.project.id,
+                event_id=event_id,
+                type=PerformanceP95EndpointRegressionGroupType.type_id,
+                event_data={
+                    "fingerprint": ["group-1"],
+                    "timestamp": before_now(minutes=i + 10).isoformat(),
+                    "transaction": "/books/",
+                },
+                evidence_data={
+                    "breakpoint": before_now(minutes=i + 10).timestamp(),
+                },
+            )
+            self.store_transaction_metric(
+                metric="transaction.duration",
+                tags={"transaction": "/books/"},
+                value=1,
+                timestamp=before_now(minutes=i + 10),
+                project=self.project.id,
+            )
+        group = Group.objects.first()
+        group.update(type=PerformanceP95EndpointRegressionGroupType.type_id)
+
+        with self.feature(self.features):
+            image_block = ImageBlockBuilder(group=group).build_image_block()
+
+        assert image_block and "type" in image_block and image_block["type"] == "image"
+        assert "_media/" in image_block["image_url"]

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -20,9 +20,9 @@ from sentry.integrations.slack.message_builder.issues import (
     get_context,
     get_option_groups_block_kit,
     get_tags,
-    time_since,
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
+from sentry.integrations.slack.message_builder.time_utils import time_since
 from sentry.issues.grouptype import (
     ErrorGroupType,
     FeedbackGroup,


### PR DESCRIPTION
The goal of this PR is that add a chartcuterie request on the path of sending slack notification to add image to endpoint regression issue alerts.
If image generation fails we still send the message, just without image.