### PR TITLE
ref: use `decoding=None` for `OAuth1` to ensure correct header types

### DIFF
--- a/src/sentry/integrations/bitbucket_server/client.py
+++ b/src/sentry/integrations/bitbucket_server/client.py
@@ -76,6 +76,7 @@ class BitbucketServerSetupClient(ApiClient):
             rsa_key=self.private_key,
             signature_method=SIGNATURE_RSA,
             signature_type="auth_header",
+            decoding=None,
         )
         url = self.access_token_url.format(self.base_url)
         resp = self.post(url, auth=auth, allow_text=True)
@@ -91,6 +92,7 @@ class BitbucketServerSetupClient(ApiClient):
                 rsa_key=self.private_key,
                 signature_method=SIGNATURE_RSA,
                 signature_type="auth_header",
+                decoding=None,
             )
         return self._request(*args, **kwargs)
 
@@ -134,6 +136,7 @@ class BitbucketServerClient(ApiClient):
             resource_owner_secret=self.identity.data["access_token_secret"],
             signature_method=SIGNATURE_RSA,
             signature_type="auth_header",
+            decoding=None,
         )
         prepared_request.prepare_auth(auth=auth_scheme)
         return prepared_request

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -84,6 +84,7 @@ class JiraServerClient(ApiClient):
             resource_owner_secret=self.identity.data["access_token_secret"],
             signature_method=SIGNATURE_RSA,
             signature_type="auth_header",
+            decoding=None,
         )
         prepared_request.prepare_auth(auth=auth_scheme)
         return prepared_request
@@ -269,6 +270,7 @@ class JiraServerSetupClient(ApiClient):
             rsa_key=self.private_key,
             signature_method=SIGNATURE_RSA,
             signature_type="auth_header",
+            decoding=None,
         )
         url = self.access_token_url.format(self.base_url)
         resp = self.post(url, auth=auth, allow_text=True)
@@ -282,6 +284,7 @@ class JiraServerSetupClient(ApiClient):
             resource_owner_secret=credentials["access_token_secret"],
             signature_method=SIGNATURE_RSA,
             signature_type="auth_header",
+            decoding=None,
         )
 
         # Create a JWT token that we can add to the webhook URL
@@ -305,5 +308,6 @@ class JiraServerSetupClient(ApiClient):
                 rsa_key=self.private_key,
                 signature_method=SIGNATURE_RSA,
                 signature_type="auth_header",
+                decoding=None,
             )
         return self._request(*args, **kwargs)

--- a/src/sentry_plugins/bitbucket/client.py
+++ b/src/sentry_plugins/bitbucket/client.py
@@ -23,6 +23,7 @@ class BitbucketClient(AuthApiClient):
             self.auth.tokens["oauth_token"],
             self.auth.tokens["oauth_token_secret"],
             signature_type="auth_header",
+            decoding=None,
         )
         return kwargs
 

--- a/tests/sentry/integrations/bitbucket_server/test_client.py
+++ b/tests/sentry/integrations/bitbucket_server/test_client.py
@@ -64,7 +64,7 @@ class BitbucketServerClientTest(TestCase, BaseTestCase):
             "oauth_signature",
         ]
         for hc in header_components:
-            assert hc in str(request.headers["Authorization"])
+            assert hc in request.headers["Authorization"]
 
     @responses.activate
     def test_get_repo_authentication(self):
@@ -80,4 +80,4 @@ class BitbucketServerClientTest(TestCase, BaseTestCase):
         assert res["slug"] == "helloworld"
 
         assert len(responses.calls) == 1
-        assert b"oauth_consumer_key" in responses.calls[0].request.headers["Authorization"]
+        assert "oauth_consumer_key" in responses.calls[0].request.headers["Authorization"]

--- a/tests/sentry_plugins/bitbucket/test_plugin.py
+++ b/tests/sentry_plugins/bitbucket/test_plugin.py
@@ -81,7 +81,7 @@ class BitbucketPluginTest(PluginTestCase):
         assert self.plugin.create_issue(request, group, form_data) == 1
 
         request = responses.calls[-1].request
-        assert request.headers.get("Authorization", b"").startswith(b"OAuth ")
+        assert request.headers["Authorization"].startswith("OAuth ")
 
     @responses.activate
     def test_link_issue(self):


### PR DESCRIPTION
with the default (`decoding='UTF-8'`) the headers are *encoded* as utf-8 whereas requests expects `str` -- this is usually not a problem but it's better to conform to the expected types so the type checker can help us here

<!-- Describe your PR here. -->