### PR TITLE
feat(mobile-ui): Extend MetricsQueryBuilder and add gauge metrics

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -64,7 +64,7 @@ from sentry.snuba.metrics.extraction import (
     should_use_on_demand_metrics_for_querying,
 )
 from sentry.snuba.metrics.fields import histogram as metrics_histogram
-from sentry.snuba.metrics.naming_layer.mri import extract_use_case_id
+from sentry.snuba.metrics.naming_layer.mri import extract_use_case_id, is_mri
 from sentry.snuba.metrics.query import (
     MetricField,
     MetricGroupByField,
@@ -1350,6 +1350,9 @@ class MetricsQueryBuilder(QueryBuilder):
         }
 
         primary_metric = metrics_map[self.use_case_id].get(column, column)
+        if not is_mri(primary_metric) and not primary_metric.startswith("measurements."):
+            return None
+
         # Custom measurements are prefixed with "measurements." and always map to distributions
         prefix = "d" if primary_metric.startswith("measurements.") else primary_metric.split(":")[0]
         if prefix not in prefix_to_function_map or prefix_to_function_map.get(prefix) is None:

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -784,7 +784,7 @@ class MetricsQueryBuilder(QueryBuilder):
         if type(allowed_prefixes) is str:
             allowed_prefixes = {allowed_prefixes}
 
-        if metric_id is None or metric_id == -1:
+        if metric_id is None:
             return True
 
         primary_metric = indexer.reverse_resolve(self.use_case_id, self.organization_id, metric_id)

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1326,6 +1326,12 @@ class MetricsQueryBuilder(QueryBuilder):
     def _get_metric_prefix(
         self, snql_function: fields.MetricsFunction, column: str | None
     ) -> str | None:
+        if self.use_metrics_layer or self.use_case_id not in {
+            UseCaseID.SPANS,
+            UseCaseID.TRANSACTIONS,
+        }:
+            return None
+
         prefix_to_function_map = {
             "d": snql_function.snql_distribution,
             "s": snql_function.snql_set,
@@ -1333,13 +1339,13 @@ class MetricsQueryBuilder(QueryBuilder):
             "g": snql_function.snql_gauge,
         }
 
