### PR TITLE
fix(ui): Make concurrent renderer option not prefer disk

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -496,7 +496,7 @@ register(
     "frontend.react-concurrent-renderer-enabled",
     type=Bool,
     default=False,
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Analytics


### PR DESCRIPTION
change flags to only FLAG_AUTOMATOR_MODIFIABLE. i don't really know what any of the flags do
