### PR TITLE
chore(github): fix name of extensibility agent option and add an org option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -549,7 +549,16 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register("github-login.organization", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
-register("github-extension", default=False, flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE)
+register(
+    "github-extension.enabled",
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "github-extension.enabled-orgs",
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # VSTS Integration
 register("vsts.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)


### PR DESCRIPTION
I somehow missed committing the `.enabled part` to the `github-extension` option. Also adding another option so it's easy to add orgs in, it will be the Sentry org first for internal testing (and later Github). We are assuming the user is only a member of one of these orgs.

Note that this is a temporary workaround for the demo.