### PR TITLE
ref(crons): Improve naming of clock tick dispatch code

### DIFF
--- a/src/sentry/monitors/clock_dispatch.py
+++ b/src/sentry/monitors/clock_dispatch.py
@@ -25,9 +25,9 @@ def _int_or_none(s: str | None) -> int | None:
         return int(s)
 
 
-def _dispatch_tasks(ts: datetime):
+def _dispatch_tick(ts: datetime):
     """
-    Dispatch monitor tasks triggered by the consumer clock.
+    Dispatch a clock tick which will trigger monitor tasks.
 
     These tasks are triggered via the consumer processing check-ins. This
     allows the monitor tasks to be synchronized to any backlog of check-ins
@@ -45,7 +45,7 @@ def _dispatch_tasks(ts: datetime):
     check_timeout.delay(current_datetime=ts)
 
 
-def try_monitor_tasks_trigger(ts: datetime, partition: int):
+def try_monitor_clock_tick(ts: datetime, partition: int):
     """
     Handles triggering the monitor tasks when we've rolled over the minute.
 
@@ -121,4 +121,4 @@ def try_monitor_tasks_trigger(ts: datetime, partition: int):
             scope.set_extra("slowest_part_ts", slowest_part_ts)
             sentry_sdk.capture_message("Monitor task dispatch minute skipped")
 
-    _dispatch_tasks(tick)
+    _dispatch_tick(tick)

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -29,7 +29,7 @@ from sentry.killswitches import killswitch_matches_context
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.models.user import User
-from sentry.monitors.clock_dispatch import try_monitor_tasks_trigger
+from sentry.monitors.clock_dispatch import try_monitor_clock_tick
 from sentry.monitors.constants import PermitCheckInStatus
 from sentry.monitors.logic.mark_failed import mark_failed
 from sentry.monitors.logic.mark_ok import mark_ok
@@ -905,7 +905,7 @@ def process_batch(executor: ThreadPoolExecutor, message: Message[ValuesBatch[Kaf
     # Attempt to trigger monitor tasks across processed partitions
     for partition, ts in latest_partition_ts.items():
         try:
-            try_monitor_tasks_trigger(ts, partition)
+            try_monitor_clock_tick(ts, partition)
         except Exception:
             logger.exception("Failed to trigger monitor tasks")
 
@@ -923,7 +923,7 @@ def process_single(message: Message[KafkaPayload]):
         partition = message.value.partition.index
 
         try:
-            try_monitor_tasks_trigger(ts, partition)
+            try_monitor_clock_tick(ts, partition)
         except Exception:
             logger.exception("Failed to trigger monitor tasks")
 

--- a/src/sentry/monitors/tasks/clock_pulse.py
+++ b/src/sentry/monitors/tasks/clock_pulse.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from sentry_kafka_schemas.schema_types.ingest_monitors_v1 import ClockPulse
 
 from sentry.conf.types.kafka_definition import Topic
-from sentry.monitors.clock_dispatch import try_monitor_tasks_trigger
+from sentry.monitors.clock_dispatch import try_monitor_clock_tick
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils.arroyo_producer import SingletonProducer
@@ -65,7 +65,7 @@ def clock_pulse(current_datetime=None):
     if settings.SENTRY_EVENTSTREAM != "sentry.eventstream.kafka.KafkaEventStream":
         # Directly trigger try_monitor_tasks_trigger in dev
         for partition in _get_partitions().values():
-            try_monitor_tasks_trigger(current_datetime, partition.id)
+            try_monitor_clock_tick(current_datetime, partition.id)
         return
 
     message: ClockPulse = {

--- a/tests/sentry/monitors/test_clock_dispatch.py
+++ b/tests/sentry/monitors/test_clock_dispatch.py
@@ -3,42 +3,42 @@ from unittest import mock
 
 from django.utils import timezone
 
-from sentry.monitors.clock_dispatch import try_monitor_tasks_trigger
+from sentry.monitors.clock_dispatch import try_monitor_clock_tick
 
 
-@mock.patch("sentry.monitors.clock_dispatch._dispatch_tasks")
-def test_monitor_task_trigger(dispatch_tasks):
+@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
+def test_monitor_task_trigger(dispatch_tick):
     now = timezone.now().replace(second=0, microsecond=0)
 
     # Assumes a single partition for simplicitly. Multi-partition cases are
     # covered in further test cases.
 
     # First checkin triggers tasks
-    try_monitor_tasks_trigger(ts=now, partition=0)
-    assert dispatch_tasks.call_count == 1
+    try_monitor_clock_tick(ts=now, partition=0)
+    assert dispatch_tick.call_count == 1
 
     # 5 seconds later does NOT trigger the task
-    try_monitor_tasks_trigger(ts=now + timedelta(seconds=5), partition=0)
-    assert dispatch_tasks.call_count == 1
+    try_monitor_clock_tick(ts=now + timedelta(seconds=5), partition=0)
+    assert dispatch_tick.call_count == 1
 
     # a minute later DOES trigger the task
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1), partition=0)
-    assert dispatch_tasks.call_count == 2
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
+    assert dispatch_tick.call_count == 2
 
     # Same time does NOT trigger the task
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1), partition=0)
-    assert dispatch_tasks.call_count == 2
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
+    assert dispatch_tick.call_count == 2
 
     # A skipped minute triggers the task AND captures an error
     with mock.patch("sentry_sdk.capture_message") as capture_message:
         assert capture_message.call_count == 0
