### PR TITLE
fix(replays): look for replay_id in context as well for hasReplays

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -33,6 +33,7 @@ import {
 } from 'sentry/utils/events';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {projectCanLinkToReplay} from 'sentry/utils/replays/projectSupportsReplay';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -237,7 +238,7 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
   const xlargeViewport = useMedia(`(min-width: ${theme.breakpoints.xlarge})`);
   const organization = useOrganization();
 
-  const hasReplay = Boolean(event?.tags?.find(({key}) => key === 'replayId')?.value);
+  const hasReplay = Boolean(getReplayIdFromEvent(event));
   const isReplayEnabled =
     organization.features.includes('session-replay') &&
     projectCanLinkToReplay(group.project);

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -43,6 +43,7 @@ import {IssueCategory, IssueType} from 'sentry/types';
 import type {EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {shouldShowCustomErrorResourceConfig} from 'sentry/utils/issueTypeConfig';
+import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ResourcesAndMaybeSolutions} from 'sentry/views/issueDetails/resourcesAndMaybeSolutions';
 
@@ -86,7 +87,7 @@ function DefaultGroupEventDetailsContent({
   const hasNewTagsUI = useHasNewTagsUI();
 
   const projectSlug = project.slug;
-  const hasReplay = Boolean(event.tags?.find(({key}) => key === 'replayId')?.value);
+  const hasReplay = Boolean(getReplayIdFromEvent(event));
   const mechanism = event.tags?.find(({key}) => key === 'mechanism')?.value;
   const isANR = mechanism === 'ANR' || mechanism === 'AppExitInfo';
   const hasAnrImprovementsFeature = organization.features.includes('anr-improvements');

--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -24,6 +24,7 @@ import type {
 } from 'sentry/utils/performance/quickTrace/types';
 import {isTransaction} from 'sentry/utils/performance/quickTrace/utils';
 import Projects from 'sentry/utils/projects';
+import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import theme from 'sentry/utils/theme';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import EventCreatedTooltip from 'sentry/views/issueDetails/eventCreatedTooltip';
@@ -95,7 +96,7 @@ class EventMetas extends Component<Props, State> {
     const hasReplay =
       organization.features.includes('session-replay') &&
       Boolean(event.entries.find(({type}) => type === 'breadcrumbs')) &&
-      Boolean(event?.tags?.find(({key}) => key === 'replayId')?.value);
+      Boolean(getReplayIdFromEvent(event));
 
     const type = isTransaction(event) ? 'transaction' : 'event';
 


### PR DESCRIPTION
replace the various places where we look for `replayId` in the tags of an event with `getReplayIdFromEvent`, which will check the tags and the context.

For some events we are only writing the context and not the tag, so this will be more correct going forward.