### PR TITLE
fix(trace): fix children calculation

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -1263,9 +1263,10 @@ function Connectors(props: {
   manager: VirtualizedViewManager;
   node: TraceTreeNode<TraceTree.NodeValue>;
 }) {
+  const hasChildren =
+    (props.node.expanded || props.node.zoomedIn) && props.node.children.length > 0;
   const showVerticalConnector =
-    ((props.node.expanded || props.node.zoomedIn) && props.node.children.length > 0) ||
-    (props.node.value && isParentAutogroupedNode(props.node));
+    hasChildren || (props.node.value && isParentAutogroupedNode(props.node));
 
   // If the tail node of the collapsed node has no children,
   // we don't want to render the vertical connector as no children
@@ -1274,13 +1275,14 @@ function Connectors(props: {
     showVerticalConnector &&
     props.node.value &&
     props.node instanceof ParentAutogroupNode &&
-    !props.node.tail.children.length;
+    (!props.node.tail.children.length ||
+      (!props.node.tail.expanded && !props.node.expanded));
 
   return (
     <Fragment>
       {props.node.connectors.map((c, i) => {
         return (
-          <div
+          <span
             key={i}
             style={{
               left: -(
@@ -1292,12 +1294,12 @@ function Connectors(props: {
         );
       })}
       {showVerticalConnector && !hideVerticalConnector ? (
-        <div className="TraceExpandedVerticalConnector" />
+        <span className="TraceExpandedVerticalConnector" />
       ) : null}
       {props.node.isLastChild ? (
-        <div className="TraceVerticalLastChildConnector" />
+        <span className="TraceVerticalLastChildConnector" />
       ) : (
-        <div className="TraceVerticalConnector" />
+        <span className="TraceVerticalConnector" />
       )}
     </Fragment>
   );

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1001,7 +1001,6 @@ export class TraceTree {
 
         this._list.splice(index + 1, childrenCount);
 
-        node.getVisibleChildrenCount();
         const newChildren = [node.head].concat(
           node.head.getVisibleChildren() as TraceTreeNode<TraceTree.Span>[]
         );
@@ -1638,6 +1637,13 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
   getVisibleChildrenCount(): number {
     const stack: TraceTreeNode<TraceTree.NodeValue>[] = [];
     let count = 0;
+
+    if (isParentAutogroupedNode(this)) {
+      if (this.expanded) {
+        return this.head.getVisibleChildrenCount();
+      }
+      return this.tail.getVisibleChildrenCount();
+    }
 
     if (
       this.expanded ||

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1645,11 +1645,7 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
       return this.tail.getVisibleChildrenCount();
     }
 
-    if (
-      this.expanded ||
-      isParentAutogroupedNode(this) ||
-      isMissingInstrumentationNode(this)
-    ) {
+    if (this.expanded || isMissingInstrumentationNode(this)) {
       for (let i = this.children.length - 1; i >= 0; i--) {
         stack.push(this.children[i]);
       }


### PR DESCRIPTION
Intermediary nodes between the head and tail chain can be collapsed. We werent accounting for this, meaning the child count number was wrong, causing us to remove nodes from the tree that we shouldnt be removing as the index overflowed the child count