### PR TITLE
fix(issue-details): Allow for_review query to refresh page with real-time updates

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -597,15 +597,13 @@ class IssueListOverview extends Component<Props, State> {
         });
       }
     } else {
-      if (!isForReviewQuery(query)) {
-        GroupStore.loadInitialData([]);
+      GroupStore.loadInitialData([]);
 
-        this.setState({
-          issuesLoading: true,
-          queryCount: 0,
-          error: null,
-        });
-      }
+      this.setState({
+        issuesLoading: true,
+        queryCount: 0,
+        error: null,
+      });
     }
 
     const transaction = getCurrentSentryReactTransaction();

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -586,17 +586,7 @@ class IssueListOverview extends Component<Props, State> {
     const {organization} = this.props;
     const query = this.getQuery();
 
-    if (!this.state.realtimeActive) {
-      if (!this.actionTaken && !this.undo) {
-        GroupStore.loadInitialData([]);
-
-        this.setState({
-          issuesLoading: true,
-          queryCount: 0,
-          error: null,
-        });
-      }
-    } else {
+    if (this.state.realtimeActive || (!this.actionTaken && !this.undo)) {
       GroupStore.loadInitialData([]);
 
       this.setState({


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry/issues/69088

This check seems to be the reason for the inconsistencies with the issue details page with real-time updates and the `for_review` query, but it looks deliberate, so if anyone knows why this might be the case, I can look at accommodating that in a revision to this PR.