### PR TITLE
ref(trace-explorer): Bring trace id condition closer to query builder

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -305,7 +305,6 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             ],
             key=lambda trace: trace["trace"],  # type: ignore[arg-type, return-value]
         )
-        assert 0
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -305,6 +305,7 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             ],
             key=lambda trace: trace["trace"],  # type: ignore[arg-type, return-value]
         )
+        assert 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Having the trace id condition at the bottom makes for an unclear control flow. This brings to condition next to each query builder individually.