### PR TITLE
ref(rules): Remove state from RuleBase

### DIFF
--- a/src/sentry/integrations/discord/actions/issue_alert/notification.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/notification.py
@@ -6,7 +6,7 @@ from sentry.integrations.discord.actions.issue_alert.form import DiscordNotifySe
 from sentry.integrations.discord.client import DiscordClient
 from sentry.integrations.discord.message_builder.issues import DiscordIssuesMessageBuilder
 from sentry.rules.actions import IntegrationEventAction
-from sentry.rules.base import CallbackFuture, EventState
+from sentry.rules.base import CallbackFuture
 from sentry.types.rules import RuleFuture
 from sentry.utils import metrics
 
@@ -31,7 +31,7 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
         }
 
     def after(
-        self, event: GroupEvent, state: EventState, notification_uuid: str | None = None
+        self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture, None, None]:
         channel_id = self.get_option("channel_id")
         tags = set(self.get_tags_list())

--- a/src/sentry/integrations/msteams/actions/notification.py
+++ b/src/sentry/integrations/msteams/actions/notification.py
@@ -7,7 +7,6 @@ from sentry.integrations.msteams.card_builder.issues import MSTeamsIssueMessageB
 from sentry.integrations.msteams.client import MsTeamsClient
 from sentry.integrations.msteams.utils import get_channel_id
 from sentry.rules.actions import IntegrationEventAction
-from sentry.rules.base import EventState
 from sentry.services.hybrid_cloud.integration import RpcIntegration
 from sentry.utils import metrics
 
@@ -41,7 +40,7 @@ class MsTeamsNotifyServiceAction(IntegrationEventAction):
             a for a in super().get_integrations() if a.metadata.get("installation_type") != "tenant"
         ]
 
-    def after(self, event: GroupEvent, state: EventState, notification_uuid: str | None = None):
+    def after(self, event: GroupEvent, notification_uuid: str | None = None):
         channel = self.get_option("channel_id")
 
         integration = self.get_integration()

--- a/src/sentry/integrations/opsgenie/actions/notification.py
+++ b/src/sentry/integrations/opsgenie/actions/notification.py
@@ -39,7 +39,7 @@ class OpsgenieNotifyTeamAction(IntegrationEventAction):
             },
         }
 
-    def after(self, event, state, notification_uuid: str | None = None):
+    def after(self, event, notification_uuid: str | None = None):
         integration = self.get_integration()
         if not integration:
             logger.error("Integration removed, but the rule still refers to it")

--- a/src/sentry/integrations/pagerduty/actions/notification.py
+++ b/src/sentry/integrations/pagerduty/actions/notification.py
@@ -57,7 +57,7 @@ class PagerDutyNotifyServiceAction(IntegrationEventAction):
                 return pds
         return None
 
-    def after(self, event, state, notification_uuid: str | None = None):
+    def after(self, event, notification_uuid: str | None = None):
         integration = self.get_integration()
         log_context = {
             "organization_id": self.project.organization_id,

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -23,7 +23,6 @@ from sentry.integrations.slack.utils import get_channel_id
 from sentry.models.integrations.integration import Integration
 from sentry.models.rule import Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
-from sentry.rules import EventState
 from sentry.rules.actions import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
 from sentry.services.hybrid_cloud.integration import RpcIntegration
@@ -64,7 +63,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         )
 
     def after(
-        self, event: GroupEvent, state: EventState, notification_uuid: str | None = None
+        self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture, None, None]:
         channel = self.get_option("channel_id")
         tags = set(self.get_tags_list())

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -34,7 +34,7 @@ class NotifyEmailAction(EventAction):
             self.data = {**self.data, "fallthroughType": FallthroughChoiceType.ACTIVE_MEMBERS.value}
         return self.label.format(**self.data)
 
