### PR TITLE
chore(metrics): rename metrics experimental flag

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -230,7 +230,7 @@ class AlertRuleSerializer(Serializer):
 
         env = obj.snuba_query.environment
         allow_mri = features.has(
-            "organizations:ddm-experimental",
+            "organizations:custom-metrics",
             obj.organization,
             actor=user,
         )

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1522,8 +1522,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:dashboards-mep": False,
     # Enable release health widget in dashboards
     "organizations:dashboards-rh-widget": False,
-    # Enables experimental WIP ddm related features
-    "organizations:ddm-experimental": False,
+    # Enables experimental WIP custom metrics related features
+    "organizations:custom-metrics-experimental": False,
     # Delightful Developer Metrics (DDM):
     # Enable UI (requires custom-metrics flag as well)
     "organizations:ddm-ui": False,

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -58,7 +58,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:dashboards-mep", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:dashboards-rh-widget", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:ddm-dashboard-import", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    manager.add("organizations:ddm-experimental", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:custom-metrics-experimental", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:ddm-metrics-api-unit-normalization", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:ddm-sidebar-item-hidden", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:metrics-stats", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/static/app/utils/metrics/features.tsx
+++ b/static/app/utils/metrics/features.tsx
@@ -2,7 +2,7 @@ import type {Organization} from 'sentry/types/organization';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
 export function hasMetricsExperimentalFeature(organization: Organization) {
-  return organization.features.includes('ddm-experimental');
+  return organization.features.includes('custom-metrics-experimental');
 }
 
 export function hasMetricsUI(organization: Organization) {


### PR DESCRIPTION
renames `ddm-experimental` to `custom-metrics-experimental` to align naming with other custom metrics feature flags 

Can be deployed both to FE and BE at the same time as there are no FER usages 