### PR TITLE
feat(slack): Debug function to generate slack block kit preview URLs

### DIFF
--- a/src/sentry/testutils/helpers/slack.py
+++ b/src/sentry/testutils/helpers/slack.py
@@ -1,4 +1,4 @@
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, quote
 
 import responses
 
@@ -128,6 +128,23 @@ def get_blocks_and_fallback_text(index=0):
     blocks = json.loads(data["blocks"][0])
     fallback_text = data["text"][0]
     return blocks, fallback_text
+
+
+def get_block_kit_preview_url(index=0) -> str:
+    assert len(responses.calls) >= 1
+    data = parse_qs(responses.calls[index].request.body)
+    assert "blocks" in data
+    assert data["blocks"][0]
+
+    stringified_blocks = data["blocks"][0]
+    blocks = json.loads(data["blocks"][0])
+    stringified_blocks = json.dumps({"blocks": blocks})
+
+    encoded_blocks = quote(stringified_blocks)
+    base_url = "https://app.slack.com/block-kit-builder/#"
+
+    preview_url = f"{base_url}{encoded_blocks}"
+    return preview_url
 
 
 def setup_slack_with_identities(organization, user):


### PR DESCRIPTION
Make it easier to generate Slack block kit preview URLs for debugging/development:

<img width="1920" alt="Screenshot 2024-04-22 at 7 26 23 PM" src="https://github.com/getsentry/sentry/assets/139499/9f749310-16f3-4adc-bfc2-8ef8501d0d5c">

This was inspired by: https://github.com/raycharius/slack-block-builder/blob/fac1baf4054ebfa5241d6065db54858f1522fe7d/src/internal/methods/other-methods.ts#L68-L83

For example: https://app.slack.com/block-kit-builder/T024ZCV9U#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22*You've%20reached%2080%25%20of%20your%20performance%20unit%20quota%20limit*%20%20%5CnYour%20organization%20*baz*%20has%20consumed%2080%25%20of%20its%20%3Chttps://docs.sentry.io/product/performance/transaction-summary/%7Cperformance%20unit%3E%20capacity.%20We'll%20drop%20performance%20units%20when%20you%20exceed%20your%20quota.%22%7D%7D,%7B%22type%22:%22context%22,%22elements%22:%5B%7B%22type%22:%22mrkdwn%22,%22text%22:%22You%20are%20receiving%20this%20notification%20because%20you%20have%20the%20scope%20org:billing%20%7C%20%3Chttp://baz.testserver/settings/account/notifications/quota/?referrer=reserved_quota_threshold-slack-user&notification_uuid=fc0f0579-6133-400a-8c3b-7002c27749f7%7CNotification%20Settings%3E%22%7D%5D%7D,%7B%22type%22:%22actions%22,%22elements%22:%5B%7B%22type%22:%22button%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Increase%20budget%22%7D,%22url%22:%22http://baz.testserver/settings/billing/checkout/?referrer=reserved_quota_threshold-slack-user&notification_uuid=fc0f0579-6133-400a-8c3b-7002c27749f7#step2%22,%22value%22:%22link_clicked%22%7D,%7B%22type%22:%22button%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22View%20Consumption%22%7D,%22url%22:%22http://baz.testserver/settings/billing/overview/?referrer=reserved_quota_threshold-slack-user&notification_uuid=fc0f0579-6133-400a-8c3b-7002c27749f7&category=transactions%22,%22value%22:%22link_clicked%22%7D%5D%7D%5D%7D