-        try_monitor_tasks_trigger(ts=now + timedelta(minutes=3, seconds=5), partition=0)
-        assert dispatch_tasks.call_count == 3
+        try_monitor_clock_tick(ts=now + timedelta(minutes=3, seconds=5), partition=0)
+        assert dispatch_tick.call_count == 3
         capture_message.assert_called_with("Monitor task dispatch minute skipped")
 
 
-@mock.patch("sentry.monitors.clock_dispatch._dispatch_tasks")
-def test_monitor_task_trigger_partition_desync(dispatch_tasks):
+@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
+def test_monitor_task_trigger_partition_desync(dispatch_tick):
     """
     When consumer partitions are not completely synchronized we may read
     timestamps in a non-monotonic order. In this scenario we want to make
@@ -48,28 +48,28 @@ def test_monitor_task_trigger_partition_desync(dispatch_tasks):
 
     # First message in partition 0 with timestamp just after the minute
     # boundary triggers the task
-    try_monitor_tasks_trigger(ts=now + timedelta(seconds=1), partition=0)
-    assert dispatch_tasks.call_count == 1
+    try_monitor_clock_tick(ts=now + timedelta(seconds=1), partition=0)
+    assert dispatch_tick.call_count == 1
 
     # Second message in a partition 1 has a timestamp just before the minute
     # boundary, should not trigger anything since we've already ticked ahead of
     # this
-    try_monitor_tasks_trigger(ts=now - timedelta(seconds=1), partition=1)
-    assert dispatch_tasks.call_count == 1
+    try_monitor_clock_tick(ts=now - timedelta(seconds=1), partition=1)
+    assert dispatch_tick.call_count == 1
 
     # Third message in partition 1 again just after the minute boundary does
     # NOT trigger the task, we've already ticked at that time.
-    try_monitor_tasks_trigger(ts=now + timedelta(seconds=1), partition=1)
-    assert dispatch_tasks.call_count == 1
+    try_monitor_clock_tick(ts=now + timedelta(seconds=1), partition=1)
+    assert dispatch_tick.call_count == 1
 
     # Next two messages in both partitions move the clock forward
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1, seconds=1), partition=0)
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1, seconds=1), partition=1)
-    assert dispatch_tasks.call_count == 2
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1, seconds=1), partition=0)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1, seconds=1), partition=1)
+    assert dispatch_tick.call_count == 2
 
 
-@mock.patch("sentry.monitors.clock_dispatch._dispatch_tasks")
-def test_monitor_task_trigger_partition_sync(dispatch_tasks):
+@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
+def test_monitor_task_trigger_partition_sync(dispatch_tick):
     """
     When the kafka topic has multiple partitions we want to only tick our clock
     forward once all partitions have caught up. This test simulates that
@@ -77,27 +77,27 @@ def test_monitor_task_trigger_partition_sync(dispatch_tasks):
     now = timezone.now().replace(second=0, microsecond=0)
 
     # Tick for 4 partitions
