### PR TITLE
perf(orjson): Create several options to enable orjson experimentally

### DIFF
--- a/src/flagpole/__init__.py
+++ b/src/flagpole/__init__.py
@@ -111,7 +111,7 @@ class Feature(BaseModel):
         cls, name: str, config_json: str, context_builder: ContextBuilder | None = None
     ) -> Feature:
         try:
-            config_data_dict = json.loads(config_json)
+            config_data_dict = json.loads_experimental("flagpole.enable-orjson", config_json)
         except json.JSONDecodeError as decode_error:
             raise InvalidFeatureFlagConfiguration("Invalid feature json provided") from decode_error
 

--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -188,7 +188,7 @@ class U2fInterface(AuthenticatorInterface):
         return rv
 
     def try_enroll(self, enrollment_data, response_data, device_name=None, state=None):
-        data = json.loads(response_data)
+        data = json.loads_experimental("auth.enable-orjson", response_data)
         client_data = ClientData(websafe_decode(data["response"]["clientDataJSON"]))
         att_obj = base.AttestationObject(websafe_decode(data["response"]["attestationObject"]))
         binding = self.webauthn_registration_server.register_complete(state, client_data, att_obj)

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -433,7 +433,9 @@ class AuthIdentityHandler:
             # add events that we can handle on the front end
             provider = self.auth_provider.provider if self.auth_provider else None
             params = {
-                "frontend_events": json.dumps({"event_name": "Sign Up", "event_label": provider})
+                "frontend_events": json.dumps_experimental(
+                    "auth.enable-orjson", {"event_name": "Sign Up", "event_label": provider}
+                )
             }
             url = add_params_to_url(url, params)
         response = HttpResponseRedirect(url)

--- a/src/sentry/auth/idpmigration.py
+++ b/src/sentry/auth/idpmigration.py
@@ -103,7 +103,9 @@ class AccountConfirmLink:
             "provider": self.provider.provider,
         }
         cluster.setex(
-            self.verification_key, int(_TTL.total_seconds()), json.dumps(verification_value)
+            self.verification_key,
+            int(_TTL.total_seconds()),
+            json.dumps_experimental("auth.enable-orjson", verification_value),
         )
 
 
@@ -115,7 +117,9 @@ def get_verification_value_from_key(key: str) -> dict[str, Any] | None:
         metrics.incr("idpmigration.confirmation_failure", sample_rate=1.0)
         return None
 
