### PR TITLE
Revert "perf(indexer): Drop unnecessary work in the multiprocessing phase upon shutdown"

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1288,14 +1288,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Option to drop any in-flight work in the multiprocesing strategy
-# of the indexer during consumer shutdowns, rebalances, etc.
-register(
-    "sentry-metrics.indexer.drop-work-in-multiprocessing",
-    default=True,  # False means we don't drop any work
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Global and per-organization limits on the writes to the string indexer's DB.
 #
 # Format is a list of dictionaries of format {

--- a/src/sentry/sentry_metrics/consumers/indexer/common.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/common.py
@@ -12,7 +12,6 @@ from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
 from arroyo.types import Message, Value
 
-from sentry import options
 from sentry.sentry_metrics.consumers.indexer.routing_producer import RoutingPayload
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.utils import metrics
@@ -154,9 +153,6 @@ class BatchMessages(ProcessingStep[KafkaPayload]):
                 len(self.__batch),
                 last.committable,
             )
-
-        if options.get("sentry-metrics.indexer.drop-work-in-multiprocessing"):
-            timeout = 0.0
 
         self.__next_step.close()
         self.__next_step.join(timeout)

--- a/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_gen_metrics_multiprocess_steps.py
@@ -158,7 +158,6 @@ def test_batch_messages_rejected_message() -> None:
     assert next_step.submit.called
 
 
-@pytest.mark.django_db
 def test_batch_messages_join() -> None:
     next_step = Mock()
 


### PR DESCRIPTION
Reverts getsentry/sentry#68813

We found that this change is actually making things worse. Higher backlogs on the indexer during deploy. 