### PR TITLE
feat(ds): Show investigation bias

### DIFF
--- a/static/app/components/dynamicSampling/investigationRule.spec.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.spec.tsx
@@ -83,33 +83,6 @@ describe('InvestigationRule', function () {
     expect(buttons).toHaveLength(0);
   }
 
-  it('does not render when feature not enabled', async function () {
-    initComponentEnvironment({hasFeature: false, hasRule: false});
-
-    render(
-      <InvestigationRuleCreation buttonProps={{}} eventView={eventView} numSamples={1} />
-    );
-    await expectNotToRender();
-    // check we didn't call the endpoint to check if a rule exists for no reason
-    expect(getRuleMock).toHaveBeenCalledTimes(0);
-  });
-
-  it('does not render when enough samples are present', async function () {
-    initComponentEnvironment({hasFeature: true, hasRule: false});
-
-    render(
-      <InvestigationRuleCreation
-        buttonProps={{}}
-        eventView={eventView}
-        numSamples={10} // enough samples not to render the InvestigationRule component
-      />,
-      {organization}
-    );
-    await expectNotToRender();
-    // check we didn't call the endpoint to check if a rule exists for no reason
-    expect(getRuleMock).toHaveBeenCalledTimes(0);
-  });
-
   it('shows a button when not enough samples are present and there is no rule', async function () {
     initComponentEnvironment({hasFeature: true, hasRule: false});
     render(

--- a/static/app/components/dynamicSampling/investigationRule.spec.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.spec.tsx
@@ -36,9 +36,8 @@ describe('InvestigationRule', function () {
     };
   }
 
-  function initComponentEnvironment({hasFeature, hasRule}) {
-    const features = hasFeature ? ['investigation-bias'] : [];
-    initialize({organization: {features}});
+  function initComponentEnvironment({hasRule}) {
+    initialize();
 
     if (hasRule) {
       getRuleMock = MockApiClient.addMockResponse({
@@ -83,8 +82,8 @@ describe('InvestigationRule', function () {
     expect(buttons).toHaveLength(0);
   }
 
-  it('shows a button when not enough samples are present and there is no rule', async function () {
-    initComponentEnvironment({hasFeature: true, hasRule: false});
+  it('shows a button when there is no rule', async function () {
+    initComponentEnvironment({hasRule: false});
     render(
       <InvestigationRuleCreation buttonProps={{}} eventView={eventView} numSamples={1} />,
       {organization}
@@ -100,8 +99,8 @@ describe('InvestigationRule', function () {
     expect(getRuleMock).toHaveBeenCalledTimes(1);
   });
 
-  it('shows a label when not enough samples are present and there is a rule', async function () {
-    initComponentEnvironment({hasFeature: true, hasRule: true});
+  it('shows a label when there is a rule', async function () {
+    initComponentEnvironment({hasRule: true});
     render(
       <InvestigationRuleCreation buttonProps={{}} eventView={eventView} numSamples={1} />,
       {organization}
@@ -118,7 +117,7 @@ describe('InvestigationRule', function () {
   });
 
   it('does render disabled when the rule is not a transaction rule', async function () {
-    initComponentEnvironment({hasFeature: true, hasRule: false});
+    initComponentEnvironment({hasRule: false});
     const getRule = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
       method: 'GET',
@@ -144,7 +143,7 @@ describe('InvestigationRule', function () {
   });
 
   it('does not render when there is an unknown error but shows an error', async function () {
-    initComponentEnvironment({hasFeature: true, hasRule: false});
+    initComponentEnvironment({hasRule: false});
     const getRule = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
       method: 'GET',
@@ -163,7 +162,7 @@ describe('InvestigationRule', function () {
   });
 
   it('should create a new rule when clicking on the button and update the UI', async function () {
-    initComponentEnvironment({hasFeature: true, hasRule: false});
+    initComponentEnvironment({hasRule: false});
     const createRule = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
       method: 'POST',
@@ -204,7 +203,7 @@ describe('InvestigationRule', function () {
   });
 
   it('should show an error when creating a new rule fails', async function () {
-    initComponentEnvironment({hasFeature: true, hasRule: false});
+    initComponentEnvironment({hasRule: false});
     const createRule = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
       method: 'POST',
@@ -232,7 +231,7 @@ describe('InvestigationRule', function () {
   });
 
   it('should show notify the user when too many rules have been created', async function () {
-    initComponentEnvironment({hasFeature: true, hasRule: false});
+    initComponentEnvironment({hasRule: false});
     const createRule = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
       method: 'POST',

--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import moment from 'moment';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import Feature from 'sentry/components/acl/feature';
 import type {BaseButtonProps} from 'sentry/components/button';
 import {Button} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -81,16 +80,12 @@ function hasTooFewSamples(numSamples: number | null | undefined) {
 function useGetExistingRule(
   query: string,
   projects: number[],
-  organization: Organization,
-  numSamples: number | null | undefined
+  organization: Organization
 ) {
-  const enabled = hasTooFewSamples(numSamples);
-
   const result = useApiQuery<CustomDynamicSamplingRule | '' | null>(
     makeRuleExistsQueryKey(query, projects, organization),
     {
       staleTime: 0,
-      enabled,
       // No retries for 4XX errors.
       // This makes the error feedback a lot faster, and there is no unnecessary network traffic.
       retry: (failureCount, error) => {
@@ -204,10 +199,11 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
     isLoading,
     isError,
     error,
-  } = useGetExistingRule(query, projects, organization, props.numSamples);
+  } = useGetExistingRule(query, projects, organization);
 
   const isTransactionQueryMissing = checkIsTransactionQueryMissing(error);
   const isBreakingRequestError = isError && !isTransactionQueryMissing;
+  const isLikelyMoreNeeded = hasTooFewSamples(props.numSamples);
 
   useEffect(() => {
     if (isBreakingRequestError) {
@@ -215,11 +211,6 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
     }
   }, [isBreakingRequestError]);
 
-  if (!hasTooFewSamples(props.numSamples)) {
-    // no results yet (we can't take a decision) or enough results,
-    // we don't need investigation rule UI
-    return null;
-  }
   if (isLoading) {
     return null;
   }
@@ -283,7 +274,7 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
       }
     >
       <Button
-        priority="primary"
+        priority={isLikelyMoreNeeded ? 'primary' : 'default'}
         {...props.buttonProps}
         disabled={isTransactionQueryMissing}
         onClick={() => createInvestigationRule({organization, period, projects, query})}
@@ -302,11 +293,7 @@ export function InvestigationRuleCreation(props: Props) {
     return null;
   }
 
-  return (
-    <Feature features="investigation-bias">
-      <InvestigationRuleCreationInternal {...props} organization={organization} />
-    </Feature>
-  );
+  return <InvestigationRuleCreationInternal {...props} organization={organization} />;
 }
 
 const StyledIconQuestion = styled(IconQuestion)`

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -57,6 +57,10 @@ describe('Discover > Homepage', () => {
       url: '/organizations/org-slug/releases/stats/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
+      body: '',
+    });
     mockHomepage = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/discover/homepage/',
       method: 'GET',

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
@@ -134,6 +134,10 @@ describe('Transaction Summary Content', function () {
       url: `/projects/org-slug/project-slug/profiling/functions/`,
       body: {functions: []},
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
+      body: '',
+    });
   });
 
   afterEach(function () {


### PR DESCRIPTION
This PR changes the behavior of the "Get Samples" button. The button will now be displayed at all times, regardless of the number of samples available. However, dynamic sampling still needs to be active, with the server-side sampling rate below 100%.