### PR TITLE
ref(grouping): Pass event rather than event id to `get_grouping_info`

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -146,9 +146,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         latest_event = group.get_latest_event()
         stacktrace_string = ""
         if latest_event.data.get("exception"):
-            grouping_info = get_grouping_info(
-                None, project=group.project, event_id=latest_event.event_id
-            )
+            grouping_info = get_grouping_info(None, project=group.project, event=latest_event)
             stacktrace_string = get_stacktrace_string(grouping_info)
 
         if stacktrace_string == "":

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-from sentry import eventstore
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.eventstore.models import Event
 from sentry.grouping.api import GroupingConfigNotFound
@@ -14,12 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_grouping_info(
-    config_name: str | None, project: Project, event_id: str
+    config_name: str | None, project: Project, event: Event
 ) -> dict[str, dict[str, Any]]:
-    event = eventstore.backend.get_event_by_id(project.id, event_id)
-    if event is None:
-        raise ResourceDoesNotExist
-
     # We always fetch the stored hashes here.  The reason for this is
     # that we want to show in the UI if the forced grouping algorithm
     # produced hashes that would normally also appear in the event.

--- a/tests/sentry/api/endpoints/test_event_grouping_info.py
+++ b/tests/sentry/api/endpoints/test_event_grouping_info.py
@@ -96,16 +96,28 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
             "d74ed7012596c3fb",
         ]
 
-    def test_get_grouping_info_no_event(self):
-        with pytest.raises(ResourceDoesNotExist):
-            get_grouping_info(None, self.project, "fake-event-id")
+    def test_no_event(self):
+        url = reverse(
+            "sentry-api-0-event-grouping-info",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_id_or_slug": self.project.slug,
+                "event_id": "fake-event-id",
+            },
+        )
+
+        response = self.client.get(url, format="json")
+
+        assert response.exception is True
+        assert response.status_code == 404
+        assert response.status_text == "Not Found"
 
     def test_get_grouping_info_unkown_grouping_config(self):
         data = load_data(platform="javascript")
         event = self.store_event(data=data, project_id=self.project.id)
 
         with pytest.raises(ResourceDoesNotExist):
-            get_grouping_info("fake-config", self.project, event.event_id)
+            get_grouping_info("fake-config", self.project, event)
 
     @mock.patch("sentry.grouping.grouping_info.logger")
     @mock.patch("sentry.grouping.grouping_info.metrics")
@@ -128,7 +140,7 @@ class EventGroupingInfoEndpointTestCase(APITestCase, PerformanceIssueTestCase):
             "sentry.eventstore.models.BaseEvent.get_grouping_variants"
         ) as mock_get_grouping_variants:
             mock_get_grouping_variants.return_value = python_grouping_variants
-            get_grouping_info(None, self.project, javascript_event.event_id)
+            get_grouping_info(None, self.project, javascript_event)
 
         mock_metrics.incr.assert_called_with("event_grouping_info.hash_mismatch")
         mock_logger.error.assert_called_with(

--- a/tests/sentry/grouping/test_grouping_info.py
+++ b/tests/sentry/grouping/test_grouping_info.py
@@ -1,0 +1,18 @@
+from sentry.grouping.grouping_info import get_grouping_info
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.eventprocessing import save_new_event
+
+NEWSTYLE_CONFIG = "newstyle:2023-01-11"
+
+
+class GroupingInfoTest(TestCase):
+    def test_get_grouping_info_error_event(self):
+        event = save_new_event({"message": "Dogs are great!"}, self.project)
+
+        grouping_info = get_grouping_info(NEWSTYLE_CONFIG, self.project, event)
+
+        assert grouping_info["default"]["type"] == "component"
+        assert grouping_info["default"]["description"] == "message"
+        assert grouping_info["default"]["component"]["contributes"] is True
+        assert grouping_info["default"]["config"]["id"] == NEWSTYLE_CONFIG
+        assert grouping_info["default"]["key"] == "default"


### PR DESCRIPTION
This changes `get_grouping_info` so that it takes in an `Event` object rather than an event id, for use in cases where the event data is coming from a source other than nodestore.

(This was pulled out of https://github.com/getsentry/sentry/pull/68466 into a separate PR to make rebasing easier.)