### PR TITLE
fix(relay): Temporarily disable passive limits [INC-730]

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -289,7 +289,8 @@ def get_metrics_config(timeout: TimeChecker, project: Project) -> Mapping[str, A
                 "namespace": namespace.value,
             }
             if id in passive_limits:
-                limit["passive"] = True
+                # HACK inc-730: reduce pressure on memory by disabling limits for passive projects
+                continue
             cardinality_limits.append(limit)
 
         clos: list[CardinalityLimitOption] = options.get("relay.cardinality-limiter.limits")

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_cardinality_limits/True/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_cardinality_limits/True/REGION.pysnap
@@ -1,47 +1,9 @@
 ---
+created: '2024-04-24T09:41:31.898387+00:00'
+creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 cardinalityLimits:
-- id: transactions
-  limit: 10
-  namespace: transactions
-  passive: true
-  scope: organization
-  window:
-    granularitySeconds: 100
-    windowSeconds: 1000
-- id: sessions
-  limit: 20
-  namespace: sessions
-  passive: true
-  scope: organization
-  window:
-    granularitySeconds: 200
-    windowSeconds: 2000
-- id: spans
-  limit: 30
-  namespace: spans
-  passive: true
-  scope: organization
-  window:
-    granularitySeconds: 300
-    windowSeconds: 3000
-- id: custom
-  limit: 40
-  namespace: custom
-  passive: true
-  scope: organization
-  window:
-    granularitySeconds: 400
-    windowSeconds: 4000
-- id: profiles
-  limit: 60
-  namespace: profiles
-  passive: true
-  scope: organization
-  window:
-    granularitySeconds: 600
-    windowSeconds: 3600
 - id: test2
   limit: 80
   report: true


### PR DESCRIPTION
Passive projects do not enforce the cardinality limit, so it has no product impact to disable them entirely.