### PR TITLE
fix(segmentedControl): Remove animation when control changes size

### DIFF
--- a/static/app/components/segmentedControl.tsx
+++ b/static/app/components/segmentedControl.tsx
@@ -166,6 +166,8 @@ function Segment<Value extends string>({
           transition={{type: 'tween', ease: 'easeOut', duration: 0.2}}
           priority={priority}
           aria-hidden
+          // Prevent animations until the user has made a change
+          layoutDependency={isSelected}
         />
       )}
 


### PR DESCRIPTION
sometimes the segmented control changes size before the user has interacted with it, it should only animate when changing states.

https://www.framer.com/motion/component/###layoutdependency

before

https://github.com/getsentry/sentry/assets/1400464/e025cd43-ff34-4940-ac5d-7461c379622d

after

https://github.com/getsentry/sentry/assets/1400464/3b8f474a-d091-4d5c-8f9a-9dc4d8352b13

