### PR TITLE
fix(trace): Handle multiple perf issues in a trace

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -177,7 +177,10 @@ class TraceEvent:
         self.fetched_nodestore: bool = span_serialized
         self.span_serialized = span_serialized
         if len(self.event["issue.ids"]) > 0:
-            self.load_performance_issues(light, snuba_params)
+            if self.span_serialized:
+                self.load_span_serialized_performance_issues(light, snuba_params)
+            else:
+                self.load_performance_issues(light, snuba_params)
 
     @property
     def nodestore_event(self) -> Event | None:
@@ -188,6 +191,64 @@ class TraceEvent:
                     self.event["project.id"], self.event["id"]
                 )
         return self._nodestore_event
+
+    def load_span_serialized_performance_issues(
+        self, light: bool, snuba_params: ParamsType
+    ) -> None:
+        """Rewriting load_performance_issues from scratch so the logic is more independent"""
+        for group_id in self.event["issue.ids"]:
+            group = Group.objects.filter(id=group_id, project=self.event["project.id"]).first()
+            if group is None:
+                continue
+
+            unique_spans: set[str] = set()
+            start: float | None = None
+            end: float | None = None
+            for problem in self.event["issue_occurrences"]:
+                parent_span_ids = problem.evidence_data.get("parent_span_ids")
+                if parent_span_ids is not None:
+                    unique_spans = unique_spans.union(parent_span_ids)
+            span = list(unique_spans)
+            for event_span in self.event["occurrence_spans"]:
+                suspect_spans: list[str] = []
+                for problem in self.event["issue_occurrences"]:
+                    offender_span_ids = problem.evidence_data.get("offender_span_ids", [])
+                    if event_span.get("span_id") in offender_span_ids:
+                        start_timestamp = float(event_span.get("precise.start_ts"))
+                        if start is None:
+                            start = start_timestamp
+                        else:
+                            start = min(start, start_timestamp)
+                        end_timestamp = float(event_span.get("precise.finish_ts"))
+                        if end is None:
+                            end = end_timestamp
+                        else:
+                            end = max(end, end_timestamp)
+                        suspect_spans.append(event_span.get("span_id"))
+            # Logic for qualified_short_id is copied from property on the Group model
+            # to prevent an N+1 query from accessing project.slug everytime
+            qualified_short_id = None
+            project_slug = self.event["project"]
+            if group.short_id is not None:
+                qualified_short_id = f"{project_slug.upper()}-{base32_encode(group.short_id)}"
+
+            self.performance_issues.append(
+                {
+                    "event_id": self.event["id"],
+                    "issue_id": group_id,
+                    "issue_short_id": qualified_short_id,
+                    "span": span,
+                    "suspect_spans": suspect_spans,
+                    "project_id": self.event["project.id"],
+                    "project_slug": self.event["project"],
+                    "title": group.title,
+                    "level": constants.LOG_LEVELS[group.level],
+                    "culprit": group.culprit,
+                    "type": group.type,
+                    "start": start,
+                    "end": end,
+                }
+            )
 
     def load_performance_issues(self, light: bool, snuba_params: ParamsType | None) -> None:
         """Doesn't get suspect spans, since we don't need that for the light view"""
@@ -203,29 +264,8 @@ class TraceEvent:
             if light:
                 # This value doesn't matter for the light view
                 span = [self.event["trace.span"]]
-            elif "occurrence_spans" in self.event:
-                for problem in self.event["issue_occurrences"]:
-                    parent_span_ids = problem.evidence_data.get("parent_span_ids")
-                    if parent_span_ids is not None:
-                        unique_spans = unique_spans.union(parent_span_ids)
-                span = list(unique_spans)
-                for event_span in self.event["occurrence_spans"]:
-                    for problem in self.event["issue_occurrences"]:
-                        offender_span_ids = problem.evidence_data.get("offender_span_ids", [])
-                        if event_span.get("span_id") in offender_span_ids:
-                            start_timestamp = float(event_span.get("precise.start_ts"))
-                            if start is None:
-                                start = start_timestamp
-                            else:
-                                start = min(start, start_timestamp)
-                            end_timestamp = float(event_span.get("precise.finish_ts"))
-                            if end is None:
-                                end = end_timestamp
-                            else:
-                                end = max(end, end_timestamp)
-                            suspect_spans.append(event_span.get("span_id"))
             else:
