### PR TITLE
feat(ui): Keep stable references to lazy components

### DIFF
--- a/static/app/components/events/rrwebIntegration.tsx
+++ b/static/app/components/events/rrwebIntegration.tsx
@@ -1,3 +1,4 @@
+import {lazy} from 'react';
 import styled from '@emotion/styled';
 
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
@@ -17,6 +18,8 @@ type Props = {
   orgId: Organization['id'];
   projectSlug: Project['slug'];
 };
+
+const LazyReplayer = lazy(() => import('./rrwebReplayer'));
 
 function EventRRWebIntegrationContent({orgId, projectSlug, event}: Props) {
   const {
@@ -61,7 +64,7 @@ function EventRRWebIntegrationContent({orgId, projectSlug, event}: Props) {
   return (
     <StyledReplayEventDataSection type="context-replay" title={t('Replay')}>
       <LazyLoad
-        component={() => import('./rrwebReplayer')}
+        LazyComponent={LazyReplayer}
         urls={attachmentList.map(createAttachmentUrl)}
       />
     </StyledReplayEventDataSection>

--- a/static/app/components/feedback/feedbackItem/replaySection.tsx
+++ b/static/app/components/feedback/feedbackItem/replaySection.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {lazy} from 'react';
 
 import LazyLoad from 'sentry/components/lazyLoad';
 import type {Organization} from 'sentry/types/organization';
@@ -15,18 +15,16 @@ const CLIP_OFFSETS = {
   durationBeforeMs: 20_000,
 };
 
+const LazyReplayClipPreviewComponent = lazy(
+  () => import('sentry/components/events/eventReplay/replayClipPreview')
+);
+const LazyReplayPreviewComponent = lazy(
+  () => import('sentry/components/events/eventReplay/replayPreview')
+);
+
 export default function ReplaySection({eventTimestampMs, organization, replayId}: Props) {
   const hasUserFeedbackReplayClip = organization.features.includes(
     'user-feedback-replay-clip'
-  );
-
-  const replayPreview = useCallback(
-    () => import('sentry/components/events/eventReplay/replayPreview'),
-    []
-  );
-  const replayClipPreview = useCallback(
-    () => import('sentry/components/events/eventReplay/replayClipPreview'),
-    []
   );
 
   const props = {
@@ -45,8 +43,12 @@ export default function ReplaySection({eventTimestampMs, organization, replayId}
   };
 
   return hasUserFeedbackReplayClip ? (
-    <LazyLoad {...props} component={replayClipPreview} clipOffsets={CLIP_OFFSETS} />
+    <LazyLoad
+      {...props}
+      LazyComponent={LazyReplayClipPreviewComponent}
+      clipOffsets={CLIP_OFFSETS}
+    />
   ) : (
-    <LazyLoad {...props} component={replayPreview} />
+    <LazyLoad {...props} LazyComponent={LazyReplayPreviewComponent} />
   );
 }

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -15,9 +15,15 @@ type ComponentType = React.ComponentType<any>;
 
 type Props<C extends ComponentType> = React.ComponentProps<C> & {
   /**
-   * Accepts a function to trigger the import resolution of the component.
+   * Optionally wrap the component with lazy() before passing it to LazyLoad.
    */
-  component: () => PromisedImport<C>;
+  LazyComponent?: React.LazyExoticComponent<C>;
+
+  /**
+   * Accepts a function to trigger the import resolution of the component.
+   * @deprecated Use `LazyComponent` instead and keep lazy() calls out of the render path.
+   */
+  component?: () => PromisedImport<C>;
 
   /**
    * Override the default fallback component.
@@ -31,17 +37,24 @@ type Props<C extends ComponentType> = React.ComponentProps<C> & {
  * LazyLoad is used to dynamically load codesplit components via a `import`
  * call. This is primarily used in our routing tree.
  *
- * <LazyLoad component={() => import('./myComponent')} someComponentProps={...} />
+ * Outside the render path
+ * Const LazyComponent = lazy(() => import('./myComponent'))
+ *
+ * <LazyLoad LazyComponent={LazyComponent} someComponentProps={...} />
  */
 function LazyLoad<C extends ComponentType>({
   component,
   loadingFallback,
+  LazyComponent,
   ...props
 }: Props<C>) {
-  const LazyComponent = useMemo(
-    () => lazy<C>(() => retryableImport(component)),
-    [component]
-  );
+  const LazyLoadedComponent = useMemo(() => {
+    if (LazyComponent) {
+      return LazyComponent;
+    }
+
+    return lazy<C>(() => retryableImport(component));
+  }, [component, LazyComponent]);
 
   return (
     <ErrorBoundary>
@@ -54,7 +67,7 @@ function LazyLoad<C extends ComponentType>({
           )
         }
       >
-        <LazyComponent {...(props as React.ComponentProps<C>)} />
+        <LazyLoadedComponent {...(props as React.ComponentProps<C>)} />
       </Suspense>
     </ErrorBoundary>
   );

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -15,7 +15,7 @@ type ComponentType = React.ComponentType<any>;
 
 type Props<C extends ComponentType> = React.ComponentProps<C> & {
   /**
-   * Optionally wrap the component with lazy() before passing it to LazyLoad.
+   * Wrap the component with lazy() before passing it to LazyLoad.
    */
   LazyComponent?: React.LazyExoticComponent<C>;
 
@@ -38,7 +38,7 @@ type Props<C extends ComponentType> = React.ComponentProps<C> & {
  * call. This is primarily used in our routing tree.
  *
  * Outside the render path
- * Const LazyComponent = lazy(() => import('./myComponent'))
+ * const LazyComponent = lazy(() => import('./myComponent'))
  *
  * <LazyLoad LazyComponent={LazyComponent} someComponentProps={...} />
  */

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, lazy} from 'react';
 import {IndexRedirect, Redirect} from 'react-router';
 import memoize from 'lodash/memoize';
 
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import HookStore from 'sentry/stores/hookStore';
 import type {HookName} from 'sentry/types/hooks';
 import errorHandler from 'sentry/utils/errorHandler';
+import retryableImport from 'sentry/utils/retryableImport';
 import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 import withDomainRequired from 'sentry/utils/withDomainRequired';
 import App from 'sentry/views/app';
@@ -39,11 +40,12 @@ const SafeLazyLoad = errorHandler(LazyLoad);
 export function makeLazyloadComponent<C extends React.ComponentType<any>>(
   resolve: () => Promise<{default: C}>
 ) {
+  const LazyComponent = lazy<C>(() => retryableImport(resolve));
   // XXX: Assign the component to a variable so it has a displayname
   function RouteLazyLoad(props: React.ComponentProps<C>) {
     // we can use this hook to set the organization as it's
     // a child of the organization context
-    return <SafeLazyLoad {...props} component={resolve} />;
+    return <SafeLazyLoad {...props} LazyComponent={LazyComponent} />;
   }
 
   return RouteLazyLoad;


### PR DESCRIPTION
This pr pulls the `lazy()` call out of the render path.

In concurrent mode, a spinner is sometimes shown on route change even though the component has already been loaded. We should try to keep stable references to `lazy(() => import('./whatever'));` to benefit from the caching react lazy does and avoid the tick from .then() that is needed to resolve a fresh promise, even if webpack has cached the result already.


[From the docs](https://react.dev/reference/react/lazy#lazy)
> Call lazy outside your components to declare a lazy-loaded React component:

example: go to the subscription page https://sentry.sentry.io/settings/billing/overview/ and flick between the tabs

before - spinner every time you switch tabs even after the component is loaded

https://github.com/getsentry/sentry/assets/1400464/c955c438-4f8f-4caa-93f5-ee1eb795edf7


after - spinner or flicker only when the bundle is loaded the first time. this could be prefetched

https://github.com/getsentry/sentry/assets/1400464/4a75cca4-f353-4008-b9ca-b4b2d4e21ca3


part of https://github.com/getsentry/frontend-tsc/issues/63