-    verification_value: dict[str, Any] = json.loads(verification_str)
+    verification_value: dict[str, Any] = json.loads_experimental(
+        "auth.enable-orjson", verification_str
+    )
     metrics.incr(
         "idpmigration.confirmation_success",
         tags={"provider": verification_value.get("provider")},

--- a/src/sentry/auth/providers/fly/client.py
+++ b/src/sentry/auth/providers/fly/client.py
@@ -35,7 +35,7 @@ class FlyClient:
             raise FlyApiError(f"{e}", status=getattr(e, "status_code", 0))
         if req.status_code < 200 or req.status_code >= 300:
             raise FlyApiError(req.content, status=req.status_code)
-        return json.loads(req.content)
+        return json.loads_experimental("auth.enable-orjson", req.content)
 
     def get_info(self):
         """

--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -35,7 +35,7 @@ class GitHubClient:
             raise GitHubApiError(f"{e}", status=getattr(e, "status_code", 0))
         if req.status_code < 200 or req.status_code >= 300:
             raise GitHubApiError(req.content, status=req.status_code)
-        return json.loads(req.content)
+        return json.loads_experimental("auth.enable-orjson", req.content)
 
     def get_org_list(self):
         return self._request("/user/orgs")

--- a/src/sentry/auth/providers/google/views.py
+++ b/src/sentry/auth/providers/google/views.py
@@ -34,7 +34,7 @@ class FetchUser(AuthView):
             return helper.error(ERR_INVALID_RESPONSE)
 
         try:
-            payload = json.loads(payload)
+            payload = json.loads_experimental("auth.enable-orjson", payload)
         except Exception as exc:
             logger.exception("Unable to decode id_token payload: %s", exc)
             return helper.error(ERR_INVALID_RESPONSE)

--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -93,7 +93,7 @@ class OAuth2Callback(AuthView):
         body = safe_urlread(req)
         if req.headers["Content-Type"].startswith("application/x-www-form-urlencoded"):
             return dict(parse_qsl(body))
-        return json.loads(body)
+        return json.loads_experimental("auth.enable-orjson", body)
 
     def dispatch(self, request: Request, helper) -> HttpResponse:
         error = request.GET.get("error")
@@ -192,7 +192,7 @@ class OAuth2Provider(Provider, abc.ABC):
 
         try:
             body = safe_urlread(req)
-            payload = json.loads(body)
+            payload = json.loads_experimental("auth.enable-orjson", body)
         except Exception:
             payload = {}
 

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -436,7 +436,7 @@ class Superuser(ElevatedMode):
         else:
             try:
                 # need to use json loads as the data is no longer in request.data
-                su_access_json = json.loads(request.body)
+                su_access_json = json.loads_experimental("auth.enable-orjson", request.body)
             except json.JSONDecodeError:
                 metrics.incr(
                     "superuser.failure",

--- a/src/sentry/backup/crypto.py
+++ b/src/sentry/backup/crypto.py
@@ -135,7 +135,9 @@ def create_encrypted_export_tarball(json_export: json.JSONData, encryptor: Encry
     pem = encryptor.get_public_key_pem()
     data_encryption_key = Fernet.generate_key()
     backup_encryptor = Fernet(data_encryption_key)
-    encrypted_json_export = backup_encryptor.encrypt(json.dumps(json_export).encode("utf-8"))
+    encrypted_json_export = backup_encryptor.encrypt(
+        json.dumps_experimental("backup.enable-orjson", json_export).encode()
+    )
 
     # Encrypt the newly minted DEK using asymmetric public key encryption.
     dek_encryption_key = serialization.load_pem_public_key(pem, default_backend())
@@ -299,7 +301,7 @@ class GCPKMSDecryptor(Decryptor):
         gcp_kms_config_bytes = self.__fp.read()
 
         # Read the user supplied configuration into the proper format.
-        gcp_kms_config_json = json.loads(gcp_kms_config_bytes)
+        gcp_kms_config_json = json.loads_experimental("backup.enable-orjson", gcp_kms_config_bytes)
         try:
             crypto_key_version = CryptoKeyVersion(**gcp_kms_config_json)
         except TypeError:

--- a/src/sentry/backup/exports.py
+++ b/src/sentry/backup/exports.py
@@ -134,7 +134,7 @@ def _export(
         # TODO(getsentry/team-ospo#190): Since the structure of this data is very predictable (an
         # array of serialized model objects), we could probably avoid re-ingesting the JSON string
         # as a future optimization.
-        for json_model in sentry_json.loads(result.json_data):
+        for json_model in sentry_json.loads_experimental("backup.enable-orjson", result.json_data):
             json_export.append(json_model)
 
     # If no `encryptor` argument was passed in, this is an unencrypted export, so we can just dump

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -164,7 +164,7 @@ def _import(
         # Parse the content JSON and remove and fields that we have marked for deletion in the
         # function.
         shimmed_models = set(DELETED_FIELDS.keys())
-        content_as_json = json.loads(content)  # type: ignore[arg-type]
+        content_as_json = json.loads_experimental("backup.enable-orjson", content)  # type: ignore[arg-type]
         for json_model in content_as_json:
             if json_model["model"] in shimmed_models:
                 fields_to_remove = DELETED_FIELDS[json_model["model"]]
@@ -172,7 +172,7 @@ def _import(
                     json_model["fields"].pop(field, None)
 
         # Return the content to byte form, as that is what the Django deserializer expects.
-        content = json.dumps(content_as_json)
+        content = json.dumps_experimental("backup.enable-orjson", content_as_json)
 
     filters = []
     if filter_by is not None:
@@ -254,7 +254,7 @@ def _import(
     # NOT including the current instance.
     def yield_json_models(content) -> Iterator[tuple[NormalizedModelName, str, int]]:
         # TODO(getsentry#team-ospo/190): Better error handling for unparsable JSON.
-        models = json.loads(content)
+        models = json.loads_experimental("backup.enable-orjson", content)
         last_seen_model_name: NormalizedModelName | None = None
         batch: list[type[Model]] = []
         num_current_model_instances_yielded = 0
@@ -264,7 +264,7 @@ def _import(
                 if last_seen_model_name is not None and len(batch) > 0:
                     yield (
                         last_seen_model_name,
-                        json.dumps(batch),
+                        json.dumps_experimental("backup.enable-orjson", batch),
                         num_current_model_instances_yielded,
                     )
 
@@ -279,7 +279,11 @@ def _import(
             batch.append(model)
 
         if last_seen_model_name is not None and batch:
-            yield (last_seen_model_name, json.dumps(batch), num_current_model_instances_yielded)
+            yield (
+                last_seen_model_name,
+                json.dumps_experimental("backup.enable-orjson", batch),
+                num_current_model_instances_yielded,
+            )
 
     # A wrapper for some immutable state we need when performing a single `do_write().
     @dataclass(frozen=True)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2451,11 +2451,13 @@ def _get_severity_score(event: Event) -> tuple[float, str]:
                 response = severity_connection_pool.urlopen(
                     "POST",
                     "/v0/issues/severity-score",
-                    body=json.dumps(payload),
+                    body=json.dumps_experimental("event-manager.enable-orjson", payload),
                     headers={"content-type": "application/json;charset=utf-8"},
                     timeout=timeout,
                 )
-                severity = json.loads(response.data).get("severity")
+                severity = json.loads_experimental(
+                    "event-manager.enable-orjson", response.data
+                ).get("severity")
                 reason = "ml"
         except MaxRetryError as e:
             logger.warning(
@@ -2801,7 +2803,9 @@ def _materialize_event_metrics(jobs: Sequence[Job]) -> None:
         job["event"].data["_metrics"] = event_metrics
 
         # Capture the actual size that goes into node store.
-        event_metrics["bytes.stored.event"] = len(json.dumps(dict(job["event"].data.items())))
+        event_metrics["bytes.stored.event"] = len(
+            json.dumps_experimental("event-manager.enable-orjson", dict(job["event"].data.items()))
+        )
 
         for metric_name in ("flag.processing.error", "flag.processing.fatal"):
             if event_metrics.get(metric_name):

--- a/src/sentry/eventstore/compressor.py
+++ b/src/sentry/eventstore/compressor.py
@@ -62,7 +62,9 @@ def deduplicate(data):
             continue
 
         to_deduplicate, to_inline = interface.encode(data.pop(key))
-        to_deduplicate_serialized = json.dumps(to_deduplicate).encode()
+        to_deduplicate_serialized = json.dumps_experimental(
+            "eventstore.enable-orjson", to_deduplicate
+        ).encode()
         checksum = hashlib.md5(to_deduplicate_serialized).hexdigest()
         extra_keys[checksum] = to_deduplicate
         patchsets.append([key, checksum, to_inline])

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -525,7 +525,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
 
     @property
     def size(self) -> int:
-        return len(json.dumps(dict(self.data)))
+        return len(json.dumps_experimental("eventstore.enable-orjson", dict(self.data)))
 
     def get_email_subject(self) -> str:
         template = self.project.get_option("mail:subject_template")

--- a/src/sentry/eventstore/reprocessing/redis.py
+++ b/src/sentry/eventstore/reprocessing/redis.py
@@ -161,8 +161,9 @@ class RedisReprocessingStore(ReprocessingStore):
         self.redis.setex(
             _get_info_reprocessed_key(group_id),
             settings.SENTRY_REPROCESSING_SYNC_TTL,
-            json.dumps(
-                {"dateCreated": date_created, "syncCount": sync_count, "totalEvents": event_count}
+            json.dumps_experimental(
+                "eventstore.enable-orjson",
+                {"dateCreated": date_created, "syncCount": sync_count, "totalEvents": event_count},
             ),
         )
 
@@ -176,4 +177,4 @@ class RedisReprocessingStore(ReprocessingStore):
         info = self.redis.get(_get_info_reprocessed_key(group_id))
         if info is None:
             return None
-        return json.loads(info)
+        return json.loads_experimental("eventstore.enable-orjson", info)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -650,6 +650,7 @@ register("auth.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("backup.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("event-manager.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("eventstore.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("flagpole.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Kafka Publisher
 register("kafka-publisher.raw-event-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -647,6 +647,7 @@ register(
 register("snuba.snql.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("integrations.slack.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("auth.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("backup.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Kafka Publisher
 register("kafka-publisher.raw-event-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -646,6 +646,7 @@ register(
 
 register("snuba.snql.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("integrations.slack.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("auth.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Kafka Publisher
 register("kafka-publisher.raw-event-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -649,6 +649,7 @@ register("integrations.slack.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_M
 register("auth.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("backup.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("event-manager.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("eventstore.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Kafka Publisher
 register("kafka-publisher.raw-event-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -648,6 +648,7 @@ register("snuba.snql.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABL
 register("integrations.slack.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("auth.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("backup.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("event-manager.enable-orjson", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Kafka Publisher
 register("kafka-publisher.raw-event-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/flagpole/test_feature.py
+++ b/tests/flagpole/test_feature.py
@@ -4,6 +4,13 @@ import pytest
 
 from flagpole import ContextBuilder, EvaluationContext, Feature, InvalidFeatureFlagConfiguration
 from flagpole.operators import OperatorKind
+from sentry.testutils.helpers import override_options
+
+
+@pytest.fixture(autouse=True)
+def run_before_each():
+    with override_options({"flagpole.enable-orjson": 0.0}):
+        yield
 
 
 class TestParseFeatureConfig:

--- a/tests/sentry/auth/providers/fly/test_client.py
+++ b/tests/sentry/auth/providers/fly/test_client.py
@@ -5,6 +5,13 @@ import responses
 
 from sentry.auth.providers.fly.client import FlyClient
 from sentry.auth.providers.fly.constants import ACCESS_TOKEN_URL
+from sentry.testutils.helpers import override_options
+
+
+@pytest.fixture(autouse=True)
+def run_before_each():
+    with override_options({"auth.enable-orjson": 0.0}):
+        yield
 
 
 @pytest.fixture

--- a/tests/sentry/eventstore/processing/test_redis_cluster.py
+++ b/tests/sentry/eventstore/processing/test_redis_cluster.py
@@ -1,7 +1,16 @@
 from datetime import datetime
 
+import pytest
+
 from sentry.eventstore.reprocessing.redis import RedisReprocessingStore
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.redis import use_redis_cluster
+
+
+@pytest.fixture(autouse=True)
+def run_before_each():
+    with override_options({"eventstore.enable-orjson": 0.0}):
+        yield
 
 
 @use_redis_cluster()

--- a/tests/sentry/eventstore/test_compressor.py
+++ b/tests/sentry/eventstore/test_compressor.py
@@ -1,6 +1,15 @@
 import copy
 
+import pytest
+
 from sentry.eventstore.compressor import assemble, deduplicate
+from sentry.testutils.helpers import override_options
+
+
+@pytest.fixture(autouse=True)
+def run_before_each():
+    with override_options({"eventstore.enable-orjson": 0.0}):
+        yield
 
 
 def _assert_roundtrip(data, assert_extra_keys=None):


### PR DESCRIPTION
This creates the following rate-based options for enabling `orjson` in various modules:

* ~`apidocs.enable-orjson`~
* `auth.enable-orjson`
* `backup.enable-orjson`
* `event-manager.enable-orjson`
* `eventstore.enable-orjson`
* `flagpole.enable-orjson`

ref: https://github.com/getsentry/sentry/issues/68903

Edit: removed apidocs because there are considerations about formatting.