### PR TITLE
fix(routes): Use different route to perform event redirect

### DIFF
--- a/static/app/views/projectEventRedirect.tsx
+++ b/static/app/views/projectEventRedirect.tsx
@@ -24,7 +24,8 @@ function ProjectEventRedirect({router}: Props) {
     // This presumes that _this_ React view/route is only reachable at
     // /:org/:project/events/:eventId (the same URL which serves the ProjectEventRedirect
     // Django view).
-    const endpoint = router.location.pathname;
+    const [_, organization, ...rest] = router.location.pathname.split('/');
+    const endpoint = ['', 'organizations', organization, 'projects', ...rest].join('/');
 
     // Use XmlHttpRequest directly instead of our client API helper (fetch),
     // because you can't reach the underlying XHR via $.ajax, and we need

--- a/static/app/views/projectEventRedirect.tsx
+++ b/static/app/views/projectEventRedirect.tsx
@@ -4,6 +4,7 @@ import type {RouteComponentProps} from 'react-router';
 import DetailedError from 'sentry/components/errors/detailedError';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
+import {useParams} from 'sentry/utils/useParams';
 
 type Props = RouteComponentProps<{}, {}>;
 
@@ -20,12 +21,13 @@ type Props = RouteComponentProps<{}, {}>;
 function ProjectEventRedirect({router}: Props) {
   const [error, setError] = useState<string | null>(null);
 
+  const params = useParams();
+
   useEffect(() => {
     // This presumes that _this_ React view/route is only reachable at
     // /:org/:project/events/:eventId (the same URL which serves the ProjectEventRedirect
     // Django view).
-    const [_, organization, ...rest] = router.location.pathname.split('/');
-    const endpoint = ['', 'organizations', organization, 'projects', ...rest].join('/');
+    const endpoint = `/organizations/${params.orgId}/projects/${params.projectId}/events/${params.eventId}/`;
 
     // Use XmlHttpRequest directly instead of our client API helper (fetch),
     // because you can't reach the underlying XHR via $.ajax, and we need
@@ -56,7 +58,7 @@ function ProjectEventRedirect({router}: Props) {
     xhr.onerror = () => {
       setError(t('Could not load the requested event'));
     };
-  });
+  }, [params, router]);
 
   return error ? (
     <DetailedError heading={t('Not found')} message={error} hideSupportLinks />


### PR DESCRIPTION
There are some org slugs that collide with marketing routes. When this happens, this request to attempt a redirect gets routed to vercel and results in an unexpected 404. This same redirect endpoint is also available at a different route that looks like `/organizations/{org_slug}/projects{proj_slug}/events/{event_id}` that will not be redirected. So change the endpoint to avoid the issue with the redirect.