### PR TITLE
feat(metrics): Add examples for each metric type

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets.tsx
@@ -1,0 +1,262 @@
+const JSCounterSnippet = `
+// Increment a counter by one for each button click.
+Sentry.metrics.increment("button_click", 1, {
+  tags: { browser: "Firefox", app_version: "1.0.0" },
+});`;
+
+const JSDistributionSnippet = `
+// Add '15.0' to a distribution
+// used for tracking the loading times of a component.
+Sentry.metrics.distribution("component_load_time", 15.0, {
+  tags: { type: "important" },
+  unit: "millisecond",
+});`;
+
+const JSGaugeSnippet = `
+// Add 34% to a gauge tracking CPU usage.
+Sentry.metrics.gauge("cpu_usage", 34, {
+  tags: { os: "MacOS" },
+  unit: "percent",
+});`;
+
+const JSSetSnippet = `
+// Add 'jane' to a set
+// used for tracking the number of users that viewed a page.
+Sentry.metrics.set("user_view", "jane");`;
+
+const javascript = {
+  counter: JSCounterSnippet,
+  distribution: JSDistributionSnippet,
+  gauge: JSGaugeSnippet,
+  set: JSSetSnippet,
+};
+
+const pythonCounterSnippet = `
+# Increment a counter by one for each button click.
+sentry_sdk.metrics.incr(
+	key="button_click",
+	value=1,
+	tags={
+		"browser": "Firefox",
+		"app_version": "1.0.0"
+	}
+)`;
+
+const pythonDistributionSnippet = `
+# Add '15.0' to a distribution
+# used for tracking the loading times of a component.
+sentry_sdk.metrics.distribution(
+	key="page_load",
+	value=15.0,
+	unit="millisecond",
+	tags={
+		"page": "/home"
+	}
+)`;
+
+const pythonGaugeSnippet = `
+# Add '15.0' to a gauge
+# used for tracking the loading times for a page.
+sentry_sdk.metrics.gauge(
+	key="page_load",
+	value=15.0,
+	unit="millisecond",
+	tags={
+		"page": "/home"
+	}
+)`;
+
+const pythonSetSnippet = `
+# Add 'jane' to a set
+# used for tracking the number of users that viewed a page.
+sentry_sdk.metrics.set(
+	key="user_view",
+	value="jane",
+	unit="username",
+	tags={
+		"page": "/home"
+	}
+)`;
+
+const python = {
+  counter: pythonCounterSnippet,
+  distribution: pythonDistributionSnippet,
+  gauge: pythonGaugeSnippet,
+  set: pythonSetSnippet,
+};
+
+const dotnetCounterSnippet = `
+// Incrementing a counter by one for each button click.
+SentrySdk.Metrics.Increment("ButtonClicked",
+    tags: new Dictionary<string, string> {{ "region", "us-west-1" }});`;
+
+const dotnetDistributionSnippet = `
+// Add '15' to a distribution used to track the loading time.
+SentrySdk.Metrics.Distribution("LoadingTime",
+    15,
+    unit: MeasurementUnit.Duration.Millisecond,
+    tags: new Dictionary<string, string> {{ "region", "us-west-1" }})`;
+
+const dotnetGaugeSnippet = `
+// Adding '15' to a gauge used to track the loading time.
+SentrySdk.Metrics.Gauge("LoadingTime",
+    15,
+    unit: MeasurementUnit.Duration.Millisecond,
+    tags: new Dictionary<string, string> {{ "region", "us-west-1" }});`;
+
+const dotnetSetSnippet = `
+// Adding a set of unique occurrences.
+SentrySdk.Metrics.Set("UserView", "Rufus",
+    unit: MeasurementUnit.Custom("username"),
+    tags: new Dictionary<string, string> {{ "region", "us-west-1" }});
+`;
+
+const dotnet = {
+  counter: dotnetCounterSnippet,
+  distribution: dotnetDistributionSnippet,
+  gauge: dotnetGaugeSnippet,
+  set: dotnetSetSnippet,
+};
+
+const rubyCounterSnippet = `
+# Incrementing a counter by one for each button click.
+Sentry::Metrics.increment('button_click', 1, tags: {
+  browser: 'firefox'
+})`;
+
+const rubyDistributionSnippet = `
+# Add '15' to a distribution used to track the loading time.
+Sentry::Metrics.distribution(
+  'page_load',
+  15.0,
+  unit: 'millisecond',
+  tags: { page: '/home' }
+)`;
+
+const rubyGaugeSnippet = `
+# Add '15.0' to a gauge used for tracking the loading times for a page.
+Sentry::Metrics.gauge('page_load', 15.0, unit: 'millisecond')`;
+
+const rubySetSnippet = `
+# Add 'jane' to a set
+# used for tracking the number of users that viewed a page.
+Sentry::Metrics.set('user_view', 'jane', unit: 'username')`;
+
+const ruby = {
+  counter: rubyCounterSnippet,
+  distribution: rubyDistributionSnippet,
+  gauge: rubyGaugeSnippet,
+  set: rubySetSnippet,
+};
+
+const dartCounterSnippet = `
+// Incrementing a counter by one for each button click.
+Sentry.metrics().increment(
+  'button_login_click', // key
+  value: 1,
+  unit: null,
+  tags: {'provider': 'e-mail'},
+);`;
+
+const dartDistributionSnippet = `
+// Add '15' to a distribution
+// used to track the loading time of an image.
+Sentry.metrics().distribution(
+  'image_download_duration', // key
+  value: 150,
+  unit: DurationSentryMeasurementUnit.milliSecond,
+  tags: {'type': 'thumbnail'},
+);`;
+
+const dartGaugeSnippet = `
+// Add '15.0' to a gauge
+// used for tracking the loading times for a page.
+Sentry.metrics().gauge(
+  'page_load', // key
+  value: 15,
+  unit: DurationSentryMeasurementUnit.milliSecond,
+  tags: {'page': '/home'},
+);`;
+
+const dartSetSnippet = `
+// Add 'jane' to a set
+// used for tracking the number of users that viewed a page.
+Sentry.metrics().set(
+  'user_view', // key
+  stringValue: 'jane',
+  unit: CustomSentryMeasurementUnit('username'),
+  tags: {'page': 'home'},
+);`;
+
+const dart = {
+  counter: dartCounterSnippet,
+  distribution: dartDistributionSnippet,
+  gauge: dartGaugeSnippet,
+  set: dartSetSnippet,
+};
+
+const phpCounterSnippet = `
+// Increment a counter by one for each button click.
+\\Sentry\\metrics()->increment(
+    key: 'button_click',
+    value: 1,
+    tags: [
+        'browser' => 'Firefox',
+        'app_version' => '1.0.0',
+    ],
+)`;
+
+const phpDistributionSnippet = `
+// Add '15.0' to a distribution
+// used for tracking the loading times per page.
+\\Sentry\\metrics()->distribution(
+    key: 'page_load',
+    value: 15.0,
+    unit: \\Sentry\\Metrics\\MetricsUnit::millisecond(),
+    tags: [
+        'page' => '/home',
+    ],
+)`;
+
+const phpGaugeSnippet = `
+// Add '15.0' to a gauge
+// used for tracking the loading times for a page.
+\\Sentry\\metrics()->gauge(
+    key: 'page_load',
+    value: 15.0,
+    unit: \\Sentry\\Metrics\\MetricsUnit::millisecond(),
+    tags: [
+        'page' => '/home',
+    ],
+)`;
+
+const phpSetSnippet = `
+// Add 'jane' to a set
+// used for tracking the number of users that viewed a page.
+\\Sentry\\metrics()->set(
+    key: 'user_view',
+    value: 'jane',
+    unit: \\Sentry\\Metrics\\MetricsUnit::custom('username'),
+    tags: [
+        'page' => '/home',
+    ],
+)
+`;
+
+const php = {
+  counter: phpCounterSnippet,
+  distribution: phpDistributionSnippet,
+  gauge: phpGaugeSnippet,
+  set: phpSetSnippet,
+};
+
+const exampleSnippets = {
+  dart,
+  dotnet,
+  javascript,
+  php,
+  python,
+  ruby,
+};
+
+export default exampleSnippets;

