### PR TITLE
fix(replay): Request extra errors from discover at all times

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -183,6 +183,76 @@ describe('useReplayData', () => {
     );
   });
 
+  it('should always fetch DISCOVER & ISSUE_PLATFORM errors', async () => {
+    const startedAt = new Date('12:00:00 01-01-2023');
+    const finishedAt = new Date('12:00:10 01-01-2023');
+
+    const {mockReplayResponse, expectedReplay} = getMockReplayRecord({
+      started_at: startedAt,
+      finished_at: finishedAt,
+      duration: duration(10, 'seconds'),
+      count_errors: 0,
+      count_segments: 0,
+      error_ids: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
+      body: {data: mockReplayResponse},
+    });
+    const mockedErrorEventsMetaCall = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays-events-meta/`,
+      body: {},
+      headers: {
+        Link: [
+          '<http://localhost/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1"',
+          '<http://localhost/?cursor=0:2:0>; rel="next"; results="false"; cursor="0:1:0"',
+        ].join(','),
+      },
+      match: [
+        (_url, options) => options.query?.dataset === DiscoverDatasets.DISCOVER,
+        (_url, options) => options.query?.query === `replayId:[${mockReplayResponse.id}]`,
+        (_url, options) => options.query?.cursor === '0:0:0',
+      ],
+    });
+
+    const mockedIssuePlatformEventsMetaCall = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays-events-meta/`,
+      body: {},
+      headers: {
+        Link: [
+          '<http://localhost/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1"',
+          '<http://localhost/?cursor=0:2:0>; rel="next"; results="false"; cursor="0:1:0"',
+        ].join(','),
+      },
+      match: [
+        (_url, options) => options.query?.dataset === DiscoverDatasets.ISSUE_PLATFORM,
+        (_url, options) => options.query?.query === `replayId:[${mockReplayResponse.id}]`,
+        (_url, options) => options.query?.cursor === '0:0:0',
+      ],
+    });
+
+    const {result} = renderHook(useReplayData, {
+      wrapper,
+      initialProps: {
+        replayId: mockReplayResponse.id,
+        orgSlug: organization.slug,
+        errorsPerPage: 1,
+      },
+    });
+
+    await waitFor(() => expect(mockedErrorEventsMetaCall).toHaveBeenCalledTimes(1));
+    expect(mockedIssuePlatformEventsMetaCall).toHaveBeenCalledTimes(1);
+
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        attachments: [],
+        errors: [],
+        replayRecord: expectedReplay,
+      })
+    );
+  });
+
   it('should concat N error responses and pass them through to Replay Reader', async () => {
     const ERROR_IDS = [
       '5c83aaccfffb4a708ae893bad9be3a1c',
@@ -195,7 +265,7 @@ describe('useReplayData', () => {
       started_at: startedAt,
       finished_at: finishedAt,
       duration: duration(10, 'seconds'),
-      count_errors: 2,
+      count_errors: ERROR_IDS.length,
       count_segments: 0,
       error_ids: ERROR_IDS,
     });
@@ -323,7 +393,7 @@ describe('useReplayData', () => {
   });
 
   it('should incrementally load attachments and errors', async () => {
-    const ERROR_ID = '5c83aaccfffb4a708ae893bad9be3a1c';
+    const ERROR_IDS = ['5c83aaccfffb4a708ae893bad9be3a1c'];
     const startedAt = new Date('12:00:00 01-01-2023');
     const finishedAt = new Date('12:00:10 01-01-2023');
 
@@ -331,16 +401,16 @@ describe('useReplayData', () => {
       started_at: startedAt,
       finished_at: finishedAt,
       duration: duration(10, 'seconds'),
-      count_errors: 1,
+      count_errors: ERROR_IDS.length,
       count_segments: 1,
-      error_ids: [ERROR_ID],
+      error_ids: ERROR_IDS,
     });
     const mockSegmentResponse = RRWebInitFrameEventsFixture({
       timestamp: startedAt,
     });
     const mockErrorResponse = [
       ReplayErrorFixture({
-        id: ERROR_ID,
+        id: ERROR_IDS[0],
         issue: 'JAVASCRIPT-123E',
         timestamp: startedAt.toISOString(),
       }),

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -197,7 +197,10 @@ function useReplayData({
   const links = parseLinkHeader(linkHeader);
   const {pages: extraErrorPages, isFetching: isFetchingExtraErrors} =
     useFetchSequentialPages<{data: ReplayError[]}>({
-      enabled: !fetchReplayError && !isFetchingErrors && Boolean(links.next?.results),
+      enabled:
+        !fetchReplayError &&
+        !isFetchingErrors &&
+        (!replayRecord?.count_errors || Boolean(links.next?.results)),
       initialCursor: links.next?.cursor,
       getQueryKey: getErrorsQueryKey,
       perPage: errorsPerPage,


### PR DESCRIPTION
We always want to request errors from `DiscoverDatasets.DISCOVER` and `DiscoverDatasets.ISSUE_PLATFORM` because we could have errors from backend services (Discover) or Performance errors (Issue Platform) that are not part of the `error_count: number` or `errors: string[]` list.

When we do have something in the `errors` list then we still want to pre-fetch those items. We know there will be N items (at least) so we can request M pages, but there might be more pages to follow. This change edits the condition for fetching errors after, or in lieu of, the initial parallel requests.

---

**Simple case (new)**
- `fetchReplayError` is falsey (the replayRecord was fetching successfully)
- `isFetchingErrors` is falesy (we're didn't fetch anything already because replayRecord.errors was empty)
- Nothing in `replayRecord.errors` or `replayRecord.count_errors` (we don't expect to have fetched anything already)

In this case we fire off sequential requests to get errors from DISCOVER dataset. success!

**Existing case**
- `fetchReplayError` is falsey (the replayRecord was fetching successfully)
- `isFetchingErrors` is true (we are fetching errors in parallel, need to wait, we expect there will be at least N rows returned)
- IDs exist in `replayRecord.errors` and `replayRecord.count_errors` (we fetched M pages to get N rows already, but the last page returned `links.next` which might have more rows)
.... after the parallel calls are done....
- `isFetchingErrors` is falsey (we are done fetching errors in parallel!)
- IDs exist in `replayRecord.errors` and `replayRecord.count_errors` (we waited, and now that part is done)
- If `links.next.results` is set then we start fetching sequentially until it gets set to `false`.

--- 

Test plan:

We can see that the UI is requesting errors from both datasets, in this case nothing is returned:
![SCR-20240430-khnb](https://github.com/getsentry/sentry/assets/187460/98e25e16-30fd-4b40-836d-aadaf0132741)
