### PR TITLE
feat(actor) Start dual writing for Rule

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -326,7 +326,11 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             owner = data.get("owner")
             if owner:
                 try:
-                    kwargs["owner"] = owner.resolve_to_actor().id
+                    # TODO(mark) Use owner.resolve() instead when owner is removed.
+                    actor = owner.resolve_to_actor()
+                    kwargs["owner"] = actor.id
+                    kwargs["owner_user_id"] = actor.user_id
+                    kwargs["owner_team_id"] = actor.team_id
                 except (User.DoesNotExist, Team.DoesNotExist):
                     return Response(
                         "Could not resolve owner",

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -825,7 +825,11 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         owner = data.get("owner")
         if owner:
             try:
-                kwargs["owner"] = owner.resolve_to_actor().id
+                # TODO(mark) Use owner.resolve() intead when owner is removed.
+                actor = owner.resolve_to_actor()
+                kwargs["owner"] = actor.id
+                kwargs["owner_user_id"] = actor.user_id
+                kwargs["owner_team_id"] = actor.team_id
             except (User.DoesNotExist, Team.DoesNotExist):
                 return Response(
                     "Could not resolve owner",

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -182,7 +182,10 @@ class RuleSerializer(RuleSetSerializer):
         if self.validated_data.get("frequency"):
             rule.data["frequency"] = self.validated_data["frequency"]
         if self.validated_data.get("owner"):
-            rule.owner = self.validated_data["owner"].resolve_to_actor()
+            actor = self.validated_data["owner"].resolve_to_actor()
+            rule.owner_id = actor.id
+            rule.owner_user_id = actor.user_id
+            rule.owner_team_id = actor.team_id
         rule.save()
         return rule
 

--- a/src/sentry/mediators/project_rules/creator.py
+++ b/src/sentry/mediators/project_rules/creator.py
@@ -3,7 +3,6 @@ from rest_framework.request import Request
 
 from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
-from sentry.models.actor import Actor
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 
@@ -11,7 +10,9 @@ from sentry.models.rule import Rule
 class Creator(Mediator):
     name = Param(str)
     environment = Param(int, required=False)
-    owner = Param(Actor, required=False)
+    owner = Param(int, required=False)
+    owner_team_id = Param(int, required=False)
+    owner_user_id = Param(int, required=False)
     project = Param(Project)
     action_match = Param(str)
     filter_match = Param(str, required=False)
@@ -40,7 +41,9 @@ class Creator(Mediator):
         }
         _kwargs = {
             "label": self.name,
-            "owner": Actor.objects.get(id=self.owner) if self.owner else None,
+            "owner_id": self.owner,
+            "owner_team_id": self.owner_team_id,
+            "owner_user_id": self.owner_user_id,
             "environment_id": self.environment or None,
             "project": self.project,
             "data": data,

--- a/src/sentry/mediators/project_rules/updater.py
+++ b/src/sentry/mediators/project_rules/updater.py
@@ -3,7 +3,6 @@ from rest_framework.request import Request
 
 from sentry.mediators.mediator import Mediator
 from sentry.mediators.param import Param
-from sentry.models.actor import Actor
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 
@@ -12,6 +11,8 @@ class Updater(Mediator):
     rule = Param(Rule)
     name = Param(str, required=False)
     owner = Param(int, required=False)
+    owner_team_id = Param(int, required=False)
+    owner_user_id = Param(int, required=False)
     environment = Param(int, required=False)
     project = Param(Project)
     action_match = Param(str, required=False)
@@ -40,7 +41,9 @@ class Updater(Mediator):
             self.rule.label = self.name
 
     def _update_owner(self) -> None:
-        self.rule.owner = Actor.objects.get(id=self.owner) if self.owner else None
+        self.rule.owner_id = self.owner
+        self.rule.owner_user_id = self.owner_user_id
+        self.rule.owner_team_id = self.owner_team_id
 
     def _update_environment(self):
         self.rule.environment_id = self.environment

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -534,6 +534,43 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["id"] == str(self.rule.id)
         assert_rule_from_payload(self.rule, payload)
 
+    def test_update_owner_type(self):
+        team = self.create_team(organization=self.organization)
+        actions = [{"id": "sentry.rules.actions.notify_event.NotifyEventAction"}]
+        payload = {
+            "name": "hello world 2",
+            "owner": f"team:{team.id}",
+            "actionMatch": "all",
+            "actions": actions,
+            "conditions": self.first_seen_condition,
+        }
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
+        )
+        assert response.data["id"] == str(self.rule.id)
+        assert response.data["owner"] == f"team:{team.id}"
+        rule = Rule.objects.get(id=response.data["id"])
+        assert rule.owner_id
+        assert rule.owner_team_id == team.id
+        assert rule.owner_user_id is None
+
+        payload = {
+            "name": "hello world 2",
+            "owner": f"user:{self.user.id}",
+            "actionMatch": "all",
+            "actions": actions,
+            "conditions": self.first_seen_condition,
+        }
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
+        )
+        assert response.data["id"] == str(self.rule.id)
+        assert response.data["owner"] == f"user:{self.user.id}"
+        rule = Rule.objects.get(id=response.data["id"])
+        assert rule.owner_id
+        assert rule.owner_team_id is None
+        assert rule.owner_user_id == self.user.id
+
     def test_update_name(self):
         conditions = [
             {

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -541,6 +541,27 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         )
         assert str(response.data["owner"][0]) == "Team is not a member of this organization"
 
+    def test_team_owner(self):
+        team = self.create_team(organization=self.organization)
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            name="test",
+            owner=f"team:{team.id}",
+            actionMatch="any",
+            filterMatch="any",
+            frequency=5,
+            actions=self.notify_event_action,
+            conditions=self.first_seen_condition,
+        )
+        assert response.status_code == 200
+        assert response.data["owner"] == f"team:{team.id}"
+
+        rule = Rule.objects.get(id=response.data["id"])
+        assert rule.owner_id
+        assert rule.owner_team_id == team.id
+        assert rule.owner_user_id is None
+
     def test_frequency_percent_validation(self):
         condition = {
             "id": "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
@@ -747,6 +768,8 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             "actions": payload.get("actions", []),
             "frequency": payload.get("frequency"),
             "user_id": self.user.id,
+            "owner_user_id": self.user.id,
+            "owner_team_id": None,
             "uuid": "abc123",
         }
         call_args = mock_find_channel_id_for_alert_rule.call_args[1]["kwargs"]

