### PR TITLE
feat(spans-metrics): Extend avg_if and avg_compare to frame metrics

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -331,6 +331,10 @@ SPAN_METRICS_MAP = {
     "http.decoded_response_content_length": "d:spans/http.decoded_response_content_length@byte",
     "http.response_transfer_size": "d:spans/http.response_transfer_size@byte",
     "cache.item_size": "d:spans/cache.item_size@byte",
+    "mobile.slow_frames": "g:spans/mobile.slow_frames@none",
+    "mobile.frozen_frames": "g:spans/mobile.frozen_frames@none",
+    "mobile.total_frames": "g:spans/mobile.total_frames@none",
+    "mobile.frames_delay": "g:spans/mobile.frames_delay@second",
 }
 SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
 # 50 to match the size of tables in the UI + 1 for pagination reasons
@@ -352,7 +356,13 @@ METRIC_DURATION_COLUMNS = {
 SPAN_METRIC_DURATION_COLUMNS = {
     key
     for key, value in SPAN_METRICS_MAP.items()
-    if value.endswith("@millisecond") and value.startswith("d:")
+    if (value.endswith("@millisecond") and value.startswith("d:"))
+    or (value.endswith("@second") and value.startswith("g:"))
+}
+SPAN_METRIC_COUNT_COLUMNS = {
+    key
+    for key, value in SPAN_METRICS_MAP.items()
+    if value.endswith("@none") and value.startswith("g:")
 }
 SPAN_METRIC_BYTES_COLUMNS = {
     key

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -173,7 +173,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     required_args=[
                         fields.MetricArg(
                             "column",
-                            allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
+                            allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
+                            | constants.SPAN_METRIC_COUNT_COLUMNS,
                         ),
                         fields.MetricArg(
                             "if_col",
@@ -486,7 +487,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     required_args=[
                         fields.MetricArg(
                             "column",
-                            allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
+                            allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
+                            | constants.SPAN_METRIC_COUNT_COLUMNS,
                             allow_custom_measurements=False,
                         ),
                         fields.MetricArg(

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1438,6 +1438,53 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {"count_op(queue.submit.celery)": 1, "count_op(queue.task.celery)": 1},
         ]
 
+    def test_frames_metrics(self):
+        for index, release in enumerate(["foo", "bar"]):
+            self.store_span_metric(
+                1 + 10 * index,
+                internal_metric=constants.SPAN_METRICS_MAP["mobile.slow_frames"],
+                timestamp=self.six_min_ago,
+                tags={"release": release},
+            )
+            self.store_span_metric(
+                2 + 10 * index,
+                internal_metric=constants.SPAN_METRICS_MAP["mobile.frozen_frames"],
+                timestamp=self.six_min_ago,
+                tags={"release": release},
+            )
+            self.store_span_metric(
+                3 + 10 * index,
+                internal_metric=constants.SPAN_METRICS_MAP["mobile.frames_delay"],
+                timestamp=self.six_min_ago,
+                tags={"release": release},
+            )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "avg_if(mobile.slow_frames,release,foo)",
+                    "avg_if(mobile.frozen_frames,release,bar)",
+                    "avg_compare(mobile.slow_frames,release,foo,bar)",
+                    "avg_if(mobile.frames_delay,release,foo)",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data == [
+            {
+                "avg_compare(mobile.slow_frames,release,foo,bar)": 10.0,
+                "avg_if(mobile.slow_frames,release,foo)": 1.0,
+                "avg_if(mobile.frames_delay,release,foo)": 3.0,
+                "avg_if(mobile.frozen_frames,release,bar)": 12.0,
+            }
+        ]
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest


### PR DESCRIPTION
Adds a `SPAN_METRIC_COUNT_COLUMNS` constant that exposes gauge metrics with no unit. Also adds `frames_delay` to the `SPAN_METRIC_DURATION_COLUMNS` definition by including seconds as the unit.