-        use_case_to_metrics_map = {
+        metrics_map = {
             UseCaseID.SPANS: constants.SPAN_METRICS_MAP,
             UseCaseID.TRANSACTIONS: constants.METRICS_MAP,
         }
 
         prefix = None
-        primary_metric = use_case_to_metrics_map[self.use_case_id].get(column)
+        primary_metric = metrics_map[self.use_case_id].get(column)
         prefix = primary_metric.split(":")[0] if primary_metric else None
         if prefix is not None and prefix_to_function_map.get(prefix) is None:
             raise IncompatibleMetricsQuery(

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -779,10 +779,10 @@ class MetricsQueryBuilder(QueryBuilder):
             return env_conditions[0]
 
     def _evaluate_metric_matches_function(
-        self, metric_id: int | None, expected_prefix: set[str] | str
+        self, metric_id: int | None, allowed_prefixes: set[str] | str
     ):
-        if type(expected_prefix) is str:
-            expected_prefix = {expected_prefix}
+        if type(allowed_prefixes) is str:
+            allowed_prefixes = {allowed_prefixes}
 
         if metric_id is None or metric_id == -1:
             return True
@@ -791,12 +791,12 @@ class MetricsQueryBuilder(QueryBuilder):
         metric_prefix = primary_metric.split(":")[0] if primary_metric else None
 
         is_requested_metric_matching_function = (
-            metric_prefix is not None and metric_prefix in expected_prefix
+            metric_prefix is not None and metric_prefix in allowed_prefixes
         )
         is_compatible_measurement = (
             metric_prefix is not None
             and metric_prefix.startswith("measurements")
-            and "measurements" in expected_prefix
+            and "measurements" in allowed_prefixes
         )
 
         return is_requested_metric_matching_function or is_compatible_measurement

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -595,7 +595,7 @@ class MetricsQueryBuilder(QueryBuilder):
     ) -> SelectType | None:
         metric_id = arguments.get("metric_id")
 
-        if snql_function.snql_distribution is not None and self.evaluate_metric_matches_function(
+        if snql_function.snql_distribution is not None and self._evaluate_metric_matches_function(
             metric_id, "d"
         ):
             resolved_function = snql_function.snql_distribution(arguments, alias)
@@ -607,7 +607,7 @@ class MetricsQueryBuilder(QueryBuilder):
                 # Still add to aggregates so groupby is correct
                 self.aggregates.append(resolved_function)
             return resolved_function
-        if snql_function.snql_set is not None and self.evaluate_metric_matches_function(
+        if snql_function.snql_set is not None and self._evaluate_metric_matches_function(
             metric_id, "s"
         ):
             resolved_function = snql_function.snql_set(arguments, alias)
@@ -616,7 +616,7 @@ class MetricsQueryBuilder(QueryBuilder):
                 # Still add to aggregates so groupby is correct
                 self.aggregates.append(resolved_function)
             return resolved_function
-        if snql_function.snql_counter is not None and self.evaluate_metric_matches_function(
+        if snql_function.snql_counter is not None and self._evaluate_metric_matches_function(
             metric_id, "c"
         ):
             resolved_function = snql_function.snql_counter(arguments, alias)
@@ -625,7 +625,7 @@ class MetricsQueryBuilder(QueryBuilder):
                 # Still add to aggregates so groupby is correct
                 self.aggregates.append(resolved_function)
             return resolved_function
-        if snql_function.snql_gauge is not None and self.evaluate_metric_matches_function(
+        if snql_function.snql_gauge is not None and self._evaluate_metric_matches_function(
             metric_id, "g"
         ):
             resolved_function = snql_function.snql_gauge(arguments, alias)

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -356,8 +356,7 @@ METRIC_DURATION_COLUMNS = {
 SPAN_METRIC_DURATION_COLUMNS = {
     key
     for key, value in SPAN_METRICS_MAP.items()
-    if (value.endswith("@millisecond") and value.startswith("d:"))
-    or (value.endswith("@second") and value.startswith("g:"))
+    if value.endswith("@millisecond") or value.endswith("@second")
 }
 SPAN_METRIC_COUNT_COLUMNS = {
     key

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -331,6 +331,10 @@ SPAN_METRICS_MAP = {
     "http.decoded_response_content_length": "d:spans/http.decoded_response_content_length@byte",
     "http.response_transfer_size": "d:spans/http.response_transfer_size@byte",
     "cache.item_size": "d:spans/cache.item_size@byte",
+    "mobile.slow_frames": "g:spans/mobile.slow_frames@none",
+    "mobile.frozen_frames": "g:spans/mobile.frozen_frames@none",
+    "mobile.total_frames": "g:spans/mobile.total_frames@none",
+    "mobile.frames_delay": "g:spans/mobile.frames_delay@second",
 }
 SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
 # 50 to match the size of tables in the UI + 1 for pagination reasons
@@ -352,7 +356,13 @@ METRIC_DURATION_COLUMNS = {
 SPAN_METRIC_DURATION_COLUMNS = {
     key
     for key, value in SPAN_METRICS_MAP.items()
-    if value.endswith("@millisecond") and value.startswith("d:")
+    if (value.endswith("@millisecond") and value.startswith("d:"))
+    or (value.endswith("@second") and value.startswith("g:"))
+}
+SPAN_METRIC_COUNT_COLUMNS = {
+    key
+    for key, value in SPAN_METRICS_MAP.items()
+    if value.endswith("@none") and value.startswith("g:")
 }
 SPAN_METRIC_BYTES_COLUMNS = {
     key

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -173,7 +173,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     required_args=[
                         fields.MetricArg(
                             "column",
-                            allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
+                            allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
+                            | constants.SPAN_METRIC_COUNT_COLUMNS,
                         ),
                         fields.MetricArg(
                             "if_col",
@@ -486,7 +487,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                     required_args=[
                         fields.MetricArg(
                             "column",
-                            allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS,
+                            allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
+                            | constants.SPAN_METRIC_COUNT_COLUMNS,
                             allow_custom_measurements=False,
                         ),
                         fields.MetricArg(

--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -185,29 +185,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                         ),
                     ],
                     calculated_args=[resolve_metric_id],
-                    snql_distribution=lambda args, alias: Function(
-                        "avgIf",
-                        [
-                            Column("value"),
-                            Function(
-                                "and",
-                                [
-                                    Function(
-                                        "equals",
-                                        [
-                                            Column("metric_id"),
-                                            args["metric_id"],
-                                        ],
-                                    ),
-                                    Function(
-                                        "equals",
-                                        [self.builder.column(args["if_col"]), args["if_val"]],
-                                    ),
-                                ],
-                            ),
-                        ],
-                        alias,
-                    ),
+                    snql_gauge=self._resolve_avg_if,
+                    snql_distribution=self._resolve_avg_if,
                     result_type_fn=self.reflective_result_type(),
                     default_result_type="duration",
                 ),
@@ -506,9 +485,8 @@ class SpansMetricsDatasetConfig(DatasetConfig):
                         ),
                     ],
                     calculated_args=[resolve_metric_id],
-                    snql_distribution=lambda args, alias: function_aliases.resolve_avg_compare(
-                        self.builder.column, args, alias
-                    ),
+                    snql_gauge=self._resolve_avg_compare,
+                    snql_distribution=self._resolve_avg_compare,
                     default_result_type="percent_change",
                 ),
                 fields.MetricsFunction(
@@ -1072,6 +1050,34 @@ class SpansMetricsDatasetConfig(DatasetConfig):
             ),
             alias,
         )
+
+    def _resolve_avg_if(self, args, alias):
+        return Function(
+            "avgIf",
+            [
+                Column("value"),
+                Function(
+                    "and",
+                    [
+                        Function(
+                            "equals",
+                            [
+                                Column("metric_id"),
+                                args["metric_id"],
+                            ],
+                        ),
+                        Function(
+                            "equals",
+                            [self.builder.column(args["if_col"]), args["if_val"]],
+                        ),
+                    ],
+                ),
+            ],
+            alias,
+        )
+
+    def _resolve_avg_compare(self, args, alias):
+        return function_aliases.resolve_avg_compare(self.builder.column, args, alias)
 
     @property
     def orderby_converter(self) -> Mapping[str, OrderBy]:

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2193,6 +2193,7 @@ class MetricsFunction(SnQLFunction):
         self.snql_distribution = kwargs.pop("snql_distribution", None)
         self.snql_set = kwargs.pop("snql_set", None)
         self.snql_counter = kwargs.pop("snql_counter", None)
+        self.snql_gauge = kwargs.pop("snql_gauge", None)
         self.snql_metric_layer = kwargs.pop("snql_metric_layer", None)
         self.is_percentile = kwargs.pop("is_percentile", False)
         super().__init__(*args, **kwargs)
@@ -2210,11 +2211,12 @@ class MetricsFunction(SnQLFunction):
                     self.snql_distribution is not None,
                     self.snql_set is not None,
                     self.snql_counter is not None,
+                    self.snql_gauge is not None,
                     self.snql_column is not None,
                     self.snql_metric_layer is not None,
                 ]
             )
-            == 1
+            >= 1
         )
 
         # assert that no duplicate argument names are used

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2174,7 +2174,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
 
     def store_span_metric(
         self,
-        value: list[int] | int,
+        value: dict[str, int] | list[int] | int,
         metric: str = "span.self_time",
         internal_metric: str | None = None,
         entity: str | None = None,

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -1483,8 +1483,12 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         # Handled by the discover transform later so its fine that this is nan
         assert math.isnan(data["p50"])
 
+    @mock.patch(
+        "sentry.search.events.builder.metrics.indexer.reverse_resolve",
+        return_value=constants.METRICS_MAP["measurements.lcp"],
+    )
     @mock.patch("sentry.search.events.builder.metrics.indexer.resolve", return_value=-1)
-    def test_multiple_references_only_resolve_index_once(self, mock_indexer):
+    def test_multiple_references_only_resolve_index_once(self, mock_indexer, _mock_reverse_resolve):
         MetricsQueryBuilder(
             self.params,
             query=f"project:{self.project.slug} transaction:foo_transaction transaction:foo_transaction",

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -1613,13 +1613,11 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             )
         },
     )
-    @mock.patch(
+    @mock.patch.dict(
         "sentry.search.events.builder.metrics.constants.METRICS_MAP",
-        return_value={"mocked_gauge": "g:mocked_gauge@none"},
+        {"mocked_gauge": "g:mock/mocked_gauge@none"},
     )
-    def test_missing_function_implementation_for_metric_type(
-        self, _mocked_metrics_map, _mocked_function_converter
-    ):
+    def test_missing_function_implementation_for_metric_type(self, _mocked_function_converter):
         # Mocks count_unique to allow the mocked_gauge column
         # but the metric type does not have a gauge implementation
         with pytest.raises(IncompatibleMetricsQuery) as err:

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1442,19 +1442,22 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         for index, release in enumerate(["foo", "bar"]):
             self.store_span_metric(
                 1 + 10 * index,
-                internal_metric=constants.SPAN_METRICS_MAP["mobile.slow_frames"],
+                entity="metrics_gauges",
+                metric="mobile.slow_frames",
                 timestamp=self.six_min_ago,
                 tags={"release": release},
             )
             self.store_span_metric(
                 2 + 10 * index,
-                internal_metric=constants.SPAN_METRICS_MAP["mobile.frozen_frames"],
+                entity="metrics_gauges",
+                metric="mobile.frozen_frames",
                 timestamp=self.six_min_ago,
                 tags={"release": release},
             )
             self.store_span_metric(
                 3 + 10 * index,
-                internal_metric=constants.SPAN_METRICS_MAP["mobile.frames_delay"],
+                entity="metrics_gauges",
+                metric="mobile.frames_delay",
                 timestamp=self.six_min_ago,
                 tags={"release": release},
             )

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -1438,6 +1438,53 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             {"count_op(queue.submit.celery)": 1, "count_op(queue.task.celery)": 1},
         ]
 
+    def test_frames_metrics(self):
+        for index, release in enumerate(["foo", "bar"]):
+            self.store_span_metric(
+                1 + 10 * index,
+                internal_metric=constants.SPAN_METRICS_MAP["mobile.slow_frames"],
+                timestamp=self.six_min_ago,
+                tags={"release": release},
+            )
+            self.store_span_metric(
+                2 + 10 * index,
+                internal_metric=constants.SPAN_METRICS_MAP["mobile.frozen_frames"],
+                timestamp=self.six_min_ago,
+                tags={"release": release},
+            )
+            self.store_span_metric(
+                3 + 10 * index,
+                internal_metric=constants.SPAN_METRICS_MAP["mobile.frames_delay"],
+                timestamp=self.six_min_ago,
+                tags={"release": release},
+            )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "avg_if(mobile.slow_frames,release,foo)",
+                    "avg_if(mobile.frozen_frames,release,bar)",
+                    "avg_compare(mobile.slow_frames,release,foo,bar)",
+                    "avg_if(mobile.frames_delay,release,foo)",
+                ],
+                "query": "",
+                "project": self.project.id,
+                "dataset": "spansMetrics",
+                "statsPeriod": "1h",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert data == [
+            {
+                "avg_compare(mobile.slow_frames,release,foo,bar)": 10.0,
+                "avg_if(mobile.slow_frames,release,foo)": 1.0,
+                "avg_if(mobile.frames_delay,release,foo)": 3.0,
+                "avg_if(mobile.frozen_frames,release,bar)": 12.0,
+            }
+        ]
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     OrganizationEventsMetricsEnhancedPerformanceEndpointTest


### PR DESCRIPTION
Extends the MetricsQueryBuilder to support gauges because we're trying to leverage gauges more and the mobile metrics for frame information are gauges.

I've added a `snql_gauge` method to the `MetricsFunction` class and make sure the function gets routed to the proper database table. The bulk of this PR is r.e. how I'm influencing the query builder to ensure that we set the right attributes to query the correct table, i.e. my `_evaluate_metric_matches_function` helper