### PR TITLE
Reduce Metric Alert Load on Snuba

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1653,6 +1653,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:metric-alert-chartcuterie": False,
     # Enable ignoring archived issues in metric alerts
     "organizations:metric-alert-ignore-archived": False,
+    # Enable load shedding for newly created metric alerts
+    "organizations:metric-alert-load-shedding": False,
     # Enable threshold period in metric alert rule builder
     "organizations:metric-alert-threshold-period": False,
     # Enables the metrics metadata.

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -105,6 +105,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:metric-alert-ignore-archived", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:metric-alert-load-shedding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:metric-alert-threshold-period", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:metric-meta", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:metrics-api-new-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -105,7 +105,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:metric-alert-ignore-archived", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    manager.add("organizations:metric-alert-load-shedding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+    manager.add("organizations:metric-alert-load-shedding", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:metric-alert-threshold-period", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:metric-meta", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:metrics-api-new-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -461,7 +461,7 @@ class AlertRuleNameAlreadyUsedError(Exception):
 # Default values for `SnubaQuery.resolution`, in minutes.
 DEFAULT_ALERT_RULE_RESOLUTION = 1
 DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER = 2
-DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS = {
+DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION = {
     30: 2,
     60: 3,
     90: 3,
@@ -485,13 +485,13 @@ def get_alert_resolution(time_window: int, organization) -> int:
     resolution = DEFAULT_ALERT_RULE_RESOLUTION
 
     if features.has("organizations:metric-alert-load-shedding", organization=organization):
-        windows = sorted(DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS.keys())
+        windows = sorted(DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION.keys())
         index = bisect.bisect_right(windows, time_window)
 
         if index == 0:
             return DEFAULT_ALERT_RULE_RESOLUTION
 
-        resolution = DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[windows[index - 1]]
+        resolution = DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[windows[index - 1]]
 
     return resolution
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -484,9 +484,14 @@ def get_alert_resolution(time_window: int, organization) -> int:
     resolution = DEFAULT_ALERT_RULE_RESOLUTION
 
     if features.has("organizations:metric-alert-load-shedding", organization=organization):
-        resolution = DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS.get(
-            time_window, DEFAULT_ALERT_RULE_RESOLUTION
-        )
+        alert_resolution_windows = sorted(DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS.keys())
+        lower_bound = 0
+
+        for window in alert_resolution_windows:
+            if lower_bound < time_window <= window:
+                return DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[window]
+
+        return DEFAULT_ALERT_RULE_RESOLUTION
 
     return resolution
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -780,6 +780,7 @@ def update_alert_rule(
         updated_query_fields["resolution"] = timedelta(minutes=resolution)
         updated_fields["comparison_delta"] = comparison_delta
 
+    # Update the resolution if we changed the time_window but not the comparison_delta, and there was a previous comparison_delta set.
     if time_window and comparison_delta is NOT_SET and alert_rule.comparison_delta is not None:
         resolution = (
             get_alert_resolution(time_window, organization=alert_rule.organization)

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bisect
 import logging
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
@@ -484,14 +485,13 @@ def get_alert_resolution(time_window: int, organization) -> int:
     resolution = DEFAULT_ALERT_RULE_RESOLUTION
 
     if features.has("organizations:metric-alert-load-shedding", organization=organization):
-        alert_resolution_windows = sorted(DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS.keys())
-        lower_bound = 0
+        windows = sorted(DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS.keys())
+        index = bisect.bisect_right(windows, time_window)
 
-        for window in alert_resolution_windows:
-            if lower_bound < time_window <= window:
-                return DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[window]
+        if index == 0:
+            return DEFAULT_ALERT_RULE_RESOLUTION
 
-        return DEFAULT_ALERT_RULE_RESOLUTION
+        resolution = DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[windows[index - 1]]
 
     return resolution
 

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -13,7 +13,7 @@ from rest_framework.exceptions import ErrorDetail
 from sentry.auth.access import from_user
 from sentry.incidents.logic import (
     DEFAULT_ALERT_RULE_RESOLUTION,
-    DEFAULT_CMP_ALERT_RULE_RESOLUTION,
+    DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER,
     ChannelLookupTimeoutError,
     create_alert_rule_trigger,
 )
@@ -689,7 +689,9 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
         triggers = {trigger.label: trigger for trigger in alert_rule.alertruletrigger_set.all()}
         assert triggers["critical"].alert_threshold == 150
         assert triggers["warning"].alert_threshold == 140
-        assert alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
+        assert (
+            alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER * 60
+        )
 
     def test_comparison_delta_below(self):
         params = self.valid_params.copy()
@@ -706,7 +708,9 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
         triggers = {trigger.label: trigger for trigger in alert_rule.alertruletrigger_set.all()}
         assert triggers["critical"].alert_threshold == 50
         assert triggers["warning"].alert_threshold == 60
-        assert alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
+        assert (
+            alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER * 60
+        )
 
         params["comparison_delta"] = None
         params["resolveThreshold"] = 100

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -16,7 +16,7 @@ from sentry.incidents.events import (
     IncidentCreatedEvent,
     IncidentStatusUpdatedEvent,
 )
-from sentry.incidents.logic import (  # get_alert_resolution,
+from sentry.incidents.logic import (
     CRITICAL_TRIGGER_LABEL,
     DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS,
     DEFAULT_ALERT_RULE_RESOLUTION,
@@ -2813,19 +2813,3 @@ class TestCustomMetricAlertRule(TestCase):
         )
 
         mocked_schedule_invalidate_project_config.assert_not_called()
-
-
-class TestGetAlertResolution(TestCase):
-    def test_get_alert_resolution(self):
-        # Test that the default resolution is used
-        pass
-
-    # Enable the feature and ensure it's using the new resolution
-    def test_get_alert_resolution_load_shedding(self):
-        # test that the lookup table is used
-        pass
-
-    # Enable the feature and get resolution, should be the default alert resolution
-    def test_get_alert_resolution_load_shedding_unknown_time_window(self):
-        # test that it returns default if the time window is unknown
-        pass

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -18,8 +18,8 @@ from sentry.incidents.events import (
 )
 from sentry.incidents.logic import (
     CRITICAL_TRIGGER_LABEL,
-    DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS,
     DEFAULT_ALERT_RULE_RESOLUTION,
+    DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION,
     DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER,
     WARNING_TRIGGER_LABEL,
     WINDOWED_STATS_DATA_POINTS,
@@ -774,7 +774,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
 
         assert (
             alert_rule.snuba_query.resolution
-            == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[time_window] * 60
+            == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window] * 60
         )
 
     @with_feature("organizations:metric-alert-load-shedding")
@@ -797,7 +797,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
 
         assert (
             alert_rule.snuba_query.resolution
-            == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[time_window]
+            == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window]
             * 60
             * DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER
         )
@@ -1155,14 +1155,14 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
         assert (
             alert_rule.snuba_query.resolution
-            == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[time_window] * 60
+            == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window] * 60
         )
 
         time_window = 90
         updated_alert_rule = update_alert_rule(alert_rule, time_window=time_window)
         assert (
             updated_alert_rule.snuba_query.resolution
-            == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[time_window] * 60
+            == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window] * 60
         )
 
     @with_feature("organizations:metric-alert-load-shedding")
@@ -1185,7 +1185,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
         assert (
             alert_rule.snuba_query.resolution
-            == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[time_window]
+            == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window]
             * DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER
             * 60
         )
@@ -1195,7 +1195,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
 
         assert (
             updated_alert_rule.snuba_query.resolution
-            == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[time_window]
+            == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window]
             * DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER
             * 60
         )
@@ -1222,7 +1222,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         updated_alert_rule = update_alert_rule(alert_rule, comparison_delta=90)
         assert (
             updated_alert_rule.snuba_query.resolution
-            == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[time_window]
+            == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window]
             * DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER
             * 60
         )
