### PR TITLE
feat(crons): Add crons.use_clock_pulse_consumer option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1815,6 +1815,14 @@ register(
 # Killswitch for monitor check-ins
 register("crons.organization.disable-check-in", type=Sequence, default=[])
 
+# Controls the method of clock task dispatch. This is part of GH-58410 and will
+# enable dispatching via the clock pulse consumer instead of using celery tassk
+register(
+    "crons.use_clock_pulse_consumer",
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Turns on and off the running for dynamic sampling collect_orgs.
 register("dynamic-sampling.tasks.collect_orgs", default=False, flags=FLAG_MODIFIABLE_BOOL)
 


### PR DESCRIPTION
This will control producing clock pulse messages into a kafka topic
instead of dispatching to celery