### PR TITLE
fix(performance): Save query state earlier

### DIFF
--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment, useEffect, useLayoutEffect} from 'react';
 
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {
@@ -104,7 +104,7 @@ function QueryResultSaver<T extends WidgetDataConstraint>(
 
   const transformed = query.transform(props.queryProps, results, props.query);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const isMetricsData = getIsMetricsDataFromResults(
       results,
       props.queryProps.fields[0]


### PR DESCRIPTION
When interacting with the accordion component, a new component is rendered but a second later it shows the loading state. Updating the query state as early as possible to avoid rendering the chart then removing it for the query.

before - a bit hard to see in the video recommend using slower playback speed.

https://github.com/getsentry/sentry/assets/1400464/0339c032-e75c-4bbf-b4fb-f67ed735139a

after

https://github.com/getsentry/sentry/assets/1400464/13d928b6-29a1-43fb-a0cb-9cc15306e295

should be the last part of https://github.com/getsentry/frontend-tsc/issues/64