### PR TITLE
feat(event-tags): Implement the highlights section and update modal

### DIFF
--- a/static/app/components/events/contextSummary/index.tsx
+++ b/static/app/components/events/contextSummary/index.tsx
@@ -1,7 +1,5 @@
 import styled from '@emotion/styled';
 
-import {EventDataSection} from 'sentry/components/events/eventDataSection';
-import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -53,7 +51,6 @@ type Props = {
 };
 
 function ContextSummary({event}: Props) {
-  const hasNewTagsUI = useHasNewTagsUI();
   if (objectIsEmpty(event.contexts)) {
     return null;
   }
@@ -116,19 +113,6 @@ function ContextSummary({event}: Props) {
 
     return <Component key={key} {...props} />;
   });
-
-  if (hasNewTagsUI) {
-    // TODO(Leander): When a design is confirmed, move this to HighlightsDataSection
-    return (
-      <EventDataSection
-        title={t('Highlighted Event Data')}
-        data-test-id="highlighted-event-data"
-        type="highlighted-event-data"
-      >
-        <Wrapper>{contexts}</Wrapper>
-      </EventDataSection>
-    );
-  }
 
   return <Wrapper>{contexts}</Wrapper>;
 }

--- a/static/app/components/events/contextSummary/index.tsx
+++ b/static/app/components/events/contextSummary/index.tsx
@@ -114,7 +114,7 @@ function ContextSummary({event}: Props) {
     return <Component key={key} {...props} />;
   });
 
-  return <Wrapper>{contexts}</Wrapper>;
+  return <Wrapper data-test-id="context-summary">{contexts}</Wrapper>;
 }
 
 export default ContextSummary;

