### PR TITLE
fix: annotate and update _only_ new projects & update tests

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -825,18 +825,27 @@ def update_alert_rule(
                     sub for sub in existing_subs if sub.project_id in excluded_project_ids
                 ]
         elif projects is not None:
+            # All project slugs that currently exist for the alert rule
             existing_project_slugs = {sub.project.slug for sub in existing_subs}
-            # Determine whether we've added any new projects as part of this update
+
+            # All project slugs being provided as part of the update
+            updated_project_slugs = {project.slug for project in projects}
+
+            # Set of projects provided in the update, but don't already exist
             new_projects = [
                 project for project in projects if project.slug not in existing_project_slugs
             ]
-            updated_project_slugs = {project.slug for project in projects}
 
             # Delete any projects for the alert rule that were removed as part of this update
             AlertRuleProjects.objects.filter(
-                alert_rule_id=alert_rule.id, project__slug__in=existing_project_slugs
-            ).exclude(project__slug__in=updated_project_slugs).delete()
-            for project in projects:
+                alert_rule_id=alert_rule.id,  # for the alert rule
+                project__slug__in=existing_project_slugs,  # that are in the existing project slugs
+            ).exclude(
+                project__slug__in=updated_project_slugs  # but not included with the updated project slugs
+            ).delete()
+
+            # Add any new projects to the alert rule
+            for project in new_projects:
                 alert_rule.projects.add(project)
             # Find any subscriptions that were removed as part of this update
             deleted_subs = [

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -823,11 +823,13 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         )
         query_update = "level:warning"
         new_project = self.create_project(fire_project_created=True)
-        updated_projects = [self.project, new_project]
+        project_updates = [self.project, new_project]
         with self.tasks():
-            update_alert_rule(alert_rule, projects=updated_projects, query=query_update)
+            update_alert_rule(alert_rule, projects=project_updates, query=query_update)
         updated_subscriptions = alert_rule.snuba_query.subscriptions.all()
-        assert {sub.project for sub in updated_subscriptions} == set(updated_projects)
+        updated_projects = alert_rule.projects.all()
+        assert {sub.project for sub in updated_subscriptions} == set(project_updates)
+        assert set(updated_projects) == set(project_updates)
         for sub in updated_subscriptions:
             assert sub.snuba_query.query == query_update
 


### PR DESCRIPTION
Rather than attempting to create an AlertRuleProject for all the updating projects
only create new for the new projects