### PR TITLE
fix(metrics): Fix 500 error when filtering for unknown project slugs in Metrics API

### DIFF
--- a/src/sentry/sentry_metrics/querying/data/mapping/mapper.py
+++ b/src/sentry/sentry_metrics/querying/data/mapping/mapper.py
@@ -79,7 +79,9 @@ class Project2ProjectIDMapper(Mapper):
 
     def forward(self, projects: Sequence[Project], value: str) -> int:
         if value not in self.map:
-            self.map[value] = None
+            # if the project cannot be found, set the project_id to 0 so that it is passed to Snuba and returns empty
+            # results as usual, as opposed to throwing an error.
+            self.map[value] = 0
             for project in projects:
                 if project.slug == value:
                     self.map[value] = project.id

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -1958,3 +1958,32 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert len(data) == 1
         assert data[0]["series"] == [None, None, None]
         assert data[0]["totals"] is None
+
+    @pytest.mark.xfail(
+        reason="Filtering for unknown project slugs is currently not handled and leads to an exception"
+    )
+    @with_feature("organizations:ddm-metrics-api-unit-normalization")
+    def test_filter_by_unknown_project_slug(self) -> None:
+        self.empty_project = self.create_project(name="empty project")
+
+        mql = self.mql(
+            "avg",
+            TransactionMRI.DURATION.value,
+            filters="project:unknown-project",
+        )
+        query = MQLQuery(mql)
+
+        results = self.run_query(
+            mql_queries=[query],
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.empty_project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        data = results["data"][0]
+        assert len(data) == 1
+        assert data[0]["series"] == [None, None, None]
+        assert data[0]["totals"] is None

--- a/tests/sentry/sentry_metrics/querying/data/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/data/test_api.py
@@ -1959,9 +1959,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert data[0]["series"] == [None, None, None]
         assert data[0]["totals"] is None
 
-    @pytest.mark.xfail(
-        reason="Filtering for unknown project slugs is currently not handled and leads to an exception"
-    )
     @with_feature("organizations:ddm-metrics-api-unit-normalization")
     def test_filter_by_unknown_project_slug(self) -> None:
         self.empty_project = self.create_project(name="empty project")


### PR DESCRIPTION
Adds test and fix for https://github.com/orgs/getsentry/projects/149?pane=issue&itemId=60338353

Fixes https://github.com/getsentry/sentry/issues/69395