### PR TITLE
fix(replays): handle empty tracklist in video player

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -526,6 +526,10 @@ export class VideoReplayer {
   protected async loadSegmentAtTime(
     videoOffsetMs: number = 0
   ): Promise<number | undefined> {
+    if (!this._trackList.length) {
+      return undefined;
+    }
+
     const {segment: segmentIndex, previousSegment: previousSegmentIndex} =
       this.getSegmentIndexForTime(videoOffsetMs);
 


### PR DESCRIPTION
- fixes JAVASCRIPT-2SRY
- clicking on the linked error link in breadcrumbs was calling `findVideoSegmentIndex` with an empty `trackList` , leading to this type error

before:

https://github.com/getsentry/sentry/assets/56095982/a5bd3895-ecd5-45f6-bb27-afea87a7e6cb


after:



https://github.com/getsentry/sentry/assets/56095982/e8fa576d-86b3-49ac-9d23-57cef5c9b8f4

