### PR TITLE
feat(user): Add option to only return verified emails from get_email_addresses

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -196,7 +196,7 @@ class UserService(RpcService):
     @rpc_method
     @abstractmethod
     def verify_user_emails(
-        self, *, user_id_emails: list[UserIdEmailArgs]
+        self, *, user_id_emails: list[UserIdEmailArgs], only_verified: bool
     ) -> dict[int, RpcVerifyUserEmail]:
         pass
 

--- a/src/sentry/utils/email/manager.py
+++ b/src/sentry/utils/email/manager.py
@@ -14,7 +14,7 @@ logger = logging.getLogger("sentry.mail")
 
 
 def get_email_addresses(
-    user_ids: Iterable[int], project: Project | None = None
+    user_ids: Iterable[int], project: Project | None = None, only_verified: bool = False
 ) -> Mapping[int, str]:
     """
     Find the best email addresses for a collection of users. If a project is
@@ -33,7 +33,9 @@ def get_email_addresses(
         for option in (o for o in options if o.value and not is_fake_email(o.value)):
             user_id_emails.append(UserIdEmailArgs(user_id=int(option.user_id), email=option.value))
 
-        user_id_emails_exists = user_service.verify_user_emails(user_id_emails=user_id_emails)
+        user_id_emails_exists = user_service.verify_user_emails(
+            user_id_emails=user_id_emails, only_verified=only_verified
+        )
 
         for user_id_key in user_id_emails_exists.keys():
             user_id = int(user_id_key)


### PR DESCRIPTION
Will be used to fetch only verified emails when notifying users that their monitors have been in a broken state for an extended period of time