### PR TITLE
fix(api): raise InvalidParams if date filter not optional

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -233,6 +233,8 @@ def get_date_range_from_stats_period(
             raise InvalidParams(str(e))
     elif optional:
         return None, None
+    else:
+        raise InvalidParams("start and end are both required")
 
     if start >= end:
         raise InvalidParams("start must be before end")


### PR DESCRIPTION
When using `ProjectEndpoint.get_filter_params`, like so: https://github.com/getsentry/sentry/blob/2263a2bc1b475b7f4cbc7273f9825eea02537541/src/sentry/replays/endpoints/project_replay_viewed_by.py#L69-L69

I think it'd be good to raise if we use `date_filter_optional` and the date filters are missing.
