### PR TITLE
ref(trace): enforce cursor and watch for external resize events

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useLayoutEffect, useMemo, useRef} from 'react';
+import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
@@ -186,6 +186,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
     [props.traceGridRef, props.manager, trace_dispatch]
   );
 
+  const [drawerRef, setDrawerRef] = useState<HTMLDivElement | null>(null);
   const drawerOptions: Pick<UsePassiveResizableDrawerOptions, 'min' | 'initialSize'> =
     useMemo(() => {
       const initialSizeInPercentage =
@@ -205,9 +206,10 @@ export function TraceDrawer(props: TraceDrawerProps) {
       return {
         min: props.trace_state.preferences.layout === 'drawer bottom' ? 27 : 300,
         initialSize,
+        ref: drawerRef,
       };
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.traceGridRef, props.trace_state.preferences.layout]);
+    }, [props.traceGridRef, props.trace_state.preferences.layout, drawerRef]);
 
   const resizableDrawerOptions: UsePassiveResizableDrawerOptions = useMemo(() => {
     return {
@@ -332,7 +334,7 @@ export function TraceDrawer(props: TraceDrawerProps) {
   }
 
   return (
-    <PanelWrapper layout={props.trace_state.preferences.layout}>
+    <PanelWrapper ref={setDrawerRef} layout={props.trace_state.preferences.layout}>
       <ResizeableHandle
         layout={props.trace_state.preferences.layout}
         onMouseDown={onMouseDown}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/usePassiveResizeableDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/usePassiveResizeableDrawer.tsx
@@ -76,6 +76,7 @@ export function usePassiveResizableDrawer(options: UsePassiveResizableDrawerOpti
   const onMouseUp = useCallback(() => {
     document.body.style.pointerEvents = '';
     document.body.style.userSelect = '';
+    document.body.style.cursor = '';
     document.documentElement.style.cursor = '';
     document.removeEventListener('mousemove', onMouseMove);
     document.removeEventListener('mouseup', onMouseUp);
@@ -85,10 +86,14 @@ export function usePassiveResizableDrawer(options: UsePassiveResizableDrawerOpti
     (evt: React.MouseEvent<HTMLElement>) => {
       currentMouseVectorRaf.current = [evt.clientX, evt.clientY];
 
+      document.body.style.cursor =
+        (direction === 'left' || direction === 'right' ? 'ew-resize' : 'ns-resize') +
+        ' !important';
+
       document.addEventListener('mousemove', onMouseMove, {passive: false});
       document.addEventListener('mouseup', onMouseUp);
     },
-    [onMouseMove, onMouseUp]
+    [onMouseMove, onMouseUp, direction]
   );
 
   useLayoutEffect(() => {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -219,7 +219,9 @@ export class VirtualizedViewManager {
     this.dividerScale = this.trace_view.width === this.trace_space.width ? 1 : undefined;
     this.dividerStartVec = [event.clientX, event.clientY];
     this.previousDividerClientVec = [event.clientX, event.clientY];
-    this.container.style.userSelect = 'none';
+
+    document.body.style.cursor = 'ew-resize !important';
+    document.body.style.userSelect = 'none';
 
     document.addEventListener('mouseup', this.onDividerMouseUp, {passive: true});
     document.addEventListener('mousemove', this.onDividerMouseMove, {
@@ -239,7 +241,8 @@ export class VirtualizedViewManager {
     this.columns.list.width = this.columns.list.width + distancePercentage;
     this.columns.span_list.width = this.columns.span_list.width - distancePercentage;
 
-    this.container.style.userSelect = 'auto';
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
 
     this.dividerStartVec = null;
     this.previousDividerClientVec = null;


### PR DESCRIPTION
If you previously resized the window and then the drawer, we would have used a wrong size which made the UI jump to a wrong starting height.