### PR TITLE
Raise an error rather than relying on Snuba telling us

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -583,13 +583,16 @@ class BaseQueryBuilder:
         if self.end:
             conditions.append(Condition(self.column("timestamp"), Op.LT, self.end))
 
-        conditions.append(
-            Condition(
-                self.column("project_id"),
-                Op.IN,
-                self.params.project_ids,
+        # The if clause will prevent calling Snuba with an empty list of projects and complain with:
+        # sentry.utils.snuba.SnubaError: validation failed for entity events: missing required conditions for project_id
+        if self.params.project_ids:
+            conditions.append(
+                Condition(
+                    self.column("project_id"),
+                    Op.IN,
+                    self.params.project_ids,
+                )
             )
-        )
 
         if len(self.params.environments) > 0:
             term = event_search.SearchFilter(

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -583,8 +583,9 @@ class BaseQueryBuilder:
         if self.end:
             conditions.append(Condition(self.column("timestamp"), Op.LT, self.end))
 
-        # The if clause will prevent calling Snuba with an empty list of projects and complain with:
-        # sentry.utils.snuba.SnubaError: validation failed for entity events: missing required conditions for project_id
+        # The clause will prevent calling Snuba with an empty list of projects, thus, returning
+        # no data. It will not instead complain with:
+        # sentry.utils.snuba.UnqualifiedQueryError: validation failed for entity events: missing required conditions for project_id
         if self.params.project_ids:
             conditions.append(
                 Condition(

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -716,9 +716,11 @@ def translate_meta_results(
                         results.append(
                             {
                                 "name": parent_alias,
-                                "type": record["type"]
-                                if defined_parent_meta_type is None
-                                else defined_parent_meta_type,
+                                "type": (
+                                    record["type"]
+                                    if defined_parent_meta_type is None
+                                    else defined_parent_meta_type
+                                ),
                             }
                         )
                     continue
@@ -911,9 +913,11 @@ class SnubaQueryBuilder:
                                 alias=condition.lhs.alias,
                             )[0],
                             op=condition.op,
-                            rhs=resolve_tag_value(self._use_case_id, self._org_id, condition.rhs)
-                            if require_rhs_condition_resolution(condition.lhs.op)
-                            else condition.rhs,
+                            rhs=(
+                                resolve_tag_value(self._use_case_id, self._org_id, condition.rhs)
+                                if require_rhs_condition_resolution(condition.lhs.op)
+                                else condition.rhs
+                            ),
                         )
                     )
                 except IndexError:
@@ -1339,9 +1343,11 @@ class SnubaResultConverter:
         # to determine whether we need to reverse the tag value or not.
         groupby_alias_to_groupby_column = (
             {
-                metric_groupby_obj.alias: metric_groupby_obj.field
-                if isinstance(metric_groupby_obj.field, str)
-                else metric_groupby_obj.field.op
+                metric_groupby_obj.alias: (
+                    metric_groupby_obj.field
+                    if isinstance(metric_groupby_obj.field, str)
+                    else metric_groupby_obj.field.op
+                )
                 for metric_groupby_obj in self._metrics_query.groupby
             }
             if self._metrics_query.groupby
@@ -1352,13 +1358,15 @@ class SnubaResultConverter:
             dict(
                 by=dict(
                     (
-                        key,
-                        reverse_resolve_tag_value(
-                            self._use_case_id, self._organization_id, value, weak=True
-                        ),
+                        (
+                            key,
+                            reverse_resolve_tag_value(
+                                self._use_case_id, self._organization_id, value, weak=True
+                            ),
+                        )
+                        if groupby_alias_to_groupby_column.get(key) not in NON_RESOLVABLE_TAG_VALUES
+                        else (key, value)
                     )
-                    if groupby_alias_to_groupby_column.get(key) not in NON_RESOLVABLE_TAG_VALUES
-                    else (key, value)
                     for key, value in tags
                 ),
                 **data,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1033,6 +1033,8 @@ def _bulk_snuba_query(
                     raise RateLimitExceeded(error["message"])
                 elif error["type"] == "schema":
                     raise SchemaValidationError(error["message"])
+                elif error["type"] == "invalid_query":
+                    raise UnqualifiedQueryError(error["message"])
                 elif error["type"] == "clickhouse":
                     raise clickhouse_error_codes_map.get(error["code"], QueryExecutionError)(
                         error["message"]

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -638,6 +638,8 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert "queries" in response.data, response.data
 
     def test_save_with_total_count(self):
+        # We cannot query the Discover entity without a project being defined for the org
+        self.create_project()
         data = {
             "title": "Test Query",
             "displayType": "table",

--- a/tests/sentry/dynamic_sampling/tasks/test_custom_rule_notifications.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_custom_rule_notifications.py
@@ -49,6 +49,8 @@ class CustomRuleNotificationsTest(TestCase, SnubaTestCase):
         """
         Tests that the num_samples function returns the correct number of samples
         """
+        # We cannot query the discover_transactions entity without a project being defined for the org
+        self.create_project()
         num_samples = get_num_samples(self.rule)
         assert num_samples == 0
         self.create_transaction()

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -16,8 +16,9 @@ from sentry.search.events import constants
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import TestCase
-from sentry.utils.snuba import QueryOutsideRetentionError
+from sentry.utils.snuba import QueryOutsideRetentionError, UnqualifiedQueryError, bulk_snuba_queries
 from sentry.utils.validators import INVALID_ID_DETAILS
 
 pytestmark = pytest.mark.sentry_metrics
@@ -66,6 +67,27 @@ class QueryBuilderTest(TestCase):
             ],
         )
         query.get_snql_query().validate()
+
+    def test_query_without_project_ids(self):
+        params = {
+            "start": self.params["start"],
+            "end": self.params["end"],
+            "organization_id": self.organization.id,
+        }
+        with pytest.raises(UnqualifiedQueryError):
+            query = QueryBuilder(Dataset.Discover, params, query="foo", selected_columns=["id"])
+            bulk_snuba_queries([query.get_snql_query()], referrer=Referrer.TESTING_TEST.value)
+
+    def test_query_with_empty_project_ids(self):
+        params = {
+            "start": self.params["start"],
+            "end": self.params["end"],
+            "project_id": [],  # We add an empty project_id list
+            "organization_id": self.organization.id,
+        }
+        with pytest.raises(UnqualifiedQueryError):
+            query = QueryBuilder(Dataset.Discover, params, query="foo", selected_columns=["id"])
+            bulk_snuba_queries([query.get_snql_query()], referrer=Referrer.TESTING_TEST.value)
 
     def test_simple_orderby(self):
         query = QueryBuilder(

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -68,7 +68,7 @@ class QueryBuilderTest(TestCase):
         )
         query.get_snql_query().validate()
 
-    def test_query_without_project_ids(self):
+    def test_project_ids_missing(self):
         params: ParamsType = {
             "start": self.params["start"],
             "end": self.params["end"],
@@ -78,7 +78,7 @@ class QueryBuilderTest(TestCase):
             query = QueryBuilder(Dataset.Discover, params, query="foo", selected_columns=["id"])
             bulk_snuba_queries([query.get_snql_query()], referrer=Referrer.TESTING_TEST.value)
 
-    def test_query_with_empty_project_ids(self):
+    def test_project_ids_with_empty_list(self):
         params: ParamsType = {
             "start": self.params["start"],
             "end": self.params["end"],

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -69,7 +69,7 @@ class QueryBuilderTest(TestCase):
         query.get_snql_query().validate()
 
     def test_query_without_project_ids(self):
-        params = {
+        params: ParamsType = {
             "start": self.params["start"],
             "end": self.params["end"],
             "organization_id": self.organization.id,
@@ -79,7 +79,7 @@ class QueryBuilderTest(TestCase):
             bulk_snuba_queries([query.get_snql_query()], referrer=Referrer.TESTING_TEST.value)
 
     def test_query_with_empty_project_ids(self):
-        params = {
+        params: ParamsType = {
             "start": self.params["start"],
             "end": self.params["end"],
             "project_id": [],  # We add an empty project_id list


### PR DESCRIPTION
This PR raises an error if `project_ids` are not defined. It requires some extra work to fix a bunch of tests.
It's based on #69577