### PR TITLE
feat(autofix): Add analytics to Autofix buttons

### DIFF
--- a/static/app/components/events/autofix/autofixBanner.tsx
+++ b/static/app/components/events/autofix/autofixBanner.tsx
@@ -25,7 +25,11 @@ export function AutofixBanner({groupId, triggerAutofix, hasSuccessfulSetup}: Pro
   const isSentryEmployee = useIsSentryEmployee();
   const onClickGiveInstructions = () => {
     openModal(deps => (
-      <AutofixInstructionsModal {...deps} triggerAutofix={triggerAutofix} />
+      <AutofixInstructionsModal
+        {...deps}
+        triggerAutofix={triggerAutofix}
+        groupId={groupId}
+      />
     ));
   };
 
@@ -44,10 +48,22 @@ export function AutofixBanner({groupId, triggerAutofix, hasSuccessfulSetup}: Pro
         <ContextArea>
           {hasSuccessfulSetup ? (
             <Fragment>
-              <Button onClick={() => triggerAutofix('')} size="sm">
+              <Button
+                onClick={() => triggerAutofix('')}
+                size="sm"
+                analyticsEventKey="autofix.start_fix_clicked"
+                analyticsEventName="Autofix: Start Fix Clicked"
+                analyticsParams={{group_id: groupId}}
+              >
                 {t('Gimme Fix')}
               </Button>
-              <Button onClick={onClickGiveInstructions} size="sm">
+              <Button
+                onClick={onClickGiveInstructions}
+                size="sm"
+                analyticsEventKey="autofix.give_instructions_clicked"
+                analyticsEventName="Autofix: Give Instructions Clicked"
+                analyticsParams={{group_id: groupId}}
+              >
                 {t('Give Instructions')}
               </Button>
             </Fragment>
@@ -55,6 +71,7 @@ export function AutofixBanner({groupId, triggerAutofix, hasSuccessfulSetup}: Pro
             <Button
               analyticsEventKey="autofix.setup_clicked"
               analyticsEventName="Autofix: Setup Clicked"
+              analyticsParams={{group_id: groupId}}
               onClick={() => {
                 openModal(deps => <AutofixSetupModal {...deps} groupId={groupId} />);
               }}

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -82,7 +82,14 @@ function AutofixRepoChange({
         </div>
         {!change.pull_request ? (
           <Actions>
-            <Button size="xs" onClick={() => createPr()} busy={isLoading}>
+            <Button
+              size="xs"
+              onClick={() => createPr()}
+              busy={isLoading}
+              analyticsEventName="Autofix: Create PR Clicked"
+              analyticsEventKey="autofix.create_pr_clicked"
+              analyticsParams={{group_id: groupId}}
+            >
               {t('Create a Pull Request')}
             </Button>
           </Actions>
@@ -92,6 +99,9 @@ function AutofixRepoChange({
             icon={<IconOpen size="xs" />}
             href={change.pull_request.pr_url}
             external
+            analyticsEventName="Autofix: View PR Clicked"
+            analyticsEventKey="autofix.view_pr_clicked"
+            analyticsParams={{group_id: groupId}}
           >
             {t('View Pull Request')}
           </LinkButton>

--- a/static/app/components/events/autofix/autofixInstructionsModal.tsx
+++ b/static/app/components/events/autofix/autofixInstructionsModal.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface AutofixContextModalProps extends ModalRenderProps {
+  groupId: string;
   triggerAutofix: (value: string) => void;
 }
 
@@ -17,6 +18,7 @@ export function AutofixInstructionsModal({
   Footer,
   closeModal,
   triggerAutofix,
+  groupId,
 }: AutofixContextModalProps) {
   return (
     <Form
@@ -54,7 +56,13 @@ export function AutofixInstructionsModal({
       <Footer>
         <FooterButtons>
           <Button onClick={closeModal}>{t('Cancel')}</Button>
-          <Button priority="primary" type="submit">
+          <Button
+            priority="primary"
+            type="submit"
+            analyticsEventKey="autofix.start_fix_with_instructions_clicked"
+            analyticsEventName="Autofix: Start Fix With Instructions Clicked"
+            analyticsParams={{group_id: groupId}}
+          >
             {t("Let's go!")}
           </Button>
         </FooterButtons>

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -178,6 +178,9 @@ function CauseSuggestedFix({
           size="xs"
           onClick={() => handleSelectFix({causeId, fixId: suggestedFix.id})}
           busy={isLoading}
+          analyticsEventName="Autofix: Root Cause Fix Selected"
+          analyticsEventKey="autofix.root_cause_fix_selected"
+          analyticsParams={{group_id: groupId}}
         >
           {t('Continue With This Fix')}
         </Button>
@@ -296,6 +299,9 @@ function ProvideYourOwn({
             onClick={() => handleSelectFix({customRootCause: text})}
             disabled={!text}
             busy={isLoading}
+            analyticsEventName="Autofix: Root Cause Custom Cause Provided"
+            analyticsEventKey="autofix.root_cause_custom_cause_provided"
+            analyticsParams={{group_id: groupId}}
           >
             {t('Continue With This Fix')}
           </Button>

--- a/static/app/components/events/autofix/index.tsx
+++ b/static/app/components/events/autofix/index.tsx
@@ -5,6 +5,7 @@ import type {GroupWithAutofix} from 'sentry/components/events/autofix/types';
 import {useAiAutofix} from 'sentry/components/events/autofix/useAutofix';
 import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
 import type {Event} from 'sentry/types/event';
+import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 
 interface Props {
   event: Event;
@@ -16,6 +17,10 @@ export function Autofix({event, group}: Props) {
 
   const {hasSuccessfulSetup} = useAutofixSetup({
     groupId: group.id,
+  });
+
+  useRouteAnalyticsParams({
+    autofix_status: autofixData?.status ?? 'none',
   });
 
   return (

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -622,6 +622,8 @@ function useTrackView({
     // Will be updated in SuspectCommits if there are suspect commits
     num_suspect_commits: 0,
     suspect_commit_calculation: 'no suspect commit',
+    // Will be updated in Autofix if enabled
+    autofix_status: 'none',
   });
   useDisableRouteAnalytics(!group || !event || !project);
 }


### PR DESCRIPTION
- Adds `autofix_status` to the `issue_details.viewed` event
- Names and adds `group_id` to all button click analytic events (start fix, provide instructions, select root cause, create/view pr)