### PR TITLE
feat(new-trace): Adding issues link to trace header.

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -1,14 +1,11 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
-import * as qs from 'query-string';
 
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import Count from 'sentry/components/count';
 import EventOrGroupExtraDetails from 'sentry/components/eventOrGroupExtraDetails';
-import Link from 'sentry/components/links/link';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import PanelItem from 'sentry/components/panels/panelItem';
@@ -20,21 +17,12 @@ import {space} from 'sentry/styles/space';
 import type {Group, Organization} from 'sentry/types';
 import type {TraceErrorOrIssue} from 'sentry/utils/performance/quickTrace/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {decodeScalar} from 'sentry/utils/queryString';
-import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
 import type {
   TraceTree,
   TraceTreeNode,
 } from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 
-import {
-  isAutogroupedNode,
-  isMissingInstrumentationNode,
-  isSpanNode,
-  isTraceErrorNode,
-  isTransactionNode,
-} from '../../../guards';
+import {TraceDrawerComponents} from '../styles';
 
 import {IssueSummary} from './issueSummary';
 
@@ -139,43 +127,8 @@ export function IssueList({issues, node, organization}: IssueListProps) {
   );
 }
 
-function getSearchParamFromNode(node: TraceTreeNode<TraceTree.NodeValue>) {
-  if (isTransactionNode(node) || isTraceErrorNode(node)) {
-    return `id:${node.value.event_id}`;
-  }
-
-  // Issues associated to a span or autogrouped node are not queryable, so we query by
-  // the parent transaction's id
-  const parentTransaction = node.parent_transaction;
-  if ((isSpanNode(node) || isAutogroupedNode(node)) && parentTransaction) {
-    return `id:${parentTransaction.value.event_id}`;
-  }
-
-  if (isMissingInstrumentationNode(node)) {
-    throw new Error('Missing instrumentation nodes do not have associated issues');
-  }
-
-  return '';
-}
-
 function IssueListHeader({node}: {node: TraceTreeNode<TraceTree.NodeValue>}) {
   const {errors, performance_issues} = node;
-  const organization = useOrganization();
-  const params = useParams<{traceSlug?: string}>();
-
-  const traceSlug = params.traceSlug?.trim() ?? '';
-
-  const dateSelection = useMemo(() => {
-    const normalizedParams = normalizeDateTimeParams(qs.parse(window.location.search), {
-      allowAbsolutePageDatetime: true,
-    });
-    const start = decodeScalar(normalizedParams.start);
-    const end = decodeScalar(normalizedParams.end);
-    const statsPeriod = decodeScalar(normalizedParams.statsPeriod);
-
-    return {start, end, statsPeriod};
-  }, []);
-
   const [singular, plural] = useMemo((): [string, string] => {
     const label = [t('Issue'), t('Issues')] as [string, string];
     for (const event of errors) {
@@ -192,24 +145,7 @@ function IssueListHeader({node}: {node: TraceTreeNode<TraceTree.NodeValue>}) {
         {errors.size + performance_issues.size > MAX_DISPLAYED_ISSUES_COUNT
           ? tct(`[count]+  issues, [link]`, {
               count: MAX_DISPLAYED_ISSUES_COUNT,
-              link: (
-                <StyledLink
-                  to={{
-                    pathname: `/organizations/${organization.slug}/issues/`,
-                    query: {
-                      query: `trace:${traceSlug} ${getSearchParamFromNode(node)}`,
-                      start: dateSelection.start,
-                      end: dateSelection.end,
-                      statsPeriod: dateSelection.statsPeriod,
-                      // If we don't pass the project param, the issues page will filter by the last selected project.
-                      // Traces can have multiple projects, so we query issues by all projects and rely on our search query to filter the results.
-                      project: -1,
-                    },
-                  }}
-                >
-                  {t('View All')}
-                </StyledLink>
-              ),
+              link: <StyledIssuesLink node={node}>{t('View All')}</StyledIssuesLink>,
             })
           : errors.size > 0 && performance_issues.size === 0
             ? tct('[count] [text]', {
@@ -247,7 +183,7 @@ function IssueListHeader({node}: {node: TraceTreeNode<TraceTree.NodeValue>}) {
   );
 }
 
-const StyledLink = styled(Link)`
+const StyledIssuesLink = styled(TraceDrawerComponents.IssuesLink)`
   margin-left: ${space(0.5)};
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -5,16 +5,24 @@ import * as qs from 'query-string';
 import {Button as CommonButton, LinkButton} from 'sentry/components/button';
 import {DataSection} from 'sentry/components/events/styles';
 import type {LazyRenderProps} from 'sentry/components/lazyRender';
+import Link from 'sentry/components/links/link';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getDuration} from 'sentry/utils/formatters';
+import {decodeScalar} from 'sentry/utils/queryString';
 import type {ColorOrAlias} from 'sentry/utils/theme';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import {
   isAutogroupedNode,
+  isMissingInstrumentationNode,
   isSpanNode,
+  isTraceErrorNode,
+  isTransactionNode,
 } from 'sentry/views/performance/newTraceDetails/guards';
 import type {
   TraceTree,
@@ -285,6 +293,67 @@ function TableRow({
   );
 }
 
+function getSearchParamFromNode(node: TraceTreeNode<TraceTree.NodeValue>) {
+  if (isTransactionNode(node) || isTraceErrorNode(node)) {
+    return `id:${node.value.event_id}`;
+  }
+
+  // Issues associated to a span or autogrouped node are not queryable, so we query by
+  // the parent transaction's id
+  const parentTransaction = node.parent_transaction;
+  if ((isSpanNode(node) || isAutogroupedNode(node)) && parentTransaction) {
+    return `id:${parentTransaction.value.event_id}`;
+  }
+
+  if (isMissingInstrumentationNode(node)) {
+    throw new Error('Missing instrumentation nodes do not have associated issues');
+  }
+
+  return '';
+}
+
+function IssuesLink({
+  node,
+  children,
+}: {
+  children: React.ReactNode;
+  node?: TraceTreeNode<TraceTree.NodeValue>;
+}) {
+  const organization = useOrganization();
+  const params = useParams<{traceSlug?: string}>();
+  const traceSlug = params.traceSlug?.trim() ?? '';
+
+  const dateSelection = useMemo(() => {
+    const normalizedParams = normalizeDateTimeParams(qs.parse(window.location.search), {
+      allowAbsolutePageDatetime: true,
+    });
+    const start = decodeScalar(normalizedParams.start);
+    const end = decodeScalar(normalizedParams.end);
+    const statsPeriod = decodeScalar(normalizedParams.statsPeriod);
+
+    return {start, end, statsPeriod};
+  }, []);
+
+  return (
+    <Link
+      to={{
+        pathname: `/organizations/${organization.slug}/issues/`,
+        query: {
+          query: `trace:${traceSlug} ${node ? getSearchParamFromNode(node) : ''}`,
+          start: dateSelection.start,
+          end: dateSelection.end,
+          statsPeriod: dateSelection.statsPeriod,
+          // If we don't pass the project param, the issues page will filter by the last selected project.
+          // Traces can have multiple projects, so we query issues by all projects and rely on our search query to filter the results.
+          project: -1,
+        },
+      }}
+    >
+      {children}
+    </Link>
+  );
+}
+
 const LAZY_RENDER_PROPS: Partial<LazyRenderProps> = {
   observerOptions: {rootMargin: '50px'},
 };
@@ -343,6 +412,7 @@ const TraceDrawerComponents = {
   Duration,
   TableRow,
   LAZY_RENDER_PROPS,
+  IssuesLink,
 };
 
 export {TraceDrawerComponents};

--- a/static/app/views/performance/newTraceDetails/traceHeader.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader.tsx
@@ -24,6 +24,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {BrowserDisplay} from '../transactionDetails/eventMetas';
 import {MetaData} from '../transactionDetails/styles';
 
+import {TraceDrawerComponents} from './traceDrawer/details/styles';
 import type {TraceTree} from './traceModels/traceTree';
 import {isTraceNode} from './guards';
 
@@ -221,8 +222,10 @@ export function TraceHeader({
             >
               {metaResults.isLoading ? (
                 <LoadingIndicator size={20} mini />
-              ) : errorsAndIssuesCount >= 0 ? (
-                errorsAndIssuesCount
+              ) : errorsAndIssuesCount > 0 ? (
+                <TraceDrawerComponents.IssuesLink>
+                  {errorsAndIssuesCount}
+                </TraceDrawerComponents.IssuesLink>
               ) : (
                 '\u2014'
               )}


### PR DESCRIPTION
Clicking the link takes use to issues landing whilst filtering by the traceslug:
<img width="622" alt="Screenshot 2024-04-23 at 5 14 53 PM" src="https://github.com/getsentry/sentry/assets/60121741/8352d0c2-b166-49b6-81ce-55e60b987227">
