### PR TITLE
Add new MRIs to static strings

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -101,6 +101,9 @@ TRANSACTION_METRICS_NAMES = {
     "d:transactions/measurements.score.weight.fid@ratio": PREFIX + 146,
     "d:transactions/measurements.score.weight.lcp@ratio": PREFIX + 147,
     "d:transactions/measurements.score.weight.ttfb@ratio": PREFIX + 148,
+    "g:spans/self_time@millisecond": PREFIX + 149,
+    "g:spans/self_time_light@millisecond": PREFIX + 150,
+    "g:spans/total_time@millisecond": PREFIX + 151,
     # Last possible index: 199
 }
 

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -101,9 +101,6 @@ TRANSACTION_METRICS_NAMES = {
     "d:transactions/measurements.score.weight.fid@ratio": PREFIX + 146,
     "d:transactions/measurements.score.weight.lcp@ratio": PREFIX + 147,
     "d:transactions/measurements.score.weight.ttfb@ratio": PREFIX + 148,
-    "g:spans/self_time@millisecond": PREFIX + 149,
-    "g:spans/self_time_light@millisecond": PREFIX + 150,
-    "g:spans/total_time@millisecond": PREFIX + 151,
     # Last possible index: 199
 }
 
@@ -230,6 +227,9 @@ SPAN_METRICS_NAMES = {
     "d:spans/webvital.score.weight.inp@ratio": PREFIX + 416,
     "d:spans/webvital.inp@millisecond": PREFIX + 417,
     "c:spans/usage@none": PREFIX + 418,
+    "g:spans/self_time@millisecond": PREFIX + 419,
+    "g:spans/self_time_light@millisecond": PREFIX + 420,
+    "g:spans/total_time@millisecond": PREFIX + 421,
     # Last possible index: 499
 }
 

--- a/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
+++ b/tests/sentry/sentry_metrics/test_prevent_modifications_to_indexer_strings.py
@@ -1,7 +1,7 @@
 from hashlib import sha256
 
 LOCKED_FILE = "src/sentry/sentry_metrics/indexer/strings.py"
-LOCKED_DIGEST = "890c15103cfd9315583cfd72e4488a310e67e0c5acaddae7780cebb6e586dc70"
+LOCKED_DIGEST = "c667a458c2cc081103a289c84bb4a2d7b6c6d785e542e6f22d997657568ddf68"
 MESSAGE = f"""{LOCKED_FILE} is locked.
 
 * We have detected you made changes to this file.


### PR DESCRIPTION
See https://github.com/getsentry/sentry-options-automator/pull/1179.

IMO MRIs should be still allowed to be static, because it facilitates queries with the cardinality analyzer, and they are unique enough to not cause accidental naming clashes with customer tags.