### PR TITLE
perf: Experimentally use orjson in Slack integration

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any
 
-import orjson
 from django.utils import timezone
 from django.utils.timesince import timesince
 from django.utils.translation import gettext as _
@@ -15,7 +14,6 @@ from sentry import tagstore
 from sentry.api.endpoints.group_details import get_group_global_count
 from sentry.constants import LOG_LEVELS_MAP
 from sentry.eventstore.models import GroupEvent
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.message_builder import (
     build_attachment_replay_link,
     build_attachment_text,
@@ -686,10 +684,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if rule_id:
             block_id["rule"] = rule_id
 
-        if in_random_rollout("integrations.slack.enable-orjson"):
-            block_id = orjson.dumps(block_id)
-        else:
-            block_id = json.dumps(block_id)
+        block_id = json.dumps_experimantal("integrations.slack.enable-orjson", block_id)
 
         return self._build_blocks(
             *blocks,

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -684,11 +684,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if rule_id:
             block_id["rule"] = rule_id
 
-        block_id = json.dumps_experimantal("integrations.slack.enable-orjson", block_id)
-
         return self._build_blocks(
             *blocks,
             fallback_text=self.build_fallback_text(obj, project.slug),
-            block_id=block_id,
+            block_id=json.dumps_experimantal("integrations.slack.enable-orjson", block_id),
             skip_fallback=self.skip_fallback,
         )

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -687,6 +687,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         return self._build_blocks(
             *blocks,
             fallback_text=self.build_fallback_text(obj, project.slug),
-            block_id=json.dumps_experimantal("integrations.slack.enable-orjson", block_id),
+            block_id=json.dumps_experimental("integrations.slack.enable-orjson", block_id),
             skip_fallback=self.skip_fallback,
         )

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any
 
+import orjson
 from django.utils import timezone
 from django.utils.timesince import timesince
 from django.utils.translation import gettext as _
@@ -14,6 +15,7 @@ from sentry import tagstore
 from sentry.api.endpoints.group_details import get_group_global_count
 from sentry.constants import LOG_LEVELS_MAP
 from sentry.eventstore.models import GroupEvent
+from sentry.features.rollout import in_random_rollout
 from sentry.integrations.message_builder import (
     build_attachment_replay_link,
     build_attachment_text,
@@ -684,9 +686,14 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if rule_id:
             block_id["rule"] = rule_id
 
+        if in_random_rollout("integrations.slack.enable-orjson"):
+            block_id = orjson.dumps(block_id)
+        else:
+            block_id = json.dumps(block_id)
+
         return self._build_blocks(
             *blocks,
             fallback_text=self.build_fallback_text(obj, project.slug),
-            block_id=json.dumps(block_id),
+            block_id=block_id,
             skip_fallback=self.skip_fallback,
         )

--- a/src/sentry/integrations/slack/message_builder/notifications/base.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/base.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-import orjson
-
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
@@ -36,10 +33,11 @@ class SlackNotificationsMessageBuilder(BlockSlackMessageBuilder):
             self.recipient, ExternalProviders.SLACK
         )
         actions = self.notification.get_message_actions(self.recipient, ExternalProviders.SLACK)
-        if in_random_rollout("integrations.slack.enable-orjson"):
-            callback_id = orjson.dumps(callback_id_raw) if callback_id_raw else None
-        else:
-            callback_id = json.dumps(callback_id_raw) if callback_id_raw else None
+        callback_id = (
+            json.dumps_experimental("integrations.slack.enable-orjson", callback_id_raw)
+            if callback_id_raw
+            else None
+        )
 
         first_block_text = ""
         if title_link:

--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -4,11 +4,9 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlencode
 
-import orjson
 from sentry_relay.processing import parse_release
 
 from sentry import features
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.message_builder import build_attachment_text, build_attachment_title
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.utils.escape import escape_slack_text
@@ -191,10 +189,11 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
 
         text = subject
         callback_id_raw = self.notification.get_callback_data()
-        if in_random_rollout("integrations.slack.enable-orjson"):
-            callback_id = orjson.dumps(callback_id_raw) if callback_id_raw else None
-        else:
-            callback_id = json.dumps(callback_id_raw) if callback_id_raw else None
+        callback_id = (
+            json.dumps_experimental("integrations.slack.enable-orjson", callback_id_raw)
+            if callback_id_raw
+            else None
+        )
 
         footer = self.notification.build_notification_footer(
             self.recipient, ExternalProviders.SLACK

--- a/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/daily_summary.py
@@ -4,9 +4,11 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlencode
 
+import orjson
 from sentry_relay.processing import parse_release
 
 from sentry import features
+from sentry.features.rollout import in_random_rollout
 from sentry.integrations.message_builder import build_attachment_text, build_attachment_title
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.utils.escape import escape_slack_text
@@ -189,7 +191,11 @@ class SlackDailySummaryMessageBuilder(SlackNotificationsMessageBuilder):
 
         text = subject
         callback_id_raw = self.notification.get_callback_data()
-        callback_id = json.dumps(callback_id_raw) if callback_id_raw else None
+        if in_random_rollout("integrations.slack.enable-orjson"):
+            callback_id = orjson.dumps(callback_id_raw) if callback_id_raw else None
+        else:
+            callback_id = json.dumps(callback_id_raw) if callback_id_raw else None
+
         footer = self.notification.build_notification_footer(
             self.recipient, ExternalProviders.SLACK
         )

--- a/src/sentry/integrations/slack/message_builder/prompt.py
+++ b/src/sentry/integrations/slack/message_builder/prompt.py
@@ -1,3 +1,6 @@
+import orjson
+
+from sentry.features.rollout import in_random_rollout
 from sentry.integrations.slack.message_builder import SlackBody
 from sentry.utils import json
 
@@ -12,11 +15,18 @@ class SlackPromptLinkMessageBuilder(BlockSlackMessageBuilder):
         self.url = url
 
     def build(self) -> SlackBody:
-        return {
-            "blocks": json.dumps(
+        if in_random_rollout("integrations.slack.enable-orjson"):
+            blocks = orjson.dumps(
                 [
                     self.get_markdown_block(LINK_IDENTITY_MESSAGE),
                     self.get_action_block([("Link", self.url, "link"), ("Cancel", None, "ignore")]),
                 ]
             )
-        }
+        else:
+            blocks = json.dumps(
+                [
+                    self.get_markdown_block(LINK_IDENTITY_MESSAGE),
+                    self.get_action_block([("Link", self.url, "link"), ("Cancel", None, "ignore")]),
+                ]
+            )
+        return {"blocks": blocks}

--- a/src/sentry/integrations/slack/message_builder/prompt.py
+++ b/src/sentry/integrations/slack/message_builder/prompt.py
@@ -12,11 +12,12 @@ class SlackPromptLinkMessageBuilder(BlockSlackMessageBuilder):
         self.url = url
 
     def build(self) -> SlackBody:
-        blocks = json.dumps_experimental(
-            "integrations.slack.enable-orjson",
-            [
-                self.get_markdown_block(LINK_IDENTITY_MESSAGE),
-                self.get_action_block([("Link", self.url, "link"), ("Cancel", None, "ignore")]),
-            ],
-        )
-        return {"blocks": blocks}
+        return {
+            "blocks": json.dumps_experimental(
+                "integrations.slack.enable-orjson",
+                [
+                    self.get_markdown_block(LINK_IDENTITY_MESSAGE),
+                    self.get_action_block([("Link", self.url, "link"), ("Cancel", None, "ignore")]),
+                ],
+            )
+        }

--- a/src/sentry/integrations/slack/message_builder/prompt.py
+++ b/src/sentry/integrations/slack/message_builder/prompt.py
@@ -1,6 +1,3 @@
-import orjson
-
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.slack.message_builder import SlackBody
 from sentry.utils import json
 
@@ -15,18 +12,11 @@ class SlackPromptLinkMessageBuilder(BlockSlackMessageBuilder):
         self.url = url
 
     def build(self) -> SlackBody:
-        if in_random_rollout("integrations.slack.enable-orjson"):
-            blocks = orjson.dumps(
-                [
-                    self.get_markdown_block(LINK_IDENTITY_MESSAGE),
-                    self.get_action_block([("Link", self.url, "link"), ("Cancel", None, "ignore")]),
-                ]
-            )
-        else:
-            blocks = json.dumps(
-                [
-                    self.get_markdown_block(LINK_IDENTITY_MESSAGE),
-                    self.get_action_block([("Link", self.url, "link"), ("Cancel", None, "ignore")]),
-                ]
-            )
+        blocks = json.dumps_experimental(
+            "integrations.slack.enable-orjson",
+            [
+                self.get_markdown_block(LINK_IDENTITY_MESSAGE),
+                self.get_action_block([("Link", self.url, "link"), ("Cancel", None, "ignore")]),
+            ],
+        )
         return {"blocks": blocks}

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -5,10 +5,8 @@ from collections.abc import Iterable, Mapping
 from copy import copy
 from typing import Any
 
-import orjson
 import sentry_sdk
 
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.notifications import get_context, get_integrations_by_channel_by_recipient
 from sentry.integrations.slack.message_builder import SlackBlock
@@ -27,14 +25,6 @@ from sentry.utils import json, metrics
 
 logger = logging.getLogger("sentry.notifications")
 SLACK_TIMEOUT = 5
-
-
-# TODO: remove this when orjson experiment is successful
-def dump_json(data) -> str | bytes:
-    if in_random_rollout("integrations.slack.enable-orjson"):
-        return orjson.dumps(data)
-    else:
-        return json.dumps(data)
 
 
 class SlackNotifyBasicMixin(NotifyBasicMixin):
@@ -104,7 +94,7 @@ def _notify_recipient(
             "unfurl_links": False,
             "unfurl_media": False,
             "text": text if text else "",
-            "blocks": dump_json(blocks),
+            "blocks": json.dumps_experimental("integrations.slack.enable-orjson", blocks),
         }
         callback_id = local_attachments.get("callback_id")
         if callback_id:
@@ -112,7 +102,9 @@ def _notify_recipient(
             if isinstance(callback_id, str):
                 payload["callback_id"] = callback_id
             else:
-                payload["callback_id"] = dump_json(local_attachments.get("callback_id"))
+                payload["callback_id"] = json.dumps_experimental(
+                    "integrations.slack.enable-orjson", local_attachments.get("callback_id")
+                )
 
         post_message_task = post_message
         if SiloMode.get_current_mode() == SiloMode.CONTROL:

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -20,7 +20,8 @@ def load_json(data: Any) -> JSONData:
         # Span is required because `json.loads` calls it by default
         with sentry_sdk.start_span(op="sentry.utils.json.loads"):
             return orjson.loads(data)
-    return json.loads(data)
+    else:
+        return json.loads(data)
 
 
 class SlackActionRequest(SlackRequest):

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -2,26 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-import orjson
-import sentry_sdk
 from django.utils.functional import cached_property
 from rest_framework import status
 
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.slack.requests.base import SlackRequest, SlackRequestError
 from sentry.models.group import Group
 from sentry.utils import json
 from sentry.utils.json import JSONData
-
-
-# TODO: remove this once we're confident that orjson is working as expected
-def load_json(data: Any) -> JSONData:
-    if in_random_rollout("integrations.slack.enable-orjson"):
-        # Span is required because `json.loads` calls it by default
-        with sentry_sdk.start_span(op="sentry.utils.json.loads"):
-            return orjson.loads(data)
-    else:
-        return json.loads(data)
 
 
 class SlackActionRequest(SlackRequest):
@@ -50,7 +37,9 @@ class SlackActionRequest(SlackRequest):
             - is_message: did the original message have a 'message' type
         """
         if self.data.get("callback_id"):
-            return load_json(self.data["callback_id"])
+            return json.loads_experimental(
+                "integrations.slack.enable-orjson", self.data["callback_id"]
+            )
 
         # XXX(CEO): can't really feature flag this but the block kit data is very different
 
@@ -58,20 +47,29 @@ class SlackActionRequest(SlackRequest):
         # we don't do anything with it until the user hits "Submit" but we need to handle it anyway
         if self.data["type"] == "block_actions":
             if self.data.get("view"):
-                return load_json(self.data["view"]["private_metadata"])
+                return json.loads_experimental(
+                    "integrations.slack.enable-orjson", self.data["view"]["private_metadata"]
+                )
 
             elif self.data.get("container", {}).get(
                 "is_app_unfurl"
             ):  # for actions taken on interactive unfurls
-                return load_json(self.data["app_unfurl"]["blocks"][0]["block_id"])
-            return load_json(self.data["message"]["blocks"][0]["block_id"])
+                return json.loads_experimental(
+                    "integrations.slack.enable-orjson",
+                    self.data["app_unfurl"]["blocks"][0]["block_id"],
+                )
+            return json.loads_experimental(
+                "integrations.slack.enable-orjson", self.data["message"]["blocks"][0]["block_id"]
+            )
 
         if self.data["type"] == "view_submission":
-            return load_json(self.data["view"]["private_metadata"])
+            return json.loads_experimental(
+                "integrations.slack.enable-orjson", self.data["view"]["private_metadata"]
+            )
 
         for data in self.data["message"]["blocks"]:
             if data["type"] == "section" and len(data["block_id"]) > 5:
-                return load_json(data["block_id"])
+                return json.loads_experimental("integrations.slack.enable-orjson", data["block_id"])
                 # a bit hacky, you can only provide a block ID per block (not per entire message),
                 # and if not provided slack generates a 5 char long one. our provided block_id is at least '{issue: <issue_id>}'
                 # so we know it's longer than 5 chars
@@ -88,7 +86,9 @@ class SlackActionRequest(SlackRequest):
             raise SlackRequestError(status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            self._data = load_json(self.data["payload"])
+            self._data = json.loads_experimental(
+                "integrations.slack.enable-orjson", self.data["payload"]
+            )
         except (KeyError, IndexError, TypeError, ValueError):
             raise SlackRequestError(status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/integrations/slack/requests/options_load.py
+++ b/src/sentry/integrations/slack/requests/options_load.py
@@ -2,13 +2,26 @@ from __future__ import annotations
 
 from typing import Any
 
+import orjson
+import sentry_sdk
 from rest_framework import status
 
+from sentry.features.rollout import in_random_rollout
 from sentry.integrations.slack.requests.base import SlackRequest, SlackRequestError
 from sentry.models.group import Group
 from sentry.utils import json
+from sentry.utils.json import JSONData
 
 VALID_PAYLOAD_TYPES = ["block_suggestion"]
+
+
+# TODO: remove this once we're confident that orjson is working as expected
+def load_json(data: Any) -> JSONData:
+    if in_random_rollout("integrations.slack.enable-orjson"):
+        # Span is required because `json.loads` calls it by default
+        with sentry_sdk.start_span(op="sentry.utils.json.loads"):
+            return orjson.loads(data)
+    return json.loads(data)
 
 
 class SlackOptionsLoadRequest(SlackRequest):
@@ -19,8 +32,8 @@ class SlackOptionsLoadRequest(SlackRequest):
     @property
     def group_id(self) -> int:
         if self.data.get("container", {}).get("is_app_unfurl"):
-            return int(json.loads(self.data["app_unfurl"]["blocks"][0]["block_id"])["issue"])
-        return int(json.loads(self.data["message"]["blocks"][0]["block_id"])["issue"])
+            return int(load_json(self.data["app_unfurl"]["blocks"][0]["block_id"])["issue"])
+        return int(load_json(self.data["message"]["blocks"][0]["block_id"])["issue"])
 
     @property
     def substring(self) -> str:
@@ -33,7 +46,7 @@ class SlackOptionsLoadRequest(SlackRequest):
             raise SlackRequestError(status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            self._data = json.loads(self.data["payload"])
+            self._data = load_json(self.data["payload"])
         except (KeyError, IndexError, TypeError, ValueError):
             raise SlackRequestError(status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/integrations/slack/requests/options_load.py
+++ b/src/sentry/integrations/slack/requests/options_load.py
@@ -21,7 +21,8 @@ def load_json(data: Any) -> JSONData:
         # Span is required because `json.loads` calls it by default
         with sentry_sdk.start_span(op="sentry.utils.json.loads"):
             return orjson.loads(data)
-    return json.loads(data)
+    else:
+        return json.loads(data)
 
 
 class SlackOptionsLoadRequest(SlackRequest):

--- a/src/sentry/integrations/slack/requests/options_load.py
+++ b/src/sentry/integrations/slack/requests/options_load.py
@@ -2,27 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-import orjson
-import sentry_sdk
 from rest_framework import status
 
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.slack.requests.base import SlackRequest, SlackRequestError
 from sentry.models.group import Group
 from sentry.utils import json
-from sentry.utils.json import JSONData
 
 VALID_PAYLOAD_TYPES = ["block_suggestion"]
-
-
-# TODO: remove this once we're confident that orjson is working as expected
-def load_json(data: Any) -> JSONData:
-    if in_random_rollout("integrations.slack.enable-orjson"):
-        # Span is required because `json.loads` calls it by default
-        with sentry_sdk.start_span(op="sentry.utils.json.loads"):
-            return orjson.loads(data)
-    else:
-        return json.loads(data)
 
 
 class SlackOptionsLoadRequest(SlackRequest):
@@ -33,8 +19,17 @@ class SlackOptionsLoadRequest(SlackRequest):
     @property
     def group_id(self) -> int:
         if self.data.get("container", {}).get("is_app_unfurl"):
-            return int(load_json(self.data["app_unfurl"]["blocks"][0]["block_id"])["issue"])
-        return int(load_json(self.data["message"]["blocks"][0]["block_id"])["issue"])
+            return int(
+                json.loads_experimental(
+                    "integrations.slack.enable-orjson",
+                    self.data["app_unfurl"]["blocks"][0]["block_id"],
+                )["issue"]
+            )
+        return int(
+            json.loads_experimental(
+                "integrations.slack.enable-orjson", self.data["message"]["blocks"][0]["block_id"]
+            )["issue"]
+        )
 
     @property
     def substring(self) -> str:
@@ -47,7 +42,9 @@ class SlackOptionsLoadRequest(SlackRequest):
             raise SlackRequestError(status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            self._data = load_json(self.data["payload"])
+            self._data = json.loads_experimental(
+                "integrations.slack.enable-orjson", self.data["payload"]
+            )
         except (KeyError, IndexError, TypeError, ValueError):
             raise SlackRequestError(status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 from logging import Logger, getLogger
 
-import orjson
-
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.repository import get_default_issue_alert_repository
 from sentry.integrations.repository.issue_alert import (
     IssueAlertNotificationMessage,
@@ -204,10 +201,9 @@ class SlackService:
         )
         payload.update(slack_payload)
         # TODO (Yash): Users should not have to remember to do this, interface should handle serializing the field
-        if in_random_rollout("integrations.slack.enable-orjson"):
-            payload["blocks"] = orjson.dumps(payload.get("blocks"))
-        else:
-            payload["blocks"] = json.dumps(payload.get("blocks"))
+        payload["blocks"] = json.dumps_experimental(
+            "integrations.slack.enable-orjson", payload.get("blocks")
+        )
         try:
             client.post("/chat.postMessage", data=payload, timeout=5)
         except Exception as err:

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from logging import Logger, getLogger
 
+import orjson
+
+from sentry.features.rollout import in_random_rollout
 from sentry.integrations.repository import get_default_issue_alert_repository
 from sentry.integrations.repository.issue_alert import (
     IssueAlertNotificationMessage,
@@ -201,7 +204,10 @@ class SlackService:
         )
         payload.update(slack_payload)
         # TODO (Yash): Users should not have to remember to do this, interface should handle serializing the field
-        payload["blocks"] = json.dumps(payload.get("blocks"))
+        if in_random_rollout("integrations.slack.enable-orjson"):
+            payload["blocks"] = orjson.dumps(payload.get("blocks"))
+        else:
+            payload["blocks"] = json.dumps(payload.get("blocks"))
         try:
             client.post("/chat.postMessage", data=payload, timeout=5)
         except Exception as err:

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -59,12 +59,11 @@ def send_incident_alert_notification(
     ).build()
     text = attachment["text"]
     blocks = {"blocks": attachment["blocks"], "color": attachment["color"]}
-    attachments = json.dumps_experimental("integrations.slack.enable-orjson", [blocks])
 
     payload = {
         "channel": channel,
         "text": text,
-        "attachments": attachments,
+        "attachments": json.dumps_experimental("integrations.slack.enable-orjson", [blocks]),
         # Prevent duplicate unfurl
         # https://api.slack.com/reference/messaging/link-unfurling#no_unfurling_please
         "unfurl_links": False,

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-import orjson
 import sentry_sdk
 
 from sentry import features
 from sentry.constants import ObjectStatus
-from sentry.features.rollout import in_random_rollout
 from sentry.incidents.charts import build_metric_alert_chart
 from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import Incident, IncidentStatus
@@ -61,11 +59,7 @@ def send_incident_alert_notification(
     ).build()
     text = attachment["text"]
     blocks = {"blocks": attachment["blocks"], "color": attachment["color"]}
-
-    if in_random_rollout("integrations.slack.enable-orjson"):
-        attachments = orjson.dumps([blocks])
-    else:
-        attachments = json.dumps([blocks])
+    attachments = json.dumps_experimental("integrations.slack.enable-orjson", [blocks])
 
     payload = {
         "channel": channel,

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -102,7 +102,8 @@ def load_json(data: Any) -> JSONData:
         # Span is required because `json.loads` calls it by default
         with sentry_sdk.start_span(op="sentry.utils.json.loads"):
             return orjson.loads(data)
-    return json.loads(data)
+    else:
+        return json.loads(data)
 
 
 # TODO: remove this when orjson experiment is successful

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -197,7 +197,7 @@ class SlackActionEndpoint(Endpoint):
             if view:
                 private_metadata = view.get("private_metadata")
                 if private_metadata:
-                    data = json.dumps_experimental(
+                    data = json.loads_experimental(
                         "integrations.slack.enable-orjson", private_metadata
                     )
                     channel_id = data.get("channel_id")
@@ -583,7 +583,7 @@ class SlackActionEndpoint(Endpoint):
             # use the original response_url to update the link attachment
             slack_client = SlackClient(integration_id=slack_request.integration.id)
             try:
-                private_metadata = json.dumps_experimental(
+                private_metadata = json.loads_experimental(
                     "integrations.slack.enable-orjson",
                     slack_request.data["view"]["private_metadata"],
                 )

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from collections.abc import Mapping, MutableMapping
 from typing import Any
 
-import orjson
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -12,7 +11,6 @@ from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import all_silo_endpoint
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.help import SlackHelpMessageBuilder
 from sentry.integrations.slack.message_builder.prompt import SlackPromptLinkMessageBuilder
@@ -29,14 +27,6 @@ from sentry.utils.urls import parse_link
 from ..utils import logger
 from .base import SlackDMEndpoint
 from .command import LINK_FROM_CHANNEL_MESSAGE
-
-
-# TODO: remove this when orjson experiment is successful
-def dump_json(data) -> str | bytes:
-    if in_random_rollout("integrations.slack.enable-orjson"):
-        return orjson.dumps(data)
-    else:
-        return json.dumps(data)
 
 
 @all_silo_endpoint  # Only challenge verification is handled at control
@@ -166,7 +156,9 @@ class SlackEventEndpoint(SlackDMEndpoint):
                 return True
 
             # Don't unfurl the same thing multiple times
-            seen_marker = hash(dump_json((link_type, args)))
+            seen_marker = hash(
+                json.dumps_experimental("integrations.slack.enable-orjson", (link_type, args))
+            )
             if seen_marker in links_seen:
                 continue
 
@@ -202,7 +194,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
         payload = {
             "channel": data["channel"],
             "ts": data["message_ts"],
-            "unfurls": dump_json(results),
+            "unfurls": json.dumps_experimental("integrations.slack.enable-orjson", results),
         }
 
         client = SlackClient(integration_id=slack_request.integration.id)

--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -4,7 +4,6 @@ import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-import orjson
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,7 +12,6 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
-from sentry.features.rollout import in_random_rollout
 from sentry.integrations.message_builder import format_actor_options
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.requests.options_load import SlackOptionsLoadRequest
@@ -96,10 +94,7 @@ class SlackOptionsLoadEndpoint(Endpoint):
         if not group or not features.has(
             "organizations:slack-block-kit", group.project.organization
         ):
-            if in_random_rollout("integrations.slack.enable-orjson"):
-                request_data = orjson.dumps(slack_request.data)
-            else:
-                request_data = json.dumps(slack_request.data)
+            request_data = json.dumps("integrations.slack.enable-orjson", slack_request.data)
 
             logger.exception(
                 "slack.options_load.request-error",

--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -94,14 +94,14 @@ class SlackOptionsLoadEndpoint(Endpoint):
         if not group or not features.has(
             "organizations:slack-block-kit", group.project.organization
         ):
-            request_data = json.dumps("integrations.slack.enable-orjson", slack_request.data)
-
             logger.exception(
                 "slack.options_load.request-error",
                 extra={
                     "group_id": group.id if group else None,
                     "organization_id": group.project.organization.id if group else None,
-                    "request_data": request_data,
+                    "request_data": json.dumps_experimental(
+                        "integrations.slack.enable-orjson", slack_request.data
+                    ),
                 },
             )
             return self.respond(status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+import orjson
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -12,6 +13,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.features.rollout import in_random_rollout
 from sentry.integrations.message_builder import format_actor_options
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.requests.options_load import SlackOptionsLoadRequest
@@ -94,12 +96,17 @@ class SlackOptionsLoadEndpoint(Endpoint):
         if not group or not features.has(
             "organizations:slack-block-kit", group.project.organization
         ):
+            if in_random_rollout("integrations.slack.enable-orjson"):
+                request_data = orjson.dumps(slack_request.data)
+            else:
+                request_data = json.dumps(slack_request.data)
+
             logger.exception(
                 "slack.options_load.request-error",
                 extra={
                     "group_id": group.id if group else None,
                     "organization_id": group.project.organization.id if group else None,
-                    "request_data": json.dumps(slack_request.data),
+                    "request_data": request_data,
                 },
             )
             return self.respond(status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -630,6 +630,7 @@ register(
 )
 
 register("snuba.snql.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("integrations.slack.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Kafka Publisher
 register("kafka-publisher.raw-event-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -136,7 +136,7 @@ def load(fp: IO[str] | IO[bytes], **kwargs: NoReturn) -> JSONData:
 def loads(
     value: str | bytes, use_rapid_json: bool = False, skip_trace: bool = False, **kwargs: NoReturn
 ) -> JSONData:
-    with sentry_sdk.start_span(op="sentry.utils.json.loads") if not skip_trace else nullcontext():  # type: ignore[attr-defined]
+    with sentry_sdk.start_span(op="sentry.utils.json.loads") if not skip_trace else nullcontext():
         if use_rapid_json is True:
             return rapidjson.loads(value)
         else:
@@ -149,7 +149,9 @@ def loads_experimental(option_name: str, data: str | bytes, skip_trace: bool = F
     from sentry.features.rollout import in_random_rollout
 
     if in_random_rollout(option_name):
-        with sentry_sdk.start_span(op="sentry.utils.json.loads") if not skip_trace else nullcontext():  # type: ignore[attr-defined]
+        with sentry_sdk.start_span(
+            op="sentry.utils.json.loads"
+        ) if not skip_trace else nullcontext():
             return orjson.loads(data)
     else:
         return loads(data, skip_trace)
@@ -161,7 +163,7 @@ def dumps_experimental(option_name: str, data: JSONData) -> str:
     from sentry.features.rollout import in_random_rollout
 
     if in_random_rollout(option_name):
-        return orjson.dumps(data).decode("utf-8")
+        return orjson.dumps(data).decode()
     else:
         return dumps(data)
 

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -21,7 +21,6 @@ from simplejson import _default_decoder  # type: ignore[attr-defined]  # noqa: S
 from simplejson import JSONDecodeError, JSONEncoder  # noqa: S003
 
 from bitfield.types import BitHandler
-from sentry.features.rollout import in_random_rollout
 
 # A more traditional raw import from django_stubs_ext.aliases here breaks monkeypatching,
 # So we jump through hoops to get only the exact types
@@ -147,6 +146,8 @@ def loads(
 # loads JSON with `orjson` or the default function depending on `option_name`
 # TODO: remove this once we're confident that orjson is working as expected
 def loads_experimental(option_name: str, data: str | bytes, skip_trace: bool = False) -> JSONData:
+    from sentry.features.rollout import in_random_rollout
+
     if in_random_rollout(option_name):
         if skip_trace:
             return orjson.loads(data)
@@ -160,9 +161,11 @@ def loads_experimental(option_name: str, data: str | bytes, skip_trace: bool = F
 
 # dumps JSON with `orjson` or the default function depending on `option_name`
 # TODO: remove this when orjson experiment is successful
-def dumps_experimental(option_name: str, data: JSONData) -> str | bytes:
+def dumps_experimental(option_name: str, data: JSONData) -> str:
+    from sentry.features.rollout import in_random_rollout
+
     if in_random_rollout(option_name):
-        return orjson.dumps(data)
+        return orjson.dumps(data).decode("utf-8")
     else:
         return dumps(data)
 

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -149,12 +149,8 @@ def loads_experimental(option_name: str, data: str | bytes, skip_trace: bool = F
     from sentry.features.rollout import in_random_rollout
 
     if in_random_rollout(option_name):
-        if skip_trace:
+        with sentry_sdk.start_span(op="sentry.utils.json.loads") if not skip_trace else nullcontext():  # type: ignore[attr-defined]
             return orjson.loads(data)
-        else:
-            # manually create the span
-            with sentry_sdk.start_span(op="sentry.utils.json.loads"):
-                return orjson.loads(data)
     else:
         return loads(data, skip_trace)
 


### PR DESCRIPTION
This adds an option `"integrations.slack.enable-orjson"` to enable `orjson` for json parsing (ETA: and dumping) in the slack integration.

Ref: https://github.com/getsentry/sentry/issues/68903