### PR TITLE
feat(ai): AI Analytics details pages

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1495,6 +1495,10 @@ function buildRoutes() {
   const aiAnalyticsRoutes = (
     <Route path="/ai-analytics/" withOrgPath>
       <IndexRoute component={make(() => import('sentry/views/aiAnalytics/landing'))} />
+      <Route
+        path="pipeline-type/:groupId/"
+        component={make(() => import('sentry/views/aiAnalytics/aiAnalyticsDetailsPage'))}
+      />
     </Route>
   );
 

--- a/static/app/views/aiAnalytics/aiAnalyticsDetailsPage.tsx
+++ b/static/app/views/aiAnalytics/aiAnalyticsDetailsPage.tsx
@@ -1,0 +1,161 @@
+import styled from '@emotion/styled';
+
+import Feature from 'sentry/components/acl/feature';
+import {Alert} from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  NumberOfPipelinesChart,
+  PipelineDurationChart,
+} from 'sentry/views/aiAnalytics/aiAnalyticsCharts';
+import {PipelineSpansTable} from 'sentry/views/aiAnalytics/pipelineSpansTable';
+import {MetricReadout} from 'sentry/views/performance/metricReadout';
+import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
+import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
+import {
+  SpanFunction,
+  SpanMetricsField,
+  type SpanMetricsQueryFilters,
+} from 'sentry/views/starfish/types';
+import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+
+function NoAccessComponent() {
+  return (
+    <Layout.Page withPadding>
+      <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+    </Layout.Page>
+  );
+}
+interface Props {
+  params: {
+    groupId: string;
+  };
+}
+
+export default function AiAnalyticsPage({params}: Props) {
+  const organization = useOrganization();
+  const {groupId} = params;
+
+  const filters: SpanMetricsQueryFilters = {
+    'span.group': groupId,
+    'span.category': 'ai.pipeline',
+  };
+
+  const {data, isLoading: areSpanMetricsLoading} = useSpanMetrics({
+    search: MutableSearch.fromQueryObject(filters),
+    fields: [
+      SpanMetricsField.SPAN_OP,
+      SpanMetricsField.SPAN_DESCRIPTION,
+      'count()',
+      `${SpanFunction.SPM}()`,
+      `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
+    ],
+    enabled: Boolean(groupId),
+    referrer: 'api.ai-pipelines.view',
+  });
+  const spanMetrics = data[0] ?? {};
+
+  return (
+    <PageFiltersContainer>
+      <SentryDocumentTitle
+        title={`AI Analytics — ${spanMetrics['span.description'] ?? t('(no name)')}`}
+      >
+        <Layout.Page>
+          <Feature
+            features="ai-analytics"
+            organization={organization}
+            renderDisabled={NoAccessComponent}
+          >
+            <NoProjectMessage organization={organization}>
+              <Layout.Header>
+                <Layout.HeaderContent>
+                  <Layout.Title>
+                    {`${t('AI Analytics')} - ${spanMetrics['span.description'] ?? t('(no name)')}`}
+                    <PageHeadingQuestionTooltip
+                      title={t(
+                        'If this name is too generic, read the docs to learn how to change it.'
+                      )}
+                      docsUrl="https://docs.sentry.io/product/ai-analytics/"
+                    />
+                  </Layout.Title>
+                </Layout.HeaderContent>
+              </Layout.Header>
+              <Layout.Body>
+                <Layout.Main fullWidth>
+                  <ModuleLayout.Layout>
+                    <ModuleLayout.Full>
+                      <SpaceBetweenWrap>
+                        <PageFilterBar condensed>
+                          <ProjectPageFilter />
+                          <EnvironmentPageFilter />
+                          <DatePageFilter />
+                        </PageFilterBar>
+                        <MetricsRibbon>
+                          <MetricReadout
+                            title={t('Total Runs')}
+                            value={spanMetrics['count()']}
+                            unit={'count'}
+                            isLoading={areSpanMetricsLoading}
+                          />
+
+                          <MetricReadout
+                            title={t('Runs Per Minute')}
+                            value={spanMetrics?.[`${SpanFunction.SPM}()`]}
+                            unit={RateUnit.PER_MINUTE}
+                            isLoading={areSpanMetricsLoading}
+                          />
+
+                          <MetricReadout
+                            title={DataTitles.avg}
+                            value={
+                              spanMetrics?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]
+                            }
+                            unit={DurationUnit.MILLISECOND}
+                            isLoading={areSpanMetricsLoading}
+                          />
+                        </MetricsRibbon>
+                      </SpaceBetweenWrap>
+                    </ModuleLayout.Full>
+                    <ModuleLayout.Half>
+                      <NumberOfPipelinesChart groupId={groupId} />
+                    </ModuleLayout.Half>
+                    <ModuleLayout.Half>
+                      <PipelineDurationChart groupId={groupId} />
+                    </ModuleLayout.Half>
+                    <ModuleLayout.Full>
+                      <PipelineSpansTable groupId={groupId} />
+                    </ModuleLayout.Full>
+                  </ModuleLayout.Layout>
+                </Layout.Main>
+              </Layout.Body>
+            </NoProjectMessage>
+          </Feature>
+        </Layout.Page>
+      </SentryDocumentTitle>
+    </PageFiltersContainer>
+  );
+}
+
+const SpaceBetweenWrap = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+`;
+
+const MetricsRibbon = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(4)};
+`;

--- a/static/app/views/aiAnalytics/aiAnalyticsDetailsPage.tsx
+++ b/static/app/views/aiAnalytics/aiAnalyticsDetailsPage.tsx
@@ -60,7 +60,7 @@ export default function AiAnalyticsPage({params}: Props) {
       SpanMetricsField.SPAN_DESCRIPTION,
       'count()',
       `${SpanFunction.SPM}()`,
-      `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
+      `avg(${SpanMetricsField.SPAN_DURATION})`,
     ],
     enabled: Boolean(groupId),
     referrer: 'api.ai-pipelines.view',
@@ -120,7 +120,7 @@ export default function AiAnalyticsPage({params}: Props) {
                           <MetricReadout
                             title={DataTitles.avg}
                             value={
-                              spanMetrics?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]
+                              spanMetrics?.[`avg(${SpanMetricsField.SPAN_DURATION})`]
                             }
                             unit={DurationUnit.MILLISECOND}
                             isLoading={areSpanMetricsLoading}

--- a/static/app/views/aiAnalytics/pipelineSpansTable.tsx
+++ b/static/app/views/aiAnalytics/pipelineSpansTable.tsx
@@ -1,114 +1,88 @@
-import {browserHistory} from 'react-router';
 import type {Location} from 'history';
 
-import type {GridColumnHeader} from 'sentry/components/gridEditable';
-import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  type GridColumnHeader,
+} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
-import type {CursorHandler} from 'sentry/components/pagination';
-import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
+import type {Organization} from 'sentry/types';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Sort} from 'sentry/utils/discover/fields';
-import {RATE_UNIT_TITLE, RateUnit} from 'sentry/utils/discover/fields';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
-import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
-import type {MetricsResponse} from 'sentry/views/starfish/types';
+import {useIndexedSpans} from 'sentry/views/starfish/queries/useIndexedSpans';
+import {SpanIndexedField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
-import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 
-type Row = Pick<
-  MetricsResponse,
-  | 'project.id'
-  | 'span.description'
-  | 'span.group'
-  | 'spm()'
-  | 'avg(span.duration)'
-  | 'sum(span.duration)'
-  | 'time_spent_percentage()'
->;
-
-type Column = GridColumnHeader<
-  'span.description' | 'spm()' | 'avg(span.duration)' | 'time_spent_percentage()'
->;
+type Column = GridColumnHeader<SpanIndexedField.ID | SpanIndexedField.SPAN_DURATION>;
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: 'span.description',
-    name: t('AI Pipeline name'),
+    key: SpanIndexedField.ID,
+    name: t('ID'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'spm()',
-    name: `${t('Times')} ${RATE_UNIT_TITLE[RateUnit.PER_MINUTE]}`,
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: `avg(span.duration)`,
-    name: DataTitles.avg,
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'time_spent_percentage()',
-    name: DataTitles.timeSpent,
+    key: SpanIndexedField.SPAN_DURATION,
+    name: t('Total duration'),
     width: COL_WIDTH_UNDEFINED,
   },
 ];
 
