### PR TITLE
feat(feedback): add option for ingesting feedback+attachments in same envelope

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -470,6 +470,12 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Separate the logic for producing feedbacks from generic events, and handle attachments in the same envelope
+register(
+    "feedback.ingest-inline-attachments",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Extract spans only from a random fraction of transactions.
 #

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -18,6 +18,7 @@ RELAY_OPTIONS: list[str] = [
     "relay.metric-bucket-distribution-encodings",
     "relay.metric-stats.rollout-rate",
     "feedback.ingest-topic.rollout-rate",
+    "feedback.ingest-inline-attachments",
     "relay.span-extraction.sample-rate",
 ]
 


### PR DESCRIPTION
Needed for https://github.com/getsentry/relay/pull/3403

For relay, using an option is way simpler than a FF. This option will also be used to test separating the logic for producing feedbacks (`user_report_v2`'s in `store.rs`)