--- a/tests/sentry/api/endpoints/test_project_team_details.py
+++ b/tests/sentry/api/endpoints/test_project_team_details.py
@@ -83,9 +83,11 @@ class ProjectTeamDetailsDeleteTest(ProjectTeamDetailsTest):
 
         # Associate rules with the team that also get deleted:
         # self.create_rule(name="test_rule", owner=f"team:{team.id}")
-        r1 = Rule.objects.create(label="test rule", project=project, owner=team.actor)
+        r1 = Rule.objects.create(
+            label="test rule", project=project, owner=team.actor, owner_team=team
+        )
         r2 = Rule.objects.create(
-            label="another test rule", project=another_project, owner=team.actor
+            label="another test rule", project=another_project, owner=team.actor, owner_team=team
         )
         ar1 = self.create_alert_rule(
             name="test alert rule", owner=team.actor.get_actor_tuple(), projects=[project]

--- a/tests/sentry/api/endpoints/test_rule_snooze.py
+++ b/tests/sentry/api/endpoints/test_rule_snooze.py
@@ -15,7 +15,10 @@ from sentry.utils.actor import ActorTuple
 class BaseRuleSnoozeTest(APITestCase):
     def setUp(self):
         self.issue_alert_rule = Rule.objects.create(
-            label="test rule", project=self.project, owner=self.team.actor
+            label="test rule",
+            project=self.project,
+            owner=self.team.actor,
+            owner_team_id=self.team.id,
         )
         self.metric_alert_rule = self.create_alert_rule(
             organization=self.project.organization, projects=[self.project]
@@ -216,7 +219,10 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
         """Test that if a user doesn't belong to the team that can edit an issue alert rule, they can still mute it for just themselves."""
         other_team = self.create_team()
         other_issue_alert_rule = Rule.objects.create(
-            label="test rule", project=self.project, owner=other_team.actor
+            label="test rule",
+            project=self.project,
+            owner=other_team.actor,
+            owner_team_id=other_team.id,
         )
         data = {"target": "me"}
         response = self.get_response(

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -17,6 +17,7 @@ from sentry.models.rule import Rule
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.snuba.models import SnubaQueryEventType
 from sentry.testutils.cases import APITestCase, TestCase
+from sentry.utils.actor import ActorTuple
 
 NOT_SET = object()
 
@@ -104,7 +105,12 @@ class BaseAlertRuleSerializerTest:
         if data.get("date_added"):
             rule.date_added = data["date_added"]
         if data.get("owner"):
-            rule.owner = data["owner"]
+            # TODO(mark) This will need to change when Actor is removed.
+            actor = ActorTuple.from_actor_identifier(data["owner"]).resolve_to_actor()
+            assert actor, "Should not be None"
+            rule.owner_id = actor.id
+            rule.owner_user_id = actor.user_id
+            rule.owner_team_id = actor.team_id
 
         rule.save()
         return rule

--- a/tests/sentry/deletions/test_team.py
+++ b/tests/sentry/deletions/test_team.py
@@ -29,7 +29,9 @@ class DeleteTeamTest(TestCase, HybridCloudTestMixin):
     def test_alert_blanking(self):
         team = self.create_team(name="test")
         project = self.create_project(teams=[team], name="test1")
-        rule = Rule.objects.create(label="test rule", project=project, owner=team.actor)
+        rule = Rule.objects.create(
+            label="test rule", project=project, owner=team.actor, owner_team_id=team.id
+        )
         alert_rule = self.create_alert_rule(
             name="test alert rule", owner=team.actor.get_actor_tuple(), projects=[project]
         )
@@ -44,7 +46,9 @@ class DeleteTeamTest(TestCase, HybridCloudTestMixin):
         alert_rule.refresh_from_db()
         rule.refresh_from_db()
         assert rule.owner_id is None, "Should be blank when team is deleted."
+        assert rule.owner_team_id is None, "Should be blank when team is deleted."
         assert alert_rule.owner_id is None, "Should be blank when team is deleted."
+        assert alert_rule.team_id is None, "Should be blank when team is deleted."
 
     def test_monitor_blanking(self):
         team = self.create_team(name="test")

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -512,7 +512,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "actions": [],
                 "actionMatch": "all",
                 "date_added": before_now(minutes=4),
-                "owner": self.team.actor,
+                "owner": f"team:{self.team.id}",
             }
         )
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -553,7 +553,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "actions": [],
                 "actionMatch": "all",
                 "date_added": before_now(minutes=4),
-                "owner": another_org_team.actor,
+                "owner": f"team:{another_org_team.id}",
             }
         )
 
