### PR TITLE
feat(event-tags): Add highlight fields to settings page

### DIFF
--- a/static/app/components/events/highlights/highlightsSettingsForm.spec.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.spec.tsx
@@ -67,16 +67,8 @@ describe('HighlightsSettingForm', function () {
     expect(screen.getByText('Highlighted Context')).toBeInTheDocument();
     const contextInput = screen.getByRole('textbox', {name: 'Highlighted Context'});
 
-    // React Testing Library requires these characters to be escaped by having two
-    const rtlEscapeCharacters = new Set(['{', '[']);
-    const rtlSafeNewContext = JSON.stringify(newContext)
-      .split('')
-      .map(character =>
-        rtlEscapeCharacters.has(character) ? `${character}${character}` : character
-      )
-      .join('');
     await userEvent.clear(contextInput);
-    await userEvent.type(contextInput, rtlSafeNewContext);
+    await userEvent.paste(JSON.stringify(newContext));
     await userEvent.click(screen.getByText('Highlights'));
 
     expect(updateProjectMock).toHaveBeenCalledWith(

--- a/static/app/components/events/highlights/highlightsSettingsForm.spec.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.spec.tsx
@@ -1,0 +1,89 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import HighlightsSettingsForm from 'sentry/components/events/highlights/highlightsSettingsForm';
+
+describe('HighlightsSettingForm', function () {
+  const organization = OrganizationFixture({features: ['event-tags-tree-ui']});
+  const highlightTags = ['environment', 'handled', 'release', 'url'];
+  const highlightContext = {
+    user: ['email'],
+    browser: ['name', 'version'],
+  };
+  const project = ProjectFixture({highlightContext, highlightTags});
+
+  beforeEach(async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: {...project, highlightTags, highlightContext},
+    });
+    render(<HighlightsSettingsForm projectSlug={project.slug} />, {organization});
+    await screen.findByText('Highlights');
+  });
+
+  it('should render with highlights from detailed project', function () {
+    expect(screen.getByText('Highlighted Tags')).toBeInTheDocument();
+    const tagInput = screen.getByRole('textbox', {name: 'Highlighted Tags'});
+    expect(tagInput).toHaveValue(highlightTags.join('\n'));
+
+    expect(screen.getByText('Highlighted Context')).toBeInTheDocument();
+    const contextInput = screen.getByRole('textbox', {name: 'Highlighted Context'});
+    expect(contextInput).toHaveValue(JSON.stringify(highlightContext, null, 2));
+  });
+
+  it('should allow the Highlight Tags field to mutate highlights', async function () {
+    const newTag = 'orchid';
+    const url = `/projects/${organization.slug}/${project.slug}/`;
+    const updateProjectMock = MockApiClient.addMockResponse({
+      url,
+      method: 'PUT',
+      body: {...project, highlightTags: [...highlightTags, newTag], highlightContext},
+    });
+
+    expect(screen.getByText('Highlighted Tags')).toBeInTheDocument();
+    const tagInput = screen.getByRole('textbox', {name: 'Highlighted Tags'});
+
+    await userEvent.type(tagInput, `\n${newTag}`);
+    await userEvent.click(screen.getByText('Highlights'));
+    expect(updateProjectMock).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        data: {highlightTags: [...highlightTags, newTag]},
+      })
+    );
+  });
+
+  it('should allow the Highlight Context field to mutate highlights', async function () {
+    const newContext = {flower: ['leafCount', 'petalCount']};
+    const url = `/projects/${organization.slug}/${project.slug}/`;
+    const updateProjectMock = MockApiClient.addMockResponse({
+      url,
+      method: 'PUT',
+      body: {...project, highlightTags, highlightContext: newContext},
+    });
+
+    expect(screen.getByText('Highlighted Context')).toBeInTheDocument();
+    const contextInput = screen.getByRole('textbox', {name: 'Highlighted Context'});
+
+    // React Testing Library requires these characters to be escaped by having two
+    const rtlEscapeCharacters = new Set(['{', '[']);
+    const rtlSafeNewContext = JSON.stringify(newContext)
+      .split('')
+      .map(character =>
+        rtlEscapeCharacters.has(character) ? `${character}${character}` : character
+      )
+      .join('');
+    await userEvent.clear(contextInput);
+    await userEvent.type(contextInput, rtlSafeNewContext);
+    await userEvent.click(screen.getByText('Highlights'));
+
+    expect(updateProjectMock).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        data: {highlightContext: newContext},
+      })
+    );
+  });
+});

