### PR TITLE
feat(integrations): copy rotated client secret easily

### DIFF
--- a/static/app/views/settings/account/apiApplications/details.spec.tsx
+++ b/static/app/views/settings/account/apiApplications/details.spec.tsx
@@ -109,9 +109,10 @@ describe('ApiApplications', function () {
     expect(
       screen.getByText('This will be the only time your client secret is visible!')
     ).toBeInTheDocument();
-    expect(screen.getByText('Rotated Client Secret')).toBeInTheDocument();
-    expect(screen.getByText('Your client secret is:')).toBeInTheDocument();
-    expect(screen.getByText('newSecret!')).toBeInTheDocument();
+    expect(screen.getByText('Your new Client Secret')).toBeInTheDocument();
+    expect(screen.getByLabelText<HTMLInputElement>('new-client-secret')).toHaveValue(
+      'newSecret!'
+    );
 
     expect(rotateSecretApiCall).toHaveBeenCalledTimes(1);
   });

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -38,15 +38,14 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
       );
       openModal(({Body, Header}) => (
         <Fragment>
-          <Header>{t('Rotated Client Secret')}</Header>
+          <Header>{t('Your new Client Secret')}</Header>
           <Body>
             <Alert type="info" showIcon>
               {t('This will be the only time your client secret is visible!')}
             </Alert>
-            <p>
-              {t('Your client secret is:')}
-              <code>{rotateResponse.clientSecret}</code>
-            </p>
+            <TextCopyInput aria-label="new-client-secret">
+              {rotateResponse.clientSecret}
+            </TextCopyInput>
           </Body>
         </Fragment>
       ));

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -636,9 +636,10 @@ describe('Sentry Application Details', function () {
       expect(
         screen.getByText('This will be the only time your client secret is visible!')
       ).toBeInTheDocument();
-      expect(screen.getByText('Rotated Client Secret')).toBeInTheDocument();
-      expect(screen.getByText('Your client secret is:')).toBeInTheDocument();
-      expect(screen.getByText('newSecret!')).toBeInTheDocument();
+      expect(screen.getByText('Your new Client Secret')).toBeInTheDocument();
+      expect(screen.getByLabelText<HTMLInputElement>('new-client-secret')).toHaveValue(
+        'newSecret!'
+      );
 
       expect(rotateSecretApiCall).toHaveBeenCalledTimes(1);
     });

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -328,15 +328,14 @@ class SentryApplicationDetails extends DeprecatedAsyncView<Props, State> {
       );
       openModal(({Body, Header}) => (
         <Fragment>
-          <Header>{t('Rotated Client Secret')}</Header>
+          <Header>{t('Your new Client Secret')}</Header>
           <Body>
             <Alert type="info" showIcon>
               {t('This will be the only time your client secret is visible!')}
             </Alert>
-            <p>
-              {t('Your client secret is:')}
-              <code>{rotateResponse.clientSecret}</code>
-            </p>
+            <TextCopyInput aria-label="new-client-secret">
+              {rotateResponse.clientSecret}
+            </TextCopyInput>
           </Body>
         </Fragment>
       ));


### PR DESCRIPTION
Before:
<img width="616" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/99116361-1c43-457a-81e0-89b9e59f452b">

After:
<img width="616" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/539e4191-c6a4-4800-824b-bbbdb267dbee">
