### PR TITLE
feat(metrics): Add gauges support for spans

### DIFF
--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -193,6 +193,7 @@ USE_CASE_ID_TO_ENTITY_KEYS = {
         EntityKey.GenericMetricsCounters,
         EntityKey.GenericMetricsSets,
         EntityKey.GenericMetricsDistributions,
+        EntityKey.GenericMetricsGauges,
     },
     UseCaseID.TRANSACTIONS: {
         EntityKey.GenericMetricsCounters,


### PR DESCRIPTION
This PR adds gauges support for spans since they were added but never surfaced in the product endpoints.