### PR TITLE
ref(rules): Remove empty strings from rule data in serializer

### DIFF
--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -37,13 +37,9 @@ class RuleNodeField(serializers.Field):
         if "id" not in data:
             raise ValidationError("Missing attribute 'id'")
 
-        data_to_remove = []
-        for key, value in data.items():
+        for key, value in list(data.items()):
             if not value:
-                data_to_remove.append(key)
-
-        for rm_data in data_to_remove:
-            del data[rm_data]
+                del data[key]
 
         cls = rules.get(data["id"], self.type_name)
         if cls is None:

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -37,6 +37,14 @@ class RuleNodeField(serializers.Field):
         if "id" not in data:
             raise ValidationError("Missing attribute 'id'")
 
+        data_to_remove = []
+        for key, value in data.items():
+            if not value:
+                data_to_remove.append(key)
+
+        for rm_data in data_to_remove:
+            del data[rm_data]
+
         cls = rules.get(data["id"], self.type_name)
         if cls is None:
             msg = "Invalid node. Could not find '%s'"


### PR DESCRIPTION
There's an issue in Sentry where an organization created some alert rules with Terraform and added a `comparisonInterval` with a value of "" that's causing issues in the rule processor, since we expect there to be either a value or nothing. In general, we don't want to store empty strings in rule data, so this PR checks for them and discards them if found.

Closes https://sentry.sentry.io/issues/5245475486/