### PR TITLE
ref(rules): Handle action match in delayed rule processor

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -61,10 +61,8 @@ def get_rules_to_groups(rulegroup_to_events: dict[str, str]) -> DefaultDict[int,
 
 def get_rule_to_slow_conditions(
     alert_rules: list[Rule],
-) -> DefaultDict[Rule, list[MutableMapping[str, str] | None]]:
-    rule_to_slow_conditions: DefaultDict[Rule, list[MutableMapping[str, str] | None]] = defaultdict(
-        list
-    )
+) -> DefaultDict[Rule, list[MutableMapping[str, str]]]:
+    rule_to_slow_conditions: DefaultDict[Rule, list[MutableMapping[str, str]]] = defaultdict(list)
     for rule in alert_rules:
         slow_conditions = get_slow_conditions(rule)
         for condition_data in slow_conditions:
@@ -141,7 +139,7 @@ def get_condition_group_results(
 
 def get_rules_to_fire(
     condition_group_results: dict[UniqueCondition, dict[int, int]],
-    rule_to_slow_conditions: DefaultDict[Rule, list[MutableMapping[str, str] | None]],
+    rule_to_slow_conditions: DefaultDict[Rule, list[MutableMapping[str, str]]],
     rules_to_groups: DefaultDict[int, set[int]],
 ) -> DefaultDict[Rule, set[int]]:
     rules_to_fire = defaultdict(set)
@@ -150,24 +148,23 @@ def get_rules_to_fire(
         for group_id in rules_to_groups[alert_rule.id]:
             conditions_matched = 0
             for slow_condition in slow_conditions:
-                if slow_condition:
-                    unique_condition = UniqueCondition(
-                        str(slow_condition.get("id")),
-                        str(slow_condition.get("interval")),
-                        alert_rule.environment_id,
-                    )
-                    results = condition_group_results.get(unique_condition, {})
-                    if results:
-                        target_value = int(str(slow_condition.get("value")))
-                        if results[group_id] >= target_value:
-                            if action_match == "any":
-                                rules_to_fire[alert_rule].add(group_id)
-                                break
-                            conditions_matched += 1
-                        else:
-                            if action_match == "all":
-                                # We failed to match all conditions for this group, skip
-                                break
+                unique_condition = UniqueCondition(
+                    str(slow_condition.get("id")),
+                    str(slow_condition.get("interval")),
+                    alert_rule.environment_id,
+                )
+                results = condition_group_results.get(unique_condition, {})
+                if results:
+                    target_value = int(str(slow_condition.get("value")))
+                    if results[group_id] > target_value:
+                        if action_match == "any":
+                            rules_to_fire[alert_rule].add(group_id)
+                            break
+                        conditions_matched += 1
+                    else:
+                        if action_match == "all":
+                            # We failed to match all conditions for this group, skip
+                            break
             if action_match == "all" and conditions_matched == len(slow_conditions):
                 rules_to_fire[alert_rule].add(group_id)
     return rules_to_fire

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -281,6 +281,12 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         group5 = event5.group
         assert group5
         assert self.group1
+        condition_wont_pass_rule = self.create_project_rule(
+            project=self.project,
+            condition_match=[self.create_event_frequency_condition(value=100)],
+            environment_id=self.environment.id,
+        )
+
         self.push_to_hash(
             self.project.id, two_conditions_match_all_rule.id, group5.id, event5.event_id
         )
@@ -290,3 +296,4 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
             assert self.rule1 in rules
             assert self.rule2 in rules
             assert two_conditions_match_all_rule in rules
+            assert condition_wont_pass_rule not in rules

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -289,6 +289,7 @@ class ProcessDelayedAlertConditionsTest(TestCase, APITestCase, BaseEventFrequenc
         group6 = event6.group
         assert group6
         assert self.group1
+        assert self.group2
         condition_wont_pass_rule = self.create_project_rule(
             project=self.project,
             condition_match=[self.create_event_frequency_condition(value=100)],


### PR DESCRIPTION
Another follow up to https://github.com/getsentry/sentry/pull/69167, specifically the [comment about handling any and all action matches](https://github.com/getsentry/sentry/pull/69167#discussion_r1578586261) to check if the rule is for "any" or "all" conditions and only add to the list to be fired if it matches accordingly.

