### PR TITLE
fix(useoverlay): Enable closest overlay behavior for any element type

### DIFF
--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -241,7 +241,7 @@ function useOverlay({
 
   // Get props for overlay element
   const interactedOutside = useRef(false);
-  const interactOutsideTrigger = useRef<HTMLButtonElement | null>(null);
+  const interactOutsideTrigger = useRef<HTMLElement | null>(null);
   const {overlayProps: overlayAriaProps} = useOverlayAria(
     {
       onClose: () => {
@@ -272,8 +272,8 @@ function useOverlay({
           // Check if the target is inside a different overlay trigger. If yes, then we
           // should activate that trigger after this overlay has closed (see the onClose
           // prop above). This allows users to quickly jump between adjacent overlays.
-          const closestOverlayTrigger = target.closest?.<HTMLButtonElement>(
-            'button[aria-expanded="false"], input[role="combobox"][aria-expanded="false"]'
+          const closestOverlayTrigger = target.closest?.<HTMLElement>(
+            '[aria-expanded="false"]'
           );
           if (closestOverlayTrigger && closestOverlayTrigger !== triggerRef.current) {
             interactOutsideTrigger.current = closestOverlayTrigger;


### PR DESCRIPTION
This logic ensures that, when an overlay is open, you don't need to click twice to open a different overlay. It was looking specifically for either a button or input with `aria-expanded`. I'm developing a new component that has yet another element type, so instead of adding that too I think we can just remove the element restriction.