### PR TITLE
 ref(event-tags): Refactor work for Issue Details changes

### DIFF
--- a/static/app/components/events/contexts/contextCard.tsx
+++ b/static/app/components/events/contexts/contextCard.tsx
@@ -2,6 +2,7 @@ import {Link} from 'react-router';
 import styled from '@emotion/styled';
 import startCase from 'lodash/startCase';
 
+import type {ContextValue} from 'sentry/components/events/contexts';
 import {
   getContextMeta,
   getContextTitle,
@@ -11,8 +12,7 @@ import {AnnotatedTextErrors} from 'sentry/components/events/meta/annotatedText/a
 import Panel from 'sentry/components/panels/panel';
 import {StructuredData} from 'sentry/components/structuredEventData';
 import {space} from 'sentry/styles/space';
-import type {Group, KeyValueListDataItem, Project, Event} from 'sentry/types';
-
+import type {Event, Group, KeyValueListDataItem, Project} from 'sentry/types';
 import {defined, objectIsEmpty} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -22,7 +22,7 @@ interface ContextCardProps {
   type: string;
   group?: Group;
   project?: Project;
-  value?: Record<string, any>;
+  value?: ContextValue;
 }
 
 interface ContextCardContentConfig {
@@ -69,13 +69,13 @@ export function ContextCardContent({
   return (
     <ContextContent hasErrors={hasErrors} {...props}>
       <ContextSubject>{contextSubject}</ContextSubject>
-      <ContextValue hasErrors={hasErrors} className="ctx-row-value">
+      <ContextValueWrapper hasErrors={hasErrors} className="ctx-row-value">
         {defined(action?.link) ? (
           <Link to={action.link}>{dataComponent}</Link>
         ) : (
           dataComponent
         )}
-      </ContextValue>
+      </ContextValueWrapper>
       <ContextErrors>
         <AnnotatedTextErrors errors={contextErrors} />
       </ContextErrors>
@@ -155,7 +155,7 @@ const ContextSubject = styled('div')`
   word-wrap: break-word;
 `;
 
-const ContextValue = styled(ContextSubject)<{hasErrors: boolean}>`
+const ContextValueWrapper = styled(ContextSubject)<{hasErrors: boolean}>`
   color: ${p => (p.hasErrors ? 'inherit' : p.theme.textColor)};
   grid-column: span ${p => (p.hasErrors ? 1 : 2)};
 `;

--- a/static/app/components/events/contexts/contextDataSection.tsx
+++ b/static/app/components/events/contexts/contextDataSection.tsx
@@ -1,20 +1,38 @@
 import {useRef} from 'react';
 import styled from '@emotion/styled';
 
+import {getOrderedContextItems} from 'sentry/components/events/contexts';
+import ContextCard from 'sentry/components/events/contexts/contextCard';
 import {CONTEXT_DOCS_LINK} from 'sentry/components/events/contextSummary/utils';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {useIssueDetailsColumnCount} from 'sentry/components/events/eventTags/util';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
+import type {Event, Group, Project} from 'sentry/types';
 
 interface ContextDataSectionProps {
-  cards: React.ReactNode[];
+  event: Event;
+  group?: Group;
+  project?: Project;
 }
 
-function ContextDataSection({cards}: ContextDataSectionProps) {
+function ContextDataSection({event, group, project}: ContextDataSectionProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);
   const columns: React.ReactNode[] = [];
+
+  const cards = getOrderedContextItems(event).map(([alias, contextValue]) => (
+    <ContextCard
+      key={alias}
+      type={contextValue.type}
+      alias={alias}
+      value={contextValue}
+      event={event}
+      group={group}
+      project={project}
+    />
+  ));
+
   const columnSize = Math.ceil(cards.length / columnCount);
   for (let i = 0; i < cards.length; i += columnSize) {
     columns.push(<CardColumn key={i}>{cards.slice(i, i + columnSize)}</CardColumn>);

--- a/static/app/components/events/contexts/contextDataSection.tsx
+++ b/static/app/components/events/contexts/contextDataSection.tsx
@@ -21,7 +21,7 @@ function ContextDataSection({event, group, project}: ContextDataSectionProps) {
   const columnCount = useIssueDetailsColumnCount(containerRef);
   const columns: React.ReactNode[] = [];
 
-  const cards = getOrderedContextItems(event).map(([alias, contextValue]) => (
+  const cards = getOrderedContextItems(event).map(({alias, value: contextValue}) => (
     <ContextCard
       key={alias}
       type={contextValue.type}

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -143,18 +143,18 @@ function TagTreeColumns({
         // If it's the last entry, create a column with the remaining rows
         if (index === tagTreeRowGroups.length - 1) {
           columns.push(
-            <TreeColumn key={columns.length} data-test-id="tag-tree-column">
+            <TagColumn key={columns.length} data-test-id="tag-tree-column">
               {tagTreeRowGroups.slice(startIndex)}
-            </TreeColumn>
+            </TagColumn>
           );
           return {startIndex, runningTotal, columns};
         }
-        // If we reach the goal column size, wrap rows in a TreeColumn.
+        // If we reach the goal column size, wrap rows in a TagColumn.
         if (runningTotal >= columnRowGoal) {
           columns.push(
-            <TreeColumn key={columns.length} data-test-id="tag-tree-column">
+            <TagColumn key={columns.length} data-test-id="tag-tree-column">
               {tagTreeRowGroups.slice(startIndex, index)}
-            </TreeColumn>
+            </TagColumn>
           );
           runningTotal = 0;
           startIndex = index;
@@ -174,25 +174,20 @@ function EventTagsTree(props: EventTagsTreeProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);
   return (
-    <TreeContainer ref={containerRef}>
-      <TreeGarden columnCount={columnCount}>
-        <TagTreeColumns columnCount={columnCount} {...props} />
-      </TreeGarden>
-    </TreeContainer>
+    <TagContainer columnCount={columnCount} ref={containerRef}>
+      <TagTreeColumns columnCount={columnCount} {...props} />
+    </TagContainer>
   );
 }
 
-const TreeContainer = styled('div')`
+export const TagContainer = styled('div')<{columnCount: number}>`
   margin-top: ${space(1.5)};
-`;
-
-const TreeGarden = styled('div')<{columnCount: number}>`
   display: grid;
   grid-template-columns: repeat(${p => p.columnCount}, 1fr);
   align-items: start;
 `;
 
-const TreeColumn = styled('div')`
+export const TagColumn = styled('div')`
   display: grid;
   grid-template-columns: minmax(auto, 175px) 1fr;
   grid-column-gap: ${space(3)};

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -143,18 +143,18 @@ function TagTreeColumns({
         // If it's the last entry, create a column with the remaining rows
         if (index === tagTreeRowGroups.length - 1) {
           columns.push(
-            <TagColumn key={columns.length} data-test-id="tag-tree-column">
+            <TreeColumn key={columns.length} data-test-id="tag-tree-column">
               {tagTreeRowGroups.slice(startIndex)}
-            </TagColumn>
+            </TreeColumn>
           );
           return {startIndex, runningTotal, columns};
         }
-        // If we reach the goal column size, wrap rows in a TagColumn.
+        // If we reach the goal column size, wrap rows in a TreeColumn.
         if (runningTotal >= columnRowGoal) {
           columns.push(
-            <TagColumn key={columns.length} data-test-id="tag-tree-column">
+            <TreeColumn key={columns.length} data-test-id="tag-tree-column">
               {tagTreeRowGroups.slice(startIndex, index)}
-            </TagColumn>
+            </TreeColumn>
           );
           runningTotal = 0;
           startIndex = index;
@@ -174,20 +174,20 @@ function EventTagsTree(props: EventTagsTreeProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);
   return (
-    <TagContainer columnCount={columnCount} ref={containerRef}>
+    <TreeContainer columnCount={columnCount} ref={containerRef}>
       <TagTreeColumns columnCount={columnCount} {...props} />
-    </TagContainer>
+    </TreeContainer>
   );
 }
 
-export const TagContainer = styled('div')<{columnCount: number}>`
+export const TreeContainer = styled('div')<{columnCount: number}>`
   margin-top: ${space(1.5)};
   display: grid;
   grid-template-columns: repeat(${p => p.columnCount}, 1fr);
   align-items: start;
 `;
 
-export const TagColumn = styled('div')`
+export const TreeColumn = styled('div')`
   display: grid;
   grid-template-columns: minmax(auto, 175px) 1fr;
   grid-column-gap: ${space(3)};

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -216,7 +216,7 @@ function EventTagsTreeRowDropdown({
   );
 }
 
-export const TreeRow = styled('div')<{hasErrors: boolean}>`
+const TreeRow = styled('div')<{hasErrors: boolean}>`
   border-radius: ${space(0.5)};
   padding-left: ${space(1)};
   position: relative;
@@ -282,7 +282,7 @@ const TreeValueTrunk = styled('div')`
   grid-column-gap: ${space(0.5)};
 `;
 
-export const TreeValue = styled('div')<{hasErrors?: boolean}>`
+const TreeValue = styled('div')<{hasErrors?: boolean}>`
   padding: ${space(0.25)} 0;
   align-self: start;
   font-family: ${p => p.theme.text.familyMono};
@@ -292,7 +292,7 @@ export const TreeValue = styled('div')<{hasErrors?: boolean}>`
   color: ${p => (p.hasErrors ? 'inherit' : p.theme.textColor)};
 `;
 
-export const TreeKey = styled(TreeValue)<{hasErrors?: boolean}>`
+const TreeKey = styled(TreeValue)<{hasErrors?: boolean}>`
   color: ${p => (p.hasErrors ? 'inherit' : p.theme.subText)};
 `;
 

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -173,7 +173,7 @@ const ISSUE_DETAILS_COLUMN_BREAKPOINTS = [
  * accurately describe the available space.
  */
 export function useIssueDetailsColumnCount(elementRef: RefObject<HTMLElement>): number {
-  const {width} = useDimensions({elementRef});
+  const {width} = useDimensions<HTMLElement>({elementRef});
   const breakPoint = ISSUE_DETAILS_COLUMN_BREAKPOINTS.find(
     ({minWidth}) => width >= minWidth
   );

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -172,8 +172,8 @@ const ISSUE_DETAILS_COLUMN_BREAKPOINTS = [
  * rendered in the page contents, modals, and asides, we can't rely on window breakpoint to
  * accurately describe the available space.
  */
-export function useIssueDetailsColumnCount(containerRef: RefObject<HTMLElement>): number {
-  const {width} = useDimensions<HTMLElement>({elementRef: containerRef});
+export function useIssueDetailsColumnCount(elementRef: RefObject<HTMLElement>): number {
+  const {width} = useDimensions({elementRef});
   const breakPoint = ISSUE_DETAILS_COLUMN_BREAKPOINTS.find(
     ({minWidth}) => width >= minWidth
   );

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -513,7 +513,7 @@ describe('EventTagsAndScreenshot', function () {
     });
   });
 
-  describe("renders changes for 'event-tags-new-ui' flag", function () {
+  describe("renders changes for 'event-tags-tree-ui' flag", function () {
     const featuredOrganization = OrganizationFixture({
       features: ['event-attachments', 'event-tags-tree-ui'],
     });
@@ -594,7 +594,7 @@ describe('EventTagsAndScreenshot', function () {
       assertFlagAndQueryParamWork();
     });
 
-    it("allows filtering with 'event-tags-new-ui' flag", async function () {
+    it("allows filtering with 'event-tags-tree-ui' flag", async function () {
       MockApiClient.addMockResponse({
         url: `/projects/${featuredOrganization.slug}/${project.slug}/events/${event.id}/attachments/`,
         body: [],
@@ -635,7 +635,7 @@ describe('EventTagsAndScreenshot', function () {
       expect(rows).toHaveLength(allTags.length);
     });
 
-    it("promotes custom tags with 'event-tags-new-ui' flag", async function () {
+    it("promotes custom tags with 'event-tags-tree-ui' flag", async function () {
       MockApiClient.addMockResponse({
         url: `/projects/${featuredOrganization.slug}/${project.slug}/events/${event.id}/attachments/`,
         body: [],

--- a/static/app/components/events/highlights/util.spec.tsx
+++ b/static/app/components/events/highlights/util.spec.tsx
@@ -92,7 +92,7 @@ describe('getHighlightContextData', function () {
     expect(highlightCtxData[0].type).toBe('default');
     expect(highlightCtxData[0].data).toHaveLength(highlightContext.keyboard.length);
     const highlightCtxDataKeys = new Set(highlightCtxData[0].data.map(({key}) => key));
-    for (const ctxKey in highlightContext.keyboard) {
+    for (const ctxKey of highlightContext.keyboard) {
       expect(highlightCtxDataKeys.has(ctxKey)).toBe(true);
     }
   });

--- a/static/app/components/events/highlights/util.tsx
+++ b/static/app/components/events/highlights/util.tsx
@@ -2,16 +2,15 @@ import {getOrderedContextItems} from 'sentry/components/events/contexts';
 import {getFormattedContextData} from 'sentry/components/events/contexts/utils';
 import type {TagTreeContent} from 'sentry/components/events/eventTags/eventTagsTree';
 import type {
-  HighlightContext,
-  HighlightTags,
-} from 'sentry/components/events/highlights/highlightsDataSection';
-import type {
   Event,
   EventTag,
   KeyValueListData,
   Organization,
   Project,
 } from 'sentry/types';
+
+export type HighlightTags = Required<Project>['highlightTags'];
+export type HighlightContext = Required<Project>['highlightContext'];
 
 export function getHighlightContextItems({
   event,

--- a/static/app/components/events/highlights/util.tsx
+++ b/static/app/components/events/highlights/util.tsx
@@ -1,0 +1,88 @@
+import {getOrderedContextItems} from 'sentry/components/events/contexts';
+import {getFormattedContextData} from 'sentry/components/events/contexts/utils';
+import type {TagTreeContent} from 'sentry/components/events/eventTags/eventTagsTree';
+import type {
+  HighlightContext,
+  HighlightTags,
+} from 'sentry/components/events/highlights/highlightsDataSection';
+import type {
+  Event,
+  EventTag,
+  KeyValueListData,
+  Organization,
+  Project,
+} from 'sentry/types';
+
+export function getHighlightContextItems({
+  event,
+  highlightContext,
+  project,
+  organization,
+}: {
+  event: Event;
+  highlightContext: HighlightContext;
+  organization: Organization;
+  project: Project;
+}) {
+  const highlightContextSets: Record<string, Set<string>> = Object.entries(
+    highlightContext
+  ).reduce(
+    (hcSets, [contextType, contextKeys]) => ({
+      ...hcSets,
+      [contextType]: new Set(contextKeys),
+    }),
+    {}
+  );
+  const allContextDataMap: Record<string, {contextType: string; data: KeyValueListData}> =
+    getOrderedContextItems(event).reduce((ctxMap, [alias, contextValue]) => {
+      ctxMap[alias] = {
+        contextType: contextValue.type,
+        data: getFormattedContextData({
+          event,
+          contextType: contextValue.type,
+          contextValue,
+          organization,
+          project,
+        }),
+      };
+      return ctxMap;
+    }, {});
+  // 2D Array of highlighted context data. We flatten it because
+  const highlightContextDataItems: [alias: string, KeyValueListData][] = Object.entries(
+    allContextDataMap
+  ).map(([alias, {contextType, data}]) => {
+    // Find the key set from highlight preferences
+    const highlightContextKeys =
+      highlightContextSets[alias] ?? highlightContextSets[contextType] ?? new Set([]);
+    // Filter to only items from that set
+    const highlightContextData: KeyValueListData = data.filter(
+      ({key, subject}) =>
+        // Need to do both since they differ
+        highlightContextKeys.has(key) || highlightContextKeys.has(subject)
+    );
+    return [alias, highlightContextData];
+  });
+
+  return highlightContextDataItems;
+}
+
+export function getHighlightTagItems({
+  event,
+  highlightTags,
+}: {
+  event: Event;
+  highlightTags: HighlightTags;
+}): Required<TagTreeContent>[] {
+  const EMPTY_TAG_VALUE = '';
+  const tagMap: Record<string, {meta: Record<string, any>; tag: EventTag}> =
+    event.tags.reduce((tm, tag, i) => {
+      tm[tag.key] = {tag, meta: event._meta?.tags?.[i]};
+      return tm;
+    }, {});
+  return highlightTags.map(tagKey => ({
+    subtree: {},
+    meta: tagMap[tagKey]?.meta ?? {},
+    value: tagMap[tagKey]?.tag?.value ?? EMPTY_TAG_VALUE,
+    originalTag: tagMap[tagKey]?.tag ?? {key: tagKey, value: EMPTY_TAG_VALUE},
+  }));
+}

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -652,7 +652,7 @@ export interface ResponseContext {
   type: 'response';
 }
 
-type EventContexts = {
+export type EventContexts = {
   'Memory Info'?: MemoryInfoContext;
   'ThreadPool Info'?: ThreadPoolInfoContext;
   browser?: BrowserContext;

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -59,6 +59,8 @@ export type Project = {
   builtinSymbolSources?: string[];
   defaultEnvironment?: string;
   hasUserReports?: boolean;
+  highlightContext?: Record<string, string[]>;
+  highlightTags?: string[];
   latestDeploys?: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;
   latestRelease?: {version: string} | null;
   options?: Record<string, boolean | string>;

--- a/static/app/utils/useDetailedProject.tsx
+++ b/static/app/utils/useDetailedProject.tsx
@@ -1,0 +1,26 @@
+import type {Project} from 'sentry/types';
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+
+interface DetailedProjectParameters {
+  orgSlug: string;
+  projectSlug: string;
+}
+
+export const makeDetailedProjectQueryKey = ({
+  orgSlug,
+  projectSlug,
+}: DetailedProjectParameters): ApiQueryKey => [`/projects/${orgSlug}/${projectSlug}/`];
+
+export function useDetailedProject(
+  params: DetailedProjectParameters,
+  options: Partial<UseApiQueryOptions<Project>> = {}
+) {
+  return useApiQuery<Project>(makeDetailedProjectQueryKey(params), {
+    staleTime: Infinity,
+    ...options,
+  });
+}


### PR DESCRIPTION
No significant changes here, but a lot of the util/refactors/new props are necessary for enabling rendering custom highlights.

List of changes:
- Pulls out the list of context items from the `EventContexts` component
- Pulls the context content out of the `ContextCard` component (with a config to edit how its rendered)
- Adds a config to `EventTagsTreeRow` component to edit how its rendered
- Remove a div from the `EventTagsTree`
- Creates the `ContextCard` components from the `EventContexts` component into the `ContextDataSection`
- Implement a hook to get a detailed project from a slug (since `useProjects` does not render with the `DetailedProjectSerializer`)
- Correct the flag name on some frontend tests
- Rename param for `useIssueDetailsColumnCount` hook
- Adds `highlightContext` and `highlightTags` to the Project type

