### PR TITLE
fix(linting): Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <p align="center">
     <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
-      <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84">
+      <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84" />
     </a>
   </p>
   <p align="center">
@@ -14,10 +14,10 @@
 Sentry is a developer-first error tracking and performance monitoring platform that helps developers see what actually matters, solve quicker, and learn continuously about their applications.
 
 <p align="center">
-  <img src="https://github.com/getsentry/sentry/raw/master/.github/screenshots/projects.png" width="270">
-  <img src="https://github.com/getsentry/sentry/raw/master/.github/screenshots/issue-details.png" width="270">
-  <img src="https://github.com/getsentry/sentry/raw/master/.github/screenshots/transaction-summary.png" width="270">
-  <img src="https://github.com/getsentry/sentry/raw/master/.github/screenshots/releases.png" width="270">
+  <img src="https://github.com/getsentry/sentry/raw/master/.github/screenshots/projects.png" width="270" />
+  <img src="https://github.com/getsentry/sentry/raw/master/.github/screenshots/issue-details.png" width="270" />
+  <img src="https://github.com/getsentry/sentry/raw/master/.github/screenshots/transaction-summary.png" width="270" />
+  <img src="https://github.com/getsentry/sentry/raw/master/.github/screenshots/releases.png" width="270" />
 </p>
 
 ## Official Sentry SDKs


### PR DESCRIPTION
Close `img` tags in `README.md`.

#### Background
Linting fails in [another PR](https://github.com/getsentry/sentry/pull/67576) that edits `README.md` as the `img` tags are not closed.
