### PR TITLE
fix(app-start): Add trace to event samples query

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -82,7 +82,7 @@ export function EventSamples({
 
   const newQuery: NewQuery = {
     name: '',
-    fields: ['transaction.id', 'project.name', 'profile_id', 'span.duration'],
+    fields: ['trace', 'transaction.id', 'project.name', 'profile_id', 'span.duration'],
     query: searchQuery.formatString(),
     dataset: DiscoverDatasets.SPANS_INDEXED,
     version: 2,

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.spec.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.spec.tsx
@@ -236,4 +236,38 @@ describe('EventSamplesTable', function () {
       '/mock-pathname/?customSortKey=-duration'
     );
   });
+
+  it('only displays data for the columns defined in the name map', async function () {
+    mockQuery = {
+      name: '',
+      fields: ['transaction.id', 'duration'],
+      query: '',
+      version: 2,
+    };
+
+    mockEventView = EventView.fromNewQueryWithLocation(mockQuery, mockLocation);
+    render(
+      <EventSamplesTable
+        eventIdKey="transaction.id"
+        columnNameMap={{duration: 'Duration'}}
+        cursorName="customCursorName"
+        eventView={mockEventView}
+        isLoading={false}
+        profileIdKey="profile.id"
+        sort={{
+          field: 'transaction.id',
+          kind: 'desc',
+        }}
+        sortKey="customSortKey"
+        data={{data: [{id: '1', 'transaction.id': 'abc', duration: 'def'}], meta: {}}}
+      />
+    );
+
+    // Although ID is queried for, because it's not defined in the map
+    // it isn't rendered
+    expect(
+      await screen.findByRole('columnheader', {name: 'Duration'})
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('columnheader')).toHaveLength(1);
+  });
 });

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.tsx
@@ -188,7 +188,9 @@ export function EventSamplesTable({
           isLoading={isLoading}
           data={data?.data as TableDataRow[]}
           columnOrder={eventViewColumns
-            .filter((col: TableColumn<React.ReactText>) => col.name !== 'project.name')
+            .filter((col: TableColumn<React.ReactText>) =>
+              Object.keys(columnNameMap).includes(col.name)
+            )
             .map((col: TableColumn<React.ReactText>) => {
               return {...col, name: columnNameMap[col.key]};
             })}


### PR DESCRIPTION
The UI expects this data field to be present, otherwise the URLs for the events don't route properly. Add the field but also restrict the visible columns to ones defined in the name map