### PR TITLE
ref(metrics): remove format using unit and op

### DIFF
--- a/static/app/utils/metrics/formatters.spec.tsx
+++ b/static/app/utils/metrics/formatters.spec.tsx
@@ -1,33 +1,7 @@
 import {
-  formatMetricsUsingUnitAndOp,
   formatMetricUsingFixedUnit,
   formattingSupportedMetricUnits,
 } from 'sentry/utils/metrics/formatters';
-
-describe('formatMetricsUsingUnitAndOp', () => {
-  it('should format the value according to the unit', () => {
-    // Test cases for different units
-    expect(formatMetricsUsingUnitAndOp(123456, 'millisecond')).toEqual('2.06min');
-    expect(formatMetricsUsingUnitAndOp(5000, 'second')).toEqual('1.39hr');
-    expect(formatMetricsUsingUnitAndOp(600, 'byte')).toEqual('600 B');
-    expect(formatMetricsUsingUnitAndOp(4096, 'kibibyte')).toEqual('4.0 MiB');
-    expect(formatMetricsUsingUnitAndOp(3145728, 'megabyte')).toEqual('3.15 TB');
-    expect(formatMetricsUsingUnitAndOp(3145728, 'megabytes')).toEqual('3.15 TB');
-    expect(formatMetricsUsingUnitAndOp(0.99, 'ratio')).toEqual('99%');
-    expect(formatMetricsUsingUnitAndOp(99, 'percent')).toEqual('99%');
-  });
-
-  it('should handle value as null', () => {
-    expect(formatMetricsUsingUnitAndOp(null, 'millisecond')).toEqual('—');
-    expect(formatMetricsUsingUnitAndOp(null, 'byte')).toEqual('—');
-    expect(formatMetricsUsingUnitAndOp(null, 'megabyte')).toEqual('—');
-  });
-
-  it('should format count operation as a number', () => {
-    expect(formatMetricsUsingUnitAndOp(99, 'none', 'count')).toEqual('99');
-    expect(formatMetricsUsingUnitAndOp(null, 'none', 'count')).toEqual('');
-  });
-});
 
 describe('formatMetricUsingFixedUnit', () => {
   it('should return the formatted value with the short form of the given unit', () => {

--- a/static/app/utils/metrics/formatters.tsx
+++ b/static/app/utils/metrics/formatters.tsx
@@ -3,7 +3,6 @@ import type {MetricType} from 'sentry/types/metrics';
 import {defined, formatBytesBase2, formatBytesBase10} from 'sentry/utils';
 import {
   DAY,
-  formatAbbreviatedNumber,
   formatAbbreviatedNumberWithDynamicPrecision,
   formatNumberWithDynamicDecimalPoints,
   HOUR,
@@ -280,16 +279,4 @@ export function formatMetricUsingFixedUnit(
   return op === 'count'
     ? formattedNumber
     : `${formattedNumber}${getShortMetricUnit(unit)}`.trim();
-}
-
-export function formatMetricsUsingUnitAndOp(
-  value: number | null,
-  unit: string,
-  operation?: string
-) {
-  if (operation === 'count') {
-    // if the operation is count, we want to ignore the unit and always format the value as a number
-    return value ? formatAbbreviatedNumber(value, 2) : '';
-  }
-  return formatMetricUsingUnit(value, unit);
 }

--- a/static/app/views/metrics/chart/useMetricChartSamples.tsx
+++ b/static/app/views/metrics/chart/useMetricChartSamples.tsx
@@ -11,7 +11,7 @@ import type {EChartClickHandler, ReactEchartsRef} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import mergeRefs from 'sentry/utils/mergeRefs';
 import {isCumulativeOp} from 'sentry/utils/metrics';
-import {formatMetricsUsingUnitAndOp} from 'sentry/utils/metrics/formatters';
+import {formatMetricUsingUnit} from 'sentry/utils/metrics/formatters';
 import {
   getSummaryValueForOp,
   type MetricsSamplesResults,
@@ -126,7 +126,7 @@ export function useMetricChartSamples({
         // We need to access the sample as the charts datapoints are fit to the charts viewport
         const sample = samplesById[label ?? ''];
         const yValue = getSummaryValueForOp(sample.summary, operation);
-        return formatMetricsUsingUnitAndOp(yValue, unit, operation);
+        return formatMetricUsingUnit(yValue, unit);
       },
     };
   }, [operation, samplesById, unit]);


### PR DESCRIPTION
Removes last usage of `formatMetricsUsingUnitAndOp `