### PR TITLE
chore(post-process): Remove `Event.build_group_events`

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import logging
 import string
-from collections.abc import Generator, Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 from copy import deepcopy
 from datetime import datetime, timezone
 from hashlib import md5
@@ -702,13 +702,6 @@ class Event(BaseEvent):
     def groups(self, values: Sequence[Group] | None):
         self._groups_cache = values
         self._group_ids = [group.id for group in values] if values else None
-
-    def build_group_events(self) -> Generator[GroupEvent, None, None]:
-        """
-        Yields a GroupEvent for each Group associated with this Event.
-        """
-        for group in self.groups:
-            yield GroupEvent.from_event(self, group)
 
     def for_group(self, group: Group) -> GroupEvent:
         return GroupEvent.from_event(self, group)

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -534,57 +534,6 @@ class EventGroupsTest(TestCase):
         assert event.groups == [self.group]
 
 
-class EventBuildGroupEventsTest(TestCase):
-    def test_none(self):
-        event = Event(
-            event_id="a" * 32,
-            data={
-                "level": "info",
-                "message": "Foo bar",
-                "culprit": "app/components/events/eventEntries in map",
-                "type": "transaction",
-                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-            },
-            project_id=self.project.id,
-        )
-        assert list(event.build_group_events()) == []
-
-    def test(self):
-        event = Event(
-            event_id="a" * 32,
-            data={
-                "level": "info",
-                "message": "Foo bar",
-                "culprit": "app/components/events/eventEntries in map",
-                "type": "transaction",
-                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-            },
-            project_id=self.project.id,
-            groups=[self.group],
-        )
-        assert list(event.build_group_events()) == [GroupEvent.from_event(event, self.group)]
-
-    def test_multiple(self):
-        self.group_2 = self.create_group()
-        event = Event(
-            event_id="a" * 32,
-            data={
-                "level": "info",
-                "message": "Foo bar",
-                "culprit": "app/components/events/eventEntries in map",
-                "type": "transaction",
-                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-            },
-            project_id=self.project.id,
-            groups=[self.group, self.group_2],
-        )
-        sort_key = lambda group_event: (group_event.event_id, group_event.group_id)
-        assert sorted(event.build_group_events(), key=sort_key) == sorted(
-            [GroupEvent.from_event(event, self.group), GroupEvent.from_event(event, self.group_2)],
-            key=sort_key,
-        )
-
-
 class EventForGroupTest(TestCase):
     def test(self):
         event = Event(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -212,7 +212,7 @@ class UnfurlTest(TestCase):
         assert (
             unfurls[links[1].url]
             == SlackIssuesMessageBuilder(
-                group2, next(iter(event.build_group_events())), link_to_event=True
+                group2, event.for_group(group2), link_to_event=True
             ).build()
         )
 
@@ -242,7 +242,7 @@ class UnfurlTest(TestCase):
         assert (
             unfurls[links[1].url]
             == SlackIssuesMessageBuilder(
-                group2, next(iter(event.build_group_events())), link_to_event=True
+                group2, event.for_group(group2), link_to_event=True
             ).build()
         )
 


### PR DESCRIPTION
This isn't necessary anymore - events can have at most one group, and so we can use `Event.for_group` instead. We'll probably continue simplifying this more.

<!-- Describe your PR here. -->