### PR TITLE
fix(replays): normalize replay_id assertion in test

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6300,7 +6300,7 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
             "email": "hellboy@bar.com",
             "ip_address": "127.0.0.1",
         }
-        replay_id = str(uuid.uuid4())
+        replay_id = str(uuid.uuid4().hex)
         with self.options({"issues.group_attributes.send_kafka": True}):
             event = self.store_event(
                 data={
@@ -6343,7 +6343,8 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
         assert response.status_code == 200, response.content
 
         data = response.data["data"][0]
-
+        returned_replay_id = data.pop("replayId")
+        assert returned_replay_id.replace("-", "") == replay_id
         assert data == {
             "id": event.event_id,
             "events.transaction": "",
@@ -6354,7 +6355,6 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
             "user.display": user_data["email"],
             "device": "Mac",
             "os": "",
-            "replayId": replay_id,
             "events.timestamp": event.datetime.replace(microsecond=0).isoformat(),
         }
 


### PR DESCRIPTION
We are changing the replay_id field to have the uuid processing like all of our other uuid fields, which strips dashes. This test caused a CI failure when snuba was updated.

This PR simply normalizes the replay_id when it checks the equality. I can revert this commit after the Snuba PR is merged. This is only an issue on the issue platform dataset, and I have high confidence that removing dashes from this field will not cause problems.