### PR TITLE
test(features): Test 0.0 and 1.0 feature rollout

### DIFF
--- a/tests/sentry/features/test_rollout.py
+++ b/tests/sentry/features/test_rollout.py
@@ -32,6 +32,12 @@ def run_random_sample(option_name: str) -> Sequence[int]:
 def test_in_random_rollout(register_option) -> None:
     success = 0
     failure = 0
+
+    with override_options({"feature.rollout": 0.0}):
+        success, failure = run_random_sample("feature.rollout")
+        assert success == 0
+        assert failure == 1000
+
     with override_options({"feature.rollout": 0.25}):
         success, failure = run_random_sample("feature.rollout")
         assert success + failure == 1000
@@ -41,6 +47,11 @@ def test_in_random_rollout(register_option) -> None:
         success, failure = run_random_sample("feature.rollout")
         assert success + failure == 1000
         assert 0.65 < success / (failure + success) < 0.85, "within margin of error"
+
+    with override_options({"feature.rollout": 1.0}):
+        success, failure = run_random_sample("feature.rollout")
+        assert success == 1000
+        assert failure == 0
 
 
 def run_rollout_group(option_name: str, id: int | str) -> Sequence[int]:


### PR DESCRIPTION
Extend the test_in_random_rollout to test a 0.0 and 1.0 rollout.

While playing around with `in_random_rollout,` I added these two small test cases to understand whether the code handles sample rates of 0.0 and 1.0 correctly. 