-    try_monitor_tasks_trigger(ts=now, partition=0)
-    try_monitor_tasks_trigger(ts=now, partition=1)
-    try_monitor_tasks_trigger(ts=now, partition=2)
-    try_monitor_tasks_trigger(ts=now, partition=3)
-    assert dispatch_tasks.call_count == 1
-    assert dispatch_tasks.mock_calls[0] == mock.call(now)
+    try_monitor_clock_tick(ts=now, partition=0)
+    try_monitor_clock_tick(ts=now, partition=1)
+    try_monitor_clock_tick(ts=now, partition=2)
+    try_monitor_clock_tick(ts=now, partition=3)
+    assert dispatch_tick.call_count == 1
+    assert dispatch_tick.mock_calls[0] == mock.call(now)
 
     # Tick forward 3 of the partitions, global clock does not tick
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1), partition=0)
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1), partition=1)
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1), partition=2)
-    assert dispatch_tasks.call_count == 1
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=1)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=2)
+    assert dispatch_tick.call_count == 1
 
     # Slowest partition ticks forward, global clock ticks
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1), partition=3)
-    assert dispatch_tasks.call_count == 2
-    assert dispatch_tasks.mock_calls[1] == mock.call(now + timedelta(minutes=1))
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=3)
+    assert dispatch_tick.call_count == 2
+    assert dispatch_tick.mock_calls[1] == mock.call(now + timedelta(minutes=1))
 
 
-@mock.patch("sentry.monitors.clock_dispatch._dispatch_tasks")
-def test_monitor_task_trigger_partition_tick_skip(dispatch_tasks):
+@mock.patch("sentry.monitors.clock_dispatch._dispatch_tick")
+def test_monitor_task_trigger_partition_tick_skip(dispatch_tick):
     """
     In a scenario where all partitions move multiple ticks past the slowest
     partition we may end up skipping a tick.
@@ -105,28 +105,28 @@ def test_monitor_task_trigger_partition_tick_skip(dispatch_tasks):
     now = timezone.now().replace(second=0, microsecond=0)
 
     # Tick for 4 partitions
-    try_monitor_tasks_trigger(ts=now, partition=0)
-    try_monitor_tasks_trigger(ts=now, partition=1)
-    try_monitor_tasks_trigger(ts=now, partition=2)
-    try_monitor_tasks_trigger(ts=now, partition=3)
-    assert dispatch_tasks.call_count == 1
-    assert dispatch_tasks.mock_calls[0] == mock.call(now)
+    try_monitor_clock_tick(ts=now, partition=0)
+    try_monitor_clock_tick(ts=now, partition=1)
+    try_monitor_clock_tick(ts=now, partition=2)
+    try_monitor_clock_tick(ts=now, partition=3)
+    assert dispatch_tick.call_count == 1
+    assert dispatch_tick.mock_calls[0] == mock.call(now)
 
     # Tick forward twice for 3 partitions
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1), partition=0)
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1), partition=1)
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=1), partition=2)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=0)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=1)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=1), partition=2)
 
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=2), partition=0)
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=3), partition=1)
-    try_monitor_tasks_trigger(ts=now + timedelta(minutes=3), partition=2)
-    assert dispatch_tasks.call_count == 1
+    try_monitor_clock_tick(ts=now + timedelta(minutes=2), partition=0)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=3), partition=1)
+    try_monitor_clock_tick(ts=now + timedelta(minutes=3), partition=2)
+    assert dispatch_tick.call_count == 1
 
     # Slowest partition catches up, but has a timestamp gap, capture the fact
     # that we skipped a minute
     with mock.patch("sentry_sdk.capture_message") as capture_message:
         assert capture_message.call_count == 0
-        try_monitor_tasks_trigger(ts=now + timedelta(minutes=2), partition=3)
+        try_monitor_clock_tick(ts=now + timedelta(minutes=2), partition=3)
         capture_message.assert_called_with("Monitor task dispatch minute skipped")
 
     # XXX(epurkhiser): Another approach we could take here is to detect the
@@ -139,5 +139,5 @@ def test_monitor_task_trigger_partition_tick_skip(dispatch_tasks):
     #
     # In practice this should almost never happen since we have a high volume of
 
-    assert dispatch_tasks.call_count == 2
-    assert dispatch_tasks.mock_calls[1] == mock.call(now + timedelta(minutes=2))
+    assert dispatch_tick.call_count == 2
+    assert dispatch_tick.mock_calls[1] == mock.call(now + timedelta(minutes=2))


### PR DESCRIPTION
In the future these tasks will be triggered via kafka, let's clarify
what these functions are doing to allow that to make sense once it works
like that.