### PR TITLE
feat(sidebar): disable tooltip when floating accordion is open

### DIFF
--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -122,6 +122,7 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
             aria-expanded={expanded}
             aria-owns={contentId}
             onClick={handleMainItemClick}
+            isOpenInFloatingSidebar={isOpenInFloatingSidebar}
             trailingItems={
               <SidebarAccordionExpandButton
                 size="zero"

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -204,7 +204,10 @@ function SidebarItem({
 
   return (
     <Tooltip
-      disabled={!isInCollapsedState || (shouldAccordionFloat && isOpenInFloatingSidebar)}
+      disabled={
+        (!isInCollapsedState && !isTop) ||
+        (shouldAccordionFloat && isOpenInFloatingSidebar)
+      }
       title={
         <Flex align="center">
           {label} {badges}

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -204,11 +204,7 @@ function SidebarItem({
 
   return (
     <Tooltip
-      disabled={
-        !isInCollapsedState ||
-        isInFloatingAccordion ||
-        (shouldAccordionFloat && isOpenInFloatingSidebar)
-      }
+      disabled={!isInCollapsedState || (shouldAccordionFloat && isOpenInFloatingSidebar)}
       title={
         <Flex align="center">
           {label} {badges}

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -205,7 +205,9 @@ function SidebarItem({
   return (
     <Tooltip
       disabled={
-        isInFloatingAccordion || (shouldAccordionFloat && isOpenInFloatingSidebar)
+        !isInCollapsedState ||
+        isInFloatingAccordion ||
+        (shouldAccordionFloat && isOpenInFloatingSidebar)
       }
       title={
         <Flex align="center">

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -102,6 +102,10 @@ export type SidebarItemProps = {
    * An optional prefix that can be used to reset the "new" indicator
    */
   isNewSeenKeySuffix?: string;
+  /**
+   * Is this item expanded in the floating sidebar
+   */
+  isOpenInFloatingSidebar?: boolean;
   onClick?: (id: string, e: React.MouseEvent<HTMLAnchorElement>) => void;
   search?: string;
   to?: string;
@@ -138,6 +142,7 @@ function SidebarItem({
   variant,
   isNested,
   isMainItem,
+  isOpenInFloatingSidebar,
   ...props
 }: SidebarItemProps) {
   const {setExpandedItemId, shouldAccordionFloat} = useContext(ExpandedContext);
@@ -199,7 +204,9 @@ function SidebarItem({
 
   return (
     <Tooltip
-      disabled={!isInCollapsedState && !isTop}
+      disabled={
+        isInFloatingAccordion || (shouldAccordionFloat && isOpenInFloatingSidebar)
+      }
       title={
         <Flex align="center">
           {label} {badges}


### PR DESCRIPTION
Some have felt it feels a bit annoying when the tooltip overlaps the floating sidebar, this PR is up to see how people feel about the attempt to fix this, we don't have to merge this in necessarily.

In this PR i'm disabling the tooltip for the floating accordion item only. So when you click on an item with subitems, the tooltip will immediately disappear for the current item and can only reappear when you close the sub menu. This also means that all tooltips still work when nothing is open.

There are two other alternatives, let me know if there are any strong feelings towards them
1. Completely disable tooltips for all items which have sub items (I personally like have some tooltips, so I like the current solution)
2. Hide the tooltip onclick, and still allow the tooltip if you hover back onto the item (I think I like this option the most, but it sounds a little more tricky)

Before behaviour immediately after clicking the item
![image](https://github.com/getsentry/sentry/assets/44422760/df8bed79-17a1-4d7b-8427-69d153b7659e)


After behaviour immediately after clicking the item
![image](https://github.com/getsentry/sentry/assets/44422760/ab995b05-eb30-488b-8826-581b4dc6ed32)
