### PR TITLE
fix(sdk): Fix FE transaction durations

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -117,6 +117,15 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
           partialDesc => !span.description?.includes(partialDesc)
         );
       });
+
+      // If we removed any spans at the end above, the end timestamp needs to be adjusted again.
+      if (event.spans) {
+        const newEndTimestamp = Math.max(
+          ...event.spans.map(span => span.endTimestamp ?? 0)
+        );
+        event.timestamp = newEndTimestamp;
+      }
+
       if (event.transaction) {
         event.transaction = normalizeUrl(event.transaction, {forceCustomerDomain: true});
       }


### PR DESCRIPTION
### Summary
Our transaction durations, particularly for our navigation transactions, aren't correct on the frontend. Our transactions contained some junk / ignored analytics spans which were removed in beforeSend but we hadn't readjusted the transaction end afterwards. This should be built into the sdk (the ability to ignore spans as a hook) which would let us delete this code, but for now we can get better durations for navigations etc.

#### Other
- Longer form explanation of the problem / suggested fix https://github.com/getsentry/sentry-javascript/issues/8041