### PR TITLE
feat(perf): Add HTTP module unknown domain banner

### DIFF
--- a/static/app/views/performance/http/httpDomainSummaryPage.tsx
+++ b/static/app/views/performance/http/httpDomainSummaryPage.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import Alert from 'sentry/components/alert';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import FeatureBadge from 'sentry/components/badge/featureBadge';
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
@@ -186,6 +188,21 @@ export function HTTPDomainSummaryPage() {
       <Layout.Body>
         <Layout.Main fullWidth>
           <FloatingFeedbackWidget />
+
+          {domain === '' && (
+            <Alert type="info">
+              {tct(
+                '"Unknown Domain" entries can be caused by instrumentation errors. Please refer to our [link] for more information.',
+                {
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/product/performance/requests/">
+                      documentation
+                    </ExternalLink>
+                  ),
+                }
+              )}
+            </Alert>
+          )}
 
           <ModuleLayout.Layout>
             <ModuleLayout.Full>


### PR DESCRIPTION
**e.g.,**
<img width="840" alt="Screenshot 2024-04-23 at 12 13 13 PM" src="https://github.com/getsentry/sentry/assets/989898/f3c9a6de-9dc9-404e-8ad1-2f059c655f25">

Unknown domains are an annoying and fixable error. I don't want people to just give up when they see this! It might be a matter of updating their SDK, or something else simple.
