### PR TITLE
fix(severity): Stop trying to get a new title for events with placeholder

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2412,15 +2412,9 @@ def _get_severity_score(event: Event) -> tuple[float, str]:
         # Fall back to using just the title for events without an exception.
         title = event.title
 
-    # If the event hasn't yet been given a helpful title, attempt to calculate one
+    # If all we have is `<unlabeled event>` (or one of its equally unhelpful friends), bail
     if title in PLACEHOLDER_EVENT_TITLES:
-        title = event_type.get_title(metadata)
-
-    # If there's still nothing helpful to be had, bail
-    if title in PLACEHOLDER_EVENT_TITLES:
-        logger_data.update(
-            {"event_type": event_type.key, "event_title": event.title, "computed_title": title}
-        )
+        logger_data.update({"event_type": event_type.key, "title": title})
         logger.warning(
             "Unable to get severity score because of unusable `message` value '%s'",
             title,


### PR DESCRIPTION
Back when I initially wrote the making-the-API-call-to-seer part of the severity POC, I didn't have a solid understanding of how events get their titles. Having just worked on [a fix specifically on that topic](https://github.com/getsentry/sentry/pull/69398), though, I now know that the "this event has a placeholder title, but maybe if we recalculate the title we'll come up with something better" bit was wishful thinking. At that point in the process, if there were a useful title to be had, the event would already have it.

This therefore removes that second attempt at getting a title, and updates the corresponding test to match. 

(This change was prompted by the change in https://github.com/getsentry/sentry/pull/69397 causing the test to fail for a different reason (hardcoding the expected title value), but the fix here takes care of that as well.)