### PR TITLE
feat(dynamic-sampling): Remove dynamic sampling of low volume projects

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -79,7 +79,6 @@ SAMPLED_TASKS = {
     "sentry.monitors.tasks.mark_checkin_timeout": 0.05,
     "sentry.monitors.tasks.clock_pulse": 1.0,
     "sentry.tasks.auto_enable_codecov": settings.SAMPLED_DEFAULT_RATE,
-    "sentry.dynamic_sampling.tasks.boost_low_volume_projects": 0.2,
     "sentry.dynamic_sampling.tasks.boost_low_volume_transactions": 0.2,
     "sentry.dynamic_sampling.tasks.recalibrate_orgs": 0.2,
     "sentry.dynamic_sampling.tasks.sliding_window_org": 0.2,


### PR DESCRIPTION
Some transactions seem to be dropped in relay due to dynamic sampling when there is a structure like this: 
infrequent parent task (e.g. 10 / minute)
	-> calls frequent child task (e.g. 100k per parent)

This configuration change is done to generate an example where dynamic sampling does not interfere, to check whether dynamic sampling is to blame for some weird behaviour, where there are samples for the parent, but not the child task, despite the child being much more common.