--- a/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
@@ -279,28 +279,89 @@ const getJvmPropertiesConfigureSnippet = (_: DocsParams) => `
 sentry.enable-metrics=true`;
 
 const getJvmJavaVerifySnippet = () => `
-// Incrementing a counter by one for each button click.
 final Map<String, String> tags = new HashMap<>();
-tags.put("provider", "e-mail");
+tags.put("app-version", "1.0.0");
 
+// Incrementing a counter by one for each button click.
 Sentry.metrics().increment(
     "button_login_click", // key
     1.0,                  // value
     null,                 // unit
     tags                  // tags
-);`;
+);
+
+// Add '150' to a distribution
+// used to track the loading time of an image.
+Sentry.metrics().distribution(
+  "image_download_duration",
+  150.0,
+  MeasurementUnit.Duration.MILLISECOND,
+  tags
+);
+
+// Add '15.0' to a gauge
+// used for tracking the loading times for a page.
+Sentry.metrics().gauge(
+  "page_load",
+  15.0,
+  MeasurementUnit.Duration.MILLISECOND,
+  tags
+);
+
+// Add 'jane' to a set
+// used for tracking the number of users that viewed a page.
+Sentry.metrics().set(
+  "user_view",
+  "jane",
+  new MeasurementUnit.Custom("username"),
+  tags
+);
+
+`;
 
 const getJvmKotlinVerifySnippet = () => `
 // Incrementing a counter by one for each button click.