@@ -833,7 +833,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
                 "actions": [],
                 "actionMatch": "all",
                 "date_added": before_now(minutes=2),
-                "owner": team.actor,
+                "owner": f"team:{team.id}",
             }
         )
         team.delete()

--- a/tests/sentry/mediators/project_rules/test_creator.py
+++ b/tests/sentry/mediators/project_rules/test_creator.py
@@ -19,6 +19,7 @@ class TestCreator(TestCase):
         self.creator = Creator(
             name="New Cool Rule",
             owner=get_actor_for_user(self.user).id,
+            owner_user_id=self.user.id,
             project=self.project,
             action_match="all",
             filter_match="any",
@@ -44,6 +45,8 @@ class TestCreator(TestCase):
         rule = Rule.objects.get(id=r.id)
         assert rule.label == "New Cool Rule"
         assert rule.owner == get_actor_for_user(self.user)
+        assert rule.owner_user_id == self.user.id
+        assert rule.owner_team_id is None
         assert rule.project == self.project
         assert rule.environment_id is None
         assert rule.data == {

--- a/tests/sentry/mediators/project_rules/test_updater.py
+++ b/tests/sentry/mediators/project_rules/test_updater.py
@@ -22,19 +22,30 @@ class TestUpdater(TestCase):
 
     def test_update_owner(self):
         self.updater.owner = get_actor_for_user(self.user).id
+        self.updater.owner_user_id = self.user.id
         self.updater.call()
         with assume_test_silo_mode_of(User):
             self.user = User.objects.get(id=self.user.id)
         assert self.rule.owner == get_actor_for_user(self.user)
+        assert self.rule.owner_user_id == self.user.id
+        assert self.rule.owner_team_id is None
 
         team = self.create_team()
         self.updater.owner = team.actor.id
+        self.updater.owner_team_id = team.id
+        self.updater.owner_user_id = None
         self.updater.call()
         assert self.rule.owner == team.actor
+        assert self.rule.owner_team_id == team.id
+        assert self.rule.owner_user_id is None
 
         self.updater.owner = None
+        self.updater.owner_user_id = None
+        self.updater.owner_team_id = None
         self.updater.call()
         assert self.rule.owner is None
+        assert self.rule.owner_team_id is None
+        assert self.rule.owner_user_id is None
 
     def test_update_environment(self):
         self.updater.environment = 3

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -234,15 +234,25 @@ class ProjectTest(APITestCase, TestCase):
             environment=environment,
         )
         snuba_query = SnubaQuery.objects.filter(id=alert_rule.snuba_query_id).get()
-        rule1 = Rule.objects.create(label="another test rule", project=project, owner=team.actor)
+        rule1 = Rule.objects.create(
+            label="another test rule", project=project, owner=team.actor, owner_team=team
+        )
         rule2 = Rule.objects.create(
-            label="rule4", project=project, owner=get_actor_for_user(from_user)
+            label="rule4",
+            project=project,
+            owner=get_actor_for_user(from_user),
+            owner_user_id=from_user.id,
         )
 
         # should keep their owners
-        rule3 = Rule.objects.create(label="rule2", project=project, owner=to_team.actor)
+        rule3 = Rule.objects.create(
+            label="rule2", project=project, owner=to_team.actor, owner_team=to_team
+        )
         rule4 = Rule.objects.create(
-            label="rule3", project=project, owner=get_actor_for_user(to_user)
+            label="rule3",
+            project=project,
+            owner=get_actor_for_user(to_user),
+            owner_user_id=to_user.id,
         )
 
         assert EnvironmentProject.objects.count() == 1

--- a/tests/sentry/models/test_rulesnooze.py
+++ b/tests/sentry/models/test_rulesnooze.py
@@ -11,7 +11,7 @@ from sentry.testutils.cases import APITestCase
 class RuleSnoozeTest(APITestCase):
     def setUp(self):
         self.issue_alert_rule = Rule.objects.create(
-            label="test rule", project=self.project, owner=self.team.actor
+            label="test rule", project=self.project, owner=self.team.actor, owner_team=self.team
         )
         self.metric_alert_rule = self.create_alert_rule(
             organization=self.project.organization, projects=[self.project]
@@ -44,7 +44,10 @@ class RuleSnoozeTest(APITestCase):
         assert RuleSnooze.objects.filter(id=issue_alert_rule_snooze_user_until.id).exists()
 
         issue_alert_rule2 = Rule.objects.create(
-            label="test rule", project=self.project, owner=self.team.actor
+            label="test rule",
+            project=self.project,
+            owner=self.team.actor,
+            owner_team=self.team,
         )
         issue_alert_rule_snooze_user_forever = self.snooze_rule(
             user_id=self.user.id, owner_id=self.user.id, rule=issue_alert_rule2

--- a/tests/sentry/tasks/test_clear_expired_rulesnoozes.py
+++ b/tests/sentry/tasks/test_clear_expired_rulesnoozes.py
@@ -9,7 +9,7 @@ from sentry.testutils.cases import APITestCase
 class ClearExpiredRuleSnoozesTest(APITestCase):
     def setUp(self):
         self.issue_alert_rule = Rule.objects.create(
-            label="test rule", project=self.project, owner=self.team.actor
+            label="test rule", project=self.project, owner=self.team.actor, owner_team=self.team
         )
         self.metric_alert_rule = self.create_alert_rule(
             organization=self.project.organization, projects=[self.project]


### PR DESCRIPTION
Write to both the `owner` and `owner_user_id` and `owner_team_id` columns. Part of the work to remove `Actor`.

Refs HC-1169