### PR TITLE
deps(ui): Use non web cbor

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "babel-plugin-add-react-displayname": "^0.0.5",
     "browserslist": "^4.22.2",
     "buffer": "^6.0.3",
-    "cbor-web": "^8.1.0",
+    "cbor": "^9.0.2",
     "classnames": "2.3.1",
     "color": "^4.2.3",
     "compression-webpack-plugin": "11.1.0",

--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -1,6 +1,6 @@
 import {Component} from 'react';
 import * as Sentry from '@sentry/react';
-import * as cbor from 'cbor-web';
+import {decodeFirst} from 'cbor';
 
 import {base64urlToBuffer, bufferToBase64url} from 'sentry/components/u2f/webAuthnHelper';
 import {t, tct} from 'sentry/locale';
@@ -188,7 +188,7 @@ class U2fInterface extends Component<Props, State> {
       const challengeArray = base64urlToBuffer(
         this.props.challengeData.webAuthnAuthenticationData
       );
-      const challenge = cbor.decodeFirst(challengeArray);
+      const challenge = decodeFirst(challengeArray);
       challenge
         .then(data => {
           this.webAuthnSignIn(data);
@@ -205,7 +205,7 @@ class U2fInterface extends Component<Props, State> {
       const challengeArray = base64urlToBuffer(
         this.props.challengeData.webAuthnRegisterData
       );
-      const challenge = cbor.decodeFirst(challengeArray);
+      const challenge = decodeFirst(challengeArray);
       // challenge contains a PublicKeyCredentialRequestOptions object for webauthn registration
       challenge
         .then(data => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4768,10 +4768,12 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001283, caniuse-lite@^1.0.30001587:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz#2f44ed6e21d359e914271ae35b68903632628ccf"
   integrity sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==
 
-cbor-web@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/cbor-web/-/cbor-web-8.1.0.tgz#c1148e91ca6bfc0f5c07c1df164854596e2e33d6"
-  integrity sha512-2hWHHMVrfffgoEmsAUh8vCxHoLa1vgodtC73+C5cSarkJlwTapnqAzcHINlP6Ej0DXuP4OmmJ9LF+JaNM5Lj/g==
+cbor@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-9.0.2.tgz#536b4f2d544411e70ec2b19a2453f10f83cd9fdb"
+  integrity sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==
+  dependencies:
+    nofilter "^3.1.0"
 
 chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
@@ -8942,6 +8944,11 @@ node-releases@^2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
+
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 nopt@^7.2.0:
   version "7.2.0"


### PR DESCRIPTION
We have the pollyfills that are bundled already. (Buffer) cbor and cbor-web are the same code base, but cbor-web has bundled various dependencies into the package for you. We don't necessary need that feature since we use webpack to do that. It is causing duplicate packages.

from the cbor-web readme

>This package bundles the [cbor](https://github.com/hildjj/node-cbor/blob/HEAD/packages/cbor) package for easy use on the web. The following packages are bundled in as well, to reduce the degree of difficulty:
>
> [buffer](https://github.com/feross/buffer)
> [nofilter](https://github.com/hildjj/nofilter)
> [process](https://github.com/shtylman/node-process)
> [stream-browserify](https://github.com/browserify/stream-browserify)
