### PR TITLE
feat(relocation): Add API to list relocation's GCS artifacts

### DIFF
--- a/src/sentry/api/endpoints/relocations/artifacts/index.py
+++ b/src/sentry/api/endpoints/relocations/artifacts/index.py
@@ -1,0 +1,73 @@
+import logging
+
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.exceptions import ResourceDoesNotExist, StaffRequired, SuperuserRequired
+from sentry.api.permissions import SuperuserOrStaffFeatureFlaggedPermission
+from sentry.auth.elevated_mode import has_elevated_mode
+from sentry.auth.staff import has_staff_option
+from sentry.models.files.utils import get_relocation_storage
+from sentry.models.relocation import Relocation
+
+ERR_NEED_RELOCATION_ADMIN = (
+    "Cannot view relocation artifacts, as you do not have the appropriate permissions."
+)
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class RelocationArtifactIndexEndpoint(Endpoint):
+    owner = ApiOwner.OPEN_SOURCE
+    publish_status = {
+        # TODO(getsentry/team-ospo#214): Stabilize before GA.
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
+
+    def get(self, request: Request, relocation_uuid: str) -> Response:
+        """
+        Lists all relocation bucket files associated with a relocation
+        ``````````````````````````````````````````````````
+
+        :pparam string relocation_uuid: a UUID identifying the relocation.
+
+        :auth: required
+        """
+
+        logger.info("relocations.artifact.index.get.start", extra={"caller": request.user.id})
+
+        # TODO(schew2381): Remove the superuser reference below after feature flag is removed.
+        # Must be superuser/staff AND have a `UserPermission` of `relocation.admin` to see access!
+        if not has_elevated_mode(request):
+            if has_staff_option(request.user):
+                raise StaffRequired
+            raise SuperuserRequired
+
+        if not request.access.has_permission("relocation.admin"):
+            raise PermissionDenied(ERR_NEED_RELOCATION_ADMIN)
+
+        try:
+            relocation: Relocation = Relocation.objects.get(uuid=relocation_uuid)
+        except Relocation.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        relocation_storage = get_relocation_storage()
+        (dirs, files) = relocation_storage.listdir(f"runs/{relocation.uuid}")
+
+        # Only check one level deep - no need to recurse.
+        for dir in dirs:
+            (_, dir_files) = relocation_storage.listdir(f"runs/{relocation.uuid}/{dir}")
+            files += [f"{dir}/{file}" for file in dir_files]
+
+        # TODO(azaslavsky): We should use a cleverer, asynchronous way to get all these sizes.
+        file_metadata = [
+            {"path": f, "bytes": relocation_storage.size(f"runs/{relocation.uuid}/{f}")}
+            for f in sorted(files)
+        ]
+        return self.respond({"files": file_metadata})

--- a/src/sentry/api/endpoints/relocations/details.py
+++ b/src/sentry/api/endpoints/relocations/details.py
@@ -21,7 +21,6 @@ class RelocationDetailsEndpoint(Endpoint):
         # TODO(getsentry/team-ospo#214): Stabilize before GA.
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
-    # TODO(getsentry/team-ospo#214): Open up permissions before GA.
     permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
 
     def get(self, request: Request, relocation_uuid: str) -> Response:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -41,6 +41,7 @@ from sentry.api.endpoints.release_thresholds.release_threshold_status_index impo
     ReleaseThresholdStatusIndexEndpoint,
 )
 from sentry.api.endpoints.relocations.abort import RelocationAbortEndpoint
+from sentry.api.endpoints.relocations.artifacts.index import RelocationArtifactIndexEndpoint
 from sentry.api.endpoints.relocations.cancel import RelocationCancelEndpoint
 from sentry.api.endpoints.relocations.details import RelocationDetailsEndpoint
 from sentry.api.endpoints.relocations.index import RelocationIndexEndpoint
@@ -863,6 +864,11 @@ RELOCATION_URLS = [
         r"^(?P<relocation_uuid>[^\/]+)/unpause/$",
         RelocationUnpauseEndpoint.as_view(),
         name="sentry-api-0-relocations-unpause",
+    ),
+    re_path(
+        r"^(?P<relocation_uuid>[^\/]+)/artifacts/$",
+        RelocationArtifactIndexEndpoint.as_view(),
+        name="sentry-api-0-relocations-artifacts-index",
     ),
 ]
 

--- a/src/sentry/models/files/utils.py
+++ b/src/sentry/models/files/utils.py
@@ -7,6 +7,7 @@ from hashlib import sha1
 from typing import IO, TYPE_CHECKING, TypeVar
 
 from django.conf import settings
+from django.core.files.storage import Storage
 from django.utils import timezone
 
 from sentry.utils.imports import import_string
@@ -92,7 +93,7 @@ def get_storage(config=None):
     return storage(**options)
 
 
-def get_relocation_storage(config=None):
+def get_relocation_storage(config=None) -> Storage:
     from sentry import options as options_store
 
     backend = options_store.get("filestore.relocation-backend")

