### PR TITLE
ref(rules): Update apply_rule to enqueue rules with slow conditions

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -161,7 +161,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-spans-new-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-streamed-spans-exp-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
     manager.add("organizations:performance-streamed-spans-exp-visible", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-    manager.add("organizations:process-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+    manager.add("organizations:process-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     manager.add("organizations:performance-trends-issues", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-trends-new-data-date-range-default", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:performance-use-metrics", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -23,6 +23,7 @@ from sentry.rules.conditions.event_frequency import (
 from sentry.rules.processing.processor import (
     activate_downstream_actions,
     bulk_get_rule_status,
+    PROJECT_ID_BUFFER_LIST_KEY,
     is_condition_slow,
     split_conditions_and_filters,
 )
@@ -32,9 +33,6 @@ from sentry.utils import json, metrics
 from sentry.utils.safe import safe_execute
 
 logger = logging.getLogger("sentry.rules.delayed_processing")
-
-
-PROJECT_ID_BUFFER_LIST_KEY = "project_id_buffer_list"
 
 
 class UniqueCondition(NamedTuple):

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -21,9 +21,9 @@ from sentry.rules.conditions.event_frequency import (
     EventFrequencyConditionData,
 )
 from sentry.rules.processing.processor import (
+    PROJECT_ID_BUFFER_LIST_KEY,
     activate_downstream_actions,
     bulk_get_rule_status,
-    PROJECT_ID_BUFFER_LIST_KEY,
     is_condition_slow,
     split_conditions_and_filters,
 )

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -335,16 +335,17 @@ class RuleProcessor:
                 return
 
         predicate_func = get_match_function(condition_match)
+        if not predicate_func:
+            log_string = f"Unsupported condition_match {condition_match} for rule {rule.id}"
+            logger.error(
+                log_string,
+                filter_match,
+                rule.id,
+                extra={**logging_details},
+            )
+            return
+
         if condition_list:
-            if not predicate_func:
-                log_string = f"Unsupported condition_match {condition_match} for rule {rule.id}"
-                logger.error(
-                    log_string,
-                    filter_match,
-                    rule.id,
-                    extra={**logging_details},
-                )
-                return
             predicate_iter = (self.condition_matches(f, state, rule) for f in condition_list)
             result = predicate_func(predicate_iter)
 

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -337,6 +337,7 @@ class RuleProcessor:
         predicate_func = get_match_function(condition_match)
         if condition_list:
             predicate_iter = (self.condition_matches(f, state, rule) for f in condition_list)
+            result = predicate_func(predicate_iter)
             if not predicate_func:
                 log_string = f"Unsupported condition_match {condition_match} for rule {rule.id}"
                 logger.error(
@@ -347,38 +348,21 @@ class RuleProcessor:
                 )
                 return
 
-            if condition_match == "any":  # is there an enum val for this
-                # a fast condition failed and we have no slow conditions to check
-                if not predicate_func(predicate_iter) and not slow_conditions:
-                    return
-                # a fast condition failed and we have slow conditions to enqueue for delayed processing
-                if (
-                    not predicate_func(predicate_iter)
-                    and slow_conditions
-                    and process_slow_conditions_later
-                ):
+            if condition_match == "any" and not result:
+                if slow_conditions and process_slow_conditions_later:
                     self.enqueue_rule(rule)
                     return
-                # no fast conditions to check, but we have slow conditions to enqueue for delayed processing
-                if not predicate_iter and slow_conditions and process_slow_conditions_later:
-                    self.enqueue_rule(rule)
-                    return
+                return
 
             elif condition_match == "all":
-                # return early if the condition(s) failed. There's no point checking the slow conditions in this case, since we already failed.
-                if not predicate_func(predicate_iter):
+                if not result:
                     return
 
-                # all fast conditions passed and we have slow conditions to check
-                if (
-                    predicate_func(predicate_iter)
-                    and slow_conditions
-                    and process_slow_conditions_later
-                ):
+                if slow_conditions and process_slow_conditions_later:
                     self.enqueue_rule(rule)
                     return
 
-        if not condition_list and slow_conditions and process_slow_conditions_later:
+        if slow_conditions and process_slow_conditions_later:
             self.enqueue_rule(rule)
             return
 

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -345,9 +345,11 @@ class RuleProcessor:
             )
             return
 
-        if fast_conditions or slow_conditions:
+        if slow_conditions or fast_conditions:
             predicate_iter = (self.condition_matches(f, state, rule) for f in condition_list)
-            result = predicate_func(predicate_iter)
+            result = False
+            if predicate_func:
+                result = predicate_func(predicate_iter)
 
             if condition_match == "any":
                 if not result and slow_conditions and process_slow_conditions_later:

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -321,7 +321,7 @@ class RuleProcessor:
         if process_slow_conditions_later:
             condition_list = fast_conditions
         else:
-            fast_conditions.extend(slow_conditions)
+            fast_conditions.extend(slow_conditions)  # type: ignore[arg-type]
             condition_list = fast_conditions
 
         for predicate_list, match, name in (

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -346,22 +346,20 @@ class RuleProcessor:
                 )
                 return
             predicate_iter = (self.condition_matches(f, state, rule) for f in condition_list)
-            if predicate_iter:
-                result = predicate_func(predicate_iter)
+            result = predicate_func(predicate_iter)
 
-                if condition_match == "any" and not result:
-                    if slow_conditions and process_slow_conditions_later:
-                        self.enqueue_rule(rule)
-                        return
+            if condition_match == "any" and not result:
+                if slow_conditions and process_slow_conditions_later:
+                    self.enqueue_rule(rule)
+                return
+
+            elif condition_match == "all":
+                if not result:
                     return
 
-                elif condition_match == "all":
-                    if not result:
-                        return
-
-                    if slow_conditions and process_slow_conditions_later:
-                        self.enqueue_rule(rule)
-                        return
+                if slow_conditions and process_slow_conditions_later:
+                    self.enqueue_rule(rule)
+                    return
 
         if slow_conditions and process_slow_conditions_later:
             self.enqueue_rule(rule)

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -333,10 +333,8 @@ class RuleProcessor:
             predicate_iter = (self.condition_matches(f, state, rule) for f in predicate_list)
             predicate_func = get_match_function(match)
             if predicate_func:
-                if not predicate_func(predicate_iter):
-                    if slow_conditions:
-                        # prevent return here if slow_conditions exist, because we have more evaluation to do
-                        continue
+                if not predicate_func(predicate_iter) and not slow_conditions:
+                    # prevent return here if slow_conditions exist, because we have more evaluation to do
                     return
             else:
                 log_string = f"Unsupported {name}_match {match!r} for rule {rule.id}"

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -11,7 +11,7 @@ from sentry import options
 from sentry.buffer.redis import BufferHookEvent, RedisBuffer, redis_buffer_registry
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.rules.processing.delayed_processing import PROJECT_ID_BUFFER_LIST_KEY
+from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -13,8 +13,8 @@ from sentry.rules.processing.delayed_processing import (
     apply_delayed,
     process_delayed_alert_conditions,
 )
-from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, TestCase
 from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
+from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, TestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.utils import json

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -10,11 +10,11 @@ from sentry.eventstore.models import Event
 from sentry.models.project import Project
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.processing.delayed_processing import (
-    PROJECT_ID_BUFFER_LIST_KEY,
     apply_delayed,
     process_delayed_alert_conditions,
 )
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, TestCase
+from sentry.rules.processing.processor import PROJECT_ID_BUFFER_LIST_KEY
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.utils import json

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -113,7 +113,7 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
             assert getattr(rule_fire_history, "notification_uuid", None) is not None
 
     @with_feature("organizations:process-slow-alerts")
-    def test_delayed_rule_match_any_slow_conditions(self):
+    def test_delayed_rule_match_any_slow_conditionss(self):
         """
         Test that a rule with only 'slow' conditions and action match of 'any' gets added to the Redis buffer and does not immediately fire when the 'fast' condition fails to pass
         """
@@ -124,6 +124,7 @@ class RuleProcessorTest(TestCase, PerformanceIssueTestCase):
                 "actions": [EMAIL_ACTION_DATA],
             },
         )
+        self.rule.save()
         rp = RuleProcessor(
             self.group_event,
             is_new=True,

--- a/tests/sentry/rules/processing/test_processor.py
+++ b/tests/sentry/rules/processing/test_processor.py
@@ -139,7 +139,9 @@ class RuleProcessorTest(TestCase):
         assert project_ids[0][0] == self.project.id
         rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": self.project.id})
         assert rulegroup_to_events == {
-            f"{self.rule.id}:{self.group_event.group.id}": self.group_event.event_id
+            f"{self.rule.id}:{self.group_event.group.id}": json.dumps(
+                {"event_id": self.group_event.event_id, "occurrence_id": None}
+            )
         }
 
     @with_feature("organizations:process-slow-alerts")
@@ -177,7 +179,9 @@ class RuleProcessorTest(TestCase):
         assert project_ids[0][0] == self.project.id
         rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": self.project.id})
         assert rulegroup_to_events == {
-            f"{self.rule.id}:{self.group_event.group.id}": self.group_event.event_id
+            f"{self.rule.id}:{self.group_event.group.id}": json.dumps(
+                {"event_id": self.group_event.event_id, "occurrence_id": None}
+            )
         }
 
     @with_feature("organizations:process-slow-alerts")
@@ -214,7 +218,9 @@ class RuleProcessorTest(TestCase):
         assert project_ids[0][0] == self.project.id
         rulegroup_to_events = buffer.get_hash(model=Project, field={"project_id": self.project.id})
         assert rulegroup_to_events == {
-            f"{self.rule.id}:{self.group_event.group.id}": self.group_event.event_id
+            f"{self.rule.id}:{self.group_event.group.id}": json.dumps(
+                {"event_id": self.group_event.event_id, "occurrence_id": None}
+            )
         }
 
     def test_ignored_issue(self):


### PR DESCRIPTION
Update `apply_rule` to add rules with "slow" conditions (aka conditions that query Snuba) to a buffer to be evaluated in a task. If a rule with a slow condition has an `action_match` of "all" it will go to the buffer, and if a rule with an `action_match`" of "any" will go to the buffer if the "fast" conditions have failed.

Closes https://github.com/getsentry/team-core-product-foundations/issues/244