### PR TITLE
fix(hybridcloud) Improve API gateway routing for error-embed

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3970,7 +3970,6 @@ REGION_PINNED_URL_NAMES = {
     "sentry-api-0-relays-details",
     # Backwards compatibility for US customers.
     # New usage of these is region scoped.
-    "sentry-error-page-embed",
     "sentry-js-sdk-loader",
     "sentry-release-hook",
     "sentry-api-0-organizations",

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -155,7 +155,8 @@ def proxy_error_embed_request(
 ) -> HttpResponseBase | None:
     try:
         parsed = urlparse(dsn)
-    except Exception:
+    except Exception as err:
+        logger.info("apigateway.error_embed.invalid_dsn", extra={"dsn": dsn, "error": err})
         return None
     host = parsed.netloc
     app_host = urlparse(options.get("system.url-prefix")).netloc

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from wsgiref.util import is_hop_by_hop
 
 from django.conf import settings
@@ -16,6 +16,7 @@ from requests import Response as ExternalResponse
 from requests import request as external_request
 from requests.exceptions import Timeout
 
+from sentry import options
 from sentry.api.exceptions import RequestTimeout
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
@@ -145,6 +146,36 @@ def proxy_sentryapp_request(
     except (RegionResolutionError, OrganizationMapping.DoesNotExist) as e:
         logger.info("region_resolution_error", extra={"app_slug": app_id_or_slug, "error": str(e)})
         return HttpResponse(status=404)
+
+    return proxy_region_request(request, region, url_name)
+
+
+def proxy_error_embed_request(
+    request: HttpRequest, dsn: str, url_name: str
+) -> HttpResponseBase | None:
+    try:
+        parsed = urlparse(dsn)
+    except Exception:
+        return None
+    host = parsed.netloc
+    app_host = urlparse(options.get("system.url-prefix")).netloc
+    if not host.endswith(app_host):
+        # Don't further parse URLs that aren't for us.
+        return None
+
+    app_segments = app_host.split(".")
+    host_segments = host.split(".")
+    if len(host_segments) - len(app_segments) < 3:
+        # If we don't have a o123.ingest.{region}.{app_host} style domain
+        # we forward to the monolith region
+        region = get_region_by_name(settings.SENTRY_MONOLITH_REGION)
+        return proxy_region_request(request, region, url_name)
+    try:
+        region_offset = len(app_segments) + 1
+        region_segment = host_segments[region_offset * -1]
+        region = get_region_by_name(region_segment)
+    except Exception:
+        return None
 
     return proxy_region_request(request, region, url_name)
 

--- a/src/sentry/testutils/helpers/apigateway.py
+++ b/src/sentry/testutils/helpers/apigateway.py
@@ -66,6 +66,11 @@ urlpatterns = [
         RegionEndpoint.as_view(),
         name="region-endpoint-id-or-slug",
     ),
+    re_path(
+        r"^api/embed/error-page/$",
+        RegionEndpoint.as_view(),
+        name="sentry-error-page-embed",
+    ),
 ] + api_urls.urlpatterns
 
 


### PR DESCRIPTION
The browser SDK is still creating URLs for the error-embed views using `sentry.io` for customers in all regions. Remove the error-embed view from the region pin list and create DSN based routing. I don't love this solution, but it should be robust enough to handle the scenarios that customers are having problems with.

Refs HC-1182
Refs getsentry/sentry-javascript#11813