### PR TITLE
feat(trace-explorer): Load more spans results per trace

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -128,17 +128,11 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             "meta": {
                 "dataset": "unknown",
                 "datasetReason": "unchanged",
-                "fields": {
-                    "id": "string",
-                    "parent_span": "string",
-                },
+                "fields": {},
                 "isMetricsData": False,
                 "isMetricsExtractedData": False,
                 "tips": {},
-                "units": {
-                    "id": None,
-                    "parent_span": None,
-                },
+                "units": {},
             },
         }
 
@@ -172,8 +166,8 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 parent_span_id=span_ids[0],
                 timestamp=timestamps[-1],
                 transaction="bar",
-                duration=30_000,
-                exclusive_time=30_000,
+                duration=30_000 + i,
+                exclusive_time=30_000 + i,
                 tags={"foo": "bar" if idx != 0 else "baz"},
             )
 
@@ -199,16 +193,18 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                 parent_span_id=span_ids[4],
                 timestamp=timestamps[-1],
                 transaction="baz",
-                duration=20_000,
-                exclusive_time=20_000,
+                duration=20_000 + i,
+                exclusive_time=20_000 + i,
                 tags={"foo": "bar"},
             )
 
         query = {
             "project": [project_2.id],
-            "field": ["id", "parent_span"],
+            "field": ["id", "parent_span", "span.duration"],
             "query": "foo:bar",
+            "suggestedQuery": "foo:baz",
             "maxSpansPerTrace": 2,
+            "sort": ["-span.duration"],
         }
 
         response = self.do_request(query)
@@ -220,6 +216,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             "fields": {
                 "id": "string",
                 "parent_span": "string",
+                "span.duration": "duration",
             },
             "isMetricsData": False,
             "isMetricsExtractedData": False,
@@ -227,12 +224,11 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             "units": {
                 "id": None,
                 "parent_span": None,
+                "span.duration": "millisecond",
             },
         }
 
         result_data = sorted(response.data["data"], key=lambda trace: trace["trace"])
-        for row in result_data:
-            row["spans"].sort(key=lambda span: span["id"])
 
         assert result_data == sorted(
             [
@@ -253,24 +249,25 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         {
                             "project": project_2.slug,
                             "start": int(timestamps[1].timestamp() * 1000),
-                            "end": int(timestamps[3].timestamp() * 1000) + 30_000,
+                            "end": int(timestamps[3].timestamp() * 1000) + 30_003,
                             "kind": "project",
                         },
                         {
                             "project": project_1.slug,
-                            "start": int(timestamps[3].timestamp() * 1000) + 30_000,
+                            "start": int(timestamps[3].timestamp() * 1000) + 30_003,
                             "end": int(timestamps[0].timestamp() * 1000) + 60_100,
                             "kind": "project",
                         },
                     ],
-                    "spans": sorted(
-                        [
-                            # span_ids[1] does not match
-                            {"id": span_ids[2], "parent_span": span_ids[0]},
-                            {"id": span_ids[3], "parent_span": span_ids[0]},
-                        ],
-                        key=lambda span: span["id"],
-                    ),
+                    "spans": [
+                        {"id": span_ids[3], "parent_span": span_ids[0], "span.duration": 30_003.0},
+                        {"id": span_ids[2], "parent_span": span_ids[0], "span.duration": 30_002.0},
+                        # span_ids[1] does not match the user query
+                    ],
+                    "suggestedSpans": [
+                        # span_ids[1] matchees the suggested query
+                        {"id": span_ids[1], "parent_span": span_ids[0], "span.duration": 30_001.0},
+                    ],
                 },
                 {
                     "trace": trace_id_2,
@@ -289,23 +286,21 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
                         {
                             "project": project_2.slug,
                             "start": int(timestamps[5].timestamp() * 1000),
-                            "end": int(timestamps[6].timestamp() * 1000) + 20_000,
+                            "end": int(timestamps[6].timestamp() * 1000) + 20_006,
                             "kind": "project",
                         },
                         {
                             "project": project_1.slug,
-                            "start": int(timestamps[6].timestamp() * 1000) + 20_000,
+                            "start": int(timestamps[6].timestamp() * 1000) + 20_006,
                             "end": int(timestamps[4].timestamp() * 1000) + 90_123,
                             "kind": "project",
                         },
                     ],
-                    "spans": sorted(
-                        [
-                            {"id": span_ids[5], "parent_span": span_ids[4]},
-                            {"id": span_ids[6], "parent_span": span_ids[4]},
-                        ],
-                        key=lambda span: span["id"],
-                    ),
+                    "spans": [
+                        {"id": span_ids[6], "parent_span": span_ids[4], "span.duration": 20_006.0},
+                        {"id": span_ids[5], "parent_span": span_ids[4], "span.duration": 20_005.0},
+                    ],
+                    "suggestedSpans": [],
                 },
             ],
             key=lambda trace: trace["trace"],  # type: ignore[arg-type, return-value]


### PR DESCRIPTION
The fast query to narrow down a list of trace ids often only returns 1 span per trace. This splits the span fetching into 2 stages. 1 to fetch trace ids fast, then another to fetch the spans in the trace that match the conditions. It also includes a suggested spans list that can be used to render some suggestions based on a different set of conditions.