### PR TITLE
feat(replay): add seen_by_id alias for replay search

### DIFF
--- a/src/sentry/replays/usecases/query/configs/aggregate.py
+++ b/src/sentry/replays/usecases/query/configs/aggregate.py
@@ -145,6 +145,7 @@ search_config["warning_id"] = search_config["warning_ids"]
 
 
 search_config["release"] = search_config["releases"]
+search_config["seen_by_id"] = search_config["viewed_by_id"]
 search_config["trace_id"] = search_config["trace_ids"]
 search_config["trace"] = search_config["trace_ids"]
 search_config["url"] = search_config["urls"]

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -709,6 +709,10 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 "count_infos:<3",
                 "viewed_by_id:1",
                 "!viewed_by_id:2",
+                "viewed_by_id:[1,2]",
+                "seen_by_id:1",
+                "!seen_by_id:2",
+                "seen_by_id:[1,2]",
             ]
 
             for query in queries:
@@ -758,6 +762,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 "!activity:3",
                 "activity:<2",
                 "viewed_by_id:2",
+                "seen_by_id:2",
             ]
             for query in null_queries:
                 response = self.client.get(self.url + f"?field=id&query={query}")


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/pull/69364

also tests a list of user ids