### PR TITLE
ref(grouping): Use a dataclass for seer grouping request typing

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Mapping, Sequence
+from dataclasses import asdict
 from typing import Any, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
@@ -154,19 +155,19 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         if stacktrace_string == "":
             return Response([])  # No exception, stacktrace or in-app frames
 
-        similar_issues_params: SimilarIssuesEmbeddingsRequest = {
-            "group_id": group.id,
-            "project_id": group.project.id,
-            "stacktrace": stacktrace_string,
-            "message": group.message,
-        }
+        similar_issues_params = SimilarIssuesEmbeddingsRequest(
+            group_id=group.id,
+            project_id=group.project.id,
+            stacktrace=stacktrace_string,
+            message=group.message,
+        )
         # Add optional parameters
         if request.GET.get("k"):
-            similar_issues_params.update({"k": int(request.GET["k"])})
+            similar_issues_params.k = int(request.GET["k"])
         if request.GET.get("threshold"):
-            similar_issues_params.update({"threshold": float(request.GET["threshold"])})
+            similar_issues_params.threshold = float(request.GET["threshold"])
 
-        extra: dict[str, Any] = dict(similar_issues_params.copy())
+        extra = asdict(similar_issues_params)
         extra["group_message"] = extra.pop("message")
         logger.info("Similar issues embeddings parameters", extra=extra)
 

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict, dataclass
 from typing import TypedDict
 
 import sentry_sdk
@@ -80,16 +81,14 @@ def detect_breakpoints(breakpoint_request) -> BreakpointResponse:
     return {"data": []}
 
 
-class SimilarIssuesEmbeddingsRequestNotRequired(TypedDict, total=False):
-    k: int
-    threshold: float
-
-
-class SimilarIssuesEmbeddingsRequest(SimilarIssuesEmbeddingsRequestNotRequired):
+@dataclass
+class SimilarIssuesEmbeddingsRequest:
     group_id: int
     project_id: int
     stacktrace: str
     message: str
+    k: int | None = 1  # how many neighbors to find
+    threshold: float | None = None
 
 
 class SimilarIssuesEmbeddingsData(TypedDict):
@@ -110,7 +109,7 @@ def get_similar_issues_embeddings(
     response = seer_staging_connection_pool.urlopen(
         "POST",
         "/v0/issues/similar-issues",
-        body=json.dumps(similar_issues_request),
+        body=json.dumps(asdict(similar_issues_request)),
         headers={"Content-Type": "application/json;charset=utf-8"},
     )
 

--- a/tests/sentry/seer/test_utils.py
+++ b/tests/sentry/seer/test_utils.py
@@ -67,12 +67,12 @@ def test_simple_similar_issues_embeddings(mock_seer_request):
     }
     mock_seer_request.return_value = HTTPResponse(json.dumps(expected_return_value).encode("utf-8"))
 
-    params: SimilarIssuesEmbeddingsRequest = {
-        "group_id": 1,
-        "project_id": 1,
-        "stacktrace": "string",
-        "message": "message",
-    }
+    params = SimilarIssuesEmbeddingsRequest(
+        group_id=1,
+        project_id=1,
+        stacktrace="string",
+        message="message",
+    )
     response = get_similar_issues_embeddings(params)
     assert response == expected_return_value
 
@@ -83,11 +83,11 @@ def test_empty_similar_issues_embeddings(mock_seer_request):
 
     mock_seer_request.return_value = HTTPResponse([])
 
-    params: SimilarIssuesEmbeddingsRequest = {
-        "group_id": 1,
-        "project_id": 1,
-        "stacktrace": "string",
-        "message": "message",
-    }
+    params = SimilarIssuesEmbeddingsRequest(
+        group_id=1,
+        project_id=1,
+        stacktrace="string",
+        message="message",
+    )
     response = get_similar_issues_embeddings(params)
     assert response == {"responses": []}


### PR DESCRIPTION
This switches to using a dataclass for typing requests to seer for similar groups, primarily to make it easier to handle optional attributes.

In the long run, we might consider switching the typing for other associated types to dataclasses as well, for consistency, but to keep things simple for now I'm just switching this one since it's the only one with optional fields.