### PR TITLE
fix(compactSelect): Register select options earlier

### DIFF
--- a/static/app/components/compactSelect/list.tsx
+++ b/static/app/components/compactSelect/list.tsx
@@ -1,4 +1,4 @@
-import {createContext, useCallback, useContext, useEffect, useMemo} from 'react';
+import {createContext, useCallback, useContext, useLayoutEffect, useMemo} from 'react';
 import {useFocusManager} from '@react-aria/focus';
 import type {AriaGridListOptions} from '@react-aria/gridlist';
 import type {AriaListBoxOptions} from '@react-aria/listbox';
@@ -232,7 +232,7 @@ function List<Value extends SelectKey>({
   });
 
   // Register the initialized list state once on mount
-  useEffect(() => {
+  useLayoutEffect(() => {
     registerListState(compositeIndex, listState);
     saveSelectedOptions(
       compositeIndex,


### PR DESCRIPTION
In react concurrent mode some dropdowns flash, possibly because the context is empty and is filled slightly after. This switches it to fill the context earlier.

example compact select flickering to a weird state in concurrent mode

https://github.com/getsentry/sentry/assets/1400464/c7348a4a-1667-4df9-8ec8-e1ddf7651b98