@@ -1252,7 +1252,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         )
         assert (
             updated_alert_rule.snuba_query.resolution
-            == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[time_window]
+            == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window]
             * DEFAULT_CMP_ALERT_RULE_RESOLUTION_MULTIPLIER
             * 60
         )
@@ -2826,7 +2826,7 @@ class TestGetAlertResolution(TestCase):
     def test_enabled_feature(self):
         time_window = 30
         result = get_alert_resolution(time_window, self.organization)
-        assert result == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[time_window]
+        assert result == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[time_window]
 
     @with_feature("organizations:metric-alert-load-shedding")
     def test_low_range(self):
@@ -2836,11 +2836,11 @@ class TestGetAlertResolution(TestCase):
 
     @with_feature("organizations:metric-alert-load-shedding")
     def test_high_range(self):
-        last_window = list(DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS.keys())[-1]
+        last_window = list(DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION.keys())[-1]
         time_window = last_window + 1000
         result = get_alert_resolution(time_window, self.organization)
 
-        assert result == DEFAULT_ALERT_RULE_LOAD_SHEDDING_RESOLUTIONS[last_window]
+        assert result == DEFAULT_ALERT_RULE_WINDOW_TO_RESOLUTION[last_window]
 
     @with_feature("organizations:metric-alert-load-shedding")
     def test_mid_range(self):


### PR DESCRIPTION
## Description

This PR will help address [#inc-719](https://sentry.slack.com/archives/C06V504V789) by reducing load on snuba. This PR will read the `"organizations:metric-alert-load-shedding"` feature and change the resolution of the metric alert according to the [window -> resolution mapping](https://github.com/getsentry/sentry/compare/jcallender/metric-alert-load-shedding?expand=1#diff-54ef12aa467e9e032fcdeb5d98079424d01fb28db982938d9e8db849ae78dd5eR463-R471). [Estimated savings](https://docs.google.com/spreadsheets/d/1maiAp69LHVbEDRQsub4HvL5WpfhS5AWJZ3py6oD27cQ/edit#gid=1827329865) based on this mapping, is about 87% reduction in load.

---

[This PR](https://github.com/getsentry/sentry/pull/69224/files) was reverted during a deploy yesterday. The deploy issue was unrelated to these changes.