-                if self.nodestore_event is not None or self.span_serialized:
+                if self.nodestore_event is not None:
                     occurrence_query = QueryBuilder(
                         Dataset.IssuePlatform,
                         snuba_params,
@@ -483,6 +523,7 @@ def update_params_with_trace_timestamp_projects(
     params["project_id"] = project_ids
 
 
+@sentry_sdk.tracing.trace
 def query_trace_data(
     trace_id: str,
     params: Mapping[str, str],
@@ -580,11 +621,15 @@ def query_trace_data(
     ]
 
     # Join group IDs from the occurrence dataset to transactions data
-    occurrence_issue_ids = {row["event_id"]: row["issue.ids"] for row in transformed_results[2]}
-    occurrence_ids = {row["event_id"]: row["occurrence_id"] for row in transformed_results[2]}
+    occurrence_issue_ids = defaultdict(list)
+    occurrence_ids = defaultdict(list)
+    for row in transformed_results[2]:
+        occurrence_issue_ids[row["event_id"]].extend(row["issue.ids"])
+        occurrence_ids[row["event_id"]].append(row["occurrence_id"])
+
     for result in transformed_results[0]:
-        result["issue.ids"] = occurrence_issue_ids.get(result["id"], {})
-        result["occurrence_id"] = occurrence_ids.get(result["id"])
+        result["issue.ids"] = occurrence_issue_ids.get(result["id"], [])
+        result["occurrence_id"] = occurrence_ids.get(result["id"], [])
         result["trace.parent_transaction"] = None
         if use_spans:
             result["measurements"] = {
@@ -636,6 +681,7 @@ def pad_span_id(span):
     return span.rjust(16, "0")
 
 
+@sentry_sdk.tracing.trace
 def augment_transactions_with_spans(
     transactions: Sequence[SnubaTransaction],
     errors: Sequence[SnubaError],
@@ -685,7 +731,7 @@ def augment_transactions_with_spans(
             if project not in problem_project_map:
                 problem_project_map[project] = []
             if transaction["occurrence_id"] is not None:
-                problem_project_map[project].append(transaction["occurrence_id"])
+                problem_project_map[project].extend(transaction["occurrence_id"])
 
             if not transaction["trace.parent_span"]:
                 continue

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3328,7 +3328,8 @@ class TraceTestCase(SpanTestCase):
                     PerformanceFileIOMainThreadGroupType,
                     "noise_config",
                     new=NoiseConfig(0, timedelta(minutes=1)),
-                ), mock.patch.object(
+                ),
+                mock.patch.object(
                     PerformanceSlowDBQueryGroupType,
                     "noise_config",
                     new=NoiseConfig(0, timedelta(minutes=1)),

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -70,6 +70,7 @@ from sentry.issues.grouptype import (
     NoiseConfig,
     PerformanceFileIOMainThreadGroupType,
     PerformanceNPlusOneGroupType,
+    PerformanceSlowDBQueryGroupType,
 )
 from sentry.issues.ingest import send_issue_occurrence_to_eventstream
 from sentry.mail import mail_adapter
@@ -3278,6 +3279,7 @@ class TraceTestCase(SpanTestCase):
         span_id: str | None = None,
         measurements: dict[str, int | float] | None = None,
         file_io_performance_issue: bool = False,
+        slow_db_performance_issue: bool = False,
         start_timestamp: datetime | None = None,
         store_event_kwargs: dict[str, Any] | None = None,
     ) -> Event:
@@ -3311,10 +3313,23 @@ class TraceTestCase(SpanTestCase):
             new_span["data"].update({"duration": 1, "blocked_main_thread": True})
             new_span["span_id"] = "0012" * 4
             data["spans"].append(new_span)
+        if slow_db_performance_issue:
+            new_span = data["spans"][0].copy()
+            if "data" not in new_span:
+                new_span["data"] = {}
+            new_span["op"] = "db"
+            new_span["description"] = "SELECT * FROM table"
+            new_span["data"].update({"duration": 10_000})
+            new_span["span_id"] = "0013" * 4
+            data["spans"].append(new_span)
         with self.feature(self.FEATURES):
             with (
                 mock.patch.object(
                     PerformanceFileIOMainThreadGroupType,
+                    "noise_config",
+                    new=NoiseConfig(0, timedelta(minutes=1)),
+                ), mock.patch.object(
+                    PerformanceSlowDBQueryGroupType,
                     "noise_config",
                     new=NoiseConfig(0, timedelta(minutes=1)),
                 ),
@@ -3322,6 +3337,7 @@ class TraceTestCase(SpanTestCase):
                     {
                         "performance.issues.all.problem-detection": 1.0,
                         "performance-file-io-main-thread-creation": 1.0,
+                        "performance.issues.slow_db_query.problem-creation": 1.0,
                     }
                 ),
             ):
@@ -3395,6 +3411,7 @@ class TraceTestCase(SpanTestCase):
             },
             parent_span_id=None,
             file_io_performance_issue=True,
+            slow_db_performance_issue=True,
             project_id=self.project.id,
             milliseconds=3000,
         )

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -18,6 +18,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase, Tr
         "organizations:performance-view",
         "organizations:performance-file-io-main-thread-detector",
         "organizations:trace-view-load-more",
+        "organizations:performance-slow-db-issue",
     ]
 
     def setUp(self):
@@ -36,6 +37,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointTestBase, Tr
         super().setUp()
         options.set("performance.issues.all.problem-detection", 1.0)
         options.set("performance.issues.file_io_main_thread.problem-creation", 1.0)
+        options.set("performance.issues.slow_db_query.problem-creation", 1.0)
         self.login_as(user=self.user)
 
         self.url = reverse(
@@ -566,12 +568,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             assert root["generation"] == 0
         assert root["transaction.duration"] == 3000
         assert len(root["children"]) == 3
-        assert len(root["performance_issues"]) == 1
-        # The perf issue is added as the last span
-        perf_issue_span = self.root_event.data["spans"][-1]
-        assert root["performance_issues"][0]["suspect_spans"][0] == perf_issue_span["span_id"]
-        assert root["performance_issues"][0]["start"] == perf_issue_span["start_timestamp"]
-        assert root["performance_issues"][0]["end"] == perf_issue_span["timestamp"]
+        self.assert_performance_issues(root)
 
         for i, gen1 in enumerate(root["children"]):
             self.assert_event(gen1, self.gen1_events[i], f"gen1_{i}")
@@ -603,6 +600,10 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
                 assert len(gen3["children"]) == 0
             elif gen2_no_children:
                 assert len(gen2["children"]) == 0
+
+    def assert_performance_issues(self, root):
+        """Broken in the non-spans endpoint, but we're not maintaining that anymore"""
+        pass
 
     def client_get(self, data, url=None):
         if url is None:
@@ -1317,6 +1318,16 @@ class OrganizationEventsTraceEndpointTestUsingSpans(OrganizationEventsTraceEndpo
         data["useSpans"] = 1
         return super().client_get(data, url)
 
+    def assert_performance_issues(self, root):
+        assert len(root["performance_issues"]) == 2
+        # The perf issues are the last 2 spans
+        perf_issue_spans = {span["span_id"]: span for span in self.root_event.data["spans"][-2:]}
+        for perf_issue in root["performance_issues"]:
+            assert len(perf_issue["suspect_spans"]) == 1
+            expected = perf_issue_spans[perf_issue["suspect_spans"][0]]
+            assert perf_issue["start"] == expected["start_timestamp"]
+            assert perf_issue["end"] == expected["timestamp"]
+
     def test_simple(self):
         self.load_trace()
         with self.feature(self.FEATURES):
@@ -1520,7 +1531,7 @@ class OrganizationEventsTraceMetaEndpointTest(OrganizationEventsTraceEndpointBas
         assert data["projects"] == 4
         assert data["transactions"] == 8
         assert data["errors"] == 0
-        assert data["performance_issues"] == 1
+        assert data["performance_issues"] == 2
 
     def test_with_errors(self):
         self.load_trace()
@@ -1536,7 +1547,7 @@ class OrganizationEventsTraceMetaEndpointTest(OrganizationEventsTraceEndpointBas
         assert data["projects"] == 4
         assert data["transactions"] == 8
         assert data["errors"] == 2
-        assert data["performance_issues"] == 1
+        assert data["performance_issues"] == 2
 
     def test_with_default(self):
         self.load_trace()
@@ -1552,4 +1563,4 @@ class OrganizationEventsTraceMetaEndpointTest(OrganizationEventsTraceEndpointBas
         assert data["projects"] == 4
         assert data["transactions"] == 8
         assert data["errors"] == 1
-        assert data["performance_issues"] == 1
+        assert data["performance_issues"] == 2

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -6,7 +6,6 @@ import pytest
 from django.urls import NoReverseMatch, reverse
 
 from sentry import options
-from sentry.issues.grouptype import PerformanceFileIOMainThreadGroupType
 from sentry.testutils.cases import TraceTestCase
 from sentry.utils.samples import load_data
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
@@ -679,12 +678,6 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
                 assert root_tags[key[7:]] == value, f"tags - {key}"
         assert root["measurements"]["lcp"]["value"] == 1000
         assert root["measurements"]["fcp"]["value"] == 750
-        assert "issue_short_id" in trace_transaction["performance_issues"][0]
-        assert trace_transaction["performance_issues"][0]["culprit"] == "root"
-        assert (
-            trace_transaction["performance_issues"][0]["type"]
-            == PerformanceFileIOMainThreadGroupType.type_id
-        )
 
     def test_detailed_trace_with_bad_tags(self):
         """Basically test that we're actually using the event serializer's method for tags"""


### PR DESCRIPTION
- This fixes a bug where we weren't handling multiple perf issues in a single trace since we did it by mapping event_ids to occurrence_ids, but there could be multiple occurrence_id for a given event_id
- This also fixes a bug (only with new spans view) where the list of suspect spans was _all_ the suspect spans across all perf issues for every perf issue, rather than just the suspect spans for a given perf issue
- Snuck some decorators to add more tracing too