--- a/static/app/components/events/contexts/contextCard.tsx
+++ b/static/app/components/events/contexts/contextCard.tsx
@@ -69,16 +69,20 @@ export function ContextCardContent({
   return (
     <ContextContent hasErrors={hasErrors} {...props}>
       <ContextSubject>{contextSubject}</ContextSubject>
-      <ContextValueWrapper hasErrors={hasErrors} className="ctx-row-value">
-        {defined(action?.link) ? (
-          <Link to={action.link}>{dataComponent}</Link>
-        ) : (
-          dataComponent
+      <ContextValueSection hasErrors={hasErrors}>
+        <ContextValueWrapper>
+          {defined(action?.link) ? (
+            <Link to={action.link}>{dataComponent}</Link>
+          ) : (
+            dataComponent
+          )}
+        </ContextValueWrapper>
+        {hasErrors && (
+          <ContextErrors>
+            <AnnotatedTextErrors errors={contextErrors} />
+          </ContextErrors>
         )}
-      </ContextValueWrapper>
-      <ContextErrors>
-        <AnnotatedTextErrors errors={contextErrors} />
-      </ContextErrors>
+      </ContextValueSection>
     </ContextContent>
   );
 }
@@ -120,7 +124,7 @@ const Card = styled(Panel)`
   padding: ${space(0.75)};
   display: grid;
   column-gap: ${space(1.5)};
-  grid-template-columns: minmax(100px, auto) 1fr 30px;
+  grid-template-columns: minmax(100px, auto) 1fr;
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
@@ -135,7 +139,7 @@ const ContextTitle = styled('p')`
 const ContextContent = styled('div')<{hasErrors: boolean}>`
   display: grid;
   grid-template-columns: subgrid;
-  grid-column: span 3;
+  grid-column: span 2;
   column-gap: ${space(1.5)};
   padding: ${space(0.25)} ${space(0.75)};
   border-radius: 4px;
@@ -152,12 +156,19 @@ const ContextContent = styled('div')<{hasErrors: boolean}>`
 const ContextSubject = styled('div')`
   grid-column: span 1;
   font-family: ${p => p.theme.text.familyMono};
-  word-wrap: break-word;
+  word-break: break-word;
 `;
 
-const ContextValueWrapper = styled(ContextSubject)<{hasErrors: boolean}>`
+const ContextValueSection = styled(ContextSubject)<{hasErrors: boolean}>`
   color: ${p => (p.hasErrors ? 'inherit' : p.theme.textColor)};
-  grid-column: span ${p => (p.hasErrors ? 1 : 2)};
+  grid-column: span 1;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-column-gap: ${space(0.5)};
+`;
+
+const ContextValueWrapper = styled('div')`
+  word-break: break-word;
 `;
 
 const ContextErrors = styled('div')``;

--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -102,6 +102,7 @@ function getTagTreeRows({
       tagKey={tagKey}
       content={content}
       spacerCount={spacerCount}
+      data-test-id="tag-tree-row"
       {...props}
     />,
     ...subtreeRows,

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -51,7 +51,7 @@ export default function EventTagsTreeRow({
 
   if (!originalTag) {
     return (
-      <TreeRow data-test-id="tag-tree-row" hasErrors={hasTagErrors} {...props}>
+      <TreeRow hasErrors={hasTagErrors} {...props}>
         <TreeKeyTrunk spacerCount={spacerCount}>
           {spacerCount > 0 && (
             <Fragment>
@@ -89,7 +89,7 @@ export default function EventTagsTreeRow({
   );
 
   return (
-    <TreeRow data-test-id="tag-tree-row" hasErrors={hasTagErrors} {...props}>
+    <TreeRow hasErrors={hasTagErrors} {...props}>
       <TreeKeyTrunk spacerCount={spacerCount}>
         {spacerCount > 0 && (
           <Fragment>

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -51,7 +51,7 @@ export default function EventTagsTreeRow({
 
   if (!originalTag) {
     return (
-      <TreeRow data-test-id="tag-tree-row" hasErrors={hasTagErrors}>
+      <TreeRow data-test-id="tag-tree-row" hasErrors={hasTagErrors} {...props}>
         <TreeKeyTrunk spacerCount={spacerCount}>
           {spacerCount > 0 && (
             <Fragment>

--- a/static/app/components/events/highlights/editHighlightsModal.spec.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.spec.tsx
@@ -198,7 +198,7 @@ describe('EditHighlightsModal', function () {
         selector: 'div',
       });
       const removeButton = previewTagItem?.closest(
-        "div[data-test-id='highlight-tag-row']"
+        "div[data-test-id='highlights-preview-tag']"
       )?.previousSibling;
       expect(removeButton).toBeEnabled();
     });
@@ -274,7 +274,9 @@ describe('EditHighlightsModal', function () {
     ]);
     allHighlightCtxTitles.forEach(title => {
       const previewCtxItem = within(previewSection).getByText(title) as HTMLElement;
-      const removeButton = previewCtxItem?.parentNode?.previousSibling;
+      const removeButton = previewCtxItem?.closest(
+        "div[data-test-id='highlights-preview-ctx']"
+      )?.previousSibling;
       expect(removeButton).toBeEnabled();
     });
 

--- a/static/app/components/events/highlights/editHighlightsModal.spec.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.spec.tsx
@@ -1,0 +1,300 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {
+  act,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import EditHighlightsModal, {
+  type EditHighlightsModalProps,
+} from 'sentry/components/events/highlights/editHighlightsModal';
+import {
+  TEST_EVENT_CONTEXTS,
+  TEST_EVENT_TAGS,
+} from 'sentry/components/events/highlights/util.spec';
+import ModalStore from 'sentry/stores/modalStore';
+import type {Project} from 'sentry/types';
+
+describe('EditHighlightsModal', function () {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+  const event = EventFixture({
+    contexts: TEST_EVENT_CONTEXTS,
+    tags: TEST_EVENT_TAGS,
+  });
+  const url = `/projects/${organization.slug}/${project.slug}/`;
+  const highlightTags = ['release', 'url', 'missingTag'];
+  const highlightContext = {
+    keyboard: ['brand', 'switches'],
+    os: ['name'],
+    missingType: ['missingKey'],
+  };
+  // For ease of testing, avoids converting 'os' -> 'client_os' -> 'Client Os'
+  const highlightContextTitles = [
+    'Keyboard: brand',
+    'Keyboard: switches',
+    'Client Os: Name',
+    'Missing Type: missingKey',
+  ];
+  const highlightContextSet = new Set([
+    'keyboard:brand',
+    'keyboard:switches',
+    'os:name',
+    'missingType:missingKey',
+  ]);
+
+  const highlightPreset: Project['highlightPreset'] = {
+    context: {presetType: ['presetKey']},
+    tags: ['presetTag'],
+  };
+  const closeModal = jest.fn();
+
+  function renderModal(editHighlightModalProps?: Partial<EditHighlightsModalProps>) {
+    act(() => {
+      openModal(
+        modalProps => (
+          <EditHighlightsModal
+            event={event}
+            project={project}
+            highlightContext={highlightContext}
+            highlightTags={highlightTags}
+            highlightPreset={highlightPreset}
+            {...editHighlightModalProps}
+            {...modalProps}
+          />
+        ),
+        {onClose: closeModal}
+      );
+    });
+  }
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    jest.resetAllMocks();
+    ModalStore.reset();
+    renderGlobalModal();
+  });
+
+  it('should renders with basic functions', async function () {
+    renderModal({highlightContext: {}, highlightTags: []});
+    expect(screen.getByText('Edit Event Highlights')).toBeInTheDocument();
+    expect(screen.getByTestId('highlights-preview-section')).toBeInTheDocument();
+    expect(screen.getByTestId('highlights-empty-message')).toBeInTheDocument();
+    expect(screen.getByTestId('highlights-tag-section')).toBeInTheDocument();
+    expect(screen.getByTestId('highlights-context-section')).toBeInTheDocument();
+
+    const defaultButton = screen.getByRole('button', {name: 'Use Defaults'});
+    await userEvent.click(defaultButton);
+    expect(screen.queryByTestId('highlights-empty-message')).not.toBeInTheDocument();
+
+    const updateProjectMock = MockApiClient.addMockResponse({
+      url,
+      method: 'PUT',
+      body: project,
+    });
+    const cancelButton = screen.getByRole('button', {name: 'Cancel'});
+    await userEvent.click(cancelButton);
+    expect(updateProjectMock).not.toHaveBeenCalled();
+    expect(closeModal).toHaveBeenCalled();
+
+    // Reopen the modal to test cancel button
+    jest.resetAllMocks();
+    renderModal({highlightContext: {}, highlightTags: []});
+    const saveButton = screen.getByRole('button', {name: 'Save'});
+    await userEvent.click(saveButton);
+    expect(updateProjectMock).toHaveBeenCalled();
+    expect(closeModal).toHaveBeenCalled();
+  });
+
+  it('should update preview section from user selection', async function () {
+    const updateProjectMock = MockApiClient.addMockResponse({
+      url,
+      method: 'PUT',
+      body: project,
+    });
+    renderModal();
+
+    // Existing Tags and Context Keys should be highlighted
+    const previewSection = screen.getByTestId('highlights-preview-section');
+    expect(screen.queryByTestId('highlights-empty-message')).not.toBeInTheDocument();
+
+    highlightTags.forEach(tag => {
+      const tagItem = within(previewSection).getByText(tag, {selector: 'div'});
+      expect(tagItem).toBeInTheDocument();
+    });
+    const previewTagButtons = screen.queryAllByTestId('highlights-remove-tag');
+    expect(previewTagButtons).toHaveLength(highlightTags.length);
+
+    highlightContextTitles.forEach(titleString => {
+      const contextItem = within(previewSection).getByText(titleString);
+      expect(contextItem).toBeInTheDocument();
+    });
+    const previewCtxButtons = screen.queryAllByTestId('highlights-remove-ctx');
+    expect(previewCtxButtons).toHaveLength(highlightContextTitles.length);
+
+    // Default should unselect the current values
+    const defaultButton = screen.getByRole('button', {name: 'Use Defaults'});
+    await userEvent.click(defaultButton);
+    highlightTags.forEach(tag => {
+      const tagItem = within(previewSection).queryByText(tag, {selector: 'div'});
+      expect(tagItem).not.toBeInTheDocument();
+    });
+    highlightContextTitles.forEach(titleString => {
+      const contextItem = within(previewSection).queryByText(titleString);
+      expect(contextItem).not.toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+    expect(updateProjectMock).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        data: {
+          highlightContext: highlightPreset.context,
+          highlightTags: highlightPreset.tags,
+        },
+      })
+    );
+    expect(closeModal).toHaveBeenCalled();
+  });
+
+  it('should update tag section from user selection', async function () {
+    const updateProjectMock = MockApiClient.addMockResponse({
+      url,
+      method: 'PUT',
+      body: project,
+    });
+    renderModal({highlightContext: {}});
+
+    const tagSection = screen.getByTestId('highlights-tag-section');
+    const previewSection = screen.getByTestId('highlights-preview-section');
+    const highlightTagSet = new Set(highlightTags);
+    const previewTagButtons = screen.queryAllByTestId('highlights-remove-tag');
+    expect(previewTagButtons).toHaveLength(highlightTags.length);
+
+    // Reflects accurate values on first load
+    const tagTestPromises = event.tags.map(async tag => {
+      const tagItem = within(tagSection).getByText(tag.key);
+      expect(tagItem).toBeInTheDocument();
+      const isHighlighted = highlightTagSet.has(tag.key);
+      const addButton = within(tagSection).getByRole('button', {
+        name: `Add ${tag.key} tag to highlights`,
+      });
+      expect(tagItem).toHaveAttribute('aria-disabled', String(isHighlighted));
+      expect(addButton).toHaveAttribute('aria-disabled', String(isHighlighted));
+      if (!isHighlighted) {
+        const previewTagItem = within(previewSection).queryByText(tag.key, {
+          selector: 'div',
+        });
+        expect(previewTagItem).not.toBeInTheDocument();
+        await userEvent.click(addButton);
+      }
+      const previewTagItem = within(previewSection).getByText(tag.key, {
+        selector: 'div',
+      });
+      const removeButton = previewTagItem?.closest(
+        "div[data-test-id='tag-tree-row']"
+      )?.previousSibling;
+      expect(removeButton).toBeEnabled();
+    });
+    await Promise.all(tagTestPromises);
+
+    // All event tags should be present now
+    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+    expect(updateProjectMock).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        data: {
+          highlightContext: {},
+          highlightTags: expect.arrayContaining(event.tags.map(t => t.key)),
+        },
+      })
+    );
+    expect(closeModal).toHaveBeenCalled();
+  });
+
+  it('should update context section from user selection', async function () {
+    const updateProjectMock = MockApiClient.addMockResponse({
+      url,
+      method: 'PUT',
+      body: project,
+    });
+    renderModal({highlightTags: []});
+
+    const ctxSection = screen.getByTestId('highlights-context-section');
+    const previewSection = screen.getByTestId('highlights-preview-section');
+    const previewCtxButtons = screen.queryAllByTestId('highlights-remove-ctx');
+    expect(previewCtxButtons).toHaveLength(Object.values(highlightContext).flat().length);
+
+    // Reflects accurate values on first load
+    const ctxTestPromises = Object.entries(event.contexts).map(
+      async ([ctxType, ctxData]) => {
+        const ctxHeader = within(ctxSection).getByText(new RegExp(ctxType, 'i'));
+        expect(ctxHeader).toBeInTheDocument();
+        const ctxContainer = ctxHeader.parentNode as HTMLElement;
+
+        const ctxKeyPromises = Object.keys(ctxData).map(async ctxKey => {
+          if (ctxKey === 'type') {
+            return;
+          }
+          const ctxItem = within(ctxContainer).getByText(ctxKey);
+          expect(ctxItem).toBeInTheDocument();
+
+          const addButton = within(ctxContainer).getByRole('button', {
+            name: `Add ${ctxKey} from ${ctxType} context to highlights`,
+          });
+
+          const isHighlighted = highlightContextSet.has(`${ctxType}:${ctxKey}`);
+          expect(ctxItem).toHaveAttribute('aria-disabled', String(isHighlighted));
+          expect(addButton).toHaveAttribute('aria-disabled', String(isHighlighted));
+          if (!isHighlighted) {
+            const previewCtxItem = within(previewSection).queryByText(
+              new RegExp(`${ctxType}: ${ctxKey}`, 'i')
+            );
+            expect(previewCtxItem).not.toBeInTheDocument();
+            await userEvent.click(addButton);
+          }
+        });
+        await Promise.all(ctxKeyPromises);
+      }
+    );
+    await Promise.all(ctxTestPromises);
+
+    // These come from the event, and existing highlights
+    const allHighlightCtxTitles = highlightContextTitles.concat([
+      'Keyboard: switches',
+      'Client Os: Version',
+      'Runtime: Version',
+      'Runtime: Name',
+    ]);
+    allHighlightCtxTitles.forEach(title => {
+      const previewCtxItem = within(previewSection).getByText(title) as HTMLElement;
+      const removeButton = previewCtxItem?.parentNode?.previousSibling;
+      expect(removeButton).toBeEnabled();
+    });
+
+    // All event tags should be present now
+    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+    expect(updateProjectMock).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        data: {
+          highlightContext: {
+            client_os: ['name', 'version'],
+            keyboard: ['brand', 'switches', 'percent'],
+            missingType: ['missingKey'],
+            os: ['name'],
+            runtime: ['name', 'version'],
+          },
+          highlightTags: [],
+        },
+      })
+    );
+    expect(closeModal).toHaveBeenCalled();
+  });
+});

--- a/static/app/components/events/highlights/editHighlightsModal.spec.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.spec.tsx
@@ -198,7 +198,7 @@ describe('EditHighlightsModal', function () {
         selector: 'div',
       });
       const removeButton = previewTagItem?.closest(
-        "div[data-test-id='tag-tree-row']"
+        "div[data-test-id='highlight-tag-row']"
       )?.previousSibling;
       expect(removeButton).toBeEnabled();
     });

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -1,0 +1,467 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import {getOrderedContextItems} from 'sentry/components/events/contexts';
+import {ContextCardContent} from 'sentry/components/events/contexts/contextCard';
+import {getContextMeta} from 'sentry/components/events/contexts/utils';
+import EventTagsTreeRow from 'sentry/components/events/eventTags/eventTagsTreeRow';
+import type {
+  HighlightContext,
+  HighlightTags,
+} from 'sentry/components/events/highlights/highlightsDataSection';
+import {
+  getHighlightContextItems,
+  getHighlightTagItems,
+} from 'sentry/components/events/highlights/util';
+import {IconAdd, IconSubtract} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event, Project} from 'sentry/types';
+import {useMutation} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface EditHighlightsModalProps extends ModalRenderProps {
+  event: Event;
+  highlightContext: HighlightContext;
+  highlightTags: HighlightTags;
+  project: Project;
+}
+
+interface EditPreviewHighlightSectionProps {
+  event: Event;
+  highlightContext: HighlightContext;
+  highlightTags: HighlightTags;
+  onRemoveContextKey: (contextType: string, contextKey: string) => void;
+  onRemoveTag: (tagKey: string) => void;
+  project: Project;
+}
+
+function EditPreviewHighlightSection({
+  event,
+  project,
+  highlightContext,
+  highlightTags,
+  onRemoveContextKey,
+  onRemoveTag,
+}: EditPreviewHighlightSectionProps) {
+  const organization = useOrganization();
+  const previewColumnCount = 2;
+
+  const highlightContextDataItems = getHighlightContextItems({
+    event,
+    project,
+    organization,
+    highlightContext,
+  });
+  const highlightContextRows = highlightContextDataItems.reduce<React.ReactNode[]>(
+    (rowList, [alias, items], i) => {
+      const meta = getContextMeta(event, alias);
+      const newRows = items.map((item, j) => (
+        <Fragment key={`edit-highlight-ctx-${i}-${j}`}>
+          <EditButton
+            aria-label={`Remove from highlights`}
+            icon={<IconSubtract />}
+            size="xs"
+            onClick={() => onRemoveContextKey(alias, item.key)}
+          />
+          <EditPreviewContextItem
+            meta={meta}
+            item={item}
+            alias={alias}
+            config={{includeAliasInSubject: true, disableErrors: true}}
+          />
+        </Fragment>
+      ));
+      return [...rowList, ...newRows];
+    },
+    []
+  );
+
+  const highlightTagItems = getHighlightTagItems({event, highlightTags});
+  const highlightTagRows = highlightTagItems.map((content, i) => (
+    <Fragment key={`edit-highlight-tag-${i}`}>
+      <EditButton
+        aria-label={`Remove from highlights`}
+        icon={<IconSubtract />}
+        size="xs"
+        onClick={() => onRemoveTag(content.originalTag.key)}
+      />
+      <EditPreviewTagItem
+        content={content}
+        event={event}
+        tagKey={content.originalTag.key}
+        projectSlug={project.slug}
+        config={{disableActions: true, disableRichValue: true}}
+      />
+    </Fragment>
+  ));
+
+  const rows = [...highlightTagRows, ...highlightContextRows];
+  const columns: React.ReactNode[] = [];
+  const columnSize = Math.ceil(rows.length / previewColumnCount);
+  for (let i = 0; i < rows.length; i += columnSize) {
+    columns.push(
+      <EditPreviewColumn key={`edit-highlight-column-${i}`}>
+        {rows.slice(i, i + columnSize)}
+      </EditPreviewColumn>
+    );
+  }
+  return (
+    <EditHighlightPreview columnCount={previewColumnCount}>
+      {columns}
+    </EditHighlightPreview>
+  );
+}
+
+interface EditTagHighlightSectionProps {
+  columnCount: number;
+  event: EditHighlightsModalProps['event'];
+  highlightTags: HighlightTags;
+  onAddTag: (tagKey: string) => void;
+}
+
+function EditTagHighlightSection({
+  columnCount,
+  event,
+  highlightTags,
+  onAddTag,
+}: EditTagHighlightSectionProps) {
+  const tagData = event.tags.map(tag => tag.key);
+  const tagColumnSize = Math.ceil(tagData.length / columnCount);
+  const tagColumns: React.ReactNode[] = [];
+  const highlightTagsSet = new Set(highlightTags);
+  for (let i = 0; i < tagData.length; i += tagColumnSize) {
+    tagColumns.push(
+      <EditHighlightColumn key={`tag-column-${i}`}>
+        {tagData.slice(i, i + tagColumnSize).map((tagKey, j) => {
+          const isDisabled = highlightTagsSet.has(tagKey);
+          return (
+            <EditTagContainer key={`tag-${i}-${j}`}>
+              <EditButton
+                aria-label={`Add ${tagKey} tag to highlights`}
+                icon={<IconAdd />}
+                size="xs"
+                onClick={() => onAddTag(tagKey)}
+                disabled={isDisabled}
+                title={isDisabled && t('Already highlighted')}
+                tooltipProps={{delay: 500}}
+              />
+              <HighlightKey disabled={isDisabled} aria-disabled={isDisabled}>
+                {tagKey}
+              </HighlightKey>
+            </EditTagContainer>
+          );
+        })}
+      </EditHighlightColumn>
+    );
+  }
+  return (
+    <EditHighlightSection>
+      <Subtitle>{t('Tags')}</Subtitle>
+      <EditHighlightSectionContent columnCount={columnCount}>
+        {tagColumns}
+      </EditHighlightSectionContent>
+    </EditHighlightSection>
+  );
+}
+
+interface EditContextHighlightSectionProps {
+  columnCount: number;
+  event: EditHighlightsModalProps['event'];
+  highlightContext: HighlightContext;
+  onAddContextKey: (contextType: string, contextKey: string) => void;
+}
+
+function EditContextHighlightSection({
+  columnCount,
+  event,
+  highlightContext,
+  onAddContextKey,
+}: EditContextHighlightSectionProps) {
+  const ctxDisableMap: Record<string, Set<string>> = Object.entries(
+    highlightContext
+  ).reduce(
+    (disableMap, [contextType, contextKeys]) => ({
+      ...disableMap,
+      [contextType]: new Set(contextKeys ?? []),
+    }),
+    {}
+  );
+  const ctxData: Record<string, string[]> = getOrderedContextItems(event).reduce(
+    (acc, [alias, context]) => {
+      acc[alias] = Object.keys(context).filter(k => k !== 'type');
+      return acc;
+    },
+    {}
+  );
+  const ctxItems = Object.entries(ctxData);
+  const ctxColumnSize = Math.ceil(ctxItems.length / columnCount);
+  const contextColumns: React.ReactNode[] = [];
+  for (let i = 0; i < ctxItems.length; i += ctxColumnSize) {
+    contextColumns.push(
+      <EditHighlightColumn key={`ctx-column-${i}`}>
+        {ctxItems.slice(i, i + ctxColumnSize).map(([contextType, contextKeys], j) => (
+          <EditContextContainer key={`ctxv-item-${i}-${j}`}>
+            <ContextType>{contextType}</ContextType>
+            {contextKeys.map((contextKey, k) => {
+              const isDisabled = ctxDisableMap[contextType]?.has(contextKey) ?? false;
+              return (
+                <Fragment key={`ctx-key-${i}-${j}-${k}`}>
+                  <EditButton
+                    aria-label={`Add ${contextKey} from ${contextType} context to highlights`}
+                    icon={<IconAdd />}
+                    size="xs"
+                    onClick={() => onAddContextKey(contextType, contextKey)}
+                    disabled={isDisabled}
+                    title={isDisabled && t('Already highlighted')}
+                    tooltipProps={{delay: 500}}
+                  />
+                  <HighlightKey disabled={isDisabled} aria-disabled={isDisabled}>
+                    {contextKey}
+                  </HighlightKey>
+                </Fragment>
+              );
+            })}
+          </EditContextContainer>
+        ))}
+      </EditHighlightColumn>
+    );
+  }
+
+  return (
+    <EditHighlightSection>
+      <Subtitle>{t('Context')}</Subtitle>
+      <EditHighlightSectionContent columnCount={columnCount}>
+        {contextColumns}
+      </EditHighlightSectionContent>
+    </EditHighlightSection>
+  );
+}
+
+export default function EditHighlightsModal({
+  Header,
+  Body,
+  Footer,
+  event,
+  highlightContext: prevHighlightContext,
+  highlightTags: prevHighlightTags,
+  project,
+  closeModal,
+}: EditHighlightsModalProps) {
+  const [highlightContext, setHighlightContext] =
+    useState<HighlightContext>(prevHighlightContext);
+  const [highlightTags, setHighlightTags] = useState<HighlightTags>(prevHighlightTags);
+
+  const organization = useOrganization();
+  const api = useApi();
+
+  const {mutate: saveHighlights, isLoading} = useMutation<Project, RequestError>({
+    mutationFn: () => {
+      return api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
+        method: 'PUT',
+        data: {
+          highlightContext,
+          highlightTags,
+        },
+      });
+    },
+    onSuccess: (_updatedProject: Project) => {
+      addSuccessMessage(
+        tct(`Successfully updated highlights for '[projectName]' project`, {
+          projectName: project.name,
+        })
+      );
+      closeModal();
+    },
+    onError: _error => {
+      addErrorMessage(
+        tct(`Failed to update highlights for '[projectName]' project`, {
+          projectName: project.name,
+        })
+      );
+    },
+  });
+
+  const columnCount = 3;
+  return (
+    <Fragment>
+      <Header>
+        <Title>{t('Edit Event Highlights')}</Title>
+      </Header>
+      <Body>
+        <EditPreviewHighlightSection
+          event={event}
+          highlightTags={highlightTags}
+          highlightContext={highlightContext}
+          onRemoveTag={tagKey =>
+            setHighlightTags(highlightTags.filter(tag => tag !== tagKey))
+          }
+          onRemoveContextKey={(contextType, contextKey) =>
+            setHighlightContext({
+              ...highlightContext,
+              [contextType]: (highlightContext[contextType] ?? []).filter(
+                key => key !== contextKey
+              ),
+            })
+          }
+          project={project}
+        />
+        <EditTagHighlightSection
+          event={event}
+          columnCount={columnCount}
+          highlightTags={highlightTags}
+          onAddTag={tagKey => setHighlightTags([...highlightTags, tagKey])}
+        />
+        <EditContextHighlightSection
+          event={event}
+          columnCount={columnCount}
+          highlightContext={highlightContext}
+          onAddContextKey={(contextType, contextKey) =>
+            setHighlightContext({
+              ...highlightContext,
+              [contextType]: [...(highlightContext[contextType] ?? []), contextKey],
+            })
+          }
+        />
+      </Body>
+      <Footer>
+        <ButtonBar gap={1}>
+          <Button onClick={closeModal} size="sm">
+            {t('Cancel')}
+          </Button>
+          <Button
+            disabled={isLoading}
+            onClick={() => saveHighlights()}
+            priority="primary"
+            size="sm"
+          >
+            {isLoading ? t('Saving...') : t('Save')}
+          </Button>
+        </ButtonBar>
+      </Footer>
+    </Fragment>
+  );
+}
+
+const Title = styled('h3')`
+  font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const Subtitle = styled('h4')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  border-bottom: 1px solid ${p => p.theme.border};
+  margin-bottom: ${space(1.5)};
+  padding-bottom: ${space(0.5)};
+`;
+
+const EditHighlightPreview = styled('div')<{columnCount: number}>`
+  border: 1px dashed ${p => p.theme.border};
+  border-radius: 4px;
+  padding: ${space(2)};
+  display: grid;
+  grid-template-columns: repeat(${p => p.columnCount}, minmax(0, 1fr));
+  align-items: start;
+  margin: 0 -${space(1.5)};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const EditHighlightSection = styled('div')`
+  margin-top: 25px;
+`;
+
+const EditHighlightSectionContent = styled('div')<{columnCount: number}>`
+  display: grid;
+  grid-template-columns: repeat(${p => p.columnCount}, minmax(0, 1fr));
+`;
+
+const EditHighlightColumn = styled('div')`
+  grid-column: span 1;
+  &:not(:first-child) {
+    border-left: 1px solid ${p => p.theme.innerBorder};
+    padding-left: ${space(2)};
+    margin-left: -1px;
+  }
+  &:not(:last-child) {
+    border-right: 1px solid ${p => p.theme.innerBorder};
+    padding-right: ${space(2)};
+  }
+`;
+
+const EditPreviewColumn = styled(EditHighlightColumn)`
+  display: grid;
+  grid-template-columns: 22px auto 1fr;
+  column-gap: 0;
+  button {
+    margin-right: ${space(0.25)};
+  }
+`;
+
+const EditPreviewContextItem = styled(ContextCardContent)`
+  font-size: ${p => p.theme.fontSizeSmall};
+  grid-column: span 2;
+  .ctx-row-value {
+    grid-column: span 1;
+  }
+  &:nth-child(4n-2) {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+`;
+
+const EditPreviewTagItem = styled(EventTagsTreeRow)`
+  &:nth-child(4n-2) {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+`;
+
+const EditTagContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  font-size: ${p => p.theme.fontSizeSmall};
+  align-items: center;
+`;
+
+const EditContextContainer = styled(EditTagContainer)`
+  margin-bottom: ${space(1)};
+`;
+
+const EditButton = styled(Button)`
+  grid-column: span 1;
+  color: ${p => (p.disabled ? p.theme.disabledBorder : p.theme.subText)};
+  border-color: ${p => (p.disabled ? p.theme.disabledBorder : p.theme.border)};
+  width: 18px;
+  height: 18px;
+  min-height: 18px;
+  border-radius: 4px;
+  margin: ${space(0.25)} 0;
+  align-self: start;
+  svg {
+    height: 10px;
+    width: 10px;
+  }
+  &:hover {
+    color: ${p => (p.disabled ? p.theme.disabledBorder : p.theme.subText)};
+  }
+`;
+
+const HighlightKey = styled('p')<{disabled?: boolean}>`
+  grid-column: span 1;
+  color: ${p => (p.disabled ? p.theme.disabledBorder : p.theme.subText)};
+  font-family: ${p => p.theme.text.familyMono};
+  margin-bottom: 0;
+  word-wrap: break-word;
+  word-break: break-all;
+  display: inline-block;
+`;
+
+const ContextType = styled('p')`
+  grid-column: span 2;
+  font-weight: bold;
+  text-transform: capitalize;
+  margin-bottom: ${space(0.25)};
+`;

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -12,7 +12,7 @@ import EventTagsTreeRow from 'sentry/components/events/eventTags/eventTagsTreeRo
 import type {
   HighlightContext,
   HighlightTags,
-} from 'sentry/components/events/highlights/highlightsDataSection';
+} from 'sentry/components/events/highlights/util';
 import {
   getHighlightContextItems,
   getHighlightTagItems,

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -31,10 +31,7 @@ interface EditHighlightsModalProps extends ModalRenderProps {
   highlightContext: HighlightContext;
   highlightTags: HighlightTags;
   project: Project;
-  highlightPreset?: {
-    highlightContext: HighlightContext;
-    highlightTags: HighlightTags;
-  };
+  highlightPreset?: Project['highlightPreset'];
 }
 
 interface EditPreviewHighlightSectionProps {
@@ -356,8 +353,8 @@ export default function EditHighlightsModal({
           {highlightPreset && (
             <Button
               onClick={() => {
-                setHighlightContext(highlightPreset.highlightContext);
-                setHighlightTags(highlightPreset.highlightTags);
+                setHighlightContext(highlightPreset.context);
+                setHighlightTags(highlightPreset.tags);
               }}
             >
               {t('Use Defaults')}

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -79,6 +79,7 @@ function EditPreviewHighlightSection({
             item={item}
             alias={alias}
             config={{includeAliasInSubject: true, disableErrors: true}}
+            data-test-id="highlights-preview-ctx"
           />
         </Fragment>
       ));
@@ -103,6 +104,7 @@ function EditPreviewHighlightSection({
         tagKey={content.originalTag.key}
         projectSlug={project.slug}
         config={{disableActions: true, disableRichValue: true}}
+        data-test-id="highlights-preview-tag"
       />
     </Fragment>
   ));

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -114,7 +114,13 @@ function EditPreviewHighlightSection({
   }
   return (
     <EditHighlightPreview columnCount={previewColumnCount}>
-      {columns}
+      {columns.length > 0 ? (
+        columns
+      ) : (
+        <EmptyHighlightMessage columnCount={previewColumnCount}>
+          {t('Promote tags or context keys to highlights for quicker debugging!')}
+        </EmptyHighlightMessage>
+      )}
     </EditHighlightPreview>
   );
 }
@@ -369,6 +375,13 @@ const EditHighlightPreview = styled('div')<{columnCount: number}>`
   align-items: start;
   margin: 0 -${space(1.5)};
   font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const EmptyHighlightMessage = styled('div')<{columnCount: number}>`
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.subText};
+  grid-column: span ${p => p.columnCount};
+  text-align: center;
 `;
 
 const EditHighlightSection = styled('div')`

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -31,6 +31,10 @@ interface EditHighlightsModalProps extends ModalRenderProps {
   highlightContext: HighlightContext;
   highlightTags: HighlightTags;
   project: Project;
+  highlightPreset?: {
+    highlightContext: HighlightContext;
+    highlightTags: HighlightTags;
+  };
 }
 
 interface EditPreviewHighlightSectionProps {
@@ -257,6 +261,7 @@ export default function EditHighlightsModal({
   event,
   highlightContext: prevHighlightContext,
   highlightTags: prevHighlightTags,
+  highlightPreset,
   project,
   closeModal,
 }: EditHighlightsModalProps) {
@@ -348,6 +353,16 @@ export default function EditHighlightsModal({
           <Button onClick={closeModal} size="sm">
             {t('Cancel')}
           </Button>
+          {highlightPreset && (
+            <Button
+              onClick={() => {
+                setHighlightContext(highlightPreset.highlightContext);
+                setHighlightTags(highlightPreset.highlightTags);
+              }}
+            >
+              {t('Use Defaults')}
+            </Button>
+          )}
           <Button
             disabled={isLoading}
             onClick={() => saveHighlights()}

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -281,17 +281,21 @@ export default function EditHighlightsModal({
   const api = useApi();
   const queryClient = useQueryClient();
 
-  const {mutate: saveHighlights, isLoading} = useMutation<Project, RequestError>({
-    mutationFn: () => {
+  const {mutate: saveHighlights, isLoading} = useMutation<
+    Project,
+    RequestError,
+    {
+      highlightContext: HighlightContext;
+      highlightTags: HighlightTags;
+    }
+  >({
+    mutationFn: data => {
       return api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
         method: 'PUT',
-        data: {
-          highlightContext,
-          highlightTags,
-        },
+        data,
       });
     },
-    onSuccess: (_updatedProject: Project) => {
+    onSuccess: (updatedProject: Project) => {
       addSuccessMessage(
         tct(`Successfully updated highlights for '[projectName]' project`, {
           projectName: project.name,
@@ -303,7 +307,8 @@ export default function EditHighlightsModal({
           orgSlug: organization.slug,
           projectSlug: project.slug,
         }),
-        data => (data ? {...data, highlightTags, highlightContext} : data)
+        data =>
+          updatedProject ? updatedProject : {...data, highlightTags, highlightContext}
       );
       closeModal();
     },
@@ -386,7 +391,7 @@ export default function EditHighlightsModal({
           )}
           <Button
             disabled={isLoading}
-            onClick={() => saveHighlights()}
+            onClick={() => saveHighlights({highlightContext, highlightTags})}
             priority="primary"
             size="sm"
           >

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -309,11 +309,18 @@ export default function EditHighlightsModal({
             setHighlightTags(highlightTags.filter(tag => tag !== tagKey))
           }
           onRemoveContextKey={(contextType, contextKey) =>
-            setHighlightContext({
-              ...highlightContext,
-              [contextType]: (highlightContext[contextType] ?? []).filter(
+            setHighlightContext(() => {
+              const {[contextType]: highlightContextKeys, ...newHighlightContext} =
+                highlightContext;
+              const newHighlightContextKeys = (highlightContextKeys ?? []).filter(
                 key => key !== contextKey
-              ),
+              );
+              return newHighlightContextKeys.length === 0
+                ? newHighlightContext
+                : {
+                    ...newHighlightContext,
+                    [contextType]: newHighlightContextKeys,
+                  };
             })
           }
           project={project}
@@ -408,7 +415,7 @@ const EditHighlightColumn = styled('div')`
 
 const EditPreviewColumn = styled(EditHighlightColumn)`
   display: grid;
-  grid-template-columns: 22px auto 1fr;
+  grid-template-columns: 22px minmax(auto, 175px) 1fr;
   column-gap: 0;
   button {
     margin-right: ${space(0.25)};
@@ -418,9 +425,6 @@ const EditPreviewColumn = styled(EditHighlightColumn)`
 const EditPreviewContextItem = styled(ContextCardContent)`
   font-size: ${p => p.theme.fontSizeSmall};
   grid-column: span 2;
-  .ctx-row-value {
-    grid-column: span 1;
-  }
   &:nth-child(4n-2) {
     background-color: ${p => p.theme.backgroundSecondary};
   }

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -14,8 +14,8 @@ import type {
   HighlightTags,
 } from 'sentry/components/events/highlights/util';
 import {
-  getHighlightContextItems,
-  getHighlightTagItems,
+  getHighlightContextData,
+  getHighlightTagData,
 } from 'sentry/components/events/highlights/util';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -53,16 +53,16 @@ function EditPreviewHighlightSection({
   const organization = useOrganization();
   const previewColumnCount = 2;
 
-  const highlightContextDataItems = getHighlightContextItems({
+  const highlightContextDataItems = getHighlightContextData({
     event,
     project,
     organization,
     highlightContext,
   });
   const highlightContextRows = highlightContextDataItems.reduce<React.ReactNode[]>(
-    (rowList, [alias, items], i) => {
+    (rowList, {alias, data}, i) => {
       const meta = getContextMeta(event, alias);
-      const newRows = items.map((item, j) => (
+      const newRows = data.map((item, j) => (
         <Fragment key={`edit-highlight-ctx-${i}-${j}`}>
           <EditButton
             aria-label={`Remove from highlights`}
@@ -83,7 +83,7 @@ function EditPreviewHighlightSection({
     []
   );
 
-  const highlightTagItems = getHighlightTagItems({event, highlightTags});
+  const highlightTagItems = getHighlightTagData({event, highlightTags});
   const highlightTagRows = highlightTagItems.map((content, i) => (
     <Fragment key={`edit-highlight-tag-${i}`}>
       <EditButton
@@ -194,8 +194,8 @@ function EditContextHighlightSection({
     {}
   );
   const ctxData: Record<string, string[]> = getOrderedContextItems(event).reduce(
-    (acc, [alias, context]) => {
-      acc[alias] = Object.keys(context).filter(k => k !== 'type');
+    (acc, {alias, value}) => {
+      acc[alias] = Object.keys(value).filter(k => k !== 'type');
       return acc;
     },
     {}

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -27,7 +27,7 @@ import useApi from 'sentry/utils/useApi';
 import {makeDetailedProjectQueryKey} from 'sentry/utils/useDetailedProject';
 import useOrganization from 'sentry/utils/useOrganization';
 
-interface EditHighlightsModalProps extends ModalRenderProps {
+export interface EditHighlightsModalProps extends ModalRenderProps {
   event: Event;
   highlightContext: HighlightContext;
   highlightTags: HighlightTags;
@@ -51,6 +51,7 @@ function EditPreviewHighlightSection({
   highlightTags,
   onRemoveContextKey,
   onRemoveTag,
+  ...props
 }: EditPreviewHighlightSectionProps) {
   const organization = useOrganization();
   const previewColumnCount = 2;
@@ -71,6 +72,7 @@ function EditPreviewHighlightSection({
             icon={<IconSubtract />}
             size="xs"
             onClick={() => onRemoveContextKey(alias, item.key)}
+            data-test-id="highlights-remove-ctx"
           />
           <EditPreviewContextItem
             meta={meta}
@@ -93,6 +95,7 @@ function EditPreviewHighlightSection({
         icon={<IconSubtract />}
         size="xs"
         onClick={() => onRemoveTag(content.originalTag.key)}
+        data-test-id="highlights-remove-tag"
       />
       <EditPreviewTagItem
         content={content}
@@ -115,11 +118,14 @@ function EditPreviewHighlightSection({
     );
   }
   return (
-    <EditHighlightPreview columnCount={previewColumnCount}>
+    <EditHighlightPreview columnCount={previewColumnCount} {...props}>
       {columns.length > 0 ? (
         columns
       ) : (
-        <EmptyHighlightMessage columnCount={previewColumnCount}>
+        <EmptyHighlightMessage
+          columnCount={previewColumnCount}
+          data-test-id="highlights-empty-message"
+        >
           {t('Promote tags or context keys to highlights for quicker debugging!')}
         </EmptyHighlightMessage>
       )}
@@ -139,6 +145,7 @@ function EditTagHighlightSection({
   event,
   highlightTags,
   onAddTag,
+  ...props
 }: EditTagHighlightSectionProps) {
   const tagData = event.tags.map(tag => tag.key);
   const tagColumnSize = Math.ceil(tagData.length / columnCount);
@@ -170,7 +177,7 @@ function EditTagHighlightSection({
     );
   }
   return (
-    <EditHighlightSection>
+    <EditHighlightSection {...props}>
       <Subtitle>{t('Tags')}</Subtitle>
       <EditHighlightSectionContent columnCount={columnCount}>
         {tagColumns}
@@ -191,6 +198,7 @@ function EditContextHighlightSection({
   event,
   highlightContext,
   onAddContextKey,
+  ...props
 }: EditContextHighlightSectionProps) {
   const ctxDisableMap: Record<string, Set<string>> = Object.entries(
     highlightContext
@@ -243,7 +251,7 @@ function EditContextHighlightSection({
   }
 
   return (
-    <EditHighlightSection>
+    <EditHighlightSection {...props}>
       <Subtitle>{t('Context')}</Subtitle>
       <EditHighlightSectionContent columnCount={columnCount}>
         {contextColumns}
@@ -336,12 +344,14 @@ export default function EditHighlightsModal({
             })
           }
           project={project}
+          data-test-id="highlights-preview-section"
         />
         <EditTagHighlightSection
           event={event}
           columnCount={columnCount}
           highlightTags={highlightTags}
           onAddTag={tagKey => setHighlightTags([...highlightTags, tagKey])}
+          data-test-id="highlights-tag-section"
         />
         <EditContextHighlightSection
           event={event}
@@ -353,6 +363,7 @@ export default function EditHighlightsModal({
               [contextType]: [...(highlightContext[contextType] ?? []), contextKey],
             })
           }
+          data-test-id="highlights-context-section"
         />
       </Body>
       <Footer>

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -356,6 +356,7 @@ export default function EditHighlightsModal({
                 setHighlightContext(highlightPreset.context);
                 setHighlightTags(highlightPreset.tags);
               }}
+              size="sm"
             >
               {t('Use Defaults')}
             </Button>

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -21,9 +21,10 @@ import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Project} from 'sentry/types';
-import {useMutation} from 'sentry/utils/queryClient';
+import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
+import {makeDetailedProjectQueryKey} from 'sentry/utils/useDetailedProject';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface EditHighlightsModalProps extends ModalRenderProps {
@@ -268,6 +269,7 @@ export default function EditHighlightsModal({
 
   const organization = useOrganization();
   const api = useApi();
+  const queryClient = useQueryClient();
 
   const {mutate: saveHighlights, isLoading} = useMutation<Project, RequestError>({
     mutationFn: () => {
@@ -284,6 +286,14 @@ export default function EditHighlightsModal({
         tct(`Successfully updated highlights for '[projectName]' project`, {
           projectName: project.name,
         })
+      );
+      setApiQueryData<Project>(
+        queryClient,
+        makeDetailedProjectQueryKey({
+          orgSlug: organization.slug,
+          projectSlug: project.slug,
+        }),
+        data => (data ? {...data, highlightTags, highlightContext} : data)
       );
       closeModal();
     },

--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -1,0 +1,71 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import HighlightsDataSection from 'sentry/components/events/highlights/highlightsDataSection';
+
+HighlightsDataSection;
+
+import {
+  TEST_EVENT_CONTEXTS,
+  TEST_EVENT_TAGS,
+} from 'sentry/components/events/highlights/util.spec';
+
+describe('HighlightsDataSection', function () {
+  const organization = OrganizationFixture({features: ['event-tags-tree-ui']});
+  const project = ProjectFixture();
+  const event = EventFixture({
+    contexts: TEST_EVENT_CONTEXTS,
+    tags: TEST_EVENT_TAGS,
+  });
+  const group = GroupFixture();
+  const highlightTags = ['environment', 'handled', 'transaction', 'url'];
+  const highlightContext = {
+    user: ['email'],
+    browser: ['name', 'version'],
+  };
+  const highlightContextTitles = ['User: email', 'Browser: name', 'Browser: version'];
+  it('renders an empty state', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: {...project, highlightTags: [], highlightContext: {}},
+    });
+    render(
+      <HighlightsDataSection
+        event={event}
+        group={group}
+        project={project}
+        viewAllRef={'ref' as any}
+      />,
+      {organization}
+    );
+    expect(screen.getByText('Event Highlights')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(await screen.findByText("There's nothing here...")).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Edit'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Add Highlights'})).toBeInTheDocument();
+  });
+
+  it('renders highlights from the detailed project API response', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: {...project, highlightTags, highlightContext},
+    });
+
+    render(<HighlightsDataSection event={event} group={group} project={project} />, {
+      organization,
+    });
+    expect(screen.getByText('Event Highlights')).toBeInTheDocument();
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
+    const tagRows = screen.queryAllByTestId('highlight-tag-row');
+    expect(tagRows.length).toBe(highlightTags.length);
+    const ctxRows = screen.queryAllByTestId('highlight-context-row');
+    expect(ctxRows.length).toBe(Object.values(highlightContext).flat().length);
+    highlightContextTitles.forEach(title => {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -38,7 +38,7 @@ describe('HighlightsDataSection', function () {
         event={event}
         group={group}
         project={project}
-        viewAllRef={'ref' as any}
+        viewAllRef={{current: null}}
       />,
       {organization}
     );

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -35,8 +35,6 @@ interface HighlightsSectionProps {
   project: Project;
   viewAllRef?: React.RefObject<HTMLElement>;
 }
-export type HighlightTags = Required<Project>['highlightTags'];
-export type HighlightContext = Required<Project>['highlightContext'];
 
 export default function HighlightsDataSection({
   event,

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -1,20 +1,172 @@
-import ContextSummary from 'sentry/components/events/contextSummary';
-import {useHasNewTagsUI} from 'sentry/components/events/eventTags/util';
-import type {Event} from 'sentry/types/event';
-import type {Group} from 'sentry/types/group';
-import type {Project} from 'sentry/types/project';
+import {useRef} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import {ContextCardContent} from 'sentry/components/events/contexts/contextCard';
+import {getContextMeta} from 'sentry/components/events/contexts/utils';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import {
+  TreeColumn,
+  TreeContainer,
+} from 'sentry/components/events/eventTags/eventTagsTree';
+import EventTagsTreeRow from 'sentry/components/events/eventTags/eventTagsTreeRow';
+import {
+  useHasNewTagsUI,
+  useIssueDetailsColumnCount,
+} from 'sentry/components/events/eventTags/util';
+import EditHighlightsModal from 'sentry/components/events/highlights/editHighlightsModal';
+import {
+  getHighlightContextItems,
+  getHighlightTagItems,
+} from 'sentry/components/events/highlights/util';
+import {IconEdit} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event, Group, Project} from 'sentry/types';
+import {useDetailedProject} from 'sentry/utils/useDetailedProject';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface HighlightsSectionProps {
   event: Event;
   group: Group;
   project: Project;
+  viewAllRef?: React.RefObject<HTMLElement>;
 }
+export type HighlightTags = Required<Project>['highlightTags'];
+export type HighlightContext = Required<Project>['highlightContext'];
 
-export default function HighlightsDataSection({event}: HighlightsSectionProps) {
+export default function HighlightsDataSection({
+  event,
+  project,
+  viewAllRef,
+}: HighlightsSectionProps) {
   const hasNewTagsUI = useHasNewTagsUI();
+  const organization = useOrganization();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const columnCount = useIssueDetailsColumnCount(containerRef);
+  const {
+    isLoading,
+    data: detailedProject,
+    refetch,
+  } = useDetailedProject({
+    orgSlug: organization.slug,
+    projectSlug: project.slug,
+  });
+
   if (!hasNewTagsUI) {
     return null;
   }
-  // TODO(Leander): When a design is confirmed, remove this usage of ContextSummary
-  return <ContextSummary event={event} />;
+
+  const highlightContext = detailedProject?.highlightContext ?? {};
+  const highlightTags = detailedProject?.highlightTags ?? [];
+  const viewAllButton = viewAllRef ? (
+    <Button
+      onClick={() => viewAllRef?.current?.scrollIntoView({behavior: 'smooth'})}
+      size="xs"
+    >
+      {t('View All')}
+    </Button>
+  ) : null;
+
+  const highlightContextDataItems = getHighlightContextItems({
+    event,
+    project,
+    organization,
+    highlightContext,
+  });
+  const highlightContextRows = highlightContextDataItems.reduce<React.ReactNode[]>(
+    (rowList, [alias, items], i) => {
+      const meta = getContextMeta(event, alias);
+      const newRows = items.map((item, j) => (
+        <HighlightContextContent
+          key={`highlight-ctx-${i}-${j}`}
+          meta={meta}
+          item={item}
+          alias={alias}
+          config={{includeAliasInSubject: true}}
+        />
+      ));
+      return [...rowList, ...newRows];
+    },
+    []
+  );
+
+  const highlightTagItems = getHighlightTagItems({event, highlightTags});
+  const highlightTagRows = highlightTagItems.map((content, i) => (
+    <EventTagsTreeRow
+      key={`highlight-tag-${i}`}
+      content={content}
+      event={event}
+      tagKey={content.originalTag.key}
+      projectSlug={project.slug}
+    />
+  ));
+
+  const rows = [...highlightTagRows, ...highlightContextRows];
+  const columns: React.ReactNode[] = [];
+  const columnSize = Math.ceil(rows.length / columnCount);
+  for (let i = 0; i < rows.length; i += columnSize) {
+    columns.push(
+      <HighlightColumn key={`highlight-column-${i}`}>
+        {rows.slice(i, i + columnSize)}
+      </HighlightColumn>
+    );
+  }
+
+  return (
+    <EventDataSection
+      title={t('Event Highlights')}
+      data-test-id="event-highlights"
+      type="event-highlights"
+      actions={
+        <ButtonBar gap={1}>
+          {viewAllButton}
+          <Button
+            size="xs"
+            icon={<IconEdit />}
+            onClick={() =>
+              openModal(
+                deps => (
+                  <EditHighlightsModal
+                    event={event}
+                    highlightContext={highlightContext}
+                    highlightTags={highlightTags}
+                    project={detailedProject ?? project}
+                    {...deps}
+                  />
+                ),
+                {modalCss: highlightModalCss, onClose: refetch}
+              )
+            }
+          >
+            {t('Edit')}
+          </Button>
+        </ButtonBar>
+      }
+    >
+      <HighlightContainer columnCount={columnCount} ref={containerRef}>
+        {isLoading ? null : columns}
+      </HighlightContainer>
+    </EventDataSection>
+  );
 }
+
+const HighlightContainer = styled(TreeContainer)<{columnCount: number}>`
+  margin-top: 0;
+  margin-bottom: ${space(2)};
+`;
+
+const HighlightColumn = styled(TreeColumn)`
+  grid-column: span 1;
+`;
+
+const HighlightContextContent = styled(ContextCardContent)`
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+export const highlightModalCss = css`
+  width: 850px;
+`;

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -19,8 +19,8 @@ import {
 } from 'sentry/components/events/eventTags/util';
 import EditHighlightsModal from 'sentry/components/events/highlights/editHighlightsModal';
 import {
-  getHighlightContextItems,
-  getHighlightTagItems,
+  getHighlightContextData,
+  getHighlightTagData,
 } from 'sentry/components/events/highlights/util';
 import {IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -69,16 +69,16 @@ export default function HighlightsDataSection({
     </Button>
   ) : null;
 
-  const highlightContextDataItems = getHighlightContextItems({
+  const highlightContextDataItems = getHighlightContextData({
     event,
     project,
     organization,
     highlightContext,
   });
   const highlightContextRows = highlightContextDataItems.reduce<React.ReactNode[]>(
-    (rowList, [alias, items], i) => {
+    (rowList, {alias, data}, i) => {
       const meta = getContextMeta(event, alias);
-      const newRows = items.map((item, j) => (
+      const newRows = data.map((item, j) => (
         <HighlightContextContent
           key={`highlight-ctx-${i}-${j}`}
           meta={meta}
@@ -92,7 +92,7 @@ export default function HighlightsDataSection({
     []
   );
 
-  const highlightTagItems = getHighlightTagItems({event, highlightTags});
+  const highlightTagItems = getHighlightTagData({event, highlightTags});
   const highlightTagRows = highlightTagItems.map((content, i) => (
     <EventTagsTreeRow
       key={`highlight-tag-${i}`}

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -60,6 +60,13 @@ export default function HighlightsDataSection({
 
   const highlightContext = detailedProject?.highlightContext ?? {};
   const highlightTags = detailedProject?.highlightTags ?? [];
+
+  // The API will return default values for tags/context. The only way to have none is to set it to
+  // empty yourself, meaning the user does not want this section to appear.
+  if (Object.keys(highlightContext).length === 0 && highlightTags.length === 0) {
+    return null;
+  }
+
   const viewAllButton = viewAllRef ? (
     <Button
       onClick={() => viewAllRef?.current?.scrollIntoView({behavior: 'smooth'})}

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -129,6 +129,7 @@ export default function HighlightsDataSection({
           highlightContext={highlightContext}
           highlightTags={highlightTags}
           project={detailedProject ?? project}
+          highlightPreset={detailedProject?.highlightPreset}
           {...deps}
         />
       ),

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -46,11 +46,7 @@ export default function HighlightsDataSection({
   const organization = useOrganization();
   const containerRef = useRef<HTMLDivElement>(null);
   const columnCount = useIssueDetailsColumnCount(containerRef);
-  const {
-    isLoading,
-    data: detailedProject,
-    refetch,
-  } = useDetailedProject({
+  const {isLoading, data: detailedProject} = useDetailedProject({
     orgSlug: organization.slug,
     projectSlug: project.slug,
   });
@@ -133,7 +129,7 @@ export default function HighlightsDataSection({
           {...deps}
         />
       ),
-      {modalCss: highlightModalCss, onClose: refetch}
+      {modalCss: highlightModalCss}
     );
   }
 

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -88,6 +88,7 @@ export default function HighlightsDataSection({
           item={item}
           alias={alias}
           config={{includeAliasInSubject: true}}
+          data-test-id="highlight-context-row"
         />
       ));
       return [...rowList, ...newRows];
@@ -103,6 +104,7 @@ export default function HighlightsDataSection({
       event={event}
       tagKey={content.originalTag.key}
       projectSlug={project.slug}
+      data-test-id="highlight-tag-row"
     />
   ));
 

--- a/static/app/components/events/highlights/util.spec.tsx
+++ b/static/app/components/events/highlights/util.spec.tsx
@@ -8,7 +8,7 @@ import {
   getHighlightTagData,
 } from 'sentry/components/events/highlights/util';
 
-const TEST_EVENT_CONTEXTS = {
+export const TEST_EVENT_CONTEXTS = {
   keyboard: {
     type: 'default',
     brand: 'keychron',
@@ -30,7 +30,7 @@ const TEST_EVENT_CONTEXTS = {
   },
 };
 
-const TEST_EVENT_TAGS = [
+export const TEST_EVENT_TAGS = [
   {
     key: 'browser',
     value: 'Chrome 1.2.3',

--- a/static/app/components/events/highlights/util.spec.tsx
+++ b/static/app/components/events/highlights/util.spec.tsx
@@ -3,6 +3,7 @@ import {EventFixture} from 'sentry-fixture/event';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {
+  EMPTY_HIGHLIGHT_DEFAULT,
   getHighlightContextData,
   getHighlightTagData,
 } from 'sentry/components/events/highlights/util';
@@ -78,8 +79,9 @@ describe('getHighlightContextData', function () {
     const event = EventFixture({
       contexts: TEST_EVENT_CONTEXTS,
     });
+    const missingContextKey = 'color';
     const highlightContext = {
-      keyboard: ['brand', 'switches'],
+      keyboard: ['brand', 'switches', missingContextKey],
     };
     const highlightCtxData = getHighlightContextData({
       event,
@@ -95,6 +97,10 @@ describe('getHighlightContextData', function () {
     for (const ctxKey of highlightContext.keyboard) {
       expect(highlightCtxDataKeys.has(ctxKey)).toBe(true);
     }
+    const missingCtxHighlightFromEvent = highlightCtxData[0].data?.find(
+      d => d.key === missingContextKey
+    );
+    expect(missingCtxHighlightFromEvent?.value).toBe(EMPTY_HIGHLIGHT_DEFAULT);
   });
 
   it.each([
@@ -122,7 +128,8 @@ describe('getHighlightTagData', function () {
     const event = EventFixture({
       tags: TEST_EVENT_TAGS,
     });
-    const highlightTags = ['release', 'url', 'environment'];
+    const missingTag = 'zamboni';
+    const highlightTags = ['release', 'url', 'environment', missingTag];
     const highlightTagsSet = new Set(highlightTags);
 
     const highlightTagData = getHighlightTagData({event, highlightTags});
@@ -131,5 +138,9 @@ describe('getHighlightTagData', function () {
     for (const content of highlightTagData) {
       expect(highlightTagsSet.has(content.originalTag.key)).toBe(true);
     }
+    const missingTagHighlightFromEvent = highlightTagData.find(
+      td => td.originalTag.key === missingTag
+    );
+    expect(missingTagHighlightFromEvent?.value).toBe(EMPTY_HIGHLIGHT_DEFAULT);
   });
 });

--- a/static/app/components/events/highlights/util.tsx
+++ b/static/app/components/events/highlights/util.tsx
@@ -14,12 +14,62 @@ import type {
   Organization,
   Project,
 } from 'sentry/types';
+import {defined} from 'sentry/utils';
 
 export type HighlightTags = Required<Project>['highlightTags'];
 export type HighlightContext = Required<Project>['highlightContext'];
 
 interface ContextData extends ContextItem {
   data: KeyValueListData;
+}
+
+const EMPTY_HIGHLIGHT_DEFAULT = '--';
+
+/**
+ * Helper function to use try HighlightContext saved values on multiple fields improve match rate.
+ * E.g. Matching 'os' on 'client_os', and 'Operating System', matching 'trace_id' on 'Trace ID'
+ */
+function getFuzzyHighlightContext(
+  highlightContext: HighlightContext,
+  {alias, type: contextType, value, data}: ContextData
+) {
+  const highlightContextSets: Record<ContextData['type'], Set<string>> = Object.entries(
+    highlightContext
+  ).reduce(
+    (hcSets, [ctxType, contextKeys]) => ({
+      ...hcSets,
+      [ctxType]: new Set(contextKeys),
+    }),
+    {}
+  );
+  const title = getContextTitle({alias, type: contextType, value});
+  let highlightKey: string | undefined = undefined;
+  if (highlightContextSets.hasOwnProperty(alias)) {
+    highlightKey = alias;
+  } else if (highlightContextSets.hasOwnProperty(contextType)) {
+    highlightKey = contextType;
+  } else if (highlightContextSets.hasOwnProperty(title)) {
+    highlightKey = title;
+  }
+
+  if (!defined(highlightKey)) {
+    return {
+      highlightKey,
+      highlightItems: [],
+    };
+  }
+
+  const highlightContextKeys = highlightContextSets[highlightKey];
+  const highlightItems: KeyValueListData = data.filter(
+    ({key, subject}) =>
+      // We match on key (e.g. 'trace_id') and subject (e.g. 'Trace ID')
+      highlightContextKeys.has(key) || highlightContextKeys.has(subject)
+  );
+
+  return {
+    highlightKey,
+    highlightItems,
+  };
 }
 
 export function getHighlightContextData({
@@ -33,17 +83,23 @@ export function getHighlightContextData({
   organization: Organization;
   project: Project;
 }) {
-  const highlightContextSets: Record<ContextData['type'], Set<string>> = Object.entries(
-    highlightContext
-  ).reduce(
-    (hcSets, [contextType, contextKeys]) => ({
-      ...hcSets,
-      [contextType]: new Set(contextKeys),
-    }),
-    {}
+  const highlightContextData: ContextData[] = Object.entries(highlightContext).map(
+    ([contextType, contextKeys]) => ({
+      alias: contextType,
+      type: contextType,
+      value: EMPTY_HIGHLIGHT_DEFAULT,
+      data: contextKeys.map(
+        contextKey => ({
+          key: contextKey,
+          subject: contextKey,
+          value: EMPTY_HIGHLIGHT_DEFAULT,
+        }),
+        {}
+      ),
+    })
   );
 
-  const allContextData: ContextData[] = getOrderedContextItems(event).map(
+  const eventContextData: ContextData[] = getOrderedContextItems(event).map(
     ({alias, type, value}) => ({
       alias,
       type,
@@ -58,26 +114,28 @@ export function getHighlightContextData({
     })
   );
 
-  const highlightContextData: ContextData[] = allContextData
-    .map(({alias, type: contextType, value, data}) => {
-      // Find the highlight key set for this type of context
-      // We match on alias (e.g. 'client_os'), type (e.g. 'os') and title (e.g. 'Operating System')
-      const highlightContextKeys =
-        highlightContextSets[alias] ??
-        highlightContextSets[contextType] ??
-        highlightContextSets[getContextTitle({alias, type: contextType, value})] ??
-        new Set([]);
-      // Filter data to only items from that set
-      const highlightContextItems: KeyValueListData = data.filter(
-        ({key, subject}) =>
-          // We match on key (e.g. 'trace_id') and subject (e.g. 'Trace ID')
-          highlightContextKeys.has(key) || highlightContextKeys.has(subject)
-      );
-      return {alias, type: contextType, data: highlightContextItems, value: value};
-    })
-    // Retain only entries with highlights
-    .filter(({data}) => data.length > 0);
-
+  eventContextData.forEach(ctxData => {
+    const {highlightItems, highlightKey} = getFuzzyHighlightContext(
+      highlightContext,
+      ctxData
+    );
+    if (!highlightKey || highlightItems.length === 0) {
+      return;
+    }
+    const highlightItemKeys = new Set(highlightItems.map(item => item.key));
+    const matchingHighlight = highlightContextData.find(
+      hCtxData => hCtxData.type === highlightKey
+    );
+    if (!matchingHighlight) {
+      return;
+    }
+    matchingHighlight.data = [
+      ...highlightItems,
+      ...matchingHighlight.data.filter(
+        emptyItem => !highlightItemKeys.has(emptyItem.key)
+      ),
+    ];
+  });
   return highlightContextData;
 }
 
@@ -88,7 +146,6 @@ export function getHighlightTagData({
   event: Event;
   highlightTags: HighlightTags;
 }): Required<TagTreeContent>[] {
-  const EMPTY_TAG_VALUE = '';
   const tagMap: Record<string, {meta: Record<string, any>; tag: EventTag}> =
     event.tags.reduce((tm, tag, i) => {
       tm[tag.key] = {tag, meta: event._meta?.tags?.[i]};
@@ -97,7 +154,7 @@ export function getHighlightTagData({
   return highlightTags.map(tagKey => ({
     subtree: {},
     meta: tagMap[tagKey]?.meta ?? {},
-    value: tagMap[tagKey]?.tag?.value ?? EMPTY_TAG_VALUE,
-    originalTag: tagMap[tagKey]?.tag ?? {key: tagKey, value: EMPTY_TAG_VALUE},
+    value: tagMap[tagKey]?.tag?.value ?? EMPTY_HIGHLIGHT_DEFAULT,
+    originalTag: tagMap[tagKey]?.tag ?? {key: tagKey, value: EMPTY_HIGHLIGHT_DEFAULT},
   }));
 }

--- a/static/app/components/events/highlights/util.tsx
+++ b/static/app/components/events/highlights/util.tsx
@@ -23,7 +23,7 @@ interface ContextData extends ContextItem {
   data: KeyValueListData;
 }
 
-const EMPTY_HIGHLIGHT_DEFAULT = '--';
+export const EMPTY_HIGHLIGHT_DEFAULT = '--';
 
 /**
  * Helper function to use try HighlightContext saved values on multiple fields improve match rate.
@@ -129,6 +129,10 @@ export function getHighlightContextData({
     if (!matchingHighlight) {
       return;
     }
+    // We can't use Object.assign since the 'data' property is being mutated
+    matchingHighlight.type = ctxData.type;
+    matchingHighlight.value = ctxData.value;
+    matchingHighlight.alias = ctxData.alias;
     matchingHighlight.data = [
       ...highlightItems,
       ...matchingHighlight.data.filter(

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -61,8 +61,8 @@ export type Project = {
   hasUserReports?: boolean;
   highlightContext?: Record<string, string[]>;
   highlightPreset?: {
-    highlightContext: Record<string, string[]>;
-    highlightTags: string[];
+    context: Record<string, string[]>;
+    tags: string[];
   };
   highlightTags?: string[];
   latestDeploys?: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -60,6 +60,10 @@ export type Project = {
   defaultEnvironment?: string;
   hasUserReports?: boolean;
   highlightContext?: Record<string, string[]>;
+  highlightPreset?: {
+    highlightContext: Record<string, string[]>;
+    highlightTags: string[];
+  };
   highlightTags?: string[];
   latestDeploys?: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;
   latestRelease?: {version: string} | null;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -497,7 +497,7 @@ describe('groupEventDetails', () => {
   describe('changes to event tags ui', () => {
     async function assertNewTagsView() {
       expect(await screen.findByText('Event ID:')).toBeInTheDocument();
-      const contextSummary = screen.getByTestId('highlighted-event-data');
+      const contextSummary = screen.getByTestId('event-highlights');
       const contextSummaryContainer = within(contextSummary);
       // 3 contexts in makeDefaultMockData.event.contexts, trace is ignored
       expect(contextSummaryContainer.queryAllByTestId('context-item')).toHaveLength(3);

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -497,11 +497,18 @@ describe('groupEventDetails', () => {
   describe('changes to event tags ui', () => {
     async function assertNewTagsView() {
       expect(await screen.findByText('Event ID:')).toBeInTheDocument();
-      const contextSummary = screen.getByTestId('event-highlights');
-      const contextSummaryContainer = within(contextSummary);
-      // 3 contexts in makeDefaultMockData.event.contexts, trace is ignored
-      expect(contextSummaryContainer.queryAllByTestId('context-item')).toHaveLength(3);
+      expect(screen.queryByTestId('context-summary')).not.toBeInTheDocument();
       expect(screen.getByTestId('event-tags')).toBeInTheDocument();
+      const highlights = screen.getByTestId('event-highlights');
+      expect(
+        within(highlights).getByRole('button', {name: 'View All'})
+      ).toBeInTheDocument();
+      expect(within(highlights).getByRole('button', {name: 'Edit'})).toBeInTheDocument();
+      // No highlights setup
+      expect(
+        within(highlights).getByRole('button', {name: 'Add Highlights'})
+      ).toBeInTheDocument();
+      expect(screen.getByText("There's nothing here...")).toBeInTheDocument();
     }
 
     it('works with the feature flag', async function () {

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {CommitRow} from 'sentry/components/commitRow';
@@ -85,6 +85,7 @@ function DefaultGroupEventDetailsContent({
 }: Required<GroupEventDetailsContentProps>) {
   const organization = useOrganization();
   const hasNewTagsUI = useHasNewTagsUI();
+  const tagsRef = useRef<HTMLDivElement>(null);
 
   const projectSlug = project.slug;
   const hasReplay = Boolean(getReplayIdFromEvent(event));
@@ -130,7 +131,12 @@ function DefaultGroupEventDetailsContent({
           project={project}
         />
       )}
-      <HighlightsDataSection event={event} group={group} project={project} />
+      <HighlightsDataSection
+        event={event}
+        group={group}
+        project={project}
+        viewAllRef={tagsRef}
+      />
       {!hasNewTagsUI && (
         <EventTagsAndScreenshot event={event} projectSlug={project.slug} />
       )}
@@ -165,7 +171,9 @@ function DefaultGroupEventDetailsContent({
       <GroupEventEntry entryType={EntryType.DEBUGMETA} {...eventEntryProps} />
       <GroupEventEntry entryType={EntryType.REQUEST} {...eventEntryProps} />
       {hasNewTagsUI && (
-        <EventTagsAndScreenshot event={event} projectSlug={project.slug} />
+        <div ref={tagsRef}>
+          <EventTagsAndScreenshot event={event} projectSlug={project.slug} />
+        </div>
       )}
       <EventContexts group={group} event={event} />
       <EventExtraData event={event} />


### PR DESCRIPTION
Implements the highlights section on the issue details page to replace the context summary. For now, there are no icons, and the context items are prefixed with their context alias (e.g. "Runtime: Version", rather than "Version")

**todo**
- [x] Add tests 
- [x] Better empty state for highlight data section
- [x] Better empty state for highlight preview in modal
- [x] Allow resetting to defaults
- [x] Add screenshots/video

**loading state**
<img width="803" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/25c471c9-3ea0-4bf0-a83d-6ed81c3cda76">

**empty state**
<img width="803" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/94c4df5a-7969-4866-b8f3-a8a5521ef9ff">

**base state**
<img width="803" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/ddbdd02b-6585-4d14-bb84-566b929677e3">

**modal header and tags**
<img width="827" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/c7972d01-f177-4bce-9dce-c0c2de80b355">

**context and modal footer**
<img width="828" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/ae02b795-69e1-46d2-83a1-917a4d0d8eb4">

**empty preview**
<img width="824" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/56ca248b-2dff-43fb-8a6e-a6ba314bbb85">

**without flag**
<img width="798" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/f137ae56-d321-4e0d-9651-2e538cb8d7e3">


----


https://github.com/getsentry/sentry/assets/35509934/0754c73a-6a0e-4cb0-bad9-c66f4067ad54


