### PR TITLE
fix(trace): fix wheel delta for mouse

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -17,6 +17,14 @@ function easeOutSine(x: number): number {
   return Math.sin((x * Math.PI) / 2);
 }
 
+function getHorizontalDelta(x: number, y: number): number {
+  if (x >= 0 && y >= 0) {
+    return Math.max(x, y);
+  }
+
+  return Math.min(x, y);
+}
+
 type ViewColumn = {
   column_nodes: TraceTreeNode<TraceTree.NodeValue>[];
   column_refs: (HTMLElement | undefined)[];
@@ -510,7 +518,10 @@ export class VirtualizedViewManager {
       this.enqueueOnWheelEndRaf();
 
       // Holding shift key allows for horizontal scrolling
-      const distance = event.shiftKey ? event.deltaY : event.deltaX;
+      const distance = event.shiftKey
+        ? getHorizontalDelta(event.deltaX, event.deltaY)
+        : event.deltaX;
+
       if (
         event.shiftKey ||
         (!event.shiftKey && Math.abs(event.deltaX) > Math.abs(event.deltaY))


### PR DESCRIPTION
Holding shiftkey causes deltaY to be reported as deltaX when using a mouse, meaning we were always reading 0 value...