### PR TITLE
fix(autofix): Send body/json string in requests.post

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_update.py
+++ b/src/sentry/api/endpoints/group_autofix_update.py
@@ -34,7 +34,7 @@ class GroupAutofixUpdateEndpoint(GroupEndpoint):
 
         response = requests.post(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update",
-            data=request.data,
+            data=request.body,
             headers={"content-type": "application/json;charset=utf-8"},
         )
 

--- a/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
+++ b/src/sentry/api/endpoints/project_autofix_create_codebase_index.py
@@ -12,6 +12,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.repos import get_repos_from_project_code_mappings
 from sentry.models.project import Project
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -35,11 +36,13 @@ class ProjectAutofixCreateCodebaseIndexEndpoint(ProjectEndpoint):
         for repo in repos:
             response = requests.post(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
-                data={
-                    "organization_id": project.organization.id,
-                    "project_id": project.id,
-                    "repo": repo,
-                },
+                data=json.dumps(
+                    {
+                        "organization_id": project.organization.id,
+                        "project_id": project.id,
+                        "repo": repo,
+                    }
+                ),
                 headers={"content-type": "application/json;charset=utf-8"},
             )
 

--- a/tests/sentry/api/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_update.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from rest_framework import status
 
 from sentry.testutils.cases import APITestCase
+from sentry.utils import json
 
 
 class TestGroupAutofixUpdate(APITestCase):
@@ -34,14 +35,16 @@ class TestGroupAutofixUpdate(APITestCase):
         assert response.status_code == status.HTTP_202_ACCEPTED
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update",
-            data={
-                "run_id": 123,
-                "payload": {
-                    "type": "select_root_cause",
-                    "cause_id": 456,
-                    "fix_id": 789,
-                },
-            },
+            data=json.dumps(
+                {
+                    "run_id": 123,
+                    "payload": {
+                        "type": "select_root_cause",
+                        "cause_id": 456,
+                        "fix_id": 789,
+                    },
+                }
+            ).encode("utf-8"),
             headers={"content-type": "application/json;charset=utf-8"},
         )
 
@@ -51,14 +54,16 @@ class TestGroupAutofixUpdate(APITestCase):
 
         response = self.client.post(
             self.url,
-            data={
-                "run_id": 123,
-                "payload": {
-                    "type": "select_root_cause",
-                    "cause_id": 456,
-                    "fix_id": 789,
-                },
-            },
+            data=json.dumps(
+                {
+                    "run_id": 123,
+                    "payload": {
+                        "type": "select_root_cause",
+                        "cause_id": 456,
+                        "fix_id": 789,
+                    },
+                }
+            ).encode("utf-8"),
             format="json",
         )
 

--- a/tests/sentry/api/endpoints/test_project_autofix_create_codebase_index.py
+++ b/tests/sentry/api/endpoints/test_project_autofix_create_codebase_index.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from sentry.testutils.cases import APITestCase
+from sentry.utils import json
 
 
 class TestProjectAutofixCodebaseIndexCreate(APITestCase):
@@ -38,15 +39,17 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
         assert response.status_code == status.HTTP_202_ACCEPTED
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
-            data={
-                "organization_id": self.project.organization.id,
-                "project_id": self.project.id,
-                "repo": {
-                    "provider": "integrations:github",
-                    "owner": "getsentry",
-                    "name": "sentry",
-                },
-            },
+            data=json.dumps(
+                {
+                    "organization_id": self.project.organization.id,
+                    "project_id": self.project.id,
+                    "repo": {
+                        "provider": "integrations:github",
+                        "owner": "getsentry",
+                        "name": "sentry",
+                    },
+                }
+            ),
             headers={"content-type": "application/json;charset=utf-8"},
         )
 
@@ -76,28 +79,32 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
         calls = [
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
-                data={
-                    "organization_id": self.project.organization.id,
-                    "project_id": self.project.id,
-                    "repo": {
-                        "provider": "integrations:github",
-                        "owner": "getsentry",
-                        "name": "sentry",
-                    },
-                },
+                data=json.dumps(
+                    {
+                        "organization_id": self.project.organization.id,
+                        "project_id": self.project.id,
+                        "repo": {
+                            "provider": "integrations:github",
+                            "owner": "getsentry",
+                            "name": "sentry",
+                        },
+                    }
+                ),
                 headers={"content-type": "application/json;charset=utf-8"},
             ),
             call(
                 f"{settings.SEER_AUTOFIX_URL}/v1/automation/codebase/index/create",
-                data={
-                    "organization_id": self.project.organization.id,
-                    "project_id": self.project.id,
-                    "repo": {
-                        "provider": "integrations:github",
-                        "owner": "getsentry",
-                        "name": "relay",
-                    },
-                },
+                data=json.dumps(
+                    {
+                        "organization_id": self.project.organization.id,
+                        "project_id": self.project.id,
+                        "repo": {
+                            "provider": "integrations:github",
+                            "owner": "getsentry",
+                            "name": "relay",
+                        },
+                    }
+                ),
                 headers={"content-type": "application/json;charset=utf-8"},
             ),
         ]


### PR DESCRIPTION
Correctly sends the req body and json string in requests.post
Should not have trusted gpt.