### PR TITLE
perf(indexer): Try orjson for the reconstruct messages step

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1288,6 +1288,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Option to enable orjson for JSON parsing in reconstruct_messages function
+register(
+    "sentry-metrics.indexer.reconstruct.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+
 # Global and per-organization limits on the writes to the string indexer's DB.
 #
 # Format is a list of dictionaries of format {

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -18,6 +18,7 @@ from sentry_kafka_schemas.schema_types.snuba_generic_metrics_v1 import GenericMe
 from sentry_kafka_schemas.schema_types.snuba_metrics_v1 import Metric
 
 from sentry import options
+from sentry.features.rollout import in_random_rollout
 from sentry.sentry_metrics.aggregation_option_registry import get_aggregation_options
 from sentry.sentry_metrics.configuration import MAX_INDEXED_COLUMN_LENGTH
 from sentry.sentry_metrics.consumers.indexer.common import (
@@ -499,9 +500,14 @@ class IndexerBatch:
                 with metrics.timer(
                     "metrics_consumer.reconstruct_messages.build_new_payload.json_step"
                 ):
+                    if in_random_rollout("sentry-metrics.indexer.reconstruct.enable-orjson"):
+                        serialized_msg = orjson.dumps(new_payload_value).encode()
+                    else:
+                        serialized_msg = rapidjson.dumps(new_payload_value).encode()
+
                     kafka_payload = KafkaPayload(
                         key=message.payload.key,
-                        value=rapidjson.dumps(new_payload_value).encode(),
+                        value=serialized_msg,
                         headers=[
                             *message.payload.headers,
                             ("mapping_sources", mapping_header_content),

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -501,13 +501,13 @@ class IndexerBatch:
                     "metrics_consumer.reconstruct_messages.build_new_payload.json_step"
                 ):
                     if in_random_rollout("sentry-metrics.indexer.reconstruct.enable-orjson"):
-                        serialized_msg = orjson.dumps(new_payload_value).encode()
+                        serialized_msg = orjson.dumps(new_payload_value)
                     else:
-                        serialized_msg = rapidjson.dumps(new_payload_value).encode()
+                        serialized_msg = rapidjson.dumps(new_payload_value)
 
                     kafka_payload = KafkaPayload(
                         key=message.payload.key,
-                        value=serialized_msg,
+                        value=serialized_msg.encode(),
                         headers=[
                             *message.payload.headers,
                             ("mapping_sources", mapping_header_content),

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -503,11 +503,11 @@ class IndexerBatch:
                     if in_random_rollout("sentry-metrics.indexer.reconstruct.enable-orjson"):
                         serialized_msg = orjson.dumps(new_payload_value)
                     else:
-                        serialized_msg = rapidjson.dumps(new_payload_value)
+                        serialized_msg = rapidjson.dumps(new_payload_value).encode()
 
                     kafka_payload = KafkaPayload(
                         key=message.payload.key,
-                        value=serialized_msg.encode(),
+                        value=serialized_msg,
                         headers=[
                             *message.payload.headers,
                             ("mapping_sources", mapping_header_content),


### PR DESCRIPTION
We've seen `orjson` have promising results from switching out the existing json library in the deserialization step: https://github.com/getsentry/sentry/pull/68802 and https://github.com/getsentry/sentry/pull/68936. We're seeing lower processing times for the indexer. 

Let's also try it on the serialization step and see if we can get further improvements out of processing time on the indexer. 