### PR TITLE
ref(api-idorslug): Use `isdigit` instead of `isnumeric`

### DIFF
--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -57,7 +57,7 @@ class GroupEndpoint(Endpoint):
                     id_or_slug_path_params_enabled(
                         self.convert_args.__qualname__, str(organization_slug)
                     )
-                    and str(organization_slug).isnumeric()
+                    and str(organization_slug).isdigit()
                 ):
                     organization = Organization.objects.get_from_cache(id=organization_slug)
                 else:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -256,7 +256,7 @@ class ControlSiloOrganizationEndpoint(Endpoint):
 
         if (
             id_or_slug_path_params_enabled(self.convert_args.__qualname__, str(organization_slug))
-            and str(organization_slug).isnumeric()
+            and str(organization_slug).isdigit()
         ):
             # It is ok that `get_organization_by_id` doesn't check for visibility as we
             # don't check the visibility in `get_organization_by_slug` either (only_active=False).
@@ -557,7 +557,7 @@ class OrganizationEndpoint(Endpoint):
                 id_or_slug_path_params_enabled(
                     self.convert_args.__qualname__, str(organization_slug)
                 )
-                and str(organization_slug).isnumeric()
+                and str(organization_slug).isdigit()
             ):
                 organization = Organization.objects.get_from_cache(id=organization_slug)
             else:

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -279,7 +279,7 @@ class RegionSentryAppBaseEndpoint(IntegrationPlatformEndpoint):
     ):
         if (
             id_or_slug_path_params_enabled(self.convert_args.__qualname__)
-            and str(sentry_app_id_or_slug).isnumeric()
+            and str(sentry_app_id_or_slug).isdigit()
         ):
             sentry_app = app_service.get_sentry_app_by_id(id=int(sentry_app_id_or_slug))
         else:
@@ -333,7 +333,7 @@ class SentryAppInstallationsBaseEndpoint(IntegrationPlatformEndpoint):
 
         if (
             id_or_slug_path_params_enabled(self.convert_args.__qualname__, str(organization_slug))
-            and str(organization_slug).isnumeric()
+            and str(organization_slug).isdigit()
         ):
             organization = organization_service.get_org_by_id(
                 id=int(organization_slug), **extra_args

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -87,7 +87,7 @@ def get_invite_state(
                 convert_args_class=AcceptOrganizationInvite,
                 organization_slug=str(organization_id_or_slug),
             )
-            and str(organization_id_or_slug).isnumeric()
+            and str(organization_id_or_slug).isdigit()
         ):
             invite_context = organization_service.get_invite_by_id(
                 organization_id=organization_id_or_slug,

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -93,7 +93,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
 
         # Get the organization integration
         org_integration_id_header = request.headers.get(PROXY_OI_HEADER)
-        if org_integration_id_header is None or not org_integration_id_header.isnumeric():
+        if org_integration_id_header is None or not org_integration_id_header.isdigit():
             logger.info("integration_proxy.missing_org_integration", extra=self.log_extra)
             return False
         org_integration_id = int(org_integration_id_header)

--- a/src/sentry/api/endpoints/organization_region.py
+++ b/src/sentry/api/endpoints/organization_region.py
@@ -65,7 +65,7 @@ class OrganizationRegionEndpoint(Endpoint):
                 id_or_slug_path_params_enabled(
                     self.convert_args.__qualname__, str(organization_slug)
                 )
-                and str(organization_slug).isnumeric()
+                and str(organization_slug).isdigit()
             ):
                 org_mapping = OrganizationMapping.objects.get(organization_id=organization_slug)
             else:

--- a/src/sentry/db/models/fields/slug.py
+++ b/src/sentry/db/models/fields/slug.py
@@ -32,7 +32,7 @@ class IdOrSlugLookup(Lookup):
             id_column_quoted = '"id"'
             slug_column_quoted = '"slug"'
 
-        if rhs_params and str(rhs_params[0]).isnumeric():
+        if rhs_params and str(rhs_params[0]).isdigit():
             # If numeric, use the 'id' field for comparison
             if table_name:
                 return f"{table_name_quoted}.{id_column_quoted} = {rhs}", rhs_params

--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -132,7 +132,7 @@ def proxy_sentryapp_request(
 ) -> HttpResponseBase:
     """Take a django request object and proxy it to the region of the organization that owns a sentryapp"""
     try:
-        if app_id_or_slug.isnumeric():
+        if app_id_or_slug.isdigit():
             sentry_app = SentryApp.objects.get(id=app_id_or_slug)
         else:
             sentry_app = SentryApp.objects.get(slug=app_id_or_slug)

--- a/src/sentry/models/releases/util.py
+++ b/src/sentry/models/releases/util.py
@@ -76,7 +76,7 @@ class ReleaseQuerySet(BaseQuerySet):
                 )
             )
 
-        if build.isnumeric() and validate_bigint(int(build)):
+        if build.isdigit() and validate_bigint(int(build)):
             qs = getattr(qs, query_func)(**{f"build_number__{operator}": int(build)})
         else:
             if not build or build.endswith("*"):

--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -69,7 +69,7 @@ class MonitorEndpoint(Endpoint):
                 id_or_slug_path_params_enabled(
                     self.convert_args.__qualname__, str(organization_slug)
                 )
-                and str(organization_slug).isnumeric()
+                and str(organization_slug).isdigit()
             ):
                 organization = Organization.objects.get_from_cache(id=organization_slug)
             else:

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_attachment.py
@@ -99,7 +99,7 @@ class MonitorIngestCheckinAttachmentEndpoint(Endpoint):
                         id_or_slug_path_params_enabled(
                             self.convert_args.__qualname__, str(organization_slug)
                         )
-                        and str(organization_slug).isnumeric()
+                        and str(organization_slug).isdigit()
                     ):
                         organization = Organization.objects.get_from_cache(id=organization_slug)
                     else:

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -270,7 +270,7 @@ def get_region_for_organization(organization_id_or_slug: str) -> Region:
 
     if (
         id_or_slug_path_params_enabled(organization_slug=organization_id_or_slug)
-        and organization_id_or_slug.isnumeric()
+        and organization_id_or_slug.isdigit()
     ):
         mapping = OrganizationMapping.objects.filter(
             organization_id=organization_id_or_slug


### PR DESCRIPTION
@schew2381  called out that using `isdigit` is safer than `isnumeric` in our case, so updated all the function calls.

