### PR TITLE
fix(backup): Add some comparator fixes

### DIFF
--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -819,6 +819,7 @@ def get_default_comparators() -> dict[str, list[JSONScrubbingComparator]]:
             ],
             "sentry.dashboardwidgetqueryondemand": [DateUpdatedComparator("date_modified")],
             "sentry.dashboardwidgetquery": [DateUpdatedComparator("date_modified")],
+            "sentry.email": [DateUpdatedComparator("date_added")],
             "sentry.organization": [AutoSuffixComparator("slug")],
             "sentry.organizationintegration": [DateUpdatedComparator("date_updated")],
             "sentry.organizationmember": [

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -137,7 +137,7 @@ class BaseModel(models.Model):
         return self.__relocation_scope__
 
     @classmethod
-    def get_relocation_ordinal_fields(self) -> list[str] | None:
+    def get_relocation_ordinal_fields(self, _json_model: JSONData) -> list[str] | None:
         """
         Retrieves the custom ordinal fields for models that may be re-used at import time (that is,
         the `write_relocation_import()` method may return an `ImportKind` besides

--- a/src/sentry/models/options/user_option.py
+++ b/src/sentry/models/options/user_option.py
@@ -13,6 +13,7 @@ from sentry.db.models import FlexibleForeignKey, Model, control_silo_only_model,
 from sentry.db.models.fields import PickledObjectField
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager import OptionManager, Value
+from sentry.utils.json import JSONData
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -209,6 +210,17 @@ class UserOption(Model):
         unique_together = (("user", "project_id", "key"), ("user", "organization_id", "key"))
 
     __repr__ = sane_repr("user_id", "project_id", "organization_id", "key", "value")
+
+    @classmethod
+    def get_relocation_ordinal_fields(self, json_model: JSONData) -> list[str] | None:
+        # "global" user options (those with no organization and/or project scope) get a custom
+        # ordinal; non-global ones use the default ordering.
+        org_id = json_model["fields"].get("organization_id", None)
+        project_id = json_model["fields"].get("project_id", None)
+        if org_id is None and project_id is None:
+            return ["user", "key"]
+
+        return None
 
     def normalize_before_relocation_import(
         self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags

--- a/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
+++ b/tests/sentry/backup/snapshots/test_comparators/test_default_comparators.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-04-22T16:37:52.501407+00:00'
+created: '2024-04-24T17:50:56.140742+00:00'
 creator: sentry
 source: tests/sentry/backup/test_comparators.py
 ---
@@ -460,6 +460,9 @@ source: tests/sentry/backup/test_comparators.py
     - doc_integration
   model_name: sentry.docintegrationavatar
 - comparators:
+  - class: DateUpdatedComparator
+    fields:
+    - date_added
   - class: EmailObfuscatingComparator
     fields:
     - email

--- a/tests/sentry/backup/test_validate.py
+++ b/tests/sentry/backup/test_validate.py
@@ -794,9 +794,110 @@ def test_good_user_custom_ordinal():
     assert len(findings) == 0
 
 
-# TODO(azaslavsky): This is a temporary fix. Remove it once we have a more sustainable export-side
-# solution.
-def test_good_user_option_temp_fix():
+def test_good_user_option_custom_ordinal():
+    left = json.loads(
+        """
+            [
+                {
+                    "model": "sentry.user",
+                    "pk": 1,
+                    "fields": {
+                        "password": "abc123",
+                        "last_login": null,
+                        "username": "first@example.com",
+                        "name": "",
+                        "email": "first@example.com"
+                    }
+                },
+                {
+                    "model": "sentry.user",
+                    "pk": 2,
+                    "fields": {
+                        "password": "abc123",
+                        "last_login": null,
+                        "username": "second@example.com",
+                        "name": "",
+                        "email": "second@example.com"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 1,
+                    "fields": {
+                        "user": 1,
+                        "key": "foo",
+                        "value": "1"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 2,
+                    "fields": {
+                        "user": 2,
+                        "key": "foo",
+                        "value": "2"
+                    }
+                }
+            ]
+        """
+    )
+
+    # Note that the `user`s of the `useroption` models here are reversed.
+    right = json.loads(
+        """
+            [
+                {
+                    "model": "sentry.user",
+                    "pk": 1,
+                    "fields": {
+                        "password": "abc123",
+                        "last_login": null,
+                        "username": "first@example.com",
+                        "name": "",
+                        "email": "first@example.com"
+                    }
+                },
+                {
+                    "model": "sentry.user",
+                    "pk": 2,
+                    "fields": {
+                        "password": "abc123",
+                        "last_login": null,
+                        "username": "second@example.com",
+                        "name": "",
+                        "email": "second@example.com"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 1,
+                    "fields": {
+                        "user": 2,
+                        "key": "foo",
+                        "value": "2"
+                    }
+                },
+                {
+                    "model": "sentry.useroption",
+                    "pk": 2,
+                    "fields": {
+                        "user": 1,
+                        "key": "foo",
+                        "value": "1"
+                    }
+                }
+            ]
+        """
+    )
+    out = validate(left, right)
+    findings = out.findings
+
+    assert len(findings) == 0
+
+
+# This tests for a prod-only check that is not enumerated in Django: that there can only be one copy
+# of a global option (no org_id/project_id) per key per user.
+def test_good_user_option_duplicate_globals():
     left = json.loads(
         """
             [


### PR DESCRIPTION
This adds a couple of simple fixes: `sentry.email` now has its `date_added` checked for updated dates (since this field is autosaved, these dates could change during import). Additionally, the global `user_import` deduping logic has been scoped down and simplified.
