### PR TITLE
fix: show time window select if monitorType is NOT activated

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -383,7 +383,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
             alertType={alertType}
             required
           />
-          {monitorType === MonitorType.CONTINUOUS && (
+          {monitorType !== MonitorType.ACTIVATED && (
             <SelectControl
               name="timeWindow"
               styles={this.selectControlStyles}


### PR DESCRIPTION
Slight oops where i removed the timewindow in the alerts form