### PR TITLE
fix(sdk-crashes): Fix sample rate

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -108,8 +108,8 @@ class SDKCrashDetection:
         metrics.incr("post_process.sdk_crash_monitoring.detecting_sdk_crash", tags=metric_tags)
 
         if sdk_crash_detector.is_sdk_crash(frames):
-            # TODO this rollout rate is backwards
-            if random.random() >= sample_rate:
+            # The sample rate is backwards on purpose, because we return None if we don't want to sample an event.
+            if random.random() > sample_rate:
                 return None
 
             sdk_crash_event_data = strip_event_data(event.data, sdk_crash_detector)

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -172,42 +172,34 @@ class SDKCrashDetectionTest(
         return self.store_event(data=data, project_id=project_id, assert_no_errors=assert_no_errors)
 
 
+@pytest.mark.parametrize(
+    ["sample_rate", "random_value", "sampled"],
+    [
+        (0.0, 0.0001, False),
+        (0.0, 0.5, False),
+        (1.0, 0.0001, True),
+        (1.0, 0.9999, True),
+        (0.1, 0.09, True),
+        (0.1, 0.1, True),
+        (0.1, 0.11, False),
+    ],
+)
 @django_db_all
 @pytest.mark.snuba
-@patch("random.random", return_value=0.0)
 @patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection.sdk_crash_reporter")
-def test_sample_is_rate_zero(mock_sdk_crash_reporter, mock_random, store_event):
+def test_sample_rate(mock_sdk_crash_reporter, store_event, sample_rate, random_value, sampled):
     event = store_event(data=get_crash_event())
 
-    configs = build_sdk_configs()
-    configs[0].sample_rate = 0.0
+    with patch("random.random", return_value=random_value):
+        configs = build_sdk_configs()
+        configs[0].sample_rate = sample_rate
 
-    sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
+        sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
 
-    assert mock_sdk_crash_reporter.report.call_count == 0
-
-
-@django_db_all
-@pytest.mark.snuba
-@patch("random.random", return_value=0.1)
-@patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection.sdk_crash_reporter")
-def test_sampling_rate(mock_sdk_crash_reporter, mock_random, store_event):
-    event = store_event(data=get_crash_event())
-
-    configs = build_sdk_configs()
-
-    # not sampled
-    configs[0].sample_rate = 0.09
-    sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
-
-    configs[0].sample_rate = 0.1
-    sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
-
-    # sampled
-    configs[0].sample_rate = 0.11
-    sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
-
-    assert mock_sdk_crash_reporter.report.call_count == 1
+        if sampled:
+            assert mock_sdk_crash_reporter.report.call_count == 1
+        else:
+            assert mock_sdk_crash_reporter.report.call_count == 0
 
 
 @django_db_all

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -179,9 +179,12 @@ class SDKCrashDetectionTest(
         (0.0, 0.5, False),
         (1.0, 0.0001, True),
         (1.0, 0.9999, True),
+        (0.1, 0.0001, True),
         (0.1, 0.09, True),
         (0.1, 0.1, True),
         (0.1, 0.11, False),
+        (0.1, 0.5, False),
+        (0.1, 0.999, False),
     ],
 )
 @django_db_all


### PR DESCRIPTION
This PR adds a comment on why the sample rate is backward and fixes an off-by-one error.
