### PR TITLE
ref(rules): Don't pass buffer to apply_delayed

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -38,10 +38,10 @@ class Buffer(Service):
 
     def get_hash(
         self, model: type[models.Model], field: dict[str, models.Model | str | int]
-    ) -> list[dict[str, str]]:
+    ) -> None:
         return
 
-    def get_set(self, key: str) -> list[set[int]]:
+    def get_set(self, key: str) -> None:
         return
 
     def incr(

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -39,7 +39,7 @@ class Buffer(Service):
     def get_hash(
         self, model: type[models.Model], field: dict[str, models.Model | str | int]
     ) -> dict[str, str]:
-        return []
+        return {}
 
     def get_set(self, key: str) -> list[tuple[int, datetime]]:
         return []

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -38,11 +38,11 @@ class Buffer(Service):
 
     def get_hash(
         self, model: type[models.Model], field: dict[str, models.Model | str | int]
-    ) -> None:
-        return
+    ) -> dict[str, str]:
+        return []
 
-    def get_set(self, key: str) -> None:
-        return
+    def get_set(self, key: str) -> list[tuple[int, datetime]]:
+        return []
 
     def incr(
         self,

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -36,6 +36,14 @@ class Buffer(Service):
         """
         return {col: 0 for col in columns}
 
+    def get_hash(
+        self, model: type[models.Model], field: dict[str, models.Model | str | int]
+    ) -> list[dict[str, str]]:
+        return
+
+    def get_set(self, key: str) -> list[set[int]]:
+        return
+
     def incr(
         self,
         model: type[models.Model],

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -273,7 +273,7 @@ class RedisBuffer(Buffer):
         getattr(pipe, operation.value)(key, *args, **kwargs)
         if args:
             pipe.expire(key, self.key_expire)
-        return pipe.execute()
+        return pipe.execute()[0]
 
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
         self._execute_redis_operation(key, RedisOperation.SORTED_SET_ADD, {value: time()})
@@ -283,7 +283,7 @@ class RedisBuffer(Buffer):
             key, RedisOperation.SORTED_SET_GET_RANGE, start=0, end=-1, withscores=True
         )
         decoded_set = []
-        for items in redis_set[0]:
+        for items in redis_set:
             item = items[0]
             if isinstance(item, bytes):
                 item = item.decode("utf-8")
@@ -319,7 +319,7 @@ class RedisBuffer(Buffer):
         key = self._make_key(model, field)
         redis_hash = self._execute_redis_operation(key, RedisOperation.HASH_GET_ALL)
         decoded_hash = {}
-        for key, value in redis_hash[0].items():
+        for key, value in redis_hash.items():
             if isinstance(key, bytes):
                 key = key.decode("utf-8")
             if isinstance(value, bytes):

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -319,12 +319,12 @@ class RedisBuffer(Buffer):
         key = self._make_key(model, field)
         redis_hash = self._execute_redis_operation(key, RedisOperation.HASH_GET_ALL)
         decoded_hash = {}
-        for key, value in redis_hash.items():
-            if isinstance(key, bytes):
-                key = key.decode("utf-8")
-            if isinstance(value, bytes):
-                value = value.decode("utf-8")
-            decoded_hash[key] = value
+        for k, v in redis_hash.items():
+            if isinstance(k, bytes):
+                k = k.decode("utf-8")
+            if isinstance(v, bytes):
+                v = v.decode("utf-8")
+            decoded_hash[k] = v
 
         return decoded_hash
 

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -50,14 +50,11 @@ def get_slow_conditions(rule: Rule) -> list[MutableMapping[str, str]]:
     return slow_conditions
 
 
-def get_rules_to_groups(
-    rulegroup_to_events: list[dict[bytes, bytes]]
-) -> DefaultDict[int, set[int]]:
+def get_rules_to_groups(rulegroup_to_events: list[dict[str, str]]) -> DefaultDict[int, set[int]]:
     rules_to_groups: DefaultDict[int, set[int]] = defaultdict(set)
-    for rulegroup_to_event in rulegroup_to_events:
-        for rule_group in rulegroup_to_event.keys():
-            rule_id, group_id = rule_group.decode("utf-8").split(":")
-            rules_to_groups[int(rule_id)].add(int(group_id))
+    for rule_group in rulegroup_to_events.keys():
+        rule_id, group_id = rule_group.split(":")
+        rules_to_groups[int(rule_id)].add(int(group_id))
 
     return rules_to_groups
 
@@ -170,7 +167,7 @@ def get_rules_to_fire(
 def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
     with metrics.timer("delayed_processing.process_all_conditions.duration"):
         project_ids = buffer.get_set(PROJECT_ID_BUFFER_LIST_KEY)
-        for project_id in project_ids[0]:
+        for project_id in project_ids:
             with metrics.timer("delayed_processing.process_project.duration"):
                 apply_delayed.delay(project_id=project_id)
 
@@ -189,7 +186,7 @@ def apply_delayed(project_id: int) -> DefaultDict[Rule, set[int]] | None:
     Grab rules, groups, and events from the Redis buffer, evaluate the "slow" conditions in a bulk snuba query, and fire them if they pass
     """
     # STEP 1: Fetch the rulegroup_to_events mapping for the project from redis
-    project = Project.objects.get(id=project_id)
+    project = Project.objects.get_from_cache(id=project_id)
     buffer = RedisBuffer()
     rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": project.id})
     # STEP 2: Map each rule to the groups that must be checked for that rule.

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -50,7 +50,7 @@ def get_slow_conditions(rule: Rule) -> list[MutableMapping[str, str]]:
     return slow_conditions
 
 
-def get_rules_to_groups(rulegroup_to_events: list[dict[str, str]]) -> DefaultDict[int, set[int]]:
+def get_rules_to_groups(rulegroup_to_events: dict[str, str]) -> DefaultDict[int, set[int]]:
     rules_to_groups: DefaultDict[int, set[int]] = defaultdict(set)
     for rule_group in rulegroup_to_events.keys():
         rule_id, group_id = rule_group.split(":")

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -50,7 +50,9 @@ def get_slow_conditions(rule: Rule) -> list[MutableMapping[str, str]]:
     return slow_conditions
 
 
-def get_rules_to_groups(rulegroup_to_events: list[dict[str, str]]) -> DefaultDict[int, set[int]]:
+def get_rules_to_groups(
+    rulegroup_to_events: list[dict[bytes, bytes]]
+) -> DefaultDict[int, set[int]]:
     rules_to_groups: DefaultDict[int, set[int]] = defaultdict(set)
     for rulegroup_to_event in rulegroup_to_events:
         for rule_group in rulegroup_to_event.keys():

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1,13 +1,15 @@
 import copy
 from datetime import UTC, datetime
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 
-from sentry.db import models
+from sentry.buffer.redis import RedisBuffer
 from sentry.eventstore.models import Event
+from sentry.models.project import Project
 from sentry.rules.processing.delayed_processing import (
+    PROJECT_ID_BUFFER_LIST_KEY,
     apply_delayed,
     process_delayed_alert_conditions,
 )
@@ -52,8 +54,17 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         condition_id = f"sentry.rules.conditions.event_frequency.{id}"
         return {"interval": interval, "id": condition_id, "value": value}
 
+    def push_to_hash(self, project_id, rule_id, group_id, event_id):
+        self.redis_buffer.push_to_hash(
+            model=Project,
+            filters={"project_id": project_id},
+            field=f"{rule_id}:{group_id}",
+            value=event_id,
+        )
+
     def setUp(self):
         super().setUp()
+        self.redis_buffer = RedisBuffer()
         self.event_frequency_condition = self.create_event_frequency_condition()
         self.event_frequency_condition2 = self.create_event_frequency_condition(value=2)
         self.event_frequency_condition3 = self.create_event_frequency_condition(
@@ -126,74 +137,65 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
             self.project.id: self.rulegroup_event_mapping_one,
             self.project_two.id: self.rulegroup_event_mapping_two,
         }
+        self.redis_buffer.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=self.project.id)
+        self.redis_buffer.push_to_sorted_set(
+            key=PROJECT_ID_BUFFER_LIST_KEY, value=self.project_two.id
+        )
 
