### PR TITLE
feat(traces): Add a splitByChar optimization to spans

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -652,6 +652,19 @@ def query_trace_data(
     return transformed_results[0], transformed_results[1]
 
 
+def strip_span_id(span_id):
+    """Span ids are stored as integers in snuba to save space, but this means if the span id has a 00 prefix the
+    returned value is different
+
+        Need to do this with a while loop cause doing hex(int(span_id, 16)) will turn something like 0abc into abc which
+        differs from the behaviour we're seeing when clickhouse does it
+    """
+    result = span_id
+    while result.startswith("00"):
+        result = result.removeprefix("00")
+    return result
+
+
 def build_span_query(trace_id, spans_params, query_spans):
     parents_query = SpansIndexedQueryBuilder(
         Dataset.SpansIndexed,
@@ -666,18 +679,25 @@ def build_span_query(trace_id, spans_params, query_spans):
         orderby=["precise.start_ts", "id"],
         limit=10000,
     )
+    # Performance improvement, snuba's parser is extremely slow when we're sending thousands of
+    # span_ids here, using a `splitByChar` means that snuba will not parse the giant list of spans
+    span_minimum = options.get("performance.traces.span_query_minimum_spans")
+    sentry_sdk.set_measurement("trace_view.spans.span_minimum", span_minimum)
+    sentry_sdk.set_tag("trace_view.split_by_char.optimization", len(query_spans) > span_minimum)
+    if len(query_spans) > span_minimum:
+        # TODO because we're not doing an IN on a list of literals, snuba will not optimize the query with the HexInt
+        # column processor which means we won't be taking advantage of the span_id index but if we only do this when we
+        # have a lot of query_spans we should have a great performance improvement still once we do that we can simplify
+        # this code and always apply this optimization
+        span_condition_value = Function(
+            "splitByChar", [",", ",".join(strip_span_id(span_id) for span_id in query_spans)]
+        )
+    else:
+        span_condition_value = Function("tuple", list(query_spans))
     # Building the condition manually, a performance optimization since we might put thousands of span ids
     # and this way we skip both parsimonious and the builder
     parents_query.add_conditions(
-        [
-            Condition(
-                Column(parents_query.resolve_column_name("id")),
-                Op.IN,
-                # Another performance improvement, using a tuple instead of an array will cause clickhouse to use
-                # the bloom filter index
-                Function("tuple", list(query_spans)),
-            )
-        ]
+        [Condition(Column(parents_query.resolve_column_name("id")), Op.IN, span_condition_value)]
     )
     return parents_query
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1689,7 +1689,7 @@ register(
 register(
     "performance.traces.span_query_minimum_spans",
     type=Int,
-    default=500,
+    default=10000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1686,6 +1686,12 @@ register(
     default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )  # hours
+register(
+    "performance.traces.span_query_minimum_spans",
+    type=Int,
+    default=500,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Dynamic Sampling system-wide options
 # Size of the sliding window used for dynamic sampling. It is defaulted to 24 hours.

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1548,6 +1548,21 @@ class OrganizationEventsTraceEndpointTestUsingSpans(OrganizationEventsTraceEndpo
         assert "transaction.status" not in trace_transaction
         assert "tags" not in trace_transaction
 
+    def test_split_by_char_optimization(self):
+        self.load_trace()
+        # This changes the span_id condition so its a split on a string instead of an array
+        options.set("performance.traces.span_query_minimum_spans", 1)
+        with self.feature(self.FEATURES):
+            response = self.client_get(
+                data={},
+            )
+        assert response.status_code == 200, response.content
+        trace_transaction = response.data["transactions"][0]
+        self.assert_trace_data(trace_transaction)
+        # We shouldn't have detailed fields here
+        assert "transaction.status" not in trace_transaction
+        assert "tags" not in trace_transaction
+
 
 class OrganizationEventsTraceMetaEndpointTest(OrganizationEventsTraceEndpointBase):
     url_name = "sentry-api-0-organization-events-trace-meta"


### PR DESCRIPTION
- This uses splitByChar for the span_id condition, which should significantly speed up snuba parsing since we're no longer parsing a list of thousands of span ids, but instead parsing a single str that then gets split by clickhouse
- The one major drawback of this approach is snuba only uses the literal `span_id` column when the value is an array or tuple of literals
- There's an option to enable/disable this optimization, we may need to tune when we enable this since for low span_id counts we're slowing the query down by not using the index, but we're definitely speeding queries up when there's a lot of span_ids
  - We can turn this optimization off by increasing the option to any value above 5000