### PR TITLE
fix(metrics): remove assert totals in get_crash_free_rate

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -171,8 +171,11 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                     )
             except Exception as e:
                 logger.exception("Unable to log; %s", e)
-            assert totals is not None
-            ret_val[project_id] = totals * 100
+
+            if totals is not None:
+                ret_val[project_id] = totals * 100
+            else:
+                ret_val[project_id] = None
 
         return ret_val
 

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -45,9 +45,8 @@ from sentry.snuba.metrics import (
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.sessions import _make_stats, get_rollup_starts_and_buckets
 from sentry.snuba.sessions_v2 import QueryDefinition
-from sentry.utils import json
 from sentry.utils.dates import to_datetime
-from sentry.utils.safe import get_path
+from sentry.utils.safe import PathSearchable, get_path
 from sentry.utils.snuba import QueryOutsideRetentionError
 
 SMALLEST_METRICS_BUCKET = 10
@@ -122,6 +121,24 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         return projects, org_ids.pop()
 
     @staticmethod
+    def _extract_crash_free_rate_from_result_groups(
+        result_groups: list[PathSearchable],
+    ) -> dict[int, float | None]:
+        crash_free_rates: dict[int, float | None] = {}
+        for result_group in result_groups:
+            project_id = get_path(result_group, "by", "project_id")
+            if project_id is None:
+                continue
+
+            totals = get_path(result_group, "totals", "rate", should_log=True)
+            if totals is not None:
+                crash_free_rates[project_id] = totals * 100
+            else:
+                crash_free_rates[project_id] = None
+
+        return crash_free_rates
+
+    @staticmethod
     def _get_crash_free_rate_data(
         org_id: int,
         projects: Sequence[Project],
@@ -151,33 +168,10 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             include_totals=True,
         )
         result = get_series(projects=projects, metrics_query=query, use_case_id=USE_CASE_ID)
-
-        groups = get_path(result, "groups", default=[])
-        ret_val = {}
-        for group in groups:
-            project_id = get_path(group, "by", "project_id")
-            assert project_id is not None
-            totals = get_path(group, "totals", "rate", should_log=True)
-            try:
-                if totals is None:
-                    logger.info(
-                        "sentry.release_health.metrics._get_crash_free_rate_data.totals_is_none",
-                        extra={
-                            "group": json.dumps(group),
-                            "project_id": json.dumps(project_id),
-                            "organization_id": org_id,
-                            "timeseries_for_query": json.dumps(result),
-                        },
-                    )
-            except Exception as e:
-                logger.exception("Unable to log; %s", e)
-
-            if totals is not None:
-                ret_val[project_id] = totals * 100
-            else:
-                ret_val[project_id] = None
-
-        return ret_val
+        result_groups = get_path(result, "groups", default=[])
+        return MetricsReleaseHealthBackend._extract_crash_free_rate_from_result_groups(
+            result_groups=result_groups
+        )
 
     def is_metrics_based(self) -> bool:
         return True

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -121,7 +121,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         return projects, org_ids.pop()
 
     @staticmethod
-    def _extract_crash_free_rate_from_result_groups(
+    def _extract_crash_free_rates_from_result_groups(
         result_groups: list[PathSearchable],
     ) -> dict[int, float | None]:
         crash_free_rates: dict[int, float | None] = {}
@@ -169,7 +169,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )
         result = get_series(projects=projects, metrics_query=query, use_case_id=USE_CASE_ID)
         result_groups = get_path(result, "groups", default=[])
-        return MetricsReleaseHealthBackend._extract_crash_free_rate_from_result_groups(
+        return MetricsReleaseHealthBackend._extract_crash_free_rates_from_result_groups(
             result_groups=result_groups
         )
 

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -46,7 +46,7 @@ from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.sessions import _make_stats, get_rollup_starts_and_buckets
 from sentry.snuba.sessions_v2 import QueryDefinition
 from sentry.utils.dates import to_datetime
-from sentry.utils.safe import PathSearchable, get_path
+from sentry.utils.safe import get_path
 from sentry.utils.snuba import QueryOutsideRetentionError
 
 SMALLEST_METRICS_BUCKET = 10
@@ -122,7 +122,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
     @staticmethod
     def _extract_crash_free_rates_from_result_groups(
-        result_groups: list[PathSearchable],
+        result_groups: Sequence[Any],
     ) -> dict[int, float | None]:
         crash_free_rates: dict[int, float | None] = {}
         for result_group in result_groups:
@@ -145,7 +145,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         start: datetime,
         end: datetime,
         rollup: int,
-    ) -> dict[int, float]:
+    ) -> dict[int, float | None]:
 
         project_ids = [p.id for p in projects]
 

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -995,6 +995,31 @@ class GetCrashFreeRateTestCase(TestCase, BaseMetricsTestCase):
             },
         }
 
