### PR TITLE
ref(ch-upgrades): testing ch 23.8 DONT MERGE

### DIFF
--- a/config/clickhouse/loc_config.xml
+++ b/config/clickhouse/loc_config.xml
@@ -1,3 +1,6 @@
 <yandex>
     <max_server_memory_usage_to_ram_ratio>0.3</max_server_memory_usage_to_ram_ratio>
+    <merge_tree>
+        <old_parts_lifetime>1</old_parts_lifetime>
+    </merge_tree>
 </yandex>

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2893,14 +2893,7 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
     ),
     "clickhouse": lambda settings, options: (
         {
-            "image": (
-                "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:21.8.13.1.altinitystable"
-                if not ARM64
-                # altinity provides clickhouse support to other companies
-                # Official support: https://github.com/ClickHouse/ClickHouse/issues/22222
-                # This image is build with this script https://gist.github.com/filimonov/5f9732909ff66d5d0a65b8283382590d
-                else "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:21.6.1.6734-testing-arm"
-            ),
+            "image": "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.8.8.21.altinitystable",
             "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
             "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],
             # The arm image does not properly load the MAX_MEMORY_USAGE_RATIO


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/69063 but with altinity 23.8 - making sure the getsentry tests pass in this version too. 