--- a/static/app/components/events/highlights/highlightsSettingsForm.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.tsx
@@ -1,0 +1,78 @@
+import {hasEveryAccess} from 'sentry/components/acl/access';
+import {CONTEXT_DOCS_LINK} from 'sentry/components/events/contextSummary/utils';
+import JsonForm from 'sentry/components/forms/jsonForm';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
+import {convertMultilineFieldValue, extractMultilineFields} from 'sentry/utils';
+import {useDetailedProject} from 'sentry/utils/useDetailedProject';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface HighlightsSettingsFormProps {
+  projectSlug;
+}
+
+export default function HighlightsSettingsForm({
+  projectSlug,
+}: HighlightsSettingsFormProps) {
+  const organization = useOrganization();
+  const {data: project} = useDetailedProject({orgSlug: organization.slug, projectSlug});
+  if (!organization.features.includes('event-tags-tree-ui') || !project) {
+    return null;
+  }
+  const access = new Set(organization.access.concat(project.access));
+  return (
+    <JsonForm
+      access={access}
+      disabled={!hasEveryAccess(['project:write'], {organization, project})}
+      title={t('Highlights')}
+      fields={[
+        {
+          name: 'highlightTags',
+          type: 'string',
+          multiline: true,
+          autosize: true,
+          rows: 1,
+          placeholder: t('environment, release, my-tag'),
+          label: t('Highlighted Tags'),
+          help: t('Separate tag keys with a newline.'),
+          getValue: val => extractMultilineFields(val),
+          setValue: val => convertMultilineFieldValue(val),
+        },
+        {
+          name: 'highlightContext',
+          type: 'textarea',
+          multiline: true,
+          autosize: true,
+          rows: 1,
+          placeholder: t('{"browser": ["name"], "my-ctx": ["my-key"]}'),
+          label: t('Highlighted Context'),
+          help: tct(
+            'Enter a valid JSON entry for mapping [Structured Context] types, to their keys. E.g. [example]',
+            {
+              link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
+              example: '{"user": ["id", "email"]}',
+            }
+          ),
+          getValue: (val: string) => (val === '' ? {} : JSON.parse(val)),
+          setValue: (val: string) => {
+            const schema = JSON.stringify(val, null, 2);
+            if (schema === '{}') {
+              return '';
+            }
+            return schema;
+          },
+          validate: ({id, form}) => {
+            if (form.highlightContext) {
+              try {
+                JSON.parse(form.highlightContext);
+              } catch (e) {
+                return [[id, 'Invalid JSON']];
+              }
+            }
+            return [];
+          },
+        },
+      ]}
+    />
+  );
+}

