### PR TITLE
fix(setup-wizard): Always create a new user API token

### DIFF
--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -154,15 +154,12 @@ def get_token(mappings: list[OrganizationMapping], user: RpcUser):
             return token
 
     # Otherwise, generate a user token
-    tokens = ApiToken.objects.filter(user_id=user.id)
-    token = next((token for token in tokens if "project:releases" in token.get_scopes()), None)
-    if token is None:
-        token = ApiToken.objects.create(
-            user_id=user.id,
-            scope_list=["project:releases"],
-            token_type=AuthTokenType.USER,
-            expires_at=None,
-        )
+    token = ApiToken.objects.create(
+        user_id=user.id,
+        scope_list=["project:releases"],
+        token_type=AuthTokenType.USER,
+        expires_at=None,
+    )
     return serialize(token)
 
 

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -2,9 +2,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY
-from sentry.api.serializers import serialize
 from sentry.cache import default_cache
-from sentry.models.apitoken import ApiToken
 from sentry.models.projectkey import ProjectKey
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import PermissionTestCase
@@ -90,13 +88,6 @@ class SetupWizard(PermissionTestCase):
         assert len(cached.get("projects")[0].get("keys")) == 2
 
     def test_return_user_auth_token_if_multiple_orgs(self):
-        user_api_token = ApiToken.objects.create_or_update(
-            user=self.user,
-            scope_list=["project:releases"],
-            refresh_token=None,
-            expires_at=None,
-        )[0]
-
         self.org = self.create_organization(name="org1", owner=self.user)
         self.org2 = self.create_organization(name="org2", owner=self.user)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
@@ -115,8 +106,11 @@ class SetupWizard(PermissionTestCase):
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/setup-wizard.html")
         cached = default_cache.get(key)
+
         assert cached.get("apiKeys") is not None
-        assert cached.get("apiKeys") == serialize(user_api_token)
+
+        token = cached.get("apiKeys")["token"]
+        assert token.startswith("sntryu_")
 
     def test_return_org_auth_token_if_one_org(self):
         self.org = self.create_organization(owner=self.user)

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -115,7 +115,7 @@ class SetupWizard(PermissionTestCase):
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/setup-wizard.html")
         cached = default_cache.get(key)
-
+        assert cached.get("apiKeys") is not None
         assert cached.get("apiKeys") == serialize(user_api_token)
 
     def test_return_org_auth_token_if_one_org(self):


### PR DESCRIPTION
In the wizard endpoint, we’d reuse existing user auth tokens of the authenticated user if:
1. the user was part of multiple orgs (==> we can't create an org-based token)
2. AND we found one that satisfied the necessary permissions for sourcemap upload. 
 
With https://github.com/getsentry/sentry/pull/68148 being merged, we cannot do this anymore. Plain user auth token values are only gonna be available directly after the token was created. 

For the fix, this PR makes a change to the wizard endpoint to always create a new user API token. This now works  just like when we create an org token for single-org users.

Closes: https://github.com/getsentry/sentry/pull/69381