### PR TITLE
ref(trace): output a flattened list of tokens with injected AND and proper parenthesis as tokens

### DIFF
--- a/static/app/components/searchSyntax/evaluator.spec.tsx
+++ b/static/app/components/searchSyntax/evaluator.spec.tsx
@@ -1,20 +1,25 @@
-import {flattenTokenTree} from 'sentry/components/searchSyntax/evaluator';
+import {
+  insertImplicitAND,
+  type ProcessedTokenResult,
+  toFlattened,
+} from 'sentry/components/searchSyntax/evaluator';
 import {
   parseSearch,
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
 
-const tokensToString = (tokens: TokenResult<Token>[]): string => {
+const tokensToString = (tokens: ProcessedTokenResult[]): string => {
   let str = '';
 
   for (const token of tokens) {
+    let concatstr;
     switch (token.type) {
       case Token.FREE_TEXT:
-        str += token.text;
+        concatstr = token.text;
         break;
       case Token.SPACES:
-        str += 'space';
+        concatstr = 'space';
         break;
       case Token.VALUE_DURATION:
       case Token.VALUE_BOOLEAN:
@@ -24,26 +29,40 @@ const tokensToString = (tokens: TokenResult<Token>[]): string => {
       case Token.VALUE_TEXT:
       case Token.VALUE_ISO_8601_DATE:
       case Token.VALUE_RELATIVE_DATE:
-        str += token.value;
+        concatstr = token.value;
         break;
+      case Token.LOGIC_GROUP:
       case Token.LOGIC_BOOLEAN:
-        str += token.text;
+        concatstr = token.text;
         break;
       case Token.KEY_SIMPLE:
-        str += token.text + ':';
+        concatstr = token.text + ':';
         break;
       case Token.VALUE_NUMBER_LIST:
       case Token.VALUE_TEXT_LIST:
-        str += token.text;
+        concatstr = token.text;
         break;
       case Token.KEY_EXPLICIT_TAG:
-        str += token.key;
+        concatstr = token.key;
         break;
+      case 'L_PAREN': {
+        concatstr = '(';
+        break;
+      }
+      case 'R_PAREN': {
+        concatstr = ')';
+        break;
+      }
       default: {
+        concatstr = token.text;
         break;
       }
     }
-    str += tokens.indexOf(token) !== tokens.length - 1 ? ' ' : '';
+
+    // The parsing logic text() captures leading/trailing spaces in some cases.
+    // We'll just trim them so the tests are easier to read.
+    str += concatstr.trim();
+    str += concatstr && tokens.indexOf(token) !== tokens.length - 1 ? ' ' : '';
   }
 
   return str;
@@ -62,17 +81,120 @@ describe('Search Syntax Evaluator', () => {
     it('flattens simple expressions', () => {
       const tokens = parseSearch('is:unresolved duration:>1h');
       assertTokens(tokens);
-      const flattened = flattenTokenTree(tokens);
+      const flattened = toFlattened(tokens);
       expect(flattened).toHaveLength(2);
-      expect(tokensToString(flattened)).toBe('is:unresolved space duration:>1h space');
+      expect(tokensToString(flattened)).toBe('is:unresolved duration:>1h');
     });
-    it.todo('handles filters');
-    it.todo('handles free text');
-    it.todo('handles key explicit tags');
-    it.todo('handles aggregate args');
-    it.todo('handles aggregate params');
-    it.todo('handles tags');
-    it.todo('handles logical booleans');
-    it.todo('handles logical groups');
+    it('handles filters', () => {
+      const tokens = parseSearch('has:unresolved duration:[1,2,3]');
+      assertTokens(tokens);
+      const flattened = toFlattened(tokens);
+      expect(flattened).toHaveLength(2);
+      expect(tokensToString(flattened)).toBe('has:unresolved duration:[1,2,3]');
+    });
+    it('handles free text', () => {
+      const tokens = parseSearch('hello world');
+      assertTokens(tokens);
+      const flattened = toFlattened(tokens);
+      expect(flattened).toHaveLength(1);
+      expect(tokensToString(flattened)).toBe('hello world');
+    });
+    it('handles logical booleans', () => {
+      const tokens = parseSearch('hello AND world');
+      assertTokens(tokens);
+      const flattened = toFlattened(tokens);
+      expect(flattened).toHaveLength(3);
+      expect(tokensToString(flattened)).toBe('hello AND world');
+    });
+    it('handles logical groups', () => {
+      const tokens = parseSearch('is:unresolved AND (is:dead OR is:alive)');
+      assertTokens(tokens);
+      const flattened = toFlattened(tokens);
+      expect(flattened).toHaveLength(7);
+      expect(tokensToString(flattened)).toBe('is:unresolved AND ( is:dead OR is:alive )');
+    });
+  });
+
+  describe('injects implicit AND', () => {
+    describe('boolean operators', () => {
+      it('implicit AND', () => {
+        const tokens = toFlattened(parseSearch('is:unresolved duration:>1h')!);
+        const withImplicitAND = insertImplicitAND(tokens);
+        expect(tokensToString(withImplicitAND)).toBe('is:unresolved AND duration:>1h');
+      });
+
+      it('explicit AND', () => {
+        const tokens = toFlattened(parseSearch('is:unresolved AND duration:>1h')!);
+        const withImplicitAND = insertImplicitAND(tokens);
+        expect(tokensToString(withImplicitAND)).toBe('is:unresolved AND duration:>1h');
+      });
+
+      it('multiple implicit AND', () => {
+        const tokens = toFlattened(
+          parseSearch('is:unresolved duration:>1h duration:<1m')!
+        );
+        const withImplicitAND = insertImplicitAND(tokens);
+        expect(tokensToString(withImplicitAND)).toBe(
+          'is:unresolved AND duration:>1h AND duration:<1m'
+        );
+      });
+
+      it('explicit OR', () => {
+        const tokens = toFlattened(parseSearch('is:unresolved OR duration:>1h')!);
+        const withImplicitAND = insertImplicitAND(tokens);
+        expect(tokensToString(withImplicitAND)).toBe('is:unresolved OR duration:>1h');
+      });
+
+      it('multiple explicit OR', () => {
+        const tokens = toFlattened(
+          parseSearch('is:unresolved OR duration:>1h OR duration:<1h')!
+        );
+        const withImplicitAND = insertImplicitAND(tokens);
+        expect(tokensToString(withImplicitAND)).toBe(
+          'is:unresolved OR duration:>1h OR duration:<1h'
+        );
+      });
+
+      it('with logical groups', () => {
+        const tokens = toFlattened(parseSearch('is:unresolved (duration:>1h)')!);
+        const withImplicitAND = insertImplicitAND(tokens);
+        expect(tokensToString(withImplicitAND)).toBe(
+          'is:unresolved AND ( duration:>1h )'
+        );
+      });
+    });
+
+    describe('logical groups', () => {
+      it('explicit OR', () => {
+        const tokens = toFlattened(parseSearch('is:unresolved OR ( duration:>1h )')!);
+        const withImplicitAND = insertImplicitAND(tokens);
+        expect(tokensToString(withImplicitAND)).toBe('is:unresolved OR ( duration:>1h )');
+      });
+      it('explicit AND', () => {
+        const tokens = toFlattened(parseSearch('is:unresolved AND ( duration:>1h )')!);
+        expect(tokensToString(tokens)).toBe('is:unresolved AND ( duration:>1h )');
+      });
+    });
+
+    describe('complex expressions', () => {
+      it('handles complex expressions', () => {
+        const tokens = toFlattened(
+          parseSearch('is:unresolved AND ( duration:>1h OR duration:<1h )')!
+        );
+        expect(tokensToString(tokens)).toBe(
+          'is:unresolved AND ( duration:>1h OR duration:<1h )'
+        );
+      });
+
+      it('handles complex expressions with implicit AND', () => {
+        const tokens = toFlattened(
+          parseSearch('is:unresolved ( duration:>1h OR ( duration:<1h duration:1m ) )')!
+        );
+        const withImplicitAND = insertImplicitAND(tokens);
+        expect(tokensToString(withImplicitAND)).toBe(
+          'is:unresolved AND ( duration:>1h OR ( duration:<1h AND duration:1m ) )'
+        );
+      });
+    });
   });
 });

--- a/static/app/components/searchSyntax/evaluator.spec.tsx
+++ b/static/app/components/searchSyntax/evaluator.spec.tsx
@@ -1,0 +1,78 @@
+import {flattenTokenTree} from 'sentry/components/searchSyntax/evaluator';
+import {
+  parseSearch,
+  Token,
+  type TokenResult,
+} from 'sentry/components/searchSyntax/parser';
+
+const tokensToString = (tokens: TokenResult<Token>[]): string => {
+  let str = '';
+
+  for (const token of tokens) {
+    switch (token.type) {
+      case Token.FREE_TEXT:
+        str += token.text;
+        break;
+      case Token.SPACES:
+        str += 'space';
+        break;
+      case Token.VALUE_DURATION:
+      case Token.VALUE_BOOLEAN:
+      case Token.VALUE_NUMBER:
+      case Token.VALUE_SIZE:
+      case Token.VALUE_PERCENTAGE:
+      case Token.VALUE_TEXT:
+      case Token.VALUE_ISO_8601_DATE:
+      case Token.VALUE_RELATIVE_DATE:
+        str += token.value;
+        break;
+      case Token.LOGIC_BOOLEAN:
+        str += token.text;
+        break;
+      case Token.KEY_SIMPLE:
+        str += token.text + ':';
+        break;
+      case Token.VALUE_NUMBER_LIST:
+      case Token.VALUE_TEXT_LIST:
+        str += token.text;
+        break;
+      case Token.KEY_EXPLICIT_TAG:
+        str += token.key;
+        break;
+      default: {
+        break;
+      }
+    }
+    str += tokens.indexOf(token) !== tokens.length - 1 ? ' ' : '';
+  }
+
+  return str;
+};
+
+function assertTokens(
+  tokens: TokenResult<Token>[] | null
+): asserts tokens is TokenResult<Token>[] {
+  if (tokens === null) {
+    throw new Error('Expected tokens to be an array');
+  }
+}
+
+describe('Search Syntax Evaluator', () => {
+  describe('flatten tree', () => {
+    it('flattens simple expressions', () => {
+      const tokens = parseSearch('is:unresolved duration:>1h');
+      assertTokens(tokens);
+      const flattened = flattenTokenTree(tokens);
+      expect(flattened).toHaveLength(2);
+      expect(tokensToString(flattened)).toBe('is:unresolved space duration:>1h space');
+    });
+    it.todo('handles filters');
+    it.todo('handles free text');
+    it.todo('handles key explicit tags');
+    it.todo('handles aggregate args');
+    it.todo('handles aggregate params');
+    it.todo('handles tags');
+    it.todo('handles logical booleans');
+    it.todo('handles logical groups');
+  });
+});

--- a/static/app/components/searchSyntax/evaluator.tsx
+++ b/static/app/components/searchSyntax/evaluator.tsx
@@ -1,0 +1,47 @@
+// To evaluate a result of the search syntax, we flatten the AST,
+// transform it to postfix notation which gets rid of parenthesis and tokens
+// that do not hold any value as they cannot be evaluated and then evaluate
+// the postfix notation.
+
+import {
+  type ParseResult,
+  Token,
+  type TokenResult,
+} from 'sentry/components/searchSyntax/parser';
+import {treeTransformer} from 'sentry/components/searchSyntax/utils';
+
+// This uses the treeTransformer utility to flatten the AST tree into a flat array of tokens
+// that can be evaluated. Since we use the treeTransformer utility, it means we need to return
+// the token in the transform function to keep the token we are iterating on.
+export function flattenTokenTree(tokens: ParseResult): TokenResult<Token>[] {
+  const result: TokenResult<Token>[] = [];
+
+  function visitor(token: TokenResult<Token> | null): TokenResult<Token> | null {
+    if (token === null) {
+      return null;
+    }
+
+    switch (token.type) {
+      case Token.SPACES:
+      case Token.VALUE_BOOLEAN:
+      case Token.VALUE_DURATION:
+      case Token.VALUE_ISO_8601_DATE:
+      case Token.VALUE_SIZE:
+      case Token.VALUE_NUMBER_LIST:
+      case Token.VALUE_NUMBER:
+      case Token.VALUE_TEXT:
+      case Token.VALUE_TEXT_LIST:
+      case Token.VALUE_RELATIVE_DATE:
+      case Token.VALUE_PERCENTAGE:
+      case Token.KEY_SIMPLE:
+        return token;
+      default:
+        break;
+    }
+
+    result.push(token);
+    return token;
+  }
+  treeTransformer({tree: tokens, transform: visitor});
+  return result;
+}


### PR DESCRIPTION
This will enable us to construct an ast based on the precedence order. From here, all we need to do is convert to infix/postfix and evaluate the expression