### PR TITLE
feat(cache): add miss rate chart cache module

### DIFF
--- a/static/app/views/performance/cache/cacheLandingPage.tsx
+++ b/static/app/views/performance/cache/cacheLandingPage.tsx
@@ -4,15 +4,39 @@ import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t} from 'sentry/locale';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {CacheHitMissChart} from 'sentry/views/performance/cache/charts/hitMissChart';
+import {Referrer} from 'sentry/views/performance/cache/referrers';
 import {MODULE_TITLE, RELEASE_LEVEL} from 'sentry/views/performance/cache/settings';
+import {convertHitRateToMissRate} from 'sentry/views/performance/cache/utils';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/performance/modulePageProviders';
+import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
+import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 
 export function CacheLandingPage() {
   const organization = useOrganization();
+
+  const filters: SpanMetricsQueryFilters = {
+    'span.op': 'cache.get_item',
+  };
+
+  const {
+    isLoading: isCacheHitRateLoading,
+    data: cacheHitRateData,
+    error: cacheHitRateError,
+  } = useSpanMetricsSeries({
+    yAxis: [`cache_hit_rate()`],
+    search: MutableSearch.fromQueryObject(filters),
+    referrer: Referrer.LANDING_CACHE_HIT_MISS_CHART,
+  });
 
   return (
     <React.Fragment>
@@ -44,7 +68,18 @@ export function CacheLandingPage() {
 
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
-              <div>TEST</div>
+              <PageFilterBar condensed>
+                <ProjectPageFilter />
+                <EnvironmentPageFilter />
+                <DatePageFilter />
+              </PageFilterBar>
+            </ModuleLayout.Full>
+            <ModuleLayout.Full>
+              <CacheHitMissChart
+                series={[convertHitRateToMissRate(cacheHitRateData['cache_hit_rate()'])]}
+                isLoading={isCacheHitRateLoading}
+                error={cacheHitRateError}
+              />
             </ModuleLayout.Full>
           </ModuleLayout.Layout>
         </Layout.Main>

--- a/static/app/views/performance/cache/charts/hitMissChart.tsx
+++ b/static/app/views/performance/cache/charts/hitMissChart.tsx
@@ -1,0 +1,39 @@
+import type {Series} from 'sentry/types/echarts';
+import {formatPercentage} from 'sentry/utils/formatters';
+import {CHART_HEIGHT} from 'sentry/views/performance/http/settings';
+import {AVG_COLOR} from 'sentry/views/starfish/colours';
+import Chart, {ChartType} from 'sentry/views/starfish/components/chart';
+import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+
+type Props = {
+  isLoading: boolean;
+  series: Series[];
+  error?: Error | null;
+};
+
+export function CacheHitMissChart({series, isLoading, error}: Props) {
+  return (
+    <ChartPanel title={DataTitles.cacheMissRate}>
+      <Chart
+        showLegend
+        height={CHART_HEIGHT}
+        grid={{
+          left: '4px',
+          right: '0',
+          top: '8px',
+          bottom: '0',
+        }}
+        data={series}
+        loading={isLoading}
+        error={error}
+        chartColors={[AVG_COLOR]}
+        type={ChartType.LINE}
+        aggregateOutputFormat="percentage"
+        tooltipFormatterOptions={{
+          valueFormatter: value => formatPercentage(1 - value), // Api returns hit rate, but we display miss rate
+        }}
+      />
+    </ChartPanel>
+  );
+}

--- a/static/app/views/performance/cache/referrers.ts
+++ b/static/app/views/performance/cache/referrers.ts
@@ -1,0 +1,11 @@
+const referrerPrefix = 'api.performance.cache';
+
+enum ReferrerSuffix {
+  LANDING_CACHE_HIT_MISS_CHART = `landing-cache-hit-miss-chart`,
+}
+
+type PrefixedReferrer = {
+  [key in keyof typeof ReferrerSuffix]: `${typeof referrerPrefix}.${(typeof ReferrerSuffix)[key]}`;
+};
+
+export const Referrer: PrefixedReferrer = ReferrerSuffix as unknown as PrefixedReferrer;

--- a/static/app/views/performance/cache/settings.ts
+++ b/static/app/views/performance/cache/settings.ts
@@ -11,3 +11,5 @@ export const releaseLevelAsBadgeProps = {
 };
 
 export const MODULE_TITLE = t('Cache');
+
+export const CHART_HEIGHT = 200;

--- a/static/app/views/performance/cache/utils.ts
+++ b/static/app/views/performance/cache/utils.ts
@@ -1,0 +1,12 @@
+import type {Series} from 'sentry/types/echarts';
+
+export const convertHitRateToMissRate = (hitRateSeries: Series): Series => {
+  return {
+    ...hitRateSeries,
+    seriesName: 'cache_miss_rate()', // TODO - this can just be a discover function
+    data: hitRateSeries.data.map(dataPoint => ({
+      ...dataPoint,
+      value: dataPoint.value ? 1 - dataPoint.value : 0,
+    })),
+  };
+};

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -83,6 +83,7 @@ export const SPAN_FUNCTIONS = [
   'time_spent_percentage',
   'http_response_rate',
   'http_error_count',
+  'cache_hit_rate',
 ] as const;
 
 const BREAKPOINT_CONDITIONS = ['less', 'greater'] as const;
@@ -207,6 +208,7 @@ export enum SpanFunction {
   TIME_SPENT_PERCENTAGE = 'time_spent_percentage',
   HTTP_ERROR_COUNT = 'http_error_count',
   HTTP_RESPONSE_RATE = 'http_response_rate',
+  CACHE_HIT_RATE = 'cache_hit_rate',
 }
 
 export const StarfishDatasetFields = {
@@ -244,6 +246,12 @@ export const STARFISH_AGGREGATION_FIELDS: Record<
   },
   [SpanFunction.HTTP_RESPONSE_RATE]: {
     desc: t('Percentage of HTTP responses by code'),
+    defaultOutputType: 'percentage',
+    kind: FieldKind.FUNCTION,
+    valueType: FieldValueType.NUMBER,
+  },
+  [SpanFunction.CACHE_HIT_RATE]: {
+    desc: t('Percentage of cache hits'),
     defaultOutputType: 'percentage',
     kind: FieldKind.FUNCTION,
     valueType: FieldValueType.NUMBER,

--- a/static/app/views/starfish/views/spans/types.tsx
+++ b/static/app/views/starfish/views/spans/types.tsx
@@ -21,7 +21,8 @@ export type DataKey =
   | 'avg(http.response_transfer_size)'
   | 'bundleSize'
   | 'unsuccessfulHTTPCodes'
-  | 'httpCodeBreakdown';
+  | 'httpCodeBreakdown'
+  | 'cacheMissRate';
 
 export const DataTitles: Record<DataKey, string> = {
   change: t('Change'),
@@ -43,6 +44,7 @@ export const DataTitles: Record<DataKey, string> = {
   'avg(http.response_transfer_size)': t('Avg Transfer Size'),
   unsuccessfulHTTPCodes: t('Response Codes (3XX, 4XX, 5XX)'),
   httpCodeBreakdown: t('Response Code Breakdown'),
+  cacheMissRate: t('Miss Rate'),
 };
 
 export const getThroughputTitle = (


### PR DESCRIPTION
![image](https://github.com/getsentry/sentry/assets/44422760/3a064db6-bde8-4c5e-9bc6-65daf08c1343)

1. Adds a cache miss rate chart
2. Adds project filters, date filters, and environment filters