### PR TITLE
feat(cardinality-limit): Apply project and organization option cardinality limits

### DIFF
--- a/tests/sentry/relay/snapshots/test_config/test_project_config_cardinality_limits/False/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_cardinality_limits/False/REGION.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-04-24T14:41:11.777485+00:00'
+creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 cardinalityLimits:
@@ -37,6 +39,18 @@ cardinalityLimits:
   window:
     granularitySeconds: 600
     windowSeconds: 3600
+- id: test3
+  limit: 90
+  scope: name
+  window:
+    granularitySeconds: 900
+    windowSeconds: 9000
+- id: test4
+  limit: 100
+  scope: name
+  window:
+    granularitySeconds: 1000
+    windowSeconds: 10000
 - id: test2
   limit: 80
   report: true

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_cardinality_limits/True/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_cardinality_limits/True/REGION.pysnap
@@ -1,9 +1,21 @@
 ---
-created: '2024-04-24T09:41:31.898387+00:00'
+created: '2024-04-24T14:41:12.052529+00:00'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 cardinalityLimits:
+- id: test3
+  limit: 90
+  scope: name
+  window:
+    granularitySeconds: 900
+    windowSeconds: 9000
+- id: test4
+  limit: 100
+  scope: name
+  window:
+    granularitySeconds: 1000
+    windowSeconds: 10000
 - id: test2
   limit: 80
   report: true

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -553,9 +553,9 @@ def test_project_config_satisfaction_thresholds(
 def test_has_metric_extraction(default_project, feature_flag, killswitch):
     options = override_options(
         {
-            "relay.drop-transaction-metrics": [{"project_id": default_project.id}]
-            if killswitch
-            else []
+            "relay.drop-transaction-metrics": (
+                [{"project_id": default_project.id}] if killswitch else []
+            )
         }
     )
     feature = Feature(
@@ -938,6 +938,34 @@ def test_project_config_cardinality_limits(default_project, insta_snapshot, pass
         },
     ]
 
+    default_project.update_option(
+        "relay.cardinality-limiter.limits",
+        [
+            {
+                "limit": {
+                    "id": "test3",
+                    "window": {"windowSeconds": 9000, "granularitySeconds": 900},
+                    "limit": 90,
+                    "scope": "name",
+                }
+            }
+        ],
+    )
+
+    default_project.organization.update_option(
+        "relay.cardinality-limiter.limits",
+        [
+            {
+                "limit": {
+                    "id": "test4",
+                    "window": {"windowSeconds": 10000, "granularitySeconds": 1000},
+                    "limit": 100,
+                    "scope": "name",
+                }
+            }
+        ],
+    )
+
     features = Feature({"organizations:relay-cardinality-limiter": True})
 
     with override_options(options), features:
@@ -947,6 +975,130 @@ def test_project_config_cardinality_limits(default_project, insta_snapshot, pass
         _validate_project_config(cfg["config"])
 
         insta_snapshot(cfg["config"]["metrics"])
+
+
+@django_db_all
+@region_silo_test
+def test_project_config_cardinality_limits_project_options_override_other_options(default_project):
+    options: dict[Any, Any] = {
+        "sentry-metrics.cardinality-limiter.limits.transactions.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.sessions.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.spans.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.custom.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.generic-metrics.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.profiles.per-org": None,
+    }
+
+    options["relay.cardinality-limiter.limits"] = [
+        {
+            "limit": {
+                "id": "test1",
+                "window": {"windowSeconds": 1000, "granularitySeconds": 100},
+                "limit": 10,
+                "scope": "name",
+            },
+        },
+    ]
+
+    default_project.organization.update_option(
+        "relay.cardinality-limiter.limits",
+        [
+            {
+                "limit": {
+                    "id": "test1",
+                    "window": {"windowSeconds": 2000, "granularitySeconds": 200},
+                    "limit": 20,
+                    "scope": "name",
+                }
+            }
+        ],
+    )
+
+    default_project.update_option(
+        "relay.cardinality-limiter.limits",
+        [
+            {
+                "limit": {
+                    "id": "test1",
+                    "window": {"windowSeconds": 3000, "granularitySeconds": 300},
+                    "limit": 30,
+                    "scope": "project",
+                }
+            }
+        ],
+    )
+
+    features = Feature({"organizations:relay-cardinality-limiter": True})
+
+    with override_options(options), features:
+        project_cfg = get_project_config(default_project, full_config=True)
+
+        cfg = project_cfg.to_dict()
+        _validate_project_config(cfg["config"])
+
+        assert cfg["config"]["metrics"]["cardinalityLimits"] == [
+            {
+                "id": "test1",
+                "window": {"windowSeconds": 3000, "granularitySeconds": 300},
+                "limit": 30,
+                "scope": "project",
+            }
+        ]
+
+
+@django_db_all
+@region_silo_test
+def test_project_config_cardinality_limits_organization_options_override_options(default_project):
+    options: dict[Any, Any] = {
+        "sentry-metrics.cardinality-limiter.limits.transactions.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.sessions.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.spans.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.custom.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.generic-metrics.per-org": None,
+        "sentry-metrics.cardinality-limiter.limits.profiles.per-org": None,
+    }
+
+    options["relay.cardinality-limiter.limits"] = [
+        {
+            "limit": {
+                "id": "test1",
+                "window": {"windowSeconds": 1000, "granularitySeconds": 100},
+                "limit": 10,
+                "scope": "name",
+            },
+        },
+    ]
+
+    default_project.organization.update_option(
+        "relay.cardinality-limiter.limits",
+        [
+            {
+                "limit": {
+                    "id": "test1",
+                    "window": {"windowSeconds": 2000, "granularitySeconds": 200},
+                    "limit": 20,
+                    "scope": "project",
+                }
+            }
+        ],
+    )
+
+    features = Feature({"organizations:relay-cardinality-limiter": True})
+
+    with override_options(options), features:
+        project_cfg = get_project_config(default_project, full_config=True)
+
+        cfg = project_cfg.to_dict()
+        _validate_project_config(cfg["config"])
+
+        assert cfg["config"]["metrics"]["cardinalityLimits"] == [
+            {
+                "id": "test1",
+                "window": {"windowSeconds": 2000, "granularitySeconds": 200},
+                "limit": 20,
+                "scope": "project",
+            }
+        ]
 
 
 @patch(


### PR DESCRIPTION
- Allow defining limits from project and organization options.

- Add logic for overriding cardinality limits by id:
Limits take precedence in the following order: `project.options` > `organization.options` > `options` (automator).

In follow-up PR we will utilize the precedence mechanism to add settings for `name` scoped cardinality limits on org  and project level.
Whereby, the project setting should override the org setting.