### PR TITLE
ref(replays): add fallback response/request body size in network tab

### DIFF
--- a/static/app/views/replays/detail/network/details/sections.tsx
+++ b/static/app/views/replays/detail/network/details/sections.tsx
@@ -54,7 +54,9 @@ export function GeneralSection({item, startTimestampMs}: SectionProps) {
       key: t('Request Body Size'),
       value: (
         <SizeTooltip>
-          {formatBytesBase10(requestFrame?.data?.request?.size ?? 0)}
+          {formatBytesBase10(
+            requestFrame?.data?.request?.size ?? requestFrame?.data?.requestBodySize ?? 0
+          )}
         </SizeTooltip>
       ),
     },
@@ -62,7 +64,11 @@ export function GeneralSection({item, startTimestampMs}: SectionProps) {
       key: t('Response Body Size'),
       value: (
         <SizeTooltip>
-          {formatBytesBase10(requestFrame?.data?.response?.size ?? 0)}
+          {formatBytesBase10(
+            requestFrame?.data?.response?.size ??
+              requestFrame?.data?.responseBodySize ??
+              0
+          )}
         </SizeTooltip>
       ),
     },


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/69413

currently we use only `data[request][size]` to display request body sizes when a network row is expanded (see [here](https://github.com/getsentry/sentry/blob/041286de2c73ebffcbda1746aae18f486339ec74/static/app/views/replays/detail/network/details/sections.tsx#L53-L68)) but they are not always being sent (e.g. when request/response details reporting is disabled). notice how in the first pic, the size is 13.62 kB in the column, but 0 when the row is expanded.


before:

![image](https://github.com/getsentry/sentry/assets/56095982/47eb4cac-6d59-45cc-b234-c6a9c339717e)

this bug was happening for some mobile replays. let's add an additional fallback to `data[requestBodySize]` to fix this:



after:

<img width="432" alt="SCR-20240422-ksvc" src="https://github.com/getsentry/sentry/assets/56095982/4e19dab6-5cfb-4f98-8856-7b0a4fef7153">
