### PR TITLE
ref: remove * imports from sentry.silo

### DIFF
--- a/fixtures/gitlab.py
+++ b/fixtures/gitlab.py
@@ -3,7 +3,7 @@ from time import time
 from sentry.models.identity import Identity, IdentityProvider
 from sentry.models.integrations.integration import Integration
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/src/sentry/analytics/__init__.py
+++ b/src/sentry/analytics/__init__.py
@@ -20,8 +20,8 @@ __all__ = (
 
 backend = LazyServiceWrapper(
     backend_base=Analytics,
-    backend_path=get_backend_path(options.get("analytics.backend")),  # type: ignore[has-type]  # mypy is confused by a circular import
-    options=options.get("analytics.options"),  # type: ignore[has-type]  # mypy is confused by a circular import
+    backend_path=get_backend_path(options.get("analytics.backend")),
+    options=options.get("analytics.options"),
 )
 
 record = backend.record

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -39,7 +39,7 @@ from sentry.services.hybrid_cloud.auth import AuthenticatedToken
 from sentry.services.hybrid_cloud.rpc import compare_signature
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloLimit, SiloMode
+from sentry.silo.base import SiloLimit, SiloMode
 from sentry.utils.linksign import process_signature
 from sentry.utils.sdk import configure_scope
 from sentry.utils.security.orgauthtoken_token import SENTRY_ORG_AUTH_TOKEN_PREFIX, hash_token

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -32,7 +32,7 @@ from sentry.auth import access
 from sentry.auth.staff import has_staff_option
 from sentry.models.environment import Environment
 from sentry.ratelimits.config import DEFAULT_RATE_LIMIT_CONFIG, RateLimitConfig
-from sentry.silo import SiloLimit, SiloMode
+from sentry.silo.base import SiloLimit, SiloMode
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
 from sentry.utils.audit import create_audit_entry

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -40,7 +40,7 @@ from sentry.services.hybrid_cloud.organization import (
     RpcUserOrganizationContext,
     organization_service,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.types.region import get_local_region
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.sdk import capture_exception, merge_context_into_scope

--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -12,7 +12,7 @@ from django.db.models.fields.related import ForeignKey, OneToOneField
 
 from sentry.backup.helpers import EXCLUDED_APPS
 from sentry.backup.scopes import RelocationScope
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.utils import json
 
 

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -15,7 +15,7 @@ from sentry.models.files.file import File
 from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.fileblobindex import FileBlobIndex
 from sentry.models.files.utils import DEFAULT_BLOB_SIZE, MAX_FILE_SIZE, AssembleChecksumMismatch
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.db import atomic_transaction

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -18,7 +18,7 @@ from sentry.backup.dependencies import (
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.sanitize import SanitizableField, Sanitizer
 from sentry.backup.scopes import ImportScope, RelocationScope
-from sentry.silo import SiloLimit, SiloMode
+from sentry.silo.base import SiloLimit, SiloMode
 from sentry.utils.json import JSONData
 
 from .fields.bounded import BoundedBigAutoField

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -18,7 +18,7 @@ from sentry.db.models.manager import M, make_key
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.db.models.query import create_or_update
 from sentry.db.postgres.transactions import django_test_transaction_water_mark
-from sentry.silo import SiloLimit
+from sentry.silo.base import SiloLimit
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 

--- a/src/sentry/db/models/outboxes.py
+++ b/src/sentry/db/models/outboxes.py
@@ -11,7 +11,7 @@ from sentry_sdk.api import capture_exception
 
 from sentry.db.models import BaseManager, Model
 from sentry.signals import post_upgrade
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.types.region import find_regions_for_orgs, find_regions_for_user
 from sentry.utils.env import in_test_environment
 from sentry.utils.snowflake import SnowflakeIdMixin

--- a/src/sentry/db/postgres/transactions.py
+++ b/src/sentry/db/postgres/transactions.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.db import connections, transaction
 from django.db.transaction import Atomic, get_connection
 
-from sentry.silo import SiloMode, SingleProcessSiloModeState
+from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.utils.env import in_test_environment
 
 

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -59,7 +59,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.snuba.referrer import Referrer

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -47,7 +47,7 @@ from sentry.dynamic_sampling.tasks.utils import (
 from sentry.models.organization import Organization
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.snuba.referrer import Referrer

--- a/src/sentry/dynamic_sampling/tasks/collect_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/collect_orgs.py
@@ -6,7 +6,7 @@ from sentry.dynamic_sampling.tasks.constants import MAX_PROJECTS_PER_QUERY, MAX_
 from sentry.dynamic_sampling.tasks.logging import log_task_execution, log_task_timeout
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 

--- a/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
+++ b/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
@@ -18,7 +18,7 @@ from sentry.dynamic_sampling.tasks.utils import (
 )
 from sentry.models.dynamicsampling import CustomDynamicSamplingRule
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba import discover
 from sentry.tasks.base import instrumented_task
 from sentry.utils.email import MessageBuilder

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -29,7 +29,7 @@ from sentry.dynamic_sampling.tasks.utils import (
     has_dynamic_sampling,
 )
 from sentry.models.organization import Organization
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -20,7 +20,7 @@ from sentry.dynamic_sampling.tasks.helpers.sliding_window import (
 )
 from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task_with_context
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 

--- a/src/sentry/hybridcloud/apigateway/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway/apigateway.py
@@ -14,8 +14,7 @@ from sentry.hybridcloud.apigateway.proxy import (
     proxy_sentryapp_request,
     proxy_sentryappinstallation_request,
 )
-from sentry.silo import SiloMode
-from sentry.silo.base import SiloLimit
+from sentry.silo.base import SiloLimit, SiloMode
 from sentry.types.region import get_region_by_name
 from sentry.utils import metrics
 

--- a/src/sentry/hybridcloud/rpc/services/caching/impl.py
+++ b/src/sentry/hybridcloud/rpc/services/caching/impl.py
@@ -9,7 +9,7 @@ from sentry.hybridcloud.models.cacheversion import (
     RegionCacheVersion,
 )
 from sentry.hybridcloud.rpc.services.caching import ControlCachingService, RegionCachingService
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 _V = TypeVar("_V")
 

--- a/src/sentry/hybridcloud/rpc/services/caching/service.py
+++ b/src/sentry/hybridcloud/rpc/services/caching/service.py
@@ -10,7 +10,7 @@ import pydantic
 
 from sentry.services.hybrid_cloud.region import ByRegionName
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 

--- a/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/service.py
+++ b/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/service.py
@@ -9,7 +9,7 @@ from sentry.hybridcloud.rpc_services.control_organization_provisioning.model imp
 )
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.services.organization.model import OrganizationProvisioningOptions
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class ControlOrganizationProvisioningRpcService(RpcService):

--- a/src/sentry/hybridcloud/rpc_services/region_organization_provisioning/service.py
+++ b/src/sentry/hybridcloud/rpc_services/region_organization_provisioning/service.py
@@ -6,7 +6,7 @@ from sentry.hybridcloud.rpc_services.control_organization_provisioning import (
 from sentry.services.hybrid_cloud.region import ByRegionName
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
 from sentry.services.organization import OrganizationProvisioningOptions
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class RegionOrganizationProvisioningRpcService(RpcService):

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -24,7 +24,7 @@ from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.models.project import Project
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription
 from sentry.snuba.query_subscriptions.consumer import register_subscriber

--- a/src/sentry/integrations/discord/webhooks/base.py
+++ b/src/sentry/integrations/discord/webhooks/base.py
@@ -14,7 +14,7 @@ from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.integrations.discord.requests.base import DiscordRequest, DiscordRequestError
 from sentry.integrations.discord.webhooks.command import DiscordCommandHandler
 from sentry.integrations.discord.webhooks.message_component import DiscordMessageComponentHandler
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 from .types import DiscordResponseTypes
 

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -24,7 +24,7 @@ from sentry.services.hybrid_cloud.identity.model import RpcIdentity
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.utils import json, jwt
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.signing import sign

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -18,7 +18,7 @@ from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.integrations.slack import post_message, post_message_control
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json, metrics

--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -6,7 +6,7 @@ from sentry import features
 from sentry.integrations.slack.service import SlackService
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -41,7 +41,7 @@ from sentry.shared_integrations.exceptions import (
     IntegrationError,
     IntegrationProviderError,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.integrations import migrate_repo
 from sentry.utils.http import absolute_uri
 from sentry.utils.json import JSONData

--- a/src/sentry/issues/forecasts.py
+++ b/src/sentry/issues/forecasts.py
@@ -15,7 +15,7 @@ from sentry.issues.escalating import (
 from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
 from sentry.issues.escalating_issues_alg import generate_issue_forecast, standard_version
 from sentry.models.group import Group
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/mediators/token_exchange/grant_exchanger.py
+++ b/src/sentry/mediators/token_exchange/grant_exchanger.py
@@ -16,7 +16,7 @@ from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 
 
 class GrantExchanger(Mediator):

--- a/src/sentry/middleware/integrations/integration_control.py
+++ b/src/sentry/middleware/integrations/integration_control.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
 
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -21,7 +21,7 @@ from sentry.ratelimits import backend as ratelimiter
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
-from sentry.silo import SiloLimit, SiloMode
+from sentry.silo.base import SiloLimit, SiloMode
 from sentry.silo.client import RegionSiloClient, SiloClientError
 from sentry.types.region import Region, find_regions_for_orgs, get_region_by_name
 from sentry.utils import metrics

--- a/src/sentry/models/avatars/base.py
+++ b/src/sentry/models/avatars/base.py
@@ -15,7 +15,7 @@ from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model
 from sentry.models.files.control_file import ControlFile
 from sentry.models.files.file import File
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.types.region import get_local_region
 from sentry.utils.cache import cache
 from sentry.utils.db import atomic_transaction

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -12,7 +12,8 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.features.rollout import in_random_rollout
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 
 
 @region_silo_only_model

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -36,7 +36,8 @@ from sentry.db.postgres.transactions import (
     in_test_assert_no_transaction,
 )
 from sentry.services.hybrid_cloud import REGION_NAME_LENGTH
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.utils import metrics
 
 THE_PAST = datetime.datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=datetime.UTC)

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -18,7 +18,7 @@ from sentry.db.models import (
 )
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 delete_logger = logging.getLogger("sentry.deletions.api")
 

--- a/src/sentry/models/tombstone.py
+++ b/src/sentry/models/tombstone.py
@@ -11,7 +11,7 @@ from sentry.db.models import (
     region_silo_only_model,
     sane_repr,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class TombstoneBase(Model):

--- a/src/sentry/models/userrole.py
+++ b/src/sentry/models/userrole.py
@@ -11,7 +11,7 @@ from sentry.db.models.fields.foreignkey import FlexibleForeignKey
 from sentry.db.models.outboxes import ControlOutboxProducingModel
 from sentry.models.outbox import ControlOutboxBase, OutboxCategory
 from sentry.signals import post_upgrade
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.types.region import find_all_region_names
 
 MAX_USER_ROLE_NAME_LENGTH = 32

--- a/src/sentry/monitors/tasks/check_missed.py
+++ b/src/sentry/monitors/tasks/check_missed.py
@@ -13,7 +13,7 @@ from sentry.monitors.models import (
     MonitorType,
 )
 from sentry.monitors.schedule import get_prev_schedule
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 

--- a/src/sentry/monitors/tasks/check_timeout.py
+++ b/src/sentry/monitors/tasks/check_timeout.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from sentry.monitors.logic.mark_failed import mark_failed
 from sentry.monitors.models import CheckInStatus, MonitorCheckIn
 from sentry.monitors.schedule import get_prev_schedule
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 

--- a/src/sentry/monitors/tasks/clock_pulse.py
+++ b/src/sentry/monitors/tasks/clock_pulse.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from sentry.conf.types.kafka_definition import Topic
 from sentry.monitors.clock_dispatch import try_monitor_tasks_trigger
 from sentry.monitors.types import ClockPulseMessage
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils.arroyo_producer import SingletonProducer
 from sentry.utils.kafka_config import (

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -80,7 +80,7 @@ class OptionsStore:
     @classmethod
     def model_cls(cls):
         from sentry.models.options import ControlOption, Option
-        from sentry.silo import SiloMode
+        from sentry.silo.base import SiloMode
 
         if SiloMode.get_current_mode() == SiloMode.CONTROL:
             return ControlOption

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -33,7 +33,7 @@ from sentry.profiles.java import (
 )
 from sentry.profiles.utils import get_from_profiling_service
 from sentry.signals import first_profile_received
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, metrics
 from sentry.utils.outcomes import Outcome, track_outcome

--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -21,7 +21,7 @@ from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.services.hybrid_cloud.util import region_silo_function
 from sentry.services.organization import organization_provisioning_service
 from sentry.signals import post_upgrade, project_created
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.utils.env import in_test_environment
 from sentry.utils.settings import is_self_hosted
 

--- a/src/sentry/receivers/outbox/__init__.py
+++ b/src/sentry/receivers/outbox/__init__.py
@@ -57,7 +57,7 @@ from sentry.services.hybrid_cloud.tombstone import (
     control_tombstone_service,
     region_tombstone_service,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 T = TypeVar("T", bound=Model)
 

--- a/src/sentry/receivers/users.py
+++ b/src/sentry/receivers/users.py
@@ -2,7 +2,7 @@ import sys
 
 from sentry.models.user import User
 from sentry.signals import post_upgrade
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.utils.settings import is_self_hosted
 
 

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -10,7 +10,7 @@ from sentry.replays.lib.storage import filestore, make_video_filename, storage, 
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.usecases.events import archive_event
 from sentry.replays.usecases.reader import fetch_segments_metadata
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.pubsub import KafkaPublisher

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -5,7 +5,7 @@ from django.db.utils import ProgrammingError
 
 from sentry.runner.decorators import configuration
 from sentry.signals import post_upgrade
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 def _check_history() -> None:

--- a/src/sentry/services/hybrid_cloud/__init__.py
+++ b/src/sentry/services/hybrid_cloud/__init__.py
@@ -12,7 +12,7 @@ import pydantic
 from django.db import router, transaction
 from django.db.models import Model
 
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.utils.env import in_test_environment
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/services/hybrid_cloud/access/service.py
+++ b/src/sentry/services/hybrid_cloud/access/service.py
@@ -12,7 +12,7 @@ from sentry.services.hybrid_cloud.auth import (
     RpcMemberSsoState,
 )
 from sentry.services.hybrid_cloud.organization import RpcOrganizationMemberSummary
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 _SSO_BYPASS = RpcMemberSsoState(is_required=False, is_valid=True)
 _SSO_NONMEMBER = RpcMemberSsoState(is_required=False, is_valid=False)

--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -20,7 +20,7 @@ from sentry.services.hybrid_cloud.auth import AuthenticationContext
 from sentry.services.hybrid_cloud.filter_query import OpaqueSerializedResponse
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.services.hybrid_cloud.user import RpcUser
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class AppService(RpcService):

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -24,7 +24,7 @@ from sentry.services.hybrid_cloud.auth import (
 from sentry.services.hybrid_cloud.auth.serial import serialize_api_key, serialize_auth_provider
 from sentry.services.hybrid_cloud.organization.service import organization_service
 from sentry.signals import sso_enabled
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 
 
 class DatabaseBackedAuthService(AuthService):

--- a/src/sentry/services/hybrid_cloud/auth/service.py
+++ b/src/sentry/services/hybrid_cloud/auth/service.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from sentry.services.hybrid_cloud.auth import RpcApiKey, RpcAuthProvider, RpcOrganizationAuthConfig
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class AuthService(RpcService):

--- a/src/sentry/services/hybrid_cloud/filter_query.py
+++ b/src/sentry/services/hybrid_cloud/filter_query.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union
 from django.db.models import Model, QuerySet
 
 from sentry.services.hybrid_cloud import RpcModel
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 if TYPE_CHECKING:
     from sentry.api.serializers import Serializer

--- a/src/sentry/services/hybrid_cloud/hook/service.py
+++ b/src/sentry/services/hybrid_cloud/hook/service.py
@@ -8,7 +8,7 @@ import abc
 from sentry.services.hybrid_cloud.hook import RpcServiceHook
 from sentry.services.hybrid_cloud.region import ByOrganizationId
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class HookService(RpcService):

--- a/src/sentry/services/hybrid_cloud/identity/service.py
+++ b/src/sentry/services/hybrid_cloud/identity/service.py
@@ -9,7 +9,7 @@ from typing import Any
 from sentry.services.hybrid_cloud.identity import RpcIdentity, RpcIdentityProvider
 from sentry.services.hybrid_cloud.identity.model import IdentityFilterArgs
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class IdentityService(RpcService):

--- a/src/sentry/services/hybrid_cloud/import_export/service.py
+++ b/src/sentry/services/hybrid_cloud/import_export/service.py
@@ -19,7 +19,7 @@ from sentry.services.hybrid_cloud.import_export.model import (
     RpcPrimaryKeyMap,
 )
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 DEFAULT_IMPORT_FLAGS = RpcImportFlags.into_rpc(ImportFlags())
 

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -14,7 +14,7 @@ from sentry.services.hybrid_cloud.integration.model import (
 )
 from sentry.services.hybrid_cloud.pagination import RpcPaginationArgs, RpcPaginationResult
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class IntegrationService(RpcService):

--- a/src/sentry/services/hybrid_cloud/log/impl.py
+++ b/src/sentry/services/hybrid_cloud/log/impl.py
@@ -11,7 +11,7 @@ from sentry.models.outbox import OutboxCategory, OutboxScope, RegionOutbox
 from sentry.models.user import User
 from sentry.models.userip import UserIP
 from sentry.services.hybrid_cloud.log import AuditLogEvent, LogService, UserIpEvent
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 
 
 class DatabaseBackedLogService(LogService):

--- a/src/sentry/services/hybrid_cloud/log/service.py
+++ b/src/sentry/services/hybrid_cloud/log/service.py
@@ -7,7 +7,7 @@ import abc
 
 from sentry.services.hybrid_cloud import silo_mode_delegation
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 from .model import AuditLogEvent, UserIpEvent
 

--- a/src/sentry/services/hybrid_cloud/lost_password_hash/service.py
+++ b/src/sentry/services/hybrid_cloud/lost_password_hash/service.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 
 from sentry.services.hybrid_cloud.lost_password_hash import RpcLostPasswordHash
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class LostPasswordHashService(RpcService):

--- a/src/sentry/services/hybrid_cloud/notifications/service.py
+++ b/src/sentry/services/hybrid_cloud/notifications/service.py
@@ -12,7 +12,7 @@ from sentry.notifications.types import (
 )
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.types.integrations import ExternalProviderEnum, ExternalProviders
 
 

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -60,7 +60,7 @@ from sentry.services.hybrid_cloud.organization_actions.impl import (
 )
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.util import flags_to_bits
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 from sentry.tasks.auth import email_unlink_notifications
 from sentry.types.region import find_regions_for_orgs
 from sentry.utils.audit import create_org_delete_log

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -35,7 +35,7 @@ from sentry.services.hybrid_cloud.region import (
 )
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
 from sentry.services.hybrid_cloud.user.model import RpcUser
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class OrganizationService(RpcService):

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -11,7 +11,7 @@ from sentry.services.hybrid_cloud.organization_mapping import (
     RpcOrganizationMappingUpdate,
 )
 from sentry.services.hybrid_cloud.organization_mapping.serial import serialize_organization_mapping
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 
 
 class OrganizationMappingConsistencyException(Exception):

--- a/src/sentry/services/hybrid_cloud/organization_mapping/service.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/service.py
@@ -10,7 +10,7 @@ from sentry.services.hybrid_cloud.organization_mapping import (
     RpcOrganizationMappingUpdate,
 )
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class OrganizationMappingService(RpcService):

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/impl.py
@@ -17,7 +17,7 @@ from sentry.services.hybrid_cloud.organizationmember_mapping import (
 from sentry.services.hybrid_cloud.organizationmember_mapping.serial import (
     serialize_org_member_mapping,
 )
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 
 
 class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingService):

--- a/src/sentry/services/hybrid_cloud/organizationmember_mapping/service.py
+++ b/src/sentry/services/hybrid_cloud/organizationmember_mapping/service.py
@@ -10,7 +10,7 @@ from sentry.services.hybrid_cloud.organizationmember_mapping import (
     RpcOrganizationMemberMappingUpdate,
 )
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class OrganizationMemberMappingService(RpcService):

--- a/src/sentry/services/hybrid_cloud/orgauthtoken/service.py
+++ b/src/sentry/services/hybrid_cloud/orgauthtoken/service.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from sentry.services.hybrid_cloud import silo_mode_delegation
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class OrgAuthTokenService(RpcService):

--- a/src/sentry/services/hybrid_cloud/project/service.py
+++ b/src/sentry/services/hybrid_cloud/project/service.py
@@ -20,7 +20,7 @@ from sentry.services.hybrid_cloud.region import (
 )
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
 from sentry.services.hybrid_cloud.user import RpcUser
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class ProjectService(RpcService):

--- a/src/sentry/services/hybrid_cloud/project_key/service.py
+++ b/src/sentry/services/hybrid_cloud/project_key/service.py
@@ -8,7 +8,7 @@ from abc import abstractmethod
 from sentry.services.hybrid_cloud.project_key import ProjectKeyRole, RpcProjectKey
 from sentry.services.hybrid_cloud.region import ByOrganizationId, ByRegionName
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class ProjectKeyService(RpcService):

--- a/src/sentry/services/hybrid_cloud/replica/service.py
+++ b/src/sentry/services/hybrid_cloud/replica/service.py
@@ -14,7 +14,7 @@ from sentry.services.hybrid_cloud.organization import RpcOrganizationMemberTeam,
 from sentry.services.hybrid_cloud.orgauthtoken.model import RpcOrgAuthToken
 from sentry.services.hybrid_cloud.region import ByRegionName
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method, rpc_method
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class ControlReplicaService(RpcService):

--- a/src/sentry/services/hybrid_cloud/repository/service.py
+++ b/src/sentry/services/hybrid_cloud/repository/service.py
@@ -11,7 +11,7 @@ from sentry.services.hybrid_cloud.repository import RpcRepository
 from sentry.services.hybrid_cloud.repository.model import RpcCreateRepository
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method
 from sentry.services.hybrid_cloud.user.model import RpcUser
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class RepositoryService(RpcService):

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -22,7 +22,7 @@ from sentry import options
 from sentry.services.hybrid_cloud import ArgumentDict, DelegatedBySiloMode, RpcModel
 from sentry.services.hybrid_cloud.rpcmetrics import RpcMetricRecord
 from sentry.services.hybrid_cloud.sig import SerializableFunctionSignature
-from sentry.silo import SiloMode, SingleProcessSiloModeState
+from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.types.region import Region, RegionMappingNotFound
 from sentry.utils import json, metrics
 from sentry.utils.env import in_test_environment

--- a/src/sentry/services/hybrid_cloud/tombstone/service.py
+++ b/src/sentry/services/hybrid_cloud/tombstone/service.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from sentry.services.hybrid_cloud.region import ByRegionName
 from sentry.services.hybrid_cloud.rpc import RpcService, regional_rpc_method, rpc_method
 from sentry.services.hybrid_cloud.tombstone import RpcTombstone
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 # the tombstone service itself is unaware of model mapping, that is the responsibility of the caller and the outbox

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -23,7 +23,7 @@ from sentry.services.hybrid_cloud.user.model import (
     RpcVerifyUserEmail,
     UserIdEmailArgs,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 class UserService(RpcService):

--- a/src/sentry/services/hybrid_cloud/user_option/service.py
+++ b/src/sentry/services/hybrid_cloud/user_option/service.py
@@ -11,7 +11,7 @@ from sentry.services.hybrid_cloud.filter_query import OpaqueSerializedResponse
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user_option import RpcUserOption, UserOptionFilterArgs
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 
 
 def get_option_from_list(

--- a/src/sentry/services/organization/provisioning.py
+++ b/src/sentry/services/organization/provisioning.py
@@ -15,7 +15,7 @@ from sentry.models.organizationslugreservation import (
 from sentry.models.outbox import OutboxCategory, outbox_context, process_control_outbox
 from sentry.services.hybrid_cloud.organization import RpcOrganization, organization_service
 from sentry.services.organization.model import OrganizationProvisioningOptions
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.types.region import get_local_region
 
 

--- a/src/sentry/silo/__init__.py
+++ b/src/sentry/silo/__init__.py
@@ -1,2 +1,0 @@
-from .base import *  # NOQA
-from .safety import *  # NOQA

--- a/src/sentry/silo/patches/silo_aware_transaction_patch.py
+++ b/src/sentry/silo/patches/silo_aware_transaction_patch.py
@@ -89,7 +89,7 @@ def is_in_test_case_body() -> bool:
 
 def validate_transaction_using_for_silo_mode(using: str | None):
     from sentry.models.outbox import ControlOutbox, RegionOutbox
-    from sentry.silo import SiloMode
+    from sentry.silo.base import SiloMode
 
     if using is None:
         raise TransactionMissingDBException("'using' must be specified when creating a transaction")

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -1,6 +1,6 @@
 import logging
 
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils.safe import safe_execute
 from sentry.utils.sdk import bind_organization_context

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -37,7 +37,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releasefile import ReleaseArchive, ReleaseFile, update_artifact_index
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.db import atomic_transaction

--- a/src/sentry/tasks/auth.py
+++ b/src/sentry/tasks/auth.py
@@ -17,7 +17,7 @@ from sentry.models.useremail import UserEmail
 from sentry.services.hybrid_cloud.organization.service import organization_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.tasks.base import instrumented_task, retry
 from sentry.types.region import RegionMappingNotFound

--- a/src/sentry/tasks/auto_enable_codecov.py
+++ b/src/sentry/tasks/auto_enable_codecov.py
@@ -3,7 +3,7 @@ import logging
 from sentry import audit_log, features
 from sentry.integrations.utils.codecov import has_codecov_integration
 from sentry.models.organization import Organization, OrganizationStatus
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.query import RangeQuerySetWrapper

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -10,7 +10,7 @@ from sentry.issues.ongoing import bulk_transition_group_to_ongoing
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus
 from sentry.monitoring.queues import backend
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.types.group import GroupSubStatus
 from sentry.utils import metrics

--- a/src/sentry/tasks/auto_remove_inbox.py
+++ b/src/sentry/tasks/auto_remove_inbox.py
@@ -1,6 +1,6 @@
 from sentry.db.deletion import BulkDeleteQuery
 from sentry.models.groupinbox import GroupInbox
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -15,7 +15,7 @@ from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.models.groupinbox import GroupInboxRemoveAction, remove_group_from_inbox
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.auto_ongoing_issues import log_error_if_queue_has_items
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.integrations import kick_off_status_syncs

--- a/src/sentry/tasks/backfill_outboxes.py
+++ b/src/sentry/tasks/backfill_outboxes.py
@@ -15,7 +15,7 @@ from sentry import options
 from sentry.db.models.outboxes import ControlOutboxProducingModel, RegionOutboxProducingModel
 from sentry.models.outbox import outbox_context
 from sentry.models.user import User
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.utils import json, metrics, redis
 
 

--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -19,7 +19,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.events.builder import MetricsQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import query as discover_query
 from sentry.snuba.metrics.extraction import (

--- a/src/sentry/tasks/check_auth.py
+++ b/src/sentry/tasks/check_auth.py
@@ -13,8 +13,8 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.services.hybrid_cloud.organization import RpcOrganizationMember, organization_service
-from sentry.silo import unguarded_write
 from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.env import in_test_environment

--- a/src/sentry/tasks/clear_expired_resolutions.py
+++ b/src/sentry/tasks/clear_expired_resolutions.py
@@ -3,7 +3,7 @@ from django.db.models import Q
 from sentry.models.activity import Activity
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.release import Release
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.types.activity import ActivityType
 

--- a/src/sentry/tasks/clear_expired_rulesnoozes.py
+++ b/src/sentry/tasks/clear_expired_rulesnoozes.py
@@ -1,7 +1,7 @@
 from django.utils import timezone
 
 from sentry.models.rulesnooze import RuleSnooze
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 

--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -5,7 +5,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.groupinbox import GroupInboxReason
 from sentry.models.groupsnooze import GroupSnooze
 from sentry.signals import issue_unignored
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 

--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -6,7 +6,7 @@ from sentry.models.organization import Organization
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.projectownership import ProjectOwnership
 from sentry.notifications.notifications.codeowners_auto_sync import AutoSyncNotification
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 
 

--- a/src/sentry/tasks/codeowners/update_code_owners_schema.py
+++ b/src/sentry/tasks/codeowners/update_code_owners_schema.py
@@ -8,7 +8,7 @@ from sentry.models.integrations.integration import Integration
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.services.hybrid_cloud.integration import RpcIntegration
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, load_model_from_db, retry
 
 

--- a/src/sentry/tasks/collect_project_platforms.py
+++ b/src/sentry/tasks/collect_project_platforms.py
@@ -6,7 +6,7 @@ from sentry.constants import VALID_PLATFORMS
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.projectplatform import ProjectPlatform
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -35,7 +35,7 @@ from sentry.models.pullrequest import (
 )
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.groupowner import process_suspect_commits
 from sentry.utils import metrics

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -20,7 +20,7 @@ from sentry.plugins.base import bindings
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri

--- a/src/sentry/tasks/deletion/groups.py
+++ b/src/sentry/tasks/deletion/groups.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
 from sentry.exceptions import DeleteAborted
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
 from sentry.tasks.deletion.scheduled import MAX_RETRIES, logger
 

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -24,7 +24,7 @@ from django.utils import timezone
 
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.models.tombstone import TombstoneBase
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, metrics, redis
 

--- a/src/sentry/tasks/deletion/scheduled.py
+++ b/src/sentry/tasks/deletion/scheduled.py
@@ -15,7 +15,7 @@ from sentry.models.scheduledeletion import (
     ScheduledDeletion,
 )
 from sentry.signals import pending_delete
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils.env import in_test_environment
 

--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -7,7 +7,7 @@ from sentry.digests.backends.base import InvalidState
 from sentry.digests.notifications import build_digest, split_key
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import snuba
 

--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -4,7 +4,7 @@ from sentry.auth import access
 from sentry.models.group import Group
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils.email import send_messages
 

--- a/src/sentry/tasks/files.py
+++ b/src/sentry/tasks/files.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from django.db import DatabaseError, IntegrityError, router
 from django.utils import timezone
 
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.deletion.scheduled import MAX_RETRIES
 from sentry.utils.db import atomic_transaction

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -10,7 +10,7 @@ from sentry.models.commit import Commit
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.project import Project
 from sentry.models.release import Release
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
 from sentry.utils.cache import cache

--- a/src/sentry/tasks/integrations/create_comment.py
+++ b/src/sentry/tasks/integrations/create_comment.py
@@ -2,7 +2,7 @@ from sentry import analytics
 from sentry.models.activity import Activity
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.services.hybrid_cloud.util import region_silo_function
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.integrations import should_comment_sync
 from sentry.types.activity import ActivityType

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -18,7 +18,7 @@ from sentry.models.pullrequest import PullRequestComment
 from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task

--- a/src/sentry/tasks/integrations/kick_off_status_syncs_impl.py
+++ b/src/sentry/tasks/integrations/kick_off_status_syncs_impl.py
@@ -1,5 +1,5 @@
 from sentry.models.grouplink import GroupLink
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
 
 

--- a/src/sentry/tasks/integrations/link_all_repos.py
+++ b/src/sentry/tasks/integrations/link_all_repos.py
@@ -7,7 +7,7 @@ from sentry.plugins.providers.integration_repository import (
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
 

--- a/src/sentry/tasks/integrations/migrate_repo.py
+++ b/src/sentry/tasks/integrations/migrate_repo.py
@@ -5,7 +5,7 @@ from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.repository import repository_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.integrations import logger
 

--- a/src/sentry/tasks/integrations/slack/find_channel_id_for_alert_rule.py
+++ b/src/sentry/tasks/integrations/slack/find_channel_id_for_alert_rule.py
@@ -18,7 +18,7 @@ from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 logger = logging.getLogger("sentry.integrations.slack.tasks")

--- a/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
+++ b/src/sentry/tasks/integrations/slack/find_channel_id_for_rule.py
@@ -15,7 +15,7 @@ from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, DuplicateDisplayNameError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 logger = logging.getLogger("sentry.integrations.slack.tasks")

--- a/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
+++ b/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
@@ -10,7 +10,7 @@ from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.models.useremail import UserEmail
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 logger = logging.getLogger("sentry.integrations.slack.tasks")

--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from sentry.integrations.slack.client import SlackClient
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 logger = logging.getLogger("sentry.integrations.slack.tasks")

--- a/src/sentry/tasks/integrations/sync_assignee_outbound_impl.py
+++ b/src/sentry/tasks/integrations/sync_assignee_outbound_impl.py
@@ -5,7 +5,7 @@ from sentry.models.organization import Organization
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 
 

--- a/src/sentry/tasks/integrations/sync_metadata.py
+++ b/src/sentry/tasks/integrations/sync_metadata.py
@@ -1,6 +1,6 @@
 from sentry.models.integrations.integration import Integration
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 
 

--- a/src/sentry/tasks/integrations/sync_status_inbound.py
+++ b/src/sentry/tasks/integrations/sync_status_inbound.py
@@ -13,7 +13,7 @@ from sentry.models.integrations.integration import Integration
 from sentry.models.organization import Organization
 from sentry.models.release import Release, ReleaseStatus, follows_semver_versioning_scheme
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus

--- a/src/sentry/tasks/integrations/sync_status_outbound.py
+++ b/src/sentry/tasks/integrations/sync_status_outbound.py
@@ -3,7 +3,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.integrations.integration import Integration
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
 
 

--- a/src/sentry/tasks/integrations/update_comment.py
+++ b/src/sentry/tasks/integrations/update_comment.py
@@ -2,7 +2,7 @@ from sentry import analytics
 from sentry.models.activity import Activity
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.integrations.integration import Integration
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.integrations import should_comment_sync
 from sentry.types.activity import ActivityType

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -7,7 +7,7 @@ from django.db.models import F
 from django.db.models.base import Model
 
 from sentry import eventstream, similarity, tsdb
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.tsdb.base import TSDBModel
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -23,7 +23,7 @@ from sentry.replays.lib.kafka import initialize_replays_publisher
 from sentry.sentry_metrics.client import generic_metrics_backend
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.signals import event_processed, issue_unignored, transaction_processed
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json, metrics

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -6,7 +6,7 @@ from django.db import router, transaction
 
 from sentry.models.organization import Organization
 from sentry.relay import projectconfig_cache, projectconfig_debounce_cache
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.sdk import set_current_event_project

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -46,7 +46,7 @@ from sentry.services.hybrid_cloud.lost_password_hash import lost_password_hash_s
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.signals import relocated, relocation_redeem_promo_code
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json
 from sentry.utils.db import atomic_transaction

--- a/src/sentry/tasks/repository.py
+++ b/src/sentry/tasks/repository.py
@@ -2,7 +2,7 @@ from sentry.deletions import default_manager
 from sentry.deletions.base import _delete_children
 from sentry.deletions.defaults.repository import _get_repository_child_relations
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 
 

--- a/src/sentry/tasks/reprocessing.py
+++ b/src/sentry/tasks/reprocessing.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils.locking import UnableToAcquireLock
 

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -11,7 +11,7 @@ from sentry import eventstore, eventstream, nodestore
 from sentry.eventstore.models import Event
 from sentry.models.project import Project
 from sentry.reprocessing2 import buffered_delete_old_primary_hash
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.process_buffer import buffer_incr
 from sentry.types.activity import ActivityType

--- a/src/sentry/tasks/sentry_functions.py
+++ b/src/sentry/tasks/sentry_functions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sentry.api.serializers import serialize
 from sentry.models.group import Group
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import json
 from sentry.utils.cloudfunctions import publish_message

--- a/src/sentry/tasks/servicehooks.py
+++ b/src/sentry/tasks/servicehooks.py
@@ -3,7 +3,7 @@ from time import time
 from sentry.api.serializers import serialize
 from sentry.http import safe_urlopen
 from sentry.models.servicehook import ServiceHook
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tsdb.base import TSDBModel
 from sentry.utils import json

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -23,7 +23,7 @@ from sentry.models.activity import Activity
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.stacktraces.processing import process_stacktraces, should_process_for_stacktraces
 from sentry.tasks.base import instrumented_task
 from sentry.types.activity import ActivityType

--- a/src/sentry/tasks/summaries/daily_summary.py
+++ b/src/sentry/tasks/summaries/daily_summary.py
@@ -22,7 +22,7 @@ from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.notifications import notifications_service
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.services.hybrid_cloud.user_option import user_option_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.summaries.utils import (

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -20,7 +20,7 @@ from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.notifications import notifications_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task, retry
 from sentry.tasks.summaries.utils import (

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -17,7 +17,7 @@ from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorPlatform, 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.processing import realtime_metrics
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.stacktraces.processing import StacktraceInfo, find_stacktraces_in_data
 from sentry.tasks import store
 from sentry.tasks.base import instrumented_task

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -24,7 +24,7 @@ from sentry.models.grouprelease import GroupRelease
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.userreport import UserReport
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.tsdb.base import TSDBModel
 from sentry.types.activity import ActivityType

--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -8,7 +8,7 @@ from sentry import eventstore, features
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, shim_to_feedback
 from sentry.models.project import Project
 from sentry.models.userreport import UserReport
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils.iterators import chunked
 

--- a/src/sentry/tasks/user_report.py
+++ b/src/sentry/tasks/user_report.py
@@ -1,4 +1,4 @@
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils.safe import safe_execute
 

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -8,7 +8,7 @@ from sentry.constants import ObjectStatus
 from sentry.issues.forecasts import generate_and_save_forecasts
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.types.group import GroupSubStatus
 from sentry.utils.iterators import chunked

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -2,7 +2,7 @@ from django.http import StreamingHttpResponse
 
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.commitfilechange import CommitFileChange
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -116,7 +116,7 @@ from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.aggregation_option_registry import AggregationOption
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.use_case_id_registry import METRIC_PATH_MAPPING, UseCaseID
-from sentry.silo import SiloMode, SingleProcessSiloModeState
+from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics.datasource import get_series
 from sentry.snuba.metrics.extraction import OnDemandMetricSpec

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -141,7 +141,7 @@ from sentry.services.hybrid_cloud.organization import RpcOrganization
 from sentry.services.hybrid_cloud.organization.model import RpcUserOrganizationContext
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.signals import project_created
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -24,7 +24,7 @@ from sentry.models.project import Project
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.organization import RpcOrganization
 from sentry.services.hybrid_cloud.user import RpcUser
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -94,8 +94,8 @@ from sentry.models.userrole import UserRole, UserRoleUser
 from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.nodestore.django.models import Node
 from sentry.sentry_apps.apps import SentryAppUpdater
-from sentry.silo import unguarded_write
 from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.silo import assume_test_silo_mode

--- a/src/sentry/testutils/helpers/slack.py
+++ b/src/sentry/testutils/helpers/slack.py
@@ -10,7 +10,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.organization import Organization
 from sentry.models.team import Team
 from sentry.models.user import User
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json

--- a/src/sentry/testutils/hybrid_cloud.py
+++ b/src/sentry/testutils/hybrid_cloud.py
@@ -17,7 +17,7 @@ from sentry.db.postgres.transactions import in_test_transaction_enforcement
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.scheduledeletion import BaseScheduledDeletion, get_regional_scheduled_deletion
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 
 

--- a/src/sentry/testutils/outbox.py
+++ b/src/sentry/testutils/outbox.py
@@ -9,7 +9,7 @@ from django.core.handlers.wsgi import WSGIRequest
 
 from sentry.hybridcloud.models.webhookpayload import THE_PAST, WebhookPayload
 from sentry.models.outbox import OutboxBase
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deliver_from_outbox import enqueue_outbox_jobs, enqueue_outbox_jobs_control
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -16,7 +16,7 @@ from django.conf import settings
 from sentry_sdk import Hub
 
 from sentry.runner.importer import install_plugin_apps
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.region import TestEnvRegionDirectory
 from sentry.testutils.silo import monkey_patch_single_process_silo_mode_state
 from sentry.types import region

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -20,7 +20,8 @@ from django.db.models import Model
 from django.db.models.fields.related import RelatedField
 from django.test import override_settings
 
-from sentry.silo import SiloMode, SingleProcessSiloModeState, match_fence_query
+from sentry.silo.base import SiloMode, SingleProcessSiloModeState
+from sentry.silo.safety import match_fence_query
 from sentry.testutils.region import get_test_env_directory, override_regions
 from sentry.types.region import Region, RegionCategory
 from sentry.utils.snowflake import SnowflakeIdMixin

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -13,7 +13,7 @@ from pydantic.tools import parse_obj_as
 
 from sentry import options
 from sentry.services.hybrid_cloud.util import control_silo_function
-from sentry.silo import SiloMode, SingleProcessSiloModeState
+from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.utils import json
 from sentry.utils.env import in_test_environment
 

--- a/src/sentry/utils/migrations.py
+++ b/src/sentry/utils/migrations.py
@@ -1,7 +1,7 @@
 from django.db import router
 from django.db.models import F
 
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
 
 

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -44,8 +44,7 @@ from sentry.services.hybrid_cloud.organization import (
     organization_service,
 )
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloLimit
-from sentry.silo.base import SiloMode
+from sentry.silo.base import SiloLimit, SiloMode
 from sentry.types.region import subdomain_is_region
 from sentry.utils import auth
 from sentry.utils.audit import create_audit_entry

--- a/tests/acceptance/test_proxy.py
+++ b/tests/acceptance/test_proxy.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient
 from sentry.models.apikey import ApiKey
 from sentry.models.organization import Organization
 from sentry.models.team import Team
-from sentry.silo import SiloMode, SingleProcessSiloModeState
+from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.testutils.asserts import assert_status_code
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import Factories

--- a/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issue_details.py
+++ b/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issue_details.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 
 

--- a/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issues.py
+++ b/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issues.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import responses
 from django.db import connections
 
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.pytest.sentry import get_default_silo_mode_for_test_cases
 
 pytest_plugins = ["sentry.testutils.pytest"]

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import AuthProviderTestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -35,7 +35,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
@@ -14,7 +14,7 @@ from sentry.models.notificationaction import (
     NotificationActionProject,
 )
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
@@ -14,7 +14,7 @@ from sentry.models.notificationaction import (
     NotificationActionProject,
 )
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -15,7 +15,8 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.outbox import outbox_context
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 
 from sentry import newsletter
 from sentry.receivers import create_default_projects
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -18,7 +18,7 @@ from sentry.api.utils import generate_region_url
 from sentry.models.apitoken import ApiToken
 from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.utils import MAX_FILE_SIZE
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -10,7 +10,7 @@ from sentry.models.files.file import File
 from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.fileblobindex import FileBlobIndex
 from sentry.models.files.fileblobowner import FileBlobOwner
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.assemble import (
     AssembleTask,
     ChunkFileState,

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -24,7 +24,7 @@ from sentry.models.grouptombstone import GroupTombstone
 from sentry.models.release import Release
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.plugins.base import plugins
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import freeze_time

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -6,7 +6,7 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.notifications.types import GroupSubscriptionReason
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.merge import merge_groups
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -9,7 +9,7 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.notifications.types import GroupSubscriptionReason
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType

--- a/tests/sentry/api/endpoints/test_organization_api_key_details.py
+++ b/tests/sentry/api/endpoints/test_organization_api_key_details.py
@@ -1,6 +1,6 @@
 from sentry.hybridcloud.models import ApiKeyReplica
 from sentry.models.apikey import ApiKey
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_artifactbundle_assemble.py
@@ -9,7 +9,7 @@ from sentry.models.apitoken import ApiToken
 from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.fileblobowner import FileBlobOwner
 from sentry.models.orgauthtoken import OrgAuthToken
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.assemble import ChunkFileState, assemble_artifacts
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/api/endpoints/test_organization_codeowners_associations.py
+++ b/tests/sentry/api/endpoints/test_organization_codeowners_associations.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 
 from sentry.api.validators.project_codeowners import validate_codeowners_associations
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_derive_code_mappings.py
@@ -7,7 +7,8 @@ from rest_framework import status
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -34,7 +34,7 @@ from sentry.models.organizationslugreservation import OrganizationSlugReservatio
 from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.models.user import User
 from sentry.signals import project_created
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import APITestCase, TwoFactorAPITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -13,7 +13,7 @@ from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.slug.patterns import ORG_SLUG_PATTERN
 from sentry.testutils.cases import APITestCase, TwoFactorAPITestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin

--- a/tests/sentry/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_details.py
@@ -7,7 +7,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.repository import Repository
 from sentry.models.scheduledeletion import ScheduledDeletion
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -6,7 +6,7 @@ from responses import matchers
 
 from sentry.integrations.aws_lambda.integration import AwsLambdaIntegration
 from sentry.models.projectkey import ProjectKey
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/api/endpoints/test_organization_invite_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_details.py
@@ -6,7 +6,7 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -8,7 +8,7 @@ from django.core import mail
 from sentry.models.authprovider import AuthProvider
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.slack import get_blocks_and_fallback_text

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -14,7 +14,7 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.roles import organization_roles
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -12,7 +12,7 @@ from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.useremail import UserEmail
 from sentry.roles import organization_roles
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -10,7 +10,7 @@ from rest_framework.exceptions import ErrorDetail
 from sentry.models.apitoken import ApiToken
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.metrics import (
     DERIVED_METRICS,
     SessionMRI,

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 
 from sentry.models.apikey import ApiKey
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba

--- a/tests/sentry/api/endpoints/test_organization_release_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_release_assemble.py
@@ -8,7 +8,7 @@ from sentry.models.apitoken import ApiToken
 from sentry.models.artifactbundle import ArtifactBundle
 from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.fileblobowner import FileBlobOwner
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.assemble import ChunkFileState, assemble_artifacts
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -18,7 +18,7 @@ from sentry.models.releasefile import ReleaseFile
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -34,7 +34,7 @@ from sentry.search.events.constants import (
     SEMVER_BUILD_ALIAS,
     SEMVER_PACKAGE_ALIAS,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import (
     APITestCase,
     BaseMetricsTestCase,

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -8,7 +8,7 @@ from sentry.models.commit import Commit
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.repository import Repository
 from sentry.models.scheduledeletion import RegionScheduledDeletion
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -26,7 +26,8 @@ from sentry.models.projectredirect import ProjectRedirect
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.rule import Rule
 from sentry.models.scheduledeletion import RegionScheduledDeletion
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.slug.errors import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature, with_feature

--- a/tests/sentry/api/endpoints/test_project_grouping_configs.py
+++ b/tests/sentry/api/endpoints/test_project_grouping_configs.py
@@ -3,7 +3,7 @@ from unittest import mock
 from django.urls import reverse
 
 from sentry.models.apitoken import ApiToken
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -8,8 +8,8 @@ from sentry.models.apitoken import ApiToken
 from sentry.models.integrations.sentry_app_installation_token import SentryAppInstallationToken
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey
-from sentry.silo import unguarded_write
 from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.tasks.deletion.hybrid_cloud import (
     schedule_hybrid_cloud_foreign_key_jobs,
     schedule_hybrid_cloud_foreign_key_jobs_control,

--- a/tests/sentry/api/endpoints/test_project_metrics_visibility.py
+++ b/tests/sentry/api/endpoints/test_project_metrics_visibility.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 from sentry.models.apitoken import ApiToken
 from sentry.sentry_metrics.visibility import get_metrics_blocking_state
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import ErrorDetail
 from sentry import audit_log
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.projectownership import ProjectOwnership
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/api/endpoints/test_project_plugin_details.py
+++ b/tests/sentry/api/endpoints/test_project_plugin_details.py
@@ -4,7 +4,7 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.options.project_option import ProjectOption
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.notify import NotificationPlugin
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -15,7 +15,7 @@ from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, ReleaseCommitPatchTest, TestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 
 from sentry.api.endpoints.project_repo_path_parsing import PathMappingSerializer
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -19,7 +19,7 @@ from sentry.models.actor import Actor, get_actor_for_user
 from sentry.models.environment import Environment
 from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityType
 from sentry.models.rulefirehistory import RuleFireHistory
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import freeze_time

--- a/tests/sentry/api/endpoints/test_project_rule_enable.py
+++ b/tests/sentry/api/endpoints/test_project_rule_enable.py
@@ -6,7 +6,7 @@ from sentry import audit_log
 from sentry.constants import ObjectStatus
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.rule import Rule
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -19,7 +19,7 @@ from sentry.models.actor import get_actor_for_user
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.models.user import User
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.integrations.slack.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack, with_feature

--- a/tests/sentry/api/endpoints/test_scim_user_details.py
+++ b/tests/sentry/api/endpoints/test_scim_user_details.py
@@ -7,7 +7,7 @@ from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmember import OrganizationMember
 from sentry.scim.endpoints.utils import SCIMFilterError, parse_filter_conditions
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SCIMAzureTestCase, SCIMTestCase
 from sentry.testutils.silo import assume_test_silo_mode, no_silo_test
 

--- a/tests/sentry/api/endpoints/test_scim_user_index.py
+++ b/tests/sentry/api/endpoints/test_scim_user_index.py
@@ -9,7 +9,7 @@ from sentry import audit_log
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.scim.endpoints.utils import SCIMQueryParamSerializer
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import SCIMAzureTestCase, SCIMTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from sentry.mediators.token_exchange.util import GrantTypes
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.apitoken import ApiToken
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.testutils.skips import requires_snuba

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -9,7 +9,7 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.organizationmember import OrganizationMember
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.options import override_options

--- a/tests/sentry/api/endpoints/test_team_members.py
+++ b/tests/sentry/api/endpoints/test_team_members.py
@@ -1,5 +1,5 @@
 from sentry.models.organizationmember import InviteStatus
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -12,7 +12,8 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.useremail import UserEmail
 from sentry.services.hybrid_cloud.organization.serial import serialize_member
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -17,7 +17,7 @@ from sentry.notifications.types import (
     NotificationSettingEnum,
     NotificationSettingsOptionEnum,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -29,7 +29,7 @@ from sentry.services.hybrid_cloud.rpc import (
     RpcAuthenticationSetupException,
     generate_request_signature,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -15,7 +15,7 @@ from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.permissions import SuperuserPermission
 from sentry.models.apikey import ApiKey
 from sentry.services.hybrid_cloud.util import FunctionSiloLimit
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.options import override_options

--- a/tests/sentry/api/test_invite_helper.py
+++ b/tests/sentry/api/test_invite_helper.py
@@ -4,7 +4,7 @@ from django.http import HttpRequest
 from sentry.api.invite_helper import ApiInviteHelper
 from sentry.models.organizationmember import OrganizationMember
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -19,7 +19,7 @@ from sentry.models.user import User
 from sentry.models.userrole import UserRole
 from sentry.services.hybrid_cloud.access.service import access_service
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, no_silo_test

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -18,7 +18,7 @@ from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.outbox import outbox_context
 from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organization
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test

--- a/tests/sentry/auth/test_idpmigration.py
+++ b/tests/sentry/auth/test_idpmigration.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 import sentry.auth.idpmigration as idpmigration
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmember import OrganizationMember
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json

--- a/tests/sentry/db/test_transactions.py
+++ b/tests/sentry/db/test_transactions.py
@@ -14,7 +14,7 @@ from sentry.models.organization import Organization
 from sentry.models.outbox import outbox_context
 from sentry.models.user import User
 from sentry.services.hybrid_cloud import silo_mode_delegation
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.hybrid_cloud import collect_transaction_queries

--- a/tests/sentry/deletions/test_apiapplication.py
+++ b/tests/sentry/deletions/test_apiapplication.py
@@ -3,7 +3,7 @@ from sentry.models.apigrant import ApiGrant
 from sentry.models.apitoken import ApiToken
 from sentry.models.scheduledeletion import ScheduledDeletion
 from sentry.models.servicehook import ServiceHook
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions_control
 from sentry.testutils.cases import TransactionTestCase

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -22,7 +22,7 @@ from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.models import SnubaQuery
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TransactionTestCase

--- a/tests/sentry/deletions/test_release.py
+++ b/tests/sentry/deletions/test_release.py
@@ -4,7 +4,7 @@ from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releasefile import ReleaseFile
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TransactionTestCase

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -11,8 +11,8 @@ from sentry.models.integrations.sentry_app_installation_for_provider import (
 )
 from sentry.models.servicehook import ServiceHook
 from sentry.sentry_apps.installations import SentryAppInstallationCreator
-from sentry.silo import unguarded_write
 from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/hybridcloud/apigateway/test_apigateway.py
+++ b/tests/sentry/hybridcloud/apigateway/test_apigateway.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 from django.urls import get_resolver, reverse
 from rest_framework.response import Response
 
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.helpers.apigateway import ApiGatewayTestCase, verify_request_params
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.silo import control_silo_test

--- a/tests/sentry/hybridcloud/rpc_services/test_control_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/rpc_services/test_control_organization_provisioning.py
@@ -23,7 +23,7 @@ from sentry.services.organization import (
     OrganizationProvisioningOptions,
     PostProvisionOptions,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, create_test_regions
 from sentry.types.region import get_local_region

--- a/tests/sentry/hybridcloud/rpc_services/test_region_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/rpc_services/test_region_organization_provisioning.py
@@ -21,7 +21,7 @@ from sentry.services.organization import (
     OrganizationProvisioningOptions,
     PostProvisionOptions,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, create_test_regions
 

--- a/tests/sentry/hybridcloud/test_auth.py
+++ b/tests/sentry/hybridcloud/test_auth.py
@@ -9,7 +9,7 @@ from sentry.services.hybrid_cloud.auth import (
     auth_service,
 )
 from sentry.signals import receivers_raise_on_send
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all

--- a/tests/sentry/hybridcloud/test_caching.py
+++ b/tests/sentry/hybridcloud/test_caching.py
@@ -12,7 +12,7 @@ from sentry.services.hybrid_cloud.organization.model import RpcOrganizationSumma
 from sentry.services.hybrid_cloud.organization.service import organization_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, no_silo_test

--- a/tests/sentry/hybridcloud/test_hook_service.py
+++ b/tests/sentry/hybridcloud/test_hook_service.py
@@ -1,7 +1,7 @@
 from sentry.models.servicehook import ServiceHook
 from sentry.sentry_apps.apps import consolidate_events, expand_events
 from sentry.services.hybrid_cloud.hook import hook_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 

--- a/tests/sentry/hybridcloud/test_integration.py
+++ b/tests/sentry/hybridcloud/test_integration.py
@@ -16,7 +16,7 @@ from sentry.services.hybrid_cloud.integration.serial import (
     serialize_integration,
     serialize_organization_integration,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode

--- a/tests/sentry/hybridcloud/test_log.py
+++ b/tests/sentry/hybridcloud/test_log.py
@@ -3,7 +3,7 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.outbox import OutboxScope, RegionOutbox
 from sentry.models.userip import UserIP
 from sentry.services.hybrid_cloud.log import AuditLogEvent, UserIpEvent, log_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode

--- a/tests/sentry/hybridcloud/test_organization.py
+++ b/tests/sentry/hybridcloud/test_organization.py
@@ -21,7 +21,7 @@ from sentry.services.hybrid_cloud.organization import (
 )
 from sentry.services.hybrid_cloud.organization.serial import serialize_member, unescape_flag_name
 from sentry.services.hybrid_cloud.project import RpcProject
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.task_runner import TaskRunner

--- a/tests/sentry/hybridcloud/test_organizationmapping.py
+++ b/tests/sentry/hybridcloud/test_organizationmapping.py
@@ -14,7 +14,7 @@ from sentry.services.hybrid_cloud.organization_mapping import (
 from sentry.services.hybrid_cloud.organization_mapping.serial import (
     update_organization_mapping_from_instance,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.silo import (
     assume_test_silo_mode,

--- a/tests/sentry/hybridcloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybridcloud/test_organizationmembermapping.py
@@ -6,7 +6,7 @@ from sentry.services.hybrid_cloud.organizationmember_mapping import (
     RpcOrganizationMemberMappingUpdate,
     organizationmember_mapping_service,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/hybridcloud/test_region.py
+++ b/tests/sentry/hybridcloud/test_region.py
@@ -9,7 +9,7 @@ from sentry.services.hybrid_cloud.region import (
     ByOrganizationSlug,
     RequireSingleOrganization,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test

--- a/tests/sentry/hybridcloud/test_replica.py
+++ b/tests/sentry/hybridcloud/test_replica.py
@@ -8,7 +8,7 @@ from sentry.models.outbox import outbox_context
 from sentry.models.teamreplica import TeamReplica
 from sentry.services.hybrid_cloud.auth.serial import serialize_auth_provider
 from sentry.services.hybrid_cloud.replica import region_replica_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all

--- a/tests/sentry/hybridcloud/test_rpc.py
+++ b/tests/sentry/hybridcloud/test_rpc.py
@@ -25,7 +25,8 @@ from sentry.services.hybrid_cloud.rpc import (
 )
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.region import override_regions

--- a/tests/sentry/hybridcloud/test_tombstone.py
+++ b/tests/sentry/hybridcloud/test_tombstone.py
@@ -1,5 +1,5 @@
 from sentry.models.tombstone import ControlTombstone, RegionTombstone
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -6,7 +6,7 @@ import responses
 from sentry.incidents.action_handlers import MsTeamsActionHandler
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import IncidentStatus
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -10,7 +10,7 @@ from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod
 from sentry.integrations.pagerduty.utils import add_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -11,7 +11,7 @@ from sentry.models.integrations import SentryAppComponent, SentryAppInstallation
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.app.serial import serialize_sentry_app_installation
 from sentry.services.hybrid_cloud.integration.serial import serialize_integration
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -30,7 +30,7 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -23,7 +23,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.outbox import outbox_context
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 from sentry.incidents.models.incident import IncidentActivity, IncidentActivityType
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -2,7 +2,7 @@ from functools import cached_property
 
 from sentry.api.serializers import serialize
 from sentry.incidents.models.incident import Incident, IncidentActivity, IncidentStatus
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -5,7 +5,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.auditlogentry import AuditLogEntry
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -4,7 +4,7 @@ from sentry import audit_log
 from sentry.api.serializers import serialize
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.auditlogentry import AuditLogEntry
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -40,7 +40,7 @@ from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.serial import serialize_integration
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -80,7 +80,7 @@ from sentry.models.group import GroupStatus
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.integration.serial import serialize_integration
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError, ApiTimeoutError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -13,7 +13,7 @@ from sentry.pipeline import PipelineView
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.project import project_service
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/integrations/bitbucket/test_repository.py
+++ b/tests/sentry/integrations/bitbucket/test_repository.py
@@ -9,7 +9,7 @@ from fixtures.bitbucket import COMMIT_DIFF_PATCH, COMPARE_COMMITS_EXAMPLE, REPO
 from sentry.integrations.bitbucket.repository import BitbucketRepositoryProvider
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationRepositoryTestCase, TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/integrations/bitbucket_server/test_repository.py
+++ b/tests/sentry/integrations/bitbucket_server/test_repository.py
@@ -20,7 +20,7 @@ from sentry.integrations.bitbucket_server.repository import BitbucketServerRepos
 from sentry.models.identity import Identity, IdentityStatus
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/integrations/bitbucket_server/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket_server/test_webhook.py
@@ -8,7 +8,7 @@ from fixtures.bitbucket_server import EXAMPLE_PRIVATE_KEY
 from sentry.integrations.bitbucket_server.webhook import PROVIDER_NAME
 from sentry.models.identity import Identity
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -11,7 +11,7 @@ from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_commit_shape
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -25,7 +25,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -7,7 +7,7 @@ from django.test import RequestFactory
 
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
 from sentry.models.integrations.external_issue import ExternalIssue
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_URL_HEADER, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import IntegratedApiTestCase, TestCase
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/integrations/github_enterprise/test_repository.py
+++ b/tests/sentry/integrations/github_enterprise/test_repository.py
@@ -3,7 +3,7 @@ from functools import cached_property
 import responses
 
 from sentry.integrations.github_enterprise.repository import GitHubEnterpriseRepositoryProvider
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -9,7 +9,7 @@ from sentry.models.identity import Identity
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_commit_shape
 from sentry.testutils.cases import IntegrationRepositoryTestCase
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -11,7 +11,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.grouplink import GroupLink
 from sentry.models.integrations import Integration
 from sentry.models.pullrequest import PullRequest
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
 from sentry.utils import json
 

--- a/tests/sentry/integrations/jira_server/__init__.py
+++ b/tests/sentry/integrations/jira_server/__init__.py
@@ -9,7 +9,7 @@ from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.integrations.integration import Integration
 from sentry.models.organization import Organization
 from sentry.models.user import User
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 
 EXAMPLE_PRIVATE_KEY = """-----BEGIN RSA PRIVATE KEY-----

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -19,8 +19,8 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.silo import unguarded_write
 from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -7,7 +7,7 @@ from requests.exceptions import ConnectionError
 from sentry.integrations.jira_server.integration import JiraServerIntegration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.integration.serial import serialize_integration
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -15,7 +15,7 @@ from sentry.models.authprovider import AuthProvider
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.identity import Identity, IdentityStatus
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from sentry.integrations.msteams.utils import ACTION_TYPE
 from sentry.models.identity import Identity
 from sentry.models.integrations.integration import Integration
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import jwt

--- a/tests/sentry/integrations/opsgenie/test_notify_action.py
+++ b/tests/sentry/integrations/opsgenie/test_notify_action.py
@@ -6,7 +6,7 @@ import responses
 from sentry.integrations.opsgenie.actions import OpsgenieNotifyTeamAction
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -5,7 +5,7 @@ import responses
 from sentry.integrations.pagerduty.actions.notification import PagerDutyNotifyServiceAction
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.integrations.organization_integration import OrganizationIntegration
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -26,7 +26,7 @@ from sentry.ownership.grammar import Matcher, Owner
 from sentry.ownership.grammar import Rule as GrammarRule
 from sentry.ownership.grammar import dump_schema
 from sentry.plugins.base import Notification
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE, TEST_PERF_ISSUE_OCCURRENCE

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -13,7 +13,7 @@ from sentry.integrations.slack.client import SlackClient
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.integrations.integration import Integration
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -13,7 +13,7 @@ from sentry.models.integrations.external_actor import ExternalActor
 from sentry.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.models.organization import Organization
 from sentry.models.team import Team
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import add_identity, get_response_text, install_slack, link_team
 from sentry.testutils.helpers.features import with_feature

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -23,7 +23,8 @@ from sentry.models.identity import Identity
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.release import Release
 from sentry.models.team import Team
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin

--- a/tests/sentry/integrations/slack/webhooks/commands/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/__init__.py
@@ -12,7 +12,7 @@ from sentry import options
 from sentry.integrations.slack.utils import set_signing_secret
 from sentry.models.identity import Identity
 from sentry.models.team import Team
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers import find_identity, install_slack, link_team, link_user
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -8,7 +8,7 @@ from sentry.integrations.slack.webhooks.command import (
     LINK_USER_FIRST_MESSAGE,
     TEAM_NOT_LINKED_MESSAGE,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.helpers import get_response_text, link_user
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json

--- a/tests/sentry/integrations/slack/webhooks/events/test_discover_link_shared.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_discover_link_shared.py
@@ -6,7 +6,7 @@ import responses
 
 from sentry.integrations.slack.unfurl import Handler, LinkType, make_type_coercer
 from sentry.models.identity import Identity, IdentityStatus
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json
 

--- a/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
@@ -1,7 +1,7 @@
 import responses
 
 from sentry.models.identity import Identity, IdentityStatus
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegratedApiTestCase
 from sentry.testutils.helpers import get_response_text
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -9,7 +9,7 @@ from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.release import Release
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -13,7 +13,8 @@ from sentry.models.repository import Repository
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.issue2 import IssuePlugin2
 from sentry.signals import receivers_raise_on_send
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test

--- a/tests/sentry/integrations/utils/test_codecov.py
+++ b/tests/sentry/integrations/utils/test_codecov.py
@@ -12,7 +12,8 @@ from sentry.integrations.utils.codecov import (
     has_codecov_integration,
 )
 from sentry.models.integrations.integration import Integration
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -17,7 +17,7 @@ from sentry.models.integrations.sentry_app_installation_token import SentryAppIn
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus
 from sentry.models.scheduledeletion import ScheduledDeletion
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -13,7 +13,7 @@ from fixtures.vercel import (
 )
 from sentry import VERSION
 from sentry.models.integrations.sentry_app_installation_token import SentryAppInstallationToken
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -15,7 +15,7 @@ from sentry.models.integrations.integration_external_project import IntegrationE
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationProviderError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 FULL_SCOPES = ["vso.code", "vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -18,7 +18,7 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.identity import Identity
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.services.hybrid_cloud.integration import RpcIntegration
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.http import absolute_uri

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -49,7 +49,7 @@ from sentry.search.events.constants import (
     SEMVER_PACKAGE_ALIAS,
 )
 from sentry.search.snuba.executors import GroupAttributesPostgresSnubaQueryExecutor
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
@@ -4,7 +4,7 @@ from unittest.mock import PropertyMock, patch
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.models.integrations.integration import Integration
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -15,7 +15,7 @@ from sentry.notifications.types import (
 )
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import ActivityTestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -43,7 +43,7 @@ from sentry.ownership.grammar import Matcher, Owner, dump_schema
 from sentry.plugins.base import Notification
 from sentry.replays.testutils import mock_replay
 from sentry.services.hybrid_cloud.actor import RpcActor
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, ReplaysSnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/middleware/integrations/test_classifications.py
+++ b/tests/sentry/middleware/integrations/test_classifications.py
@@ -10,7 +10,7 @@ from sentry.middleware.integrations.classifications import (
 from sentry.middleware.integrations.integration_control import IntegrationControlMiddleware
 from sentry.middleware.integrations.parsers.plugin import PluginRequestParser
 from sentry.middleware.integrations.parsers.slack import SlackRequestParser
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 
 

--- a/tests/sentry/middleware/integrations/test_integration_control.py
+++ b/tests/sentry/middleware/integrations/test_integration_control.py
@@ -13,7 +13,7 @@ from sentry.middleware.integrations.parsers.jira import JiraRequestParser
 from sentry.middleware.integrations.parsers.jira_server import JiraServerRequestParser
 from sentry.middleware.integrations.parsers.plugin import PluginRequestParser
 from sentry.middleware.integrations.parsers.slack import SlackRequestParser
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 
 

--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -9,7 +9,7 @@ from sentry.models.apitoken import ApiToken
 from sentry.models.userip import UserIP
 from sentry.services.hybrid_cloud.auth import AuthenticatedToken
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode

--- a/tests/sentry/middleware/test_proxy.py
+++ b/tests/sentry/middleware/test_proxy.py
@@ -6,7 +6,7 @@ from django.http import HttpRequest
 
 from sentry.middleware.proxy import SetRemoteAddrFromForwardedFor
 from sentry.models.team import Team
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.region import Region, RegionCategory

--- a/tests/sentry/migrations/test_0632_apitoken_backfill_last_chars.py
+++ b/tests/sentry/migrations/test_0632_apitoken_backfill_last_chars.py
@@ -1,6 +1,6 @@
 from django.db import router
 
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestMigrations
 from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import no_silo_test

--- a/tests/sentry/models/test_apikey.py
+++ b/tests/sentry/models/test_apikey.py
@@ -1,6 +1,6 @@
 from sentry.conf.server import SENTRY_SCOPE_HIERARCHY_MAPPING, SENTRY_SCOPES
 from sentry.hybridcloud.models import ApiKeyReplica
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/models/test_apitoken.py
+++ b/tests/sentry/models/test_apitoken.py
@@ -9,7 +9,7 @@ from sentry.hybridcloud.models import ApiTokenReplica
 from sentry.models.apitoken import ApiToken, NotSupported, PlaintextSecretAlreadyRead
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.integrations.sentry_app_installation_token import SentryAppInstallationToken
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/models/test_base.py
+++ b/tests/sentry/models/test_base.py
@@ -5,7 +5,7 @@ from pytest import raises
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models.base import Model, ModelSiloLimit, get_model_if_available
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -16,7 +16,7 @@ from sentry.notifications.types import (
 )
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.slack import link_team

--- a/tests/sentry/models/test_notificationsettingoption.py
+++ b/tests/sentry/models/test_notificationsettingoption.py
@@ -1,6 +1,6 @@
 from sentry.models.notificationsettingoption import NotificationSettingOption
 from sentry.models.user import User
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs_control
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/models/test_notificationsettingprovider.py
+++ b/tests/sentry/models/test_notificationsettingprovider.py
@@ -1,6 +1,6 @@
 from sentry.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.models.user import User
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs_control
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -22,7 +22,7 @@ from sentry.models.options.user_option import UserOption
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.user import User
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import (
     schedule_hybrid_cloud_foreign_key_jobs,
     schedule_hybrid_cloud_foreign_key_jobs_control,

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -15,7 +15,8 @@ from sentry.models.authprovider import AuthProvider
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationmember import INVITE_DAYS_VALID, InviteStatus, OrganizationMember
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin

--- a/tests/sentry/models/test_organizationslugreservation.py
+++ b/tests/sentry/models/test_organizationslugreservation.py
@@ -8,7 +8,7 @@ from sentry.models.organizationslugreservation import (
 )
 from sentry.models.organizationslugreservationreplica import OrganizationSlugReservationReplica
 from sentry.models.outbox import outbox_context
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, create_test_regions

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -23,7 +23,7 @@ from sentry.models.outbox import (
     outbox_context,
 )
 from sentry.models.user import User
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deliver_from_outbox import enqueue_outbox_jobs
 from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.testutils.factories import Factories

--- a/tests/sentry/models/test_projectkey.py
+++ b/tests/sentry/models/test_projectkey.py
@@ -4,7 +4,7 @@ import pytest
 from django.test import override_settings
 
 from sentry.models.projectkey import ProjectKey, ProjectKeyManager, ProjectKeyStatus
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import create_test_regions, region_silo_test

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -4,7 +4,7 @@ from sentry.models.savedsearch import SavedSearch
 from sentry.models.tombstone import RegionTombstone
 from sentry.models.user import User
 from sentry.models.useremail import UserEmail
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.testutils.cases import TestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -22,7 +22,7 @@ from sentry.models.options.user_option import UserOption
 from sentry.models.rule import Rule
 from sentry.notifications.notifications.activity.assigned import AssignedActivityNotification
 from sentry.notifications.notifications.activity.regression import RegressionActivityNotification
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.post_process import post_process_group
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/sentry/pipeline/test_pipeline.py
+++ b/tests/sentry/pipeline/test_pipeline.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest
 
 from sentry.pipeline import Pipeline, PipelineProvider, PipelineView
 from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organization
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/receivers/test_core.py
+++ b/tests/sentry/receivers/test_core.py
@@ -9,7 +9,7 @@ from sentry.models.projectkey import ProjectKey
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.receivers.core import DEFAULT_SENTRY_PROJECT_ID, create_default_projects
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
 

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -27,7 +27,7 @@ from sentry.signals import (
     plugin_enabled,
     project_created,
 )
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -19,7 +19,7 @@ from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
 from sentry.models.useremail import UserEmail
 from sentry.signals import buffer_incr_complete, receivers_raise_on_send
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -12,7 +12,7 @@ from sentry.models.groupassignee import GroupAssignee
 from sentry.models.grouplink import GroupLink
 from sentry.models.release import Release
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.features import with_feature

--- a/tests/sentry/receivers/test_transactions.py
+++ b/tests/sentry/receivers/test_transactions.py
@@ -6,7 +6,7 @@ from django.db import router
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.signals import event_processed, transaction_processed
-from sentry.silo import unguarded_write
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.skips import requires_snuba

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -4,7 +4,7 @@ import pytest
 from rest_framework import serializers
 
 from sentry.rules.actions.sentry_apps import NotifyEventSentryAppAction
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.sentry_apps import notify_sentry_app
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 
 from sentry.rules.actions.notify_event_service import NotifyEventServiceAction
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.sentry_apps import notify_sentry_app
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/runner/commands/test_createuser.py
+++ b/tests/sentry/runner/commands/test_createuser.py
@@ -6,7 +6,7 @@ from sentry.models.userrole import manage_default_super_admin_role
 from sentry.receivers import create_default_projects
 from sentry.runner.commands.createuser import createuser
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import CliTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/sentry_apps/test_sentry_app_component_preparer.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_component_preparer.py
@@ -3,7 +3,7 @@ from unittest.mock import call, patch
 from sentry.models.organization import Organization
 from sentry.sentry_apps.components import SentryAppComponentPreparer
 from sentry.services.hybrid_cloud.app.serial import serialize_sentry_app_installation
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
@@ -9,7 +9,7 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.servicehook import ServiceHook, ServiceHookProject
 from sentry.sentry_apps.installations import SentryAppInstallationCreator
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/sentry_apps/test_sentry_app_updater.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_updater.py
@@ -10,7 +10,7 @@ from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_component import SentryAppComponent
 from sentry.models.servicehook import ServiceHook
 from sentry.sentry_apps.apps import SentryAppUpdater, expand_events
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -9,7 +9,7 @@ from pytest import raises
 
 from sentry.shared_integrations.exceptions import ApiError, ApiHostError
 from sentry.shared_integrations.response.base import BaseApiResponse
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.silo.client import (
     CACHE_TIMEOUT,
     REQUEST_ATTEMPTS_LIMIT,

--- a/tests/sentry/silo/test_silo_aware_transaction_patch.py
+++ b/tests/sentry/silo/test_silo_aware_transaction_patch.py
@@ -4,7 +4,7 @@ from django.test import override_settings
 
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.silo.patches.silo_aware_transaction_patch import (
     MismatchedSiloTransactionError,
     TransactionMissingDBException,

--- a/tests/sentry/tasks/deletion/test_hybrid_cloud.py
+++ b/tests/sentry/tasks/deletion/test_hybrid_cloud.py
@@ -13,7 +13,7 @@ from sentry.models.integrations.integration import Integration
 from sentry.models.outbox import ControlOutbox, OutboxScope, outbox_context
 from sentry.models.savedsearch import SavedSearch
 from sentry.models.user import User
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import (
     get_watermark,
     schedule_hybrid_cloud_foreign_key_jobs,

--- a/tests/sentry/tasks/integrations/test_link_all_repos.py
+++ b/tests/sentry/tasks/integrations/test_link_all_repos.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.integrations.link_all_repos import link_all_repos
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test

--- a/tests/sentry/tasks/test_auth.py
+++ b/tests/sentry/tasks/test_auth.py
@@ -2,7 +2,7 @@ from django.core import mail
 
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmember import OrganizationMember
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.auth import (
     email_missing_links,
     email_missing_links_control,

--- a/tests/sentry/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/tasks/test_backfill_outboxes.py
@@ -12,7 +12,7 @@ from sentry.models.authproviderreplica import AuthProviderReplica
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.outbox import ControlOutbox, RegionOutbox, outbox_context
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.backfill_outboxes import (
     backfill_outboxes_for,
     get_backfill_key,

--- a/tests/sentry/tasks/test_check_auth.py
+++ b/tests/sentry/tasks/test_check_auth.py
@@ -8,7 +8,7 @@ from sentry.auth.providers.dummy import DummyProvider
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmember import OrganizationMember
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.check_auth import (
     AUTH_CHECK_INTERVAL,
     AUTH_CHECK_SKEW,

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -11,7 +11,7 @@ from sentry.models.latestreporeleaseenvironment import LatestRepoReleaseEnvironm
 from sentry.models.release import Release
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.commits import fetch_commits, handle_invalid_identity
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test

--- a/tests/sentry/tasks/test_groupowner.py
+++ b/tests/sentry/tasks/test_groupowner.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.tasks.groupowner import PREFERRED_GROUP_OWNER_AGE, process_suspect_commits
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -51,7 +51,8 @@ from sentry.replays.lib.kafka import clear_replay_publisher
 from sentry.rules import init_registry
 from sentry.rules.actions.base import EventAction
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.tasks.derive_code_mappings import SUPPORTED_LANGUAGES
 from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import (

--- a/tests/sentry/tasks/test_update_code_owners_schema.py
+++ b/tests/sentry/tasks/test_update_code_owners_schema.py
@@ -4,7 +4,7 @@ import pytest
 
 from sentry.models.integrations.integration import Integration
 from sentry.models.projectcodeowners import ProjectCodeOwners
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.tasks.codeowners import update_code_owners_schema
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -18,7 +18,8 @@ from sentry.models.notificationsettingoption import NotificationSettingOption
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.services.hybrid_cloud.user_option import user_option_service
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.summaries.utils import (
     ONE_DAY,

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -7,7 +7,8 @@ from django.test import RequestFactory, override_settings
 
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.silo import SiloLimit, SiloMode, unguarded_write
+from sentry.silo.base import SiloLimit, SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.region import get_test_env_directory
 from sentry.types.region import (

--- a/tests/sentry/utils/email/test_message_builder.py
+++ b/tests/sentry/utils/email/test_message_builder.py
@@ -9,7 +9,7 @@ from sentry.models.groupemailthread import GroupEmailThread
 from sentry.models.options.user_option import UserOption
 from sentry.models.user import User
 from sentry.models.useremail import UserEmail
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -7,7 +7,7 @@ from sentry.models.deletedorganization import DeletedOrganization
 from sentry.models.deletedproject import DeletedProject
 from sentry.models.deletedteam import DeletedTeam
 from sentry.models.organization import Organization, OrganizationStatus
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -17,7 +17,7 @@ from sentry.models.integrations.integration import Integration
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode

--- a/tests/sentry/utils/test_snowflake.py
+++ b/tests/sentry/utils/test_snowflake.py
@@ -4,7 +4,7 @@ import pytest
 from django.conf import settings
 from django.test import override_settings
 
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.region import override_regions

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -18,7 +18,7 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.user import User
 from sentry.receivers import create_default_projects
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -16,7 +16,7 @@ from sentry.models.organization import OrganizationStatus
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.useremail import UserEmail
 from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organization
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import AuthProviderTestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -17,7 +17,7 @@ from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import AuthProviderTestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.features import with_feature

--- a/tests/sentry/web/frontend/test_msteams_extension.py
+++ b/tests/sentry/web/frontend/test_msteams_extension.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from django.core.signing import SignatureExpired
 
 from sentry.models.organizationmember import OrganizationMember
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils.signing import sign

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -28,7 +28,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.signals import receivers_raise_on_send
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import AuthProviderTestCase, PermissionTestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner

--- a/tests/sentry/web/frontend/test_user_avatar.py
+++ b/tests/sentry/web/frontend/test_user_avatar.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from sentry.models.avatars.user_avatar import UserAvatar
 from sentry.models.files.control_file import ControlFile
 from sentry.models.files.file import File
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.web.frontend.generic import FOREVER_CACHE

--- a/tests/sentry/web/frontend/test_vercel_extension_configuration.py
+++ b/tests/sentry/web/frontend/test_vercel_extension_configuration.py
@@ -6,7 +6,8 @@ from django.db import router
 from sentry.identity.vercel import VercelIdentityProvider
 from sentry.integrations.vercel import VercelClient
 from sentry.models.organizationmember import OrganizationMember
-from sentry.silo import SiloMode, unguarded_write
+from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -14,7 +14,7 @@ from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization import organization_service
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.region import get_test_env_directory

--- a/tests/sentry_plugins/github/endpoints/test_pull_request_event.py
+++ b/tests/sentry_plugins/github/endpoints/test_pull_request_event.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry_plugins.github.testutils import (

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -27,7 +27,7 @@ from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.options.user_option import UserOption
 from sentry.models.release import Release
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -16,7 +16,7 @@ from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.notificationsettingoption import NotificationSettingOption
 from sentry.models.options.user_option import UserOption
 from sentry.notifications.types import NotificationSettingsOptionEnum
-from sentry.silo import SiloMode
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature


### PR DESCRIPTION
the star imports in sentry.silo.* are causing an import cycle which breaks mypy's inference of settings


<!-- Describe your PR here. -->