### PR TITLE
fix(perf): Fix incorrect usage of `ModuleName.HTTP`

### DIFF
--- a/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
@@ -122,7 +122,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
         <DescriptionWrapper>
           <ResourceIcon fileExtension={fileExtension} spanOp={row[SPAN_OP]} />
           <SpanDescriptionCell
-            moduleName={ModuleName.HTTP}
+            moduleName={ModuleName.RESOURCE}
             projectId={row[PROJECT_ID]}
             spanOp={row[SPAN_OP]}
             description={row[SPAN_DESCRIPTION]}

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -587,7 +587,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
               const isQueriesWidget =
                 props.chartSetting ===
                 PerformanceWidgetSetting.MOST_TIME_SPENT_DB_QUERIES;
-              const moduleName = isQueriesWidget ? ModuleName.DB : ModuleName.HTTP;
+              const moduleName = isQueriesWidget ? ModuleName.DB : ModuleName.RESOURCE;
               const timeSpentOp = isQueriesWidget ? 'op' : undefined;
               const routingContextBaseURL = isQueriesWidget
                 ? '/performance/database'

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -72,7 +72,7 @@ export function SpanDescriptionCell({
     );
   }
 
-  if (moduleName === ModuleName.HTTP) {
+  if (moduleName === ModuleName.RESOURCE) {
     return (
       <WiderHovercard
         position="right"


### PR DESCRIPTION
The `HTTP` module is for _requests_, like `http.client`. The `RESOURCE` module is for resources like `resource.js`. In a few places, we were using the `HTTP` module where it should have been `RESOURCE`