--- a/static/app/components/events/highlights/highlightsSettingsForm.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import {CONTEXT_DOCS_LINK} from 'sentry/components/events/contextSummary/utils';
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -6,6 +8,7 @@ import {t, tct} from 'sentry/locale';
 import {convertMultilineFieldValue, extractMultilineFields} from 'sentry/utils';
 import {useDetailedProject} from 'sentry/utils/useDetailedProject';
 import useOrganization from 'sentry/utils/useOrganization';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 interface HighlightsSettingsFormProps {
   projectSlug;
@@ -21,58 +24,65 @@ export default function HighlightsSettingsForm({
   }
   const access = new Set(organization.access.concat(project.access));
   return (
-    <JsonForm
-      access={access}
-      disabled={!hasEveryAccess(['project:write'], {organization, project})}
-      title={t('Highlights')}
-      fields={[
-        {
-          name: 'highlightTags',
-          type: 'string',
-          multiline: true,
-          autosize: true,
-          rows: 1,
-          placeholder: t('environment, release, my-tag'),
-          label: t('Highlighted Tags'),
-          help: t('Separate tag keys with a newline.'),
-          getValue: val => extractMultilineFields(val),
-          setValue: val => convertMultilineFieldValue(val),
-        },
-        {
-          name: 'highlightContext',
-          type: 'textarea',
-          multiline: true,
-          autosize: true,
-          rows: 1,
-          placeholder: t('{"browser": ["name"], "my-ctx": ["my-key"]}'),
-          label: t('Highlighted Context'),
-          help: tct(
-            'Enter a valid JSON entry for mapping [Structured Context] types, to their keys. E.g. [example]',
-            {
-              link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
-              example: '{"user": ["id", "email"]}',
-            }
-          ),
-          getValue: (val: string) => (val === '' ? {} : JSON.parse(val)),
-          setValue: (val: string) => {
-            const schema = JSON.stringify(val, null, 2);
-            if (schema === '{}') {
-              return '';
-            }
-            return schema;
+    <Fragment>
+      <TextBlock>
+        {t(
+          `Setup Highlights to promote your event data to the top of the issue page for quicker debugging.`
+        )}
+      </TextBlock>
+      <JsonForm
+        access={access}
+        disabled={!hasEveryAccess(['project:write'], {organization, project})}
+        title={t('Highlights')}
+        fields={[
+          {
+            name: 'highlightTags',
+            type: 'string',
+            multiline: true,
+            autosize: true,
+            rows: 1,
+            placeholder: t('environment, release, my-tag'),
+            label: t('Highlighted Tags'),
+            help: t('Separate tag keys with a newline.'),
+            getValue: val => extractMultilineFields(val),
+            setValue: val => convertMultilineFieldValue(val),
           },
-          validate: ({id, form}) => {
-            if (form.highlightContext) {
-              try {
-                JSON.parse(form.highlightContext);
-              } catch (e) {
-                return [[id, 'Invalid JSON']];
+          {
+            name: 'highlightContext',
+            type: 'textarea',
+            multiline: true,
+            autosize: true,
+            rows: 1,
+            placeholder: t('{"browser": ["name"], "my-ctx": ["my-key"]}'),
+            label: t('Highlighted Context'),
+            help: tct(
+              'Enter a valid JSON entry for mapping [Structured Context] types, to their keys. E.g. [example]',
+              {
+                link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
+                example: '{"user": ["id", "email"]}',
               }
-            }
-            return [];
+            ),
+            getValue: (val: string) => (val === '' ? {} : JSON.parse(val)),
+            setValue: (val: string) => {
+              const schema = JSON.stringify(val, null, 2);
+              if (schema === '{}') {
+                return '';
+              }
+              return schema;
+            },
+            validate: ({id, form}) => {
+              if (form.highlightContext) {
+                try {
+                  JSON.parse(form.highlightContext);
+                } catch (e) {
+                  return [[id, 'Invalid JSON']];
+                }
+              }
+              return [];
+            },
           },
-        },
-      ]}
-    />
+        ]}
+      />
+    </Fragment>
   );
 }

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -117,9 +117,12 @@ export const fields: Record<string, Field> = {
     rows: 1,
     placeholder: t('{"browser": ["name", "version"], "my-context": ["my-custom-key"]}'),
     label: t('Highlighted Context'),
-    help: tct('[link:Structured Context] keys to promote for quick debugging', {
-      link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
-    }),
+    help: tct(
+      '[link:Structured Context] keys to promote to the top of each issue page for quick debugging.',
+      {
+        link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
+      }
+    ),
     getValue: (val: string) => (val === '' ? {} : JSON.parse(val)),
     setValue: (val: string) => {
       const schema = JSON.stringify(val, null, 2);

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -2,10 +2,7 @@ import {createFilter} from 'react-select';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
-import {CONTEXT_DOCS_LINK} from 'sentry/components/events/contextSummary/utils';
-import {TAGS_DOCS_LINK} from 'sentry/components/events/eventTags/util';
 import type {Field} from 'sentry/components/forms/types';
-import ExternalLink from 'sentry/components/links/externalLink';
 import platforms from 'sentry/data/platforms';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -92,57 +89,6 @@ export const fields: Record<string, Field> = {
       },
     }),
   },
-  highlightTags: {
-    name: 'highlightTags',
-    type: 'string',
-    multiline: true,
-    autosize: true,
-    rows: 1,
-    placeholder: t('handled, environment, release, my-tag'),
-    label: t('Highlighted Tags'),
-    help: tct(
-      '[link:Tags] to promote to the top of each issue page for quick debugging. Separate entries with a newline.',
-      {
-        link: <ExternalLink openInNewTab href={TAGS_DOCS_LINK} />,
-      }
-    ),
-    getValue: val => extractMultilineFields(val),
-    setValue: val => convertMultilineFieldValue(val),
-  },
-  highlightContext: {
-    name: 'highlightContext',
-    type: 'textarea',
-    multiline: true,
-    autosize: true,
-    rows: 1,
-    placeholder: t('{"browser": ["name", "version"], "my-context": ["my-custom-key"]}'),
-    label: t('Highlighted Context'),
-    help: tct(
-      '[link:Structured Context] keys to promote to the top of each issue page for quick debugging.',
-      {
-        link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
-      }
-    ),
-    getValue: (val: string) => (val === '' ? {} : JSON.parse(val)),
-    setValue: (val: string) => {
-      const schema = JSON.stringify(val, null, 2);
-      if (schema === '{}') {
-        return '';
-      }
-      return schema;
-    },
-    validate: ({id, form}) => {
-      if (form.highlightContext) {
-        try {
-          JSON.parse(form.highlightContext);
-        } catch (e) {
-          return [[id, 'Invalid JSON']];
-        }
-      }
-      return [];
-    },
-  },
-
   subjectPrefix: {
     name: 'subjectPrefix',
     type: 'string',

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -2,7 +2,10 @@ import {createFilter} from 'react-select';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
+import {CONTEXT_DOCS_LINK} from 'sentry/components/events/contextSummary/utils';
+import {TAGS_DOCS_LINK} from 'sentry/components/events/eventTags/util';
 import type {Field} from 'sentry/components/forms/types';
+import ExternalLink from 'sentry/components/links/externalLink';
 import platforms from 'sentry/data/platforms';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -88,6 +91,53 @@ export const fields: Record<string, Field> = {
         return `${matchedPlatform?.name} ${option.value}`;
       },
     }),
+  },
+  highlightTags: {
+    name: 'highlightTags',
+    type: 'string',
+    multiline: true,
+    autosize: true,
+    rows: 1,
+    placeholder: t('handled, environment, release, my-tag'),
+    label: t('Highlighted Tags'),
+    help: tct(
+      '[link:Tags] to promote to the top of each issue page for quick debugging. Separate entries with a newline.',
+      {
+        link: <ExternalLink openInNewTab href={TAGS_DOCS_LINK} />,
+      }
+    ),
+    getValue: val => extractMultilineFields(val),
+    setValue: val => convertMultilineFieldValue(val),
+  },
+  highlightContext: {
+    name: 'highlightContext',
+    type: 'textarea',
+    multiline: true,
+    autosize: true,
+    rows: 1,
+    placeholder: t('{"browser": ["name", "version"], "my-context": ["my-custom-key"]}'),
+    label: t('Highlighted Context'),
+    help: tct('[link:Structured Context] keys to promote for quick debugging', {
+      link: <ExternalLink openInNewTab href={CONTEXT_DOCS_LINK} />,
+    }),
+    getValue: (val: string) => (val === '' ? {} : JSON.parse(val)),
+    setValue: (val: string) => {
+      const schema = JSON.stringify(val, null, 2);
+      if (schema === '{}') {
+        return '';
+      }
+      return schema;
+    },
+    validate: ({id, form}) => {
+      if (form.highlightContext) {
+        try {
+          JSON.parse(form.highlightContext);
+        } catch (e) {
+          return [[id, 'Invalid JSON']];
+        }
+      }
+      return [];
+    },
   },
 
   subjectPrefix: {

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -498,7 +498,7 @@ function buildRoutes() {
       </Route>
       <Route
         path="tags/"
-        name={t('Tags')}
+        name={t('Tags & Context')}
         component={make(() => import('sentry/views/settings/projectTags'))}
       />
       <Redirect from="issue-tracking/" to="/settings/:orgId/:projectId/plugins/" />

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -39,8 +39,8 @@ export default function getConfiguration({
         },
         {
           path: `${pathPrefix}/tags/`,
-          title: t('Tags'),
-          description: t("View and manage a  project's tags"),
+          title: t('Tags & Context'),
+          description: t("View and manage a project's tags and highlights"),
         },
         {
           path: `${pathPrefix}/environments/`,

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -40,7 +40,7 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/tags/`,
           title: t('Tags & Context'),
-          description: t("View and manage a project's tags and highlights"),
+          description: t("View and manage a project's tags and context"),
         },
         {
           path: `${pathPrefix}/environments/`,

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -313,13 +313,6 @@ class ProjectGeneralSettings extends DeprecatedAsyncView<Props, State> {
             title={t('Project Details')}
             fields={[fields.name, fields.platform]}
           />
-          {organization.features.includes('event-tags-tree-ui') && (
-            <JsonForm
-              {...jsonFormProps}
-              title={t('Highlights')}
-              fields={[fields.highlightTags, fields.highlightContext]}
-            />
-          )}
           <JsonForm
             {...jsonFormProps}
             title={t('Email')}

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -307,14 +307,19 @@ class ProjectGeneralSettings extends DeprecatedAsyncView<Props, State> {
       <div>
         <SettingsPageHeader title={t('Project Settings')} />
         <PermissionAlert project={project} />
-
         <Form {...formProps}>
           <JsonForm
             {...jsonFormProps}
             title={t('Project Details')}
             fields={[fields.name, fields.platform]}
           />
-
+          {organization.features.includes('event-tags-tree-ui') && (
+            <JsonForm
+              {...jsonFormProps}
+              title={t('Highlights')}
+              fields={[fields.highlightTags, fields.highlightContext]}
+            />
+          )}
           <JsonForm
             {...jsonFormProps}
             title={t('Email')}

--- a/static/app/views/settings/projectTags/index.spec.tsx
+++ b/static/app/views/settings/projectTags/index.spec.tsx
@@ -17,6 +17,11 @@ describe('ProjectTags', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/`,
+      method: 'GET',
+      body: project,
+    });
+    MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/tags/`,
       method: 'GET',
       body: TagsFixture(),
@@ -33,6 +38,11 @@ describe('ProjectTags', function () {
 
   it('renders empty', async function () {
     MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/`,
+      method: 'GET',
+      body: project,
+    });
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/tags/`,
       method: 'GET',

--- a/static/app/views/settings/projectTags/index.tsx
+++ b/static/app/views/settings/projectTags/index.tsx
@@ -8,6 +8,7 @@ import {Button} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import {TAGS_DOCS_LINK} from 'sentry/components/events/eventTags/util';
+import HighlightsSettingsForm from 'sentry/components/events/highlights/highlightsSettingsForm';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -87,8 +88,15 @@ function ProjectTags(props: Props) {
   const isEmpty = !tags || !tags.length;
   return (
     <Fragment>
-      <SentryDocumentTitle title={routeTitleGen(t('Tags'), projectId, false)} />
-      <SettingsPageHeader title={t('Tags')} />
+      <SentryDocumentTitle title={routeTitleGen(t('Tags & Context'), projectId, false)} />
+      <SettingsPageHeader title={t('Tags & Context')} />
+      <PermissionAlert project={project} />
+      <TextBlock>
+        {t(
+          `Setup Highlights to promot your event data to the top of the issue page for quicker debugging.`
+        )}
+      </TextBlock>
+      <HighlightsSettingsForm projectSlug={projectId} />
       <TextBlock>
         {tct(
           `Each event in Sentry may be annotated with various tags (key and value pairs).
@@ -98,8 +106,6 @@ function ProjectTags(props: Props) {
           }
         )}
       </TextBlock>
