### PR TITLE
ref(django): remove request.json_body

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -280,11 +280,9 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
     """
 
     def authenticate(self, request: Request):
-        if not request.json_body:
-            raise AuthenticationFailed("Invalid request")
 
-        client_id = request.json_body.get("client_id")
-        client_secret = request.json_body.get("client_secret")
+        client_id = request.data.get("client_id")
+        client_secret = request.data.get("client_secret")
 
         invalid_pair_error = AuthenticationFailed("Invalid Client ID / Secret pair")
 

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -281,8 +281,8 @@ class ClientIdSecretAuthentication(QuietBasicAuthentication):
 
     def authenticate(self, request: Request):
 
-        client_id = request.data.get("client_id")
-        client_secret = request.data.get("client_secret")
+        client_id = request.POST.get("client_id")
+        client_secret = request.POST.get("client_secret")
 
         invalid_pair_error = AuthenticationFailed("Invalid Client ID / Secret pair")
 

--- a/src/sentry/api/bases/doc_integrations.py
+++ b/src/sentry/api/bases/doc_integrations.py
@@ -68,7 +68,7 @@ class DocIntegrationsBaseEndpoint(Endpoint):
     permission_classes = (DocIntegrationsAndStaffPermission,)
 
     def generate_incoming_metadata(self, request: Request) -> JSONData:
-        return {k: v for k, v in request.json_body.items() if k in METADATA_PROPERTIES}
+        return {k: v for k, v in request.data.items() if k in METADATA_PROPERTIES}
 
 
 class DocIntegrationBaseEndpoint(DocIntegrationsBaseEndpoint):

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -118,7 +118,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
     permission_classes: tuple[type[BasePermission], ...] = (SentryAppsAndStaffPermission,)
 
     def _get_organization_slug(self, request: Request):
-        organization_slug = request.json_body.get("organization")
+        organization_slug = request.data.get("organization")
         if not organization_slug or not isinstance(organization_slug, str):
             error_message = "Please provide a valid value for the 'organization' field."
             raise ValidationError({"organization": to_single_line_str(error_message)})
@@ -175,7 +175,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
         objects from URI params, we're applying the same logic for a param in
         the request body.
         """
-        if not request.json_body:
+        if not request.data:
             return (args, kwargs)
 
         context = self._get_org_context(request)

--- a/src/sentry/api/endpoints/group_autofix_update.py
+++ b/src/sentry/api/endpoints/group_autofix_update.py
@@ -34,7 +34,7 @@ class GroupAutofixUpdateEndpoint(GroupEndpoint):
 
         response = requests.post(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update",
-            data=request.body,
+            data=request.data,
             headers={"content-type": "application/json;charset=utf-8"},
         )
 

--- a/src/sentry/api/endpoints/integrations/doc_integrations/details.py
+++ b/src/sentry/api/endpoints/integrations/doc_integrations/details.py
@@ -29,7 +29,7 @@ class DocIntegrationDetailsEndpoint(DocIntegrationBaseEndpoint):
         return self.respond(serialize(doc_integration, request.user), status=status.HTTP_200_OK)
 
     def put(self, request: Request, doc_integration: DocIntegration) -> Response:
-        data = request.json_body
+        data = request.data
         data["metadata"] = self.generate_incoming_metadata(request)
 
         serializer = DocIntegrationSerializer(doc_integration, data=data)

--- a/src/sentry/api/endpoints/integrations/doc_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/doc_integrations/index.py
@@ -40,7 +40,7 @@ class DocIntegrationsEndpoint(DocIntegrationsBaseEndpoint):
 
     def post(self, request: Request):
         # Override any incoming JSON for these fields
-        data = request.json_body
+        data = request.data
         data["is_draft"] = True
         data["metadata"] = self.generate_incoming_metadata(request)
         serializer = DocIntegrationSerializer(data=data)

