### PR TITLE
feat(user): Add option to only return verified emails from verify_user_emails

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -277,14 +277,18 @@ class DatabaseBackedUserService(UserService):
         user.send_confirm_emails(is_new_user=True)
 
     def verify_user_emails(
-        self, *, user_id_emails: list[UserIdEmailArgs]
+        self, *, user_id_emails: list[UserIdEmailArgs], only_verified: bool = False
     ) -> dict[int, RpcVerifyUserEmail]:
         results = {}
         for user_id_email in user_id_emails:
             user_id = user_id_email["user_id"]
             email = user_id_email["email"]
-            exists = UserEmail.objects.filter(user_id=user_id, email__iexact=email).exists()
-            results[user_id] = RpcVerifyUserEmail(email=email, exists=exists)
+
+            user_email_qs = UserEmail.objects.filter(user_id=user_id, email__iexact=email)
+            if only_verified:
+                user_email_qs = user_email_qs.filter(is_verified=True)
+
+            results[user_id] = RpcVerifyUserEmail(email=email, exists=user_email_qs.exists())
         return results
 
     def get_user_avatar(self, *, user_id: int) -> RpcAvatar | None:

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -198,7 +198,7 @@ class UserService(RpcService):
     @rpc_method
     @abstractmethod
     def verify_user_emails(
-        self, *, user_id_emails: list[UserIdEmailArgs]
+        self, *, user_id_emails: list[UserIdEmailArgs], only_verified: bool = False
     ) -> dict[int, RpcVerifyUserEmail]:
         pass
 


### PR DESCRIPTION
Will be used to fetch only verified emails when notifying users that their monitors have been in a broken state for an extended period of time

Ensured that I only updated the function with an optional parameter, and didn't have the callers use the new parameter yet.