### PR TITLE
test(ui): Prevent import from react-dom/test-util

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -94,7 +94,7 @@
     "**/config/chartcuterie/*",
     "**/node_modules/@testing-library/*",
     "**/node_modules/@tanstack/react-query",
-    "**/react-dom/test-utils/*",
+    "**/react-dom/test-utils/*"
   ],
   // Avoid relative imports
   "typescript.preferences.importModuleSpecifier": "non-relative",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -93,7 +93,8 @@
   "typescript.preferences.autoImportFileExcludePatterns": [
     "**/config/chartcuterie/*",
     "**/node_modules/@testing-library/*",
-    "**/node_modules/@tanstack/react-query"
+    "**/node_modules/@tanstack/react-query",
+    "**/react-dom/test-utils/*",
   ],
   // Avoid relative imports
   "typescript.preferences.importModuleSpecifier": "non-relative",

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -1,4 +1,3 @@
-import {act} from 'react-dom/test-utils';
 import * as Sentry from '@sentry/react';
 import MockDate from 'mockdate';
 import {DetailedEventsFixture} from 'sentry-fixture/events';
@@ -6,6 +5,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
+  act,
   findByText,
   fireEvent,
   render,


### PR DESCRIPTION
Disable the suggestion in vscode and fix import. For some reason vscode lists it first.