### PR TITLE
fix(metrics): Conditional display of add/exclude filter

### DIFF
--- a/static/app/views/metrics/summaryTable.tsx
+++ b/static/app/views/metrics/summaryTable.tsx
@@ -297,56 +297,58 @@ export const SummaryTable = memo(function SummaryTable({
                           </div>
                         )}
 
-                        <DropdownMenu
-                          items={[
-                            {
-                              key: 'add-to-filter',
-                              label: t('Add to filter'),
-                              size: 'sm',
-                              onAction: () => {
-                                handleRowFilter(
-                                  queryIndex,
-                                  {
-                                    id,
-                                    groupBy,
-                                  },
-                                  MetricSeriesFilterUpdateType.ADD
-                                );
+                        {/* do not show add/exclude filter if there's no groupby or if this is an equation */}
+                        {Object.keys(groupBy ?? {}).length > 0 && !isEquationSeries && (
+                          <DropdownMenu
+                            items={[
+                              {
+                                key: 'add-to-filter',
+                                label: t('Add to filter'),
+                                size: 'sm',
+                                onAction: () => {
+                                  handleRowFilter(
+                                    queryIndex,
+                                    {
+                                      id,
+                                      groupBy,
+                                    },
+                                    MetricSeriesFilterUpdateType.ADD
+                                  );
+                                },
                               },
-                            },
-                            {
-                              key: 'exclude-from-filter',
-                              label: t('Exclude from filter'),
-                              size: 'sm',
-                              onAction: () => {
-                                handleRowFilter(
-                                  queryIndex,
-                                  {
-                                    id,
-                                    groupBy,
-                                  },
-                                  MetricSeriesFilterUpdateType.EXCLUDE
-                                );
+                              {
+                                key: 'exclude-from-filter',
+                                label: t('Exclude from filter'),
+                                size: 'sm',
+                                onAction: () => {
+                                  handleRowFilter(
+                                    queryIndex,
+                                    {
+                                      id,
+                                      groupBy,
+                                    },
+                                    MetricSeriesFilterUpdateType.EXCLUDE
+                                  );
+                                },
                               },
-                            },
-                          ]}
-                          trigger={triggerProps => (
-                            <Button
-                              {...triggerProps}
-                              aria-label={t('Quick Context Action Menu')}
-                              data-test-id="quick-context-action-trigger"
-                              borderless
-                              size="zero"
-                              disabled={isEquationSeries}
-                              onClick={e => {
-                                e.stopPropagation();
-                                e.preventDefault();
-                                triggerProps.onClick?.(e);
-                              }}
-                              icon={<IconFilter size="sm" />}
-                            />
-                          )}
-                        />
+                            ]}
+                            trigger={triggerProps => (
+                              <Button
+                                {...triggerProps}
+                                aria-label={t('Quick Context Action Menu')}
+                                data-test-id="quick-context-action-trigger"
+                                borderless
+                                size="zero"
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  e.preventDefault();
+                                  triggerProps.onClick?.(e);
+                                }}
+                                icon={<IconFilter size="sm" />}
+                              />
+                            )}
+                          />
+                        )}
                       </ButtonBar>
                     </CenterCell>
                   )}


### PR DESCRIPTION
Displaying add/exclude filter only when it makes sense.


Before:


https://github.com/getsentry/sentry/assets/9060071/775639e6-3cfe-4212-9dee-f8b369335bdb




After:

https://github.com/getsentry/sentry/assets/9060071/510b06b4-4f64-499a-914d-2c7f79204ee2





Heads up: No Whitespace view is easier for this code review.
![CleanShot 2024-04-25 at 13 10 46](https://github.com/getsentry/sentry/assets/9060071/bd715330-a772-44c9-a65e-55cf38e7aa72)
