### PR TITLE
chore(trace-explorer): Update to use new fields

### DIFF
--- a/static/app/views/performance/traces/content.tsx
+++ b/static/app/views/performance/traces/content.tsx
@@ -128,10 +128,10 @@ export function Content() {
             {t('Trace ID')}
           </StyledPanelHeader>
           <StyledPanelHeader align="left" lightText>
-            {t('Trace Root Name')}
+            {t('Trace Root')}
           </StyledPanelHeader>
           <StyledPanelHeader align="right" lightText>
-            {t('Spans')}
+            {t('Total Spans')}
           </StyledPanelHeader>
           <StyledPanelHeader align="right" lightText>
             {t('Breakdown')}
@@ -181,11 +181,16 @@ function TraceRow({trace}: {trace: TraceResult<Field>}) {
         <TraceIdRenderer traceId={trace.trace} timestamp={trace.spans[0].timestamp} />
       </StyledPanelItem>
       <StyledPanelItem align="left">
-        {trace.name ? (
-          trace.name
-        ) : (
-          <EmptyValueContainer>{t('No Name Available')}</EmptyValueContainer>
-        )}
+        <Description>
+          {trace.project ? (
+            <ProjectRenderer projectSlug={trace.project} hideName />
+          ) : null}
+          {trace.name ? (
+            trace.name
+          ) : (
+            <EmptyValueContainer>{t('Missing Trace Root')}</EmptyValueContainer>
+          )}
+        </Description>
       </StyledPanelItem>
       <StyledPanelItem align="right">
         <Count value={trace.numSpans} />
@@ -288,7 +293,10 @@ export interface TraceResult<F extends string> {
   duration: number;
   end: number;
   name: string | null;
+  numErrors: number;
+  numOccurrences: number;
   numSpans: number;
+  project: string | null;
   spans: SpanResult<F>[];
   start: number;
   trace: string;

--- a/static/app/views/performance/traces/fieldRenderers.tsx
+++ b/static/app/views/performance/traces/fieldRenderers.tsx
@@ -25,8 +25,6 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
-import {useTraceMeta} from '../newTraceDetails/traceApi/useTraceMeta';
-
 import type {TraceResult} from './content';
 import type {Field} from './data';
 
@@ -226,12 +224,9 @@ export function TransactionRenderer({
 }
 
 export function TraceIssuesRenderer({trace}: {trace: TraceResult<Field>}) {
-  const traceMeta = useTraceMeta(trace.trace);
   const organization = useOrganization();
 
-  const issueCount = !traceMeta.data
-    ? undefined
-    : traceMeta.data.errors + traceMeta.data.performance_issues;
+  const issueCount = trace.numErrors + trace.numOccurrences;
 
   return (
     <LinkButton


### PR DESCRIPTION
The response now contains
- project
- numErrors
- numOccurrences Use these values directly instead of querying them. Also some wording changes.