### PR TITLE
fix(replay): Remove extra border radius from replay crumbs

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -64,7 +64,7 @@ function BreadcrumbItem({
 
   return (
     <CrumbItem
-      isErrorFrame={isErrorFrame(frame)}
+      data-is-error-frame={isErrorFrame(frame)}
       as={onClick && !forceSpan ? 'button' : 'span'}
       onClick={e => onClick?.(frame, e)}
       onMouseEnter={e => onMouseEnter(frame, e)}
@@ -225,14 +225,17 @@ const CrumbItem = styled(PanelItem)<{isErrorFrame?: boolean}>`
   width: 100%;
 
   font-size: ${p => p.theme.fontSizeMedium};
-  background: ${p => (p.isErrorFrame ? `${p.theme.red100}` : `transparent`)};
+  background: transparent;
+  [data-is-error-frame='true'] {
+    background: ${p => p.theme.red100};
+  }
   padding: ${space(1)};
   text-align: left;
   border: none;
   position: relative;
 
   &:hover {
-    background-color: ${p => p.theme.surface200};
+    background: ${p => p.theme.surface200};
   }
 
   /* Draw a vertical line behind the breadcrumb icon. The line connects each row together, but is truncated for the first and last items */
@@ -242,21 +245,22 @@ const CrumbItem = styled(PanelItem)<{isErrorFrame?: boolean}>`
     left: 19.5px;
     width: 1px;
     background: ${p => p.theme.gray200};
-    height: 100%;
+    top: -1px;
+    bottom: -1px;
   }
 
   &:first-of-type::after {
     top: ${space(1)};
-    bottom: 0;
+    bottom: -1px;
   }
 
   &:last-of-type::after {
-    top: 0;
-    height: ${space(1)};
+    top: -1px;
+    bottom: calc(100% - ${space(1)});
   }
 
   &:only-of-type::after {
-    height: 0;
+    display: none;
   }
 `;
 

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -231,8 +231,6 @@ const CrumbItem = styled(PanelItem)<{isErrorFrame?: boolean}>`
   border: none;
   position: relative;
 
-  border-radius: ${p => p.theme.borderRadius};
-
   &:hover {
     background-color: ${p => p.theme.surface200};
   }


### PR DESCRIPTION
This might've gotten messed up as part of https://github.com/getsentry/sentry/pull/68818

**Before:**
<img width="294" alt="SCR-20240419-ngbc" src="https://github.com/getsentry/sentry/assets/187460/828228f4-0003-4cd9-b1d0-66dc8856890e">

**After:**
<img width="324" alt="SCR-20240419-nfws" src="https://github.com/getsentry/sentry/assets/187460/edf9faaa-7c37-4a08-81f0-e4ae401c4d8a">
