### PR TITLE
ref(perf): Use `MetricReadout` in more places

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -135,7 +135,6 @@ function ResourceSummary() {
               throughput={spanMetrics['spm()']}
               timeSpentTotal={spanMetrics[`sum(${SPAN_SELF_TIME})`]}
               timeSpentPercentage={spanMetrics[`time_spent_percentage()`]}
-              spanOp={spanMetrics[SPAN_OP]}
             />
           </HeaderContainer>
           {isImage && (

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
@@ -1,24 +1,22 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
-import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {formatBytesBase2} from 'sentry/utils';
+import {DurationUnit, SizeUnit} from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {RESOURCE_THROUGHPUT_UNIT} from 'sentry/views/performance/browser/resources';
-import ResourceSize from 'sentry/views/performance/browser/resources/shared/resourceSize';
-import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
-import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
-import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
+import {MetricReadout} from 'sentry/views/performance/metricReadout';
+import {getTimeSpentExplanation} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
-import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
 type Props = {
   avgContentLength: number;
   avgDecodedContentLength: number;
   avgDuration: number;
   avgTransferSize: number;
-  spanOp: string;
   throughput: number;
   timeSpentPercentage: number;
   timeSpentTotal: number;
@@ -33,7 +31,6 @@ function ResourceInfo(props: Props) {
     throughput,
     timeSpentPercentage,
     timeSpentTotal,
-    spanOp,
   } = props;
 
   const tooltips = {
@@ -68,51 +65,54 @@ function ResourceInfo(props: Props) {
 
   return (
     <Fragment>
-      <BlockContainer>
-        <Block title={getThroughputTitle('http')}>
-          <ThroughputCell rate={throughput} unit={RESOURCE_THROUGHPUT_UNIT} />
-        </Block>
-        <Block title={DataTitles['avg(http.response_content_length)']}>
-          <Tooltip
-            isHoverable
-            title={tooltips.avgContentLength}
-            showUnderline
-            disabled={!avgContentLength}
-          >
-            <ResourceSize bytes={avgContentLength} />
-          </Tooltip>
-        </Block>
-        <Block title={DataTitles['avg(http.decoded_response_content_length)']}>
-          <Tooltip
-            isHoverable
-            title={tooltips.avgDecodedContentLength}
-            showUnderline
-            disabled={!avgDecodedContentLength}
-          >
-            <ResourceSize bytes={avgDecodedContentLength} />
-          </Tooltip>
-        </Block>
-        <Block title={DataTitles['avg(http.response_transfer_size)']}>
-          <Tooltip
-            isHoverable
-            title={tooltips.avgTransferSize}
-            showUnderline
-            disabled={!avgTransferSize}
-          >
-            <ResourceSize bytes={avgTransferSize} />
-          </Tooltip>
-        </Block>
-        <Block title={DataTitles.avg}>
-          <DurationCell milliseconds={avgDuration} />
-        </Block>
-        <Block title={DataTitles.timeSpent}>
-          <TimeSpentCell
-            percentage={timeSpentPercentage}
-            total={timeSpentTotal}
-            op={spanOp}
-          />
-        </Block>
-      </BlockContainer>
+      <MetricsRibbon>
+        <MetricReadout
+          align="left"
+          title={getThroughputTitle('resource')}
+          value={throughput}
+          unit={RESOURCE_THROUGHPUT_UNIT}
+        />
+
+        <MetricReadout
+          align="left"
+          title={DataTitles['avg(http.response_content_length)']}
+          tooltip={tooltips.avgContentLength}
+          value={avgContentLength}
+          unit={SizeUnit.BYTE}
+        />
+
+        <MetricReadout
+          align="left"
+          title={DataTitles['avg(http.decoded_response_content_length)']}
+          value={avgDecodedContentLength}
+          tooltip={tooltips.avgDecodedContentLength}
+          unit={SizeUnit.BYTE}
+        />
+
+        <MetricReadout
+          align="left"
+          title={DataTitles['avg(http.response_transfer_size)']}
+          value={avgTransferSize}
+          tooltip={tooltips.avgTransferSize}
+          unit={SizeUnit.BYTE}
+        />
+
+        <MetricReadout
+          align="left"
+          title={DataTitles.avg}
+          value={avgDuration}
+          unit={DurationUnit.MILLISECOND}
+        />
+
+        <MetricReadout
+          align="left"
+          title={DataTitles.timeSpent}
+          value={timeSpentTotal}
+          unit={DurationUnit.MILLISECOND}
+          tooltip={getTimeSpentExplanation(timeSpentPercentage, 'resource')}
+        />
+      </MetricsRibbon>
+
       {hasNoData && (
         <Alert style={{width: '100%'}} type="warning" showIcon>
           {t(
@@ -123,5 +123,11 @@ function ResourceInfo(props: Props) {
     </Fragment>
   );
 }
+
+const MetricsRibbon = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(4)};
+`;
 
 export default ResourceInfo;

--- a/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
+++ b/static/app/views/performance/mobile/appStarts/screenSummary/index.tsx
@@ -14,6 +14,7 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DurationUnit} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -150,7 +151,7 @@ function ScreenSummary() {
                   ]}
                   blocks={[
                     {
-                      type: 'duration',
+                      unit: DurationUnit.MILLISECOND,
                       allowZero: false,
                       title:
                         appStartType === COLD_START_TYPE
@@ -159,7 +160,7 @@ function ScreenSummary() {
                       dataKey: `avg_if(span.duration,release,${primaryRelease})`,
                     },
                     {
-                      type: 'duration',
+                      unit: DurationUnit.MILLISECOND,
                       allowZero: false,
                       title:
                         appStartType === COLD_START_TYPE
@@ -168,12 +169,12 @@ function ScreenSummary() {
                       dataKey: `avg_if(span.duration,release,${secondaryRelease})`,
                     },
                     {
-                      type: 'change',
+                      unit: 'percent_change',
                       title: t('Change'),
                       dataKey: `avg_compare(span.duration,release,${primaryRelease},${secondaryRelease})`,
                     },
                     {
-                      type: 'count',
+                      unit: 'count',
                       title: t('Count'),
                       dataKey: 'count()',
                     },

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/index.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/index.tsx
@@ -14,6 +14,7 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DurationUnit} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pageAlert';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -147,27 +148,27 @@ function ScreenLoadSpans() {
                     ]}
                     blocks={[
                       {
-                        type: 'duration',
+                        unit: DurationUnit.MILLISECOND,
                         dataKey: `avg_if(measurements.time_to_initial_display,release,${primaryRelease})`,
                         title: t('TTID (%s)', PRIMARY_RELEASE_ALIAS),
                       },
                       {
-                        type: 'duration',
+                        unit: DurationUnit.MILLISECOND,
                         dataKey: `avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`,
                         title: t('TTID (%s)', SECONDARY_RELEASE_ALIAS),
                       },
                       {
-                        type: 'duration',
+                        unit: DurationUnit.MILLISECOND,
                         dataKey: `avg_if(measurements.time_to_full_display,release,${primaryRelease})`,
                         title: t('TTFD (%s)', PRIMARY_RELEASE_ALIAS),
                       },
                       {
-                        type: 'duration',
+                        unit: DurationUnit.MILLISECOND,
                         dataKey: `avg_if(measurements.time_to_full_display,release,${secondaryRelease})`,
                         title: t('TTFD (%s)', SECONDARY_RELEASE_ALIAS),
                       },
                       {
-                        type: 'count',
+                        unit: 'count',
                         dataKey: 'count()',
                         title: t('Count'),
                       },

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/metricsRibbon.spec.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/metricsRibbon.spec.tsx
@@ -3,6 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {DurationUnit} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {MetricsRibbon} from 'sentry/views/performance/mobile/screenload/screenLoadSpans/metricsRibbon';
@@ -63,11 +64,11 @@ describe('MetricsRibbon', function () {
           'transaction:test-transaction',
         ]}
         blocks={[
-          {dataKey: 'count()', title: 'Count', type: 'count'},
+          {dataKey: 'count()', title: 'Count', unit: 'count'},
           {
             dataKey: 'avg(duration)',
             title: 'Custom Header',
-            type: 'duration',
+            unit: DurationUnit.MILLISECOND,
           },
         ]}
         fields={['count()', 'avg(duration)']}

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/metricsRibbon.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/metricsRibbon.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
@@ -12,6 +13,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import {
   DEFAULT_PLATFORM,
   PLATFORM_LOCAL_STORAGE_KEY,
@@ -19,20 +21,13 @@ import {
 } from 'sentry/views/performance/mobile/screenload/screens/platformSelector';
 import {useTableQuery} from 'sentry/views/performance/mobile/screenload/screens/screensTable';
 import {isCrossPlatform} from 'sentry/views/performance/mobile/screenload/screens/utils';
-import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
-import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
-import {PercentChangeCell} from 'sentry/views/starfish/components/tableCells/percentChangeCell';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
-import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
-
-const UNDEFINED_TEXT = '--';
-type BlockType = 'duration' | 'count' | 'change';
 
 interface BlockProps {
   dataKey: string | ((data?: TableDataRow[]) => number | undefined);
   title: string;
-  type: BlockType;
+  unit: ComponentProps<typeof MetricReadout>['unit'];
   allowZero?: boolean;
 }
 
@@ -101,11 +96,11 @@ export function MetricsRibbon({
 
   return (
     <BlockContainer>
-      {blocks.map(({title, dataKey, type}) => (
+      {blocks.map(({title, dataKey, unit}) => (
         <MetricsBlock
           key={title}
           title={title}
-          type={type}
+          unit={unit}
           dataKey={dataKey}
           data={data}
           isLoading={isLoading}
@@ -117,7 +112,7 @@ export function MetricsRibbon({
 
 function MetricsBlock({
   title,
-  type,
+  unit,
   data,
   dataKey,
   isLoading,
@@ -133,26 +128,16 @@ function MetricsBlock({
       ? dataKey(data?.data)
       : (data?.data?.[0]?.[dataKey] as number);
 
-  const hasData = (!isLoading && value && value !== 0) || (value === 0 && allowZero);
-
-  if (type === 'duration') {
-    return (
-      <Block title={title}>
-        {hasData ? <DurationCell milliseconds={value} /> : UNDEFINED_TEXT}
-      </Block>
-    );
-  }
-
-  if (type === 'change') {
-    return (
-      <Block title={title}>
-        {hasData ? <PercentChangeCell colorize deltaValue={value} /> : UNDEFINED_TEXT}
-      </Block>
-    );
-  }
+  const hasData = (value && value !== 0) || (value === 0 && allowZero);
 
   return (
-    <Block title={title}>{hasData ? <CountCell count={value} /> : UNDEFINED_TEXT}</Block>
+    <MetricReadout
+      title={title}
+      align="left"
+      value={hasData ? value : undefined}
+      isLoading={isLoading}
+      unit={unit}
+    />
   );
 }
 

--- a/static/app/views/performance/mobile/screenload/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/performance/mobile/screenload/screenLoadSpans/samples/samplesContainer.tsx
@@ -8,26 +8,25 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
+import {DurationUnit} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {MetricReadout} from 'sentry/views/performance/metricReadout';
 import {
   DEFAULT_PLATFORM,
   PLATFORM_LOCAL_STORAGE_KEY,
   PLATFORM_QUERY_PARAM,
 } from 'sentry/views/performance/mobile/screenload/screens/platformSelector';
 import {isCrossPlatform} from 'sentry/views/performance/mobile/screenload/screens/utils';
-import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
-import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
-import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
 import SampleTable from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable';
 
@@ -127,28 +126,22 @@ export function ScreenLoadSampleContainer({
           </SectionTitle>
         )}
       </PaddedTitle>
+
       <Container>
-        <Block title={DataTitles.avg} alignment="left">
-          <DurationCell
-            containerProps={{
-              style: {
-                textAlign: 'left',
-              },
-            }}
-            milliseconds={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
-          />
-        </Block>
-        <Block title={DataTitles.count} alignment="left">
-          <CountCell
-            containerProps={{
-              style: {
-                textAlign: 'left',
-              },
-            }}
-            count={spanMetrics?.['count()'] ?? 0}
-          />
-        </Block>
+        <MetricReadout
+          title={DataTitles.avg}
+          align="left"
+          value={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
+          unit={DurationUnit.MILLISECOND}
+        />
+        <MetricReadout
+          title={DataTitles.count}
+          align="left"
+          value={spanMetrics?.['count()'] ?? 0}
+          unit="count"
+        />
       </Container>
+
       <DurationChart
         query={
           additionalFilters

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleInfo/index.tsx
@@ -1,25 +1,15 @@
-import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
-import {RateUnit} from 'sentry/utils/discover/fields';
+import {space} from 'sentry/styles/space';
+import {DurationUnit, RateUnit} from 'sentry/utils/discover/fields';
 import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
-import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
-import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
-import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
+import {MetricReadout} from 'sentry/views/performance/metricReadout';
+import {getTimeSpentExplanation} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
+import type {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
-import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
-
-const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
-
-const DEFAULT_DISPLAYED_METRICS = [
-  'spm()',
-  `avg(${SPAN_SELF_TIME})`,
-  'time_spent_percentage()',
-];
 
 type Props = {
   groupId: string;
@@ -32,99 +22,71 @@ function SampleInfo(props: Props) {
   const {groupId, transactionName, transactionMethod} = props;
   const {setPageError} = usePageAlert();
 
-  const displayedMetrics = props.displayedMetrics ?? DEFAULT_DISPLAYED_METRICS;
-
-  const filters = {
+  const ribbonFilters: SpanMetricsQueryFilters = {
     'span.group': groupId,
     transaction: transactionName,
   };
 
   if (transactionMethod) {
-    filters['transaction.method'] = transactionMethod;
+    ribbonFilters['transaction.method'] = transactionMethod;
   }
 
-  const {data, error} = useSpanMetrics({
-    search: MutableSearch.fromQueryObject(filters),
+  const {data, error, isLoading} = useSpanMetrics({
+    search: MutableSearch.fromQueryObject(ribbonFilters),
     fields: [
-      SPAN_OP,
+      SpanMetricsField.SPAN_OP,
       'spm()',
-      `sum(${SPAN_SELF_TIME})`,
-      `avg(${SPAN_SELF_TIME})`,
+      `sum(${SpanMetricsField.SPAN_SELF_TIME})`,
+      `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
       'time_spent_percentage()',
-      'count()',
     ],
-    enabled: Object.values(filters).every(value => Boolean(value)),
+    enabled: Object.values(ribbonFilters).every(value => Boolean(value)),
     referrer: 'api.starfish.span-summary-panel-metrics',
   });
 
   const spanMetrics = data[0] ?? {};
 
-  const style: CSSProperties = {
-    textAlign: 'left',
-  };
-
   if (error) {
     setPageError(error.message);
   }
 
-  function getDisplayBlock(metric: string) {
-    switch (metric) {
-      case `avg(${SPAN_SELF_TIME})`:
-        return (
-          <Block key={metric} title={DataTitles.avg} alignment="left">
-            <DurationCell
-              containerProps={{style}}
-              milliseconds={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
-            />
-          </Block>
-        );
-      case 'count()':
-        return (
-          <Block key={metric} title={DataTitles.count} alignment="left">
-            <CountCell containerProps={{style}} count={spanMetrics?.['count()']} />
-          </Block>
-        );
-      case 'time_spent_percentage()':
-        return (
-          <Block key={metric} title={DataTitles.timeSpent} alignment="left">
-            <TimeSpentCell
-              containerProps={{style}}
-              percentage={spanMetrics?.[`time_spent_percentage()`]}
-              total={spanMetrics?.[`sum(${SPAN_SELF_TIME})`]}
-              op={spanMetrics?.['span.op']}
-            />
-          </Block>
-        );
-      case 'spm()':
-        return (
-          <Block
-            key={metric}
-            title={getThroughputTitle(spanMetrics?.[SPAN_OP])}
-            alignment="left"
-          >
-            <ThroughputCell
-              containerProps={{style}}
-              rate={spanMetrics?.['spm()']}
-              unit={RateUnit.PER_MINUTE}
-            />
-          </Block>
-        );
-      default:
-        return null;
-    }
-  }
-
   return (
-    <SampleInfoContainer>
-      <BlockContainer>
-        {displayedMetrics.map(metric => getDisplayBlock(metric))}
-      </BlockContainer>
-    </SampleInfoContainer>
+    <MetricsRibbon>
+      <MetricReadout
+        title={getThroughputTitle(spanMetrics?.[SpanMetricsField.SPAN_OP])}
+        align="left"
+        value={spanMetrics?.['spm()']}
+        unit={RateUnit.PER_MINUTE}
+        isLoading={isLoading}
+      />
+
+      <MetricReadout
+        title={DataTitles.avg}
+        align="left"
+        value={spanMetrics?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]}
+        unit={DurationUnit.MILLISECOND}
+        isLoading={isLoading}
+      />
+
+      <MetricReadout
+        title={DataTitles.timeSpent}
+        align="left"
+        value={spanMetrics?.[0]?.[`sum(${SpanMetricsField.SPAN_SELF_TIME}))`]}
+        unit={DurationUnit.MILLISECOND}
+        tooltip={getTimeSpentExplanation(
+          spanMetrics?.[0]?.['time_spent_percentage()'],
+          spanMetrics?.[SpanMetricsField.SPAN_OP]
+        )}
+        isLoading={isLoading}
+      />
+    </MetricsRibbon>
   );
 }
 
-const SampleInfoContainer = styled('div')`
+const MetricsRibbon = styled('div')`
   display: flex;
+  flex-wrap: wrap;
+  gap: ${space(4)};
 `;
 
 export default SampleInfo;


### PR DESCRIPTION
More consolidation. Using the `MetricReadout` component everywhere we were using `Block`. Since `MetricReadout` has its own defined behaviour for `isLoading` and `undefined` values this saves a bit of code, and make the UI behaviour consistent for missing values, loading states, etc.

- resource summary
- mobile samples
- sample panel
- mobile `MetricsRibbon`