-Sentry.metrics()
-    .increment(
-        "button_login_click", // key
-        1.0,                  // value
-        null,                 // unit
-        mapOf(                // tags
-            "provider" to "e-mail"
-        )
-    )`;
+Sentry.metrics().increment(
+    "button_login_click", // key
+    1.0,                  // value
+    null,                 // unit
+    mapOf(                // tags
+        "provider" to "e-mail"
+    )
+)
+
+// Add '150' to a distribution
+// used to track the loading time of an image.
+Sentry.metrics().distribution(
+  "image_download_duration",
+  150.0,
+  MeasurementUnit.Duration.MILLISECOND,
+  mapOf(
+      "type" to "thumbnail"
+  )
+)
+
+// Add '15.0' to a gauge
+// used for tracking the loading times for a page.
+Sentry.metrics().gauge(
+  "page_load",
+  15.0,
+  MeasurementUnit.Duration.MILLISECOND,
+  mapOf(
+      "page" to "/home"
+  )
+)
+
+// Add 'jane' to a set
+// used for tracking the number of users that viewed a page.
+Sentry.metrics().set(
+  "user_view",
+  "jane",
+  MeasurementUnit.Custom("username"),
+  mapOf(
+      "page" to "home"
+  )
+)`;
 
 export const getAndroidMetricsOnboarding = (): OnboardingConfig => ({
   install: (params: DocsParams) => [

--- a/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
@@ -6,6 +6,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import exampleSnippets from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets';
 import {t, tct} from 'sentry/locale';
 import {getInstallConfig as getNodeInstallConfig} from 'sentry/utils/gettingStartedDocs/node';
 
@@ -17,9 +18,34 @@ Sentry.init({
   ],
 });`;
 
-const getJSVerifySnippet = () => `
-// Add 4 to a counter named 'hits'
-Sentry.metrics.increment('hits', 4);`;
+const JSExampleConfig = {
+  code: [
+    {
+      label: 'Counter',
+      value: 'counter',
+      language: 'javascript',
+      code: exampleSnippets.javascript.counter,
+    },
+    {
+      label: 'Distribution',
+      value: 'distribution',
+      language: 'javascript',
+      code: exampleSnippets.javascript.distribution,
+    },
+    {
+      label: 'Set',
+      value: 'set',
+      language: 'javascript',
+      code: exampleSnippets.javascript.set,
+    },
+    {
+      label: 'Gauge',
+      value: 'gauge',
+      language: 'javascript',
+      code: exampleSnippets.javascript.gauge,
+    },
+  ],
+};
 
 export const getJSMetricsOnboarding = ({
   getInstallConfig,
@@ -83,8 +109,8 @@ const getJSMetricsOnboardingConfigure = (params: DocsParams) => [
       {
         code: [
           {
-            label: 'JavaScript',
-            value: 'javascript',
+            label: 'Counter',
+            value: 'counter',
             language: 'javascript',
             code: getJSConfigureSnippet(params),
           },
@@ -108,16 +134,7 @@ const getJSMetricsOnboardingVerify = ({docsLink}: {docsLink: string}) => [
       }
     ),
     configurations: [
-      {
-        code: [
-          {
-            label: 'JavaScript',
-            value: 'javascript',
-            language: 'javascript',
-            code: getJSVerifySnippet(),
-          },
-        ],
-      },
+      JSExampleConfig,
       {
         description: t(
           'With a bit of delay you can see the data appear in the Sentry UI.'
@@ -197,16 +214,7 @@ export const getJSServerMetricsOnboarding = (): OnboardingConfig => ({
         }
       ),
       configurations: [
-        {
-          code: [
-            {
-              label: 'JavaScript',
-              value: 'javascript',
-              language: 'javascript',
-              code: getJSVerifySnippet(),
-            },
-          ],
-        },
+        JSExampleConfig,
         {
           description: t(
             'With a bit of delay you can see the data appear in the Sentry UI.'
@@ -271,12 +279,28 @@ const getJvmPropertiesConfigureSnippet = (_: DocsParams) => `
 sentry.enable-metrics=true`;
 
 const getJvmJavaVerifySnippet = () => `
-// Add 4 to a counter named "hits"
-Sentry.metrics().increment("hits", 4);`;
+// Incrementing a counter by one for each button click.
+final Map<String, String> tags = new HashMap<>();
+tags.put("provider", "e-mail");
+
+Sentry.metrics().increment(
+    "button_login_click", // key
+    1.0,                  // value
+    null,                 // unit
+    tags                  // tags
+);`;
 
 const getJvmKotlinVerifySnippet = () => `
-// Add 4 to a counter named "hits"
-Sentry.metrics().increment("hits", 4)`;
+// Incrementing a counter by one for each button click.
+Sentry.metrics()
+    .increment(
+        "button_login_click", // key
+        1.0,                  // value
+        null,                 // unit
+        mapOf(                // tags
+            "provider" to "e-mail"
+        )
+    )`;
 
 export const getAndroidMetricsOnboarding = (): OnboardingConfig => ({
   install: (params: DocsParams) => [
@@ -482,10 +506,6 @@ sentry_sdk.init(
   # ...
 )`;
 
-const getPythonVerifySnippet = () => `
-# Increment a metric to see how it works
-sentry_sdk.metrics.incr("drank-drinks", 1, tags={"kind": "coffee"})`;
-
 export const getPythonMetricsOnboarding = ({
   installSnippet,
 }: {
@@ -546,10 +566,28 @@ export const getPythonMetricsOnboarding = ({
         {
           code: [
             {
-              label: 'Python',
-              value: 'python',
+              label: 'Counter',
+              value: 'counter',
               language: 'python',
-              code: getPythonVerifySnippet(),
+              code: exampleSnippets.python.counter,
+            },
+            {
+              label: 'Distribution',
+              value: 'distribution',
+              language: 'python',
+              code: exampleSnippets.python.distribution,
+            },
+            {
+              label: 'Set',
+              value: 'set',
+              language: 'python',
+              code: exampleSnippets.python.set,
+            },
+            {
+              label: 'Gauge',
+              value: 'gauge',
+              language: 'python',
+              code: exampleSnippets.python.gauge,
             },
           ],
         },
@@ -582,12 +620,6 @@ SentrySdk.Init(options =>
     EnableCodeLocations = true
   };
 });`;
-
-const getDotnetVerifySnippet = () => `
-SentrySdk.Metrics.Increment(
-  "drank-drinks",
-  tags:new Dictionary<string, string> {{"kind", "coffee"}}
-);`;
 
 export const getDotnetMetricsOnboarding = ({
   packageName,
@@ -640,8 +672,32 @@ export const getDotnetMetricsOnboarding = ({
       ),
       configurations: [
         {
-          language: 'csharp',
-          code: getDotnetVerifySnippet(),
+          code: [
+            {
+              label: 'Counter',
+              value: 'counter',
+              language: 'csharp',
+              code: exampleSnippets.dotnet.counter,
+            },
+            {
+              label: 'Distribution',
+              value: 'distribution',
+              language: 'csharp',
+              code: exampleSnippets.dotnet.distribution,
+            },
+            {
+              label: 'Set',
+              value: 'set',
+              language: 'csharp',
+              code: exampleSnippets.dotnet.set,
+            },
+            {
+              label: 'Gauge',
+              value: 'gauge',
+              language: 'csharp',
+              code: exampleSnippets.dotnet.gauge,
+            },
+          ],
         },
         {
           description: t(
@@ -668,10 +724,6 @@ Sentry.init do |config|
   # ...
   config.metrics.enabled = true
 end`;
-
-const getRubyVerifySnippet = () => `
-# Increment a metric to see how it works
-Sentry::Metrics.increment("drank-drinks", 1, tags: { kind: "coffee" })`;
 
 export const getRubyMetricsOnboarding = (): OnboardingConfig => ({
   install: () => [
@@ -730,10 +782,28 @@ export const getRubyMetricsOnboarding = (): OnboardingConfig => ({
         {
           code: [
             {
-              label: 'Ruby',
-              value: 'ruby',
+              label: 'Counter',
+              value: 'counter',
               language: 'ruby',
-              code: getRubyVerifySnippet(),
+              code: exampleSnippets.ruby.counter,
+            },
+            {
+              label: 'Distribution',
+              value: 'distribution',
+              language: 'ruby',
+              code: exampleSnippets.ruby.distribution,
+            },
+            {
+              label: 'Set',
+              value: 'set',
+              language: 'ruby',
+              code: exampleSnippets.ruby.set,
+            },
+            {
+              label: 'Gauge',
+              value: 'gauge',
+              language: 'ruby',
+              code: exampleSnippets.ruby.gauge,
             },
           ],
         },

--- a/static/app/gettingStartedDocs/apple/apple-ios.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-ios.tsx
@@ -70,6 +70,31 @@ SentrySDK.metrics
     .increment(key: "button_login_click",
                value: 1.0,
                tags: ["screen": "login"]
+    )
+
+// Add '150' to a distribution used to track the loading time.
+SentrySDK.metrics
+    .distribution(key: "image_download_duration",
+                value: 150.0,
+                unit: MeasurementUnitDuration.millisecond,
+                tags: ["screen": "login"]
+    )
+
+// Adding '1' to a gauge used to track the loading time.
+SentrySDK.metrics
+    .gauge(key: "page_load",
+          value: 1.0,
+          unit: MeasurementUnitDuration.millisecond,
+          tags: ["screen": "login"]
+    )
+
+// Add 'jane' to a set
+// used for tracking the number of users that viewed a page.
+SentrySDK.metrics
+    .set(key: "user_view",
+          value: "jane",
+          unit: MeasurementUnit(unit: "username"),
+          tags: ["screen": "login"]
     )`;
 
 const getVerifyMetricsSnippetObjC = () => `
@@ -81,6 +106,31 @@ const getVerifyMetricsSnippetObjC = () => `
     value: 1.0
     unit: SentryMeasurementUnit.none
     tags: @{ @"screen" : @"login" }
+];
+
+// Add '150' to a distribution used to track the loading time.
+[SentrySDK.metrics
+    distributionWithKey: @"image_download_duration"
+    value: 150.0
+    unit: SentryMeasurementUnitDuration.millisecond
+    tags: @{ @"screen" : @"login" }
+];
+
+// Adding '1' to a gauge used to track the loading time.
+[SentrySDK.metrics
+    gaugeWithKey: @"page_load"
+    value: 1.0
+    unit: SentryMeasurementUnitDuration.millisecond
+    tags: @{ @"screen" : @"login" }
+];
+
+// Add 'jane' to a set
+// used for tracking the number of users that viewed a page.
+[SentrySDK.metrics
+  setWithKey :@"user_view"
+  value: @"jane"
+  unit: [[SentryMeasurementUnit alloc] initWithUnit:@"username"]
+  tags: @{ @"screen" : @"login" }
 ];`;
 
 const onboarding: OnboardingConfig = {

--- a/static/app/gettingStartedDocs/apple/apple-ios.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-ios.tsx
@@ -65,6 +65,7 @@ const getConfigureMetricsSnippetObjC = (params: Params) => `
 const getVerifyMetricsSnippetSwift = () => `
 import Sentry
 
+// Incrementing a counter by one for each button click.
 SentrySDK.metrics
     .increment(key: "button_login_click",
                value: 1.0,
@@ -74,6 +75,7 @@ SentrySDK.metrics
 const getVerifyMetricsSnippetObjC = () => `
 @import Sentry;
 
+// Incrementing a counter by one for each button click.
 [SentrySDK.metrics
     incrementWithKey :@"button_login_click"
     value: 1.0

--- a/static/app/gettingStartedDocs/bun/bun.tsx
+++ b/static/app/gettingStartedDocs/bun/bun.tsx
@@ -11,6 +11,7 @@ import {
   getCrashReportModalConfigDescription,
   getCrashReportModalIntroduction,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+import exampleSnippets from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
@@ -50,10 +51,6 @@ Sentry.init({
     metricsAggregator: true,
   },
 });`;
-
-const getMetricsVerifySnippet = () => `
-// Add 4 to a counter named 'hits'
-Sentry.metrics.increment('hits', 4);`;
 
 const onboarding: OnboardingConfig = {
   install: () => [
@@ -163,10 +160,28 @@ const customMetricsOnboarding: OnboardingConfig = {
         {
           code: [
             {
-              label: 'JavaScript',
-              value: 'javascript',
+              label: 'Counter',
+              value: 'counter',
               language: 'javascript',
-              code: getMetricsVerifySnippet(),
+              code: exampleSnippets.javascript.counter,
+            },
+            {
+              label: 'Distribution',
+              value: 'distribution',
+              language: 'javascript',
+              code: exampleSnippets.javascript.distribution,
+            },
+            {
+              label: 'Set',
+              value: 'set',
+              language: 'javascript',
+              code: exampleSnippets.javascript.set,
+            },
+            {
+              label: 'Gauge',
+              value: 'gauge',
+              language: 'javascript',
+              code: exampleSnippets.javascript.gauge,
             },
           ],
         },

--- a/static/app/gettingStartedDocs/dart/dart.tsx
+++ b/static/app/gettingStartedDocs/dart/dart.tsx
@@ -10,6 +10,7 @@ import {
   getCrashReportApiIntroduction,
   getCrashReportInstallDescription,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+import exampleSnippets from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -144,12 +145,28 @@ const metricsOnboarding: OnboardingConfig = {
             {
               code: [
                 {
-                  label: 'Dart',
-                  value: 'dart',
+                  label: 'Counter',
+                  value: 'counter',
                   language: 'dart',
-                  code: `
-// Add 4 to a counter named "hits"
-Sentry.metrics().increment("hits", value: 4);`,
+                  code: exampleSnippets.dart.counter,
+                },
+                {
+                  label: 'Distribution',
+                  value: 'distribution',
+                  language: 'dart',
+                  code: exampleSnippets.dart.distribution,
+                },
+                {
+                  label: 'Set',
+                  value: 'set',
+                  language: 'dart',
+                  code: exampleSnippets.dart.set,
+                },
+                {
+                  label: 'Gauge',
+                  value: 'gauge',
+                  language: 'dart',
+                  code: exampleSnippets.dart.gauge,
                 },
               ],
             },

--- a/static/app/gettingStartedDocs/electron/electron.tsx
+++ b/static/app/gettingStartedDocs/electron/electron.tsx
@@ -16,6 +16,7 @@ import {
   getFeedbackConfigureDescription,
   getFeedbackSDKSetupSnippet,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+import exampleSnippets from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets';
 import {
   getReplayConfigureDescription,
   getReplaySDKSetupSnippet,
@@ -41,10 +42,6 @@ Sentry.init({
     metricsAggregator: true,
   },
 });`;
-
-const getMetricsVerifySnippet = () => `
-// Add 4 to a counter named 'hits'
-Sentry.metrics.increment('hits', 4);`;
 
 const getInstallConfig = () => [
   {
@@ -228,10 +225,28 @@ const customMetricsOnboarding: OnboardingConfig = {
         {
           code: [
             {
-              label: 'JavaScript',
-              value: 'javascript',
+              label: 'Counter',
+              value: 'counter',
               language: 'javascript',
-              code: getMetricsVerifySnippet(),
+              code: exampleSnippets.javascript.counter,
+            },
+            {
+              label: 'Distribution',
+              value: 'distribution',
+              language: 'javascript',
+              code: exampleSnippets.javascript.distribution,
+            },
+            {
+              label: 'Set',
+              value: 'set',
+              language: 'javascript',
+              code: exampleSnippets.javascript.set,
+            },
+            {
+              label: 'Gauge',
+              value: 'gauge',
+              language: 'javascript',
+              code: exampleSnippets.javascript.gauge,
             },
           ],
         },

--- a/static/app/gettingStartedDocs/flutter/flutter.tsx
+++ b/static/app/gettingStartedDocs/flutter/flutter.tsx
@@ -6,6 +6,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import exampleSnippets from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets';
 import {feedbackOnboardingCrashApiDart} from 'sentry/gettingStartedDocs/dart/dart';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
@@ -159,12 +160,28 @@ const metricsOnboarding: OnboardingConfig = {
             {
               code: [
                 {
-                  label: 'Dart',
-                  value: 'dart',
+                  label: 'Counter',
+                  value: 'counter',
                   language: 'dart',
-                  code: `
-// Add 4 to a counter named "hits"
-Sentry.metrics().increment("hits", value: 4);`,
+                  code: exampleSnippets.dart.counter,
+                },
+                {
+                  label: 'Distribution',
+                  value: 'distribution',
+                  language: 'dart',
+                  code: exampleSnippets.dart.distribution,
+                },
+                {
+                  label: 'Set',
+                  value: 'set',
+                  language: 'dart',
+                  code: exampleSnippets.dart.set,
+                },
+                {
+                  label: 'Gauge',
+                  value: 'gauge',
+                  language: 'dart',
+                  code: exampleSnippets.dart.gauge,
                 },
               ],
             },

--- a/static/app/gettingStartedDocs/php/laravel.tsx
+++ b/static/app/gettingStartedDocs/php/laravel.tsx
@@ -10,6 +10,7 @@ import {
   getCrashReportModalIntroduction,
   getCrashReportSDKInstallFirstStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+import exampleSnippets from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
@@ -55,13 +56,6 @@ const getMetricsInstallSnippet = () => `
 composer install sentry/sentry-laravel
 
 composer update sentry/sentry-laravel -W`;
-
-const getMetricsVerifySnippet = () => `
-use function \\Sentry\\metrics;
-
-// Add 4 to a counter named 'hits'
-metrics()->increment('hits', 4);
-`;
 
 const onboarding: OnboardingConfig = {
   introduction: () =>
@@ -218,10 +212,28 @@ const customMetricsOnboarding: OnboardingConfig = {
         {
           code: [
             {
-              label: 'PHP',
-              value: 'php',
+              label: 'Counter',
+              value: 'counter',
               language: 'php',
-              code: getMetricsVerifySnippet(),
+              code: exampleSnippets.php.counter,
+            },
+            {
+              label: 'Distribution',
+              value: 'distribution',
+              language: 'php',
+              code: exampleSnippets.php.distribution,
+            },
+            {
+              label: 'Set',
+              value: 'set',
+              language: 'php',
+              code: exampleSnippets.php.set,
+            },
+            {
+              label: 'Gauge',
+              value: 'gauge',
+              language: 'php',
+              code: exampleSnippets.php.gauge,
             },
           ],
         },

--- a/static/app/gettingStartedDocs/php/php.tsx
+++ b/static/app/gettingStartedDocs/php/php.tsx
@@ -10,6 +10,7 @@ import {
   getCrashReportModalIntroduction,
   getCrashReportPHPInstallStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+import exampleSnippets from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
@@ -44,16 +45,6 @@ try {
 } catch (\\Throwable $exception) {
   \\Sentry\\captureException($exception);
 }`;
-
-const getMetricsVerifySnippet = () => `
-use function \\Sentry\\metrics;
-
-// Add 4 to a counter named 'hits'
-metrics()->increment('hits', 4);
-metrics()->flush();
-
-// We recommend registering the flushing in a shutdownhandler
-register_shutdown_function(static fn () => metrics()->flush());`;
 
 const onboarding: OnboardingConfig = {
   install: params => [
@@ -190,10 +181,28 @@ const customMetricsOnboarding: OnboardingConfig = {
         {
           code: [
             {
-              label: 'PHP',
-              value: 'php',
+              label: 'Counter',
+              value: 'counter',
               language: 'php',
-              code: getMetricsVerifySnippet(),
+              code: exampleSnippets.php.counter,
+            },
+            {
+              label: 'Distribution',
+              value: 'distribution',
+              language: 'php',
+              code: exampleSnippets.php.distribution,
+            },
+            {
+              label: 'Set',
+              value: 'set',
+              language: 'php',
+              code: exampleSnippets.php.set,
+            },
+            {
+              label: 'Gauge',
+              value: 'gauge',
+              language: 'php',
+              code: exampleSnippets.php.gauge,
             },
           ],
         },

--- a/static/app/gettingStartedDocs/unity/unity.tsx
+++ b/static/app/gettingStartedDocs/unity/unity.tsx
@@ -12,6 +12,7 @@ import {
   getCrashReportApiIntroduction,
   getCrashReportInstallDescription,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
+import exampleSnippets from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsExampleSnippets';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -28,12 +29,6 @@ public override void Configure(SentryUnityOptions options)
       EnableCodeLocations = true
     };
 }`;
-
-const getMetricsVerifySnippet = () => `
-SentrySdk.Metrics.Increment(
-  "drank-drinks",
-  tags:new Dictionary<string, string> {{"kind", "coffee"}}
-);`;
 
 const onboarding: OnboardingConfig = {
   install: params => [
@@ -213,8 +208,32 @@ const metricsOnboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          language: 'csharp',
-          code: getMetricsVerifySnippet(),
+          code: [
+            {
+              label: 'Counter',
+              value: 'counter',
+              language: 'csharp',
+              code: exampleSnippets.dotnet.counter,
+            },
+            {
+              label: 'Distribution',
+              value: 'distribution',
+              language: 'csharp',
+              code: exampleSnippets.dotnet.distribution,
+            },
+            {
+              label: 'Set',
+              value: 'set',
+              language: 'csharp',
+              code: exampleSnippets.dotnet.set,
+            },
+            {
+              label: 'Gauge',
+              value: 'gauge',
+              language: 'csharp',
+              code: exampleSnippets.dotnet.gauge,
+            },
+          ],
         },
         {
           description: t(


### PR DESCRIPTION
Display examples for each metric type in the onboarding docs.

https://github.com/getsentry/sentry/assets/7033940/596bd5e2-b2d9-4299-a359-ee355c354052

Platforms not handled in this PR:
- Rust as examples are missing in docs.

Closes https://github.com/getsentry/sentry/issues/69953