### PR TITLE
feat(metrics): Rename block to disable

### DIFF
--- a/static/app/views/settings/projectMetrics/blockButton.tsx
+++ b/static/app/views/settings/projectMetrics/blockButton.tsx
@@ -5,41 +5,90 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconNot, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
-import type {OpenConfirmOptions} from '../../../components/confirm';
+type BlockTarget = 'metric' | 'tag';
 
-export interface BlockButtonProps
-  extends BaseButtonProps,
-    Pick<OpenConfirmOptions, 'message'> {
+export interface BlockButtonProps extends BaseButtonProps {
+  blockTarget: BlockTarget;
   hasAccess: boolean;
   isBlocked: boolean;
   onConfirm: () => void;
 }
 
-export function BlockButton({isBlocked, onConfirm, ...props}: BlockButtonProps) {
-  const button = (
-    <Button
-      {...props}
-      icon={isBlocked ? <IconPlay size="xs" /> : <IconNot size="xs" />}
-      disabled={!props.hasAccess || props.disabled}
-    >
-      {isBlocked ? t('Unblock') : t('Block')}
-    </Button>
-  );
+const tooltipText: Record<BlockTarget, string> = {
+  metric: t(
+    'Disabling a metric blocks its ingestion and makes it inaccessible in Metrics, Alerts, and Dashboards.'
+  ),
+  tag: t(
+    'Disabling a tag blocks its ingestion and makes it inaccessible in Metrics, Alerts, and Dashboards.'
+  ),
+};
 
-  return (
+const blockConfirmText: Record<BlockTarget, string> = {
+  metric: t(
+    'Are you sure you want to disable this metric? It will no longer be ingested, and will not be available for use in Metrics, Alerts, or Dashboards.'
+  ),
+  tag: t(
+    'Are you sure you want to disable this tag? It will no longer be ingested, and will not be available for use in Metrics, Alerts, or Dashboards.'
+  ),
+};
+
+const unblockConfirmText: Record<BlockTarget, string> = {
+  metric: t('Are you sure you want to activate this metric?'),
+  tag: t('Are you sure you want to activate this tag?'),
+};
+
+const blockAriaLabel: Record<BlockTarget, string> = {
+  metric: t('Disable metric'),
+  tag: t('Disable tag'),
+};
+
+const unblockAriaLabel: Record<BlockTarget, string> = {
+  metric: t('Activate metric'),
+  tag: t('Activate tag'),
+};
+
+export function BlockButton({
+  isBlocked,
+  blockTarget,
+  onConfirm,
+  hasAccess,
+  ...props
+}: BlockButtonProps) {
+  const button = (
     <Confirm
       priority="danger"
       onConfirm={onConfirm}
-      message={props.message}
-      confirmText={isBlocked ? t('Unblock') : t('Block')}
+      message={
+        isBlocked ? unblockConfirmText[blockTarget] : blockConfirmText[blockTarget]
+      }
+      confirmText={isBlocked ? t('Activate') : t('Disable')}
     >
-      {props.hasAccess ? (
-        button
-      ) : (
-        <Tooltip title={t('You do not have permissions to edit metrics.')}>
-          {button}
-        </Tooltip>
-      )}
+      <Button
+        {...props}
+        aria-label={
+          isBlocked ? unblockAriaLabel[blockTarget] : blockAriaLabel[blockTarget]
+        }
+        icon={isBlocked ? <IconPlay size="xs" /> : <IconNot size="xs" />}
+        disabled={!hasAccess || props.disabled}
+      >
+        {isBlocked ? t('Activate') : t('Disable')}
+      </Button>
     </Confirm>
+  );
+
+  const hasTooltip = !hasAccess || !isBlocked;
+
+  return hasTooltip ? (
+    <Tooltip
+      title={
+        hasAccess
+          ? tooltipText[blockTarget]
+          : t('You do not have permissions to edit metrics.')
+      }
+    >
+      {button}
+    </Tooltip>
+  ) : (
+    button
   );
 }

--- a/static/app/views/settings/projectMetrics/projectMetrics.tsx
+++ b/static/app/views/settings/projectMetrics/projectMetrics.tsx
@@ -203,14 +203,7 @@ function MetricsTable({metrics, isLoading, query, project}: MetricsTableProps) {
                 hasAccess={hasAccess}
                 disabled={blockMetricMutation.isLoading}
                 isBlocked={isBlocked}
-                aria-label={t('Block Metric')}
-                message={
-                  isBlocked
-                    ? t('Are you sure you want to unblock this metric?')
-                    : t(
-                        'Are you sure you want to block this metric? It will no longer be ingested, and will not be available for use in Metrics, Alerts, or Dashboards.'
-                      )
-                }
+                blockTarget="metric"
                 onConfirm={() => {
                   blockMetricMutation.mutate({
                     mri,

--- a/static/app/views/settings/projectMetrics/projectMetricsDetails.tsx
+++ b/static/app/views/settings/projectMetrics/projectMetricsDetails.tsx
@@ -135,14 +135,7 @@ function ProjectMetricsDetails({project, params, organization}: Props) {
               disabled={blockMetricMutation.isLoading}
               isBlocked={isBlockedMetric}
               onConfirm={handleMetricBlockToggle}
-              aria-label={t('Block Metric')}
-              message={
-                isBlockedMetric
-                  ? t('Are you sure you want to unblock this metric?')
-                  : t(
-                      'Are you sure you want to block this metric? It will no longer be ingested, and will not be available for use in Metrics, Alerts, or Dashboards.'
-                    )
-              }
+              blockTarget="metric"
             />
             <LinkButton
               to={getMetricsUrl(organization.slug, {
@@ -242,14 +235,7 @@ function ProjectMetricsDetails({project, params, organization}: Props) {
                   disabled={blockMetricMutation.isLoading || isBlockedMetric}
                   isBlocked={isBlockedTag}
                   onConfirm={() => handleMetricTagBlockToggle(key)}
-                  aria-label={t('Block tag')}
-                  message={
-                    isBlockedTag
-                      ? t('Are you sure you want to unblock this tag?')
-                      : t(
-                          'Are you sure you want to block this tag? It will no longer be ingested, and will not be available for use in Metrics, Alerts, or Dashboards.'
-                        )
-                  }
+                  blockTarget="tag"
                 />
               </TextAlignRight>
             </Fragment>


### PR DESCRIPTION
Rename block & unblock to disable & activate.
Add tooltip for disable action.
Restructure the component to make the copy easier to change next time.

![Screenshot 2024-04-23 at 09 00 34](https://github.com/getsentry/sentry/assets/7033940/1e692000-229a-44d4-a695-b2bccbac1b6b)
![Screenshot 2024-04-23 at 09 01 04](https://github.com/getsentry/sentry/assets/7033940/99675780-0033-4ff2-adbe-e1dc68401cbc)

- closes https://github.com/getsentry/sentry/issues/69392