### PR TITLE
feat(ai): Add per-pipeline token used metrics

### DIFF
--- a/static/app/views/aiAnalytics/aiAnalyticsCharts.tsx
+++ b/static/app/views/aiAnalytics/aiAnalyticsCharts.tsx
@@ -8,55 +8,6 @@ import {useMetricsQuery} from 'sentry/utils/metrics/useMetricsQuery';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {MetricChartContainer} from 'sentry/views/dashboards/metrics/chart';
 
-export function TotalTokensUsedChart() {
-  const {selection, isReady: isGlobalSelectionReady} = usePageFilters();
-  const {
-    data: timeseriesData,
-    isLoading,
-    isError,
-    error,
-  } = useMetricsQuery(
-    [
-      {
-        name: 'total',
-        mri: `c:spans/ai.total_tokens.used@none`,
-        op: 'sum',
-        // TODO this double counts the (e.g.) langchain and openai token usage
-      },
-    ],
-    selection,
-    {
-      intervalLadder: 'dashboard',
-    }
-  );
-
-  if (!isGlobalSelectionReady) {
-    return null;
-  }
-
-  if (isError) {
-    return <div>{'' + error}</div>;
-  }
-
-  return (
-    <TokenChartContainer>
-      <PanelTitle>{t('Total tokens used')}</PanelTitle>
-      <MetricChartContainer
-        timeseriesData={timeseriesData}
-        isLoading={isLoading}
-        metricQueries={[
-          {
-            name: 'mql',
-            formula: '$total',
-          },
-        ]}
-        displayType={MetricDisplayType.AREA}
-        chartHeight={200}
-      />
-    </TokenChartContainer>
-  );
-}
-
 interface NumberOfPipelinesChartProps {
   groupId?: string;
 }
@@ -165,6 +116,62 @@ export function PipelineDurationChart({groupId}: PipelineDurationChartProps) {
           {
             name: 'mql',
             formula: '$a',
+          },
+        ]}
+        displayType={MetricDisplayType.AREA}
+        chartHeight={200}
+      />
+    </TokenChartContainer>
+  );
+}
+
+interface TokensUsedChartProps {
+  groupId?: string;
+}
+export function TokensUsedChart({groupId}: TokensUsedChartProps) {
+  const {selection, isReady: isGlobalSelectionReady} = usePageFilters();
+  let query = 'span.category:"ai"';
+  if (groupId) {
+    query = `${query} span.ai.pipeline.group:"${groupId}"`;
+  }
+  const {
+    data: timeseriesData,
+    isLoading,
+    isError,
+    error,
+  } = useMetricsQuery(
+    [
+      {
+        name: 'tokens',
+        mri: `c:spans/ai.total_tokens.used@none`,
+        op: 'sum',
+        query,
+      },
+    ],
+    selection,
+    {
+      intervalLadder: 'dashboard',
+    }
+  );
+
+  if (!isGlobalSelectionReady) {
+    return null;
+  }
+
+  if (isError) {
+    return <div>{'' + error}</div>;
+  }
+
+  return (
+    <TokenChartContainer>
+      <PanelTitle>{t('AI tokens used')}</PanelTitle>
+      <MetricChartContainer
+        timeseriesData={timeseriesData}
+        isLoading={isLoading}
+        metricQueries={[
+          {
+            name: 'mql',
+            formula: '$tokens',
           },
         ]}
         displayType={MetricDisplayType.AREA}

--- a/static/app/views/aiAnalytics/aiAnalyticsCharts.tsx
+++ b/static/app/views/aiAnalytics/aiAnalyticsCharts.tsx
@@ -26,7 +26,7 @@ export function NumberOfPipelinesChart({groupId}: NumberOfPipelinesChartProps) {
     [
       {
         name: 'number',
-        mri: `d:spans/exclusive_time@millisecond`,
+        mri: `d:spans/exclusive_time_light@millisecond`,
         op: 'count',
         query,
       },

--- a/static/app/views/aiAnalytics/aiAnalyticsDetailsPage.tsx
+++ b/static/app/views/aiAnalytics/aiAnalyticsDetailsPage.tsx
@@ -19,6 +19,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {
   NumberOfPipelinesChart,
   PipelineDurationChart,
+  TokensUsedChart,
 } from 'sentry/views/aiAnalytics/aiAnalyticsCharts';
 import {PipelineSpansTable} from 'sentry/views/aiAnalytics/pipelineSpansTable';
 import {MetricReadout} from 'sentry/views/performance/metricReadout';
@@ -128,12 +129,15 @@ export default function AiAnalyticsPage({params}: Props) {
                         </MetricsRibbon>
                       </SpaceBetweenWrap>
                     </ModuleLayout.Full>
-                    <ModuleLayout.Half>
+                    <ModuleLayout.Third>
                       <NumberOfPipelinesChart groupId={groupId} />
-                    </ModuleLayout.Half>
-                    <ModuleLayout.Half>
+                    </ModuleLayout.Third>
+                    <ModuleLayout.Third>
                       <PipelineDurationChart groupId={groupId} />
-                    </ModuleLayout.Half>
+                    </ModuleLayout.Third>
+                    <ModuleLayout.Third>
+                      <TokensUsedChart groupId={groupId} />
+                    </ModuleLayout.Third>
                     <ModuleLayout.Full>
                       <PipelineSpansTable groupId={groupId} />
                     </ModuleLayout.Full>

--- a/static/app/views/aiAnalytics/landing.tsx
+++ b/static/app/views/aiAnalytics/landing.tsx
@@ -14,7 +14,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {
   NumberOfPipelinesChart,
   PipelineDurationChart,
-  TotalTokensUsedChart,
+  TokensUsedChart,
 } from 'sentry/views/aiAnalytics/aiAnalyticsCharts';
 import {PipelinesTable} from 'sentry/views/aiAnalytics/PipelinesTable';
 import * as ModuleLayout from 'sentry/views/performance/moduleLayout';
@@ -62,13 +62,13 @@ export default function AiAnalyticsPage() {
                       </PageFilterBar>
                     </ModuleLayout.Full>
                     <ModuleLayout.Third>
-                      <TotalTokensUsedChart />
-                    </ModuleLayout.Third>
-                    <ModuleLayout.Third>
                       <NumberOfPipelinesChart />
                     </ModuleLayout.Third>
                     <ModuleLayout.Third>
                       <PipelineDurationChart />
+                    </ModuleLayout.Third>
+                    <ModuleLayout.Third>
+                      <TokensUsedChart />
                     </ModuleLayout.Third>
                     <ModuleLayout.Full>
                       <PipelinesTable />


### PR DESCRIPTION
This modifies the pipeline details view to show how many tokens are used per pipeline category.