### PR TITLE
ref(ui): Extract useOwner{s,Options}

### DIFF
--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
@@ -139,7 +139,7 @@ describe('SentryMemberTeamSelectorField', () => {
       <SentryMemberTeamSelectorField
         label="Select Owner"
         onChange={mock}
-        memberOfProjectSlug={project.slug}
+        memberOfProjectSlugs={[project.slug]}
         name="team-or-member"
         multiple
       />

--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.tsx
@@ -1,12 +1,8 @@
-import {useContext, useEffect, useMemo} from 'react';
-import groupBy from 'lodash/groupBy';
+import {useContext, useMemo} from 'react';
 
-import Avatar from 'sentry/components/avatar';
 import {t} from 'sentry/locale';
-import type {DetailedTeam, Team} from 'sentry/types';
-import {useMembers} from 'sentry/utils/useMembers';
-import {useTeams} from 'sentry/utils/useTeams';
-import {useTeamsById} from 'sentry/utils/useTeamsById';
+import {useOwnerOptions} from 'sentry/utils/useOwnerOptions';
+import {useOwners} from 'sentry/utils/useOwners';
 
 import FormContext from '../formContext';
 
@@ -20,7 +16,7 @@ export interface RenderFieldProps extends SelectFieldProps<any> {
   /**
    * Ensures the only selectable teams are members of the given project.
    */
-  memberOfProjectSlug?: string;
+  memberOfProjectSlugs?: string[];
   /**
    * Use the slug as the select field value. Without setting this the numeric id
    * of the project will be used.
@@ -31,7 +27,7 @@ export interface RenderFieldProps extends SelectFieldProps<any> {
 function SentryMemberTeamSelectorField({
   avatarSize = 20,
   placeholder = t('Choose Teams and Members'),
-  memberOfProjectSlug,
+  memberOfProjectSlugs,
   ...props
 }: RenderFieldProps) {
   const {form} = useContext(FormContext);
@@ -45,88 +41,15 @@ function SentryMemberTeamSelectorField({
     [fieldValue]
   );
 
-  // Ensure the current value of the fields members is loaded
-  const ensureUserIds = useMemo(
-    () =>
-      currentValue?.filter(item => item.startsWith('user:')).map(user => user.slice(7)),
-    [currentValue]
-  );
-  useMembers({ids: ensureUserIds});
-
-  const {
-    members,
-    fetching: fetchingMembers,
-    onSearch: onMemberSearch,
-    loadMore: loadMoreMembers,
-  } = useMembers();
-
-  // XXX(epurkhiser): It would be nice to use an object as the value, but
-  // frustratingly that is difficult likely because we're recreating this
-  // object on every re-render.
-  const memberOptions = members?.map(member => ({
-    value: `user:${member.id}`,
-    label: member.name,
-    leadingItems: <Avatar user={member} size={avatarSize} />,
-  }));
-
-  // Ensure the current value of the fields teams is loaded
-  const ensureTeamIds = useMemo(
-    () =>
-      currentValue?.filter(item => item.startsWith('team:')).map(user => user.slice(5)),
-    [currentValue]
-  );
-  useTeamsById({ids: ensureTeamIds});
-
-  const {
+  const {teams, members, fetching, onTeamSearch, onMemberSearch} = useOwners({
+    currentValue,
+  });
+  const options = useOwnerOptions({
     teams,
-    fetching: fetchingTeams,
-    onSearch: onTeamSearch,
-    loadMore: loadMoreTeams,
-  } = useTeams();
-
-  const makeTeamOption = (team: Team) => ({
-    value: `team:${team.id}`,
-    label: `#${team.slug}`,
-    leadingItems: <Avatar team={team} size={avatarSize} />,
+    members,
+    avatarProps: {size: avatarSize},
+    memberOfProjectSlugs,
   });
-
-  const makeDisabledTeamOption = (team: Team) => ({
-    ...makeTeamOption(team),
-    disabled: true,
-    tooltip: t('%s is not a member of the selected project', `#${team.slug}`),
-    tooltipOptions: {position: 'left'},
-  });
-
-  // TODO(davidenwang): Fix the team type here to avoid this type cast: `as DetailedTeam[]`
-  const {disabledTeams, memberTeams, otherTeams} = groupBy(
-    teams as DetailedTeam[],
-    team =>
-      memberOfProjectSlug && !team.projects.some(({slug}) => memberOfProjectSlug === slug)
-        ? 'disabledTeams'
-        : team.isMember
-          ? 'memberTeams'
-          : 'otherTeams'
-  );
-
-  const myTeamOptions = memberTeams?.map(makeTeamOption) ?? [];
-  const otherTeamOptions = otherTeams?.map(makeTeamOption) ?? [];
-  const disabledTeamOptions = disabledTeams?.map(makeDisabledTeamOption) ?? [];
-
-  // TODO(epurkhiser): This is an unfortunate hack right now since we don't
-  // actually load members anywhere and the useMembers and useTeams hook don't
-  // handle initial loading of data.
-  //
-  // In the future when these things use react query we should be able to clean
-  // this up.
-  useEffect(
-    () => {
-      loadMoreMembers();
-      loadMoreTeams();
-    },
-    // Only ensure things are loaded at mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
 
   return (
     <SelectField
@@ -136,25 +59,8 @@ function SentryMemberTeamSelectorField({
         onMemberSearch(value);
         onTeamSearch(value);
       }}
-      isLoading={fetchingMembers || fetchingTeams}
-      options={[
-        {
-          label: t('Members'),
-          options: memberOptions,
-        },
-        {
-          label: t('My Teams'),
-          options: myTeamOptions,
-        },
-        {
-          label: t('Other Teams'),
-          options: otherTeamOptions,
-        },
-        {
-          label: t('Disabled Teams'),
-          options: disabledTeamOptions,
-        },
-      ]}
+      isLoading={fetching}
+      options={options}
       {...props}
     />
   );

--- a/static/app/utils/useOwnerOptions.spec.tsx
+++ b/static/app/utils/useOwnerOptions.spec.tsx
@@ -1,0 +1,146 @@
+import {ProjectFixture} from 'sentry-fixture/project';
+import {TeamFixture} from 'sentry-fixture/team';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useOwnerOptions} from './useOwnerOptions';
+
+describe('useOwnerOptions', () => {
+  const mockUsers = [UserFixture()];
+  const mockTeams = [TeamFixture()];
+
+  it('includes members and teams', () => {
+    const {result} = renderHook(useOwnerOptions, {
+      initialProps: {
+        teams: mockTeams,
+        members: mockUsers,
+      },
+    });
+
+    expect(result.current).toEqual([
+      {
+        label: 'Members',
+        options: [
+          {
+            label: 'Foo Bar',
+            value: 'user:1',
+            leadingItems: expect.anything(),
+          },
+        ],
+      },
+      {
+        label: 'My Teams',
+        options: [
+          {
+            label: '#team-slug',
+            value: 'team:1',
+            leadingItems: expect.anything(),
+          },
+        ],
+      },
+      {label: 'Other Teams', options: []},
+      {label: 'Disabled Teams', options: []},
+    ]);
+  });
+
+  it('separates my teams and other teams', () => {
+    const teams = [
+      TeamFixture(),
+      TeamFixture({id: '2', slug: 'other-team', isMember: false}),
+    ];
+
+    const {result} = renderHook(useOwnerOptions, {
+      initialProps: {teams},
+    });
+
+    expect(result.current).toEqual([
+      {
+        label: 'Members',
+        options: [],
+      },
+      {
+        label: 'My Teams',
+        options: [
+          {
+            label: '#team-slug',
+            value: 'team:1',
+            leadingItems: expect.anything(),
+          },
+        ],
+      },
+      {
+        label: 'Other Teams',
+        options: [
+          {
+            label: '#other-team',
+            value: 'team:2',
+            leadingItems: expect.anything(),
+          },
+        ],
+      },
+      {label: 'Disabled Teams', options: []},
+    ]);
+  });
+
+  it('disables teams not associated with the projects', () => {
+    const project1 = ProjectFixture();
+    const project2 = ProjectFixture({id: '2', slug: 'other-project'});
+    const teamWithProject1 = TeamFixture({projects: [project1], slug: 'my-team'});
+    const teamWithProject2 = TeamFixture({
+      id: '2',
+      projects: [project2],
+      slug: 'other-team',
+      isMember: false,
+    });
+    const teamWithoutProject = TeamFixture({id: '3', slug: 'disabled-team'});
+    const teams = [teamWithProject1, teamWithProject2, teamWithoutProject];
+
+    const {result} = renderHook(useOwnerOptions, {
+      initialProps: {
+        memberOfProjectSlugs: [project1.slug, project2.slug],
+        teams,
+      },
+    });
+
+    expect(result.current).toEqual([
+      {
+        label: 'Members',
+        options: [],
+      },
+      {
+        label: 'My Teams',
+        options: [
+          {
+            label: '#my-team',
+            value: 'team:1',
+            leadingItems: expect.anything(),
+          },
+        ],
+      },
+      {
+        label: 'Other Teams',
+        options: [
+          {
+            label: '#other-team',
+            value: 'team:2',
+            leadingItems: expect.anything(),
+          },
+        ],
+      },
+      {
+        label: 'Disabled Teams',
+        options: [
+          {
+            label: '#disabled-team',
+            value: 'team:3',
+            leadingItems: expect.anything(),
+            disabled: true,
+            tooltip: '#disabled-team is not a member of the selected projects',
+            tooltipOptions: {position: 'left'},
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/static/app/utils/useOwnerOptions.tsx
+++ b/static/app/utils/useOwnerOptions.tsx
@@ -1,7 +1,7 @@
 import groupBy from 'lodash/groupBy';
 
 import Avatar from 'sentry/components/avatar';
-import {BaseAvatarProps} from 'sentry/components/avatar/baseAvatar';
+import type {BaseAvatarProps} from 'sentry/components/avatar/baseAvatar';
 import {t} from 'sentry/locale';
 import type {DetailedTeam, Team, User} from 'sentry/types';
 

--- a/static/app/utils/useOwnerOptions.tsx
+++ b/static/app/utils/useOwnerOptions.tsx
@@ -1,0 +1,97 @@
+import groupBy from 'lodash/groupBy';
+
+import Avatar from 'sentry/components/avatar';
+import {BaseAvatarProps} from 'sentry/components/avatar/baseAvatar';
+import {t} from 'sentry/locale';
+import type {DetailedTeam, Team, User} from 'sentry/types';
+
+interface Options {
+  /**
+   * Props to pass to the leading avatar component
+   */
+  avatarProps?: BaseAvatarProps;
+  /**
+   * Filter teams that are not part of a the provided set of project slugs
+   */
+  memberOfProjectSlugs?: string[];
+  /**
+   * The users in the owner list
+   */
+  members?: User[];
+  /**
+   * The teams in the owners list
+   */
+  teams?: Team[];
+}
+
+/**
+ * Hook to transform a list of users and teams into a options list, intdended
+ * to be used with SelectControl or CompactSelect.
+ */
+export function useOwnerOptions({
+  teams,
+  members,
+  avatarProps,
+  memberOfProjectSlugs,
+}: Options) {
+  // XXX(epurkhiser): It would be nice to use an object as the value, but
+  // frustratingly that is difficult likely because we're recreating this
+  // object on every re-render.
+  const memberOptions =
+    members?.map(member => ({
+      value: `user:${member.id}`,
+      label: member.name,
+      leadingItems: <Avatar user={member} {...avatarProps} />,
+    })) ?? [];
+
+  const makeTeamOption = (team: Team) => ({
+    value: `team:${team.id}`,
+    label: `#${team.slug}`,
+    leadingItems: <Avatar team={team} {...avatarProps} />,
+  });
+
+  const makeDisabledTeamOption = (team: Team) => ({
+    ...makeTeamOption(team),
+    disabled: true,
+    tooltip: t('%s is not a member of the selected projects', `#${team.slug}`),
+    tooltipOptions: {position: 'left'},
+  });
+
+  const {disabledTeams, memberTeams, otherTeams} = groupBy(
+    teams as DetailedTeam[],
+    team => {
+      if (
+        memberOfProjectSlugs &&
+        !team.projects.some(({slug}) => memberOfProjectSlugs.includes(slug))
+      ) {
+        return 'disabledTeams';
+      }
+      return team.isMember ? 'memberTeams' : 'otherTeams';
+    }
+  );
+
+  const myTeamOptions = memberTeams?.map(makeTeamOption) ?? [];
+  const otherTeamOptions = otherTeams?.map(makeTeamOption) ?? [];
+  const disabledTeamOptions = disabledTeams?.map(makeDisabledTeamOption) ?? [];
+
+  const options = [
+    {
+      label: t('Members'),
+      options: memberOptions,
+    },
+    {
+      label: t('My Teams'),
+      options: myTeamOptions,
+    },
+    {
+      label: t('Other Teams'),
+      options: otherTeamOptions,
+    },
+    {
+      label: t('Disabled Teams'),
+      options: disabledTeamOptions,
+    },
+  ];
+
+  return options;
+}

--- a/static/app/utils/useOwners.spec.tsx
+++ b/static/app/utils/useOwners.spec.tsx
@@ -1,0 +1,58 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {TeamFixture} from 'sentry-fixture/team';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import MemberListStore from 'sentry/stores/memberListStore';
+import OrganizationStore from 'sentry/stores/organizationStore';
+import TeamStore from 'sentry/stores/teamStore';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+
+import {useOwners} from './useOwners';
+
+describe('useOwners', () => {
+  const org = OrganizationFixture();
+  const mockUsers = [UserFixture()];
+  const mockTeams = [TeamFixture()];
+
+  const queryClient = makeTestQueryClient();
+
+  function Wrapper({children}) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+
+  beforeEach(() => {
+    MemberListStore.init();
+    MemberListStore.loadInitialData(mockUsers);
+    TeamStore.init();
+    TeamStore.loadInitialData(mockTeams);
+    OrganizationStore.onUpdate(org, {replace: true});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/user-teams/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/teams/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/members/`,
+      body: [],
+    });
+  });
+
+  it('includes members and teams', async () => {
+    const {result} = renderHook(useOwners, {
+      wrapper: Wrapper,
+      initialProps: {},
+    });
+
+    await waitFor(() => !result.current.fetching);
+
+    expect(result.current.members).toEqual(mockUsers);
+    expect(result.current.teams).toEqual(mockTeams);
+  });
+});

--- a/static/app/utils/useOwners.tsx
+++ b/static/app/utils/useOwners.tsx
@@ -1,0 +1,72 @@
+import {useEffect, useMemo} from 'react';
+
+import {useMembers} from 'sentry/utils/useMembers';
+import {useTeams} from 'sentry/utils/useTeams';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
+
+interface Options {
+  /**
+   * The current selected values that will be ensured loaded. These should be
+   * in the actor identifier format
+   */
+  currentValue?: string[];
+}
+
+/**
+ * Hook to fetch owner options
+ */
+export function useOwners({currentValue}: Options) {
+  // Ensure the current value of the fields members is loaded
+  const ensureUserIds = useMemo(
+    () =>
+      currentValue?.filter(item => item.startsWith('user:')).map(user => user.slice(7)),
+    [currentValue]
+  );
+  useMembers({ids: ensureUserIds});
+
+  const {
+    members,
+    fetching: fetchingMembers,
+    onSearch: onMemberSearch,
+    loadMore: loadMoreMembers,
+  } = useMembers();
+
+  // Ensure the current value of the fields teams is loaded
+  const ensureTeamIds = useMemo(
+    () =>
+      currentValue?.filter(item => item.startsWith('team:')).map(user => user.slice(5)),
+    [currentValue]
+  );
+  useTeamsById({ids: ensureTeamIds});
+
+  const {
+    teams,
+    fetching: fetchingTeams,
+    onSearch: onTeamSearch,
+    loadMore: loadMoreTeams,
+  } = useTeams();
+
+  // TODO(epurkhiser): This is an unfortunate hack right now since we don't
+  // actually load members anywhere and the useMembers and useTeams hook don't
+  // handle initial loading of data.
+  //
+  // In the future when these things use react query we should be able to clean
+  // this up.
+  useEffect(
+    () => {
+      loadMoreMembers();
+      loadMoreTeams();
+    },
+    // Only ensure things are loaded at mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  return {
+    members,
+    teams,
+    fetching: fetchingMembers || fetchingTeams,
+    onMemberSearch,
+    onTeamSearch,
+  };
+}

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -505,16 +505,19 @@ function MonitorForm({
                 </AlertLink>
               )}
               <Observer>
-                {() => (
-                  <SentryMemberTeamSelectorField
-                    label={t('Notify')}
-                    help={t('Send notifications to a member or team.')}
-                    name="alertRule.targets"
-                    memberOfProjectSlug={form.current.getValue('project')?.toString()}
-                    multiple
-                    menuPlacement="auto"
-                  />
-                )}
+                {() => {
+                  const projectSlug = form.current.getValue('project')?.toString();
+                  return (
+                    <SentryMemberTeamSelectorField
+                      label={t('Notify')}
+                      help={t('Send notifications to a member or team.')}
+                      name="alertRule.targets"
+                      memberOfProjectSlugs={projectSlug ? [projectSlug] : undefined}
+                      multiple
+                      menuPlacement="auto"
+                    />
+                  );
+                }}
               </Observer>
               <Observer>
                 {() => {


### PR DESCRIPTION
This hook may be used to load member and team options for a select component.

This is a spin off of https://github.com/getsentry/sentry/pull/69269