### PR TITLE
fix(issues): Show `none` as an autocomplete option

### DIFF
--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -89,7 +89,7 @@ describe('withIssueTags HoC', function () {
 
     expect(
       screen.getByText(
-        /assigned: me, my_teams, \[me, my_teams, none\], #best-team-na, foo@example.com, joe@example.com/
+        /assigned: me, my_teams, \[me, my_teams, none\], none, #best-team-na, foo@example.com, joe@example.com/
       )
     ).toBeInTheDocument();
 
@@ -113,7 +113,7 @@ describe('withIssueTags HoC', function () {
     );
 
     expect(container).toHaveTextContent(
-      'assigned: me, my_teams, [me, my_teams, none], #best-team'
+      'assigned: me, my_teams, [me, my_teams, none], none, #best-team'
     );
     // Has the other teams/members
     expect(container).toHaveTextContent('foo@example.com, joe@example.com, #worst-team');

--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -89,7 +89,7 @@ describe('withIssueTags HoC', function () {
 
     expect(
       screen.getByText(
-        /assigned: me, my_teams, \[me, my_teams, none\], none, #best-team-na, foo@example.com, joe@example.com/
+        /assigned: me, my_teams, none, \[me, my_teams, none\], #best-team-na, foo@example.com, joe@example.com/
       )
     ).toBeInTheDocument();
 
@@ -113,7 +113,7 @@ describe('withIssueTags HoC', function () {
     );
 
     expect(container).toHaveTextContent(
-      'assigned: me, my_teams, [me, my_teams, none], none, #best-team'
+      'assigned: me, my_teams, none, [me, my_teams, none], #best-team'
     );
     // Has the other teams/members
     expect(container).toHaveTextContent('foo@example.com, joe@example.com, #worst-team');

--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -74,7 +74,7 @@ describe('withIssueTags HoC', function () {
     });
 
     expect(
-      screen.getByText(/assigned: me, my_teams, \[me, my_teams, none\]/)
+      screen.getByText(/assigned: me, my_teams, none, \[me, my_teams, none\]/)
     ).toBeInTheDocument();
 
     act(() => {

--- a/static/app/utils/withIssueTags.tsx
+++ b/static/app/utils/withIssueTags.tsx
@@ -61,8 +61,8 @@ function withIssueTags<Props extends WithIssueTagsProps>(
         .filter(team => !team.isMember)
         .map(team => `#${team.slug}`);
 
-      const meAndMyTeams = ['my_teams', '[me, my_teams, none]'];
-      const suggestedAssignees: string[] = ['me', ...meAndMyTeams, ...userTeams];
+      const meAndMyTeamsNone = ['my_teams', '[me, my_teams, none]', 'none'];
+      const suggestedAssignees: string[] = ['me', ...meAndMyTeamsNone, ...userTeams];
       const assigndValues: SearchGroup[] | string[] = [
         {
           title: t('Suggested Values'),

--- a/static/app/utils/withIssueTags.tsx
+++ b/static/app/utils/withIssueTags.tsx
@@ -61,7 +61,7 @@ function withIssueTags<Props extends WithIssueTagsProps>(
         .filter(team => !team.isMember)
         .map(team => `#${team.slug}`);
 
-      const meAndMyTeamsNone = ['my_teams', '[me, my_teams, none]', 'none'];
+      const meAndMyTeamsNone = ['my_teams', 'none', '[me, my_teams, none]'];
       const suggestedAssignees: string[] = ['me', ...meAndMyTeamsNone, ...userTeams];
       const assigndValues: SearchGroup[] | string[] = [
         {


### PR DESCRIPTION
adds none directly in autocomplete

![image](https://github.com/getsentry/sentry/assets/1400464/81dcf5e3-aefd-4f82-b318-5e3a0059cf1e)