-const SORTABLE_FIELDS = ['avg(span.duration)', 'spm()', 'time_spent_percentage()'];
+const SORTABLE_FIELDS = [SpanIndexedField.ID, SpanIndexedField.SPAN_DURATION];
 
 type ValidSort = Sort & {
-  field: 'spm()' | 'avg(span.duration)' | 'time_spent_percentage()';
+  field: SpanIndexedField.ID | SpanIndexedField.SPAN_DURATION;
 };
 
 export function isAValidSort(sort: Sort): sort is ValidSort {
   return (SORTABLE_FIELDS as unknown as string[]).includes(sort.field);
 }
 
-export function PipelinesTable() {
+interface Props {
+  groupId: string;
+}
+export function PipelineSpansTable({groupId}: Props) {
   const location = useLocation();
   const organization = useOrganization();
-  const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
+
   const sortField = decodeScalar(location.query?.[QueryParameterNames.SPANS_SORT]);
 
   let sort = decodeSorts(sortField).filter(isAValidSort)[0];
   if (!sort) {
-    sort = {field: 'time_spent_percentage()', kind: 'desc'};
+    sort = {field: SpanIndexedField.ID, kind: 'desc'};
   }
-  const {data, isLoading, meta, pageLinks, error} = useSpanMetrics({
-    search: new MutableSearch('span.category:ai.pipeline'),
-    fields: [
-      'project.id',
-      'span.group',
-      'span.description',
-      'spm()',
-      'avg(span.duration)',
-      'sum(span.duration)',
-      'time_spent_percentage()',
-    ],
-    sorts: [sort],
-    limit: 25,
-    cursor,
-    referrer: 'api.ai-pipelines.view',
-  });
 
-  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
-    browserHistory.push({
-      pathname,
-      query: {...query, [QueryParameterNames.SPANS_CURSOR]: newCursor},
-    });
-  };
+  const {
+    data: rawData,
+    meta: rawMeta,
+    error,
+    isLoading,
+  } = useIndexedSpans({
+    limit: 30,
+    sorts: [sort],
+    fields: [
+      SpanIndexedField.ID,
+      SpanIndexedField.TRACE,
+      SpanIndexedField.SPAN_DURATION,
+      SpanIndexedField.TRANSACTION_ID,
+    ],
+    referrer: 'api.ai-pipelines.view',
+    search: new MutableSearch(`span.category:ai.pipeline span.group:"${groupId}"`),
+  });
+  const data = rawData || [];
+  const meta = rawMeta as EventsMetaType;
 
   return (
     <VisuallyCompleteWithData
-      id="PipelinesTable"
+      id="PipelineSpansTable"
       hasData={data.length > 0}
       isLoading={isLoading}
     >
@@ -136,32 +110,37 @@ export function PipelinesTable() {
         }}
         location={location}
       />
-      <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
     </VisuallyCompleteWithData>
   );
 }
 
 function renderBodyCell(
   column: Column,
-  row: Row,
+  row: any,
   meta: EventsMetaType | undefined,
   location: Location,
   organization: Organization
 ) {
-  if (column.key === 'span.description') {
-    if (!row['span.description']) {
+  if (column.key === SpanIndexedField.ID) {
+    if (!row[SpanIndexedField.ID]) {
       return <span>(unknown)</span>;
     }
-    if (!row['span.group']) {
-      return <span>{row['span.description']}</span>;
+    if (!row[SpanIndexedField.TRACE]) {
+      return <span>{row[SpanIndexedField.ID]}</span>;
     }
     return (
       <Link
-        to={normalizeUrl(
-          `/organizations/${organization.slug}/ai-analytics/pipeline-type/${row['span.group']}`
+        to={getTraceDetailsUrl(
+          organization,
+          row[SpanIndexedField.TRACE],
+          {},
+          {},
+          undefined,
+          undefined,
+          row[SpanIndexedField.ID]
         )}
       >
-        {row['span.description']}
+        {row[SpanIndexedField.ID]}
       </Link>
     );
   }

--- a/static/app/views/aiAnalytics/pipelineSpansTable.tsx
+++ b/static/app/views/aiAnalytics/pipelineSpansTable.tsx
@@ -157,12 +157,10 @@ function renderBodyCell(
       <Link
         to={generateLinkToEventInTraceView({
           organization,
-          eventSlug: `${row[SpanIndexedField.PROJECT]}:${row[SpanIndexedField.TRANSACTION_ID]}`,
-          dataRow: {
-            id: row[SpanIndexedField.TRANSACTION_ID],
-            trace: row[SpanIndexedField.TRACE],
-            timestamp: row[SpanIndexedField.TIMESTAMP],
-          },
+          eventId: row[SpanIndexedField.TRANSACTION_ID],
+          projectSlug: row[SpanIndexedField.PROJECT],
+          traceSlug: row[SpanIndexedField.TRACE],
+          timestamp: row[SpanIndexedField.TIMESTAMP],
           location,
           eventView: EventView.fromLocation(location),
           spanId: row[SpanIndexedField.ID],

--- a/static/app/views/aiAnalytics/pipelineSpansTable.tsx
+++ b/static/app/views/aiAnalytics/pipelineSpansTable.tsx
@@ -7,15 +7,15 @@ import GridEditable, {
 import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types';
-import type {EventsMetaType} from 'sentry/utils/discover/eventView';
+import EventView, {type EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Sort} from 'sentry/utils/discover/fields';
+import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {useIndexedSpans} from 'sentry/views/starfish/queries/useIndexedSpans';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
@@ -97,6 +97,7 @@ export function PipelineSpansTable({groupId}: Props) {
       SpanIndexedField.TRANSACTION_ID,
       SpanIndexedField.USER,
       SpanIndexedField.TIMESTAMP,
+      SpanIndexedField.PROJECT,
     ],
     referrer: 'api.ai-pipelines.view',
     search: new MutableSearch(`span.category:ai.pipeline span.group:"${groupId}"`),
@@ -154,15 +155,18 @@ function renderBodyCell(
     }
     return (
       <Link
-        to={getTraceDetailsUrl(
+        to={generateLinkToEventInTraceView({
           organization,
-          row[SpanIndexedField.TRACE],
-          {},
-          {},
-          '',
-          row[SpanIndexedField.TRANSACTION_ID],
-          row[SpanIndexedField.ID]
-        )}
+          eventSlug: `${row[SpanIndexedField.PROJECT]}:${row[SpanIndexedField.TRANSACTION_ID]}`,
+          dataRow: {
+            id: row[SpanIndexedField.TRANSACTION_ID],
+            trace: row[SpanIndexedField.TRACE],
+            timestamp: row[SpanIndexedField.TIMESTAMP],
+          },
+          location,
+          eventView: EventView.fromLocation(location),
+          spanId: row[SpanIndexedField.ID],
+        })}
       >
         {row[SpanIndexedField.ID]}
       </Link>

--- a/static/app/views/aiAnalytics/pipelineSpansTable.tsx
+++ b/static/app/views/aiAnalytics/pipelineSpansTable.tsx
@@ -21,7 +21,12 @@ import {useIndexedSpans} from 'sentry/views/starfish/queries/useIndexedSpans';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
-type Column = GridColumnHeader<SpanIndexedField.ID | SpanIndexedField.SPAN_DURATION>;
+type Column = GridColumnHeader<
+  | SpanIndexedField.ID
+  | SpanIndexedField.SPAN_DURATION
+  | SpanIndexedField.TIMESTAMP
+  | SpanIndexedField.USER
+>;
 
 const COLUMN_ORDER: Column[] = [
   {
@@ -32,14 +37,31 @@ const COLUMN_ORDER: Column[] = [
   {
     key: SpanIndexedField.SPAN_DURATION,
     name: t('Total duration'),
+    width: 150,
+  },
+  {
+    key: SpanIndexedField.USER,
+    name: t('User'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
+    key: SpanIndexedField.TIMESTAMP,
+    name: t('Timestamp'),
     width: COL_WIDTH_UNDEFINED,
   },
 ];
 
-const SORTABLE_FIELDS = [SpanIndexedField.ID, SpanIndexedField.SPAN_DURATION];
+const SORTABLE_FIELDS = [
+  SpanIndexedField.ID,
+  SpanIndexedField.SPAN_DURATION,
+  SpanIndexedField.TIMESTAMP,
+];
 
 type ValidSort = Sort & {
-  field: SpanIndexedField.ID | SpanIndexedField.SPAN_DURATION;
+  field:
+    | SpanIndexedField.ID
+    | SpanIndexedField.SPAN_DURATION
+    | SpanIndexedField.TIMESTAMP;
 };
 
 export function isAValidSort(sort: Sort): sort is ValidSort {
@@ -57,7 +79,7 @@ export function PipelineSpansTable({groupId}: Props) {
 
   let sort = decodeSorts(sortField).filter(isAValidSort)[0];
   if (!sort) {
-    sort = {field: SpanIndexedField.ID, kind: 'desc'};
+    sort = {field: SpanIndexedField.TIMESTAMP, kind: 'desc'};
   }
 
   const {
@@ -73,6 +95,8 @@ export function PipelineSpansTable({groupId}: Props) {
       SpanIndexedField.TRACE,
       SpanIndexedField.SPAN_DURATION,
       SpanIndexedField.TRANSACTION_ID,
+      SpanIndexedField.USER,
+      SpanIndexedField.TIMESTAMP,
     ],
     referrer: 'api.ai-pipelines.view',
     search: new MutableSearch(`span.category:ai.pipeline span.group:"${groupId}"`),
@@ -135,8 +159,8 @@ function renderBodyCell(
           row[SpanIndexedField.TRACE],
           {},
           {},
-          undefined,
-          undefined,
+          '',
+          row[SpanIndexedField.TRANSACTION_ID],
           row[SpanIndexedField.ID]
         )}
       >

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -53,6 +53,7 @@ export type SpanStringFields =
   | 'span.module'
   | 'span.action'
   | 'span.group'
+  | 'span.category'
   | 'transaction'
   | 'transaction.method'
   | 'release'


### PR DESCRIPTION
Adds a page for viewing each pipeline in AI analytics, as well as a table with clickthroughs to the trace view