### PR TITLE
test(gen-metrics): Use 4 bytes for set values instead of 8

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1710,7 +1710,7 @@ class BaseMetricsTestCase(SnubaTestCase):
 
         if type == "set":
             # Relay uses a different hashing algorithm, but that's ok
-            value = [int.from_bytes(hashlib.md5(str(value).encode()).digest()[:8], "big")]
+            value = [int.from_bytes(hashlib.md5(str(value).encode()).digest()[:4], "big")]
         elif type == "distribution":
             value = [value]
         elif type == "gauge":


### PR DESCRIPTION
Relay sends `u32` for set values, but snuba consumer deserialize them as `u64`. This used to work fine when we are deserializing JSON. But we're going to encode sets/distribution values via base64 (see https://github.com/getsentry/snuba/pull/5761).

It doesn't make much sense to deserialize 4 bytes of decoded base64 buffer into an u64, so we're switching to u32 in the consumer. Turns out that some integration tests are sending 8 bytes, which causes an overflow and the CI to fail on https://github.com/getsentry/snuba/pull/5761. This pr aligns the integer width between relay and integration tests, and unblocks b64 encoding for metrics consumers.

Ran
```
pytest -k 'not __In' tests/snuba \
      tests/sentry/eventstream/kafka \
      tests/sentry/post_process_forwarder \
      tests/sentry/snuba \
      tests/sentry/eventstore/snuba \
      tests/sentry/search/events \
      tests/sentry/event_manager \
      tests/sentry/api/endpoints/test_organization_profiling_functions.py \
      tests/snuba/api/endpoints/test_organization_events_stats_mep.py \
      tests/sentry/sentry_metrics/querying \
      tests/snuba/test_snql_snuba.py \
      tests/snuba/test_metrics_layer.py
```
3 tests failed with postgres error, none of which seems to have anything to do with metrics, going to chalk it up to my local environment.

Errors:
```
ERROR tests/sentry/event_manager/grouping/test_assign_to_group.py::test_existing_group_no_new_hash[ new_logic_enabled: False - in_transition: True ] - django.db.utils.IntegrityError: ForeignKeyViolation('insert or update on table "sentry_environmentpro...
ERROR tests/sentry/event_manager/grouping/test_assign_to_group.py::test_existing_group_new_hash_exists[ secondary_hash_exists: True - new_logic_enabled: False - in_transition: True ] - django.db.utils.IntegrityError: ForeignKeyViolation('insert or update on table "sentry_environmentpro...
ERROR tests/sentry/event_manager/grouping/test_assign_to_group.py::test_existing_group_new_hash_exists[ secondary_hash_exists: False - new_logic_enabled: True - in_transition: True ] - django.db.utils.IntegrityError: ForeignKeyViolation('insert or update on table "sentry_environmentpro...

E   django.db.utils.IntegrityError: ForeignKeyViolation('insert or update on table "sentry_environmentproject" violates foreign key constraint "sentry_environmentpr_environment_id_f5d02227_fk_sentry_en"\nDETAIL:  Key (environment_id)=(7) is not present in table "sentry_environment".\n')
E   SQL: SET CONSTRAINTS ALL IMMEDIATE
```