### PR TITLE
feat(cardinality-limit): Custom metric cardinality limit option

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -105,6 +105,7 @@ class ProjectMemberSerializer(serializers.Serializer):
         "safeFields",
         "storeCrashReports",
         "relayPiiConfig",
+        "relayCustomMetricCardinalityLimit",
         "builtinSymbolSources",
         "symbolSources",
         "scrubIPAddresses",

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -264,10 +264,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         return validate_pii_config_update(organization, value)
 
     def validate_relayCustomMetricCardinalityLimit(self, value):
-        if not value:
-            return value
-
-        if value < 0:
+        if value is not None and value < 0:
             raise serializers.ValidationError("Cardinality limit must be a non-negative integer.")
 
         return value

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1025,10 +1025,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
 
     def get_custom_metric_cardinality_limit(self, attrs):
         cardinalityLimits = attrs["options"].get("relay.cardinality-limiter.limits", [])
-        if not cardinalityLimits or len(cardinalityLimits) == 0:
-            return None
-
-        for limit in cardinalityLimits:
+        for limit in cardinalityLimits or ():
             if limit.get("limit", {}).get("id") == "project-override-custom":
                 return limit.get("limit", {}).get("limit", None)
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -989,6 +989,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 "processingIssues": attrs["processing_issues"],
                 "defaultEnvironment": attrs["options"].get("sentry:default_environment"),
                 "relayPiiConfig": attrs["options"].get("sentry:relay_pii_config"),
+                "relayCustomMetricCardinalityLimit": self.get_custom_metric_cardinality_limit(
+                    attrs
+                ),
                 "builtinSymbolSources": self.get_value_with_default(
                     attrs, "sentry:builtin_symbol_sources"
                 ),
@@ -1019,6 +1022,17 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
         )
 
         return data
+
+    def get_custom_metric_cardinality_limit(self, attrs):
+        cardinalityLimits = attrs["options"].get("relay.cardinality-limiter.limits", [])
+        if not cardinalityLimits or len(cardinalityLimits) == 0:
+            return None
+
+        for limit in cardinalityLimits:
+            if limit.get("limit", {}).get("id") == "project-override-custom":
+                return limit.get("limit", {}).get("limit", None)
+
+        return None
 
     def get_audit_log_data(self):
         return {

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -68,6 +68,7 @@ OPTION_KEYS = frozenset(
         "mail:subject_template",
         "filters:react-hydration-errors",
         "filters:chunk-load-error",
+        "relay.cardinality-limiter.limits",
     ]
 )
 


### PR DESCRIPTION
Add the `relayCustomMetricCardinalityLimit` param to the project details endpoint.
It accepts a positive integer and populates the project option `relay.cardinality-limiter.limits` with a limit scoped to custom metic names.

**Note**: The current implementation allows for only one limit inside `relay.cardinality-limiter.limits`. 

Support for `relay.cardinality-limiter.limits` was added in #69573 