### PR TITLE
feat(issue-platform): add id to status change

### DIFF
--- a/src/sentry/issues/status_change_message.py
+++ b/src/sentry/issues/status_change_message.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TypedDict
 from uuid import uuid4
 
@@ -20,7 +20,7 @@ class StatusChangeMessage:
     project_id: int
     new_status: int
     new_substatus: int | None
-    id: str = uuid4()
+    id: str = field(default_factory=lambda: uuid4().hex)
 
     def to_dict(
         self,

--- a/src/sentry/issues/status_change_message.py
+++ b/src/sentry/issues/status_change_message.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TypedDict
+from uuid import uuid4
 
 
 class StatusChangeMessageData(TypedDict):
@@ -10,6 +11,7 @@ class StatusChangeMessageData(TypedDict):
     project_id: int
     new_status: int
     new_substatus: int | None
+    id: str
 
 
 @dataclass(frozen=True)
@@ -18,6 +20,7 @@ class StatusChangeMessage:
     project_id: int
     new_status: int
     new_substatus: int | None
+    id: str = uuid4()
 
     def to_dict(
         self,
@@ -27,4 +30,5 @@ class StatusChangeMessage:
             "project_id": self.project_id,
             "new_status": self.new_status,
             "new_substatus": self.new_substatus,
+            "id": self.id,
         }

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -389,7 +389,7 @@ class TestProduceOccurrenceForStatusChange(TestCase, OccurrenceTestMixin):
         assert group.status == initial_status
         assert group.substatus == initial_substatus
 
-    def test_generate_status_changes(self):
+    def test_generate_status_changes_id(self):
         status_change_1 = StatusChangeMessage(
             fingerprint=["status-change-1"],
             project_id=self.project.id,

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -388,3 +388,19 @@ class TestProduceOccurrenceForStatusChange(TestCase, OccurrenceTestMixin):
         )
         assert group.status == initial_status
         assert group.substatus == initial_substatus
+
+    def test_generate_status_changes(self):
+        status_change_1 = StatusChangeMessage(
+            fingerprint=["status-change-1"],
+            project_id=self.project.id,
+            new_status=GroupStatus.RESOLVED,
+            new_substatus=GroupSubStatus.FOREVER,
+        )
+        status_change_2 = StatusChangeMessage(
+            fingerprint=["status-change-2"],
+            project_id=self.project.id,
+            new_status=GroupStatus.RESOLVED,
+            new_substatus=GroupSubStatus.FOREVER,
+        )
+        assert status_change_1.id
+        assert status_change_1.id != status_change_2.id

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -302,6 +302,7 @@ def test_detect_transaction_trends(
     assert detect_transaction_change_points.apply_async.called
 
 
+@mock.patch("sentry.issues.status_change_message.uuid4", return_value=uuid.UUID(int=0))
 @mock.patch("sentry.tasks.statistical_detectors.raw_snql_query")
 @mock.patch("sentry.tasks.statistical_detectors.detect_transaction_change_points")
 @mock.patch("sentry.statistical_detectors.detector.produce_occurrence_to_kafka")
@@ -311,6 +312,7 @@ def test_detect_transaction_trends_auto_resolution(
     produce_occurrence_to_kafka,
     detect_transaction_change_points,
     raw_snql_query,
+    mock_uuid4,
     timestamp,
     project,
 ):
@@ -1131,10 +1133,12 @@ def test_save_regressions_with_versions(
         pytest.param(GroupStatus.IGNORED, GroupSubStatus.FOREVER, False, id="forever"),
     ],
 )
+@mock.patch("sentry.issues.status_change_message.uuid4", return_value=uuid.UUID(int=0))
 @mock.patch("sentry.statistical_detectors.detector.produce_occurrence_to_kafka")
 @django_db_all
 def test_redirect_escalations(
     produce_occurrence_to_kafka,
+    mock_uuid4,
     detector_cls,
     object_name,
     baseline,


### PR DESCRIPTION
We need to make sure we don't process the same status change message twice once we add a batched consumer. This PR adds an ID to every status change so that we can process it later.