+    def test_extract_crash_free_rate_from_result_groups(self):
+        result_groups = [
+            {"by": {"project_id": 1}, "totals": {"rate": 0.66}},
+            {"by": {"project_id": 2}, "totals": {"rate": 0.8}},
+        ]
+        crash_free_rates = self.backend._extract_crash_free_rate_from_result_groups(result_groups)
+        assert crash_free_rates[1] == 0.66 * 100
+        assert crash_free_rates[2] == 0.8 * 100
+
+    def test_extract_crash_free_rate_from_result_groups_with_none(self):
+        result_groups = [
+            {"by": {"project_id": 1}, "totals": {"rate": 0.66}},
+            {"by": {"project_id": 2}, "totals": {"rate": None}},
+        ]
+        crash_free_rates = self.backend._extract_crash_free_rate_from_result_groups(result_groups)
+        assert crash_free_rates[1] == 0.66 * 100
+        assert crash_free_rates[2] is None
+
+    def test_extract_crash_free_rate_from_result_groups_only_none(self):
+        result_groups = [
+            {"by": {"project_id": 2}, "totals": {"rate": None}},
+        ]
+        crash_free_rates = self.backend._extract_crash_free_rate_from_result_groups(result_groups)
+        assert crash_free_rates[2] is None
+
 
 class GetProjectReleasesCountTest(TestCase, BaseMetricsTestCase):
     backend = MetricsReleaseHealthBackend()

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1000,7 +1000,7 @@ class GetCrashFreeRateTestCase(TestCase, BaseMetricsTestCase):
             {"by": {"project_id": 1}, "totals": {"rate": 0.66}},
             {"by": {"project_id": 2}, "totals": {"rate": 0.8}},
         ]
-        crash_free_rates = self.backend._extract_crash_free_rate_from_result_groups(result_groups)
+        crash_free_rates = self.backend._extract_crash_free_rates_from_result_groups(result_groups)
         assert crash_free_rates[1] == 0.66 * 100
         assert crash_free_rates[2] == 0.8 * 100
 
@@ -1009,15 +1009,15 @@ class GetCrashFreeRateTestCase(TestCase, BaseMetricsTestCase):
             {"by": {"project_id": 1}, "totals": {"rate": 0.66}},
             {"by": {"project_id": 2}, "totals": {"rate": None}},
         ]
-        crash_free_rates = self.backend._extract_crash_free_rate_from_result_groups(result_groups)
+        crash_free_rates = self.backend._extract_crash_free_rates_from_result_groups(result_groups)
         assert crash_free_rates[1] == 0.66 * 100
         assert crash_free_rates[2] is None
 
-    def test_extract_crash_free_rate_from_result_groups_only_none(self):
+    def test_extract_crash_free_rates_from_result_groups_only_none(self):
         result_groups = [
             {"by": {"project_id": 2}, "totals": {"rate": None}},
         ]
-        crash_free_rates = self.backend._extract_crash_free_rate_from_result_groups(result_groups)
+        crash_free_rates = self.backend._extract_crash_free_rates_from_result_groups(result_groups)
         assert crash_free_rates[2] is None
 
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/65548

There was an assert statement to check that totals is not None in the function _get_crash_free_rate_data. This assert, when stepping through the containing functions, doesn't appear to do much other than preventing providing a None to an already None-default field. It could also be that the None was asserted so the multiplication by 100 does not fail due to type mismatch. The error scenario described in the issue could not be reproduced locally, but removing the assert and handling the None case should provide the correct behaviour.