-    def after(self, event, state, notification_uuid: str | None = None):
+    def after(self, event, notification_uuid: str | None = None):
         group = event.group
         extra = {
             "event_id": event.event_id,

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -8,7 +8,7 @@ from typing import Any
 from sentry.eventstore.models import GroupEvent
 from sentry.models.rule import Rule
 from sentry.models.rulefirehistory import RuleFireHistory
-from sentry.rules.base import CallbackFuture, EventState, RuleBase
+from sentry.rules.base import CallbackFuture, RuleBase
 
 logger = logging.getLogger("sentry.rules")
 
@@ -37,7 +37,7 @@ class EventAction(RuleBase, abc.ABC):
 
     @abc.abstractmethod
     def after(
-        self, event: GroupEvent, state: EventState, notification_uuid: str | None = None
+        self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture, None, None]:
         """
         Executed after a Rule matches.
@@ -47,10 +47,8 @@ class EventAction(RuleBase, abc.ABC):
 
         See the notification implementation for example usage.
 
-        Does not need to handle group state (e.g. is resolved or not)
-        Caller will handle state
 
-        >>> def after(self, event, state):
+        >>> def after(self, state):
         >>>     yield self.future(self.print_results)
         >>>
         >>> def print_results(self, event, futures):

--- a/src/sentry/rules/actions/integrations/create_ticket/base.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/base.py
@@ -9,7 +9,7 @@ from sentry.models.rule import Rule
 from sentry.rules.actions.integrations.base import IntegrationEventAction
 from sentry.rules.actions.integrations.create_ticket.form import IntegrationNotifyServiceForm
 from sentry.rules.actions.integrations.create_ticket.utils import create_issue
-from sentry.rules.base import CallbackFuture, EventState
+from sentry.rules.base import CallbackFuture
 from sentry.services.hybrid_cloud.integration import RpcIntegration
 
 
@@ -85,7 +85,7 @@ class TicketEventAction(IntegrationEventAction, abc.ABC):
         pass
 
     def after(
-        self, event: GroupEvent, state: EventState, notification_uuid: str | None = None
+        self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture, None, None]:
         integration_id = self.get_integration_id()
         key = f"{self.provider}:{integration_id}"

--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -2,7 +2,6 @@ from collections.abc import Generator, Sequence
 
 from sentry.eventstore.models import GroupEvent
 from sentry.plugins.base import plugins
-from sentry.rules import EventState
 from sentry.rules.actions.base import EventAction
 from sentry.rules.actions.services import LegacyPluginService
 from sentry.rules.base import CallbackFuture
@@ -33,7 +32,7 @@ class NotifyEventAction(EventAction):
         return results
 
     def after(
-        self, event: GroupEvent, state: EventState, notification_uuid: str | None = None
+        self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture, None, None]:
         group = event.group
 

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -14,7 +14,6 @@ from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.plugins.base import plugins
-from sentry.rules import EventState
 from sentry.rules.actions.base import EventAction
 from sentry.rules.actions.services import PluginService
 from sentry.rules.base import CallbackFuture
@@ -140,7 +139,7 @@ class NotifyEventServiceAction(EventAction):
         return title
 
     def after(
-        self, event: GroupEvent, state: EventState, notification_uuid: str | None = None
+        self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture, None, None]:
         service = self.get_option("service")
 

--- a/src/sentry/rules/actions/sentry_apps/notify_event.py
+++ b/src/sentry/rules/actions/sentry_apps/notify_event.py
@@ -7,7 +7,6 @@ from rest_framework import serializers
 
 from sentry.eventstore.models import GroupEvent
 from sentry.models.project import Project
-from sentry.rules import EventState
 from sentry.rules.actions.sentry_apps import SentryAppEventAction
 from sentry.rules.base import CallbackFuture
 from sentry.services.hybrid_cloud.app import (
@@ -142,7 +141,7 @@ class NotifyEventSentryAppAction(SentryAppEventAction):
             )
 
     def after(
-        self, event: GroupEvent, state: EventState, notification_uuid: str | None = None
+        self, event: GroupEvent, notification_uuid: str | None = None
     ) -> Generator[CallbackFuture, None, None]:
         sentry_app = self._get_sentry_app(event)
         yield self.future(

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -287,7 +287,6 @@ class RuleProcessor:
         notification_uuid: str | None = None,
         rule_fire_history: RuleFireHistory | None = None,
     ) -> None:
-        state = self.get_state()
         for action in rule.data.get("actions", ()):
             action_inst = instantiate_action(rule, action, rule_fire_history)
             if not action_inst:
@@ -296,7 +295,6 @@ class RuleProcessor:
             results = safe_execute(
                 action_inst.after,
                 event=self.event,
-                state=state,
                 _with_transaction=False,
                 notification_uuid=notification_uuid,
             )

--- a/tests/sentry/integrations/discord/test_issue_alert.py
+++ b/tests/sentry/integrations/discord/test_issue_alert.py
@@ -67,9 +67,7 @@ class DiscordIssueAlertTest(RuleTestCase):
     @mock.patch("sentry.analytics.record")
     def test_basic(self, mock_record):
         notification_uuid = str(uuid4())
-        results = list(
-            self.rule.after(self.event, self.get_state(), notification_uuid=notification_uuid)
-        )
+        results = list(self.rule.after(self.event, notification_uuid=notification_uuid))
         assert len(results) == 1
 
         results[0].callback(self.event, futures=[])
@@ -134,7 +132,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         )
         release.add_project(self.project)
 
-        results = list(self.rule.after(self.event, self.get_state()))
+        results = list(self.rule.after(self.event))
         assert len(results) == 1
 
         results[0].callback(self.event, futures=[])
@@ -161,7 +159,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         return_value=GroupStatus.RESOLVED,
     )
     def test_resolved(self, mock_get_status):
-        results = list(self.rule.after(self.event, self.get_state()))
+        results = list(self.rule.after(self.event))
         assert len(results) == 1
 
         results[0].callback(self.event, futures=[])
@@ -188,7 +186,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         return_value=GroupStatus.IGNORED,
     )
     def test_ignored(self, mock_get_status):
-        results = list(self.rule.after(self.event, self.get_state()))
+        results = list(self.rule.after(self.event))
         assert len(results) == 1
 
         results[0].callback(self.event, futures=[])
@@ -211,7 +209,7 @@ class DiscordIssueAlertTest(RuleTestCase):
 
     @responses.activate
     def test_feature_flag_disabled(self):
-        results = list(self.rule.after(self.event, self.get_state()))
+        results = list(self.rule.after(self.event))
         assert len(results) == 1
         results[0].callback(self.event, futures=[])
 
@@ -220,7 +218,7 @@ class DiscordIssueAlertTest(RuleTestCase):
     @responses.activate
     def test_integration_removed(self):
         integration_service.delete_integration(integration_id=self.discord_integration.id)
-        results = list(self.rule.after(self.event, self.get_state()))
+        results = list(self.rule.after(self.event))
         assert len(results) == 0
 
     @responses.activate

--- a/tests/sentry/integrations/github/test_ticket_action.py
+++ b/tests/sentry/integrations/github/test_ticket_action.py
@@ -57,7 +57,7 @@ class GitHubTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
     def trigger(self, event, rule_object):
         action = rule_object.data.get("actions", ())[0]
         action_inst = self.get_rule(data=action, rule=rule_object)
-        results = list(action_inst.after(event=event, state=self.get_state()))
+        results = list(action_inst.after(event=event))
         assert len(results) == 1
 
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)

--- a/tests/sentry/integrations/github_enterprise/test_ticket_action.py
+++ b/tests/sentry/integrations/github_enterprise/test_ticket_action.py
@@ -68,7 +68,7 @@ class GitHubEnterpriseEnterpriseTicketRulesTestCase(RuleTestCase, BaseAPITestCas
     def trigger(self, event, rule_object):
         action = rule_object.data.get("actions", ())[0]
         action_inst = self.get_rule(data=action, rule=rule_object)
-        results = list(action_inst.after(event=event, state=self.get_state()))
+        results = list(action_inst.after(event=event))
         assert len(results) == 1
 
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -84,7 +84,7 @@ class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
             content_type="application/json",
         )
 
-        results = list(self.jira_rule.after(event=event, state=self.get_state()))
+        results = list(self.jira_rule.after(event=event))
         assert len(results) == 1
 
         # Trigger rule callback
@@ -159,7 +159,7 @@ class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
             data={"provider": self.integration.provider},
         )
 
-        results = list(self.jira_rule.after(event=event, state=self.get_state()))
+        results = list(self.jira_rule.after(event=event))
         assert len(results) == 1
         results[0].callback(event, futures=[])
 

--- a/tests/sentry/integrations/jira/test_ticket_action.py
+++ b/tests/sentry/integrations/jira/test_ticket_action.py
@@ -46,7 +46,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
     def trigger(self, event, rule_object):
         action = rule_object.data.get("actions", ())[0]
         action_inst = self.get_rule(data=action, rule=rule_object)
-        results = list(action_inst.after(event=event, state=self.get_state()))
+        results = list(action_inst.after(event=event))
         assert len(results) == 1
 
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)

--- a/tests/sentry/integrations/jira_server/test_ticket_action.py
+++ b/tests/sentry/integrations/jira_server/test_ticket_action.py
@@ -49,7 +49,7 @@ class JiraServerTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
     def trigger(self, event, rule_object):
         action = rule_object.data.get("actions", ())[0]
         action_inst = self.get_rule(data=action, rule=rule_object)
-        results = list(action_inst.after(event=event, state=self.get_state()))
+        results = list(action_inst.after(event=event))
         assert len(results) == 1
 
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -49,9 +49,7 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         )
 
         notification_uuid = "123e4567-e89b-12d3-a456-426614174000"
-        results = list(
-            rule.after(event=event, state=self.get_state(), notification_uuid=notification_uuid)
-        )
+        results = list(rule.after(event=event, notification_uuid=notification_uuid))
         assert len(results) == 1
 
         responses.add(
@@ -109,7 +107,7 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         rule = self.get_rule(
             data={"team": self.integration.id, "channel": "Hellboy", "channel_id": "nb"}
         )
-        results = list(rule.after(event=group_event, state=self.get_state()))
+        results = list(rule.after(event=group_event))
         assert len(results) == 1
 
         responses.add(
@@ -147,7 +145,7 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         rule = self.get_rule(
             data={"team": self.integration.id, "channel": "Naboo", "channel_id": "nb"}
         )
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 1
 
         responses.add(

--- a/tests/sentry/integrations/opsgenie/test_notify_action.py
+++ b/tests/sentry/integrations/opsgenie/test_notify_action.py
@@ -58,9 +58,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
 
         rule = self.get_rule(data={"account": self.integration.id, "team": self.team1["id"]})
         notification_uuid = "123e4567-e89b-12d3-a456-426614174000"
-        results = list(
-            rule.after(event=event, state=self.get_state(), notification_uuid=notification_uuid)
-        )
+        results = list(rule.after(event=event, notification_uuid=notification_uuid))
         assert len(results) == 1
 
         responses.add(
@@ -194,7 +192,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
 
         rule = self.get_rule(data={"account": integration.id, "team": team2["id"]})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 1
 
         responses.add(
@@ -260,7 +258,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
         event = self.get_event()
         rule = self.get_rule(data={"account": integration.id, "team": team2["id"]})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 1
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -269,7 +267,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
         event = self.get_event()
         rule = self.get_rule(data={"account": integration.id, "team": team2["id"]})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 0
         assert (
             mock_logger.error.call_args.args[0]
@@ -284,7 +282,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
         event = self.get_event()
         rule = self.get_rule(data={"account": self.integration.id, "team": self.team1["id"]})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 0
         assert (
             mock_logger.error.call_args.args[0]
@@ -296,7 +294,7 @@ class OpsgenieNotifyTeamTest(RuleTestCase, PerformanceIssueTestCase):
     def test_api_error(self, mock_logger: MagicMock):
         event = self.get_event()
         rule = self.get_rule(data={"account": self.integration.id, "team": self.team1["id"]})
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 1
 
         responses.add(

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -68,9 +68,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         notification_uuid = "123e4567-e89b-12d3-a456-426614174000"
 
-        results = list(
-            rule.after(event=event, state=self.get_state(), notification_uuid=notification_uuid)
-        )
+        results = list(rule.after(event=event, notification_uuid=notification_uuid))
         assert len(results) == 1
 
         responses.add(
@@ -117,7 +115,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
     def test_applies_correctly_performance_issue(self):
         event = self.create_performance_issue()
         rule = self.get_rule(data={"account": self.integration.id, "service": self.service["id"]})
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 1
 
         responses.add(
@@ -152,7 +150,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         group_event.occurrence = occurrence
 
         rule = self.get_rule(data={"account": self.integration.id, "service": self.service["id"]})
-        results = list(rule.after(event=group_event, state=self.get_state()))
+        results = list(rule.after(event=group_event))
         assert len(results) == 1
 
         responses.add(
@@ -280,7 +278,7 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
         rule = self.get_rule(data={"account": integration.id, "service": service["id"]})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 1
 
         responses.add(

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -49,7 +49,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 1
 
         responses.add(
@@ -360,7 +360,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 0
 
     @responses.activate
@@ -381,9 +381,7 @@ class SlackNotifyActionTest(RuleTestCase):
             )
 
             notification_uuid = "123e4567-e89b-12d3-a456-426614174000"
-            results = list(
-                rule.after(event=event, state=self.get_state(), notification_uuid=notification_uuid)
-            )
+            results = list(rule.after(event=event, notification_uuid=notification_uuid))
             assert len(results) == 1
 
             responses.add(
@@ -433,5 +431,5 @@ class SlackNotifyActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"workspace": self.integration.id, "channel": "#my-channel"})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 1

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -67,7 +67,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
             content_type="application/json",
         )
 
-        after_res = azuredevops_rule.after(event=event, state=self.get_state())
+        after_res = azuredevops_rule.after(event=event)
         results = list(after_res)
         assert len(results) == 1
 
@@ -120,7 +120,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
         )
         azuredevops_rule.rule = Rule.objects.create(project=self.project, label="test rule")
 
-        results = list(azuredevops_rule.after(event=event, state=self.get_state()))
+        results = list(azuredevops_rule.after(event=event))
         assert len(results) == 1
         results[0].callback(event, futures=[])
         assert len(responses.calls) == 0

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -128,7 +128,7 @@ class NotifyEmailTest(RuleTestCase, PerformanceIssueTestCase):
         rule = self.get_rule(data={"targetType": "IssueOwners"})
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
         assert len(results) == 1
 
     def test_full_integration(self):

--- a/tests/sentry/rules/actions/test_notify_event.py
+++ b/tests/sentry/rules/actions/test_notify_event.py
@@ -18,7 +18,7 @@ class NotifyEventActionTest(RuleTestCase):
         rule = self.get_rule()
         rule.get_plugins = lambda: (LegacyPluginService(plugin),)
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
 
         assert len(results) == 1
         assert plugin.should_notify.call_count == 1

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -50,7 +50,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
 
         assert rule.id == SENTRY_APP_ALERT_ACTION
 
-        futures = list(rule.after(event=event, state=self.get_state()))
+        futures = list(rule.after(event=event))
         assert len(futures) == 1
         assert futures[0].callback is notify_sentry_app
         assert futures[0].kwargs["sentry_app"].id == self.app.id

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -27,7 +27,7 @@ class NotifyEventServiceActionTest(RuleTestCase):
         with patch("sentry.plugins.base.plugins.get") as get_plugin:
             get_plugin.return_value = plugin
 
-            results = list(rule.after(event=event, state=self.get_state()))
+            results = list(rule.after(event=event))
 
         assert len(results) == 1
         assert plugin.should_notify.call_count == 1
@@ -42,7 +42,7 @@ class NotifyEventServiceActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"service": "test-application"})
 
-        results = list(rule.after(event=event, state=self.get_state()))
+        results = list(rule.after(event=event))
 
         assert len(results) == 1
         assert results[0].callback is notify_sentry_app
@@ -61,7 +61,7 @@ class NotifyEventServiceActionTest(RuleTestCase):
         with patch("sentry.plugins.base.plugins.get") as get_plugin:
             get_plugin.return_value = plugin
 
-            results = list(rule.after(event=event, state=self.get_state()))
+            results = list(rule.after(event=event))
 
         assert len(results) == 2
         assert plugin.should_notify.call_count == 1


### PR DESCRIPTION
`state` isn't used in `after` anywhere and we don't have access to it for the delayed rule processing, so remove it!

Relies on https://github.com/getsentry/getsentry/pull/13777