### PR TITLE
fix(replays): dont let superusers affect viewed by

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_viewed_by.py
+++ b/src/sentry/replays/endpoints/project_replay_viewed_by.py
@@ -84,11 +84,11 @@ class ProjectReplayViewedByEndpoint(ProjectEndpoint):
         if viewed_by_ids == []:
             return Response({"data": {"viewed_by": []}}, status=200)
 
-        # Note: in the rare/error case where Snuba returns non-existent user ids, this fx will filter them out.
         serialized_users = user_service.serialize_many(
-            filter=dict(user_ids=viewed_by_ids),
+            filter=dict(user_ids=viewed_by_ids, organization_id=project.organization.id),
             as_user=serialize_generic_user(request.user),
         )
+
         serialized_users = [_normalize_user(user) for user in serialized_users]
 
         return Response({"data": {"viewed_by": serialized_users}}, status=200)
@@ -104,6 +104,11 @@ class ProjectReplayViewedByEndpoint(ProjectEndpoint):
             replay_id = str(uuid.UUID(replay_id))
         except ValueError:
             return Response(status=404)
+
+        user_orgs = user_service.get_organizations(user_id=request.user.id)
+        if project.organization.id not in [org.id for org in user_orgs]:
+            # If the user is not in the same organization as the replay, we don't need to do anything.
+            return Response(status=204)
 
         # make a query to avoid overwriting the `finished_at` column
         filter_params = self.get_filter_params(request, project, date_filter_optional=False)

--- a/tests/sentry/replays/test_project_replay_viewed_by.py
+++ b/tests/sentry/replays/test_project_replay_viewed_by.py
@@ -152,3 +152,33 @@ class ProjectReplayViewedByTest(APITestCase, ReplaysSnubaTestCase):
         with self.feature(REPLAYS_FEATURES):
             response = self.client.post(self.url, data="")
             assert response.status_code == 404
+
+    @patch("sentry.replays.endpoints.project_replay_viewed_by.publish_replay_event")
+    def test_post_replay_viewed_by_not_in_org(self, publish_replay_event):
+        with self.feature(REPLAYS_FEATURES):
+            finished_at_dt = datetime.datetime.now() - datetime.timedelta(seconds=20)
+            self.store_replays(mock_replay(finished_at_dt, self.project.id, self.replay_id))
+            self.login_as(user=self.create_user(is_superuser=True, is_staff=True), superuser=True)
+            response = self.client.post(self.url, data="")
+            assert response.status_code == 204
+            assert not publish_replay_event.called
+
+    def test_get_replay_viewed_by_user_in_other_org(self):
+        other_org_member = self.create_member(
+            organization=self.create_organization(), user=self.create_user()
+        )
+        seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=10)
+        seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=5)
+        self.store_replays(mock_replay(seq1_timestamp, self.project.id, self.replay_id))
+        self.store_replays(mock_replay(seq2_timestamp, self.project.id, self.replay_id))
+
+        self.store_replays(
+            mock_replay_viewed(
+                time.time(), self.project.id, self.replay_id, other_org_member.user_id
+            )
+        )
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.get(self.url)
+            assert response.status_code == 200
+            assert len(response.data["data"]["viewed_by"]) == 0


### PR DESCRIPTION
- dont show superusers user_ids in the viewed by response
- Don't create a viewed by record if the user is not in the org of the replay