### PR TITLE
chore(replay/issues): add issue_replay_inline_onboarding to prompts config

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -19,6 +19,7 @@ DEFAULT_PROMPTS = {
     "issue_priority": {"required_fields": ["organization_id"]},
     "data_consent_banner": {"required_fields": ["organization_id"]},
     "data_consent_priority": {"required_fields": ["organization_id"]},
+    "issue_replay_inline_onboarding": {"required_fields": ["organization_id", "project_id"]},
 }
 
 


### PR DESCRIPTION
- Relates to https://github.com/getsentry/sentry/issues/69207
- Will be used to update the dismiss mechanism of the issue details replay inline onboarding banner
- Added `project_id` as a required field since we want to store the dismissal across project

<img width="863" alt="SCR-20240423-jmxe" src="https://github.com/getsentry/sentry/assets/56095982/a9e1efc3-3325-4669-9a9b-d44dda66fcda">
