### PR TITLE
fix(perf): Set minimum value for percentage columns

### DIFF
--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -49,6 +49,8 @@ describe('getFieldRenderer', function () {
       'transaction.duration': 75,
       'timestamp.to_day': '2021-09-05T00:00:00+00:00',
       'issue.id': '123214',
+      'http_response_rate(3)': 0.012,
+      'http_response_rate(5)': 0.000021,
       lifetimeCount: 10000,
       filteredCount: 3000,
       count: 6000,
@@ -103,6 +105,34 @@ describe('getFieldRenderer', function () {
     render(renderer(data, {location, organization}) as React.ReactElement<any, any>);
 
     expect(screen.getByText(data.numeric)).toBeInTheDocument();
+  });
+
+  describe('percentage', function () {
+    it('can render percentage fields', function () {
+      const renderer = getFieldRenderer(
+        'http_response_rate(3)',
+        {
+          'http_response_rate(3)': 'percentage',
+        },
+        false
+      );
+
+      render(renderer(data, {location, organization}) as React.ReactElement<any, any>);
+      expect(screen.getByText('1.2%')).toBeInTheDocument();
+    });
+
+    it('can render very small percentages', function () {
+      const renderer = getFieldRenderer(
+        'http_response_rate(5)',
+        {
+          'http_response_rate(5)': 'percentage',
+        },
+        false
+      );
+
+      render(renderer(data, {location, organization}) as React.ReactElement<any, any>);
+      expect(screen.getByText('<0.01%')).toBeInTheDocument();
+    });
   });
 
   describe('date', function () {

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -261,7 +261,9 @@ export const FIELD_FORMATTERS: FieldFormatters = {
     isSortable: true,
     renderFunc: (field, data) => (
       <NumberContainer>
-        {typeof data[field] === 'number' ? formatPercentage(data[field]) : emptyValue}
+        {typeof data[field] === 'number'
+          ? formatPercentage(data[field], undefined, {minimumValue: 0.0001})
+          : emptyValue}
       </NumberContainer>
     ),
   },


### PR DESCRIPTION
For very small percentages, (e.g. `0.00007712`) render `"<0.01%"`, instead of the current behaviour, which is to render `"0%"` which isn't very precise.

**Before:**
<img width="702" alt="Screenshot 2024-04-19 at 2 40 44 PM" src="https://github.com/getsentry/sentry/assets/989898/fcae27cf-72c0-42da-8fd9-422d0fb812da">

**After:**
<img width="721" alt="Screenshot 2024-04-19 at 2 41 13 PM" src="https://github.com/getsentry/sentry/assets/989898/a45099ee-86bd-4fa8-be25-aeb23f8130f7">
