### PR TITLE
ref(cardinality-limit): Streamline option names for cardinality limits

### DIFF
--- a/src/sentry/sentry_metrics/use_case_id_registry.py
+++ b/src/sentry/sentry_metrics/use_case_id_registry.py
@@ -55,8 +55,8 @@ REVERSE_METRIC_PATH_MAPPING: Mapping[UseCaseKey, UseCaseID] = {
 }
 
 USE_CASE_ID_CARDINALITY_LIMIT_QUOTA_OPTIONS = {
-    UseCaseID.TRANSACTIONS: "sentry-metrics.cardinality-limiter.limits.performance.per-org",
-    UseCaseID.SESSIONS: "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
+    UseCaseID.TRANSACTIONS: "sentry-metrics.cardinality-limiter.limits.transactions.per-org",
+    UseCaseID.SESSIONS: "sentry-metrics.cardinality-limiter.limits.sessions.per-org",
     UseCaseID.SPANS: "sentry-metrics.cardinality-limiter.limits.spans.per-org",
     UseCaseID.CUSTOM: "sentry-metrics.cardinality-limiter.limits.custom.per-org",
     UseCaseID.PROFILES: "sentry-metrics.cardinality-limiter.limits.profiles.per-org",

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -885,10 +885,10 @@ def test_performance_calculate_score(default_project):
 @pytest.mark.parametrize("passive", [False, True])
 def test_project_config_cardinality_limits(default_project, insta_snapshot, passive):
     options: dict[Any, Any] = {
-        "sentry-metrics.cardinality-limiter.limits.performance.per-org": [
+        "sentry-metrics.cardinality-limiter.limits.transactions.per-org": [
             {"window_seconds": 1000, "granularity_seconds": 100, "limit": 10}
         ],
-        "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org": [
+        "sentry-metrics.cardinality-limiter.limits.sessions.per-org": [
             {"window_seconds": 2000, "granularity_seconds": 200, "limit": 20}
         ],
         "sentry-metrics.cardinality-limiter.limits.spans.per-org": [


### PR DESCRIPTION
The options for cardinality limits used the old `performance` and `releasehealth` names instead of the regular namespace identifiers `transactions` and `sessions`, respectively. Options with the correct naming had been registered before.

This PR swaps out the mapping to use the correct naming and deprecates the old options. 

Requires https://github.com/getsentry/sentry-options-automator/pull/1210