### PR TITLE
fix(performance): Add aria label to page tabs

### DIFF
--- a/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
+++ b/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
@@ -396,31 +396,33 @@ export function PageSamplePerformanceTable({transaction, search, limit = 9}: Pro
   return (
     <span>
       <SearchBarContainer>
-        {
-          <SegmentedControl
-            size="md"
-            value={datatype}
-            onChange={newDataSet => {
-              // Reset pagination and sort when switching datatypes
-              router.replace({
-                ...location,
-                query: {
-                  ...location.query,
-                  sort: undefined,
-                  cursor: undefined,
-                  [DATATYPE_KEY]: newDataSet,
-                },
-              });
-            }}
+        <SegmentedControl
+          size="md"
+          value={datatype}
+          aria-label={t('Data Type')}
+          onChange={newDataSet => {
+            // Reset pagination and sort when switching datatypes
+            router.replace({
+              ...location,
+              query: {
+                ...location.query,
+                sort: undefined,
+                cursor: undefined,
+                [DATATYPE_KEY]: newDataSet,
+              },
+            });
+          }}
+        >
+          <SegmentedControl.Item key={Datatype.PAGELOADS} aria-label={t('Pageloads')}>
+            {t('Pageloads')}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item
+            key={Datatype.INTERACTIONS}
+            aria-label={t('Interactions')}
           >
-            <SegmentedControl.Item key={Datatype.PAGELOADS}>
-              {t('Pageloads')}
-            </SegmentedControl.Item>
-            <SegmentedControl.Item key={Datatype.INTERACTIONS}>
-              {t('Interactions')}
-            </SegmentedControl.Item>
-          </SegmentedControl>
-        }
+            {t('Interactions')}
+          </SegmentedControl.Item>
+        </SegmentedControl>
 
         <StyledSearchBar
           query={query}


### PR DESCRIPTION
Fixes the console noise coming from react aria, https://github.com/getsentry/sentry/actions/runs/8787402299/job/24112929694?pr=69421#step:6:128

> If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility

removes an unused bracket
