### PR TITLE
feat(replays): Component Names in Rage & Dead Breadcrumbs

### DIFF
--- a/static/app/components/replays/breadcrumbs/selectorList.tsx
+++ b/static/app/components/replays/breadcrumbs/selectorList.tsx
@@ -19,7 +19,11 @@ export default function SelectorList({frame}: {frame: ClickFrame}) {
   return componentName ? (
     <Fragment>
       <span>{frame.message.substring(0, lastComponentIndex)}</span>
-      <Tooltip title={t('Search by this component')} isHoverable>
+      <Tooltip
+        title={t('Search by this component')}
+        containerDisplayMode="inline"
+        isHoverable
+      >
         <Link
           to={{
             pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),

--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -380,9 +380,15 @@ function defaultTitle(frame: ReplayFrame) {
 function stringifyNodeAttributes(node: SlowClickFrame['data']['node']) {
   const {tagName, attributes} = node ?? {};
   const attributesEntries = Object.entries(attributes ?? {});
-  return `${tagName}${
+  const componentName = node?.attributes['data-sentry-component'];
+
+  return `${componentName ?? tagName}${
     attributesEntries.length
-      ? attributesEntries.map(([attr, val]) => `[${attr}="${val}"]`).join('')
+      ? attributesEntries
+          .map(([attr, val]) =>
+            componentName && attr === 'data-sentry-component' ? '' : `[${attr}="${val}"]`
+          )
+          .join('')
       : ''
   }`;
 }


### PR DESCRIPTION
Use component name in rage and dead breadcrumbs if available.

Relates to https://github.com/getsentry/sentry/issues/64673