### PR TITLE
ref(perf): Move Requests module referrer strings into an enum

### DIFF
--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -94,7 +94,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: 'api.starfish.http-module-domain-summary-throughput-chart',
+          referrer: 'api.performance.http.domain-summary-throughput-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'spm()',
@@ -119,7 +119,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: 'api.starfish.http-module-domain-summary-duration-chart',
+          referrer: 'api.performance.http.domain-summary-duration-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'avg(span.self_time)',
@@ -144,7 +144,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: 'api.starfish.http-module-domain-summary-response-code-chart',
+          referrer: 'api.performance.http.domain-summary-response-code-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: [
@@ -176,7 +176,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: 'api.starfish.http-module-domain-summary-metrics-ribbon',
+          referrer: 'api.performance.http.domain-summary-metrics-ribbon',
           statsPeriod: '10d',
         },
       })
@@ -207,7 +207,7 @@ describe('HTTPSummaryPage', function () {
           cursor: '0:20:0',
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
           sort: '-time_spent_percentage()',
-          referrer: 'api.starfish.http-module-domain-summary-transactions-list',
+          referrer: 'api.performance.http.domain-summary-transactions-list',
           statsPeriod: '10d',
         },
       })
@@ -223,7 +223,7 @@ describe('HTTPSummaryPage', function () {
 
       match: [
         MockApiClient.matchQuery({
-          referrer: 'api.starfish.http-module-domain-summary-transactions-list',
+          referrer: 'api.performance.http.domain-summary-transactions-list',
         }),
       ],
       body: {

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -6,7 +6,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {HTTPDomainSummaryPage} from 'sentry/views/performance/http/httpDomainSummaryPage';
-import {Referrer} from 'sentry/views/performance/http/referrers';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
@@ -95,7 +94,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: Referrer.DOMAIN_SUMMARY_THROUGHPUT_CHART,
+          referrer: 'api.performance.http.domain-summary-throughput-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'spm()',
@@ -120,7 +119,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: Referrer.DOMAIN_SUMMARY_DURATION_CHART,
+          referrer: 'api.performance.http.domain-summary-duration-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'avg(span.self_time)',
@@ -145,7 +144,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: Referrer.DOMAIN_SUMMARY_RESPONSE_CODE_CHART,
+          referrer: 'api.performance.http.domain-summary-response-code-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: [
@@ -177,7 +176,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: Referrer.DOMAIN_SUMMARY_METRICS_RIBBON,
+          referrer: 'api.performance.http.domain-summary-metrics-ribbon',
           statsPeriod: '10d',
         },
       })
@@ -208,7 +207,7 @@ describe('HTTPSummaryPage', function () {
           cursor: '0:20:0',
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
           sort: '-time_spent_percentage()',
-          referrer: Referrer.DOMAIN_SUMMARY_TRANSACTIONS_LIST,
+          referrer: 'api.performance.http.domain-summary-transactions-list',
           statsPeriod: '10d',
         },
       })
