### PR TITLE
fix(backup): Allow small than per-model batches

### DIFF
--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -247,6 +247,11 @@ def _import(
 
     # The input JSON blob should already be ordered by model kind. We simply break it up into
     # smaller chunks, while guaranteeing that each chunk contains at most 1 model kind.
+    #
+    # This generator returns a three-tuple of values: 1. the name of the model being generated, 2. a
+    # serialized JSON string containing some number of such model instances, and 3. an offset
+    # representing how many instances of this model have already been produced by this generator,
+    # NOT including the current instance.
     def yield_json_models(content) -> Iterator[tuple[NormalizedModelName, str, int]]:
         # TODO(getsentry#team-ospo/190): Better error handling for unparsable JSON.
         models = json.loads(content)

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -65,6 +65,9 @@ DELETED_FIELDS: dict[
     "sentry.team": {"org_role"}
 }
 
+# The maximum number of models that may be sent at a time.
+MAX_BATCH_SIZE = 20
+
 
 class ImportingError(Exception):
     def __init__(self, context: RpcImportError) -> None:
@@ -143,7 +146,10 @@ def _import(
     #
     # Needless to say, there is probably a better way to do this, but we'll use this hacky
     # workaround for now to enable forward progress.
-    deferred_org_auth_tokens = None
+    #
+    # Note: this is a list serialized JSON lists of `OrgAuthToken` models, batched into
+    # `MAX_BATCH_SIZE` length batches.
+    deferred_org_auth_tokens: list[str] = []
 
     # TODO(getsentry#team-ospo/190): Reading the entire export into memory as a string is quite
     # wasteful - in the future, we should explore chunking strategies to enable a smaller memory
@@ -239,26 +245,36 @@ def _import(
 
         filters.append(email_filter)
 
-    # The input JSON blob should already be ordered by model kind. We simply break up 1 JSON blob
-    # with N model kinds into N json blobs with 1 model kind each.
-    def yield_json_models(content) -> Iterator[tuple[NormalizedModelName, str]]:
+    # The input JSON blob should already be ordered by model kind. We simply break it up into
+    # smaller chunks, while guaranteeing that each chunk contains at most 1 model kind.
+    def yield_json_models(content) -> Iterator[tuple[NormalizedModelName, str, int]]:
         # TODO(getsentry#team-ospo/190): Better error handling for unparsable JSON.
         models = json.loads(content)
         last_seen_model_name: NormalizedModelName | None = None
         batch: list[type[Model]] = []
+        num_current_model_instances_yielded = 0
         for model in models:
             model_name = NormalizedModelName(model["model"])
             if last_seen_model_name != model_name:
                 if last_seen_model_name is not None and len(batch) > 0:
-                    yield (last_seen_model_name, json.dumps(batch))
+                    yield (
+                        last_seen_model_name,
+                        json.dumps(batch),
+                        num_current_model_instances_yielded,
+                    )
 
+                num_current_model_instances_yielded = 0
                 batch = []
                 last_seen_model_name = model_name
+            if len(batch) >= MAX_BATCH_SIZE:
+                yield (last_seen_model_name, json.dumps(batch), num_current_model_instances_yielded)
+                num_current_model_instances_yielded += len(batch)
+                batch = []
 
             batch.append(model)
 
         if last_seen_model_name is not None and batch:
-            yield (last_seen_model_name, json.dumps(batch))
+            yield (last_seen_model_name, json.dumps(batch), num_current_model_instances_yielded)
 
     # A wrapper for some immutable state we need when performing a single `do_write().
     @dataclass(frozen=True)
@@ -274,6 +290,7 @@ def _import(
         pk_map: PrimaryKeyMap,
         model_name: NormalizedModelName,
         json_data: json.JSONData,
+        offset: int,
     ) -> None:
         model_relations = import_write_context.dependencies.get(model_name)
         if not model_relations:
@@ -289,6 +306,7 @@ def _import(
             filter_by=import_write_context.filter_by,
             pk_map=RpcPrimaryKeyMap.into_rpc(pk_map.partition(dep_models)),
             json_data=json_data,
+            min_ordinal=offset + 1,
         )
 
         if isinstance(result, RpcImportError):
@@ -323,8 +341,6 @@ def _import(
             control_import_chunk_replica = ControlImportChunkReplica(
                 import_uuid=flags.import_uuid,
                 model=model_name_str,
-                # TODO(getsentry/team-ospo#190): The next two fields assume the entire model is
-                # being imported in a single call; we may change this in the future.
                 min_ordinal=result.min_ordinal,
                 max_ordinal=result.max_ordinal,
                 min_source_pk=result.min_source_pk,
@@ -351,12 +367,12 @@ def _import(
     def do_writes(pk_map: PrimaryKeyMap) -> None:
         nonlocal deferred_org_auth_tokens, import_write_context
 
-        for model_name, json_data in yield_json_models(content):
+        for model_name, json_data, offset in yield_json_models(content):
             if model_name == org_auth_token_model_name:
-                deferred_org_auth_tokens = json_data
+                deferred_org_auth_tokens.append(json_data)
                 continue
 
-            do_write(import_write_context, pk_map, model_name, json_data)
+            do_write(import_write_context, pk_map, model_name, json_data, offset)
 
     # Resolves slugs for all imported organization models via the PrimaryKeyMap and reconciles
     # their slug globally via control silo by issuing a slug update.
@@ -393,7 +409,14 @@ def _import(
     resolve_org_slugs_from_pk_map(pk_map)
 
     if deferred_org_auth_tokens:
-        do_write(import_write_context, pk_map, org_auth_token_model_name, deferred_org_auth_tokens)
+        for i, deferred_org_auth_token_batch in enumerate(deferred_org_auth_tokens):
+            do_write(
+                import_write_context,
+                pk_map,
+                org_auth_token_model_name,
+                deferred_org_auth_token_batch,
+                i * MAX_BATCH_SIZE,
+            )
 
 
 def import_in_user_scope(

--- a/src/sentry/models/importchunk.py
+++ b/src/sentry/models/importchunk.py
@@ -53,7 +53,8 @@ class BaseImportChunk(DefaultFieldsModel):
     # existing database data that was kept in their stead).
     existing_map = models.JSONField(default=dict)
 
-    # A JSON object map from original pks in the source blob to the pks they "overwrote" (ie, the data from the model was imported into an existing model, and that model's pk was retained).
+    # A JSON object map from original pks in the source blob to the pks they "overwrote" (ie, the
+    # data from the model was imported into an existing model, and that model's pk was retained).
     overwrite_map = models.JSONField(default=dict)
 
     # If the inserted model has a "slug" field, or some other similar globally unique string

--- a/src/sentry/services/hybrid_cloud/import_export/impl.py
+++ b/src/sentry/services/hybrid_cloud/import_export/impl.py
@@ -49,13 +49,13 @@ from sentry.silo.base import SiloMode
 
 
 def get_existing_import_chunk(
-    model_name: NormalizedModelName, flags: ImportFlags, import_chunk_type: type[models.base.Model]
+    model_name: NormalizedModelName,
+    flags: ImportFlags,
+    import_chunk_type: type[models.base.Model],
+    min_ordinal: int,
 ) -> RpcImportOk | None:
-    # TODO(getsentry/team-ospo#190): `min_ordinal=1` assumes the entire model is being imported in a
-    # single call; we will need to change this when we implement more granular chunking in the
-    # future.
     found_chunk = import_chunk_type.objects.filter(
-        import_uuid=flags.import_uuid, model=model_name, min_ordinal=1
+        import_uuid=flags.import_uuid, model=model_name, min_ordinal=min_ordinal
     ).first()
     if found_chunk is None:
         return None
@@ -105,7 +105,15 @@ class UniversalImportExportService(ImportExportService):
         filter_by: list[RpcFilter],
         pk_map: RpcPrimaryKeyMap,
         json_data: str,
+        min_ordinal: int,
     ) -> RpcImportResult:
+        if min_ordinal < 1:
+            return RpcImportError(
+                kind=RpcImportErrorKind.InvalidMinOrdinal,
+                on=InstanceID(model_name),
+                reason=f"The model `{model_name}` was offset with an invalid `min_ordinal` of `{min_ordinal}`",
+            )
+
         batch_model_name = NormalizedModelName(model_name)
         model = get_model(batch_model_name)
         if model is None:
@@ -166,7 +174,7 @@ class UniversalImportExportService(ImportExportService):
                 # building our transaction. Thus, we'll check `get_existing_import_chunk()` again if
                 # we catch an `IntegrityError` below.
                 existing_import_chunk = get_existing_import_chunk(
-                    batch_model_name, import_flags, import_chunk_type
+                    batch_model_name, import_flags, import_chunk_type, min_ordinal
                 )
                 if existing_import_chunk is not None:
                     return existing_import_chunk
@@ -177,7 +185,7 @@ class UniversalImportExportService(ImportExportService):
                 max_old_pk = 0
                 min_inserted_pk: int | None = None
                 max_inserted_pk: int | None = None
-                counter = 0
+                last_seen_ordinal = min_ordinal - 1
                 for deserialized_object in deserialize("json", json_data, use_natural_keys=False):
                     model_instance = deserialized_object.object
                     if model_instance._meta.app_label not in EXCLUDED_APPS or model_instance:
@@ -225,7 +233,7 @@ class UniversalImportExportService(ImportExportService):
 
                                     # For models that may have circular references to themselves
                                     # (unlikely), keep track of the new pk in the input map as well.
-                                    counter += 1
+                                    last_seen_ordinal += 1
                                     new_pk, import_kind = written
                                     slug = getattr(model_instance, "slug", None)
                                     in_pk_map.insert(
@@ -250,7 +258,7 @@ class UniversalImportExportService(ImportExportService):
                                     errs = {field: error for field, error in e.message_dict.items()}
                                     return RpcImportError(
                                         kind=RpcImportErrorKind.ValidationError,
-                                        on=InstanceID(model_name, ordinal=counter),
+                                        on=InstanceID(model_name, ordinal=last_seen_ordinal),
                                         left_pk=model_instance.pk,
                                         reason=f"Django validation error encountered: {errs}",
                                     )
@@ -258,14 +266,14 @@ class UniversalImportExportService(ImportExportService):
                                 except DjangoRestFrameworkValidationError as e:
                                     return RpcImportError(
                                         kind=RpcImportErrorKind.ValidationError,
-                                        on=InstanceID(model_name, ordinal=counter),
+                                        on=InstanceID(model_name, ordinal=last_seen_ordinal),
                                         left_pk=model_instance.pk,
                                         reason=str(e),
                                     )
 
                 # If the `counter` is at 0, no model instances were actually imported, so we can
                 # return early.
-                if counter == 0:
+                if last_seen_ordinal == min_ordinal - 1:
                     return RpcImportOk(
                         mapped_pks=RpcPrimaryKeyMap.into_rpc(out_pk_map),
                         min_ordinal=None,
@@ -295,10 +303,8 @@ class UniversalImportExportService(ImportExportService):
                 import_chunk_args = {
                     "import_uuid": flags.import_uuid,
                     "model": model_name,
-                    # TODO(getsentry/team-ospo#190): The next two fields assume the entire model is
-                    # being imported in a single call; we may change this in the future.
-                    "min_ordinal": 1,
-                    "max_ordinal": counter,
+                    "min_ordinal": min_ordinal,
+                    "max_ordinal": last_seen_ordinal,
                     "min_source_pk": min_old_pk,
                     "max_source_pk": max_old_pk,
                     "min_inserted_pk": min_inserted_pk,
@@ -317,8 +323,8 @@ class UniversalImportExportService(ImportExportService):
 
                 return RpcImportOk(
                     mapped_pks=RpcPrimaryKeyMap.into_rpc(out_pk_map),
-                    min_ordinal=1,
-                    max_ordinal=counter,
+                    min_ordinal=min_ordinal,
+                    max_ordinal=last_seen_ordinal,
                     min_source_pk=min_old_pk,
                     max_source_pk=max_old_pk,
                     min_inserted_pk=min_inserted_pk,
@@ -343,11 +349,11 @@ class UniversalImportExportService(ImportExportService):
                 if desc.startswith("UniqueViolation") and import_chunk_type._meta.db_table in desc:
                     try:
                         existing_import_chunk = get_existing_import_chunk(
-                            batch_model_name, import_flags, import_chunk_type
+                            batch_model_name, import_flags, import_chunk_type, min_ordinal
                         )
                         if existing_import_chunk is None:
                             raise RuntimeError(
-                                f"Erroneous import chunk unique collision for identifier: {(import_flags.import_uuid, batch_model_name, 1)}"
+                                f"Erroneous import chunk unique collision for identifier: {(import_flags.import_uuid, batch_model_name, min_ordinal)}"
                             )
                         return existing_import_chunk
                     except Exception:

--- a/src/sentry/services/hybrid_cloud/import_export/model.py
+++ b/src/sentry/services/hybrid_cloud/import_export/model.py
@@ -129,6 +129,7 @@ class RpcImportErrorKind(str, Enum):
     DeserializationFailed = "DeserializationFailed"
     IncorrectSiloModeForModel = "IncorrectSiloModeForModel"
     IntegrityError = "IntegrityError"
+    InvalidMinOrdinal = "InvalidMinOrdinal"
     MissingImportUUID = "MissingImportUUID"
     UnknownModel = "UnknownModel"
     UnexpectedModel = "UnexpectedModel"

--- a/src/sentry/services/hybrid_cloud/import_export/service.py
+++ b/src/sentry/services/hybrid_cloud/import_export/service.py
@@ -60,6 +60,7 @@ class ImportExportService(RpcService):
         filter_by: list[RpcFilter],
         pk_map: RpcPrimaryKeyMap,
         json_data: str = "",
+        min_ordinal: int,
     ) -> RpcImportResult:
         """
         Import models of a certain kind from JSON source. Do not call this method directly - use

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -7,6 +7,7 @@ import tempfile
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 import urllib3.exceptions
@@ -22,6 +23,7 @@ from sentry.backup.crypto import LocalFileDecryptor
 from sentry.backup.dependencies import NormalizedModelName, dependencies, get_model, get_model_name
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.imports import (
+    MAX_BATCH_SIZE,
     ImportingError,
     import_in_config_scope,
     import_in_global_scope,
@@ -42,6 +44,7 @@ from sentry.models.importchunk import (
 from sentry.models.lostpasswordhash import LostPasswordHash
 from sentry.models.options.option import ControlOption, Option
 from sentry.models.options.project_option import ProjectOption
+from sentry.models.options.user_option import UserOption
 from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
@@ -69,6 +72,7 @@ from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query
+from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.backups import (
@@ -2453,6 +2457,151 @@ class CustomImportBehaviorTests(ImportTestCase):
 
             with open(tmp_path, "rb") as tmp_file:
                 verify_models_in_output(expected_models, json.load(tmp_file))
+
+
+class BatchingTests(TestCase):
+    """
+    Ensure large lists of a single model type are batched properly, and that this batching does not disrupt pk mapping. These tests do not inherit from `ImportTestCase` because they do not require a completely clean database.
+    """
+
+    def import_n_users_with_options(self, import_uuid: str, n: int) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
+            with open(tmp_path, "w") as tmp_file:
+                users = []
+                user_options = []
+                for i in range(1, n + 1):
+                    users.append(
+                        {
+                            "model": "sentry.user",
+                            "pk": i + 100,
+                            "fields": {
+                                "password": "fake",
+                                "username": f"user-{i}",
+                                "name": f"user-{i}",
+                                "email": f"{i}@example.com",
+                                "is_staff": False,
+                                "is_active": True,
+                                "is_superuser": False,
+                                "is_managed": False,
+                                "is_password_expired": False,
+                                "is_unclaimed": False,
+                                "last_password_change": "2023-06-22T22:59:57.023Z",
+                                "flags": "0",
+                                "date_joined": "2023-06-22T22:59:55.488Z",
+                                "last_active": "2023-06-22T22:59:55.489Z",
+                                "avatar_type": 0,
+                            },
+                        }
+                    )
+                    user_options.append(
+                        {
+                            "model": "sentry.useroption",
+                            "pk": i + 1000,
+                            "fields": {
+                                "user": i + 100,
+                                "key": f"key-{i}",
+                                "value": f"user-{i}",
+                            },
+                        }
+                    )
+
+                json.dump(users + user_options, tmp_file)
+
+            with open(tmp_path, "rb") as tmp_file:
+                import_in_user_scope(
+                    tmp_file, flags=ImportFlags(import_uuid=import_uuid), printer=NOOP_PRINTER
+                )
+
+    def test_exact_multiple_of_batch_size(self):
+        import_uuid = uuid4().hex
+        want_chunks = 2
+        n = MAX_BATCH_SIZE * want_chunks
+        self.import_n_users_with_options(import_uuid, n)
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            user_chunks = list(
+                ControlImportChunk.objects.filter(import_uuid=import_uuid, model="sentry.user")
+            )
+            user_option_chunks = list(
+                ControlImportChunk.objects.filter(
+                    import_uuid=import_uuid, model="sentry.useroption"
+                )
+            )
+
+            assert len(user_chunks) == want_chunks
+            assert len(user_option_chunks) == want_chunks
+
+            assert user_chunks[0].min_ordinal == 1
+            assert user_chunks[0].max_ordinal == MAX_BATCH_SIZE
+            assert user_chunks[0].min_source_pk == 101
+            assert user_chunks[0].max_source_pk == MAX_BATCH_SIZE + 100
+
+            assert user_chunks[1].min_ordinal == MAX_BATCH_SIZE + 1
+            assert user_chunks[1].max_ordinal == MAX_BATCH_SIZE * 2
+            assert user_chunks[1].min_source_pk == MAX_BATCH_SIZE + 101
+            assert user_chunks[1].max_source_pk == (MAX_BATCH_SIZE * 2) + 100
+
+            assert user_option_chunks[0].min_ordinal == 1
+            assert user_option_chunks[0].max_ordinal == MAX_BATCH_SIZE
+            assert user_option_chunks[0].min_source_pk == 1001
+            assert user_option_chunks[0].max_source_pk == MAX_BATCH_SIZE + 1000
+
+            assert user_option_chunks[1].min_ordinal == MAX_BATCH_SIZE + 1
+            assert user_option_chunks[1].max_ordinal == MAX_BATCH_SIZE * 2
+            assert user_option_chunks[1].min_source_pk == MAX_BATCH_SIZE + 1001
+            assert user_option_chunks[1].max_source_pk == (MAX_BATCH_SIZE * 2) + 1000
+
+            # Ensure pk mapping from a later batch is still consistent.
+            target = MAX_BATCH_SIZE + (MAX_BATCH_SIZE // 2)
+            user_option = UserOption.objects.get(key=f"key-{target}")
+            user = User.objects.get(id=user_option.user_id)
+            assert user.name == f"user-{target}"
+
+    def test_one_more_than_batch_size(self):
+        import_uuid = uuid4().hex
+        want_chunks = 2
+        n = MAX_BATCH_SIZE + 1
+        self.import_n_users_with_options(import_uuid, n)
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            user_chunks = list(
+                ControlImportChunk.objects.filter(import_uuid=import_uuid, model="sentry.user")
+            )
+            user_option_chunks = list(
+                ControlImportChunk.objects.filter(
+                    import_uuid=import_uuid, model="sentry.useroption"
+                )
+            )
+
+            assert len(user_chunks) == want_chunks
+            assert len(user_option_chunks) == want_chunks
+
+            assert user_chunks[0].min_ordinal == 1
+            assert user_chunks[0].max_ordinal == MAX_BATCH_SIZE
+            assert user_chunks[0].min_source_pk == 101
+            assert user_chunks[0].max_source_pk == MAX_BATCH_SIZE + 100
+
+            assert user_chunks[1].min_ordinal == MAX_BATCH_SIZE + 1
+            assert user_chunks[1].max_ordinal == MAX_BATCH_SIZE + 1
+            assert user_chunks[1].min_source_pk == MAX_BATCH_SIZE + 101
+            assert user_chunks[1].max_source_pk == MAX_BATCH_SIZE + 101
+
+            assert user_option_chunks[0].min_ordinal == 1
+            assert user_option_chunks[0].max_ordinal == MAX_BATCH_SIZE
+            assert user_option_chunks[0].min_source_pk == 1001
+            assert user_option_chunks[0].max_source_pk == MAX_BATCH_SIZE + 1000
+
+            assert user_option_chunks[1].min_ordinal == MAX_BATCH_SIZE + 1
+            assert user_option_chunks[1].max_ordinal == MAX_BATCH_SIZE + 1
+            assert user_option_chunks[1].min_source_pk == MAX_BATCH_SIZE + 1001
+            assert user_option_chunks[1].max_source_pk == MAX_BATCH_SIZE + 1001
+
+            # Ensure pk mapping from a later batch is still consistent.
+            target = MAX_BATCH_SIZE + 1
+            user_option = UserOption.objects.get(key=f"key-{target}")
+            user = User.objects.get(id=user_option.user_id)
+            assert user.name == f"user-{target}"
 
 
 @pytest.mark.skipif(reason="not legacy")

--- a/tests/sentry/backup/test_rpc.py
+++ b/tests/sentry/backup/test_rpc.py
@@ -75,6 +75,7 @@ class RpcImportRetryTests(TestCase):
                     }
                 ]
                 """,
+                min_ordinal=1,
             )
 
             assert isinstance(result, RpcImportOk)
@@ -135,6 +136,7 @@ class RpcImportRetryTests(TestCase):
                     }
                 ]
                 """,
+                min_ordinal=1,
             )
 
             assert isinstance(result, RpcImportOk)
@@ -171,16 +173,17 @@ class RpcImportRetryTests(TestCase):
 
         # First call returns `None`, but then, by the time we get around to trying to commit the
         # atomic transaction, another mocked concurrent process has written the same chunk. We
-        # should handle this gracefully by going and getting
+        # should handle this gracefully by going and getting that chunk instead.
         def wrapped_get_existing_import_chunk(
             model_name: NormalizedModelName,
             flags: ImportFlags,
             import_chunk_type: type[models.base.Model],
+            min_ordinal: int,
         ) -> RpcImportOk | None:
             nonlocal mock_call_count
             mock_call_count += 1
             if mock_call_count > 1:
-                return get_existing_import_chunk(model_name, flags, import_chunk_type)
+                return get_existing_import_chunk(model_name, flags, import_chunk_type, min_ordinal)
 
             return None
 
@@ -224,6 +227,7 @@ class RpcImportRetryTests(TestCase):
                     }
                 ]
                 """,
+                min_ordinal=1,
             )
 
             assert get_existing_import_chunk_mock.call_count == 2
@@ -268,6 +272,20 @@ class RpcImportErrorTests(TestCase):
     def json_of_exhaustive_user_with_minimum_privileges(self) -> json.JSONData:
         return deepcopy(self._json_of_exhaustive_user_with_minimum_privileges)
 
+    def test_bad_invalid_min_ordinal(self):
+        result = import_export_service.import_by_model(
+            model_name=str(USER_MODEL_NAME),
+            scope=RpcImportScope.Global,
+            flags=RpcImportFlags(import_uuid=str(uuid4().hex)),
+            filter_by=[],
+            pk_map=RpcPrimaryKeyMap(),
+            json_data="[]",
+            min_ordinal=0,
+        )
+
+        assert isinstance(result, RpcImportError)
+        assert result.get_kind() == RpcImportErrorKind.InvalidMinOrdinal
+
     def test_bad_unknown_model(self):
         result = import_export_service.import_by_model(
             model_name="sentry.doesnotexist",
@@ -276,6 +294,7 @@ class RpcImportErrorTests(TestCase):
             filter_by=[],
             pk_map=RpcPrimaryKeyMap(),
             json_data="[]",
+            min_ordinal=1,
         )
 
         assert isinstance(result, RpcImportError)
@@ -290,6 +309,7 @@ class RpcImportErrorTests(TestCase):
             filter_by=[],
             pk_map=RpcPrimaryKeyMap(),
             json_data="[]",
+            min_ordinal=1,
         )
 
         assert isinstance(result, RpcImportError)
@@ -302,6 +322,7 @@ class RpcImportErrorTests(TestCase):
             filter_by=[],
             pk_map=RpcPrimaryKeyMap(),
             json_data="[]",
+            min_ordinal=1,
         )
 
         assert isinstance(result, RpcImportError)
@@ -315,6 +336,7 @@ class RpcImportErrorTests(TestCase):
             filter_by=[],
             pk_map=RpcPrimaryKeyMap(),
             json_data="[]",
+            min_ordinal=1,
         )
 
         assert isinstance(result, RpcImportError)
@@ -328,6 +350,7 @@ class RpcImportErrorTests(TestCase):
             filter_by=[],
             pk_map=RpcPrimaryKeyMap(),
             json_data="_",
+            min_ordinal=1,
         )
 
         assert isinstance(result, RpcImportError)
@@ -349,6 +372,7 @@ class RpcImportErrorTests(TestCase):
             filter_by=[],
             pk_map=RpcPrimaryKeyMap(),
             json_data=json_data,
+            min_ordinal=1,
         )
 
         assert isinstance(result, RpcImportError)
@@ -364,6 +388,7 @@ class RpcImportErrorTests(TestCase):
             filter_by=[],
             pk_map=RpcPrimaryKeyMap(),
             json_data=json_data,
+            min_ordinal=1,
         )
 
         assert isinstance(result, RpcImportError)