-        self.mock_buffer = Mock()
-
-    def get_rulegroup_event_mapping_from_input(
-        self, model: type[models.Model], field: dict[str, models.Model | str | int]
-    ):
-        # There will only be one event per rulegroup
-        proj_id = field.popitem()[1]
-        return self.buffer_mapping[proj_id]
+        self.push_to_hash(self.project.id, self.rule1.id, self.group1.id, self.event1.event_id)
+        self.push_to_hash(self.project.id, self.rule2.id, self.group2.id, self.event2.event_id)
+        self.push_to_hash(self.project_two.id, self.rule3.id, self.group3.id, self.event3.event_id)
+        self.push_to_hash(self.project_two.id, self.rule4.id, self.group4.id, self.event4.event_id)
 
     @patch("sentry.rules.processing.delayed_processing.apply_delayed")
     def test_fetches_from_buffer_and_executes(self, mock_apply_delayed):
-        self.mock_buffer.get_set.return_value = self.buffer_mapping.keys()
         # To get the correct mapping, we need to return the correct
         # rulegroup_event mapping based on the project_id input
-        self.mock_buffer.get_hash.side_effect = self.get_rulegroup_event_mapping_from_input
+        with patch("sentry.buffer.backend.get_set", self.redis_buffer.get_set):
+            process_delayed_alert_conditions(self.redis_buffer)
 
