### PR TITLE
fix(metrics): Remove distributions from API

### DIFF
--- a/src/sentry/sentry_metrics/client/kafka.py
+++ b/src/sentry/sentry_metrics/client/kafka.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
@@ -89,36 +88,6 @@ class KafkaMetricsBackend(GenericMetricsBackend):
         }
 
         self.__produce(counter_metric, use_case_id)
-
-    def distribution(
-        self,
-        use_case_id: UseCaseID,
-        org_id: int,
-        project_id: int,
-        metric_name: str,
-        value: Sequence[int | float],
-        tags: dict[str, str],
-        unit: str | None,
-    ) -> None:
-
-        """
-        Emit a distribution metric for internal use cases only. Can
-        support a sequence of values. Note that, as of now, this function
-        will return immediately even if the metric message has not been
-        produced to the broker yet.
-        """
-        dist_metric = {
-            "org_id": org_id,
-            "project_id": project_id,
-            "name": build_mri(metric_name, "d", use_case_id, unit),
-            "value": value,
-            "timestamp": int(datetime.now().timestamp()),
-            "tags": tags,
-            "retention_days": get_retention_from_org_id(org_id),
-            "type": "d",
-        }
-
-        self.__produce(dist_metric, use_case_id)
 
     def __produce(self, metric: dict[str, Any], use_case_id: UseCaseID):
         ingest_codec.validate(metric)

--- a/src/sentry/sentry_metrics/client/snuba.py
+++ b/src/sentry/sentry_metrics/client/snuba.py
@@ -9,6 +9,7 @@ from sentry import quotas
 from sentry.sentry_metrics.client.base import GenericMetricsBackend
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.testutils.cases import BaseMetricsTestCase  # NOQA:S007
+from sentry.utils.env import in_test_environment
 
 
 def build_mri(metric_name: str, type: str, use_case_id: UseCaseID, unit: str | None) -> str:
@@ -55,7 +56,7 @@ class SnubaMetricsBackend(GenericMetricsBackend):
         """
         Emit a counter metric for internal use cases only.
         """
-
+        assert in_test_environment(), "This backend should only be used in testing environments"
         BaseMetricsTestCase.store_metric(
             name=build_mri(metric_name, "c", use_case_id, unit),
             tags=tags,
@@ -82,7 +83,7 @@ class SnubaMetricsBackend(GenericMetricsBackend):
         Emit a set metric for internal use cases only. Can support
         a sequence of values.
         """
-
+        assert in_test_environment(), "This backend should only be used in testing environments"
         for val in value:
             BaseMetricsTestCase.store_metric(
                 name=build_mri(metric_name, "s", use_case_id, unit),
@@ -110,6 +111,7 @@ class SnubaMetricsBackend(GenericMetricsBackend):
         Emit a distribution metric for internal use cases only. Can
         support a sequence of values.
         """
+        assert in_test_environment(), "This backend should only be used in testing environments"
         for val in value:
             BaseMetricsTestCase.store_metric(
                 name=build_mri(metric_name, "d", use_case_id, unit),

--- a/tests/sentry/sentry_metrics/test_kafka.py
+++ b/tests/sentry/sentry_metrics/test_kafka.py
@@ -62,33 +62,3 @@ class KafkaMetricsInterfaceTest(GenericMetricsTestMixIn, TestCase):
         assert produced_message.payload.value == counter_value
         # check that there's no other remaining message in the topic
         assert broker_storage.consume(Partition(my_topic, 0), 1) is None
-
-        # produce a distribution metric onto the third offset
-        generic_metrics_backend.distribution(
-            self.use_case_id,
-            self.org_id,
-            self.project_id,
-            self.metric_name,
-            self.dist_values,
-            self.metrics_tags,
-            self.unit,
-        )
-
-        distribution_metric = {
-            "org_id": self.org_id,
-            "project_id": self.project_id,
-            "name": self.get_mri(self.metric_name, "d", self.use_case_id, self.unit),
-            "value": self.dist_values,
-            "timestamp": int(datetime.now().timestamp()),
-            "tags": self.metrics_tags,
-            "retention_days": self.retention_days,
-            "type": "d",
-        }
-
-        distribution_value = json.dumps(distribution_metric).encode("utf-8")
-
-        produced_message = broker_storage.consume(Partition(my_topic, 0), 1)
-        assert produced_message is not None
-        assert produced_message.payload.value == distribution_value
-        # check that there's no other remaining message in the topic
-        assert broker_storage.consume(Partition(my_topic, 0), 2) is None


### PR DESCRIPTION
There are no more references to the distributions API for the generic metrics backend. Lets remove it since we want to deprecate this way of sending data going forward.