### PR TITLE
chore(fixtures): Improve types of `RouteComponentPropsFixture`

### DIFF
--- a/fixtures/js-stubs/routeComponentPropsFixture.tsx
+++ b/fixtures/js-stubs/routeComponentPropsFixture.tsx
@@ -2,8 +2,8 @@ import type {RouteComponentProps} from 'react-router';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 export function RouteComponentPropsFixture<
-  QueryParams = {orgId: string; projectId: string},
-  RouteParams = {},
+  QueryParams extends {[key: string]: string | undefined},
+  RouteParams extends {[key: string]: string | undefined},
 >(
   params: Partial<RouteComponentProps<QueryParams, RouteParams>> = {}
 ): RouteComponentProps<QueryParams, RouteParams> {

--- a/fixtures/js-stubs/routeComponentPropsFixture.tsx
+++ b/fixtures/js-stubs/routeComponentPropsFixture.tsx
@@ -2,17 +2,18 @@ import type {RouteComponentProps} from 'react-router';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 export function RouteComponentPropsFixture<
-  RouteParams = {orgId: string; projectId: string},
+  QueryParams = {orgId: string; projectId: string},
+  RouteParams = {},
 >(
-  params: Partial<RouteComponentProps<RouteParams, {}>> = {}
-): RouteComponentProps<RouteParams, {}> {
+  params: Partial<RouteComponentProps<QueryParams, RouteParams>> = {}
+): RouteComponentProps<QueryParams, RouteParams> {
   const router = RouterFixture(params);
   return {
     location: router.location,
-    params: router.params as RouteParams & {},
+    params: router.params as QueryParams & RouteParams,
     routes: router.routes,
     route: router.routes[0],
-    routeParams: router.params,
+    routeParams: router.params as RouteParams,
     router,
   };
 }

--- a/static/app/views/issueList/overview.actions.spec.tsx
+++ b/static/app/views/issueList/overview.actions.spec.tsx
@@ -111,7 +111,10 @@ describe('IssueListOverview (actions)', function () {
     ],
     savedSearch: null,
     selectedSearchId: null,
-    ...RouteComponentPropsFixture({
+    ...RouteComponentPropsFixture<
+      {orgId: string; projectId: string},
+      {searchId?: string}
+    >({
       location: LocationFixture({
         query: {query: 'is:unresolved issue.priority:[high,medium]'},
       }),

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -105,7 +105,7 @@ type Props = {
   selectedSearchId: string;
   selection: PageFilters;
   tags: TagCollection;
-} & RouteComponentProps<{searchId?: string}, {}> &
+} & RouteComponentProps<{}, {searchId?: string}> &
   WithRouteAnalyticsProps;
 
 type State = {

--- a/static/app/views/performance/transactionDetails/index.tsx
+++ b/static/app/views/performance/transactionDetails/index.tsx
@@ -9,7 +9,7 @@ import withOrganization from 'sentry/utils/withOrganization';
 
 import EventDetailsContent from './content';
 
-type Props = RouteComponentProps<{eventSlug: string}, {}> & {
+type Props = RouteComponentProps<{}, {eventSlug: string}> & {
   organization: Organization;
 };
 

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -21,7 +21,7 @@ import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
 import UpgradeGrouping from './upgradeGrouping';
 
-type Props = RouteComponentProps<{projectId: string}, {}> & {
+type Props = RouteComponentProps<{}, {projectId: string}> & {
   organization: Organization;
   project: Project;
 };


### PR DESCRIPTION
Add separate types for query and route params. It makes it possible to mock page routes for pages that have both query and path parameters.

As far as I can tell, the generic types for `RouteComponentProps` are <QueryParams, RouteParams>` rather than `<RouteParams, QueryParams>` as they're set in most places. It doesn't make a big difference, but I made the change in a few spots that caused type errors.