### PR TITLE
fix(project-release): POST should not call Snuba

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -205,6 +205,9 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
 
                 # Disable snuba here as it often causes 429s when overloaded and
                 # a freshly created release won't have health data anyways.
-                return Response(serialize(release, request.user, no_snuba=True), status=status)
+                return Response(
+                    serialize(release, request.user, no_snuba_for_release_creation=True),
+                    status=status,
+                )
             scope.set_tag("failure_reason", "serializer_error")
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -314,7 +314,7 @@ class ReleaseSerializer(Serializer):
             False,
         )
 
-    def __get_release_data_no_environment(self, project, item_list):
+    def __get_release_data_no_environment(self, project, item_list, no_snuba_for_release_creation):
         if project is not None:
             project_ids = [project.id]
             specialized = True
@@ -325,12 +325,16 @@ class ReleaseSerializer(Serializer):
 
         first_seen: dict[str, datetime.datetime] = {}
         last_seen: dict[str, datetime.datetime] = {}
-        tag_values = tagstore.backend.get_release_tags(
-            organization_id,
-            project_ids,
-            environment_id=None,
-            versions=[o.version for o in item_list],
-        )
+        if no_snuba_for_release_creation:
+            tag_values = []
+        else:
+            tag_values = tagstore.backend.get_release_tags(
+                organization_id,
+                project_ids,
+                environment_id=None,
+                versions=[o.version for o in item_list],
+            )
+
         for tv in tag_values:
             first_val = first_seen.get(tv.value)
             last_val = last_seen.get(tv.value)
@@ -416,8 +420,8 @@ class ReleaseSerializer(Serializer):
         health_stat = kwargs.get("health_stat", None)
         health_stats_period = kwargs.get("health_stats_period")
         summary_stats_period = kwargs.get("summary_stats_period")
-        no_snuba = kwargs.get("no_snuba")
-        if with_health_data and no_snuba:
+        no_snuba_for_release_creation = kwargs.get("no_snuba_for_release_creation")
+        if with_health_data and no_snuba_for_release_creation:
             raise TypeError("health data requires snuba")
 
         adoption_stages = {}
@@ -428,7 +432,7 @@ class ReleaseSerializer(Serializer):
 
         if environments is None:
             first_seen, last_seen, issue_counts_by_release = self.__get_release_data_no_environment(
-                project, item_list
+                project, item_list, no_snuba_for_release_creation
             )
         else:
             if release_project_envs is None:


### PR DESCRIPTION
Customer is hitting rate limiting when they shouldn't. ticket: https://getsentry.atlassian.net/browse/OPS-5972
It turns out project release endpoint is intentionally skipping snuba on POST requests but this call is ignoring the passed flag `no_snuba`.

More context on investigation: https://sentry.slack.com/archives/C039ZGT5K/p1714161375978469

I'm not familiar with release code so leaving it here to see if this is the right behavior. Is it ok to set tag_values to empty at the time of release creation?