### PR TITLE
chore(queries): Enable safety check by default in `RangeQuerySetWrapper`

### DIFF
--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -90,7 +90,7 @@ class RangeQuerySetWrapper:
         order_by="pk",
         callbacks=(),
         result_value_getter=None,
-        override_unique_safety_check=True,
+        override_unique_safety_check=False,
     ):
         # Support for slicing
         if queryset.query.low_mark == 0 and not (

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -60,7 +60,7 @@ class RangeQuerySetWrapperTest(TestCase):
     def test_order_by_non_unique_fails(self):
         qs = User.objects.all()
         with pytest.raises(InvalidQuerySetError):
-            self.range_wrapper(qs, order_by="name", override_unique_safety_check=False)
+            self.range_wrapper(qs, order_by="name")
 
         # Shouldn't error if the safety check is disabled
         self.range_wrapper(qs, order_by="name", override_unique_safety_check=True)
@@ -68,7 +68,7 @@ class RangeQuerySetWrapperTest(TestCase):
     def test_order_by_unique(self):
         self.create_user()
         qs = User.objects.all()
-        self.range_wrapper(qs, order_by="username", override_unique_safety_check=False)
+        self.range_wrapper(qs, order_by="username")
         assert len(list(self.range_wrapper(qs, order_by="username", step=2))) == 1
 
 


### PR DESCRIPTION
This was causing failures in getsentry, so I temporarily disabled the check by default. Now that we've fixed issues in getsentry, re-enabling by default