### PR TITLE
feat(apigateway): Added proxy support for `sentry_app_id_or_slug` path params

### DIFF
--- a/src/sentry/hybridcloud/apigateway/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway/apigateway.py
@@ -60,8 +60,8 @@ def proxy_request_if_needed(
         url_name = request.resolver_match.url_name or url_name
 
     if "organization_slug" in view_kwargs or "organization_id_or_slug" in view_kwargs:
-        org_id_or_slug: str = view_kwargs.get("organization_slug") or view_kwargs.get(
-            "organization_id_or_slug", ""
+        org_id_or_slug = str(
+            view_kwargs.get("organization_slug") or view_kwargs.get("organization_id_or_slug", "")
         )
 
         metrics.incr(
@@ -89,11 +89,13 @@ def proxy_request_if_needed(
         return proxy_sentryappinstallation_request(request, install_uuid, url_name)
 
     if (
-        "sentry_app_slug" in view_kwargs
+        ("sentry_app_slug" in view_kwargs or "sentry_app_id_or_slug" in view_kwargs)
         and request.resolver_match
         and request.resolver_match.url_name in SENTRY_APP_REGION_URL_NAMES
     ):
-        app_slug = view_kwargs["sentry_app_slug"]
+        app_id_or_slug = str(
+            view_kwargs.get("sentry_app_slug") or view_kwargs.get("sentry_app_id_or_slug", "")
+        )
         metrics.incr(
             "apigateway.proxy_request",
             tags={
@@ -101,7 +103,7 @@ def proxy_request_if_needed(
                 "kind": "sentryapp",
             },
         )
-        return proxy_sentryapp_request(request, app_slug, url_name)
+        return proxy_sentryapp_request(request, app_id_or_slug, url_name)
 
     if (
         request.resolver_match

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -126,19 +126,24 @@ def proxy_sentryappinstallation_request(
     return proxy_region_request(request, region, url_name)
 
 
-def proxy_sentryapp_request(request: HttpRequest, app_slug: str, url_name: str) -> HttpResponseBase:
+def proxy_sentryapp_request(
+    request: HttpRequest, app_id_or_slug: str, url_name: str
+) -> HttpResponseBase:
     """Take a django request object and proxy it to the region of the organization that owns a sentryapp"""
     try:
-        sentry_app = SentryApp.objects.get(slug=app_slug)
+        if app_id_or_slug.isnumeric():
+            sentry_app = SentryApp.objects.get(id=app_id_or_slug)
+        else:
+            sentry_app = SentryApp.objects.get(slug=app_id_or_slug)
     except SentryApp.DoesNotExist as e:
-        logger.info("region_resolution_error", extra={"app_slug": app_slug, "error": str(e)})
+        logger.info("region_resolution_error", extra={"app_slug": app_id_or_slug, "error": str(e)})
         return HttpResponse(status=404)
 
     try:
         organization_mapping = OrganizationMapping.objects.get(organization_id=sentry_app.owner_id)
         region = get_region_by_name(organization_mapping.region_name)
     except (RegionResolutionError, OrganizationMapping.DoesNotExist) as e:
-        logger.info("region_resolution_error", extra={"app_slug": app_slug, "error": str(e)})
+        logger.info("region_resolution_error", extra={"app_slug": app_id_or_slug, "error": str(e)})
         return HttpResponse(status=404)
 
     return proxy_region_request(request, region, url_name)

--- a/tests/sentry/hybridcloud/apigateway/test_apigateway.py
+++ b/tests/sentry/hybridcloud/apigateway/test_apigateway.py
@@ -320,12 +320,28 @@ class ApiGatewayTest(ApiGatewayTestCase):
             f"{self.REGION.address}/sentry-apps/{sentry_app.slug}/requests/",
             json={"proxy": True, "name": "requests"},
         )
+        responses.add(
+            responses.GET,
+            f"{self.REGION.address}/sentry-apps/{sentry_app.id}/interaction/",
+            json={"proxy": True, "name": "interaction"},
+        )
+        responses.add(
+            responses.GET,
+            f"{self.REGION.address}/sentry-apps/{sentry_app.id}/requests/",
+            json={"proxy": True, "name": "requests"},
+        )
 
         with override_settings(MIDDLEWARE=tuple(self.middleware)):
             resp = self.client.get(f"/sentry-apps/{sentry_app.slug}/interaction/")
             self._check_response(resp, "interaction")
 
             resp = self.client.get(f"/sentry-apps/{sentry_app.slug}/requests/")
+            self._check_response(resp, "requests")
+
+            resp = self.client.get(f"/sentry-apps/{sentry_app.id}/interaction/")
+            self._check_response(resp, "interaction")
+
+            resp = self.client.get(f"/sentry-apps/{sentry_app.id}/requests/")
             self._check_response(resp, "requests")
 
     @responses.activate


### PR DESCRIPTION
* Similar to https://github.com/getsentry/sentry/pull/69245

This PR adds support for `sentry_app_id_or_slug` existing in path parameter, so when we go change all our apis from `sentry_app_slug` to `sentry_app_id_or_slug`, we can still proxy correctly.

I also fixed a small type mismatch issue I saw with the value of `org_id_or_slug`.