### PR TITLE
ref(rules): Refactor `get_rate` to be used for bulk queries

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -229,6 +229,12 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
     def get_comparison_start_end(
         self, interval: timedelta, duration: timedelta
     ) -> tuple[datetime, datetime]:
+        """
+        Calculate the start and end times for the query. `interval` is only used for EventFrequencyPercentCondition
+        as the '5 minutes' in The issue affects more than 100 percent of sessions in 5 minutes, otherwise it's the current time.
+        `duration` is the time frame in which the condition is measuring counts, e.g. the '10 minutes' in
+        "The issue is seen more than 100 times in 10 minutes"
+        """
         end = timezone.now() - interval
         start = end - duration
         return (start, end)
@@ -249,7 +255,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
                 # automatically cached for 10s. We could consider trying to cache this and the main
                 # query for 20s to reduce the load.
                 start, end = self.get_comparison_start_end(comparison_interval, duration)
-                comparison_result = self.get_rate_single(event, start, end, environment_id)
+                comparison_result = self.query(event, start, end, environment_id=environment_id)
                 result = percent_increase(result, comparison_result)
 
         return result

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -260,36 +260,6 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
         return result
 
-    def get_rate_bulk(
-        self,
-        duration: timedelta,
-        comparison_interval: timedelta,
-        group_ids: set[int],
-        environment_id: int,
-        comparison_type: str,
-    ) -> dict[int, int]:
-        start, end = self.get_comparison_start_end(timedelta(), duration)
-        with self.get_option_override(duration):
-            result = self.batch_query(
-                group_ids=group_ids,
-                start=start,
-                end=end,
-                environment_id=environment_id,
-            )
-        if comparison_type == ComparisonType.PERCENT:
-            start, comparison_end = self.get_comparison_start_end(comparison_interval, duration)
-            comparison_result = self.batch_query(
-                group_ids=group_ids,
-                start=start,
-                end=comparison_end,
-                environment_id=environment_id,
-            )
-            result = {
-                group_id: percent_increase(result[group_id], comparison_result[group_id])
-                for group_id in group_ids
-            }
-        return result
-
     def get_snuba_query_result(
         self,
         tsdb_function: Callable[..., Any],

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -290,43 +290,63 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTest
             self.assertDoesNotPass(environment_rule, event, is_new=False)
 
     def test_one_minute_with_events(self):
-        data = {"interval": "1m", "value": 6}
+        data = {"interval": "1m", "value": 6, "comparisonType": "count", "comparisonInterval": "5m"}
         self._run_test(data=data, minutes=1, passes=True, add_events=True)
-        data = {"interval": "1m", "value": 16}
+        data = {
+            "interval": "1m",
+            "value": 16,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=1, passes=False)
 
     def test_one_hour_with_events(self):
-        data = {"interval": "1h", "value": 6}
+        data = {"interval": "1h", "value": 6, "comparisonType": "count", "comparisonInterval": "5m"}
         self._run_test(data=data, minutes=60, passes=True, add_events=True)
-        data = {"interval": "1h", "value": 16}
+        data = {
+            "interval": "1h",
+            "value": 16,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=60, passes=False)
 
     def test_one_day_with_events(self):
-        data = {"interval": "1d", "value": 6}
+        data = {"interval": "1d", "value": 6, "comparisonType": "count", "comparisonInterval": "5m"}
         self._run_test(data=data, minutes=1440, passes=True, add_events=True)
-        data = {"interval": "1d", "value": 16}
+        data = {
+            "interval": "1d",
+            "value": 16,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=1440, passes=False)
 
     def test_one_week_with_events(self):
-        data = {"interval": "1w", "value": 6}
+        data = {"interval": "1w", "value": 6, "comparisonType": "count", "comparisonInterval": "5m"}
         self._run_test(data=data, minutes=10080, passes=True, add_events=True)
-        data = {"interval": "1w", "value": 16}
+        data = {
+            "interval": "1w",
+            "value": 16,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=10080, passes=False)
 
     def test_one_minute_no_events(self):
-        data = {"interval": "1m", "value": 6}
+        data = {"interval": "1m", "value": 6, "comparisonType": "count", "comparisonInterval": "5m"}
         self._run_test(data=data, minutes=1, passes=False)
 
     def test_one_hour_no_events(self):
-        data = {"interval": "1h", "value": 6}
+        data = {"interval": "1h", "value": 6, "comparisonType": "count", "comparisonInterval": "5m"}
         self._run_test(data=data, minutes=60, passes=False)
 
     def test_one_day_no_events(self):
-        data = {"interval": "1d", "value": 6}
+        data = {"interval": "1d", "value": 6, "comparisonType": "count", "comparisonInterval": "5m"}
         self._run_test(data=data, minutes=1440, passes=False)
 
     def test_one_week_no_events(self):
-        data = {"interval": "1w", "value": 6}
+        data = {"interval": "1w", "value": 6, "comparisonType": "count", "comparisonInterval": "5m"}
         self._run_test(data=data, minutes=10080, passes=False)
 
     def test_comparison(self):
@@ -516,57 +536,117 @@ class EventFrequencyPercentConditionTestCase(BaseEventFrequencyPercentTest, Rule
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_five_minutes_with_events(self):
         self._make_sessions(60)
-        data = {"interval": "5m", "value": 39}
+        data = {
+            "interval": "5m",
+            "value": 39,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=5, passes=True, add_events=True)
-        data = {"interval": "5m", "value": 41}
+        data = {
+            "interval": "5m",
+            "value": 41,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=5, passes=False)
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_ten_minutes_with_events(self):
         self._make_sessions(60)
-        data = {"interval": "10m", "value": 49}
+        data = {
+            "interval": "10m",
+            "value": 49,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=10, passes=True, add_events=True)
-        data = {"interval": "10m", "value": 51}
+        data = {
+            "interval": "10m",
+            "value": 51,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=10, passes=False)
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_thirty_minutes_with_events(self):
         self._make_sessions(60)
-        data = {"interval": "30m", "value": 49}
+        data = {
+            "interval": "30m",
+            "value": 49,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=30, passes=True, add_events=True)
-        data = {"interval": "30m", "value": 51}
+        data = {
+            "interval": "30m",
+            "value": 51,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=30, passes=False)
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_one_hour_with_events(self):
         self._make_sessions(60)
-        data = {"interval": "1h", "value": 49}
+        data = {
+            "interval": "1h",
+            "value": 49,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=60, add_events=True, passes=True)
-        data = {"interval": "1h", "value": 51}
+        data = {
+            "interval": "1h",
+            "value": 51,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=60, passes=False)
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_five_minutes_no_events(self):
         self._make_sessions(60)
-        data = {"interval": "5m", "value": 39}
+        data = {
+            "interval": "5m",
+            "value": 39,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=5, passes=True, add_events=True)
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_ten_minutes_no_events(self):
         self._make_sessions(60)
-        data = {"interval": "10m", "value": 49}
+        data = {
+            "interval": "10m",
+            "value": 49,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=10, passes=True, add_events=True)
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_thirty_minutes_no_events(self):
         self._make_sessions(60)
-        data = {"interval": "30m", "value": 49}
+        data = {
+            "interval": "30m",
+            "value": 49,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=30, passes=True, add_events=True)
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_one_hour_no_events(self):
         self._make_sessions(60)
-        data = {"interval": "1h", "value": 49}
+        data = {
+            "interval": "1h",
+            "value": 49,
+            "comparisonType": "count",
+            "comparisonInterval": "5m",
+        }
         self._run_test(data=data, minutes=60, passes=False)
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)


### PR DESCRIPTION
The `apply_delayed` rule processor needs to call `get_rate` with bulk Snuba queries (see [this code block](https://github.com/getsentry/sentry/blob/088b9c73b604743864f76bd39a81a3238699d306/src/sentry/rules/processing/delayed_processing.py#L136-L171)), so this PR refactors `get_rate` to handle that.