### PR TITLE
fix(mobile-widgets): Return null for list query when no applicable releases

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/mobileReleaseComparisonListWidget.tsx
@@ -110,7 +110,7 @@ function MobileReleaseComparisonListWidget(props: PerformanceWidgetProps) {
     () => ({
       fields: field,
       component: provided => {
-        if (isLoadingReleases) {
+        if (isLoadingReleases || (!primaryRelease && !secondaryRelease)) {
           return null;
         }
 


### PR DESCRIPTION
If there are no applicable releases (i.e. when we query for ui.load transactions) for the project, then we should bail out of the list query. If we don't then the release filter doesn't get applied since both values are undefined and it does a query for irrelevant data.