-        process_delayed_alert_conditions(self.mock_buffer)
-
-        for project, rule_group_event_mapping in (
-            (self.project, self.rulegroup_event_mapping_one),
-            (self.project_two, self.rulegroup_event_mapping_two),
-        ):
-            assert mock_apply_delayed.delay.call_count == 2
+            for project, rule_group_event_mapping in (
+                (self.project, self.rulegroup_event_mapping_one),
+                (self.project_two, self.rulegroup_event_mapping_two),
+            ):
+                assert mock_apply_delayed.delay.call_count == 2
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_apply_delayed_rules_to_fire(self):
         """
         Test that rules of various event frequency conditions, projects, environments, etc. are properly scheduled to fire
         """
-        self.mock_buffer.get_hash.return_value = [self.rulegroup_event_mapping_one]
+        with patch("sentry.buffer.backend.get_hash", self.redis_buffer.get_hash):
+            rules = apply_delayed(self.project.id)
+            assert self.rule1 in rules
+            assert self.rule2 in rules
 
-        rules = apply_delayed(self.project.id, self.mock_buffer)
-        assert self.rule1 in rules
-        assert self.rule2 in rules
-
-        self.mock_buffer.get_hash.return_value = [self.rulegroup_event_mapping_two]
-
-        rules = apply_delayed(self.project_two.id, self.mock_buffer)
-        assert self.rule3 in rules
-        assert self.rule4 in rules
+            rules = apply_delayed(self.project_two.id)
+            assert self.rule3 in rules
+            assert self.rule4 in rules
 
     def test_apply_delayed_same_condition_diff_value(self):
         """
         Test that two rules with the same condition and interval but a different value are both scheduled to fire
         """
         rule5 = self.create_project_rule(
-            project=self.project_two,
+            project=self.project,
             condition_match=[self.event_frequency_condition2],
             environment_id=self.environment.id,
         )
