### PR TITLE
chore(analytics): Add analytics to "Read the docs" Search footer button

### DIFF
--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -8,6 +8,7 @@ import {getSearchGroupWithItemMarkedActive} from 'sentry/components/smartSearchB
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -227,6 +228,14 @@ function SearchBar(props: SearchBarProps) {
 
     browserHistory.push(normalizeUrl(next));
   };
+  const logDocsOpenedEvent = () => {
+    trackAnalytics('search.docs_opened', {
+      organization,
+      search_type: 'performance',
+      search_source: 'performance_landing',
+      query: props.query,
+    });
+  };
 
   return (
     <Container
@@ -248,6 +257,7 @@ function SearchBar(props: SearchBarProps) {
           items={searchResults}
           onClick={handleChooseItem}
           onIconClick={handleClickItemIcon}
+          onDocsOpen={() => logDocsOpenedEvent()}
         />
       )}
     </Container>

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -724,6 +724,17 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     });
   };
 
+  logDocsOpenedEvent = () => {
+    const {searchSource, savedSearchType, organization} = this.props;
+
+    trackAnalytics('search.docs_opened', {
+      organization,
+      search_type: savedSearchType === 0 ? 'issues' : 'events',
+      search_source: searchSource,
+      query: this.state.query,
+    });
+  };
+
   runShortcutOnClick = (shortcut: Shortcut) => {
     this.runShortcut(shortcut);
     this.logShortcutEvent(shortcut.shortcutType, 'click');
@@ -2088,6 +2099,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
             numericKeys={this.props.numericKeys}
             percentageKeys={this.props.percentageKeys}
             sizeKeys={this.props.sizeKeys}
+            onDocsOpen={this.logDocsOpenedEvent}
             textOperatorKeys={this.props.textOperatorKeys}
           />
         )}

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -42,6 +42,7 @@ type Props = {
   maxMenuHeight?: number;
   mergeItemsWith?: Record<string, SearchItem>;
   numericKeys?: Set<string>;
+  onDocsOpen?: () => void;
   onIconClick?: (value: string) => void;
   percentageKeys?: Set<string>;
   runShortcut?: (shortcut: Shortcut) => void;
@@ -69,6 +70,7 @@ function SearchDropdown({
   durationKeys,
   numericKeys,
   percentageKeys,
+  onDocsOpen,
   sizeKeys,
   textOperatorKeys,
   disallowedLogicalOperators,
@@ -152,6 +154,7 @@ function SearchDropdown({
           size="xs"
           href="https://docs.sentry.io/product/sentry-basics/search/"
           external
+          onClick={() => onDocsOpen?.()}
         >
           {t('Read the docs')}
         </Button>

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -35,6 +35,7 @@ export type SearchEventParameters = {
     count: number;
     multi: boolean;
   };
+  'search.docs_opened': SearchEventBase;
   'search.invalid_field': Omit<SearchEventBase, 'query'> & {attempted_field_name: string};
   'search.key_autocompleted': Omit<SearchEventBase, 'query'> & {
     item_name: string | undefined;
@@ -79,6 +80,7 @@ export const searchEventMap: Record<SearchEventKey, string | null> = {
   'search.searched': 'Search: Performed search',
   'search.key_autocompleted': 'Search: Key Autocompleted',
   'search.shortcut_used': 'Search: Shortcut Used',
+  'search.docs_opened': 'Search: Docs Opened',
   'search.search_with_invalid': 'Search: Attempted Invalid Search',
   'search.invalid_field': 'Search: Unsupported Field Warning Shown',
   'search.operator_autocompleted': 'Search: Operator Autocompleted',


### PR DESCRIPTION
This PR adds analytics for whenever a user clicks on the "Read the docs" button in the footer of the Search dropdown menu. This analytic could be a signal for user frustration within search, which will be useful to track. 

Implements #69788 