### PR TITLE
chore(build) Don't lint HTML files

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -21,7 +21,7 @@ lintable_css_in_js_rules_changed: &lintable_css_in_js_rules_changed
 # Provides list of changed files to lint against (eslint)
 lintable_modified: &lintable_modified
   - added|modified: '**/*.[tj]{s,sx}'
-  - added|modified: '**/*.{html,less,json,yml,md}'
+  - added|modified: '**/*.{less,json,yml,md}'
 
 # Trigger for when we must run full lint (eslint)
 lintable_rules_changed: &lintable_rules_changed


### PR DESCRIPTION
Most of our HTML files are actually django templates and can't be parsed by eslint. Linting them will result in blocking failures.

For example
```
ᐉ yarn eslint src/sentry/templates/sentry/emails/member-invite.html
yarn run v1.22.22
$ /Users/markstory/code/sentry/node_modules/.bin/eslint src/sentry/templates/sentry/emails/member-invite.html

/Users/markstory/code/sentry/src/sentry/templates/sentry/emails/member-invite.html
  1:1  error  Parsing error: Expression expected

✖ 1 problem (1 error, 0 warnings)
```