--- a/src/sentry/api/endpoints/integrations/sentry_apps/authorizations.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/authorizations.py
@@ -32,18 +32,18 @@ class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
             scope.set_tag("sentry_app_slug", installation.sentry_app.slug)
 
             try:
-                if request.json_body.get("grant_type") == GrantTypes.AUTHORIZATION:
+                if request.data.get("grant_type") == GrantTypes.AUTHORIZATION:
                     token = GrantExchanger.run(
                         install=installation,
-                        code=request.json_body.get("code"),
-                        client_id=request.json_body.get("client_id"),
+                        code=request.data.get("code"),
+                        client_id=request.data.get("client_id"),
                         user=promote_request_api_user(request),
                     )
-                elif request.json_body.get("grant_type") == GrantTypes.REFRESH:
+                elif request.data.get("grant_type") == GrantTypes.REFRESH:
                     token = Refresher.run(
                         install=installation,
-                        refresh_token=request.json_body.get("refresh_token"),
-                        client_id=request.json_body.get("client_id"),
+                        refresh_token=request.data.get("refresh_token"),
+                        client_id=request.data.get("client_id"),
                         user=promote_request_api_user(request),
                     )
                 else:
@@ -52,7 +52,7 @@ class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
                 logger.warning(e, exc_info=True)
                 return Response({"error": e.msg or "Unauthorized"}, status=403)
 
-            attrs = {"state": request.json_body.get("state"), "application": None}
+            attrs = {"state": request.data.get("state"), "application": None}
 
             body = ApiTokenSerializer().serialize(token, attrs, promote_request_api_user(request))
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/details.py
@@ -166,7 +166,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         return Response({"detail": ["Published apps cannot be removed."]}, status=403)
 
     def _has_hook_events(self, request: Request):
-        if not request.json_body.get("events"):
+        if not request.data.get("events"):
             return False
 
-        return "error" in request.json_body["events"]
+        return "error" in request.data["events"]

--- a/src/sentry/api/endpoints/integrations/sentry_apps/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/index.py
@@ -76,22 +76,22 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
 
     def post(self, request: Request, organization) -> Response:
         data = {
-            "name": request.json_body.get("name"),
+            "name": request.data.get("name"),
             "user": request.user,
-            "author": request.json_body.get("author"),
+            "author": request.data.get("author"),
             "organization": organization,
-            "webhookUrl": request.json_body.get("webhookUrl"),
-            "redirectUrl": request.json_body.get("redirectUrl"),
-            "isAlertable": request.json_body.get("isAlertable"),
-            "isInternal": request.json_body.get("isInternal"),
-            "verifyInstall": request.json_body.get("verifyInstall"),
-            "scopes": request.json_body.get("scopes", []),
-            "events": request.json_body.get("events", []),
-            "schema": request.json_body.get("schema", {}),
-            "overview": request.json_body.get("overview"),
-            "allowedOrigins": request.json_body.get("allowedOrigins", []),
+            "webhookUrl": request.data.get("webhookUrl"),
+            "redirectUrl": request.data.get("redirectUrl"),
+            "isAlertable": request.data.get("isAlertable"),
+            "isInternal": request.data.get("isInternal"),
+            "verifyInstall": request.data.get("verifyInstall"),
+            "scopes": request.data.get("scopes", []),
+            "events": request.data.get("events", []),
+            "schema": request.data.get("schema", {}),
+            "overview": request.data.get("overview"),
+            "allowedOrigins": request.data.get("allowedOrigins", []),
             "popularity": (
-                request.json_body.get("popularity") if is_active_superuser(request) else None
+                request.data.get("popularity") if is_active_superuser(request) else None
             ),
         }
 
@@ -154,7 +154,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
         return Response(serializer.errors, status=400)
 
     def _has_hook_events(self, request: Request):
-        if not request.json_body.get("events"):
+        if not request.data.get("events"):
             return False
 
-        return "error" in request.json_body["events"]
+        return "error" in request.data["events"]

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -69,7 +69,6 @@ class SlackRequest:
         """
         Ensure everything is present to properly process this request
         """
