### PR TITLE
fix(metrics): releases overlay

### DIFF
--- a/static/app/views/metrics/chart/chart.tsx
+++ b/static/app/views/metrics/chart/chart.tsx
@@ -191,6 +191,7 @@ export const MetricChart = memo(
             left: 0,
             right: 0,
           },
+          additionalSeries,
           tooltip: {
             formatter: (params, asyncTicket) => {
               // Only show the tooltip if the current chart is hovered
@@ -338,13 +339,14 @@ export const MetricChart = memo(
         focusArea,
         releases,
         firstUnit,
+        additionalSeries,
       ]);
 
       if (!enableZoom) {
         return (
           <ChartWrapper>
             {focusArea?.overlay}
-            <CombinedChart {...chartProps} additionalSeries={additionalSeries} />
+            <CombinedChart {...chartProps} />
           </ChartWrapper>
         );
       }

--- a/static/app/views/metrics/chart/useMetricReleases.tsx
+++ b/static/app/views/metrics/chart/useMetricReleases.tsx
@@ -174,15 +174,12 @@ export function useReleaseSeries() {
     });
 
     return {
-      id: 'releases',
       seriesName: 'Releases',
       color: theme.purple200,
       data: [],
       markLine,
       type: 'line' as any,
       name: 'Releases',
-      total: 0,
-      unit: 'none',
     };
   }, [organization, releases, router, theme, selection.datetime.utc]);
 
@@ -190,7 +187,9 @@ export function useReleaseSeries() {
     (baseProps: CombinedMetricChartProps): CombinedMetricChartProps => {
       return {
         ...baseProps,
-        series: baseProps.series ? [...baseProps.series, releaseSeries] : [releaseSeries],
+        additionalSeries: baseProps.additionalSeries
+          ? [...baseProps.additionalSeries, releaseSeries]
+          : [releaseSeries],
       };
     },
     [releaseSeries]

--- a/static/app/views/metrics/chart/useMetricReleases.tsx
+++ b/static/app/views/metrics/chart/useMetricReleases.tsx
@@ -174,12 +174,15 @@ export function useReleaseSeries() {
     });
 
     return {
+      id: 'releases',
       seriesName: 'Releases',
       color: theme.purple200,
       data: [],
       markLine,
       type: 'line' as any,
       name: 'Releases',
+      total: 0,
+      unit: 'none',
     };
   }, [organization, releases, router, theme, selection.datetime.utc]);
 
@@ -187,9 +190,7 @@ export function useReleaseSeries() {
     (baseProps: CombinedMetricChartProps): CombinedMetricChartProps => {
       return {
         ...baseProps,
-        additionalSeries: baseProps.additionalSeries
-          ? [...baseProps.additionalSeries, releaseSeries]
-          : [releaseSeries],
+        series: baseProps.series ? [...baseProps.series, releaseSeries] : [releaseSeries],
       };
     },
     [releaseSeries]


### PR DESCRIPTION
Passes release marklines as `series` instead of `additionalSeries` not to conflict with `additionalSeries` passed from the trace view