### PR TITLE
feat(discover): Prevent calling Snuba with an empty list of projects

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -583,13 +583,17 @@ class BaseQueryBuilder:
         if self.end:
             conditions.append(Condition(self.column("timestamp"), Op.LT, self.end))
 
-        conditions.append(
-            Condition(
-                self.column("project_id"),
-                Op.IN,
-                self.params.project_ids,
+        # The clause will prevent calling Snuba with an empty list of projects, thus, returning
+        # no data. It will not instead complain with:
+        # sentry.utils.snuba.UnqualifiedQueryError: validation failed for entity events: missing required conditions for project_id
+        if self.params.project_ids:
+            conditions.append(
+                Condition(
+                    self.column("project_id"),
+                    Op.IN,
+                    self.params.project_ids,
+                )
             )
-        )
 
         if len(self.params.environments) > 0:
             term = event_search.SearchFilter(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1022,6 +1022,8 @@ def _bulk_snuba_query(
                     raise RateLimitExceeded(error["message"])
                 elif error["type"] == "schema":
                     raise SchemaValidationError(error["message"])
+                elif error["type"] == "invalid_query":
+                    raise UnqualifiedQueryError(error["message"])
                 elif error["type"] == "clickhouse":
                     raise clickhouse_error_codes_map.get(error["code"], QueryExecutionError)(
                         error["message"]

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -638,6 +638,8 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert "queries" in response.data, response.data
 
     def test_save_with_total_count(self):
+        # We cannot query the Discover entity without a project being defined for the org
+        self.create_project()
         data = {
             "title": "Test Query",
             "displayType": "table",

--- a/tests/sentry/dynamic_sampling/tasks/test_custom_rule_notifications.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_custom_rule_notifications.py
@@ -49,6 +49,8 @@ class CustomRuleNotificationsTest(TestCase, SnubaTestCase):
         """
         Tests that the num_samples function returns the correct number of samples
         """
+        # We cannot query the discover_transactions entity without a project being defined for the org
+        self.create_project()
         num_samples = get_num_samples(self.rule)
         assert num_samples == 0
         self.create_transaction()


### PR DESCRIPTION
Do not include a where condition if `project_ids` is an empty list since it will return no data.
This will cause Snuba to respond that `project_ids` is missing rather than pretend that everything is fine.

In #69575 I attempt to save the call to Snuba but it requires a lot of test changes.