### PR TITLE
feat(replay): add viewed_by_ids to replay search fields

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1365,7 +1365,7 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [ReplayFieldKey.VIEWED_BY_IDS]: {
-    desc: t('Sentry user id(s) who have seen this Replay'),
+    desc: t('Sentry user ids belonging to users who have seen this Replay'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.INTEGER,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1368,7 +1368,7 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     desc: t('Sentry user id(s) who have seen this Replay'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.INTEGER,
-  }
+  },
 };
 
 export const REPLAY_CLICK_FIELDS = [

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1362,7 +1362,7 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [ReplayFieldKey.SEEN_BY_ID]: {
-    desc: t('Sentry user id(s) who have seen this Replay'),
+    desc: t('Sentry user ID(s) who have seen this replay'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.INTEGER,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1360,12 +1360,12 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [ReplayFieldKey.URLS]: {
-    desc: t('List of urls that were visited within the Replay'),
+    desc: t('List of urls that were visited within the replay'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   [ReplayFieldKey.VIEWED_BY_ID]: {
-    desc: t('Sentry user id(s) who have seen this Replay'),
+    desc: t('Sentry user ID(s) who have seen this replay'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.INTEGER,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1237,6 +1237,7 @@ export enum ReplayFieldKey {
   ERROR_IDS = 'error_ids',
   OS_NAME = 'os.name',
   OS_VERSION = 'os.version',
+  SEEN_BY_ID = 'seen_by_id',
   URLS = 'urls',
   VIEWED_BY_ID = 'viewed_by_id',
 }
@@ -1289,6 +1290,7 @@ export const REPLAY_FIELDS = [
   FieldKey.RELEASE,
   FieldKey.SDK_NAME,
   FieldKey.SDK_VERSION,
+  ReplayFieldKey.SEEN_BY_ID,
   FieldKey.TRACE,
   ReplayFieldKey.URLS,
   FieldKey.USER_EMAIL,
@@ -1358,6 +1360,11 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     desc: t('Version number of the Operating System'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+  },
+  [ReplayFieldKey.SEEN_BY_ID]: {
+    desc: t('Sentry user id(s) who have seen this Replay'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.INTEGER,
   },
   [ReplayFieldKey.URLS]: {
     desc: t('List of urls that were visited within the replay'),

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1238,7 +1238,7 @@ export enum ReplayFieldKey {
   OS_NAME = 'os.name',
   OS_VERSION = 'os.version',
   URLS = 'urls',
-  VIEWED_BY_IDS = 'viewed_by_ids',
+  VIEWED_BY_ID = 'viewed_by_id',
 }
 
 export enum ReplayClickFieldKey {
@@ -1295,7 +1295,7 @@ export const REPLAY_FIELDS = [
   FieldKey.USER_ID,
   FieldKey.USER_IP,
   FieldKey.USER_USERNAME,
-  ReplayFieldKey.VIEWED_BY_IDS,
+  ReplayFieldKey.VIEWED_BY_ID,
 ];
 
 const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
@@ -1364,8 +1364,8 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [ReplayFieldKey.VIEWED_BY_IDS]: {
-    desc: t('Sentry user ids belonging to users who have seen this Replay'),
+  [ReplayFieldKey.VIEWED_BY_ID]: {
+    desc: t('Sentry user id(s) who have seen this Replay'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.INTEGER,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1238,6 +1238,7 @@ export enum ReplayFieldKey {
   OS_NAME = 'os.name',
   OS_VERSION = 'os.version',
   URLS = 'urls',
+  VIEWED_BY_IDS = 'viewed_by_ids',
 }
 
 export enum ReplayClickFieldKey {
@@ -1294,6 +1295,7 @@ export const REPLAY_FIELDS = [
   FieldKey.USER_ID,
   FieldKey.USER_IP,
   FieldKey.USER_USERNAME,
+  ReplayFieldKey.VIEWED_BY_IDS,
 ];
 
 const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
@@ -1362,6 +1364,11 @@ const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
+  [ReplayFieldKey.VIEWED_BY_IDS]: {
+    desc: t('Sentry user id(s) who have seen this Replay'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.INTEGER,
+  }
 };
 
 export const REPLAY_CLICK_FIELDS = [


### PR DESCRIPTION
Follow up from https://github.com/getsentry/sentry/issues/64924

Before/after:
![Before](https://github.com/getsentry/sentry/assets/159852527/1bea0567-0954-474f-a2cf-2ad5b8e152fb)

<img width="683" alt="Screenshot 2024-04-19 at 3 32 34 PM" src="https://github.com/getsentry/sentry/assets/159852527/4a2d2ad7-2d0c-4c3b-9dde-31ecf32487dc">

Followed up with docs PR for searchable properties

[Trigger: Revert]