@@ -224,7 +223,7 @@ describe('HTTPSummaryPage', function () {
 
       match: [
         MockApiClient.matchQuery({
-          referrer: Referrer.DOMAIN_SUMMARY_TRANSACTIONS_LIST,
+          referrer: 'api.performance.http.domain-summary-transactions-list',
         }),
       ],
       body: {

--- a/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.spec.tsx
@@ -6,6 +6,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {HTTPDomainSummaryPage} from 'sentry/views/performance/http/httpDomainSummaryPage';
+import {Referrer} from 'sentry/views/performance/http/referrers';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
@@ -94,7 +95,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: 'api.performance.http.domain-summary-throughput-chart',
+          referrer: Referrer.DOMAIN_SUMMARY_THROUGHPUT_CHART,
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'spm()',
@@ -119,7 +120,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: 'api.performance.http.domain-summary-duration-chart',
+          referrer: Referrer.DOMAIN_SUMMARY_DURATION_CHART,
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'avg(span.self_time)',
@@ -144,7 +145,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: 'api.performance.http.domain-summary-response-code-chart',
+          referrer: Referrer.DOMAIN_SUMMARY_RESPONSE_CODE_CHART,
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: [
@@ -176,7 +177,7 @@ describe('HTTPSummaryPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
-          referrer: 'api.performance.http.domain-summary-metrics-ribbon',
+          referrer: Referrer.DOMAIN_SUMMARY_METRICS_RIBBON,
           statsPeriod: '10d',
         },
       })
@@ -207,7 +208,7 @@ describe('HTTPSummaryPage', function () {
           cursor: '0:20:0',
           query: 'span.module:http span.domain:"\\*.sentry.dev"',
           sort: '-time_spent_percentage()',
-          referrer: 'api.performance.http.domain-summary-transactions-list',
+          referrer: Referrer.DOMAIN_SUMMARY_TRANSACTIONS_LIST,
           statsPeriod: '10d',
         },
       })
@@ -223,7 +224,7 @@ describe('HTTPSummaryPage', function () {
 
       match: [
         MockApiClient.matchQuery({
-          referrer: 'api.performance.http.domain-summary-transactions-list',
+          referrer: Referrer.DOMAIN_SUMMARY_TRANSACTIONS_LIST,
         }),
       ],
       body: {

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -28,6 +28,7 @@ import {ResponseRateChart} from 'sentry/views/performance/http/charts/responseRa
 import {ThroughputChart} from 'sentry/views/performance/http/charts/throughputChart';
 import {DomainStatusLink} from 'sentry/views/performance/http/components/domainStatusLink';
 import {HTTPSamplesPanel} from 'sentry/views/performance/http/httpSamplesPanel';
+import {Referrer} from 'sentry/views/performance/http/referrers';
 import {
   MODULE_TITLE,
   NULL_DOMAIN_DESCRIPTION,
@@ -91,7 +92,7 @@ export function HTTPDomainSummaryPage() {
       'http_response_rate(5)',
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
     ],
-    referrer: 'api.performance.http.domain-summary-metrics-ribbon',
+    referrer: Referrer.DOMAIN_SUMMARY_METRICS_RIBBON,
   });
 
   const {
@@ -101,7 +102,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(filters),
     yAxis: ['spm()'],
-    referrer: 'api.performance.http.domain-summary-throughput-chart',
+    referrer: Referrer.DOMAIN_SUMMARY_THROUGHPUT_CHART,
   });
 
   const {
@@ -111,7 +112,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(filters),
     yAxis: [`avg(${SpanMetricsField.SPAN_SELF_TIME})`],
-    referrer: 'api.performance.http.domain-summary-duration-chart',
+    referrer: Referrer.DOMAIN_SUMMARY_DURATION_CHART,
   });
 
   const {
@@ -121,7 +122,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(filters),
     yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
-    referrer: 'api.performance.http.domain-summary-response-code-chart',
+    referrer: Referrer.DOMAIN_SUMMARY_RESPONSE_CODE_CHART,
   });
 
   const {
@@ -147,7 +148,7 @@ export function HTTPDomainSummaryPage() {
     sorts: [sort],
     limit: TRANSACTIONS_TABLE_ROW_COUNT,
     cursor,
-    referrer: 'api.performance.http.domain-summary-transactions-list',
+    referrer: Referrer.DOMAIN_SUMMARY_TRANSACTIONS_LIST,
   });
 
   useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);

--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -91,7 +91,7 @@ export function HTTPDomainSummaryPage() {
       'http_response_rate(5)',
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
     ],
