### PR TITLE
chore(hybridcloud) Remove coalesce for region data

### DIFF
--- a/static/app/actionCreators/organizations.spec.tsx
+++ b/static/app/actionCreators/organizations.spec.tsx
@@ -13,35 +13,6 @@ describe('fetchOrganizations', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('has a fallback to regions', async function () {
-    // @ts-ignore-next-line Need to simulate undefined
-    // key that can happen during deploy
-    ConfigStore.set('memberRegions', undefined);
-    ConfigStore.set('regions', [
-      {name: 'us', url: 'https://us.example.org'},
-      {name: 'de', url: 'https://de.example.org'},
-    ]);
-    const usMock = MockApiClient.addMockResponse({
-      url: '/organizations/',
-      body: [usorg],
-    });
-    const deMock = MockApiClient.addMockResponse({
-      url: '/organizations/',
-      body: [deorg],
-      match: [
-        function (_url: string, options: Record<string, any>) {
-          return options.host === 'https://de.example.org';
-        },
-      ],
-    });
-    const organizations = await fetchOrganizations(api);
-
-    expect(organizations).toHaveLength(2);
-    expect(organizations[0].slug).toEqual(usorg.slug);
-    expect(usMock).toHaveBeenCalledTimes(1);
-    expect(deMock).toHaveBeenCalledTimes(1);
-  });
-
   it('fetches from multiple regions', async function () {
     ConfigStore.set('memberRegions', [
       {name: 'us', url: 'https://us.example.org'},

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -215,8 +215,7 @@ export async function fetchOrganizationDetails(
  * from /organizations can vary based on query parameters
  */
 export async function fetchOrganizations(api: Client, query?: Record<string, any>) {
-  // TODO(mark) Remove coalesce after memberRegions
-  const regions = ConfigStore.get('memberRegions') ?? ConfigStore.get('regions');
+  const regions = ConfigStore.get('memberRegions');
   const results = await Promise.all(
     regions.map(region =>
       api.requestPromise(`/organizations/`, {


### PR DESCRIPTION
Remove a coalesce that I included to smooth over deploy boundaries a few months back.
