### PR TITLE
ref(api): Refactor `GroupParticipantsEndpoint` and `GroupParticipantsEndpoint`

### DIFF
--- a/src/sentry/api/endpoints/group_participants.py
+++ b/src/sentry/api/endpoints/group_participants.py
@@ -16,7 +16,7 @@ class GroupParticipantsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.UNKNOWN,
     }
 
-    def get(self, request: Request, group, organization_slug: str | None = None) -> Response:
+    def get(self, request: Request, group) -> Response:
         participants = GroupSubscriptionManager.get_participating_user_ids(group)
 
         return Response(

--- a/src/sentry/api/endpoints/shared_group_details.py
+++ b/src/sentry/api/endpoints/shared_group_details.py
@@ -47,10 +47,12 @@ class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
 
         # Checks if the organization_slug (eventually renamed to organization_id_or_slug) matches the group organization's id or slug
         if organization_slug:
-            if organization_slug != group.organization.slug and organization_slug != str(
-                group.organization.id
-            ):
-                raise ResourceDoesNotExist
+            if organization_slug.isnumeric():
+                if int(organization_slug) != group.organization.id:
+                    raise ResourceDoesNotExist
+            else:
+                if organization_slug != group.organization.slug:
+                    raise ResourceDoesNotExist
 
         if group.organization.flags.disable_shared_issues:
             raise ResourceDoesNotExist

--- a/src/sentry/api/endpoints/shared_group_details.py
+++ b/src/sentry/api/endpoints/shared_group_details.py
@@ -47,7 +47,7 @@ class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
 
         # Checks if the organization_slug (eventually renamed to organization_id_or_slug) matches the group organization's id or slug
         if organization_slug:
-            if str(organization_slug).isnumeric():
+            if str(organization_slug).isdigit():
                 if int(organization_slug) != group.organization.id:
                     raise ResourceDoesNotExist
             else:

--- a/src/sentry/api/endpoints/shared_group_details.py
+++ b/src/sentry/api/endpoints/shared_group_details.py
@@ -47,7 +47,7 @@ class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
 
         # Checks if the organization_slug (eventually renamed to organization_id_or_slug) matches the group organization's id or slug
         if organization_slug:
-            if organization_slug.isnumeric():
+            if str(organization_slug).isnumeric():
                 if int(organization_slug) != group.organization.id:
                     raise ResourceDoesNotExist
             else:

--- a/src/sentry/api/endpoints/shared_group_details.py
+++ b/src/sentry/api/endpoints/shared_group_details.py
@@ -20,7 +20,10 @@ class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
     permission_classes = ()
 
     def get(
-        self, request: Request, organization_slug: str | None = None, share_id: str | None = None
+        self,
+        request: Request,
+        organization_slug: int | str | None = None,
+        share_id: str | None = None,
     ) -> Response:
         """
         Retrieve an aggregate
@@ -42,8 +45,11 @@ class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
         except Group.DoesNotExist:
             raise ResourceDoesNotExist
 
+        # Checks if the organization_slug (eventually renamed to organization_id_or_slug) matches the group organization's id or slug
         if organization_slug:
-            if organization_slug != group.organization.slug:
+            if organization_slug != group.organization.slug and organization_slug != str(
+                group.organization.id
+            ):
                 raise ResourceDoesNotExist
 
         if group.organization.flags.disable_shared_issues:

--- a/tests/sentry/api/endpoints/test_shared_group_details.py
+++ b/tests/sentry/api/endpoints/test_shared_group_details.py
@@ -15,6 +15,7 @@ class SharedGroupDetailsTest(APITestCase):
         return (
             lambda share_id: f"/api/0/shared/issues/{share_id}/",
             lambda share_id: f"/api/0/organizations/{self.organization.slug}/shared/issues/{share_id}/",
+            lambda share_id: f"/api/0/organizations/{self.organization.id}/shared/issues/{share_id}/",
         )
 
     def test_simple(self):


### PR DESCRIPTION
I cleaned up these two endpoints as I was `organization_slug` to `organization_id_or_slug`. I removed organization_slug from one of the endpoints bc it didn't use it and added an id check for another endpoint.