### PR TITLE
fix(hybrid-cloud): Adds support for cross database tombstones

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1726,12 +1726,12 @@ register(
 register(
     "hybrid_cloud.disable_relative_upload_urls", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
+register("hybrid_cloud.allow_cross_db_tombstones", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Retry controls
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.integrationproxy.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("hyrid_cloud.allow_cross_db_tombstones", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Webhook processing controls
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1731,6 +1731,7 @@ register(
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.rpc.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybridcloud.integrationproxy.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("hyrid_cloud.allow_cross_db_tombstones", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Webhook processing controls
 register(

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -303,10 +303,9 @@ def _get_ids_to_delete(
 ) -> tuple[list[int], datetime]:
     """
     Queries the database or databases if spanning multiple), and returns
-     a list of tuples containing row ids and tombstone creation time for
-     any rows requiring cleanup.
+     a tuple with a list of row IDs to delete, and the oldest
+     tombstone timestamp for the batch.
 
-    :param self:
     :param tombstone_cls: Either a RegionTombstone or ControlTombstone, depending on
      which silo the tombstone process is running.
     :param model: The model with a HybridCloudForeignKey.

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -359,7 +359,7 @@ def get_ids_for_tombstone_cascade_cross_db(
     # the join code above. Instead, we have to manually query the tombstone IDs
     # first, then query the model for matching rows.
     tombstone_entries = tombstone_cls.objects.filter(
-        id__lte=watermark_batch.up, id__gt=watermark_batch.low
+        id__lte=watermark_batch.up, id__gt=watermark_batch.low, table_name=field.foreign_table_name
     ).values_list("object_identifier", "created_at")
 
     ids_to_check = []

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -369,6 +369,6 @@ def get_ids_for_tombstone_cascade_cross_db(
 
     field_name = f"{field.name}__in"
     query_kwargs = {field_name: ids_to_check}
-    rows_to_delete = list(model.objects.filter(**query_kwargs).values_list("id", flat=True))
+    affected_rows = list(model.objects.filter(**query_kwargs).values_list("id", flat=True))
 
-    return rows_to_delete, oldest_seen
+    return affected_rows, oldest_seen

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -302,7 +302,7 @@ def _get_model_ids_for_tombstone_cascade(
     watermark_batch: WatermarkBatch,
 ) -> tuple[list[int], datetime.datetime]:
     """
-    Queries the database or databases if spanning multiple), and returns
+    Queries the database or databases if spanning multiple, and returns
      a tuple with a list of row IDs to delete, and the oldest
      tombstone timestamp for the batch.
 

--- a/tests/sentry/tasks/deletion/test_hybrid_cloud.py
+++ b/tests/sentry/tasks/deletion/test_hybrid_cloud.py
@@ -357,7 +357,7 @@ def test_get_ids_for_tombstone_cascade_cross_db(task_runner):
 @region_silo_test
 def test_get_ids_for_tombstone_cascade_cross_db_watermark_bounds(task_runner):
     cascade_data = []
-    for i in range(4):
+    for i in range(3):
         cascade_data.append(setup_cross_db_deletion_data())
 
     unaffected_data = []
@@ -391,6 +391,14 @@ def test_get_ids_for_tombstone_cascade_cross_db_watermark_bounds(task_runner):
         (
             {"low": in_order_tombstones[2].id + 1, "up": in_order_tombstones[2].id + 5},
             [],
+        ),
+        (
+            {"low": -1, "up": in_order_tombstones[2].id + 1},
+            [
+                cascade_data[0]["monitor"].id,
+                cascade_data[1]["monitor"].id,
+                cascade_data[2]["monitor"].id,
+            ],
         ),
     ]
 


### PR DESCRIPTION
 Adds cross-database tombstone deletion support

The current tombstone code performs a join between the model and
tombstone tables to construct a minimal set of IDs to update or delete
from the target table.

Because this isn't possible when the target model lives in a different
database (e.g. crons monitors), we have to take a 2 step approach:
1. Query the tombstone table for the current IDs list matching the
watermarking batch.
2. Query the model table for all rows with a matching identifier on the
target field

There are possible performance concerns with the model-side query, so
I've placed this behind a new option named
`hyrid_cloud.allow_cross_db_tombstones`. If the flag is disabled and a
cross db tombstone cleanup is attempted, an explicit exception is raised
noting why the cleanup failed.