### PR TITLE
fix(backup): Apply prod-UserOption fix to comparison

### DIFF
--- a/tests/sentry/backup/test_validate.py
+++ b/tests/sentry/backup/test_validate.py
@@ -792,3 +792,101 @@ def test_good_user_custom_ordinal():
     findings = out.findings
 
     assert len(findings) == 0
+
+
+# TODO(azaslavsky): This is a temporary fix. Remove it once we have a more sustainable export-side
+# solution.
+def test_good_user_option_temp_fix():
+    left = json.loads(
+        """
+            [
+                {
+                    "model": "sentry.user",
+                    "pk": 1,
+                    "fields": {
+                        "password": "abc123",
+                        "last_login": null,
+                        "username": "testing@example.com",
+                        "name": "",
+                        "email": "testing@example.com"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 3,
+                    "fields": {
+                        "user": 1,
+                        "key": "foo",
+                        "value": "1"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 5,
+                    "fields": {
+                        "user": 1,
+                        "key": "foo",
+                        "value": "2"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 8,
+                    "fields": {
+                        "user": 1,
+                        "key": "bar",
+                        "value": "4"
+                    }
+                }
+            ]
+        """
+    )
+
+    right = json.loads(
+        """
+            [
+                {
+                    "model": "sentry.user",
+                    "pk": 1,
+                    "fields": {
+                        "password": "abc123",
+                        "last_login": null,
+                        "username": "testing@example.com",
+                        "name": "",
+                        "email": "testing@example.com"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 11,
+                    "fields": {
+                        "user": 1,
+                        "key": "foo",
+                        "value": "2"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 21,
+                    "fields": {
+                        "user": 1,
+                        "key": "bar",
+                        "value": "3"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 22,
+                    "fields": {
+                        "user": 1,
+                        "key": "bar",
+                        "value": "4"
+                    }
+                }
+            ]
+        """
+    )
+    out = validate(left, right)
+    findings = out.findings
+
+    assert len(findings) == 0


### PR DESCRIPTION
The fixes in https://github.com/getsentry/sentry/pull/68943 and https://github.com/getsentry/sentry/pull/69027 worked, but now fail on comparison. This PR makes comparison clever enough to detect these "duplicate" UserOption entries and avoid them.

This is a temporary fix. A more robust solution will prevent ever exporting such UserOptions, but that will take a while to percolate through the support window, so this should hold us over for the time being.