### PR TITLE
feat(crons): Use appropriate email for notifying users of broken detections/auto-mutes

### DIFF
--- a/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
+++ b/src/sentry/monitors/tasks/detect_broken_monitor_envs.py
@@ -26,6 +26,7 @@ from sentry.monitors.models import (
 )
 from sentry.tasks.base import instrumented_task
 from sentry.utils.email import MessageBuilder
+from sentry.utils.email.manager import get_email_addresses
 from sentry.utils.http import absolute_uri
 from sentry.utils.query import RangeQuerySetWrapper
 
@@ -84,18 +85,20 @@ def update_user_monitor_dictionary(
         user_monitor_entry["environment_names"].append(environment_name)
 
 
-def get_user_emails_from_monitor(
-    monitor: Monitor,
-):
+def get_user_emails_from_monitor(monitor: Monitor, project: Project):
     try:
         if monitor.owner_user_id:
             organization_member = OrganizationMember.objects.get(
                 user_id=monitor.owner_user_id, organization_id=monitor.organization_id
             )
-            return [organization_member.user_email]
+            return get_email_addresses(
+                [organization_member.user_id], project, only_verified=True
+            ).values()
         elif monitor.owner_team_id:
             team = Team.objects.get_from_cache(id=monitor.owner_team_id)
-            return team.member_set.values_list("user_email", flat=True)
+            return get_email_addresses(
+                team.member_set.values_list("user_id", flat=True), project, only_verified=True
+            ).values()
     except (OrganizationMember.DoesNotExist, Team.DoesNotExist):
         logger.info(
             "monitors.broken_detection.invalid_owner",
@@ -107,7 +110,9 @@ def get_user_emails_from_monitor(
         )
 
     project = Project.objects.get_from_cache(id=monitor.project_id)
-    return project.member_set.values_list("user_email", flat=True)
+    return get_email_addresses(
+        project.member_set.values_list("user_id", flat=True), project, only_verified=True
+    ).values()
 
 
 def generate_monitor_email_context(
@@ -217,7 +222,7 @@ def detect_broken_monitor_envs_for_org(org_id: int):
             environment_name = open_incident.monitor_environment.get_environment().name
             project = Project.objects.get_from_cache(id=open_incident.monitor.project_id)
 
-            for email in get_user_emails_from_monitor(open_incident.monitor):
+            for email in get_user_emails_from_monitor(open_incident.monitor, project):
                 if not email:
                     continue
 
@@ -236,7 +241,7 @@ def detect_broken_monitor_envs_for_org(org_id: int):
                 open_incident.monitor_environment.update(is_muted=True)
                 detection.update(env_muted_timestamp=django_timezone.now())
 
-            for email in get_user_emails_from_monitor(open_incident.monitor):
+            for email in get_user_emails_from_monitor(open_incident.monitor, project):
                 if not email:
                     continue
 


### PR DESCRIPTION
If the user set up alternative email routing for the given project of a monitor via settings like this:
<img width="1052" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/c4d7e722-233b-4b5d-9f40-ede7bf8cc939">



Then respect it when sending the broken monitor emails.