-    referrer: 'api.starfish.http-module-domain-summary-metrics-ribbon',
+    referrer: 'api.performance.http.domain-summary-metrics-ribbon',
   });
 
   const {
@@ -101,7 +101,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(filters),
     yAxis: ['spm()'],
-    referrer: 'api.starfish.http-module-domain-summary-throughput-chart',
+    referrer: 'api.performance.http.domain-summary-throughput-chart',
   });
 
   const {
@@ -111,7 +111,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(filters),
     yAxis: [`avg(${SpanMetricsField.SPAN_SELF_TIME})`],
-    referrer: 'api.starfish.http-module-domain-summary-duration-chart',
+    referrer: 'api.performance.http.domain-summary-duration-chart',
   });
 
   const {
@@ -121,7 +121,7 @@ export function HTTPDomainSummaryPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(filters),
     yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
-    referrer: 'api.starfish.http-module-domain-summary-response-code-chart',
+    referrer: 'api.performance.http.domain-summary-response-code-chart',
   });
 
   const {
@@ -147,7 +147,7 @@ export function HTTPDomainSummaryPage() {
     sorts: [sort],
     limit: TRANSACTIONS_TABLE_ROW_COUNT,
     cursor,
-    referrer: 'api.starfish.http-module-domain-summary-transactions-list',
+    referrer: 'api.performance.http.domain-summary-transactions-list',
   });
 
   useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -74,7 +74,7 @@ describe('HTTPLandingPage', function () {
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
-          referrer: 'api.starfish.http-module-landing-domains-list',
+          referrer: 'api.performance.http.landing-domains-list',
         }),
       ],
       body: {
@@ -156,7 +156,7 @@ describe('HTTPLandingPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http',
-          referrer: 'api.starfish.http-module-landing-throughput-chart',
+          referrer: 'api.performance.http.landing-throughput-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'spm()',
@@ -181,7 +181,7 @@ describe('HTTPLandingPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http',
-          referrer: 'api.starfish.http-module-landing-duration-chart',
+          referrer: 'api.performance.http.landing-duration-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'avg(span.self_time)',
@@ -206,7 +206,7 @@ describe('HTTPLandingPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http',
-          referrer: 'api.starfish.http-module-landing-response-code-chart',
+          referrer: 'api.performance.http.landing-response-code-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: [
@@ -239,7 +239,7 @@ describe('HTTPLandingPage', function () {
           per_page: 10,
           project: [],
           query: 'span.module:http span.domain:*git*',
-          referrer: 'api.starfish.http-module-landing-domains-list',
+          referrer: 'api.performance.http.landing-domains-list',
           sort: '-time_spent_percentage()',
           statsPeriod: '10d',
         },

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -8,6 +8,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {HTTPLandingPage} from 'sentry/views/performance/http/httpLandingPage';
+import {Referrer} from 'sentry/views/performance/http/referrers';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
@@ -74,7 +75,7 @@ describe('HTTPLandingPage', function () {
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
-          referrer: 'api.performance.http.landing-domains-list',
+          referrer: Referrer.LANDING_DOMAINS_LIST,
         }),
       ],
       body: {
@@ -156,7 +157,7 @@ describe('HTTPLandingPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http',
-          referrer: 'api.performance.http.landing-throughput-chart',
+          referrer: Referrer.LANDING_THROUGHPUT_CHART,
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'spm()',
@@ -181,7 +182,7 @@ describe('HTTPLandingPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http',
-          referrer: 'api.performance.http.landing-duration-chart',
+          referrer: Referrer.LANDING_DURATION_CHART,
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'avg(span.self_time)',
@@ -206,7 +207,7 @@ describe('HTTPLandingPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http',
-          referrer: 'api.performance.http.landing-response-code-chart',
+          referrer: Referrer.LANDING_RESPONSE_CODE_CHART,
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: [
@@ -239,7 +240,7 @@ describe('HTTPLandingPage', function () {
           per_page: 10,
           project: [],
           query: 'span.module:http span.domain:*git*',
-          referrer: 'api.performance.http.landing-domains-list',
+          referrer: Referrer.LANDING_DOMAINS_LIST,
           sort: '-time_spent_percentage()',
           statsPeriod: '10d',
         },

--- a/static/app/views/performance/http/httpLandingPage.spec.tsx
+++ b/static/app/views/performance/http/httpLandingPage.spec.tsx
@@ -8,7 +8,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {HTTPLandingPage} from 'sentry/views/performance/http/httpLandingPage';
-import {Referrer} from 'sentry/views/performance/http/referrers';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
@@ -75,7 +74,7 @@ describe('HTTPLandingPage', function () {
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
-          referrer: Referrer.LANDING_DOMAINS_LIST,
+          referrer: 'api.performance.http.landing-domains-list',
         }),
       ],
       body: {
@@ -157,7 +156,7 @@ describe('HTTPLandingPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http',
-          referrer: Referrer.LANDING_THROUGHPUT_CHART,
+          referrer: 'api.performance.http.landing-throughput-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'spm()',
@@ -182,7 +181,7 @@ describe('HTTPLandingPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http',
-          referrer: Referrer.LANDING_DURATION_CHART,
+          referrer: 'api.performance.http.landing-duration-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: 'avg(span.self_time)',
@@ -207,7 +206,7 @@ describe('HTTPLandingPage', function () {
           per_page: 50,
           project: [],
           query: 'span.module:http',
-          referrer: Referrer.LANDING_RESPONSE_CODE_CHART,
+          referrer: 'api.performance.http.landing-response-code-chart',
           statsPeriod: '10d',
           topEvents: undefined,
           yAxis: [
@@ -240,7 +239,7 @@ describe('HTTPLandingPage', function () {
           per_page: 10,
           project: [],
           query: 'span.module:http span.domain:*git*',
-          referrer: Referrer.LANDING_DOMAINS_LIST,
+          referrer: 'api.performance.http.landing-domains-list',
           sort: '-time_spent_percentage()',
           statsPeriod: '10d',
         },

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -80,7 +80,7 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(chartFilters),
     yAxis: ['spm()'],
-    referrer: 'api.starfish.http-module-landing-throughput-chart',
+    referrer: 'api.performance.http.landing-throughput-chart',
   });
 
   const {
@@ -90,7 +90,7 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(chartFilters),
     yAxis: [`avg(span.self_time)`],
-    referrer: 'api.starfish.http-module-landing-duration-chart',
+    referrer: 'api.performance.http.landing-duration-chart',
   });
 
   const {
@@ -100,7 +100,7 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(chartFilters),
     yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
-    referrer: 'api.starfish.http-module-landing-response-code-chart',
+    referrer: 'api.performance.http.landing-response-code-chart',
   });
 
   const domainsListResponse = useSpanMetrics({
@@ -119,7 +119,7 @@ export function HTTPLandingPage() {
     sorts: [sort],
     limit: DOMAIN_TABLE_ROW_COUNT,
     cursor,
-    referrer: 'api.starfish.http-module-landing-domains-list',
+    referrer: 'api.performance.http.landing-domains-list',
   });
 
   useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);

--- a/static/app/views/performance/http/httpLandingPage.tsx
+++ b/static/app/views/performance/http/httpLandingPage.tsx
@@ -21,6 +21,7 @@ import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/u
 import {DurationChart} from 'sentry/views/performance/http/charts/durationChart';
 import {ResponseRateChart} from 'sentry/views/performance/http/charts/responseRateChart';
 import {ThroughputChart} from 'sentry/views/performance/http/charts/throughputChart';
+import {Referrer} from 'sentry/views/performance/http/referrers';
 import {MODULE_TITLE, RELEASE_LEVEL} from 'sentry/views/performance/http/settings';
 import {
   DomainsTable,
@@ -80,7 +81,7 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(chartFilters),
     yAxis: ['spm()'],
-    referrer: 'api.performance.http.landing-throughput-chart',
+    referrer: Referrer.LANDING_THROUGHPUT_CHART,
   });
 
   const {
@@ -90,7 +91,7 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(chartFilters),
     yAxis: [`avg(span.self_time)`],
-    referrer: 'api.performance.http.landing-duration-chart',
+    referrer: Referrer.LANDING_DURATION_CHART,
   });
 
   const {
@@ -100,7 +101,7 @@ export function HTTPLandingPage() {
   } = useSpanMetricsSeries({
     search: MutableSearch.fromQueryObject(chartFilters),
     yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
-    referrer: 'api.performance.http.landing-response-code-chart',
+    referrer: Referrer.LANDING_RESPONSE_CODE_CHART,
   });
 
   const domainsListResponse = useSpanMetrics({
@@ -119,7 +120,7 @@ export function HTTPLandingPage() {
     sorts: [sort],
     limit: DOMAIN_TABLE_ROW_COUNT,
     cursor,
-    referrer: 'api.performance.http.landing-domains-list',
+    referrer: Referrer.LANDING_DOMAINS_LIST,
   });
 
   useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);

--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -64,7 +64,7 @@ describe('HTTPSamplesPanel', () => {
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
-          referrer: 'api.starfish.http-module-samples-panel-metrics-ribbon',
+          referrer: 'api.performance.http.samples-panel-metrics-ribbon',
         }),
       ],
       body: {
@@ -123,7 +123,7 @@ describe('HTTPSamplesPanel', () => {
         method: 'GET',
         match: [
           MockApiClient.matchQuery({
-            referrer: 'api.starfish.http-module-samples-panel-response-code-chart',
+            referrer: 'api.performance.http.samples-panel-response-code-chart',
           }),
         ],
         body: {
@@ -147,7 +147,7 @@ describe('HTTPSamplesPanel', () => {
         method: 'GET',
         match: [
           MockApiClient.matchQuery({
-            referrer: 'api.starfish.http-module-samples-panel-response-code-samples',
+            referrer: 'api.performance.http.samples-panel-response-code-samples',
           }),
         ],
         body: {
@@ -192,7 +192,7 @@ describe('HTTPSamplesPanel', () => {
             per_page: 50,
             project: [],
             query: 'span.module:http !has:span.domain transaction:/api/0/users',
-            referrer: 'api.starfish.http-module-samples-panel-metrics-ribbon',
+            referrer: 'api.performance.http.samples-panel-metrics-ribbon',
             statsPeriod: '10d',
           },
         })
@@ -216,7 +216,7 @@ describe('HTTPSamplesPanel', () => {
             project: [],
             query:
               'span.module:http !has:span.domain transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308]',
-            referrer: 'api.starfish.http-module-samples-panel-response-code-chart',
+            referrer: 'api.performance.http.samples-panel-response-code-chart',
             statsPeriod: '10d',
             topEvents: '5',
             yAxis: 'count()',
@@ -244,7 +244,7 @@ describe('HTTPSamplesPanel', () => {
               'span.status_code',
             ],
             sort: '-span_id',
-            referrer: 'api.starfish.http-module-samples-panel-response-code-samples',
+            referrer: 'api.performance.http.samples-panel-response-code-samples',
             statsPeriod: '10d',
           }),
         })
@@ -305,7 +305,7 @@ describe('HTTPSamplesPanel', () => {
         method: 'GET',
         match: [
           MockApiClient.matchQuery({
-            referrer: 'api.starfish.http-module-samples-panel-duration-chart',
+            referrer: 'api.performance.http.samples-panel-duration-chart',
           }),
         ],
         body: {data: [[1711393200, [{count: 900}]]]},
@@ -350,7 +350,7 @@ describe('HTTPSamplesPanel', () => {
             project: [],
             query:
               'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
-            referrer: 'api.starfish.http-module-samples-panel-duration-chart',
+            referrer: 'api.performance.http.samples-panel-duration-chart',
             statsPeriod: '10d',
             yAxis: 'avg(span.self_time)',
           }),
@@ -376,7 +376,7 @@ describe('HTTPSamplesPanel', () => {
             firstBound: expect.closeTo(333.3333),
             secondBound: expect.closeTo(666.6666),
             upperBound: 1000,
-            referrer: 'api.starfish.http-module-samples-panel-duration-samples',
+            referrer: 'api.performance.http.samples-panel-duration-samples',
             statsPeriod: '10d',
           }),
         })

--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -11,7 +11,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {HTTPSamplesPanel} from 'sentry/views/performance/http/httpSamplesPanel';
-import {Referrer} from 'sentry/views/performance/http/referrers';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
@@ -65,7 +64,7 @@ describe('HTTPSamplesPanel', () => {
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
-          referrer: Referrer.SAMPLES_PANEL_METRICS_RIBBON,
+          referrer: 'api.performance.http.samples-panel-metrics-ribbon',
         }),
       ],
       body: {
@@ -124,7 +123,7 @@ describe('HTTPSamplesPanel', () => {
         method: 'GET',
         match: [
           MockApiClient.matchQuery({
-            referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_CHART,
+            referrer: 'api.performance.http.samples-panel-response-code-chart',
           }),
         ],
         body: {
@@ -148,7 +147,7 @@ describe('HTTPSamplesPanel', () => {
         method: 'GET',
         match: [
           MockApiClient.matchQuery({
-            referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_SAMPLES,
+            referrer: 'api.performance.http.samples-panel-response-code-samples',
           }),
         ],
         body: {
@@ -193,7 +192,7 @@ describe('HTTPSamplesPanel', () => {
             per_page: 50,
             project: [],
             query: 'span.module:http !has:span.domain transaction:/api/0/users',
-            referrer: Referrer.SAMPLES_PANEL_METRICS_RIBBON,
+            referrer: 'api.performance.http.samples-panel-metrics-ribbon',
             statsPeriod: '10d',
           },
         })
@@ -217,7 +216,7 @@ describe('HTTPSamplesPanel', () => {
             project: [],
             query:
               'span.module:http !has:span.domain transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308]',
-            referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_CHART,
+            referrer: 'api.performance.http.samples-panel-response-code-chart',
             statsPeriod: '10d',
             topEvents: '5',
             yAxis: 'count()',
@@ -245,7 +244,7 @@ describe('HTTPSamplesPanel', () => {
               'span.status_code',
             ],
             sort: '-span_id',
-            referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_SAMPLES,
+            referrer: 'api.performance.http.samples-panel-response-code-samples',
             statsPeriod: '10d',
           }),
         })
@@ -306,7 +305,7 @@ describe('HTTPSamplesPanel', () => {
         method: 'GET',
         match: [
           MockApiClient.matchQuery({
-            referrer: Referrer.SAMPLES_PANEL_DURATION_CHART,
+            referrer: 'api.performance.http.samples-panel-duration-chart',
           }),
         ],
         body: {data: [[1711393200, [{count: 900}]]]},
@@ -351,7 +350,7 @@ describe('HTTPSamplesPanel', () => {
             project: [],
             query:
               'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
-            referrer: Referrer.SAMPLES_PANEL_DURATION_CHART,
+            referrer: 'api.performance.http.samples-panel-duration-chart',
             statsPeriod: '10d',
             yAxis: 'avg(span.self_time)',
           }),
@@ -377,7 +376,7 @@ describe('HTTPSamplesPanel', () => {
             firstBound: expect.closeTo(333.3333),
             secondBound: expect.closeTo(666.6666),
             upperBound: 1000,
-            referrer: Referrer.SAMPLES_PANEL_DURATION_SAMPLES,
+            referrer: 'api.performance.http.samples-panel-duration-samples',
             statsPeriod: '10d',
           }),
         })

--- a/static/app/views/performance/http/httpSamplesPanel.spec.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.spec.tsx
@@ -11,6 +11,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {HTTPSamplesPanel} from 'sentry/views/performance/http/httpSamplesPanel';
+import {Referrer} from 'sentry/views/performance/http/referrers';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
@@ -64,7 +65,7 @@ describe('HTTPSamplesPanel', () => {
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
-          referrer: 'api.performance.http.samples-panel-metrics-ribbon',
+          referrer: Referrer.SAMPLES_PANEL_METRICS_RIBBON,
         }),
       ],
       body: {
@@ -123,7 +124,7 @@ describe('HTTPSamplesPanel', () => {
         method: 'GET',
         match: [
           MockApiClient.matchQuery({
-            referrer: 'api.performance.http.samples-panel-response-code-chart',
+            referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_CHART,
           }),
         ],
         body: {
@@ -147,7 +148,7 @@ describe('HTTPSamplesPanel', () => {
         method: 'GET',
         match: [
           MockApiClient.matchQuery({
-            referrer: 'api.performance.http.samples-panel-response-code-samples',
+            referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_SAMPLES,
           }),
         ],
         body: {
@@ -192,7 +193,7 @@ describe('HTTPSamplesPanel', () => {
             per_page: 50,
             project: [],
             query: 'span.module:http !has:span.domain transaction:/api/0/users',
-            referrer: 'api.performance.http.samples-panel-metrics-ribbon',
+            referrer: Referrer.SAMPLES_PANEL_METRICS_RIBBON,
             statsPeriod: '10d',
           },
         })
@@ -216,7 +217,7 @@ describe('HTTPSamplesPanel', () => {
             project: [],
             query:
               'span.module:http !has:span.domain transaction:/api/0/users span.status_code:[300,301,302,303,304,305,307,308]',
-            referrer: 'api.performance.http.samples-panel-response-code-chart',
+            referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_CHART,
             statsPeriod: '10d',
             topEvents: '5',
             yAxis: 'count()',
@@ -244,7 +245,7 @@ describe('HTTPSamplesPanel', () => {
               'span.status_code',
             ],
             sort: '-span_id',
-            referrer: 'api.performance.http.samples-panel-response-code-samples',
+            referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_SAMPLES,
             statsPeriod: '10d',
           }),
         })
@@ -305,7 +306,7 @@ describe('HTTPSamplesPanel', () => {
         method: 'GET',
         match: [
           MockApiClient.matchQuery({
-            referrer: 'api.performance.http.samples-panel-duration-chart',
+            referrer: Referrer.SAMPLES_PANEL_DURATION_CHART,
           }),
         ],
         body: {data: [[1711393200, [{count: 900}]]]},
@@ -350,7 +351,7 @@ describe('HTTPSamplesPanel', () => {
             project: [],
             query:
               'span.module:http span.domain:"\\*.sentry.dev" transaction:/api/0/users',
-            referrer: 'api.performance.http.samples-panel-duration-chart',
+            referrer: Referrer.SAMPLES_PANEL_DURATION_CHART,
             statsPeriod: '10d',
             yAxis: 'avg(span.self_time)',
           }),
@@ -376,7 +377,7 @@ describe('HTTPSamplesPanel', () => {
             firstBound: expect.closeTo(333.3333),
             secondBound: expect.closeTo(666.6666),
             upperBound: 1000,
-            referrer: 'api.performance.http.samples-panel-duration-samples',
+            referrer: Referrer.SAMPLES_PANEL_DURATION_SAMPLES,
             statsPeriod: '10d',
           }),
         })

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -149,7 +149,7 @@ export function HTTPSamplesPanel() {
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
     ],
     enabled: isPanelOpen,
-    referrer: 'api.starfish.http-module-samples-panel-metrics-ribbon',
+    referrer: 'api.performance.http.samples-panel-metrics-ribbon',
   });
 
   const {
@@ -160,7 +160,7 @@ export function HTTPSamplesPanel() {
     search,
     yAxis: [`avg(span.self_time)`],
     enabled: isPanelOpen && query.panel === 'duration',
-    referrer: 'api.starfish.http-module-samples-panel-duration-chart',
+    referrer: 'api.performance.http.samples-panel-duration-chart',
   });
 
   const {
@@ -173,7 +173,7 @@ export function HTTPSamplesPanel() {
     yAxis: ['count()'],
     topEvents: 5,
     enabled: isPanelOpen && query.panel === 'status',
-    referrer: 'api.starfish.http-module-samples-panel-response-code-chart',
+    referrer: 'api.performance.http.samples-panel-response-code-chart',
   });
 
   // NOTE: Due to some data confusion, the `domain` column in the spans table can either be `null` or `""`. Searches like `"!has:span.domain"` are turned into the ClickHouse clause `isNull(domain)`, and do not match the empty string. We need a query that matches empty strings _and_ null_ which is `(!has:domain OR domain:[""])`. This hack can be removed in August 2024, once https://github.com/getsentry/snuba/pull/5780 has been deployed for 90 days and all `""` domains have fallen out of the data retention window. Also, `null` domains will become more rare as people upgrade the JS SDK to versions that populate the `server.address` span attribute
@@ -210,7 +210,7 @@ export function HTTPSamplesPanel() {
     min: 0,
     max: durationAxisMax,
     enabled: isPanelOpen && query.panel === 'duration' && durationAxisMax > 0,
-    referrer: 'api.starfish.http-module-samples-panel-duration-samples',
+    referrer: 'api.performance.http.samples-panel-duration-samples',
   });
 
   const {
@@ -232,7 +232,7 @@ export function HTTPSamplesPanel() {
     sorts: [SPAN_SAMPLES_SORT],
     limit: SPAN_SAMPLE_LIMIT,
     enabled: isPanelOpen && query.panel === 'status',
-    referrer: 'api.starfish.http-module-samples-panel-response-code-samples',
+    referrer: 'api.performance.http.samples-panel-response-code-samples',
   });
 
   const sampledSpanDataSeries = useSampleScatterPlotSeries(

--- a/static/app/views/performance/http/httpSamplesPanel.tsx
+++ b/static/app/views/performance/http/httpSamplesPanel.tsx
@@ -30,6 +30,7 @@ import {HTTP_RESPONSE_STATUS_CODES} from 'sentry/views/performance/http/data/def
 import {useSpanSamples} from 'sentry/views/performance/http/data/useSpanSamples';
 import decodePanel from 'sentry/views/performance/http/queryParameterDecoders/panel';
 import decodeResponseCodeClass from 'sentry/views/performance/http/queryParameterDecoders/responseCodeClass';
+import {Referrer} from 'sentry/views/performance/http/referrers';
 import {SpanSamplesTable} from 'sentry/views/performance/http/tables/spanSamplesTable';
 import {useDebouncedState} from 'sentry/views/performance/http/useDebouncedState';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
@@ -149,7 +150,7 @@ export function HTTPSamplesPanel() {
       `${SpanFunction.TIME_SPENT_PERCENTAGE}()`,
     ],
     enabled: isPanelOpen,
-    referrer: 'api.performance.http.samples-panel-metrics-ribbon',
+    referrer: Referrer.SAMPLES_PANEL_METRICS_RIBBON,
   });
 
   const {
@@ -160,7 +161,7 @@ export function HTTPSamplesPanel() {
     search,
     yAxis: [`avg(span.self_time)`],
     enabled: isPanelOpen && query.panel === 'duration',
-    referrer: 'api.performance.http.samples-panel-duration-chart',
+    referrer: Referrer.SAMPLES_PANEL_DURATION_CHART,
   });
 
   const {
@@ -173,7 +174,7 @@ export function HTTPSamplesPanel() {
     yAxis: ['count()'],
     topEvents: 5,
     enabled: isPanelOpen && query.panel === 'status',
-    referrer: 'api.performance.http.samples-panel-response-code-chart',
+    referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_CHART,
   });
 
   // NOTE: Due to some data confusion, the `domain` column in the spans table can either be `null` or `""`. Searches like `"!has:span.domain"` are turned into the ClickHouse clause `isNull(domain)`, and do not match the empty string. We need a query that matches empty strings _and_ null_ which is `(!has:domain OR domain:[""])`. This hack can be removed in August 2024, once https://github.com/getsentry/snuba/pull/5780 has been deployed for 90 days and all `""` domains have fallen out of the data retention window. Also, `null` domains will become more rare as people upgrade the JS SDK to versions that populate the `server.address` span attribute
@@ -210,7 +211,7 @@ export function HTTPSamplesPanel() {
     min: 0,
     max: durationAxisMax,
     enabled: isPanelOpen && query.panel === 'duration' && durationAxisMax > 0,
-    referrer: 'api.performance.http.samples-panel-duration-samples',
+    referrer: Referrer.SAMPLES_PANEL_DURATION_SAMPLES,
   });
 
   const {
@@ -232,7 +233,7 @@ export function HTTPSamplesPanel() {
     sorts: [SPAN_SAMPLES_SORT],
     limit: SPAN_SAMPLE_LIMIT,
     enabled: isPanelOpen && query.panel === 'status',
-    referrer: 'api.performance.http.samples-panel-response-code-samples',
+    referrer: Referrer.SAMPLES_PANEL_RESPONSE_CODE_SAMPLES,
   });
 
   const sampledSpanDataSeries = useSampleScatterPlotSeries(

--- a/static/app/views/performance/http/referrers.tsx
+++ b/static/app/views/performance/http/referrers.tsx
@@ -1,0 +1,16 @@
+export enum Referrer {
+  LANDING_DOMAINS_LIST = 'api.performance.http.landing-domains-list',
+  LANDING_DURATION_CHART = 'api.performance.http.landing-duration-chart',
+  LANDING_RESPONSE_CODE_CHART = 'api.performance.http.landing-response-code-chart',
+  LANDING_THROUGHPUT_CHART = 'api.performance.http.landing-throughput-chart',
+  DOMAIN_SUMMARY_DURATION_CHART = 'api.performance.http.domain-summary-duration-chart',
+  DOMAIN_SUMMARY_METRICS_RIBBON = 'api.performance.http.domain-summary-metrics-ribbon',
+  DOMAIN_SUMMARY_RESPONSE_CODE_CHART = 'api.performance.http.domain-summary-response-code-chart',
+  DOMAIN_SUMMARY_THROUGHPUT_CHART = 'api.performance.http.domain-summary-throughput-chart',
+  DOMAIN_SUMMARY_TRANSACTIONS_LIST = 'api.performance.http.domain-summary-transactions-list',
+  SAMPLES_PANEL_DURATION_CHART = 'api.performance.http.samples-panel-duration-chart',
+  SAMPLES_PANEL_DURATION_SAMPLES = 'api.performance.http.samples-panel-duration-samples',
+  SAMPLES_PANEL_METRICS_RIBBON = 'api.performance.http.samples-panel-metrics-ribbon',
+  SAMPLES_PANEL_RESPONSE_CODE_CHART = 'api.performance.http.samples-panel-response-code-chart',
+  SAMPLES_PANEL_RESPONSE_CODE_SAMPLES = 'api.performance.http.samples-panel-response-code-samples',
+}


### PR DESCRIPTION
Exprimenting with some organization. This seems better, and lays a path towards _requiring_ clean referrers for data hooks, which might be good for us. In the meantime, this is tidy and will make it easier to declare all of these in the backend, too.

Specs still use the strings themselves because I'm less interested in comparing enum values (e.g., I might add a bad/incorrect value to the enum and the spec would pass) than making sure the right string is sent to the backend.