### PR TITLE
fix(trace-explorer): Allow empty queries

### DIFF
--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -48,7 +48,9 @@ class TraceResult(TypedDict):
 class OrganizationTracesSerializer(serializers.Serializer):
     field = serializers.ListField(required=True, allow_empty=False, child=serializers.CharField())
     sort = serializers.ListField(required=False, allow_empty=True, child=serializers.CharField())
-    query = serializers.ListField(required=False, allow_empty=True, child=serializers.CharField())
+    query = serializers.ListField(
+        required=False, allow_empty=True, child=serializers.CharField(allow_blank=True)
+    )
     suggestedQuery = serializers.CharField(required=False)
     maxSpansPerTrace = serializers.IntegerField(default=1, min_value=1, max_value=100)
 
@@ -84,7 +86,8 @@ class OrganizationTracesEndpoint(OrganizationEventsV2EndpointBase):
                 if sample_rate <= 0:
                     sample_rate = None
 
-                user_queries = serialized.get("query", [])
+                # Filter out empty queries as they do not do anything to change the results.
+                user_queries = [query for query in serialized.get("query", []) if query]
 
                 trace_ids, min_timestamp, max_timestamp = self.get_matching_traces(
                     cast(ParamsType, params),

--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -136,6 +136,17 @@ class OrganizationTracesEndpointTest(BaseSpansTestCase, APITestCase):
             },
         }
 
+    def test_query_not_required(self):
+        query = {
+            "project": [self.project.id],
+            "field": ["id"],
+            "maxSpansPerTrace": 1,
+            "query": [""],
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.data
+
     def test_matching_tag(self):
         project_1 = self.create_project()
         project_2 = self.create_project()


### PR DESCRIPTION
Empty queries are being invalidated. They should be permitted as treated as the user did not specify any search conditions.