### PR TITLE
fix(replays): persist fast forward preference on player

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -321,6 +321,14 @@ function ProviderNonMemo({
       }
 
       const skipInactive = replayer.config.skipInactive;
+
+      if (skipInactive) {
+        // If the replayer is set to skip inactive, we should turn it off before
+        // manually scrubbing, so when the player resumes playing it's not stuck
+        // fast-forwarding even through sections with activity
+        replayer.setConfig({skipInactive: false});
+      }
+
       const time = clamp(requestedTimeMs, 0, startTimeOffsetMs + durationMs);
 
       // Sometimes rrweb doesn't get to the exact target time, as long as it has

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -333,7 +333,7 @@ function ProviderNonMemo({
         window.clearTimeout(playTimer.current);
       }
 
-      replayer.setConfig({skipInactive: skipInactive});
+      replayer.setConfig({skipInactive});
 
       if (isPlaying) {
         playTimer.current = window.setTimeout(() => replayer.play(time), 0);


### PR DESCRIPTION
- Fixes https://github.com/getsentry/sentry/issues/69660
- Unchecking "fast-forward inactivity" wasn't working if you seeked somewhere in the timeline (e.g. it would start fast forwarding again, despite the check box remaining unchecked), see before video:

https://github.com/getsentry/sentry/assets/56095982/f8b12465-0b0d-4191-b140-fb20cdf4ff3d

After:


https://github.com/getsentry/sentry/assets/56095982/7df951d4-03be-4f27-b1a1-55bd1e4d3ef9


Fast forwarding still works as expected:

https://github.com/getsentry/sentry/assets/56095982/d4340d73-9293-42cf-be56-3868d95b6a90


