### PR TITLE
feat(relocation): Add /relcations/:uuid/recover/ PUT endpoint

### DIFF
--- a/src/sentry/api/endpoints/relocations/recover.py
+++ b/src/sentry/api/endpoints/relocations/recover.py
@@ -1,0 +1,142 @@
+import logging
+from string import Template
+
+from django.db import DatabaseError, router, transaction
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.endpoints.relocations import (
+    ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP,
+    ERR_UNKNOWN_RELOCATION_STEP,
+)
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.permissions import SuperuserOrStaffFeatureFlaggedPermission
+from sentry.api.serializers import serialize
+from sentry.models.relocation import Relocation
+from sentry.tasks.relocation import TASK_MAP
+from sentry.utils.relocation import OrderedTask
+
+ERR_NOT_RECOVERABLE_STATUS = Template(
+    """Relocations can only be recovered if they have already failed; this relocation is
+    `$status`."""
+)
+ERR_NOT_RECOVERABLE_STEP = "Relocations at the validation step cannot be recovered."
+ERR_COULD_NOT_RECOVER_RELOCATION = (
+    "Could not recover relocation, perhaps because it is no longer in a failed state."
+)
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class RelocationRecoverEndpoint(Endpoint):
+    owner = ApiOwner.OPEN_SOURCE
+    publish_status = {
+        # TODO(getsentry/team-ospo#214): Stabilize before GA.
+        "PUT": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (SuperuserOrStaffFeatureFlaggedPermission,)
+
+    def _recover(self, request: Request, relocation: Relocation) -> Response | None:
+        """
+        Helper function to do just... one... more... attempt of a the last task that the relocation
+        failed at. Useful to try to recover a relocation after a fix has been pushed.
+        """
+
+        until_step = request.data.get("untilStep", None)
+        if until_step is not None:
+            try:
+                step = Relocation.Step[until_step.upper()]
+            except KeyError:
+                return Response(
+                    {"detail": ERR_UNKNOWN_RELOCATION_STEP.substitute(step=until_step)},
+                    status=400,
+                )
+
+            if step in {
+                Relocation.Step.UNKNOWN,
+                Relocation.Step.UPLOADING,
+                Relocation.Step.COMPLETED,
+            }:
+                return Response(
+                    {"detail": ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP.substitute(step=step.name)},
+                    status=400,
+                )
+
+            if step.value <= relocation.step:
+                return Response(
+                    {"detail": ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP.substitute(step=step.name)},
+                    status=400,
+                )
+
+            relocation.scheduled_pause_at_step = step.value
+
+        if relocation.status != Relocation.Status.FAILURE.value:
+            return Response(
+                {
+                    "detail": ERR_NOT_RECOVERABLE_STATUS.substitute(
+                        status=Relocation.Status(relocation.status).name
+                    )
+                },
+                status=400,
+            )
+
+        ordered_task = OrderedTask[relocation.latest_task]
+        task = TASK_MAP[ordered_task]
+        if ordered_task in {OrderedTask.VALIDATING_POLL, OrderedTask.VALIDATING_COMPLETE}:
+            return Response(
+                {"detail": ERR_NOT_RECOVERABLE_STEP},
+                status=400,
+            )
+
+        relocation.status = Relocation.Status.IN_PROGRESS.value
+        relocation.latest_task_attempts -= 1
+
+        try:
+            relocation.save()
+        except DatabaseError:
+            return Response(
+                {"detail": ERR_COULD_NOT_RECOVER_RELOCATION},
+                status=400,
+            )
+
+        task.delay(str(relocation.uuid))
+        return None
+
+    def put(self, request: Request, relocation_uuid: str) -> Response:
+        """
+        Recover a failed relocation, perhaps after a bug fix, by running the last attempted task.
+        ``````````````````````````````````````````````````
+
+        This command accepts a single optional parameter, which specifies the step BEFORE which the
+        next pause should occur. If no such parameter is specified, no future pauses are scheduled.
+
+        :pparam string relocation_uuid: a UUID identifying the relocation.
+        :param string untilStep: an optional string identifying the next step to pause before; must
+                                 be greater than the currently active step, and one of:
+                                 `PREPROCESSING`, `VALIDATING`, `IMPORTING`, `POSTPROCESSING`,
+                                 `NOTIFYING`.
+
+        :auth: required
+        """
+
+        logger.info("relocations.recover.put.start", extra={"caller": request.user.id})
+
+        # Use a `select_for_update` transaction to prevent duplicate tasks from being started by
+        # racing recover calls.
+        with transaction.atomic(using=router.db_for_write(Relocation)):
+            try:
+                relocation: Relocation = Relocation.objects.select_for_update().get(
+                    uuid=relocation_uuid
+                )
+            except Relocation.DoesNotExist:
+                raise ResourceDoesNotExist
+
+            failed = self._recover(request, relocation)
+            if failed is not None:
+                return failed
+
+        return self.respond(serialize(relocation))

--- a/src/sentry/api/serializers/models/relocation.py
+++ b/src/sentry/api/serializers/models/relocation.py
@@ -82,6 +82,8 @@ class RelocationSerializer(Serializer):
             "scheduledCancelAtStep": scheduled_at_cancel_step,
             "wantOrgSlugs": obj.want_org_slugs,
             "wantUsernames": obj.want_usernames,
+            "latestTask": obj.latest_task,
+            "latestTaskAttempts": obj.latest_task_attempts,
             "latestNotified": latest_notified,
             "latestUnclaimedEmailsSentAt": obj.latest_unclaimed_emails_sent_at,
             "importedUserIds": attrs.imported_user_ids,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -48,6 +48,7 @@ from sentry.api.endpoints.relocations.details import RelocationDetailsEndpoint
 from sentry.api.endpoints.relocations.index import RelocationIndexEndpoint
 from sentry.api.endpoints.relocations.pause import RelocationPauseEndpoint
 from sentry.api.endpoints.relocations.public_key import RelocationPublicKeyEndpoint
+from sentry.api.endpoints.relocations.recover import RelocationRecoverEndpoint
 from sentry.api.endpoints.relocations.retry import RelocationRetryEndpoint
 from sentry.api.endpoints.relocations.unpause import RelocationUnpauseEndpoint
 from sentry.api.endpoints.seer_rpc import SeerRpcServiceEndpoint
@@ -855,6 +856,11 @@ RELOCATION_URLS = [
         r"^(?P<relocation_uuid>[^\/]+)/pause/$",
         RelocationPauseEndpoint.as_view(),
         name="sentry-api-0-relocations-pause",
+    ),
+    re_path(
+        r"^(?P<relocation_uuid>[^\/]+)/recover/$",
+        RelocationRecoverEndpoint.as_view(),
+        name="sentry-api-0-relocations-recover",
     ),
     re_path(
         r"^(?P<relocation_uuid>[^\/]+)/retry/$",

--- a/tests/sentry/api/endpoints/relocations/test_recover.py
+++ b/tests/sentry/api/endpoints/relocations/test_recover.py
@@ -1,0 +1,193 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+from sentry.api.endpoints.relocations import (
+    ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP,
+    ERR_UNKNOWN_RELOCATION_STEP,
+)
+from sentry.api.endpoints.relocations.recover import (
+    ERR_NOT_RECOVERABLE_STATUS,
+    ERR_NOT_RECOVERABLE_STEP,
+)
+from sentry.models.relocation import Relocation
+from sentry.tasks.relocation import MAX_FAST_TASK_ATTEMPTS
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.utils.relocation import OrderedTask
+
+TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
+
+
+class RecoverRelocationTest(APITestCase):
+    endpoint = "sentry-api-0-relocations-recover"
+    method = "put"
+
+    def setUp(self):
+        super().setUp()
+        self.owner = self.create_user(
+            email="owner", is_superuser=False, is_staff=True, is_active=True
+        )
+        self.superuser = self.create_user(is_superuser=True)
+        self.staff_user = self.create_user(is_staff=True)
+        self.relocation: Relocation = Relocation.objects.create(
+            date_added=TEST_DATE_ADDED,
+            creator_id=self.superuser.id,
+            owner_id=self.owner.id,
+            status=Relocation.Status.FAILURE.value,
+            step=Relocation.Step.PREPROCESSING.value,
+            want_org_slugs=["foo"],
+            want_usernames=["alice", "bob"],
+            latest_notified=Relocation.EmailKind.STARTED.value,
+            latest_task=OrderedTask.PREPROCESSING_COLLIDING_USERS.name,
+            latest_task_attempts=MAX_FAST_TASK_ATTEMPTS,
+        )
+
+    @override_options({"staff.ga-rollout": True})
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_good_recover_without_pause_as_staff(self, async_task_scheduled: Mock):
+        self.login_as(user=self.staff_user, staff=True)
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
+
+        assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
+        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
+        assert response.data["scheduledPauseAtStep"] not in response.data
+        assert response.data["latestTask"] == OrderedTask.PREPROCESSING_COLLIDING_USERS.name
+        assert response.data["latestTaskAttempts"] == MAX_FAST_TASK_ATTEMPTS - 1
+
+        assert async_task_scheduled.call_count == 1
+        assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
+
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_good_recover_without_pause_as_superuser(self, async_task_scheduled: Mock):
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.get_success_response(self.relocation.uuid, status_code=200)
+
+        assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
+        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
+        assert response.data["scheduledPauseAtStep"] not in response.data
+        assert response.data["latestTask"] == OrderedTask.PREPROCESSING_COLLIDING_USERS.name
+        assert response.data["latestTaskAttempts"] == MAX_FAST_TASK_ATTEMPTS - 1
+
+        assert async_task_scheduled.call_count == 1
+        assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
+
+    @override_options({"staff.ga-rollout": True})
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_good_recover_with_pause_as_staff(self, async_task_scheduled: Mock):
+        self.login_as(user=self.staff_user, staff=True)
+        response = self.get_success_response(
+            self.relocation.uuid, untilStep=Relocation.Step.VALIDATING.name, status_code=200
+        )
+
+        assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
+        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
+        assert response.data["scheduledPauseAtStep"] == Relocation.Step.VALIDATING.name
+        assert response.data["latestTask"] == OrderedTask.PREPROCESSING_COLLIDING_USERS.name
+        assert response.data["latestTaskAttempts"] == MAX_FAST_TASK_ATTEMPTS - 1
+
+        assert async_task_scheduled.call_count == 1
+        assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
+
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_good_recover_with_pause_as_superuser(self, async_task_scheduled: Mock):
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.get_success_response(
+            self.relocation.uuid, untilStep=Relocation.Step.VALIDATING.name, status_code=200
+        )
+
+        assert response.data["status"] == Relocation.Status.IN_PROGRESS.name
+        assert response.data["step"] == Relocation.Step.PREPROCESSING.name
+        assert response.data["scheduledPauseAtStep"] == Relocation.Step.VALIDATING.name
+        assert response.data["latestTask"] == OrderedTask.PREPROCESSING_COLLIDING_USERS.name
+        assert response.data["latestTaskAttempts"] == MAX_FAST_TASK_ATTEMPTS - 1
+
+        assert async_task_scheduled.call_count == 1
+        assert async_task_scheduled.call_args.args == (str(self.relocation.uuid),)
+
+    def test_bad_not_found(self):
+        self.login_as(user=self.superuser, superuser=True)
+        does_not_exist_uuid = uuid4().hex
+        self.get_error_response(does_not_exist_uuid, status_code=404)
+
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_bad_not_yet_failed(self, async_task_scheduled: Mock):
+        self.login_as(user=self.superuser, superuser=True)
+        self.relocation.status = Relocation.Status.PAUSE.value
+        self.relocation.save()
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
+
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_NOT_RECOVERABLE_STATUS.substitute(
+            status=Relocation.Status.PAUSE.name
+        )
+
+        assert async_task_scheduled.call_count == 0
+
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_bad_invalid_pause_step(self, async_task_scheduled: Mock):
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.get_error_response(
+            self.relocation.uuid, untilStep="nonexistent", status_code=400
+        )
+
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_UNKNOWN_RELOCATION_STEP.substitute(
+            step="nonexistent"
+        )
+
+        assert async_task_scheduled.call_count == 0
+
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_bad_unknown_pause_step(self, async_task_scheduled: Mock):
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.get_error_response(
+            self.relocation.uuid, untilStep=Relocation.Step.UNKNOWN.name, status_code=400
+        )
+
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP.substitute(
+            step=Relocation.Step.UNKNOWN.name
+        )
+
+        assert async_task_scheduled.call_count == 0
+
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_bad_already_completed_pause_step(self, async_task_scheduled: Mock):
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.get_error_response(
+            self.relocation.uuid, untilStep=Relocation.Step.PREPROCESSING.name, status_code=400
+        )
+
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_COULD_NOT_PAUSE_RELOCATION_AT_STEP.substitute(
+            step=Relocation.Step.PREPROCESSING.name
+        )
+
+        assert async_task_scheduled.call_count == 0
+
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_bad_cannot_recover_at_validation_step(self, async_task_scheduled: Mock):
+        self.login_as(user=self.superuser, superuser=True)
+        self.relocation.step = Relocation.Step.VALIDATING.value
+        self.relocation.latest_task = OrderedTask.VALIDATING_POLL.name
+        self.relocation.save()
+        response = self.get_error_response(self.relocation.uuid, status_code=400)
+
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_NOT_RECOVERABLE_STEP
+
+        assert async_task_scheduled.call_count == 0
+
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_bad_no_auth(self, async_task_scheduled: Mock):
+        self.get_error_response(self.relocation.uuid, status_code=401)
+
+        assert async_task_scheduled.call_count == 0
+
+    @patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+    def test_bad_no_superuser(self, async_task_scheduled: Mock):
+        self.login_as(user=self.superuser, superuser=False)
+        self.get_error_response(self.relocation.uuid, status_code=403)
+
+        assert async_task_scheduled.call_count == 0

--- a/tests/sentry/api/serializers/test_relocation.py
+++ b/tests/sentry/api/serializers/test_relocation.py
@@ -88,8 +88,8 @@ class RelocationSerializerTest(TestCase):
         assert result["wantUsernames"] == ["alice", "bob"]
         assert not result["latestNotified"]
         assert not result["latestUnclaimedEmailsSentAt"]
-        assert "latestTask" not in result
-        assert "latestTaskAttempts" not in result
+        assert result["latestTask"] == OrderedTask.UPLOADING_COMPLETE.name
+        assert result["latestTaskAttempts"] == 1
         assert result["importedUserIds"] == []
         assert result["importedOrgIds"] == []
 
@@ -127,8 +127,8 @@ class RelocationSerializerTest(TestCase):
         assert result["wantUsernames"] == ["charlie", "denise"]
         assert result["latestNotified"] == Relocation.EmailKind.STARTED.name
         assert not result["latestUnclaimedEmailsSentAt"]
-        assert "latestTask" not in result
-        assert "latestTaskAttempts" not in result
+        assert result["latestTask"] == OrderedTask.IMPORTING.name
+        assert result["latestTaskAttempts"] == 1
         assert sorted(result["importedUserIds"]) == [
             self.first_imported_user.id,
             self.second_imported_user.id,
@@ -170,8 +170,8 @@ class RelocationSerializerTest(TestCase):
         assert result["wantUsernames"] == ["emily", "fred"]
         assert result["latestNotified"] == Relocation.EmailKind.SUCCEEDED.name
         assert result["latestUnclaimedEmailsSentAt"] == TEST_DATE_UPDATED
-        assert "latestTask" not in result
-        assert "latestTaskAttempts" not in result
+        assert result["latestTask"] == OrderedTask.COMPLETED.name
+        assert result["latestTaskAttempts"] == 1
         assert sorted(result["importedUserIds"]) == [
             self.first_imported_user.id,
             self.second_imported_user.id,
@@ -213,7 +213,7 @@ class RelocationSerializerTest(TestCase):
         assert result["wantUsernames"] == ["alice", "bob"]
         assert result["latestNotified"] == Relocation.EmailKind.FAILED.name
         assert not result["latestUnclaimedEmailsSentAt"]
-        assert "latestTask" not in result
-        assert "latestTaskAttempts" not in result
+        assert result["latestTask"] == OrderedTask.VALIDATING_COMPLETE.name
+        assert result["latestTaskAttempts"] == 1
         assert result["importedUserIds"] == []
         assert result["importedOrgIds"] == []


### PR DESCRIPTION
This allows us to recover a failed task. It is useful for shortening the "bug fix" cycle when a relocating breaks in prod, and we don't want to wait a potentially long time while it re-validates after we push a fix. It also prevents data duplication during import by allowing us to re-use the same UUID.