### PR TITLE
feat(event-tags): Provide preset highlights on API

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -955,6 +955,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                     "sentry:highlight_context",
                     attrs["highlight_preset"].get("context", {}),
                 ),
+                "highlightPreset": attrs["highlight_preset"],
                 "groupingConfig": self.get_value_with_default(attrs, "sentry:grouping_config"),
                 "groupingEnhancements": self.get_value_with_default(
                     attrs, "sentry:grouping_enhancements"

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -248,6 +248,15 @@ class ProjectDetailsTest(APITestCase):
 
         self.get_error_response(other_org.slug, "old_slug", status_code=403)
 
+    def test_highlight_preset(self):
+        assert self.project.get_option("sentry:highlight_context") is None
+        assert self.project.get_option("sentry:highlight_tags") is None
+        resp = self.get_success_response(self.project.organization.slug, self.project.slug)
+        expected_preset = get_highlight_preset_for_project(self.project)
+        assert resp.data["highlightPreset"] == expected_preset
+        assert resp.data["highlightContext"] == expected_preset["context"]
+        assert resp.data["highlightTags"] == expected_preset["tags"]
+
 
 class ProjectUpdateTestTokenAuthenticated(APITestCase):
     endpoint = "sentry-api-0-project-details"


### PR DESCRIPTION
This will allow the frontend to reset the highlight data if they choose to do so (e.g. "Revert to default values"). 

I chose this approach of serializing it, and letting the caller replace the values manually rather than creating an endpoint to hit to revert to default since that seemed a bit excessive for just these two smaller options.