--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -556,7 +556,13 @@ def get_relocations_bucket_name():
     """
 
     storage = get_relocation_storage()
-    return "default" if getattr(storage, "bucket_name", None) is None else f"{storage.bucket_name}"
+
+    # Specialize for GCS...
+    if hasattr(storage, "bucket_name"):
+        return f"{storage.bucket_name}"
+
+    # ...and the local filesystem, when testing.
+    return "default"
 
 
 def create_cloudbuild_yaml(relocation: Relocation) -> bytes:

--- a/tests/sentry/api/endpoints/relocations/artifacts/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/artifacts/test_index.py
@@ -1,0 +1,151 @@
+from datetime import datetime, timezone
+from io import StringIO
+from uuid import uuid4
+
+from sentry.api.endpoints.relocations.artifacts.index import ERR_NEED_RELOCATION_ADMIN
+from sentry.models.files.utils import get_relocation_storage
+from sentry.models.relocation import Relocation
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.utils.relocation import OrderedTask
+
+TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
+RELOCATION_ADMIN_PERMISSION = "relocation.admin"
+
+
+class GetRelocationArtifactsTest(APITestCase):
+    endpoint = "sentry-api-0-relocations-artifacts-index"
+    method = "GET"
+
+    def setUp(self):
+        super().setUp()
+        self.owner = self.create_user(email="owner@example.com", is_superuser=False, is_staff=False)
+        self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
+        self.relocation: Relocation = Relocation.objects.create(
+            date_added=TEST_DATE_ADDED,
+            creator_id=self.owner.id,
+            owner_id=self.owner.id,
+            status=Relocation.Status.PAUSE.value,
+            step=Relocation.Step.PREPROCESSING.value,
+            want_org_slugs=["foo"],
+            want_usernames=["alice", "bob"],
+            latest_notified=Relocation.EmailKind.STARTED.value,
+            latest_task=OrderedTask.PREPROCESSING_SCAN.name,
+            latest_task_attempts=1,
+        )
+
+
+class GetRelocationArtifactsGoodTest(GetRelocationArtifactsTest):
+    def setUp(self):
+        super().setUp()
+        dir = f"runs/{self.relocation.uuid}"
+        self.relocation_storage = get_relocation_storage()
+
+        # We only care about file sizes for this API.
+        self.relocation_storage.save(f"{dir}/conf/cloudbuild.yaml", StringIO("1"))
+        self.relocation_storage.save(f"{dir}/conf/cloudbuild.zip", StringIO("12"))
+        self.relocation_storage.save(
+            f"{dir}/findings/compare-baseline-config.json", StringIO("123")
+        )
+        self.relocation_storage.save(
+            f"{dir}/findings/compare-colliding-users.json", StringIO("1234")
+        )
+        self.relocation_storage.save(
+            f"{dir}/findings/export-baseline-config.json", StringIO("12345")
+        )
+        self.relocation_storage.save(
+            f"{dir}/findings/export-colliding-users.json", StringIO("123456")
+        )
+        self.relocation_storage.save(
+            f"{dir}/findings/import-baseline-config.json", StringIO("1234567")
+        )
+        self.relocation_storage.save(
+            f"{dir}/findings/import-colliding-users.json", StringIO("12345678")
+        )
+        self.relocation_storage.save(
+            f"{dir}/findings/import-raw-relocation-data.json", StringIO("123456789")
+        )
+        self.relocation_storage.save(f"{dir}/in/kms-config.json", StringIO("1234567890"))
+        self.relocation_storage.save(f"{dir}/in/baseline-config.tar", StringIO("1234567890a"))
+        self.relocation_storage.save(f"{dir}/in/colliding-users.tar", StringIO("1234567890ab"))
+        self.relocation_storage.save(f"{dir}/in/raw-relocation-data.tar", StringIO("1234567890abc"))
+        self.relocation_storage.save(f"{dir}/out/baseline-config.tar", StringIO("1234567890abcd"))
+        self.relocation_storage.save(f"{dir}/out/colliding-users.tar", StringIO("1234567890abcde"))
+
+    def test_good_with_superuser(self):
+        self.add_user_permission(self.superuser, RELOCATION_ADMIN_PERMISSION)
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.get_success_response(str(self.relocation.uuid))
+
+        assert len(response.data["files"]) == 15
+        for file_info in response.data["files"]:
+            file_name = f"runs/{self.relocation.uuid}/{file_info['path']}"
+            file_size = file_info["bytes"]
+            assert self.relocation_storage.size(file_name) == file_size
+
+    @override_options({"staff.ga-rollout": True})
+    def test_good_with_staff(self):
+        self.add_user_permission(self.staff_user, RELOCATION_ADMIN_PERMISSION)
+        self.login_as(user=self.staff_user, staff=True)
+        self.get_success_response(str(self.relocation.uuid))
+        response = self.get_success_response(str(self.relocation.uuid))
+
+        assert len(response.data["files"]) == 15
+        for file_info in response.data["files"]:
+            file_name = f"runs/{self.relocation.uuid}/{file_info['path']}"
+            file_size = file_info["bytes"]
+            assert self.relocation_storage.size(file_name) == file_size
+
+
+class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
+    @override_options({"staff.ga-rollout": True})
+    def test_bad_unprivileged_user(self):
+        self.login_as(user=self.owner, superuser=False, staff=False)
+
+        # Ensures we don't reveal existence info to improperly authenticated users.
+        does_not_exist_uuid = uuid4().hex
+        self.get_error_response(str(does_not_exist_uuid), status_code=403)
+
+    def test_bad_superuser_disabled(self):
+        self.add_user_permission(self.superuser, RELOCATION_ADMIN_PERMISSION)
+        self.login_as(user=self.superuser, superuser=False)
+
+        # Ensures we don't reveal existence info to improperly authenticated users.
+        does_not_exist_uuid = uuid4().hex
+        self.get_error_response(str(does_not_exist_uuid), status_code=403)
+
+    @override_options({"staff.ga-rollout": True})
+    def test_bad_staff_disabled(self):
+        self.add_user_permission(self.staff_user, RELOCATION_ADMIN_PERMISSION)
+        self.login_as(user=self.staff_user, staff=False)
+
+        # Ensures we don't reveal existence info to improperly authenticated users.
+        does_not_exist_uuid = uuid4().hex
+        self.get_error_response(str(does_not_exist_uuid), status_code=403)
+
+    def test_bad_has_superuser_but_no_relocation_admin_permission(self):
+        self.login_as(user=self.superuser, superuser=True)
+
+        # Ensures we don't reveal existence info to improperly authenticated users.
+        does_not_exist_uuid = uuid4().hex
+        response = self.get_error_response(str(does_not_exist_uuid), status_code=403)
+
+        assert response.data.get("detail") == ERR_NEED_RELOCATION_ADMIN
+
+    @override_options({"staff.ga-rollout": True})
+    def test_bad_has_staff_but_no_relocation_admin_permission(self):
+        self.login_as(user=self.staff_user, staff=True)
+
+        # Ensures we don't reveal existence info to improperly authenticated users.
+        does_not_exist_uuid = uuid4().hex
+        response = self.get_error_response(str(does_not_exist_uuid), status_code=403)
+
+        assert response.data.get("detail") == ERR_NEED_RELOCATION_ADMIN
+
+    @override_options({"staff.ga-rollout": True})
+    def test_bad_relocation_not_found(self):
+        self.add_user_permission(self.staff_user, RELOCATION_ADMIN_PERMISSION)
+        self.login_as(user=self.staff_user, staff=True)
+        does_not_exist_uuid = uuid4().hex
+        self.get_error_response(str(does_not_exist_uuid), status_code=404)

--- a/tests/sentry/api/endpoints/relocations/artifacts/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/artifacts/test_index.py
@@ -106,6 +106,7 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
         # Ensures we don't reveal existence info to improperly authenticated users.
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=403)
+        self.get_error_response(str(self.relocation.uuid), status_code=403)
 
     def test_bad_superuser_disabled(self):
         self.add_user_permission(self.superuser, RELOCATION_ADMIN_PERMISSION)
@@ -114,6 +115,7 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
         # Ensures we don't reveal existence info to improperly authenticated users.
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=403)
+        self.get_error_response(str(self.relocation.uuid), status_code=403)
 
     @override_options({"staff.ga-rollout": True})
     def test_bad_staff_disabled(self):
@@ -123,6 +125,7 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
         # Ensures we don't reveal existence info to improperly authenticated users.
         does_not_exist_uuid = uuid4().hex
         self.get_error_response(str(does_not_exist_uuid), status_code=403)
+        self.get_error_response(str(self.relocation.uuid), status_code=403)
 
     def test_bad_has_superuser_but_no_relocation_admin_permission(self):
         self.login_as(user=self.superuser, superuser=True)
@@ -133,6 +136,10 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
 
         assert response.data.get("detail") == ERR_NEED_RELOCATION_ADMIN
 
+        response = self.get_error_response(str(self.relocation.uuid), status_code=403)
+
+        assert response.data.get("detail") == ERR_NEED_RELOCATION_ADMIN
+
     @override_options({"staff.ga-rollout": True})
     def test_bad_has_staff_but_no_relocation_admin_permission(self):
         self.login_as(user=self.staff_user, staff=True)
@@ -140,6 +147,10 @@ class GetRelocationArtifactsBadTest(GetRelocationArtifactsTest):
         # Ensures we don't reveal existence info to improperly authenticated users.
         does_not_exist_uuid = uuid4().hex
         response = self.get_error_response(str(does_not_exist_uuid), status_code=403)
+
+        assert response.data.get("detail") == ERR_NEED_RELOCATION_ADMIN
+
+        response = self.get_error_response(str(self.relocation.uuid), status_code=403)
 
         assert response.data.get("detail") == ERR_NEED_RELOCATION_ADMIN
 


### PR DESCRIPTION
This will be used in the admin panel exclusively by users with the `relocation.admin` `UserPermission` set.