### PR TITLE
ref(rules): Pull out RuleProcessor methods to be reusable

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -8,7 +8,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers.rest_framework import RuleActionSerializer
 from sentry.models.rule import Rule
-from sentry.rules.processing.processor import RuleProcessor
+from sentry.rules.processing.processor import activate_downstream_actions
 from sentry.utils.safe import safe_execute
 from sentry.utils.samples import create_sample_event
 
@@ -60,10 +60,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
             project, platform=project.platform, default="javascript", tagged=True
         )
 
-        rp = RuleProcessor(test_event, False, False, False, False)
-        rp.activate_downstream_actions(rule)
-
-        for callback, futures in rp.grouped_futures.values():
+        for callback, futures in activate_downstream_actions(rule, test_event).values():
             safe_execute(callback, test_event, futures, _with_transaction=False)
 
         return Response()

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -75,6 +75,65 @@ def split_conditions_and_filters(rule_condition_list):
     return condition_list, filter_list
 
 
+def _build_rule_status_cache_key(rule_id: int, group_id: int) -> str:
+    return "grouprulestatus:1:%s" % hash_values([group_id, rule_id])
+
+
+def bulk_get_rule_status(rules: Sequence[Rule], group: GroupEvent) -> Mapping[int, GroupRuleStatus]:
+    keys = [_build_rule_status_cache_key(rule.id, group.id) for rule in rules]
+    cache_results: Mapping[str, GroupRuleStatus] = cache.get_many(keys)
+    missing_rule_ids: set[int] = set()
+    rule_statuses: MutableMapping[int, GroupRuleStatus] = {}
+    for key, rule in zip(keys, rules):
+        rule_status = cache_results.get(key)
+        if not rule_status:
+            missing_rule_ids.add(rule.id)
+        else:
+            rule_statuses[rule.id] = rule_status
+
+    if missing_rule_ids:
+        # If not cached, attempt to fetch status from the database
+        statuses = GroupRuleStatus.objects.filter(group=group, rule_id__in=missing_rule_ids)
+        to_cache: list[GroupRuleStatus] = list()
+        for status in statuses:
+            rule_statuses[status.rule_id] = status
+            missing_rule_ids.remove(status.rule_id)
+            to_cache.append(status)
+
+        # We might need to create some statuses if they don't already exist
+        if missing_rule_ids:
+            # We use `ignore_conflicts=True` here to avoid race conditions where the statuses
+            # might be created between when we queried above and attempt to create the rows now.
+            GroupRuleStatus.objects.bulk_create(
+                [
+                    GroupRuleStatus(rule_id=rule_id, group=group, project=group.project)
+                    for rule_id in missing_rule_ids
+                ],
+                ignore_conflicts=True,
+            )
+            # Using `ignore_conflicts=True` prevents the pk from being set on the model
+            # instances. Re-query the database to fetch the rows, they should all exist at this
+            # point.
+            statuses = GroupRuleStatus.objects.filter(group=group, rule_id__in=missing_rule_ids)
+            for status in statuses:
+                rule_statuses[status.rule_id] = status
+                missing_rule_ids.remove(status.rule_id)
+                to_cache.append(status)
+
+            if missing_rule_ids:
+                # Shouldn't happen, but log just in case
+                logger.error(
+                    "Failed to fetch some GroupRuleStatuses in RuleProcessor",
+                    extra={"missing_rule_ids": missing_rule_ids, "group_id": group.id},
+                )
+        if to_cache:
+            cache.set_many(
+                {_build_rule_status_cache_key(item.rule_id, group.id): item for item in to_cache}
+            )
+
+    return rule_statuses
+
+
 def activate_downstream_actions(
     rule: Rule,
     event: GroupEvent,
@@ -142,67 +201,6 @@ class RuleProcessor:
         """Get all of the rules for this project from the DB (or cache)."""
         rules_: Sequence[Rule] = Rule.get_for_project(self.project.id)
         return rules_
-
-    def _build_rule_status_cache_key(self, rule_id: int) -> str:
-        return "grouprulestatus:1:%s" % hash_values([self.group.id, rule_id])
-
-    def bulk_get_rule_status(self, rules: Sequence[Rule]) -> Mapping[int, GroupRuleStatus]:
-        keys = [self._build_rule_status_cache_key(rule.id) for rule in rules]
-        cache_results: Mapping[str, GroupRuleStatus] = cache.get_many(keys)
-        missing_rule_ids: set[int] = set()
-        rule_statuses: MutableMapping[int, GroupRuleStatus] = {}
-        for key, rule in zip(keys, rules):
-            rule_status = cache_results.get(key)
-            if not rule_status:
-                missing_rule_ids.add(rule.id)
-            else:
-                rule_statuses[rule.id] = rule_status
-
-        if missing_rule_ids:
-            # If not cached, attempt to fetch status from the database
-            statuses = GroupRuleStatus.objects.filter(
-                group=self.group, rule_id__in=missing_rule_ids
-            )
-            to_cache: list[GroupRuleStatus] = list()
-            for status in statuses:
-                rule_statuses[status.rule_id] = status
-                missing_rule_ids.remove(status.rule_id)
-                to_cache.append(status)
-
-            # We might need to create some statuses if they don't already exist
-            if missing_rule_ids:
-                # We use `ignore_conflicts=True` here to avoid race conditions where the statuses
-                # might be created between when we queried above and attempt to create the rows now.
-                GroupRuleStatus.objects.bulk_create(
-                    [
-                        GroupRuleStatus(rule_id=rule_id, group=self.group, project=self.project)
-                        for rule_id in missing_rule_ids
-                    ],
-                    ignore_conflicts=True,
-                )
-                # Using `ignore_conflicts=True` prevents the pk from being set on the model
-                # instances. Re-query the database to fetch the rows, they should all exist at this
-                # point.
-                statuses = GroupRuleStatus.objects.filter(
-                    group=self.group, rule_id__in=missing_rule_ids
-                )
-                for status in statuses:
-                    rule_statuses[status.rule_id] = status
-                    missing_rule_ids.remove(status.rule_id)
-                    to_cache.append(status)
-
-                if missing_rule_ids:
-                    # Shouldn't happen, but log just in case
-                    logger.error(
-                        "Failed to fetch some GroupRuleStatuses in RuleProcessor",
-                        extra={"missing_rule_ids": missing_rule_ids, "group_id": self.group.id},
-                    )
-            if to_cache:
-                cache.set_many(
-                    {self._build_rule_status_cache_key(item.rule_id): item for item in to_cache}
-                )
-
-        return rule_statuses
 
     def condition_matches(
         self,
@@ -339,7 +337,7 @@ class RuleProcessor:
         snoozed_rules = RuleSnooze.objects.filter(rule__in=rules, user_id=None).values_list(
             "rule", flat=True
         )
-        rule_statuses = self.bulk_get_rule_status(rules)
+        rule_statuses = bulk_get_rule_status(rules, self.group)
         for rule in rules:
             if rule.id not in snoozed_rules:
                 self.apply_rule(rule, rule_statuses[rule.id])

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -143,6 +143,10 @@ def activate_downstream_actions(
 ) -> MutableMapping[
     str, tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
 ]:
+    grouped_futures: MutableMapping[
+        str, tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
+    ] = {}
+
     for action in rule.data.get("actions", ()):
         action_inst = instantiate_action(rule, action, rule_fire_history)
         if not action_inst:
@@ -157,10 +161,6 @@ def activate_downstream_actions(
         if results is None:
             logger.warning("Action %s did not return any futures", action["id"])
             continue
-
-        grouped_futures: MutableMapping[
-            str, tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
-        ] = {}
 
         for future in results:
             key = future.key if future.key is not None else future.callback

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -555,7 +555,7 @@ class RuleProcessorTestFilters(TestCase):
         )
 
         with mock.patch(
-            "sentry.rules.processing.processor.RuleProcessor.bulk_get_rule_status",
+            "sentry.rules.processing.processor.bulk_get_rule_status",
             return_value={self.rule.id: grs},
         ):
             results = list(rp.apply())


### PR DESCRIPTION
Pulls out `activate_downstream_actions`, `bulk_get_rule_status`, and `build_rule_status_cache_key` to be reused by the delayed rule processor. We need the rule statuses to check and update `GroupRuleStatus` before firing the rule with `activate_downstream_actions`. 