### PR TITLE
fix(query): Guard against ordering by non unique columns in `RangeQuerySetWrapper`

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -140,6 +140,7 @@ def schedule_auto_transition_issues_new_to_ongoing(
                 limit=ITERATOR_CHUNK * CHILD_TASK_COUNT,
                 callbacks=[get_total_count],
                 order_by="first_seen",
+                override_unique_safety_check=True,
             ),
             ITERATOR_CHUNK,
         ):

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -90,7 +90,7 @@ class RangeQuerySetWrapper:
         order_by="pk",
         callbacks=(),
         result_value_getter=None,
-        override_unique_safety_check=False,
+        override_unique_safety_check=True,
     ):
         # Support for slicing
         if queryset.query.low_mark == 0 and not (

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -4,7 +4,6 @@ import re
 
 import progressbar
 from django.db import connections, router
-from django.db.models import QuerySet
 
 from sentry import eventstore
 
@@ -84,7 +83,7 @@ class RangeQuerySetWrapper:
 
     def __init__(
         self,
-        queryset: QuerySet,
+        queryset,
         step=1000,
         limit=None,
         min_id=None,

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -60,7 +60,7 @@ class RangeQuerySetWrapperTest(TestCase):
     def test_order_by_non_unique_fails(self):
         qs = User.objects.all()
         with pytest.raises(InvalidQuerySetError):
-            self.range_wrapper(qs, order_by="name")
+            self.range_wrapper(qs, order_by="name", override_unique_safety_check=False)
 
         # Shouldn't error if the safety check is disabled
         self.range_wrapper(qs, order_by="name", override_unique_safety_check=True)
@@ -68,7 +68,7 @@ class RangeQuerySetWrapperTest(TestCase):
     def test_order_by_unique(self):
         self.create_user()
         qs = User.objects.all()
-        self.range_wrapper(qs, order_by="username")
+        self.range_wrapper(qs, order_by="username", override_unique_safety_check=False)
         assert len(list(self.range_wrapper(qs, order_by="username", step=2))) == 1
 
 


### PR DESCRIPTION
Follow-up from inc-709. This incident was caused by `RangeQuerySetWrapper` looping infinitely and slamming queries into the database. It did this because we ordered on a non-unique column, and currently the logic here will loop forever when the last two rows of the result set have the same value for the sort col.
