### PR TITLE
feat(issue-platform): convert option to rollout float

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 from collections.abc import MutableMapping
 from typing import Any, cast
 
@@ -67,7 +68,7 @@ def produce_occurrence_to_kafka(
 
     partition_key = None
     if (
-        options.get("issue_platform.use_kafka_partition_key")
+        options.get("issue_platform.use_kafka_partition_key.rollout") >= random.random()
         and occurrence
         and occurrence.fingerprint
     ):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2405,9 +2405,18 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# TODO: remove once removed from options
 register(
     "issue_platform.use_kafka_partition_key",
     type=Bool,
     default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+
+register(
+    "issue_platform.use_kafka_partition_key.rollout",
+    type=Float,
+    default=0.0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -111,7 +111,7 @@ class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
     )
     @patch("sentry.issues.producer._occurrence_producer.produce")
     @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
-    @override_options({"issue_platform.use_kafka_partition_key": True})
+    @override_options({"issue_platform.use_kafka_partition_key.rollout": 1.0})
     def test_payload_sent_to_kafka_with_partition_key(
         self, mock_produce, mock_prepare_occurrence_message
     ) -> None:
@@ -135,7 +135,7 @@ class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
     )
     @patch("sentry.issues.producer._occurrence_producer.produce")
     @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
-    @override_options({"issue_platform.use_kafka_partition_key": True})
+    @override_options({"issue_platform.use_kafka_partition_key.rollout": 1.0})
     def test_payload_sent_to_kafka_with_partition_key_no_fingerprint(
         self, mock_produce, mock_prepare_occurrence_message
     ) -> None:
@@ -155,7 +155,7 @@ class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
     )
     @patch("sentry.issues.producer._occurrence_producer.produce")
     @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
-    @override_options({"issue_platform.use_kafka_partition_key": True})
+    @override_options({"issue_platform.use_kafka_partition_key.rollout": 1.0})
     def test_payload_sent_to_kafka_with_partition_key_no_occurrence(
         self, mock_produce, mock_prepare_occurrence_message
     ) -> None:


### PR DESCRIPTION
Doing the rollout as a rollout percentage is safer than a rollout boolean