### PR TITLE
ref(rules): Add delayed_rules queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -848,6 +848,7 @@ CELERY_QUEUES_REGION = [
     Queue("commits", routing_key="commits"),
     Queue("data_export", routing_key="data_export"),
     Queue("default", routing_key="default"),
+    Queue("delayed_rules", routing_key="delayed_rules"),
     Queue("digests.delivery", routing_key="digests.delivery"),
     Queue("digests.scheduling", routing_key="digests.scheduling"),
     Queue("email", routing_key="email"),

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -174,6 +174,7 @@ def process_delayed_alert_conditions(buffer: RedisBuffer) -> None:
 
 @instrumented_task(
     name="sentry.delayed_processing.tasks.apply_delayed",
+    queue="delayed_rules",
     default_retry_delay=5,
     max_retries=5,
     soft_time_limit=50,


### PR DESCRIPTION
Add a new queue `delayed_rules` for the "slow" condition alerts celery task as per [this documentation](https://www.notion.so/sentry/RabbitMQ-0b28fcb3a2174969b3c134d66550cb6c#e9973d5eb4aa4745ae78f5b88f9f4c9b). I also submitted an ops request to add workers to this. Nothing is hooked up yet so this isn't running.