### PR TITLE
ref(replays): fix timestamp for errors tab

### DIFF
--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -206,7 +206,7 @@ const ErrorTableCell = forwardRef<HTMLDivElement, Props>(
         <Cell {...columnProps} numeric>
           <ButtonWrapper>
             <TimestampButton
-              format="mm:ss.SSS"
+              format="mm:ss"
               onClick={event => {
                 event.stopPropagation();
                 onClickTimestamp(frame);


### PR DESCRIPTION
Fixes an edge case where we show `00:00.000` where everything else is `xx:xx` on the errors tab:
<img width="830" alt="SCR-20240419-kouq" src="https://github.com/getsentry/sentry/assets/56095982/b52394e1-ee4b-481d-9914-d266d0288247">

After:
<img width="586" alt="SCR-20240422-iijq" src="https://github.com/getsentry/sentry/assets/56095982/a122bc96-bde0-4d19-858a-1b4ab8309070">
