### PR TITLE
ref(py): Update monitor_consumer to handle FilteredPayload

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -16,7 +16,7 @@ from arroyo.processing.strategies.abstract import ProcessingStrategy, Processing
 from arroyo.processing.strategies.batching import BatchStep, ValuesBatch
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
-from arroyo.types import BrokerValue, Commit, Message, Partition
+from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partition
 from django.db import router, transaction
 from sentry_kafka_schemas import get_codec
 from sentry_kafka_schemas.codecs import ValidationError
@@ -910,8 +910,10 @@ def process_batch(executor: ThreadPoolExecutor, message: Message[ValuesBatch[Kaf
             logger.exception("Failed to trigger monitor tasks")
 
 
-def process_single(message: Message[KafkaPayload]):
+def process_single(message: Message[KafkaPayload | FilteredPayload]):
+    assert not isinstance(message.payload, FilteredPayload)
     assert isinstance(message.value, BrokerValue)
+
     try:
         try:
             wrapper: IngestMonitorMessage = MONITOR_CODEC.decode(message.payload.value)


### PR DESCRIPTION
This is primarily a typing adjustment. Since we're not using
`FilterStep` we're never going to actually get a `FilteredPayload`.