### PR TITLE
chore(perf): Remove unused `fillSeries` function

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -1,5 +1,4 @@
 import {t} from 'sentry/locale';
-import type {Series} from 'sentry/types/echarts';
 import {formatBytesBase2} from 'sentry/utils';
 import {formatRate} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
@@ -122,30 +121,5 @@ function ResourceSummaryCharts(props: {groupId: string}) {
     </BlockContainer>
   );
 }
-
-/**
- * Ensures a series has no zeros between two non-zero datapoints. This is useful in
- * @param series the series to fill
- * @returns a reference to the initial series filled
- */
-export const fillSeries = (series: Series): Series => {
-  if (!series.data.length) {
-    return series;
-  }
-
-  let lastSeenValue = series.data[0].value;
-
-  return {
-    ...series,
-    data: series.data.map(dataPoint => {
-      const value = dataPoint.value;
-      if (value !== lastSeenValue && value !== 0) {
-        lastSeenValue = value;
-        return {...dataPoint};
-      }
-      return {...dataPoint, value: lastSeenValue};
-    }),
-  };
-};
 
 export default ResourceSummaryCharts;


### PR DESCRIPTION
Leftover from the Starfish days. Discover endpoints do zero-filling, so we don't need this, and it's not even used anywhere anyway.
