### PR TITLE
feat(performance): Adds queue as a result for span.module

### DIFF
--- a/src/sentry/search/events/datasets/field_aliases.py
+++ b/src/sentry/search/events/datasets/field_aliases.py
@@ -110,11 +110,13 @@ def resolve_span_module(builder: builder.QueryBuilder, alias: str) -> SelectType
                         "cache",
                         "db",
                         "http",
+                        "queue",
                     ],
                     [
                         "cache",
                         "db",
                         "http",
+                        "queue",
                     ],
                     "other",
                 ],


### PR DESCRIPTION
Updates span.module to return `queue` as a result instead of being grouped under `other`