### PR TITLE
feat(perf): Add feature flag for new spans UI

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1784,6 +1784,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:performance-streamed-spans-exp-visible": False,
     # Hides some fields and sections in the transaction summary page that are being deprecated
     "organizations:performance-transaction-summary-cleanup": False,
+    # Enables the new UI for span summary and the spans tab
+    "organizations:performance-spans-new-ui": True,
     # Enable processing slow issue alerts
     "organizations:process-slow-alerts": False,
     # Enable profiling

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1785,7 +1785,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Hides some fields and sections in the transaction summary page that are being deprecated
     "organizations:performance-transaction-summary-cleanup": False,
     # Enables the new UI for span summary and the spans tab
-    "organizations:performance-spans-new-ui": True,
+    "organizations:performance-spans-new-ui": False,
     # Enable processing slow issue alerts
     "organizations:process-slow-alerts": False,
     # Enable profiling

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -166,6 +166,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-transaction-name-only-search", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-transaction-name-only-search-indexed", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-transaction-summary-cleanup", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:performance-spans-new-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-streamed-spans-exp-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:performance-streamed-spans-exp-visible", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:process-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
Adds a feature flag for switching to the new UI for the span summary / spans tab in txn summary. These pages have been updated with new designs and leverage the span metrics dataset.