-        event5 = self.create_event(self.project_two, self.now, "group-5", self.environment.name)
-        self.create_event(self.project_two, self.now, "group-5", self.environment.name)
-        self.create_event(self.project_two, self.now, "group-5", self.environment.name)
+        event5 = self.create_event(self.project, self.now, "group-5", self.environment.name)
+        self.create_event(self.project, self.now, "group-5", self.environment.name)
+        self.create_event(self.project, self.now, "group-5", self.environment.name)
         group5 = event5.group
         assert group5
         assert self.group1
+        self.push_to_hash(self.project.id, rule5.id, group5.id, event5.event_id)
 
-        self.mock_buffer.get_hash.return_value = [
-            {
-                f"{self.rule1.id}:{self.group1.id}": {self.event1.event_id},
-                f"{rule5.id}:{group5.id}": {event5.event_id},
-            },
-        ]
-
-        rules = apply_delayed(self.project.id, self.mock_buffer)
-        assert self.rule1 in rules
-        assert rule5 in rules
+        with patch("sentry.buffer.backend.get_hash", self.redis_buffer.get_hash):
+            rules = apply_delayed(self.project.id)
+            for rule in rules:
+                assert self.rule1 in rules
+                assert rule5 in rules
 
     def test_apply_delayed_same_condition_diff_interval(self):
         """
@@ -209,17 +211,12 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         group5 = event5.group
         assert group5
         assert self.group1
+        self.push_to_hash(self.project.id, diff_interval_rule.id, group5.id, event5.event_id)
 
-        self.mock_buffer.get_hash.return_value = [
-            {
-                f"{self.rule1.id}:{self.group1.id}": {self.event1.event_id},
-                f"{diff_interval_rule.id}:{group5.id}": {event5.event_id},
-            },
-        ]
-
-        rules = apply_delayed(self.project.id, self.mock_buffer)
-        assert self.rule1 in rules
-        assert diff_interval_rule in rules
+        with patch("sentry.buffer.backend.get_hash", self.redis_buffer.get_hash):
+            rules = apply_delayed(self.project.id)
+            assert self.rule1 in rules
+            assert diff_interval_rule in rules
 
     def test_apply_delayed_same_condition_diff_env(self):
         """
@@ -236,17 +233,12 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         group5 = event5.group
         assert group5
         assert self.group1
+        self.push_to_hash(self.project.id, diff_env_rule.id, group5.id, event5.event_id)
 
-        self.mock_buffer.get_hash.return_value = [
-            {
-                f"{self.rule1.id}:{self.group1.id}": {self.event1.event_id},
-                f"{diff_env_rule.id}:{group5.id}": {event5.event_id},
-            },
-        ]
-
-        rules = apply_delayed(self.project.id, self.mock_buffer)
-        assert self.rule1 in rules
-        assert diff_env_rule in rules
+        with patch("sentry.buffer.backend.get_hash", self.redis_buffer.get_hash):
+            rules = apply_delayed(self.project.id)
+            assert self.rule1 in rules
+            assert diff_env_rule in rules
 
     def test_apply_delayed_two_rules_one_fires(self):
         """
@@ -268,14 +260,9 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         group5 = event5.group
         assert group5
         assert self.group1
+        self.push_to_hash(self.project.id, no_fire_rule.id, group5.id, event5.event_id)
 
-        self.mock_buffer.get_hash.return_value = [
-            {
-                f"{self.rule1.id}:{self.group1.id}": {self.event1.event_id},
-                f"{no_fire_rule.id}:{group5.id}": {event5.event_id},
-            },
-        ]
-
-        rules = apply_delayed(self.project.id, self.mock_buffer)
-        assert self.rule1 in rules
-        assert no_fire_rule not in rules
+        with patch("sentry.buffer.backend.get_hash", self.redis_buffer.get_hash):
+            rules = apply_delayed(self.project.id)
+            assert self.rule1 in rules
+            assert no_fire_rule not in rules


### PR DESCRIPTION
Follow up to comments on https://github.com/getsentry/sentry/pull/69167 to not pass the Redis buffer to `apply_delayed`, and also a minor comment to rename a function. 