### PR TITLE
fix(hybrid-cloud): Cross-DB tombstone resubmission

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1740,6 +1740,7 @@ register(
 register(
     "hybrid_cloud.disable_relative_upload_urls", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
+register("hybrid_cloud.allow_cross_db_tombstones", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Retry controls
 register("hybridcloud.regionsiloclient.retries", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -391,7 +391,8 @@ def get_ids_cross_db_for_row_watermark(
 
     object_ids_to_check = fk_to_model_id_map.keys()
     tombstone_entries = tombstone_cls.objects.filter(
-        object_identifier__in=object_ids_to_check
+        object_identifier__in=object_ids_to_check,
+        table_name=field.foreign_table_name,
     ).values_list("object_identifier", "created_at")
 
     affected_rows: list[int] = []

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -373,12 +373,9 @@ def get_ids_for_tombstone_cascade_cross_db(
     oldest_seen = timezone.now()
     if row_after_tombstone:
         affected_rows = []
-        field_high = f"{field.name}__lte"
-        field_low = f"{field.name}__gt"
-        query_kwargs = {field_high: watermark_batch.up, field_low: watermark_batch.low}
-        model_object_id_pairs = model.objects.filter(**query_kwargs).values_list(
-            "id", f"{field.name}"
-        )
+        model_object_id_pairs = model.objects.filter(
+            id__lte=watermark_batch.up, id__gt=watermark_batch.low
+        ).values_list("id", f"{field.name}")
 
         # Construct a map of foreign key IDs to model IDs, which gives us the
         # minimal set of foreign key values to lookup in the tombstones table.

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -348,6 +348,9 @@ def _get_model_ids_for_tombstone_cascade(
 
             return to_delete_ids, oldest_seen
 
+    if not options.get("hybrid_cloud.allow_cross_db_tombstones"):
+        raise Exception("Cannot process tombstones due to model living in separate database.")
+
     # Because tombstones can span multiple databases, we can't always rely on
     # the join code above. Instead, we have to manually query IDs from the
     # watermark target table, querying the intersection of IDs manually.
@@ -408,9 +411,6 @@ def get_ids_cross_db_for_tombstone_watermark(
     field: HybridCloudForeignKey,
     tombstone_watermark_batch: WatermarkBatch,
 ) -> tuple[list[int], datetime.datetime]:
-    if not options.get("hybrid_cloud.allow_cross_db_tombstones"):
-        raise Exception("Cannot process tombstones due to model living in separate database.")
-
     oldest_seen = timezone.now()
 
     tombstone_entries = tombstone_cls.objects.filter(

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -9,6 +9,7 @@ opposing silo and are stored in Tombstone rows.  Deletions that are not successf
 Tombstone row will not, therefore, cascade to any related cross silo rows.
 """
 import datetime
+from collections import defaultdict
 from dataclasses import dataclass
 from hashlib import sha1
 from typing import Any
@@ -22,6 +23,8 @@ from django.db.models import Max, Min
 from django.db.models.manager import BaseManager
 from django.utils import timezone
 
+from sentry import options
+from sentry.db.models import Model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.models.tombstone import TombstoneBase
 from sentry.silo.base import SiloMode
@@ -237,40 +240,22 @@ def _process_tombstone_reconciliation(
 
     prefix = "tombstone"
     watermark_manager: BaseManager = tombstone_cls.objects
-    watermark_target = "t"
     if row_after_tombstone:
         prefix = "row"
         watermark_manager = field.model.objects
-        watermark_target = "r"
 
     watermark_batch = _chunk_watermark_batch(
         prefix, field, watermark_manager, batch_size=get_batch_size()
     )
     has_more = watermark_batch.has_more
-    to_delete_ids: list[int] = []
-
     if watermark_batch.low < watermark_batch.up:
-        oldest_seen: datetime.datetime = timezone.now()
-
-        with connections[router.db_for_read(model)].cursor() as conn:
-            conn.execute(
-                f"""
-                SELECT r.id, t.created_at
-                FROM {model._meta.db_table} r
-                JOIN {tombstone_cls._meta.db_table} t
-                    ON t.table_name = %(table_name)s AND t.object_identifier = r.{field.name}
-                WHERE {watermark_target}.id > %(low)s AND {watermark_target}.id <= %(up)s
-            """,
-                {
-                    "table_name": field.foreign_table_name,
-                    "low": watermark_batch.low,
-                    "up": watermark_batch.up,
-                },
-            )
-
-            for (row_id, tomb_created) in conn.fetchall():
-                to_delete_ids.append(row_id)
-                oldest_seen = min(oldest_seen, tomb_created)
+        to_delete_ids, oldest_seen = _get_model_ids_for_tombstone_cascade(
+            tombstone_cls=tombstone_cls,
+            model=model,
+            field=field,
+            row_after_tombstone=row_after_tombstone,
+            watermark_batch=watermark_batch,
+        )
 
         if field.on_delete == "CASCADE":
             task = deletions.get(
@@ -306,3 +291,126 @@ def _process_tombstone_reconciliation(
         )
 
     return has_more
+
+
+def _get_model_ids_for_tombstone_cascade(
+    tombstone_cls: type[TombstoneBase],
+    model: type[Model],
+    field: HybridCloudForeignKey,
+    row_after_tombstone: bool,
+    watermark_batch: WatermarkBatch,
+) -> tuple[list[int], datetime.datetime]:
+    """
+    Queries the database or databases if spanning multiple, and returns
+     a tuple with a list of row IDs to delete, and the oldest
+     tombstone timestamp for the batch.
+
+    :param tombstone_cls: Either a RegionTombstone or ControlTombstone, depending on
+     which silo the tombstone process is running.
+    :param model: The model with a HybridCloudForeignKey to process.
+    :param field: The HybridCloudForeignKey field from the model to process.
+    :param row_after_tombstone: Determines which table is bound by the
+     watermark batch. When set to true, the model's IDs are used as the
+     bounds, otherwise, the tombstone's IDs are used.
+    :param watermark_batch: The batch information containing ID bounds for the
+     watermark query.
+    :return:
+    """
+
+    to_delete_ids = []
+    oldest_seen = timezone.now()
+    tombstone_and_model_in_same_db = router.db_for_read(model) == router.db_for_read(tombstone_cls)
+    watermark_target = "t"
+
+    if row_after_tombstone:
+        watermark_target = "r"
+
+    if tombstone_and_model_in_same_db:
+        with connections[router.db_for_read(model)].cursor() as conn:
+            conn.execute(
+                f"""
+                    SELECT r.id, t.created_at
+                    FROM {model._meta.db_table} r
+                    JOIN {tombstone_cls._meta.db_table} t
+                        ON t.table_name = %(table_name)s AND t.object_identifier = r.{field.name}
+                    WHERE {watermark_target}.id > %(low)s AND {watermark_target}.id <= %(up)s
+                """,
+                {
+                    "table_name": field.foreign_table_name,
+                    "low": watermark_batch.low,
+                    "up": watermark_batch.up,
+                },
+            )
+
+            for (row_id, tomb_created) in conn.fetchall():
+                to_delete_ids.append(row_id)
+                oldest_seen = min(oldest_seen, tomb_created)
+
+            return to_delete_ids, oldest_seen
+
+    # Because tombstones can span multiple databases, we can't always rely on
+    # the join code above. Instead, we have to manually query IDs from the
+    # watermark target table, querying the intersection of IDs manually.
+    return get_ids_for_tombstone_cascade_cross_db(
+        tombstone_cls=tombstone_cls,
+        model=model,
+        field=field,
+        row_after_tombstone=row_after_tombstone,
+        watermark_batch=watermark_batch,
+    )
+
+
+def get_ids_for_tombstone_cascade_cross_db(
+    tombstone_cls: type[TombstoneBase],
+    model: type[Model],
+    field: HybridCloudForeignKey,
+    row_after_tombstone: bool,
+    watermark_batch: WatermarkBatch,
+) -> tuple[list[int], datetime.datetime]:
+    if not options.get("hybrid_cloud.allow_cross_db_tombstones"):
+        raise Exception("Cannot process tombstones due to model living in separate database.")
+
+    oldest_seen = timezone.now()
+    if row_after_tombstone:
+        affected_rows = []
+        field_high = f"{field.name}__lte"
+        field_low = f"{field.name}__gt"
+        query_kwargs = {field_high: watermark_batch.up, field_low: watermark_batch.low}
+        model_object_id_pairs = model.objects.filter(**query_kwargs).values_list(
+            "id", f"{field.name}"
+        )
+
+        # Construct a map of foreign key IDs to model IDs, which gives us the
+        # minimal set of foreign key values to lookup in the tombstones table.
+        fk_to_model_id_map = defaultdict(set)
+        for m_id, o_id in model_object_id_pairs:
+            fk_to_model_id_map[o_id].add(m_id)
+
+        object_ids_to_check = fk_to_model_id_map.keys()
+        tombstone_entries = tombstone_cls.objects.filter(
+            object_identifier__in=object_ids_to_check
+        ).values_list("object_identifier", "created_at")
+
+        # Once we have the intersecting tombstones, use the dictionary we
+        # created before to construct the minimal set of model IDs we need to
+        # update with cascade behavior.
+        for object_id, created_at in tombstone_entries:
+            affected_rows.extend(fk_to_model_id_map[object_id])
+            oldest_seen = min(oldest_seen, created_at)
+
+        return affected_rows, oldest_seen
+
+    tombstone_entries = tombstone_cls.objects.filter(
+        id__lte=watermark_batch.up, id__gt=watermark_batch.low, table_name=field.foreign_table_name
+    ).values_list("object_identifier", "created_at")
+
+    ids_to_check = []
+    for object_id, created_at in tombstone_entries:
+        ids_to_check.append(object_id)
+        oldest_seen = min(oldest_seen, created_at)
+
+    field_name = f"{field.name}__in"
+    query_kwargs = {field_name: ids_to_check}
+    affected_rows = list(model.objects.filter(**query_kwargs).values_list("id", flat=True))
+
+    return affected_rows, oldest_seen

--- a/tests/sentry/tasks/deletion/test_hybrid_cloud.py
+++ b/tests/sentry/tasks/deletion/test_hybrid_cloud.py
@@ -1,3 +1,4 @@
+from operator import itemgetter
 from unittest.mock import patch
 
 import pytest
@@ -12,19 +13,30 @@ from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.integrations.integration import Integration
 from sentry.models.outbox import ControlOutbox, OutboxScope, outbox_context
 from sentry.models.savedsearch import SavedSearch
+from sentry.models.tombstone import RegionTombstone
 from sentry.models.user import User
+from sentry.monitors.models import Monitor
 from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.hybrid_cloud import (
+    WatermarkBatch,
+    get_ids_for_tombstone_cascade_cross_db,
     get_watermark,
     schedule_hybrid_cloud_foreign_key_jobs,
     schedule_hybrid_cloud_foreign_key_jobs_control,
     set_watermark,
 )
+from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.testutils.silo import (
+    assume_test_silo_mode,
+    assume_test_silo_mode_of,
+    control_silo_test,
+    region_silo_test,
+)
 from sentry.types.region import find_regions_for_user
 
 
@@ -274,3 +286,310 @@ def test_set_null_deletion_behavior(task_runner):
     # Deletion set field to null
     saved_query = DiscoverSavedQuery.objects.get(id=saved_query.id)
     assert saved_query.created_by_id is None
+
+
+def setup_cross_db_deletion_data(
+    desired_user_id: int | None = None,
+    desired_monitor_id: int | None = None,
+):
+    user = Factories.create_user(id=desired_user_id)
+    organization = Factories.create_organization(owner=user, name="Delete Me")
+    project = Factories.create_project(organization=organization)
+    group = Factories.create_group(project=project)
+    with assume_test_silo_mode_of(DiscoverSavedQuery, Monitor):
+        saved_query = DiscoverSavedQuery.objects.create(
+            name="disco-query",
+            organization=organization,
+            created_by_id=user.id,
+        )
+        monitor = Monitor.objects.create(
+            id=desired_monitor_id,
+            organization_id=organization.id,
+            project_id=project.id,
+            slug="test-monitor",
+            name="Test Monitor",
+            owner_user_id=user.id,
+        )
+
+    return dict(
+        user=user,
+        organization=organization,
+        project=project,
+        monitor=monitor,
+        group=group,
+        saved_query=saved_query,
+    )
+
+
+@region_silo_test
+class TestGetIdsForTombstoneCascadeCrossDbTombstoneWatermarking(TestCase):
+    def test_get_ids_for_tombstone_cascade_cross_db(self):
+        data = setup_cross_db_deletion_data()
+
+        unaffected_data = []
+        for i in range(3):
+            unaffected_data.append(setup_cross_db_deletion_data())
+
+        user = data["user"]
+        user_id = user.id
+        monitor = data["monitor"]
+        with assume_test_silo_mode_of(User), outbox_runner():
+            user.delete()
+
+        tombstone = RegionTombstone.objects.get(
+            object_identifier=user_id, table_name=User._meta.db_table
+        )
+
+        highest_tombstone_id = RegionTombstone.objects.aggregate(Max("id"))
+        monitor_owner_field = Monitor._meta.get_field("owner_user_id")
+
+        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
+            ids, oldest_obj = get_ids_for_tombstone_cascade_cross_db(
+                tombstone_cls=RegionTombstone,
+                model=Monitor,
+                field=monitor_owner_field,
+                watermark_batch=WatermarkBatch(
+                    low=0,
+                    up=highest_tombstone_id["id__max"] + 1,
+                    has_more=False,
+                    transaction_id="foobar",
+                ),
+                row_after_tombstone=False,
+            )
+            assert ids == [monitor.id]
+            assert oldest_obj == tombstone.created_at
+
+    def test_get_ids_for_tombstone_cascade_cross_db_watermark_bounds(self):
+        cascade_data = [setup_cross_db_deletion_data() for _ in range(3)]
+
+        # Create some additional filler data
+        [setup_cross_db_deletion_data() for _ in range(3)]
+
+        in_order_tombstones = []
+        for data in cascade_data:
+            user = data["user"]
+            user_id = user.id
+            with assume_test_silo_mode_of(User), outbox_runner():
+                user.delete()
+
+            in_order_tombstones.append(
+                RegionTombstone.objects.get(
+                    object_identifier=user_id, table_name=User._meta.db_table
+                )
+            )
+
+        bounds_with_expected_results = [
+            (
+                {"low": 0, "up": in_order_tombstones[1].id},
+                [cascade_data[0]["monitor"].id, cascade_data[1]["monitor"].id],
+            ),
+            (
+                {"low": in_order_tombstones[1].id, "up": in_order_tombstones[2].id},
+                [cascade_data[2]["monitor"].id],
+            ),
+            (
+                {"low": 0, "up": in_order_tombstones[0].id - 1},
+                [],
+            ),
+            (
+                {"low": in_order_tombstones[2].id + 1, "up": in_order_tombstones[2].id + 5},
+                [],
+            ),
+            (
+                {"low": -1, "up": in_order_tombstones[2].id + 1},
+                [
+                    cascade_data[0]["monitor"].id,
+                    cascade_data[1]["monitor"].id,
+                    cascade_data[2]["monitor"].id,
+                ],
+            ),
+        ]
+
+        for bounds, bounds_with_expected_results in bounds_with_expected_results:
+            monitor_owner_field = Monitor._meta.get_field("owner_user_id")
+
+            with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
+                ids, oldest_obj = get_ids_for_tombstone_cascade_cross_db(
+                    tombstone_cls=RegionTombstone,
+                    model=Monitor,
+                    field=monitor_owner_field,
+                    watermark_batch=WatermarkBatch(
+                        low=bounds["low"],
+                        up=bounds["up"],
+                        has_more=False,
+                        transaction_id="foobar",
+                    ),
+                    row_after_tombstone=False,
+                )
+                assert ids == bounds_with_expected_results
+
+    def test_get_ids_for_tombstone_cascade_cross_db_with_multiple_tombstone_types(self):
+        data = setup_cross_db_deletion_data()
+        unaffected_data = [setup_cross_db_deletion_data() for _ in range(3)]
+
+        # Pollute the tombstone data with references to relationships in other
+        # tables matching other User IDs just to ensure we are filtering on the
+        # correct table name.
+        for udata in unaffected_data:
+            unaffected_user = udata["user"]
+            RegionTombstone.objects.create(
+                table_name="something_table", object_identifier=unaffected_user.id
+            )
+
+        user, monitor = itemgetter("user", "monitor")(data)
+        user_id = user.id
+        with assume_test_silo_mode_of(User), outbox_runner():
+            user.delete()
+
+        tombstone = RegionTombstone.objects.get(
+            object_identifier=user_id, table_name=User._meta.db_table
+        )
+
+        highest_tombstone_id = RegionTombstone.objects.aggregate(Max("id"))
+
+        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
+            ids, oldest_obj = get_ids_for_tombstone_cascade_cross_db(
+                tombstone_cls=RegionTombstone,
+                model=Monitor,
+                field=Monitor._meta.get_field("owner_user_id"),
+                watermark_batch=WatermarkBatch(
+                    low=0,
+                    up=highest_tombstone_id["id__max"] + 1,
+                    has_more=False,
+                    transaction_id="foobar",
+                ),
+                row_after_tombstone=False,
+            )
+            assert ids == [monitor.id]
+            assert oldest_obj == tombstone.created_at
+
+
+@region_silo_test
+class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
+    def test_with_simple_tombstone_intersection(self):
+        data = setup_cross_db_deletion_data(desired_user_id=10, desired_monitor_id=42)
+        user, monitor = itemgetter("user", "monitor")(data)
+
+        assert user.id == 10
+        user_id = user.id
+        assert monitor.id == 42
+
+        with assume_test_silo_mode_of(User), outbox_runner():
+            user.delete()
+
+        highest_model_id = Monitor.objects.aggregate(Max("id"))
+        tombstone = RegionTombstone.objects.get(
+            object_identifier=user_id, table_name=User._meta.db_table
+        )
+        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
+            ids, oldest_obj = get_ids_for_tombstone_cascade_cross_db(
+                tombstone_cls=RegionTombstone,
+                model=Monitor,
+                field=Monitor._meta.get_field("owner_user_id"),
+                watermark_batch=WatermarkBatch(
+                    low=0,
+                    up=highest_model_id["id__max"] + 1,
+                    has_more=False,
+                    transaction_id="foobar",
+                ),
+                row_after_tombstone=True,
+            )
+
+            assert ids == [monitor.id]
+            assert oldest_obj == tombstone.created_at
+
+    def test_with_empty_tombstones_table(self):
+        # Set up some sample data that shouldn't be affected
+        with outbox_runner():
+            [setup_cross_db_deletion_data() for _ in range(3)]
+
+        highest_model_id = Monitor.objects.aggregate(Max("id"))["id__max"]
+
+        assert highest_model_id is not None
+        assert not RegionTombstone.objects.filter().exists()
+
+        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
+            ids, oldest_obj = get_ids_for_tombstone_cascade_cross_db(
+                tombstone_cls=RegionTombstone,
+                model=Monitor,
+                field=Monitor._meta.get_field("owner_user_id"),
+                watermark_batch=WatermarkBatch(
+                    low=0,
+                    up=highest_model_id + 1,
+                    has_more=False,
+                    transaction_id="foobar",
+                ),
+                row_after_tombstone=True,
+            )
+
+            assert ids == []
+
+    def test_row_watermarking_bounds(self):
+        # In testing, the IDs for these models will be low, sequential values
+        # so adding some seed data to space the IDs out gives better insight
+        # on filter correctness.
+        desired_user_and_monitor_ids = [(10, 9), (42, 30), (77, 120)]
+        cascade_data = [
+            setup_cross_db_deletion_data(desired_user_id=user_id, desired_monitor_id=monitor_id)
+            for user_id, monitor_id in desired_user_and_monitor_ids
+        ]
+
+        # Create some additional filler data
+        [setup_cross_db_deletion_data() for _ in range(3)]
+
+        with assume_test_silo_mode_of(User), outbox_runner():
+            for data in cascade_data:
+                user = data["user"]
+                User.objects.get(id=user.id).delete()
+
+        bounds_with_expected_results = [
+            # Check rows with foreign keys > 0 and <= 30
+            (
+                {"low": 0, "up": cascade_data[1]["user"].id},
+                [cascade_data[0]["monitor"].id, cascade_data[1]["monitor"].id],
+            ),
+            (
+                {"low": cascade_data[1]["user"].id, "up": cascade_data[2]["user"].id},
+                [cascade_data[2]["monitor"].id],
+            ),
+            (
+                {"low": 0, "up": cascade_data[0]["user"].id - 1},
+                [],
+            ),
+            (
+                {"low": cascade_data[2]["user"].id + 1, "up": cascade_data[2]["user"].id + 2},
+                [],
+            ),
+            (
+                {"low": -1, "up": cascade_data[2]["user"].id + 1},
+                [
+                    cascade_data[0]["monitor"].id,
+                    cascade_data[1]["monitor"].id,
+                    cascade_data[2]["monitor"].id,
+                ],
+            ),
+            (
+                {"low": cascade_data[1]["user"].id, "up": cascade_data[2]["user"].id - 1},
+                [],
+            ),
+        ]
+
+        for bounds, bounds_with_expected_results in bounds_with_expected_results:
+            monitor_owner_field = Monitor._meta.get_field("owner_user_id")
+
+            with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
+                ids, oldest_obj = get_ids_for_tombstone_cascade_cross_db(
+                    tombstone_cls=RegionTombstone,
+                    model=Monitor,
+                    field=monitor_owner_field,
+                    watermark_batch=WatermarkBatch(
+                        low=bounds["low"],
+                        up=bounds["up"],
+                        has_more=False,
+                        transaction_id="foobar",
+                    ),
+                    row_after_tombstone=True,
+                )
+                assert (
+                    ids == bounds_with_expected_results
+                ), f"Expected  IDs '{bounds_with_expected_results}', got '{ids}', for input: '{bounds}'"

--- a/tests/sentry/tasks/deletion/test_hybrid_cloud.py
+++ b/tests/sentry/tasks/deletion/test_hybrid_cloud.py
@@ -325,122 +325,130 @@ def setup_cross_db_deletion_data(
 
 
 # TODO(Gabe): Enable this test when the multi-db test changes land
-# @region_silo_test
-# class TestCrossDatabaseTombstoneCascadeBehavior(TestCase):
-#     def assert_monitors_unchanged(self, unaffected_data: list[dict]):
-#         for u_data in unaffected_data:
-#             u_user, u_monitor = itemgetter("user", "monitor")(u_data)
-#             queried_monitor = Monitor.objects.get(id=u_monitor.id)
-#             # Validate that none of the existing user's monitors have been affected
-#             assert u_monitor.owner_user_id is not None
-#             assert u_monitor.owner_user_id == queried_monitor.owner_user_id
-#             assert u_monitor.owner_user_id == u_user.id
-#
-#     def assert_monitors_user_ids_null(self, monitors: list[Monitor]):
-#         for monitor in monitors:
-#             monitor.refresh_from_db()
-#             assert monitor.owner_user_id is None
-#
-#     def run_hybrid_cloud_fk_jobs(self):
-#         with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
-#             with BurstTaskRunner() as burst:
-#                 schedule_hybrid_cloud_foreign_key_jobs()
-#
-#             burst()
-#
-#     def test_raises_when_option_disabled(self):
-#         data = setup_cross_db_deletion_data()
-#         user, monitor = itemgetter("user", "monitor")(data)
-#         with assume_test_silo_mode_of(User), outbox_runner():
-#             User.objects.get(id=user.id).delete()
-#
-#         assert Monitor.objects.filter(id=monitor.id).exists()
-#
-#         with pytest.raises(Exception) as exc, override_options(
-#             {"hybrid_cloud.allow_cross_db_tombstones": False}
-#         ):
-#             with BurstTaskRunner() as burst:
-#                 schedule_hybrid_cloud_foreign_key_jobs()
-#
-#             burst()
-#
-#         assert exc.match("Cannot process tombstones due to model living in separate database.")
-#         assert Monitor.objects.filter(id=monitor.id).exists()
-#
-#     def test_cross_db_deletion(self):
-#         data = setup_cross_db_deletion_data()
-#         user, monitor, organization, project = itemgetter(
-#             "user", "monitor", "organization", "project"
-#         )(data)
-#         unaffected_data = [setup_cross_db_deletion_data() for _ in range(3)]
-#
-#         affected_monitors = [monitor]
-#
-#         affected_monitors.extend(
-#             [
-#                 Monitor.objects.create(
-#                     id=5 + i * 2,  # Ensure that each monitor is in its own batch
-#                     organization_id=organization.id,
-#                     project_id=project.id,
-#                     slug=f"test-monitor-{i}",
-#                     name="Test Monitor",
-#                     owner_user_id=user.id,
-#                 )
-#                 for i in range(4)
-#             ]
-#         )
-#
-#         with assume_test_silo_mode_of(User), outbox_runner():
-#             User.objects.get(id=user.id).delete()
-#
-#         assert Monitor.objects.filter(id=monitor.id).exists()
-#         assert monitor.owner_user_id == user.id
-#
-#         self.run_hybrid_cloud_fk_jobs()
-#
-#         self.assert_monitors_unchanged(unaffected_data=unaffected_data)
-#         self.assert_monitors_user_ids_null(monitors=affected_monitors)
-#
-#     def test_deletion_row_after_tombstone(self):
-#         data = setup_cross_db_deletion_data()
-#         user, monitor, organization, project = itemgetter(
-#             "user", "monitor", "organization", "project"
-#         )(data)
-#         unaffected_data = [setup_cross_db_deletion_data() for _ in range(3)]
-#
-#         affected_monitors = [monitor]
-#
-#         with assume_test_silo_mode_of(User), outbox_runner():
-#             User.objects.get(id=user.id).delete()
-#
-#         assert Monitor.objects.filter(id=monitor.id).exists()
-#         assert monitor.owner_user_id == user.id
-#
-#         self.run_hybrid_cloud_fk_jobs()
-#
-#         self.assert_monitors_unchanged(unaffected_data=unaffected_data)
-#         self.assert_monitors_user_ids_null(monitors=affected_monitors)
-#
-#         # Same as previous test, but this time with monitors created after
-#         # the tombstone has been processed
-#         affected_monitors.extend(
-#             [
-#                 Monitor.objects.create(
-#                     id=10 + i * 2,  # Ensure that each monitor is in its own batch
-#                     organization_id=organization.id,
-#                     project_id=project.id,
-#                     slug=f"test-monitor-{i}",
-#                     name="Test Monitor",
-#                     owner_user_id=user.id,
-#                 )
-#                 for i in range(4)
-#             ]
-#         )
-#
-#         self.run_hybrid_cloud_fk_jobs()
-#
-#         self.assert_monitors_unchanged(unaffected_data=unaffected_data)
-#         self.assert_monitors_user_ids_null(monitors=affected_monitors)
+@region_silo_test
+@pytest.mark.skip
+class TestCrossDatabaseTombstoneCascadeBehavior(TestCase):
+    def assert_monitors_unchanged(self, unaffected_data: list[dict]):
+        for u_data in unaffected_data:
+            u_user, u_monitor = itemgetter("user", "monitor")(u_data)
+            queried_monitor = Monitor.objects.get(id=u_monitor.id)
+            # Validate that none of the existing user's monitors have been affected
+            assert u_monitor.owner_user_id is not None
+            assert u_monitor.owner_user_id == queried_monitor.owner_user_id
+            assert u_monitor.owner_user_id == u_user.id
+
+    def assert_monitors_user_ids_null(self, monitors: list[Monitor]):
+        for monitor in monitors:
+            monitor.refresh_from_db()
+            assert monitor.owner_user_id is None
+
+    def run_hybrid_cloud_fk_jobs(self):
+        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
+            with BurstTaskRunner() as burst:
+                schedule_hybrid_cloud_foreign_key_jobs()
+
+            burst()
+
+    def test_raises_when_option_disabled(self):
+        data = setup_cross_db_deletion_data()
+        user, monitor = itemgetter("user", "monitor")(data)
+        with assume_test_silo_mode_of(User), outbox_runner():
+            User.objects.get(id=user.id).delete()
+
+        assert Monitor.objects.filter(id=monitor.id).exists()
+
+        with pytest.raises(Exception) as exc, override_options(
+            {"hybrid_cloud.allow_cross_db_tombstones": False}
+        ):
+            with BurstTaskRunner() as burst:
+                schedule_hybrid_cloud_foreign_key_jobs()
+
+            burst()
+
+        assert exc.match("Cannot process tombstones due to model living in separate database.")
+        assert Monitor.objects.filter(id=monitor.id).exists()
+
+    def test_cross_db_deletion(self):
+        data = setup_cross_db_deletion_data()
+        user, monitor, organization, project = itemgetter(
+            "user", "monitor", "organization", "project"
+        )(data)
+        unaffected_data = [setup_cross_db_deletion_data() for _ in range(3)]
+
+        affected_monitors = [monitor]
+
+        affected_monitors.extend(
+            [
+                Monitor.objects.create(
+                    id=5 + i * 2,  # Ensure that each monitor is in its own batch
+                    organization_id=organization.id,
+                    project_id=project.id,
+                    slug=f"test-monitor-{i}",
+                    name="Test Monitor",
+                    owner_user_id=user.id,
+                )
+                for i in range(4)
+            ]
+        )
+
+        with assume_test_silo_mode_of(User), outbox_runner():
+            User.objects.get(id=user.id).delete()
+
+        assert Monitor.objects.filter(id=monitor.id).exists()
+        assert monitor.owner_user_id == user.id
+
+        self.run_hybrid_cloud_fk_jobs()
+
+        self.assert_monitors_unchanged(unaffected_data=unaffected_data)
+        self.assert_monitors_user_ids_null(monitors=affected_monitors)
+
+    def test_deletion_row_after_tombstone(self):
+        data = setup_cross_db_deletion_data()
+        user, monitor, organization, project = itemgetter(
+            "user", "monitor", "organization", "project"
+        )(data)
+        unaffected_data = [setup_cross_db_deletion_data() for _ in range(3)]
+
+        affected_monitors = [monitor]
+
+        with assume_test_silo_mode_of(User), outbox_runner():
+            User.objects.get(id=user.id).delete()
+
+        assert Monitor.objects.filter(id=monitor.id).exists()
+        assert monitor.owner_user_id == user.id
+
+        self.run_hybrid_cloud_fk_jobs()
+
+        self.assert_monitors_unchanged(unaffected_data=unaffected_data)
+        self.assert_monitors_user_ids_null(monitors=affected_monitors)
+
+        # Same as previous test, but this time with monitors created after
+        # the tombstone has been processed
+        affected_monitors.extend(
+            [
+                Monitor.objects.create(
+                    id=10 + i * 2,  # Ensure that each monitor is in its own batch
+                    organization_id=organization.id,
+                    project_id=project.id,
+                    slug=f"test-monitor-{i}",
+                    name="Test Monitor",
+                    owner_user_id=user.id,
+                )
+                for i in range(4)
+            ]
+        )
+
+        self.run_hybrid_cloud_fk_jobs()
+
+        self.assert_monitors_unchanged(unaffected_data=unaffected_data)
+        self.assert_monitors_user_ids_null(monitors=affected_monitors)
+
+    def test_empty_tombstones_table(self):
+        unaffected_data = [setup_cross_db_deletion_data() for _ in range(3)]
+        assert RegionTombstone.objects.count() == 0
+
+        self.run_hybrid_cloud_fk_jobs()
+        self.assert_monitors_unchanged(unaffected_data=unaffected_data)
 
 
 @region_silo_test
@@ -709,3 +717,42 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
                 assert (
                     ids == bounds_with_expected_results
                 ), f"Expected  IDs '{bounds_with_expected_results}', got '{ids}', for input: '{bounds}'"
+
+    def test_get_ids_for_tombstone_cascade_cross_db_with_multiple_tombstone_types(self):
+        data = setup_cross_db_deletion_data()
+        unaffected_data = [setup_cross_db_deletion_data() for _ in range(3)]
+
+        # Similar to the test in the tombstone watermarking code, we pollute
+        # the data with same user IDs, but different table to ensure we only
+        # select the intersection of IDs from the monitor tombstones.
+        for udata in unaffected_data:
+            unaffected_user = udata["user"]
+            RegionTombstone.objects.create(
+                table_name="something_table", object_identifier=unaffected_user.id
+            )
+
+        user, monitor = itemgetter("user", "monitor")(data)
+        user_id = user.id
+        with assume_test_silo_mode_of(User), outbox_runner():
+            user.delete()
+
+        tombstone = RegionTombstone.objects.get(
+            object_identifier=user_id, table_name=User._meta.db_table
+        )
+
+        highest_model_id = Monitor.objects.aggregate(Max("id"))["id__max"]
+
+        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
+            ids, oldest_obj = get_ids_cross_db_for_row_watermark(
+                tombstone_cls=RegionTombstone,
+                model=Monitor,
+                field=Monitor._meta.get_field("owner_user_id"),
+                row_watermark_batch=WatermarkBatch(
+                    low=0,
+                    up=highest_model_id + 1,
+                    has_more=False,
+                    transaction_id="foobar",
+                ),
+            )
+            assert ids == [monitor.id]
+            assert oldest_obj == tombstone.created_at

--- a/tests/sentry/tasks/deletion/test_hybrid_cloud.py
+++ b/tests/sentry/tasks/deletion/test_hybrid_cloud.py
@@ -473,20 +473,19 @@ class TestGetIdsForTombstoneCascadeCrossDbTombstoneWatermarking(TestCase):
         highest_tombstone_id = RegionTombstone.objects.aggregate(Max("id"))
         monitor_owner_field = Monitor._meta.get_field("owner_user_id")
 
-        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
-            ids, oldest_obj = get_ids_cross_db_for_tombstone_watermark(
-                tombstone_cls=RegionTombstone,
-                model=Monitor,
-                field=monitor_owner_field,
-                tombstone_watermark_batch=WatermarkBatch(
-                    low=0,
-                    up=highest_tombstone_id["id__max"] + 1,
-                    has_more=False,
-                    transaction_id="foobar",
-                ),
-            )
-            assert ids == [monitor.id]
-            assert oldest_obj == tombstone.created_at
+        ids, oldest_obj = get_ids_cross_db_for_tombstone_watermark(
+            tombstone_cls=RegionTombstone,
+            model=Monitor,
+            field=monitor_owner_field,
+            tombstone_watermark_batch=WatermarkBatch(
+                low=0,
+                up=highest_tombstone_id["id__max"] + 1,
+                has_more=False,
+                transaction_id="foobar",
+            ),
+        )
+        assert ids == [monitor.id]
+        assert oldest_obj == tombstone.created_at
 
     def test_get_ids_for_tombstone_cascade_cross_db_watermark_bounds(self):
         cascade_data = [setup_cross_db_deletion_data() for _ in range(3)]
@@ -537,19 +536,18 @@ class TestGetIdsForTombstoneCascadeCrossDbTombstoneWatermarking(TestCase):
         for bounds, bounds_with_expected_results in bounds_with_expected_results:
             monitor_owner_field = Monitor._meta.get_field("owner_user_id")
 
-            with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
-                ids, oldest_obj = get_ids_cross_db_for_tombstone_watermark(
-                    tombstone_cls=RegionTombstone,
-                    model=Monitor,
-                    field=monitor_owner_field,
-                    tombstone_watermark_batch=WatermarkBatch(
-                        low=bounds["low"],
-                        up=bounds["up"],
-                        has_more=False,
-                        transaction_id="foobar",
-                    ),
-                )
-                assert ids == bounds_with_expected_results
+            ids, oldest_obj = get_ids_cross_db_for_tombstone_watermark(
+                tombstone_cls=RegionTombstone,
+                model=Monitor,
+                field=monitor_owner_field,
+                tombstone_watermark_batch=WatermarkBatch(
+                    low=bounds["low"],
+                    up=bounds["up"],
+                    has_more=False,
+                    transaction_id="foobar",
+                ),
+            )
+            assert ids == bounds_with_expected_results
 
     def test_get_ids_for_tombstone_cascade_cross_db_with_multiple_tombstone_types(self):
         data = setup_cross_db_deletion_data()
@@ -575,20 +573,19 @@ class TestGetIdsForTombstoneCascadeCrossDbTombstoneWatermarking(TestCase):
 
         highest_tombstone_id = RegionTombstone.objects.aggregate(Max("id"))
 
-        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
-            ids, oldest_obj = get_ids_cross_db_for_tombstone_watermark(
-                tombstone_cls=RegionTombstone,
-                model=Monitor,
-                field=Monitor._meta.get_field("owner_user_id"),
-                tombstone_watermark_batch=WatermarkBatch(
-                    low=0,
-                    up=highest_tombstone_id["id__max"] + 1,
-                    has_more=False,
-                    transaction_id="foobar",
-                ),
-            )
-            assert ids == [monitor.id]
-            assert oldest_obj == tombstone.created_at
+        ids, oldest_obj = get_ids_cross_db_for_tombstone_watermark(
+            tombstone_cls=RegionTombstone,
+            model=Monitor,
+            field=Monitor._meta.get_field("owner_user_id"),
+            tombstone_watermark_batch=WatermarkBatch(
+                low=0,
+                up=highest_tombstone_id["id__max"] + 1,
+                has_more=False,
+                transaction_id="foobar",
+            ),
+        )
+        assert ids == [monitor.id]
+        assert oldest_obj == tombstone.created_at
 
 
 @region_silo_test
@@ -608,21 +605,20 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
         tombstone = RegionTombstone.objects.get(
             object_identifier=user_id, table_name=User._meta.db_table
         )
-        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
-            ids, oldest_obj = get_ids_cross_db_for_row_watermark(
-                tombstone_cls=RegionTombstone,
-                model=Monitor,
-                field=Monitor._meta.get_field("owner_user_id"),
-                row_watermark_batch=WatermarkBatch(
-                    low=0,
-                    up=highest_model_id["id__max"] + 1,
-                    has_more=False,
-                    transaction_id="foobar",
-                ),
-            )
+        ids, oldest_obj = get_ids_cross_db_for_row_watermark(
+            tombstone_cls=RegionTombstone,
+            model=Monitor,
+            field=Monitor._meta.get_field("owner_user_id"),
+            row_watermark_batch=WatermarkBatch(
+                low=0,
+                up=highest_model_id["id__max"] + 1,
+                has_more=False,
+                transaction_id="foobar",
+            ),
+        )
 
-            assert ids == [monitor.id]
-            assert oldest_obj == tombstone.created_at
+        assert ids == [monitor.id]
+        assert oldest_obj == tombstone.created_at
 
     def test_with_empty_tombstones_table(self):
         # Set up some sample data that shouldn't be affected
@@ -634,20 +630,19 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
         assert highest_model_id is not None
         assert not RegionTombstone.objects.filter().exists()
 
-        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
-            ids, oldest_obj = get_ids_cross_db_for_row_watermark(
-                tombstone_cls=RegionTombstone,
-                model=Monitor,
-                field=Monitor._meta.get_field("owner_user_id"),
-                row_watermark_batch=WatermarkBatch(
-                    low=0,
-                    up=highest_model_id + 1,
-                    has_more=False,
-                    transaction_id="foobar",
-                ),
-            )
+        ids, oldest_obj = get_ids_cross_db_for_row_watermark(
+            tombstone_cls=RegionTombstone,
+            model=Monitor,
+            field=Monitor._meta.get_field("owner_user_id"),
+            row_watermark_batch=WatermarkBatch(
+                low=0,
+                up=highest_model_id + 1,
+                has_more=False,
+                transaction_id="foobar",
+            ),
+        )
 
-            assert ids == []
+        assert ids == []
 
     def test_row_watermarking_bounds(self):
         # In testing, the IDs for these models will be low, sequential values
@@ -702,21 +697,20 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
         for bounds, bounds_with_expected_results in bounds_with_expected_results:
             monitor_owner_field = Monitor._meta.get_field("owner_user_id")
 
-            with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
-                ids, oldest_obj = get_ids_cross_db_for_row_watermark(
-                    tombstone_cls=RegionTombstone,
-                    model=Monitor,
-                    field=monitor_owner_field,
-                    row_watermark_batch=WatermarkBatch(
-                        low=bounds["low"],
-                        up=bounds["up"],
-                        has_more=False,
-                        transaction_id="foobar",
-                    ),
-                )
-                assert (
-                    ids == bounds_with_expected_results
-                ), f"Expected  IDs '{bounds_with_expected_results}', got '{ids}', for input: '{bounds}'"
+            ids, oldest_obj = get_ids_cross_db_for_row_watermark(
+                tombstone_cls=RegionTombstone,
+                model=Monitor,
+                field=monitor_owner_field,
+                row_watermark_batch=WatermarkBatch(
+                    low=bounds["low"],
+                    up=bounds["up"],
+                    has_more=False,
+                    transaction_id="foobar",
+                ),
+            )
+            assert (
+                ids == bounds_with_expected_results
+            ), f"Expected  IDs '{bounds_with_expected_results}', got '{ids}', for input: '{bounds}'"
 
     def test_get_ids_for_tombstone_cascade_cross_db_with_multiple_tombstone_types(self):
         data = setup_cross_db_deletion_data()
@@ -742,17 +736,16 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
 
         highest_model_id = Monitor.objects.aggregate(Max("id"))["id__max"]
 
-        with override_options({"hybrid_cloud.allow_cross_db_tombstones": True}):
-            ids, oldest_obj = get_ids_cross_db_for_row_watermark(
-                tombstone_cls=RegionTombstone,
-                model=Monitor,
-                field=Monitor._meta.get_field("owner_user_id"),
-                row_watermark_batch=WatermarkBatch(
-                    low=0,
-                    up=highest_model_id + 1,
-                    has_more=False,
-                    transaction_id="foobar",
-                ),
-            )
-            assert ids == [monitor.id]
-            assert oldest_obj == tombstone.created_at
+        ids, oldest_obj = get_ids_cross_db_for_row_watermark(
+            tombstone_cls=RegionTombstone,
+            model=Monitor,
+            field=Monitor._meta.get_field("owner_user_id"),
+            row_watermark_batch=WatermarkBatch(
+                low=0,
+                up=highest_model_id + 1,
+                has_more=False,
+                transaction_id="foobar",
+            ),
+        )
+        assert ids == [monitor.id]
+        assert oldest_obj == tombstone.created_at

--- a/tests/sentry/tasks/deletion/test_hybrid_cloud.py
+++ b/tests/sentry/tasks/deletion/test_hybrid_cloud.py
@@ -311,6 +311,8 @@ def setup_cross_db_deletion_data(
             owner_user_id=user.id,
         )
 
+        assert monitor.owner_user_id == user.id
+
     return dict(
         user=user,
         organization=organization,
@@ -545,23 +547,23 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
         bounds_with_expected_results = [
             # Check rows with foreign keys > 0 and <= 30
             (
-                {"low": 0, "up": cascade_data[1]["user"].id},
+                {"low": 0, "up": cascade_data[1]["monitor"].id},
                 [cascade_data[0]["monitor"].id, cascade_data[1]["monitor"].id],
             ),
             (
-                {"low": cascade_data[1]["user"].id, "up": cascade_data[2]["user"].id},
+                {"low": cascade_data[1]["monitor"].id, "up": cascade_data[2]["monitor"].id},
                 [cascade_data[2]["monitor"].id],
             ),
             (
-                {"low": 0, "up": cascade_data[0]["user"].id - 1},
+                {"low": 0, "up": cascade_data[0]["monitor"].id - 1},
                 [],
             ),
             (
-                {"low": cascade_data[2]["user"].id + 1, "up": cascade_data[2]["user"].id + 2},
+                {"low": cascade_data[2]["monitor"].id + 1, "up": cascade_data[2]["monitor"].id + 2},
                 [],
             ),
             (
-                {"low": -1, "up": cascade_data[2]["user"].id + 1},
+                {"low": -1, "up": cascade_data[2]["monitor"].id + 1},
                 [
                     cascade_data[0]["monitor"].id,
                     cascade_data[1]["monitor"].id,
@@ -569,7 +571,7 @@ class TestGetIdsForTombstoneCascadeCrossDbRowWatermarking(TestCase):
                 ],
             ),
             (
-                {"low": cascade_data[1]["user"].id, "up": cascade_data[2]["user"].id - 1},
+                {"low": cascade_data[1]["monitor"].id, "up": cascade_data[2]["monitor"].id - 1},
                 [],
             ),
         ]

--- a/tests/sentry/tasks/deletion/test_hybrid_cloud.py
+++ b/tests/sentry/tasks/deletion/test_hybrid_cloud.py
@@ -324,6 +324,7 @@ def setup_cross_db_deletion_data(
     )
 
 
+# TODO(Gabe): Enable this test when the multi-db test changes land
 # @region_silo_test
 # class TestCrossDatabaseTombstoneCascadeBehavior(TestCase):
 #     def assert_monitors_unchanged(self, unaffected_data: list[dict]):
@@ -425,7 +426,7 @@ def setup_cross_db_deletion_data(
 #         affected_monitors.extend(
 #             [
 #                 Monitor.objects.create(
-#                     id=5 + i * 2,  # Ensure that each monitor is in its own batch
+#                     id=10 + i * 2,  # Ensure that each monitor is in its own batch
 #                     organization_id=organization.id,
 #                     project_id=project.id,
 #                     slug=f"test-monitor-{i}",
@@ -440,7 +441,6 @@ def setup_cross_db_deletion_data(
 #
 #         self.assert_monitors_unchanged(unaffected_data=unaffected_data)
 #         self.assert_monitors_user_ids_null(monitors=affected_monitors)
-#
 
 
 @region_silo_test


### PR DESCRIPTION
<!-- Describe your PR here. -->
Resubmission of PR #69480 with added support for row watermarking, which covers the case when a row is created after the relevant tombstone is already processed.

To make this behavior easier to test, I've split the convenience helper method that queries for model IDs requiring cascade changes into multiple new functions that can be tested individually. 

This PR also adds commented tests that assert that this watermarking behavior is working as expected. Please pay attention to both the commented and uncommented test cases when reviewing.

