### PR TITLE
fix(metrics): aggregate select overflow

### DIFF
--- a/static/app/views/metrics/queryBuilder.tsx
+++ b/static/app/views/metrics/queryBuilder.tsx
@@ -372,6 +372,8 @@ const MetricSelect = styled(CompactSelect)`
 `;
 
 const OpSelect = styled(CompactSelect)`
+  /* makes selects from different have the same width which is enough to fit all agg options except "count_unique" */
+  min-width: 128px;
   & > button {
     width: 100%;
   }

--- a/static/app/views/metrics/queryBuilder.tsx
+++ b/static/app/views/metrics/queryBuilder.tsx
@@ -372,8 +372,6 @@ const MetricSelect = styled(CompactSelect)`
 `;
 
 const OpSelect = styled(CompactSelect)`
-  width: 128px;
-  min-width: min-content;
   & > button {
     width: 100%;
   }


### PR DESCRIPTION
- fixes: #68984 

Removes fixed width of _Agg_ dropdown

### Before

Safari
<img width="1003" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/70f4f5c9-5d88-4a05-9cc1-85029fb19aaf">

Chrome
<img width="1003" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/baccd32b-65de-4709-b065-2badcf333f38">

### After

Safari
<img width="1003" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/f7658d34-be4c-4021-b310-6cc9eb9d0a25">

Chrome
<img width="1003" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/3d2b94f1-1c92-43fa-af38-0c379ca3b4b5">
