### PR TITLE
fix(post-process): Fix condition in `get_crashing_thread`

### DIFF
--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -155,9 +155,12 @@ def munged_filename_and_frames(
 
 
 def get_crashing_thread(
-    thread_frames: Sequence[Mapping[str, Any]] | None
+    thread_frames: Sequence[Mapping[str, Any]] | Mapping[str, None] | None
 ) -> Mapping[str, Any] | None:
-    if not thread_frames:
+    # Handles edge case where {"values": None} is passed in
+    if not thread_frames or (
+        isinstance(thread_frames, Mapping) and not thread_frames.get("values")
+    ):
         return None
     if len(thread_frames) == 1:
         return thread_frames[0]

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -200,6 +200,7 @@ def find_stack_frames(
             threads = get_path(event_data, "threads", "values", filter=True) or get_path(
                 event_data, "threads", filter=True
             )
+            # Handles edge case where the second call to get_path doesn't return a list of threads
             if threads == {"values": None}:
                 threads = None
             thread = get_crashing_thread(threads)

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -155,12 +155,9 @@ def munged_filename_and_frames(
 
 
 def get_crashing_thread(
-    thread_frames: Sequence[Mapping[str, Any]] | Mapping[str, None] | None
+    thread_frames: Sequence[Mapping[str, Any]] | None
 ) -> Mapping[str, Any] | None:
-    # Handles edge case where {"values": None} is passed in
-    if not thread_frames or (
-        isinstance(thread_frames, Mapping) and not thread_frames.get("values")
-    ):
+    if not thread_frames:
         return None
     if len(thread_frames) == 1:
         return thread_frames[0]
@@ -203,6 +200,8 @@ def find_stack_frames(
             threads = get_path(event_data, "threads", "values", filter=True) or get_path(
                 event_data, "threads", filter=True
             )
+            if threads == {"values": None}:
+                threads = None
             thread = get_crashing_thread(threads)
             if thread is not None:
                 frames = get_path(thread, "stacktrace", "frames") or []

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -49,7 +49,6 @@ class CrashingThreadTestCase(unittest.TestCase):
         assert not get_crashing_thread(None)
         assert not get_crashing_thread([{}, {}, {}])
         assert not get_crashing_thread([{}])
-        assert not get_crashing_thread({"values": None})
 
     def test_single_crashed_thread(self):
         thread_frames = [{"id": 1, "crashed": True}, {"id": 2, "crashed": False}]

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -49,6 +49,7 @@ class CrashingThreadTestCase(unittest.TestCase):
         assert not get_crashing_thread(None)
         assert not get_crashing_thread([{}, {}, {}])
         assert not get_crashing_thread([{}])
+        assert not get_crashing_thread({"values": None})
 
     def test_single_crashed_thread(self):
         thread_frames = [{"id": 1, "crashed": True}, {"id": 2, "crashed": False}]


### PR DESCRIPTION
Fixes https://sentry.sentry.io/issues/3938745470/

this pr fixes a bug in `get_crashing_thread`. since `threads` can either be stored as a list in `values` or directly as a list, we have two calls to `get_path`, but that creates an edge case where {"values": None} is returned by the second call. This was causing a key error since there was no condition to check for it and it was assumed that the input was a list. 