### PR TITLE
feat(mobile-starfish): Add platform compatibility checker

### DIFF
--- a/static/app/views/performance/platformCompatibilityChecker.spec.tsx
+++ b/static/app/views/performance/platformCompatibilityChecker.spec.tsx
@@ -1,0 +1,213 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+import {PlatformCompatibilityChecker} from 'sentry/views/performance/platformCompatibilityChecker';
+
+jest.mock('sentry/utils/useProjects');
+jest.mock('sentry/utils/usePageFilters');
+
+describe('PlatformCompatibilityChecker', () => {
+  let organization;
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    jest.mocked(useProjects).mockReturnValue({
+      projects: [
+        ProjectFixture({id: '1'}),
+        ProjectFixture({id: '2', slug: 'incompatible'}),
+      ],
+      onSearch: jest.fn(),
+      placeholders: [],
+      fetching: false,
+      hasMore: null,
+      fetchError: null,
+      initiallyLoaded: false,
+    });
+
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [1],
+      },
+    });
+
+    organization = OrganizationFixture();
+  });
+
+  it('renders the children if all projects are compatible', async () => {
+    // Incompatible projects response
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [],
+      },
+    });
+
+    render(
+      <PlatformCompatibilityChecker
+        compatibleSDKNames={['foobar']}
+        docsUrl="www.example.com"
+      >
+        <div>Child</div>
+      </PlatformCompatibilityChecker>
+    );
+
+    expect(await screen.findByText('Child')).toBeInTheDocument();
+  });
+
+  it('does not render the children if all selected projects are incompatible', async () => {
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [2],
+      },
+    });
+
+    // Incompatible projects response
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [{project_id: 2, 'sdk.name': 'incompatible', count: 1}],
+      },
+    });
+
+    render(
+      <PageAlertProvider>
+        <PageAlert />
+        <PlatformCompatibilityChecker
+          compatibleSDKNames={['foobar']}
+          docsUrl="www.example.com"
+        >
+          <div>Child</div>
+        </PlatformCompatibilityChecker>
+      </PageAlertProvider>
+    );
+
+    expect(
+      await screen.findByText(
+        /The following selected projects contain data from SDKs that are not supported by this view: incompatible/
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/The currently supported SDK platforms are: foobar/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Child')).not.toBeInTheDocument();
+  });
+
+  it('renders the children and a warning message if some projects are incompatible', async () => {
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [1, 2],
+      },
+    });
+
+    // Incompatible projects response
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [{project_id: 2, 'sdk.name': 'incompatible', count: 1}],
+      },
+    });
+
+    render(
+      <PageAlertProvider>
+        <PageAlert />
+        <PlatformCompatibilityChecker
+          compatibleSDKNames={['foobar']}
+          docsUrl="www.example.com"
+        >
+          <div>Child</div>
+        </PlatformCompatibilityChecker>
+      </PageAlertProvider>
+    );
+
+    expect(
+      await screen.findByText(
+        /The following selected projects contain data from SDKs that are not supported by this view: incompatible/
+      )
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Child')).toBeInTheDocument();
+  });
+
+  it('handles all project selection', async () => {
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    });
+
+    // Incompatible projects response
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [{project_id: 2, 'sdk.name': 'incompatible', count: 1}],
+      },
+    });
+
+    render(
+      <PageAlertProvider>
+        <PageAlert />
+        <PlatformCompatibilityChecker
+          compatibleSDKNames={['foobar']}
+          docsUrl="www.example.com"
+        >
+          <div>Child</div>
+        </PlatformCompatibilityChecker>
+      </PageAlertProvider>
+    );
+
+    expect(
+      await screen.findByText(
+        /The following selected projects contain data from SDKs that are not supported by this view: incompatible/
+      )
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Child')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/platformCompatibilityChecker.tsx
+++ b/static/app/views/performance/platformCompatibilityChecker.tsx
@@ -1,0 +1,136 @@
+import {useEffect, useMemo} from 'react';
+
+import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t, tct} from 'sentry/locale';
+import type {PageFilters} from 'sentry/types';
+import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import usePrevious from 'sentry/utils/usePrevious';
+import useProjects from 'sentry/utils/useProjects';
+
+const MAX_PROJECTS_TO_LIST = 3;
+
+function getEventView(selection: PageFilters, compatibleSDKNames: string[]) {
+  const {projects: selectedProjectIds} = selection;
+
+  return EventView.fromNewQueryWithPageFilters(
+    {
+      dataset: DiscoverDatasets.SPANS_INDEXED,
+      fields: ['project_id', 'sdk.name', 'count()'],
+      projects: selectedProjectIds,
+      query: `has:sdk.name !sdk.name:[${compatibleSDKNames.join(',')}]`,
+
+      name: '',
+      version: 2,
+    },
+    selection
+  );
+}
+
+type PlatformCompatibilityCheckerProps = {
+  children: React.ReactNode;
+  compatibleSDKNames: string[];
+  docsUrl: string;
+};
+
+// Checks if the currently selected platforms are compatible with the current view
+// and if there are incompatible projects, list them in a warning message.
+// If there are no compatible platforms, only return the alert, otherwise return the children
+// after setting the alert.
+export function PlatformCompatibilityChecker({
+  compatibleSDKNames,
+  children,
+  docsUrl,
+}: PlatformCompatibilityCheckerProps) {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {selection, isReady} = usePageFilters();
+  const {projects} = useProjects();
+  const {pageAlert, setPageWarning} = usePageAlert();
+  const {projects: selectedProjectIds} = selection;
+
+  // Get the projects that are incompatible with the current view
+  const {data, isLoading} = useDiscoverQuery({
+    eventView: getEventView(selection, compatibleSDKNames),
+    location,
+    orgSlug: organization.slug,
+    referrer: 'api.starfish-mobile-platform-compatibility',
+    options: {
+      enabled: isReady,
+    },
+  });
+
+  const incompatibleProjects = useMemo(() => {
+    const incompatibleProjectIds = new Set(data?.data.map(row => row.project_id));
+
+    // My Projects and All Projects are represented by an empty selection
+    // or -1. Don't filter in these cases
+    const selectedProjects =
+      selectedProjectIds.length === 0 || selectedProjectIds[0] === -1
+        ? projects
+        : projects.filter(project =>
+            selectedProjectIds.includes(parseInt(project.id, 10))
+          );
+
+    return selectedProjects.filter(project =>
+      incompatibleProjectIds.has(parseInt(project.id, 10))
+    );
+  }, [data?.data, projects, selectedProjectIds]);
+  const prevIncompatibleProjects = usePrevious(incompatibleProjects);
+
+  useEffect(() => {
+    if (incompatibleProjects.length > 0) {
+      if (incompatibleProjects !== prevIncompatibleProjects) {
+        const listedIncompatibleProjects = incompatibleProjects
+          .slice(0, MAX_PROJECTS_TO_LIST)
+          .map(project => project.slug)
+          .join(', ');
+        setPageWarning(
+          tct(
+            'The following selected projects contain data from SDKs that are not supported by this view: [projects]. The currently supported SDK platforms are: [platforms]. We recommend to filter your current project selection to the supported platforms, to learn more, [link:read the docs].',
+            {
+              projects:
+                incompatibleProjects.length <= MAX_PROJECTS_TO_LIST
+                  ? listedIncompatibleProjects
+                  : tct('[projects], and [count] more', {
+                      projects: listedIncompatibleProjects,
+                      count: incompatibleProjects.length - MAX_PROJECTS_TO_LIST,
+                    }),
+              platforms: compatibleSDKNames.join(', '),
+              link: <ExternalLink href={docsUrl}>{t('read the docs')}</ExternalLink>,
+            }
+          )
+        );
+      }
+    } else if (incompatibleProjects.length === 0 && pageAlert?.message) {
+      setPageWarning(undefined);
+    }
+  }, [
+    compatibleSDKNames,
+    docsUrl,
+    incompatibleProjects,
+    pageAlert,
+    prevIncompatibleProjects,
+    setPageWarning,
+  ]);
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  if (
+    incompatibleProjects.length > 0 &&
+    incompatibleProjects.length === selectedProjectIds.length
+  ) {
+    // Don't return anything if all projects are incompatible
+    return null;
+  }
+
+  return children;
+}

