### PR TITLE
chore(codeowners): Add `team-web-sdk-frontend` as owner for wizard-related endpoints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -416,6 +416,8 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 ## SDK
 /src/sentry/utils/sdk.py                                             @getsentry/team-web-sdk-backend
 /src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py   @getsentry/team-web-sdk-frontend
+/src/sentry/web/frontend/setup_wizard.py                             @getsentry/team-web-sdk-frontend
+/src/sentry/api/endpoints/setup_wizard.py                            @getsentry/team-web-sdk-frontend
 ## End of SDK
 
 


### PR DESCRIPTION
INC-727 follow up task

This PR adds the web SDK frontend team as codeowners of the wizard endpoints. It probably won't always help us to catch bugs in PRs touching the wizard but increases the likelihood at least by notifying us that there are changes.

closes #69571  