### PR TITLE
experimental(dynamic-sampling): Add experimental task decorator to boost low volume projects

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -90,6 +90,8 @@ def experimental_instrumented_task(name, silo_mode=None, **kwargs):
     def wrapped(func):
         @wraps(func)
         def _wrapped(*args, **kwargs):
+            kwargs.pop("__transaction_id", None)
+            kwargs.pop("__start_time", None)
             return func(*args, **kwargs)
 
         # We never use result backends in Celery. Leaving `trail=True` means that if we schedule

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -79,6 +79,7 @@ SAMPLED_TASKS = {
     "sentry.monitors.tasks.mark_checkin_timeout": 0.05,
     "sentry.monitors.tasks.clock_pulse": 1.0,
     "sentry.tasks.auto_enable_codecov": settings.SAMPLED_DEFAULT_RATE,
+    "sentry.dynamic_sampling.tasks.boost_low_volume_projects": 1.0,
     "sentry.dynamic_sampling.tasks.boost_low_volume_transactions": 0.2,
     "sentry.dynamic_sampling.tasks.recalibrate_orgs": 0.2,
     "sentry.dynamic_sampling.tasks.sliding_window_org": 0.2,


### PR DESCRIPTION
This PR contains an experimental decorator for tasks which removes some of the code used to track some of its stats.

We are planning on removing this when we are able to exclude that the removed code is the culprit of the problem we are investigating.