### PR TITLE
ref(alert rule): Check for rule existing before adding value

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -339,7 +339,7 @@ class CombinedRuleSerializer(Serializer):
         for item in item_list:
             if isinstance(item, AlertRule):
                 alert_rule = serialized_alert_rules.pop(0)
-                if "latestIncident" in self.expand:
+                if "latestIncident" in self.expand and alert_rule:
                     alert_rule["latestIncident"] = incident_map.get(item.incident_id)  # type: ignore[attr-defined]
                 results[item] = alert_rule
             elif isinstance(item, Rule):

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -333,14 +333,18 @@ class CombinedRuleSerializer(Serializer):
                 incident_map[incident.id] = serialize(incident, user=user)
 
         serialized_alert_rules = serialize(alert_rules, user=user)
-        serialized_map_by_id = {x.id: x for x in serialized_alert_rules}
+        serialized_map_by_id = {
+            serialized_alert["id"]: serialized_alert for serialized_alert in serialized_alert_rules
+        }
 
         serialized_issue_rules = serialize(
             [x for x in item_list if isinstance(x, Rule)],
             user=user,
             serializer=RuleSerializer(expand=self.expand),
         )
-        serialized_issue_rule_map_by_id = {x.id for x in serialized_issue_rules}
+        serialized_issue_rule_map_by_id = {
+            serialized_rule["id"]: serialized_rule for serialized_rule in serialized_issue_rules
+        }
 
         for item in item_list:
             item_id = str(item.id)
@@ -352,7 +356,7 @@ class CombinedRuleSerializer(Serializer):
             elif item_id in serialized_issue_rule_map_by_id:
                 results[item] = serialized_issue_rule_map_by_id[item_id]
             else:
-                logger.warning(
+                logger.error(
                     "Alert Rule found but dropped during serialization",
                     extra={
                         "id": item_id,

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -351,7 +351,7 @@ class CombinedRuleSerializer(Serializer):
             if item_id in serialized_map_by_id:
                 serialized_alert_rule = serialized_map_by_id[item_id]
                 if "latestIncident" in self.expand:
-                    serialized_alert_rule["latestIncident"] = incident_map.get(item.incident_id)  # type: ignore[attr-defined]
+                    serialized_alert_rule["latestIncident"] = incident_map.get(item.incident_id)
                 results[item] = serialized_alert_rule
             elif item_id in serialized_issue_rule_map_by_id:
                 results[item] = serialized_issue_rule_map_by_id[item_id]


### PR DESCRIPTION
I can't figure out _how_ this happens, but checking that `alert_rule` exists before trying to add a value to a non-existent dict should resolve the issue.

Fixes https://sentry.sentry.io/issues/5245194605/