-        self.request.body
         self._log_request()
         self._get_context()
         self.authorize()

--- a/tests/sentry/api/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_update.py
@@ -35,16 +35,14 @@ class TestGroupAutofixUpdate(APITestCase):
         assert response.status_code == status.HTTP_202_ACCEPTED
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update",
-            data=json.dumps(
-                {
-                    "run_id": 123,
-                    "payload": {
-                        "type": "select_root_cause",
-                        "cause_id": 456,
-                        "fix_id": 789,
-                    },
-                }
-            ).encode("utf-8"),
+            data={
+                "run_id": 123,
+                "payload": {
+                    "type": "select_root_cause",
+                    "cause_id": 456,
+                    "fix_id": 789,
+                },
+            },
             headers={"content-type": "application/json;charset=utf-8"},
         )
 

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -53,7 +53,7 @@ class TestClientIdSecretAuthentication(TestCase):
 
     def test_authenticate(self):
         request = HttpRequest()
-        request.json_body = {
+        request.data = {
             "client_id": self.api_app.client_id,
             "client_secret": self.api_app.client_secret,
         }
@@ -64,35 +64,35 @@ class TestClientIdSecretAuthentication(TestCase):
 
     def test_without_json_body(self):
         request = HttpRequest()
-        request.json_body = None
+        request.data = None
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_missing_client_id(self):
         request = HttpRequest()
-        request.json_body = {"client_secret": self.api_app.client_secret}
+        request.data = {"client_secret": self.api_app.client_secret}
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_missing_client_secret(self):
         request = HttpRequest()
-        request.json_body = {"client_id": self.api_app.client_id}
+        request.data = {"client_id": self.api_app.client_id}
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_incorrect_client_id(self):
         request = HttpRequest()
-        request.json_body = {"client_id": "notit", "client_secret": self.api_app.client_secret}
+        request.data = {"client_id": "notit", "client_secret": self.api_app.client_secret}
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)
 
     def test_incorrect_client_secret(self):
         request = HttpRequest()
-        request.json_body = {"client_id": self.api_app.client_id, "client_secret": "notit"}
+        request.data = {"client_id": self.api_app.client_id, "client_secret": "notit"}
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest import mock
 from unittest.mock import MagicMock
 
-from django.http import HttpRequest, QueryDict, StreamingHttpResponse
+from django.http import QueryDict, StreamingHttpResponse
 from django.test import override_settings
 from pytest import raises
 from rest_framework.permissions import AllowAny
@@ -497,43 +497,6 @@ class PaginateTest(APITestCase):
         assert response.status_code == 200
         assert isinstance(response, StreamingHttpResponse)
         assert response.has_header("content-type")
-
-
-class EndpointJSONBodyTest(APITestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.request = HttpRequest()
-        self.request.method = "GET"
-        self.request.META["CONTENT_TYPE"] = "application/json"
-
-    def test_json(self):
-        self.request._body = b'{"foo":"bar"}'
-
-        Endpoint().load_json_body(self.request)
-
-        assert self.request.json_body == {"foo": "bar"}
-
-    def test_invalid_json(self):
-        self.request._body = b"hello"
-
-        Endpoint().load_json_body(self.request)
-
-        assert not self.request.json_body
-
-    def test_empty_request_body(self):
-        self.request._body = b""
-
-        Endpoint().load_json_body(self.request)
-
-        assert not self.request.json_body
-
-    def test_non_json_content_type(self):
-        self.request.META["CONTENT_TYPE"] = "text/plain"
-
-        Endpoint().load_json_body(self.request)
-
-        assert not self.request.json_body
 
 
 @all_silo_test(regions=create_test_regions("us", "eu"))


### PR DESCRIPTION
removes the request.json_body attribute we set and replaces usage with simply request.data. DRF/Django automatically parses the POST data if it's application/json.

I think this must have been added before django/DRF did this.