### PR TITLE
chore(ppf): Stop sending group states from the post process forwarder

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -74,7 +74,6 @@ class EventStream(Service):
         primary_hash: str | None,
         queue: str,
         skip_consume: bool = False,
-        group_states: GroupStates | None = None,
         occurrence_id: str | None = None,
     ) -> None:
         if skip_consume:
@@ -90,7 +89,6 @@ class EventStream(Service):
                     "primary_hash": primary_hash,
                     "cache_key": cache_key,
                     "group_id": group_id,
-                    "group_states": group_states,
                     "occurrence_id": occurrence_id,
                     "project_id": project_id,
                 },
@@ -136,7 +134,6 @@ class EventStream(Service):
             primary_hash,
             self._get_queue_for_post_process(event),
             skip_consume,
-            group_states,
             occurrence_id=event.occurrence_id if isinstance(event, GroupEvent) else None,
         )
 

--- a/src/sentry/eventstream/kafka/dispatch.py
+++ b/src/sentry/eventstream/kafka/dispatch.py
@@ -8,7 +8,6 @@ from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.types import Message
 
 from sentry import options
-from sentry.eventstream.base import GroupStates
 from sentry.eventstream.kafka.protocol import (
     get_task_kwargs_for_message,
     get_task_kwargs_for_message_from_headers,
@@ -43,7 +42,6 @@ def dispatch_post_process_group_task(
     primary_hash: str | None,
     queue: str,
     skip_consume: bool = False,
-    group_states: GroupStates | None = None,
     occurrence_id: str | None = None,
 ) -> None:
     if skip_consume:
@@ -59,7 +57,6 @@ def dispatch_post_process_group_task(
                 "primary_hash": primary_hash,
                 "cache_key": cache_key,
                 "group_id": group_id,
-                "group_states": group_states,
                 "occurrence_id": occurrence_id,
                 "project_id": project_id,
             },

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -480,6 +480,5 @@ class SnubaEventStream(SnubaProtocolEventStream):
             primary_hash,
             self._get_queue_for_post_process(event),
             skip_consume,
-            group_states,
             occurrence_id=event.occurrence_id if isinstance(event, GroupEvent) else None,
         )

--- a/tests/sentry/eventstream/kafka/test_dispatch.py
+++ b/tests/sentry/eventstream/kafka/test_dispatch.py
@@ -90,7 +90,6 @@ def test_dispatch_task(mock_dispatch: Mock) -> None:
         is_regression=None,
         is_new_group_environment=False,
         queue="post_process_errors",
-        group_states=None,
         occurrence_id=None,
     )
 
@@ -117,7 +116,6 @@ def test_dispatch_task_with_occurrence(mock_post_process_group: Mock) -> None:
         "kwargs": {
             "cache_key": "e:066f15fe1cd2406aaa7c6a07471d7aef:2",
             "group_id": 44,
-            "group_states": None,
             "is_new": False,
             "is_new_group_environment": False,
             "is_regression": None,

--- a/tests/sentry/post_process_forwarder/test_post_process_forwarder.py
+++ b/tests/sentry/post_process_forwarder/test_post_process_forwarder.py
@@ -147,7 +147,6 @@ class PostProcessForwarderTest(TestCase):
                 is_regression=None,
                 queue="post_process_errors",
                 is_new_group_environment=False,
-                group_states=None,
                 occurrence_id=None,
             )
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2414,7 +2414,6 @@ class PostProcessGroupPerformanceTest(
             is_new_group_environment=False,
             cache_key=cache_key,
             group_id=None,
-            group_states=None,
         )
 
         assert transaction_processed_signal_mock.call_count == 1


### PR DESCRIPTION
We stop relying on `group_states` in https://github.com/getsentry/sentry/pull/63130. Once this has merged and is in production, we can stop sending `group_states` entirely via the ppf.

We can stop including the `group_states` info in the Kafka messages in a later pr
