### PR TITLE
feat(autofix): Send the external id of git repos to autofix

### DIFF
--- a/src/sentry/api/helpers/repos.py
+++ b/src/sentry/api/helpers/repos.py
@@ -19,6 +19,7 @@ def get_repos_from_project_code_mappings(project: Project) -> list[dict]:
                 "provider": repo.provider,
                 "owner": repo_name_sections[0],
                 "name": "/".join(repo_name_sections[1:]),
+                "external_id": repo.external_id,
             }
             repo_key = (repo_dict["provider"], repo_dict["owner"], repo_dict["name"])
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -741,7 +741,9 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
-    def create_repo(project, name=None, provider=None, integration_id=None, url=None):
+    def create_repo(
+        project, name=None, provider=None, integration_id=None, url=None, external_id=None
+    ):
         repo, _ = Repository.objects.get_or_create(
             organization_id=project.organization_id,
             name=name
@@ -749,6 +751,7 @@ class Factories:
             provider=provider,
             integration_id=integration_id,
             url=url,
+            external_id=external_id,
         )
         return repo
 

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -57,6 +57,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             project=self.project,
             name="getsentry/sentry",
             provider="integrations:github",
+            external_id="123",
         )
         self.create_code_mapping(project=self.project, repo=repo)
 
@@ -89,6 +90,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                     "provider": "integrations:github",
                     "owner": "getsentry",
                     "name": "sentry",
+                    "external_id": "123",
                 }
             ],
             ANY,
@@ -113,6 +115,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             project=self.project,
             name="getsentry/sentry",
             provider="integrations:github",
+            external_id="123",
         )
         self.create_code_mapping(project=self.project, repo=repo)
 
@@ -143,6 +146,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                     "provider": "integrations:github",
                     "owner": "getsentry",
                     "name": "sentry",
+                    "external_id": "123",
                 }
             ],
             ANY,
@@ -168,6 +172,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             project=self.project,
             name="getsentry/sentry",
             provider="integrations:github",
+            external_id="123",
         )
         self.create_code_mapping(project=self.project, repo=repo)
 
@@ -198,6 +203,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                     "provider": "integrations:github",
                     "owner": "getsentry",
                     "name": "sentry",
+                    "external_id": "123",
                 }
             ],
             ANY,
@@ -226,6 +232,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             project=self.project,
             name="getsentry/sentry",
             provider="integrations:github",
+            external_id="123",
         )
         self.create_code_mapping(project=self.project, repo=repo)
 
@@ -255,7 +262,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         release = self.create_release(project=self.project, version="1.0.0")
 
         self.create_repo(
-            project=self.project, name="invalid-repo", provider="integrations:someotherprovider"
+            project=self.project,
+            name="invalid-repo",
+            provider="integrations:someotherprovider",
+            external_id="123",
         )
 
         data = load_data("python", timestamp=before_now(minutes=1))
@@ -294,7 +304,10 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         # Creating a repository with a valid name 'getsentry/sentry'
         valid_repo = self.create_repo(
-            project=self.project, name="getsentry/sentry", provider="integrations:github"
+            project=self.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
         )
         valid_repo.save()
 

--- a/tests/sentry/api/endpoints/test_project_autofix_create_codebase_index.py
+++ b/tests/sentry/api/endpoints/test_project_autofix_create_codebase_index.py
@@ -28,7 +28,9 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
         mock_post.return_value.status_code = 200
         mock_post.return_value.json.return_value = {}
 
-        repo = self.create_repo(name="getsentry/sentry", provider="integrations:github")
+        repo = self.create_repo(
+            name="getsentry/sentry", provider="integrations:github", external_id="123"
+        )
         self.create_code_mapping(project=self.project, repo=repo)
 
         response = self.client.post(
@@ -47,6 +49,7 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
                         "provider": "integrations:github",
                         "owner": "getsentry",
                         "name": "sentry",
+                        "external_id": "123",
                     },
                 }
             ),
@@ -56,8 +59,12 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
     @patch("sentry.api.endpoints.project_autofix_create_codebase_index.requests.post")
     def test_autofix_create_multiple_repos_successful(self, mock_post):
         # Setup multiple repositories
-        repo1 = self.create_repo(name="getsentry/sentry", provider="integrations:github")
-        repo2 = self.create_repo(name="getsentry/relay", provider="integrations:github")
+        repo1 = self.create_repo(
+            name="getsentry/sentry", provider="integrations:github", external_id="123"
+        )
+        repo2 = self.create_repo(
+            name="getsentry/relay", provider="integrations:github", external_id="234"
+        )
         self.create_code_mapping(project=self.project, repo=repo1, stack_root="/path1")
         self.create_code_mapping(project=self.project, repo=repo2, stack_root="/path2")
 
@@ -87,6 +94,7 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
                             "provider": "integrations:github",
                             "owner": "getsentry",
                             "name": "sentry",
+                            "external_id": "123",
                         },
                     }
                 ),
@@ -102,6 +110,7 @@ class TestProjectAutofixCodebaseIndexCreate(APITestCase):
                             "provider": "integrations:github",
                             "owner": "getsentry",
                             "name": "relay",
+                            "external_id": "234",
                         },
                     }
                 ),

--- a/tests/sentry/api/helpers/test_repos.py
+++ b/tests/sentry/api/helpers/test_repos.py
@@ -10,8 +10,15 @@ class TestGetRepoFromCodeMappings(TestCase):
 
     def test_get_repos_from_project_code_mappings_with_data(self):
         project = self.create_project()
-        repo = self.create_repo(name="getsentry/sentry", provider="github")
+        repo = self.create_repo(name="getsentry/sentry", provider="github", external_id="123")
         self.create_code_mapping(project=project, repo=repo)
         repos = get_repos_from_project_code_mappings(project)
-        expected_repos = [{"provider": repo.provider, "owner": "getsentry", "name": "sentry"}]
+        expected_repos = [
+            {
+                "provider": repo.provider,
+                "owner": "getsentry",
+                "name": "sentry",
+                "external_id": "123",
+            }
+        ]
         self.assertEqual(repos, expected_repos)


### PR DESCRIPTION
Send the repo's external id to autofix, so we have a unique identifier for repos instead of using the slug
