### PR TITLE
fix validation condition for activated alert creation

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -604,10 +604,8 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     const hasActivatedAlerts = organization.features.includes('activated-alert-rules');
     return (
       !hasActivatedAlerts ||
-      (hasActivatedAlerts &&
-        monitorType &&
-        activationCondition !== undefined &&
-        timeWindow)
+      monitorType !== MonitorType.ACTIVATED ||
+      (activationCondition !== undefined && timeWindow)
     );
   }
 


### PR DESCRIPTION
Activated alerts are valid IF:

- the feature is not enabled
- the monitor type is `CONTINUOUS` (or just _not_ of type `ACTIVATED`)
- OR if the type is of activated, then if both activation condition AND window are properly set