### PR TITLE
chore(hybridcloud) Rename model silo annotations

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -32,6 +32,8 @@ __all__ = (
     "DefaultFieldsModel",
     "sane_repr",
     "get_model_if_available",
+    "control_silo_model",
+    "region_silo_model",
     "control_silo_only_model",
     "region_silo_only_model",
 )
@@ -440,14 +442,18 @@ class ModelSiloLimit(SiloLimit):
         return model_class
 
 
-control_silo_only_model = ModelSiloLimit(SiloMode.CONTROL)
+control_silo_model = ModelSiloLimit(SiloMode.CONTROL)
 """
 Apply to models that are shared by multiple organizations or
 require strong consistency with other Control silo resources.
 """
 
-region_silo_only_model = ModelSiloLimit(SiloMode.REGION)
+region_silo_model = ModelSiloLimit(SiloMode.REGION)
 """
 Apply to models that belong to a single organization or
 require strong consistency with other Region silo resources.
 """
+
+# Deprecated
+control_silo_only_model = control_silo_model
+region_silo_only_model = region_silo_model


### PR DESCRIPTION
Rename `control_silo_only_model` and `region_silo_only_model` to have simpler names. We scrapped the idea of models that live in both silo modes a long time ago and this naming convention is no longer helpful.

If folks are onboard with this rename I'll update all the model definitions in sentry and getsentry.