### PR TITLE
ref(event-tags): Refactor/Util work for Issue Details changes

### DIFF
--- a/static/app/components/events/contexts/contextCard.tsx
+++ b/static/app/components/events/contexts/contextCard.tsx
@@ -1,5 +1,6 @@
 import {Link} from 'react-router';
 import styled from '@emotion/styled';
+import startCase from 'lodash/startCase';
 
 import {
   getContextMeta,
@@ -10,7 +11,7 @@ import {AnnotatedTextErrors} from 'sentry/components/events/meta/annotatedText/a
 import Panel from 'sentry/components/panels/panel';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import {space} from 'sentry/styles/space';
-import type {Group, Project} from 'sentry/types';
+import type {Group, KeyValueListDataItem, Project} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import {defined, objectIsEmpty} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -24,7 +25,71 @@ interface ContextCardProps {
   value?: Record<string, any>;
 }
 
-function ContextCard({alias, event, type, project, value = {}}: ContextCardProps) {
+interface ContextCardContentConfig {
+  disableErrors?: boolean;
+  includeAliasInSubject?: boolean;
+}
+
+export interface ContextCardContentProps {
+  item: KeyValueListDataItem;
+  meta: Record<string, any>;
+  alias?: string;
+  config?: ContextCardContentConfig;
+}
+
+export function ContextCardContent({
+  item,
+  alias,
+  meta,
+  config,
+  ...props
+}: ContextCardContentProps) {
+  const {key: contextKey, subject, value: contextValue, action = {}} = item;
+  if (contextKey === 'type') {
+    return null;
+  }
+  const contextMeta = meta?.[contextKey];
+  const contextErrors = contextMeta?.['']?.err ?? [];
+  const hasErrors = contextErrors.length > 0 && !config?.disableErrors;
+
+  const dataComponent = (
+    <StructuredData
+      value={contextValue}
+      depth={0}
+      maxDefaultDepth={0}
+      meta={contextMeta}
+      withAnnotatedText
+      withOnlyFormattedText
+    />
+  );
+
+  const contextSubject =
+    config?.includeAliasInSubject && alias ? `${startCase(alias)}: ${subject}` : subject;
+
+  return (
+    <ContextContent hasErrors={hasErrors} {...props}>
+      <ContextSubject>{contextSubject}</ContextSubject>
+      <ContextValue hasErrors={hasErrors} className="ctx-row-value">
+        {defined(action?.link) ? (
+          <Link to={action.link}>{dataComponent}</Link>
+        ) : (
+          dataComponent
+        )}
+      </ContextValue>
+      <ContextErrors>
+        <AnnotatedTextErrors errors={contextErrors} />
+      </ContextErrors>
+    </ContextContent>
+  );
+}
+
+export default function ContextCard({
+  alias,
+  event,
+  type,
+  project,
+  value = {},
+}: ContextCardProps) {
   const organization = useOrganization();
   if (objectIsEmpty(value)) {
     return null;
@@ -39,43 +104,9 @@ function ContextCard({alias, event, type, project, value = {}}: ContextCardProps
     project,
   });
 
-  const content = contextItems.map(
-    ({key, subject, value: contextValue, action = {}}, i) => {
-      if (key === 'type') {
-        return null;
-      }
-      const contextMeta = meta?.[key];
-      const contextErrors = contextMeta?.['']?.err ?? [];
-      const hasErrors = contextErrors.length > 0;
-
-      const dataComponent = (
-        <StructuredData
-          value={contextValue}
-          depth={0}
-          maxDefaultDepth={0}
-          meta={contextMeta}
-          withAnnotatedText
-          withOnlyFormattedText
-        />
-      );
-
-      return (
-        <ContextContent key={i} hasErrors={hasErrors}>
-          <ContextSubject>{subject}</ContextSubject>
-          <ContextValue hasErrors={hasErrors}>
-            {defined(action?.link) ? (
-              <Link to={action.link}>{dataComponent}</Link>
-            ) : (
-              dataComponent
-            )}
-          </ContextValue>
-          <ContextErrors>
-            <AnnotatedTextErrors errors={contextErrors} />
-          </ContextErrors>
-        </ContextContent>
-      );
-    }
-  );
+  const content = contextItems.map((item, i) => (
+    <ContextCardContent key={`context-card-${i}`} meta={meta} item={item} />
+  ));
 
   return (
     <Card>
@@ -127,10 +158,6 @@ const ContextSubject = styled('div')`
 const ContextValue = styled(ContextSubject)<{hasErrors: boolean}>`
   color: ${p => (p.hasErrors ? 'inherit' : p.theme.textColor)};
   grid-column: span ${p => (p.hasErrors ? 1 : 2)};
-  /* justify-content: space-between;
-  display: inline-flex; */
 `;
 
 const ContextErrors = styled('div')``;
-
-export default ContextCard;

--- a/static/app/components/events/contexts/contextDataSection.tsx
+++ b/static/app/components/events/contexts/contextDataSection.tsx
@@ -1,20 +1,38 @@
 import {useRef} from 'react';
 import styled from '@emotion/styled';
 
+import {getOrderedContextItems} from 'sentry/components/events/contexts';
+import ContextCard from 'sentry/components/events/contexts/contextCard';
 import {CONTEXT_DOCS_LINK} from 'sentry/components/events/contextSummary/utils';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {useIssueDetailsColumnCount} from 'sentry/components/events/eventTags/util';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
+import type {Event, Group, Project} from 'sentry/types';
 
 interface ContextDataSectionProps {
-  cards: React.ReactNode[];
+  event: Event;
+  group?: Group;
+  project?: Project;
 }
 
-function ContextDataSection({cards}: ContextDataSectionProps) {
+function ContextDataSection({event, group, project}: ContextDataSectionProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);
   const columns: React.ReactNode[] = [];
+
+  const cards = getOrderedContextItems(event).map(([alias, contextValue]) => (
+    <ContextCard
+      key={alias}
+      type={contextValue.type}
+      alias={alias}
+      value={contextValue}
+      event={event}
+      group={group}
+      project={project}
+    />
+  ));
+
   const columnSize = Math.ceil(cards.length / columnCount);
   for (let i = 0; i < cards.length; i += columnSize) {
     columns.push(<CardColumn key={i}>{cards.slice(i, i + columnSize)}</CardColumn>);

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -144,18 +144,18 @@ function TagTreeColumns({
         // If it's the last entry, create a column with the remaining rows
         if (index === tagTreeRowGroups.length - 1) {
           columns.push(
-            <TagColumn key={columns.length} data-test-id="tag-tree-column">
+            <TreeColumn key={columns.length} data-test-id="tag-tree-column">
               {tagTreeRowGroups.slice(startIndex)}
-            </TagColumn>
+            </TreeColumn>
           );
           return {startIndex, runningTotal, columns};
         }
-        // If we reach the goal column size, wrap rows in a TagColumn.
+        // If we reach the goal column size, wrap rows in a TreeColumn.
         if (runningTotal >= columnRowGoal) {
           columns.push(
-            <TagColumn key={columns.length} data-test-id="tag-tree-column">
+            <TreeColumn key={columns.length} data-test-id="tag-tree-column">
               {tagTreeRowGroups.slice(startIndex, index)}
-            </TagColumn>
+            </TreeColumn>
           );
           runningTotal = 0;
           startIndex = index;
@@ -175,20 +175,20 @@ function EventTagsTree(props: EventTagsTreeProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);
   return (
-    <TagContainer columnCount={columnCount} ref={containerRef}>
+    <TreeContainer columnCount={columnCount} ref={containerRef}>
       <TagTreeColumns columnCount={columnCount} {...props} />
-    </TagContainer>
+    </TreeContainer>
   );
 }
 
-export const TagContainer = styled('div')<{columnCount: number}>`
+export const TreeContainer = styled('div')<{columnCount: number}>`
   margin-top: ${space(1.5)};
   display: grid;
   grid-template-columns: repeat(${p => p.columnCount}, 1fr);
   align-items: start;
 `;
 
-export const TagColumn = styled('div')`
+export const TreeColumn = styled('div')`
   display: grid;
   grid-template-columns: minmax(auto, 175px) 1fr;
   grid-column-gap: ${space(3)};

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -144,18 +144,18 @@ function TagTreeColumns({
         // If it's the last entry, create a column with the remaining rows
         if (index === tagTreeRowGroups.length - 1) {
           columns.push(
-            <TreeColumn key={columns.length} data-test-id="tag-tree-column">
+            <TagColumn key={columns.length} data-test-id="tag-tree-column">
               {tagTreeRowGroups.slice(startIndex)}
-            </TreeColumn>
+            </TagColumn>
           );
           return {startIndex, runningTotal, columns};
         }
-        // If we reach the goal column size, wrap rows in a TreeColumn.
+        // If we reach the goal column size, wrap rows in a TagColumn.
         if (runningTotal >= columnRowGoal) {
           columns.push(
-            <TreeColumn key={columns.length} data-test-id="tag-tree-column">
+            <TagColumn key={columns.length} data-test-id="tag-tree-column">
               {tagTreeRowGroups.slice(startIndex, index)}
-            </TreeColumn>
+            </TagColumn>
           );
           runningTotal = 0;
           startIndex = index;
@@ -175,25 +175,20 @@ function EventTagsTree(props: EventTagsTreeProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);
   return (
-    <TreeContainer ref={containerRef}>
-      <TreeGarden columnCount={columnCount}>
-        <TagTreeColumns columnCount={columnCount} {...props} />
-      </TreeGarden>
-    </TreeContainer>
+    <TagContainer columnCount={columnCount} ref={containerRef}>
+      <TagTreeColumns columnCount={columnCount} {...props} />
+    </TagContainer>
   );
 }
 
-const TreeContainer = styled('div')`
+export const TagContainer = styled('div')<{columnCount: number}>`
   margin-top: ${space(1.5)};
-`;
-
-const TreeGarden = styled('div')<{columnCount: number}>`
   display: grid;
   grid-template-columns: repeat(${p => p.columnCount}, 1fr);
   align-items: start;
 `;
 
-const TreeColumn = styled('div')`
+export const TagColumn = styled('div')`
   display: grid;
   grid-template-columns: minmax(auto, 175px) 1fr;
   grid-column-gap: ${space(3)};

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -216,7 +216,7 @@ function EventTagsTreeRowDropdown({
   );
 }
 
-export const TreeRow = styled('div')<{hasErrors: boolean}>`
+const TreeRow = styled('div')<{hasErrors: boolean}>`
   border-radius: ${space(0.5)};
   padding-left: ${space(1)};
   position: relative;
@@ -282,7 +282,7 @@ const TreeValueTrunk = styled('div')`
   grid-column-gap: ${space(0.5)};
 `;
 
-export const TreeValue = styled('div')<{hasErrors?: boolean}>`
+const TreeValue = styled('div')<{hasErrors?: boolean}>`
   padding: ${space(0.25)} 0;
   align-self: start;
   font-family: ${p => p.theme.text.familyMono};
@@ -292,7 +292,7 @@ export const TreeValue = styled('div')<{hasErrors?: boolean}>`
   color: ${p => (p.hasErrors ? 'inherit' : p.theme.textColor)};
 `;
 
-export const TreeKey = styled(TreeValue)<{hasErrors?: boolean}>`
+const TreeKey = styled(TreeValue)<{hasErrors?: boolean}>`
   color: ${p => (p.hasErrors ? 'inherit' : p.theme.subText)};
 `;
 

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -172,8 +172,8 @@ const ISSUE_DETAILS_COLUMN_BREAKPOINTS = [
  * rendered in the page contents, modals, and asides, we can't rely on window breakpoint to
  * accurately describe the available space.
  */
-export function useIssueDetailsColumnCount(containerRef: RefObject<HTMLElement>): number {
-  const {width} = useDimensions<HTMLElement>({elementRef: containerRef});
+export function useIssueDetailsColumnCount(elementRef: RefObject<HTMLElement>): number {
+  const {width} = useDimensions({elementRef});
   const breakPoint = ISSUE_DETAILS_COLUMN_BREAKPOINTS.find(
     ({minWidth}) => width >= minWidth
   );

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -514,7 +514,7 @@ describe('EventTagsAndScreenshot', function () {
     });
   });
 
-  describe("renders changes for 'event-tags-new-ui' flag", function () {
+  describe("renders changes for 'event-tags-tree-ui' flag", function () {
     const featuredOrganization = OrganizationFixture({
       features: ['event-attachments', 'event-tags-tree-ui'],
     });
@@ -595,7 +595,7 @@ describe('EventTagsAndScreenshot', function () {
       assertFlagAndQueryParamWork();
     });
 
-    it("allows filtering with 'event-tags-new-ui' flag", async function () {
+    it("allows filtering with 'event-tags-tree-ui' flag", async function () {
       MockApiClient.addMockResponse({
         url: `/projects/${featuredOrganization.slug}/${project.slug}/events/${event.id}/attachments/`,
         body: [],
@@ -636,7 +636,7 @@ describe('EventTagsAndScreenshot', function () {
       expect(rows).toHaveLength(allTags.length);
     });
 
-    it("promotes custom tags with 'event-tags-new-ui' flag", async function () {
+    it("promotes custom tags with 'event-tags-tree-ui' flag", async function () {
       MockApiClient.addMockResponse({
         url: `/projects/${featuredOrganization.slug}/${project.slug}/events/${event.id}/attachments/`,
         body: [],

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -59,6 +59,8 @@ export type Project = {
   builtinSymbolSources?: string[];
   defaultEnvironment?: string;
   hasUserReports?: boolean;
+  highlightContext?: Record<string, string[]>;
+  highlightTags?: string[];
   latestDeploys?: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;
   latestRelease?: {version: string} | null;
   options?: Record<string, boolean | string>;

--- a/static/app/utils/useDetailedProject.tsx
+++ b/static/app/utils/useDetailedProject.tsx
@@ -1,0 +1,26 @@
+import type {Project} from 'sentry/types';
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+
+interface DetailedProjectParameters {
+  orgSlug: string;
+  projectSlug: string;
+}
+
+export const makeDetailedProjectQueryKey = ({
+  orgSlug,
+  projectSlug,
+}: DetailedProjectParameters): ApiQueryKey => [`/projects/${orgSlug}/${projectSlug}/`];
+
+export function useDetailedProject(
+  params: DetailedProjectParameters,
+  options: Partial<UseApiQueryOptions<Project>> = {}
+) {
+  return useApiQuery<Project>(makeDetailedProjectQueryKey(params), {
+    staleTime: Infinity,
+    ...options,
+  });
+}


### PR DESCRIPTION
No significant changes here, but a lot of the util/refactors/new props are necessary for enabling rendering custom highlights.

List of changes:
- Pulls out the list of context items from the `EventContexts` component
- Pulls the context content out of the `ContextCard` component (with a config to edit how its rendered)
- Adds a config to `EventTagsTreeRow` component to edit how its rendered
- Remove a div from the `EventTagsTree`
- Creates the `ContextCard` components from the `EventContexts` component into the `ContextDataSection`
- Implement a hook to get a detailed project from a slug (since `useProjects` does not render with the `DetailedProjectSerializer`)
- Correct the flag name on some frontend tests
- Rename param for `useIssueDetailsColumnCount` hook
- Adds `highlightContext` and `highlightTags` to the Project type

