### PR TITLE
fix(superuser): refresh the page after submitting superuser modal

### DIFF
--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -114,16 +114,16 @@ class SudoModal extends Component<Props, State> {
     const {closeModal, isSuperuser, location, needsReload, router, retryRequest} =
       this.props;
 
-    if (!retryRequest) {
-      closeModal();
-      return;
-    }
-
     if (isSuperuser) {
       router.replace({pathname: location.pathname, state: {forceUpdate: new Date()}});
       if (needsReload) {
         window.location.reload();
       }
+      return;
+    }
+
+    if (!retryRequest) {
+      closeModal();
       return;
     }
 


### PR DESCRIPTION
When `organizationContextContainer` was replaced with `organizationContext`, it was refactored into a functional component and removed the `retryRequest` prop from the `openSudo` which used to be calling `this.fetchData`. If we move the logic around we can preserve the old behavior.

Currently

https://github.com/getsentry/sentry/assets/70817427/0ef7d970-f710-4db7-9bb6-6333b6fce657

Fix

https://github.com/getsentry/sentry/assets/70817427/93fc0c75-c780-45be-bde3-9eef1b106e9f