-
-      <PermissionAlert project={project} />
       <Panel>
         <PanelHeader>{t('Tags')}</PanelHeader>
         <PanelBody>

--- a/static/app/views/settings/projectTags/index.tsx
+++ b/static/app/views/settings/projectTags/index.tsx
@@ -91,11 +91,6 @@ function ProjectTags(props: Props) {
       <SentryDocumentTitle title={routeTitleGen(t('Tags & Context'), projectId, false)} />
       <SettingsPageHeader title={t('Tags & Context')} />
       <PermissionAlert project={project} />
-      <TextBlock>
-        {t(
-          `Setup Highlights to promot your event data to the top of the issue page for quicker debugging.`
-        )}
-      </TextBlock>
       <HighlightsSettingsForm projectSlug={projectId} />
       <TextBlock>
         {tct(


### PR DESCRIPTION
~~Requires https://github.com/getsentry/sentry/pull/69044~~
~~Requires https://github.com/getsentry/sentry/pull/69426~~

Adds some fields to the project settings page to modify tags/context highlights directly. 

**Update:** It's been moved to the Tags page, and that page title was changed to "Tags & Context"

![image](https://github.com/getsentry/sentry/assets/35509934/8d865ccb-e0cf-4cb6-8eb6-cbdd548243f8)

Without the flag, just the sidebar title and heading are still changed.


<img width="1738" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/307c0d7d-f54a-44d1-b139-12c3fbfcc7e2">


**todo**
- [x] Add tests 
- [x] Ensure the form displays with current settings and updates on blur

