### PR TITLE
fix update logic to only remove AlertRuleProjects for rules being mod…

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -832,7 +832,10 @@ def update_alert_rule(
             ]
             updated_project_slugs = {project.slug for project in projects}
 
-            AlertRuleProjects.objects.exclude(project__slug__in=updated_project_slugs).delete()
+            # Delete any projects for the alert rule that were removed as part of this update
+            AlertRuleProjects.objects.filter(
+                alert_rule_id=alert_rule.id, project__slug__in=existing_project_slugs
+            ).exclude(project__slug__in=updated_project_slugs).delete()
             for project in projects:
                 alert_rule.projects.add(project)
             # Find any subscriptions that were removed as part of this update


### PR DESCRIPTION
…ified & fix tests

Previously:
- whenever ANY rule was modified, we would delete ALL AlertRuleProjects that were not being modified

Fix:
- ONLY delete AlertRuleProjects _for alert rules being modified_ 