--- a/static/app/views/starfish/modules/mobile/appStartup.tsx
+++ b/static/app/views/starfish/modules/mobile/appStartup.tsx
@@ -22,6 +22,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
 import Onboarding from 'sentry/views/performance/onboarding';
+import {PlatformCompatibilityChecker} from 'sentry/views/performance/platformCompatibilityChecker';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import AppStartup from 'sentry/views/starfish/views/appStartup';
@@ -69,7 +70,6 @@ export default function InitializationModule() {
             <Layout.Body>
               <FloatingFeedbackWidget />
               <Layout.Main fullWidth>
-                <PageAlert />
                 <PageFiltersContainer>
                   <Container>
                     <PageFilterBar condensed>
@@ -81,11 +81,20 @@ export default function InitializationModule() {
                     <StartTypeSelector />
                   </Container>
                 </PageFiltersContainer>
+                <PageAlert />
                 <ErrorBoundary mini>
-                  {onboardingProject && (
-                    <Onboarding organization={organization} project={onboardingProject} />
-                  )}
-                  {!onboardingProject && <AppStartup chartHeight={200} />}
+                  <PlatformCompatibilityChecker
+                    compatibleSDKNames={['sentry.cocoa', 'sentry.java.android']}
+                    docsUrl="https://docs.sentry.io/product/performance/mobile-vitals/app-starts/#minimum-sdk-requirements"
+                  >
+                    {onboardingProject && (
+                      <Onboarding
+                        organization={organization}
+                        project={onboardingProject}
+                      />
+                    )}
+                    {!onboardingProject && <AppStartup chartHeight={200} />}
+                  </PlatformCompatibilityChecker>
                 </ErrorBoundary>
               </Layout.Main>
             </Layout.Body>

--- a/static/app/views/starfish/modules/mobile/pageload.spec.tsx
+++ b/static/app/views/starfish/modules/mobile/pageload.spec.tsx
@@ -133,7 +133,7 @@ describe('PageloadModule', function () {
 
     await waitFor(() => {
       expect(eventsMock).toHaveBeenNthCalledWith(
-        3,
+        4,
         expect.anything(),
         expect.objectContaining({
           query: expect.objectContaining({
@@ -169,7 +169,7 @@ describe('PageloadModule', function () {
 
     await waitFor(() => {
       expect(eventsMock).toHaveBeenNthCalledWith(
-        3,
+        4,
         expect.anything(),
         expect.objectContaining({
           query: expect.objectContaining({

--- a/static/app/views/starfish/modules/mobile/pageload.tsx
+++ b/static/app/views/starfish/modules/mobile/pageload.tsx
@@ -20,6 +20,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
 import Onboarding from 'sentry/views/performance/onboarding';
+import {PlatformCompatibilityChecker} from 'sentry/views/performance/platformCompatibilityChecker';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
 import {ScreensView, YAxis} from 'sentry/views/starfish/views/screens';
@@ -69,7 +70,6 @@ export default function PageloadModule() {
           <Layout.Body>
             <FloatingFeedbackWidget />
             <Layout.Main fullWidth>
-              <PageAlert />
               <PageFiltersContainer>
                 <Container>
                   <PageFilterBar condensed>
@@ -79,22 +79,33 @@ export default function PageloadModule() {
                   </PageFilterBar>
                   <ReleaseComparisonSelector />
                 </Container>
+                <PageAlert />
                 <ErrorBoundary mini>
-                  {onboardingProject && (
-                    <OnboardingContainer>
-                      <Onboarding
-                        organization={organization}
-                        project={onboardingProject}
+                  <PlatformCompatibilityChecker
+                    compatibleSDKNames={[
+                      'sentry.java.android',
+                      'sentry.cocoa',
+                      'sentry.javascript.react-native',
+                      'sentry.dart.flutter',
+                    ]}
+                    docsUrl="https://docs.sentry.io/product/performance/mobile-vitals/screen-loads/#minimum-sdk-requirements"
+                  >
+                    {onboardingProject && (
+                      <OnboardingContainer>
+                        <Onboarding
+                          organization={organization}
+                          project={onboardingProject}
+                        />
+                      </OnboardingContainer>
+                    )}
+                    {!onboardingProject && (
+                      <ScreensView
+                        yAxes={[YAxis.TTID, YAxis.TTFD]}
+                        chartHeight={240}
+                        project={project}
                       />
-                    </OnboardingContainer>
-                  )}
-                  {!onboardingProject && (
-                    <ScreensView
-                      yAxes={[YAxis.TTID, YAxis.TTFD]}
-                      chartHeight={240}
-                      project={project}
-                    />
-                  )}
+                    )}
+                  </PlatformCompatibilityChecker>
                 </ErrorBoundary>
               </PageFiltersContainer>
             </Layout.Main>


### PR DESCRIPTION
Adds a component that triggers a `spansIndexed` request to fetch data to
validate that the module being viewed has support for the data of the
projects selected.

This is used by the mobile modules because we've
noticed traffic from non-supported platforms and we need to more clearly
communicate to the users that they are viewing the module without the
correct projects selected.

Because we do not currently index sdk.name on span metrics, I've chosen to
go with `spansIndexed` data until we're able to collect that tag.