--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -623,12 +623,10 @@ class GoodGlobalImportConfirmDialogTests(TransactionTestCase):
 @patch("sentry.backup.imports.ImportExportService.get_importer_for_model")
 class BadImportExportDomainErrorTests(TransactionTestCase):
     def test_import_integrity_error_exit_code(self, get_importer_for_model):
-        importer_mock_fn = (
-            lambda model_name, scope, flags, filter_by, pk_map, json_data: RpcImportError(
-                kind=RpcImportErrorKind.IntegrityError,
-                on=InstanceID(model=str(get_model_name(Email)), ordinal=1),
-                reason="Test integrity error",
-            )
+        importer_mock_fn = lambda model_name, scope, flags, filter_by, pk_map, json_data, min_ordinal: RpcImportError(
+            kind=RpcImportErrorKind.IntegrityError,
+            on=InstanceID(model=str(get_model_name(Email)), ordinal=1),
+            reason="Test integrity error",
         )
         get_importer_for_model.return_value = importer_mock_fn
         # Global imports assume an empty DB, so this should fail with an `IntegrityError`.


### PR DESCRIPTION
We've experienced some database timeouts in prod imports due to very large groups of ex: user models (>1000) being written simultaneously. To resolve this problem, this PR creates a `MAX_BATCH_SIZE` constant, and then breaks writes of each model into batches of that size or smaller. This ensures that we only write a relatively small (currently 20) number of models per `import_by_model` call.