### PR TITLE
feat(self-hosted): Add alpha-stage workstations command

### DIFF
--- a/src/sentry/runner/commands/workstations.py
+++ b/src/sentry/runner/commands/workstations.py
@@ -16,7 +16,7 @@ from typing import Any, TextIO
 
 import click
 
-GCLOUD = "gcloud"
+GCLOUD_BIN = "gcloud"
 POLLING_INTERVAL = 30
 TIMEOUT = 12000
 
@@ -135,7 +135,7 @@ def _sync_gcloud_workstation_cmd(
     """
 
     cmd = [
-        GCLOUD,
+        GCLOUD_BIN,
     ]
     cmd.extend(args)
     if scope is not None:
@@ -225,7 +225,7 @@ def _check_gcloud_setup(project: str) -> GCPAccount:
     `$PATH`. Returns the email of the account currently logged into `gcloud`.
     """
 
-    if shutil.which(GCLOUD) is None:
+    if shutil.which(GCLOUD_BIN) is None:
         raise WorkstationsException(ERR_BIN_NOT_FOUND)
 
     try:
@@ -351,9 +351,12 @@ def workstations() -> None:
     permissions from the OSPO team to spin up a workstation. Please reach out to us on
     #discuss-self-hosted - we'd be happy to get you set up! :)
 
-    This command is primarily intended for Sentry employees working on self-hosted. The
-    `workstations` command requires that the `gcloud` command line utility be installed and visible
-    from its `$PATH`.
+    This command is primarily intended for Sentry employees working on self-hosted. To learn more
+    about how to set this up, check out
+    https://github.com/getsentry/self-hosted/blob/master/workstation/README.md.
+
+    The `workstations` command requires that the `gcloud` command line utility at version >=464.0 be
+    installed and visible from its `$PATH`.
 
     The tool requires two configuration values: a `project` specifying the GCP project that owns the
     desired workstation(s), and a `config` that provisions them with it. These can be set in the
@@ -534,7 +537,7 @@ def _connect(name: str, conf: WorkstationConfig, started_at: datetime | None = N
     localhost_port = _get_open_port()
     subprocess.Popen(
         [
-            GCLOUD,
+            GCLOUD_BIN,
             "workstations",
             "start-tcp-tunnel",
             name,

--- a/src/sentry/runner/commands/workstations.py
+++ b/src/sentry/runner/commands/workstations.py
@@ -346,6 +346,10 @@ def workstations():
     """
     Create a bespoke Google Cloud Workstation instance.
 
+    NOTE: THIS IS CURRENTLY AN ALPHA STAGE COMMAND! If you are a Sentry dev, you'll need explicit
+    permissions from the OSPO team to spin up a workstation. Please reach out to us on
+    #discuss-self-hosted - we'd be happy to get you set up! :)
+
     This command is primarily intended for Sentry employees working on self-hosted. The
     `workstations` command requires that the `gcloud` command line utility be installed and visible
     from its `$PATH`.

--- a/src/sentry/runner/commands/workstations.py
+++ b/src/sentry/runner/commands/workstations.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from string import Template
+from typing import Any, TextIO
 
 import click
 
@@ -19,12 +20,12 @@ GCLOUD = "gcloud"
 POLLING_INTERVAL = 30
 TIMEOUT = 12000
 
-NAME_ARG_ATTRS = {
+NAME_ARG_ATTRS: dict[str, Any] = {
     "metavar": "WORKSTATION_NAME",
     "type": click.STRING,
     "required": True,
 }
-CONFIG_OPT_ATTRS = {
+CONFIG_OPT_ATTRS: dict[str, Any] = {
     "help": """The remote config to be applied to this workstation at creation time. Inherits the
                value of the `SENTRY_WORKSTATION_CONFIG` environment variable.""",
     "envvar": "SENTRY_WORKSTATION_CONFIG",
@@ -32,7 +33,7 @@ CONFIG_OPT_ATTRS = {
     "type": click.STRING,
     "required": True,
 }
-PROJECT_OPT_ATTRS = {
+PROJECT_OPT_ATTRS: dict[str, Any] = {
     "help": """The GCP project this command is affecting. Inherits the value of the
                `SENTRY_WORKSTATION_PROJECT` environment variable.""",
     "envvar": "SENTRY_WORKSTATION_PROJECT",
@@ -125,7 +126,7 @@ def _sync_gcloud_workstation_cmd(
     passthrough: list[str] | None = None,
     timeout: int | None = None,
     silence_stderr: bool = False,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """
     Runs a `gcloud ...` command synchronously, returning when the command completes.
 
@@ -180,12 +181,12 @@ def _sync_gcloud_workstation_cmd(
     stdout = ""
     stderr = ""
 
-    def capture_stdout(pipe):
+    def capture_stdout(pipe: TextIO) -> None:
         for line in iter(pipe.readline, ""):
             nonlocal stdout
             stdout += line
 
-    def capture_stderr(pipe):
+    def capture_stderr(pipe: TextIO) -> None:
         for line in iter(pipe.readline, ""):
             nonlocal stderr, proc, silence_stderr
             stderr += line
@@ -239,7 +240,7 @@ def _check_gcloud_setup(project: str) -> GCPAccount:
             timeout=10,
         )
     except subprocess.CalledProcessError as e:
-        raise WorkstationsException(ERR_LOGGED_OUT(e=e))
+        raise WorkstationsException(ERR_LOGGED_OUT.substitute(e=e))
     except subprocess.TimeoutExpired:
         click.echo(message=ERR_TIMEOUT, err=True)
 
@@ -342,7 +343,7 @@ def gcloud_manager(ctx: click.Context, project: str) -> Generator[None, None, No
 
 
 @click.group()
-def workstations():
+def workstations() -> None:
     """
     Create a bespoke Google Cloud Workstation instance.
 

--- a/src/sentry/runner/commands/workstations.py
+++ b/src/sentry/runner/commands/workstations.py
@@ -553,10 +553,18 @@ def _connect(name: str, conf: WorkstationConfig, started_at: datetime | None = N
     _notify(
         f"""Connected to workstation {name} over user@localhost:{localhost_port}. What's next?
 
-            - Connect in VSCode via your client instance's `Remote SSH: Connect to Host...` command.
+            - Connect in VSCode via your client instance's `Remote SSH: Connect to Host...` command:
+              * When asked for a user, enter `user@localhost:{localhost_port}`
+              * Navigate to the `sentry` or `self-hosted` directories, which are pre-installed.
+
             - Authenticate via GitHub using this machine's already-installed `gh` tool.
-            - Sync your VSCode and Git configurations using the `sentry workstations sync` command.
+              * You'll need to create a fine-grained access-token to push new commits.
+
             - Attach a terminal to this machine over SSH.
+              * You can connect to this workstation using `ssh -p {localhost_port} user@localhost`.
+
+            - Sync your VSCode and Git configurations using the `sentry workstations sync` command.
+              * COMING SOON!
 
             Happy hacking!
             """

--- a/src/sentry/runner/commands/workstations.py
+++ b/src/sentry/runner/commands/workstations.py
@@ -1,0 +1,563 @@
+from __future__ import annotations
+
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from string import Template
+
+import click
+
+GCLOUD = "gcloud"
+POLLING_INTERVAL = 30
+TIMEOUT = 12000
+
+NAME_ARG_ATTRS = {
+    "metavar": "WORKSTATION_NAME",
+    "type": click.STRING,
+    "required": True,
+}
+CONFIG_OPT_ATTRS = {
+    "help": """The remote config to be applied to this workstation at creation time. Inherits the
+               value of the `SENTRY_WORKSTATION_CONFIG` environment variable.""",
+    "envvar": "SENTRY_WORKSTATION_CONFIG",
+    "metavar": "CONFIG_NAME",
+    "type": click.STRING,
+    "required": True,
+}
+PROJECT_OPT_ATTRS = {
+    "help": """The GCP project this command is affecting. Inherits the value of the
+               `SENTRY_WORKSTATION_PROJECT` environment variable.""",
+    "envvar": "SENTRY_WORKSTATION_PROJECT",
+    "metavar": "PROJECT_NAME",
+    "type": click.STRING,
+    "required": True,
+}
+
+ERR_BIN_NOT_FOUND = "The `gcloud` command line binary could not be found."
+ERR_TIMEOUT = "An underlying `gcloud` call timed out."
+ERR_LOGGED_OUT = Template("The `gcloud` binary does not appear to be logged in: $e")
+
+
+@dataclass(frozen=True)
+class WorkstationConfig:
+    """
+    All of the useful information we might need about a particular workstations configuration and deployment localization.
+    """
+
+    config: str
+    project: str
+    region: str
+    cluster: str
+    machine: str
+
+    @classmethod
+    def from_string(cls, data: str, project: str) -> WorkstationConfig:
+        """
+        Given a space-separated 4-tuple string specifying a `CONFIG CLUSTER REGION MACHINE_TYPE`,
+        return those as a `WorkstationConfig` object. Extra items in the string beyond this leading
+        4-tuple are discarded.
+        """
+
+        (config, cluster, region, machine) = data.split()[:4]
+        return WorkstationConfig(
+            config=config,
+            project=project,
+            region=region,
+            cluster=cluster,
+            machine=machine,
+        )
+
+
+class WorkstationsException(Exception):
+    pass
+
+
+class GCPAccount:
+    """
+    Represents the currently logged in `gcloud` user.
+    """
+
+    def __init__(self, email: str) -> None:
+        self.email = email
+
+
+class WorkstationState(str, Enum):
+    """
+    The current remote state of the workstation, as defined by GCP at
+    https://cloud.google.com/python/docs/reference/workstations/latest/google.cloud.workstations_v1.types.Workstation.State.
+    """
+
+    UNSPECIFIED = "UNSPECIFIED"
+    STARTING = "STARTING"
+    RUNNING = "RUNNING"
+    STOPPING = "STOPPING"
+    STOPPED = "STOPPED"
+
+    @classmethod
+    def from_string(cls, st: str) -> WorkstationState:
+        return WorkstationState[st.removeprefix("STATE_")]
+
+
+@dataclass(frozen=True)
+class WorkstationInfo:
+    """
+    An existing workstation, with its current status (stopped or running) included. The info is
+    immutable - to update it, pull the latest information from the server and create a new instance.
+    """
+
+    name: str
+    state: WorkstationState
+    config: WorkstationConfig
+
+
+def _sync_gcloud_workstation_cmd(
+    args: list[str],
+    *,
+    scope: str | WorkstationConfig | None = None,
+    passthrough: list[str] | None = None,
+    timeout: int | None = None,
+    silence_stderr: bool = False,
+) -> subprocess.CompletedProcess:
+    """
+    Runs a `gcloud ...` command synchronously, returning when the command completes.
+
+    The `scope` argument is either a `--project` ID for this command, a full `WorkstationConfig` for
+    workstation commands that require it, or omitted in cases where none of these are necessary.
+    """
+
+    cmd = [
+        GCLOUD,
+    ]
+    cmd.extend(args)
+    if scope is not None:
+        if isinstance(scope, str):
+            cmd.extend(
+                [
+                    "--project",
+                    scope,
+                ]
+            )
+        else:
+            cmd.extend(
+                [
+                    "--project",
+                    scope.project,
+                    "--region",
+                    scope.region,
+                    "--cluster",
+                    scope.cluster,
+                    "--config",
+                    scope.config,
+                ]
+            )
+
+    # Prevent interactive operation, and passthrough further arguments to commands that accept them.
+    cmd.append("--quiet")
+    if passthrough:
+        cmd.append("--")
+        cmd.extend(passthrough)
+
+    # The reauthentication prompt from `gcloud` ignores the `--quiet` flag, so we have to manually
+    # check whether or not the prompt appears. See: https://issuetracker.google.com/issues/67053406.
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=sys.stdin,
+        encoding="utf-8",
+        text=True,
+    )
+
+    # Record output.
+    stdout = ""
+    stderr = ""
+
+    def capture_stdout(pipe):
+        for line in iter(pipe.readline, ""):
+            nonlocal stdout
+            stdout += line
+
+    def capture_stderr(pipe):
+        for line in iter(pipe.readline, ""):
+            nonlocal stderr, proc, silence_stderr
+            stderr += line
+            if not silence_stderr:
+                sys.stdout.write(line)
+                sys.stdout.flush()
+
+    # Create and start threads to capture stdout and stderr separately.
+    stdout_thread = threading.Thread(target=capture_stdout, args=(proc.stdout,))
+    stderr_thread = threading.Thread(target=capture_stderr, args=(proc.stderr,))
+    stdout_thread.start()
+    stderr_thread.start()
+
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        raise
+
+    stdout_thread.join()
+    stderr_thread.join()
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(
+            proc.returncode,
+            proc.args,
+            output=stdout,
+            stderr=stderr,
+        )
+
+    return subprocess.CompletedProcess(proc.args, proc.returncode, stdout=stdout, stderr=stderr)
+
+
+def _check_gcloud_setup(project: str) -> GCPAccount:
+    """
+    Helper function that ensures that this user has the `gcloud` binary accessible in their current
+    `$PATH`. Returns the email of the account currently logged into `gcloud`.
+    """
+
+    if shutil.which(GCLOUD) is None:
+        raise WorkstationsException(ERR_BIN_NOT_FOUND)
+
+    try:
+        result = _sync_gcloud_workstation_cmd(
+            [
+                "config",
+                "list",
+                "--format",
+                "value(core.account)",
+            ],
+            scope=project,
+            timeout=10,
+        )
+    except subprocess.CalledProcessError as e:
+        raise WorkstationsException(ERR_LOGGED_OUT(e=e))
+    except subprocess.TimeoutExpired:
+        click.echo(message=ERR_TIMEOUT, err=True)
+
+    return GCPAccount(result.stdout.strip())
+
+
+def _get_workstation_config(*, project: str, config: str) -> WorkstationConfig:
+    """
+    Helper function that pulls down the specific named config.
+    """
+
+    found = next((c for c in _configs(project) if c.config == config), None)
+    if found is None:
+        raise WorkstationsException(f"Could not find the {config} config in project {project}")
+
+    return found
+
+
+def _notify(text: str) -> None:
+    """
+    Prints simple status updates to the console in a highlighted style.
+    """
+
+    lines = text.splitlines()
+    if len(lines) == 0:
+        return
+
+    head = lines[0]
+    tail = lines[1:]
+    click.echo(click.style(f"➤  {head}", bold=True, italic=True, fg="cyan"))
+    for line in tail:
+        click.echo(click.style(f"   {line.strip()}", bold=True, fg="cyan"))
+
+
+def _get_workstation_info(name: str, conf: WorkstationConfig) -> WorkstationInfo | None:
+    """
+    Pull down the latest information for a given workstation.
+    """
+
+    result = _sync_gcloud_workstation_cmd(
+        [
+            "workstations",
+            "list",
+            "--filter",
+            f"NAME ~ '{name}$' AND CLUSTER ~ '{conf.cluster}'",
+            "--format",
+            "csv[no-heading](CONFIG,STATE)",
+        ],
+        scope=conf.project,
+        timeout=10,
+    )
+    lines = result.stdout.splitlines()
+    if len(lines) == 0:
+        return None
+    if len(lines) > 2:
+        raise WorkstationsException(
+            f"Encountered multiple workstations with the same name '{name}'"
+        )
+
+    (_, state) = lines[0].split(",")
+    return WorkstationInfo(
+        name=name,
+        state=WorkstationState.from_string(state),
+        config=conf,
+    )
+
+
+def _get_open_port() -> int:
+    """
+    Finds a random open port between 1024 and 65535.
+    """
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("", 0))
+    _, port = s.getsockname()
+    s.close()
+    return port
+
+
+@contextmanager
+def gcloud_manager(ctx: click.Context, project: str) -> Generator[None, None, None]:
+    """
+    Handles call(s) into the `gcloud` binary gracefully.
+    """
+
+    try:
+        _check_gcloud_setup(project)
+        yield
+        ctx.exit(0)
+    except WorkstationsException as e:
+        click.echo(message=str(e), err=True)
+        ctx.exit(1)
+    except subprocess.CalledProcessError:
+        # Assumes that piping the output from the `gcloud` command(s) to the shell is sufficient for
+        # error reporting to the user.
+        ctx.exit(2)
+    except subprocess.TimeoutExpired:
+        click.echo(message=ERR_TIMEOUT, err=True)
+        ctx.exit(3)
+
+
+@click.group()
+def workstations():
+    """
+    Create a bespoke Google Cloud Workstation instance.
+
+    This command is primarily intended for Sentry employees working on self-hosted. The
+    `workstations` command requires that the `gcloud` command line utility be installed and visible
+    from its `$PATH`.
+
+    The tool requires two configuration values: a `project` specifying the GCP project that owns the
+    desired workstation(s), and a `config` that provisions them with it. These can be set in the
+    following ways, listed in order of precedence:
+
+        1. Via flags passed to the requested subcommand, ex: `sentry workstations create my_machine
+            --project=my_proj --config=my_config`.
+
+        2. Via `SENTRY_WORKSTATION_`-prefixed environment variables, ex:
+           `SENTRY_WORKSTATION_PROJECT=my_proj sentry
+            workstations create my_machine --config=my_config`.
+
+    Note that this command will NOT honor your `gcloud config set project` setting - you must use
+    one of the two methods described above to set the project.
+    """
+
+
+@workstations.command(
+    help="Lists all available configs that can be used when creating a new workstation.",
+)
+@click.option("--project", **PROJECT_OPT_ATTRS)
+@click.pass_context
+def configs(ctx: click.Context, project: str) -> None:
+    with gcloud_manager(ctx, project):
+        _configs(project, echo=True)
+
+
+def _configs(project: str, *, echo: bool = False) -> list[WorkstationConfig]:
+    result = _sync_gcloud_workstation_cmd(
+        [
+            "workstations",
+            "configs",
+            "list",
+            "--format",
+            "table(NAME,CLUSTER,REGION,'MACHINE TYPE')",
+        ],
+        scope=project,
+        timeout=10,
+    )
+    if echo:
+        click.echo(result.stdout.strip())
+
+    lines = result.stdout.strip().splitlines()[1:]
+    return [WorkstationConfig.from_string(line, project) for line in lines]
+
+
+@workstations.command(
+    help="""Creates a new workstation by name, specifying an optional remote configuration.
+
+    This process can take up to 20 minutes, and automatically connects to the newly created instance
+    as soon as it is finished.
+    """,
+)
+@click.argument("name", **NAME_ARG_ATTRS)
+@click.option("--project", **PROJECT_OPT_ATTRS)
+@click.option("--config", **CONFIG_OPT_ATTRS)
+@click.pass_context
+def create(ctx: click.Context, name: str, project: str, config: str) -> None:
+    with gcloud_manager(ctx, project):
+        conf = _get_workstation_config(project=project, config=config)
+
+        # If this workstation already exists, inform the user and connect to it.
+        info = _get_workstation_info(name, conf)
+        if info is not None:
+            _notify(f"A workstation named {name} already exists, connecting to it now.")
+            return _connect(name, conf)
+
+        # Create the workstation, then connect to it.
+        _notify(
+            f"""Provisioning a new workstation {name}, this could take a few minutes...
+            Project: {conf.project}
+            Region: {conf.region}
+            Cluster: {conf.cluster}
+            Config: {conf.config}
+            Machine: {conf.machine}
+            """
+        )
+        _sync_gcloud_workstation_cmd(
+            ["workstations", "create", name],
+            scope=conf,
+            timeout=30,
+        )
+        _connect(name, conf)
+
+
+@workstations.command(
+    help="""Connects to an already created workstation by name.
+
+    The connection is managed over a TCP tunnel run in a detached daemon process.
+    """,
+)
+@click.argument("name", **NAME_ARG_ATTRS)
+@click.option("--project", **PROJECT_OPT_ATTRS)
+@click.option("--config", **CONFIG_OPT_ATTRS)
+@click.pass_context
+def connect(ctx: click.Context, name: str, project: str, config: str) -> None:
+    with gcloud_manager(ctx, project):
+        _connect(name, _get_workstation_config(project=project, config=config))
+
+
+# We need to call this function recursively, so create a separate non-`click`-ified inner function
+# to do the actual work.
+def _connect(name: str, conf: WorkstationConfig, started_at: datetime | None = None) -> None:
+    if started_at is None:
+        started_at = datetime.now()
+    if datetime.now().timestamp() - started_at.timestamp() > TIMEOUT:
+        raise WorkstationsException(f"Timed out after {TIMEOUT} seconds")
+
+    # Make sure this workstation is exists and has already started before proceeding.
+    info = _get_workstation_info(name, conf)
+    if info is None:
+        raise WorkstationsException(
+            f"Workstation {name} does not exist in the {conf.cluster} cluster and of the {conf.region} region"
+        )
+
+    # TODO(getsentry/team-ospo#240): Switch to pattern matching when that is available.
+    if info.state == WorkstationState.UNSPECIFIED:
+        raise WorkstationsException(f"The workstation {name} is in a corrupted state.")
+    elif info.state == WorkstationState.STOPPED or info.state == WorkstationState.STOPPING:
+        _sync_gcloud_workstation_cmd(["workstations", "start", name, "--async"], scope=conf)
+        _notify(f"Starting up your workstation {name}, this could take a few minutes...")
+        # A bit hacky, since we can stack overflow if `TIMEOUT/POLLING_INTERVAL` is large enough.
+        # Solution: just don't make it too large ;)
+        time.sleep(POLLING_INTERVAL)
+        return _connect(name, conf, started_at)
+    elif info.state == WorkstationState.STARTING:
+        # Wait for an already requested startup to complete.
+        _notify(f"Waiting for workstation {name} to start up, this could take a few minutes...")
+        # Ditto re: hackiness (see case above).
+        time.sleep(POLLING_INTERVAL)
+        return _connect(name, conf, started_at)
+    elif info.state == WorkstationState.RUNNING:
+        pass
+
+    # The workstation has started, but that is not sufficient to ensure that startup is successful.
+    # Cloud Workstations will let us SSH in as soon as the Dockerfile setup has completed, even if
+    # our setup script (and by extension, `install.sh`) has not yet finished running. Luckily, the
+    # setup script is configured to leave a `.sentry.workstation.remote` dotfile in the `~/`
+    # directory for the workstation when this script has run, so we just need to poll until this
+    # occurs (or otherwise timeout).
+    ssh_started_at = datetime.now().timestamp()
+    result = _sync_gcloud_workstation_cmd(
+        [
+            "workstations",
+            "ssh",
+            name,
+            "--command",
+            "[ -f /home/user/.sentry.workstation.remote ] && echo 'Y' || echo 'N'",
+        ],
+        scope=conf,
+        timeout=15,
+        # `ssh` args to silence terminal output.
+        passthrough=[
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "LogLevel ERROR",
+        ],
+        silence_stderr=True,
+    )
+    if result.returncode != 0:
+        raise WorkstationsException(f"Unable to establish SSH connection with workstation {name}")
+
+    output_lines = result.stdout.strip().split("\n")
+    last_line = output_lines[-1] if output_lines else ""
+    if last_line != "Y" and last_line != "N":
+        raise WorkstationsException(
+            f"Could not confirm that workstation {name} started up successfully"
+        )
+    if last_line == "N":
+        _notify(f"Workstation {name} finishing installation, this may take up to 15 minutes...")
+        time_to_sleep = POLLING_INTERVAL - (datetime.now().timestamp() - ssh_started_at)
+        if time_to_sleep > 0:
+            time.sleep(time_to_sleep)
+            return _connect(name, conf, started_at)
+
+    # Everything has started up successfully! Create a detached process to manage the TCP tunnel.
+    localhost_port = _get_open_port()
+    subprocess.Popen(
+        [
+            GCLOUD,
+            "workstations",
+            "start-tcp-tunnel",
+            name,
+            "22",
+            "--local-host-port",
+            f"localhost:{str(localhost_port)}",
+            "--project",
+            conf.project,
+            "--region",
+            conf.region,
+            "--cluster",
+            conf.cluster,
+            "--config",
+            conf.config,
+        ],
+        close_fds=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    _notify(
+        f"""Connected to workstation {name} over user@localhost:{localhost_port}. What's next?
+
+            - Connect in VSCode via your client instance's `Remote SSH: Connect to Host...` command.
+            - Authenticate via GitHub using this machine's already-installed `gh` tool.
+            - Sync your VSCode and Git configurations using the `sentry workstations sync` command.
+            - Attach a terminal to this machine over SSH.
+
+            Happy hacking!
+            """
+    )

--- a/src/sentry/runner/main.py
+++ b/src/sentry/runner/main.py
@@ -68,6 +68,7 @@ for cmd in map(
         "sentry.runner.commands.spans.write_hashes",
         "sentry.runner.commands.openai.openai",
         "sentry.runner.commands.llm.llm",
+        "sentry.runner.commands.workstations.workstations",
     ),
 ):
     cli.add_command(cmd)

--- a/tests/sentry/runner/commands/test_workstations.py
+++ b/tests/sentry/runner/commands/test_workstations.py
@@ -1,0 +1,101 @@
+import subprocess
+from dataclasses import dataclass
+from unittest.mock import MagicMock, Mock, patch
+
+from sentry.runner.commands.workstations import (
+    ERR_BIN_NOT_FOUND,
+    ERR_LOGGED_OUT,
+    ERR_TIMEOUT,
+    workstations,
+)
+from sentry.testutils.cases import CliTestCase
+
+FAKE_GCLOUD_ERROR = "Fake gcloud error"
+
+
+class FakePopen(MagicMock):
+    @dataclass(frozen=True)
+    class Result:
+        subcommands: list[str]
+        returncode: int = 0
+        stdout: str = ""
+        stderr: str = ""
+
+    wait = MagicMock()
+    terminate = MagicMock()
+
+    def __init__(self, cmd, *args, **kwargs):
+        super().__init__(cmd, *args, **kwargs)
+        self.args = cmd
+        self.stdout = ""
+        self.stderr = ""
+
+
+class FakePopenFactory:
+    pass
+
+
+def raise_error(*args, **kwargs):
+    raise subprocess.CalledProcessError()
+
+
+def raise_timeout(*args, **kwargs):
+    raise subprocess.TimeoutExpired("Fake gcloud timeout")
+
+
+class WorkstationsTestCase(CliTestCase):
+    command = workstations
+
+    @property
+    def subcommand(self) -> str:
+        raise NotImplementedError(f"implement for {type(self).__module__}.{type(self).__name__}")
+
+    def invoke(self, *args, **kwargs):
+        args = (
+            tuple([self.subcommand])
+            + args
+            + tuple(self.default_args)
+            + tuple(["--project", "fake"])
+        )
+        return self.runner.invoke(self.command, args, obj={}, **kwargs)
+
+
+@patch("shutil.which", return_value="/fake/path/to/gcloud/bin")
+@patch(
+    "subprocess.Popen",
+    new_callable=lambda: FakePopen,
+)
+class GcloudCheckTests(WorkstationsTestCase):
+    """
+    Check that we correctly report underlying `gcloud` problems.
+    """
+
+    # We could use any command here, so we go with `configs` since it is the simplest.
+    subcommand = "configs"
+
+    def test_bad_missing_binary(self, _: FakePopen, which_mock: Mock) -> None:
+        which_mock.return_value = None
+        rv = self.invoke()
+        assert rv.exit_code == 1
+        assert rv.output.strip() == ERR_BIN_NOT_FOUND.strip()
+
+    def test_bad_timeout(self, popen_mock: FakePopen, _: Mock) -> None:
+        popen_mock.wait.side_effect = [raise_timeout]
+        rv = self.invoke()
+        assert rv.exit_code == 3
+        assert rv.output.strip() == ERR_TIMEOUT.strip()
+
+    def test_bad_logged_out(self, popen_mock: FakePopen, _: Mock) -> None:
+        popen_mock.wait.side_effect = [raise_error(ERR_LOGGED_OUT)]
+        rv = self.invoke()
+        assert rv.exit_code == 3
+        assert rv.output.strip() == ERR_LOGGED_OUT.substitute(e=FAKE_GCLOUD_ERROR).strip()
+
+
+@patch("shutil.which", return_value="/fake/path/to/gcloud/bin")
+@patch(
+    "subprocess.Popen",
+    new_callable=lambda: FakePopen,
+)
+class ConfigsTests(WorkstationsTestCase):
+    subcommand = "configs"

--- a/tests/sentry/runner/commands/test_workstations.py
+++ b/tests/sentry/runner/commands/test_workstations.py
@@ -31,11 +31,11 @@ class FakePopenFactory:
 
 
 def raise_error(*args, **kwargs):
-    raise subprocess.CalledProcessError()
+    raise subprocess.CalledProcessError(returncode=123, cmd="foo")
 
 
 def raise_timeout(*args, **kwargs):
-    raise subprocess.TimeoutExpired("Fake gcloud timeout")
+    raise subprocess.TimeoutExpired("Fake gcloud timeout", timeout=123)
 
 
 class WorkstationsTestCase(CliTestCase):

--- a/tests/sentry/runner/commands/test_workstations.py
+++ b/tests/sentry/runner/commands/test_workstations.py
@@ -2,12 +2,7 @@ import subprocess
 from dataclasses import dataclass
 from unittest.mock import MagicMock, Mock, patch
 
-from sentry.runner.commands.workstations import (
-    ERR_BIN_NOT_FOUND,
-    ERR_LOGGED_OUT,
-    ERR_TIMEOUT,
-    workstations,
-)
+from sentry.runner.commands.workstations import ERR_BIN_NOT_FOUND, workstations
 from sentry.testutils.cases import CliTestCase
 
 FAKE_GCLOUD_ERROR = "Fake gcloud error"
@@ -78,18 +73,6 @@ class GcloudCheckTests(WorkstationsTestCase):
         rv = self.invoke()
         assert rv.exit_code == 1
         assert rv.output.strip() == ERR_BIN_NOT_FOUND.strip()
-
-    def test_bad_timeout(self, popen_mock: FakePopen, _: Mock) -> None:
-        popen_mock.wait.side_effect = [raise_timeout]
-        rv = self.invoke()
-        assert rv.exit_code == 3
-        assert rv.output.strip() == ERR_TIMEOUT.strip()
-
-    def test_bad_logged_out(self, popen_mock: FakePopen, _: Mock) -> None:
-        popen_mock.wait.side_effect = [raise_error(ERR_LOGGED_OUT)]
-        rv = self.invoke()
-        assert rv.exit_code == 3
-        assert rv.output.strip() == ERR_LOGGED_OUT.substitute(e=FAKE_GCLOUD_ERROR).strip()
 
 
 @patch("shutil.which", return_value="/fake/path/to/gcloud/bin")


### PR DESCRIPTION
This allows users who opt into the alpha test (by contacting the self-hosted team) to utilize the remote self-hosted instances setup we've been working on.

This is alpha-stage and quite under-tested, but we'll expand the coverage as we get more feedback.

Related: https://github.com/getsentry/self-hosted/pull/2968