### PR TITLE
chore(issues-assignees): Deprecate AssigneeSelector and AssigneeSelectorDropdown 

### DIFF
--- a/fixtures/js-stubs/events.ts
+++ b/fixtures/js-stubs/events.ts
@@ -26,7 +26,7 @@ export function DetailedEventsFixture(): Event[] {
         {value: 'Mac OS X', key: 'os.name'},
         {value: 'd5241c9d9d2bcda918c7af72f07cea1e39a096ac', key: 'release'},
         {
-          value: 'app/components/assigneeSelector in assignedTo',
+          value: 'app/components/deprecatedAssigneeSelector in assignedTo',
           key: 'transaction',
         },
         {
@@ -63,7 +63,7 @@ export function DetailedEventsFixture(): Event[] {
       entries: [],
       title: "TypeError: Cannot read property 'assignedTo' of undefined",
       message:
-        "TypeError Cannot read property 'assignedTo' of undefined app/components/assigneeSelector in assignedTo",
+        "TypeError Cannot read property 'assignedTo' of undefined app/components/deprecatedAssigneeSelector in assignedTo",
       sdk: {
         version: '3.16.1',
         name: 'raven-js',
@@ -91,7 +91,7 @@ export function DetailedEventsFixture(): Event[] {
         {value: 'Mac OS X', key: 'os.name'},
         {value: 'd5241c9d9d2bcda918c7af72f07cea1e39a096ac', key: 'release'},
         {
-          value: 'app/components/assigneeSelector in assignedTo',
+          value: 'app/components/deprecatedAssigneeSelector in assignedTo',
           key: 'transaction',
         },
         {
@@ -128,7 +128,7 @@ export function DetailedEventsFixture(): Event[] {
       entries: [],
       title: "TypeError: Cannot read property 'assignedTo' of undefined",
       message:
-        "TypeError Cannot read property 'assignedTo' of undefined app/components/assigneeSelector in assignedTo",
+        "TypeError Cannot read property 'assignedTo' of undefined app/components/deprecatedAssigneeSelector in assignedTo",
       sdk: {
         version: '3.16.1',
         name: 'raven-js',

--- a/static/app/components/deprecatedAssigneeSelector.spec.tsx
+++ b/static/app/components/deprecatedAssigneeSelector.spec.tsx
@@ -8,8 +8,8 @@ import {UserFixture} from 'sentry-fixture/user';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
-import AssigneeSelectorComponent from 'sentry/components/assigneeSelector';
-import {putSessionUserFirst} from 'sentry/components/assigneeSelectorDropdown';
+import DeprecatedAssigneeSelector from 'sentry/components/deprecatedAssigneeSelector';
+import {putSessionUserFirst} from 'sentry/components/deprecatedAssigneeSelectorDropdown';
 import ConfigStore from 'sentry/stores/configStore';
 import GroupStore from 'sentry/stores/groupStore';
 import IndicatorStore from 'sentry/stores/indicatorStore';
@@ -21,7 +21,7 @@ jest.mock('sentry/actionCreators/modal', () => ({
   openInviteMembersModal: jest.fn(),
 }));
 
-describe('AssigneeSelector', () => {
+describe('DeprecatedAssigneeSelector', () => {
   let assignMock;
   let assignGroup2Mock;
   let USER_1, USER_2, USER_3, USER_4;
@@ -124,7 +124,9 @@ describe('AssigneeSelector', () => {
   describe('render with props', () => {
     it('renders members from the prop when present', async () => {
       MemberListStore.loadInitialData([USER_1]);
-      render(<AssigneeSelectorComponent id={GROUP_1.id} memberList={[USER_2, USER_3]} />);
+      render(
+        <DeprecatedAssigneeSelector id={GROUP_1.id} memberList={[USER_2, USER_3]} />
+      );
       await openMenu();
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
 
@@ -140,14 +142,14 @@ describe('AssigneeSelector', () => {
 
   describe('putSessionUserFirst()', () => {
     it('should place the session user at the top of the member list if present', () => {
-      render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+      render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
       jest.spyOn(ConfigStore, 'get').mockImplementation(() => USER_2);
       expect(putSessionUserFirst([USER_1, USER_2])).toEqual([USER_2, USER_1]);
       (ConfigStore.get as jest.Mock).mockRestore();
     });
 
     it("should return the same member list if the session user isn't present", () => {
-      render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+      render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
       jest.spyOn(ConfigStore, 'get').mockImplementation(() =>
         UserFixture({
           id: '555',
@@ -162,13 +164,13 @@ describe('AssigneeSelector', () => {
   });
 
   it('should initially have loading state', async () => {
-    render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
     await openMenu();
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
   });
 
   it('does not have loading state and shows member list after calling MemberListStore.loadInitialData', async () => {
-    render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
     act(() => MemberListStore.loadInitialData([USER_1, USER_2]));
     await openMenu();
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -183,7 +185,7 @@ describe('AssigneeSelector', () => {
   });
 
   it('does NOT update member list after initial load', async () => {
-    render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
     act(() => MemberListStore.loadInitialData([USER_1, USER_2]));
     await openMenu();
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -200,7 +202,7 @@ describe('AssigneeSelector', () => {
   });
 
   it('successfully assigns users', async () => {
-    render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
     act(() => MemberListStore.loadInitialData([USER_1, USER_2]));
     await openMenu();
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -229,7 +231,7 @@ describe('AssigneeSelector', () => {
         assignedTo: {...TEAM_1, type: 'team'},
       },
     });
-    render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
     act(() => MemberListStore.loadInitialData([USER_1, USER_2]));
     await openMenu();
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -251,7 +253,7 @@ describe('AssigneeSelector', () => {
   });
 
   it('successfully clears assignment', async () => {
-    render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
     act(() => MemberListStore.loadInitialData([USER_1, USER_2]));
     await openMenu();
 
@@ -283,7 +285,7 @@ describe('AssigneeSelector', () => {
 
   it('shows invite member button', async () => {
     MemberListStore.loadInitialData([USER_1, USER_2]);
-    render(<AssigneeSelectorComponent id={GROUP_1.id} />, {
+    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />, {
       context: RouterContextFixture(),
     });
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
@@ -297,7 +299,7 @@ describe('AssigneeSelector', () => {
   });
 
   it('filters user by email and selects with keyboard', async () => {
-    render(<AssigneeSelectorComponent id={GROUP_2.id} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_2.id} />);
     act(() => MemberListStore.loadInitialData([USER_1, USER_2]));
     await openMenu();
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
@@ -328,7 +330,7 @@ describe('AssigneeSelector', () => {
     jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_2);
     const addMessageSpy = jest.spyOn(IndicatorStore, 'addMessage');
 
-    render(<AssigneeSelectorComponent id={GROUP_2.id} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_2.id} />);
     act(() => MemberListStore.loadInitialData([USER_1, USER_2, USER_3, USER_4]));
 
     assignMock = MockApiClient.addMockResponse({
@@ -361,7 +363,7 @@ describe('AssigneeSelector', () => {
   it('successfully shows suggested assignees', async () => {
     jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_2);
     const onAssign = jest.fn();
-    render(<AssigneeSelectorComponent id={GROUP_2.id} onAssign={onAssign} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_2.id} onAssign={onAssign} />);
     act(() => MemberListStore.loadInitialData([USER_1, USER_2, USER_3]));
 
     expect(screen.getByTestId('suggested-avatar-stack')).toBeInTheDocument();
@@ -399,7 +401,7 @@ describe('AssigneeSelector', () => {
 
   it('renders unassigned', async () => {
     jest.spyOn(GroupStore, 'get').mockImplementation(() => GROUP_1);
-    render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+    render(<DeprecatedAssigneeSelector id={GROUP_1.id} />);
 
     await userEvent.hover(screen.getByTestId('unassigned'));
     expect(await screen.findByText('Unassigned')).toBeInTheDocument();

--- a/static/app/components/deprecatedAssigneeSelector.tsx
+++ b/static/app/components/deprecatedAssigneeSelector.tsx
@@ -1,14 +1,14 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import type {
-  AssigneeSelectorDropdownProps,
-  SuggestedAssignee,
-} from 'sentry/components/assigneeSelectorDropdown';
-import {AssigneeSelectorDropdown} from 'sentry/components/assigneeSelectorDropdown';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import SuggestedAvatarStack from 'sentry/components/avatar/suggestedAvatarStack';
 import {Chevron} from 'sentry/components/chevron';
+import type {
+  DeprecatedAssigneeSelectorDropdownProps,
+  SuggestedAssignee,
+} from 'sentry/components/deprecatedAssigneeSelectorDropdown';
+import {DeprecatedAssigneeSelectorDropdown} from 'sentry/components/deprecatedAssigneeSelectorDropdown';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -21,9 +21,9 @@ import type {Actor} from 'sentry/types/core';
 import type {SuggestedOwnerReason} from 'sentry/types/group';
 import useOrganization from 'sentry/utils/useOrganization';
 
-interface AssigneeSelectorProps
+interface DeprecatedAssigneeSelectorProps
   extends Omit<
-    AssigneeSelectorDropdownProps,
+    DeprecatedAssigneeSelectorDropdownProps,
     'children' | 'organization' | 'assignedTo'
   > {
   noDropdown?: boolean;
@@ -123,14 +123,17 @@ function AssigneeAvatar({
   );
 }
 
-function AssigneeSelector({noDropdown, ...props}: AssigneeSelectorProps) {
+function DeprecatedAssigneeSelector({
+  noDropdown,
+  ...props
+}: DeprecatedAssigneeSelectorProps) {
   const organization = useOrganization();
   const groups = useLegacyStore(GroupStore);
   const group = groups.find(item => item.id === props.id);
 
   return (
     <AssigneeWrapper>
-      <AssigneeSelectorDropdown
+      <DeprecatedAssigneeSelectorDropdown
         organization={organization}
         assignedTo={group?.assignedTo}
         {...props}
@@ -161,12 +164,12 @@ function AssigneeSelector({noDropdown, ...props}: AssigneeSelectorProps) {
             </Fragment>
           );
         }}
-      </AssigneeSelectorDropdown>
+      </DeprecatedAssigneeSelectorDropdown>
     </AssigneeWrapper>
   );
 }
 
-export default AssigneeSelector;
+export default DeprecatedAssigneeSelector;
 
 const AssigneeWrapper = styled('div')`
   display: flex;

--- a/static/app/components/deprecatedAssigneeSelectorDropdown.tsx
+++ b/static/app/components/deprecatedAssigneeSelectorDropdown.tsx
@@ -93,7 +93,7 @@ export type OnAssignCallback = (
   suggestedAssignee?: SuggestedAssignee
 ) => void;
 
-export interface AssigneeSelectorDropdownProps {
+export interface DeprecatedAssigneeSelectorDropdownProps {
   children: (props: RenderProps) => React.ReactNode;
   id: string;
   organization: Organization;
@@ -113,8 +113,8 @@ type State = {
   suggestedOwners?: SuggestedOwner[] | null;
 };
 
-export class AssigneeSelectorDropdown extends Component<
-  AssigneeSelectorDropdownProps,
+export class DeprecatedAssigneeSelectorDropdown extends Component<
+  DeprecatedAssigneeSelectorDropdownProps,
   State
 > {
   state = this.getInitialState();
@@ -136,7 +136,7 @@ export class AssigneeSelectorDropdown extends Component<
     };
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: AssigneeSelectorDropdownProps) {
+  UNSAFE_componentWillReceiveProps(nextProps: DeprecatedAssigneeSelectorDropdownProps) {
     const loading = GroupStore.hasStatus(nextProps.id, 'assignTo');
     if (nextProps.id !== this.props.id || loading !== this.state.loading) {
       const group = GroupStore.get(this.props.id);
@@ -147,7 +147,10 @@ export class AssigneeSelectorDropdown extends Component<
     }
   }
 
-  shouldComponentUpdate(nextProps: AssigneeSelectorDropdownProps, nextState: State) {
+  shouldComponentUpdate(
+    nextProps: DeprecatedAssigneeSelectorDropdownProps,
+    nextState: State
+  ) {
     if (nextState.loading !== this.state.loading) {
       return true;
     }
@@ -361,8 +364,8 @@ export class AssigneeSelectorDropdown extends Component<
     // filter out suggested assignees if a suggestion is already selected
     const suggestedAssignees = this.getSuggestedAssignees();
     const renderedAssignees: (
-      | ReturnType<AssigneeSelectorDropdown['renderTeamNode']>
-      | ReturnType<AssigneeSelectorDropdown['renderMemberNode']>
+      | ReturnType<DeprecatedAssigneeSelectorDropdown['renderTeamNode']>
+      | ReturnType<DeprecatedAssigneeSelectorDropdown['renderMemberNode']>
     )[] = [];
 
     for (let i = 0; i < suggestedAssignees.length; i++) {

--- a/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
@@ -2,9 +2,9 @@ import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
-import {AssigneeSelectorDropdown} from 'sentry/components/assigneeSelectorDropdown';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import {Button} from 'sentry/components/button';
+import {DeprecatedAssigneeSelectorDropdown} from 'sentry/components/deprecatedAssigneeSelectorDropdown';
 import useMutateFeedback from 'sentry/components/feedback/useMutateFeedback';
 import type {EventOwners} from 'sentry/components/group/assignedTo';
 import {getAssignedToDisplayName, getOwnerList} from 'sentry/components/group/assignedTo';
@@ -57,7 +57,7 @@ export default function FeedbackAssignedTo({
   const key = showActorName ? 'showActor' : 'hideActor';
 
   return (
-    <AssigneeSelectorDropdown
+    <DeprecatedAssigneeSelectorDropdown
       key={key}
       organization={organization}
       disabled={false}
@@ -94,7 +94,7 @@ export default function FeedbackAssignedTo({
           </ActorWrapper>
         </Button>
       )}
-    </AssigneeSelectorDropdown>
+    </DeprecatedAssigneeSelectorDropdown>
   );
 }
 

--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -4,14 +4,14 @@ import styled from '@emotion/styled';
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import {openIssueOwnershipRuleModal} from 'sentry/actionCreators/modal';
 import Access from 'sentry/components/acl/access';
-import type {
-  OnAssignCallback,
-  SuggestedAssignee,
-} from 'sentry/components/assigneeSelectorDropdown';
-import {AssigneeSelectorDropdown} from 'sentry/components/assigneeSelectorDropdown';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import {Button} from 'sentry/components/button';
+import type {
+  OnAssignCallback,
+  SuggestedAssignee,
+} from 'sentry/components/deprecatedAssigneeSelectorDropdown';
+import {DeprecatedAssigneeSelectorDropdown} from 'sentry/components/deprecatedAssigneeSelectorDropdown';
 import {AutoCompleteRoot} from 'sentry/components/dropdownAutoComplete/menu';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import * as SidebarSection from 'sentry/components/sidebarSection';
@@ -239,7 +239,7 @@ function AssignedTo({
         </Access>
       </StyledSidebarTitle>
       <StyledSidebarSectionContent>
-        <AssigneeSelectorDropdown
+        <DeprecatedAssigneeSelectorDropdown
           organization={organization}
           owners={owners}
           disabled={disableDropdown}
@@ -274,7 +274,7 @@ function AssignedTo({
               )}
             </DropdownButton>
           )}
-        </AssigneeSelectorDropdown>
+        </DeprecatedAssigneeSelectorDropdown>
       </StyledSidebarSectionContent>
     </SidebarSection.Wrap>
   );

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -4,10 +4,10 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
-import AssigneeSelector from 'sentry/components/assigneeSelector';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Checkbox from 'sentry/components/checkbox';
 import Count from 'sentry/components/count';
+import DeprecatedAssigneeSelector from 'sentry/components/deprecatedAssigneeSelector';
 import EventOrGroupExtraDetails from 'sentry/components/eventOrGroupExtraDetails';
 import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
@@ -136,7 +136,7 @@ function BaseGroupRow({
     };
   }, [organization, group.id, group.owners, query]);
 
-  const trackAssign: React.ComponentProps<typeof AssigneeSelector>['onAssign'] =
+  const trackAssign: React.ComponentProps<typeof DeprecatedAssigneeSelector>['onAssign'] =
     useCallback(
       (type, _assignee, suggestedAssignee) => {
         if (query !== undefined) {
@@ -467,7 +467,7 @@ function BaseGroupRow({
           ) : null}
           {withColumns.includes('assignee') && (
             <AssigneeWrapper narrowGroups={narrowGroups}>
-              <AssigneeSelector
+              <DeprecatedAssigneeSelector
                 id={group.id}
                 memberList={memberList}
                 onAssign={trackAssign}

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -3,8 +3,8 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
-import AssigneeSelector from 'sentry/components/assigneeSelector';
 import Count from 'sentry/components/count';
+import DeprecatedAssigneeSelector from 'sentry/components/deprecatedAssigneeSelector';
 import Link from 'sentry/components/links/link';
 import {getRelativeSummary} from 'sentry/components/timeRangeSelector/utils';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -94,7 +94,7 @@ const SPECIAL_FIELDS: SpecialFields = {
       const memberList = MemberListStore.getAll();
       return (
         <ActorContainer>
-          <AssigneeSelector id={data.id} memberList={memberList} noDropdown />
+          <DeprecatedAssigneeSelector id={data.id} memberList={memberList} noDropdown />
         </ActorContainer>
       );
     },

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -1,9 +1,9 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import type {OnAssignCallback} from 'sentry/components/assigneeSelectorDropdown';
 import AvatarList from 'sentry/components/avatar/avatarList';
 import {DateTime} from 'sentry/components/dateTime';
+import type {OnAssignCallback} from 'sentry/components/deprecatedAssigneeSelectorDropdown';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EventThroughput} from 'sentry/components/events/eventStatisticalDetector/eventThroughput';
 import AssignedTo from 'sentry/components/group/assignedTo';

--- a/tests/js/test-balancer/jest-balance.json
+++ b/tests/js/test-balancer/jest-balance.json
@@ -56,7 +56,7 @@
   "/static/app/views/performance/vitalDetail/index.spec.tsx": 6572,
   "/static/app/views/issueDetails/groupEvents.spec.tsx": 9434,
   "/static/app/views/alerts/rules/issue/index.spec.jsx": 13356,
-  "/static/app/components/assigneeSelector.spec.jsx": 2752,
+  "/static/app/components/deprecatedAssigneeSelector.spec.jsx": 2752,
   "/static/app/components/quickTrace/index.spec.tsx": 2283,
   "/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx": 7276,
   "/static/app/views/settings/organizationTeams/teamMembers.spec.jsx": 5285,


### PR DESCRIPTION
Replaces all instances of `<AssigneeSelector>` and `<AssigneeSelectorDropdown>` with deprecated versions in preparation for new component.

Merge branch is **not** master. It is the current working branch for upgrading the AssigneeSelector