### PR TITLE
feat(trace): Try the optimization only on transactions

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -476,6 +476,7 @@ def create_transaction_params(
     trace_id: str,
     params: Mapping[str, str],
 ) -> Mapping[str, str]:
+    """Can't use the transaction params for errors since traces can be errors only"""
     transaction_params = params.copy()
     query_metadata = options.get("performance.traces.query_timestamp_projects")
     sentry_sdk.set_tag("trace_view.queried_timestamp_projects", query_metadata)


### PR DESCRIPTION
- Only get the min/max timestamps for the transaction query, the slowest of the 3 queries in query_trace_data
- This way the query for min/max should be faster too
- Option to turn this on: https://github.com/getsentry/sentry-options-automator/pull/1261