### PR TITLE
chore(hybrid-cloud): Globally enables region urls for CLI uploads

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1799,9 +1799,7 @@ register(
     "hybrid_cloud.use_region_specific_upload_url", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
-register(
-    "hybrid_cloud.disable_relative_upload_urls", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
-)
+register("hybrid_cloud.disable_relative_upload_urls", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Retry controls
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)


### PR DESCRIPTION
<!-- Describe your PR here. -->
Now that region URLs for chunk-uploads have been tested in EU, it should be safe to globally enable this for US region as well. This PR is in tandem with an options automator change that globally enables this option as well.

