### PR TITLE
feat(issue-platform): remove option for kafka partition key

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import random
 from collections.abc import MutableMapping
 from typing import Any, cast
 
@@ -11,7 +10,6 @@ from arroyo.types import Message, Value
 from confluent_kafka import KafkaException
 from django.conf import settings
 
-from sentry import options
 from sentry.conf.types.kafka_definition import Topic
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.run import process_message
@@ -67,11 +65,7 @@ def produce_occurrence_to_kafka(
         return
 
     partition_key = None
-    if (
-        options.get("issue_platform.use_kafka_partition_key.rollout") >= random.random()
-        and occurrence
-        and occurrence.fingerprint
-    ):
+    if occurrence and occurrence.fingerprint:
         partition_key = bytes(occurrence.fingerprint[0], "utf-8")
     payload = KafkaPayload(partition_key, json.dumps(payload_data).encode("utf-8"), [])
     if settings.SENTRY_EVENTSTREAM != "sentry.eventstream.kafka.KafkaEventStream":

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2439,11 +2439,3 @@ register(
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-
-register(
-    "issue_platform.use_kafka_partition_key.rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -17,7 +17,6 @@ from sentry.models.grouphistory import STRING_TO_STATUS_LOOKUP, GroupHistory, Gr
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.group import GROUP_SUBSTATUS_TO_GROUP_HISTORY_STATUS, GroupSubStatus
@@ -94,24 +93,6 @@ class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
     )
     @patch("sentry.issues.producer._occurrence_producer.produce")
     @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
-    def test_payload_sent_to_kafka(self, mock_produce, mock_prepare_occurrence_message) -> None:
-        occurrence = self.build_occurrence(project_id=self.project.id)
-        produce_occurrence_to_kafka(
-            payload_type=PayloadType.OCCURRENCE,
-            occurrence=occurrence,
-            event_data={},
-        )
-        mock_produce.assert_called_once_with(
-            ArroyoTopic(name="ingest-occurrences"),
-            KafkaPayload(None, json.dumps({"mock_data": "great"}).encode("utf-8"), []),
-        )
-
-    @patch(
-        "sentry.issues.producer._prepare_occurrence_message", return_value={"mock_data": "great"}
-    )
-    @patch("sentry.issues.producer._occurrence_producer.produce")
-    @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
-    @override_options({"issue_platform.use_kafka_partition_key.rollout": 1.0})
     def test_payload_sent_to_kafka_with_partition_key(
         self, mock_produce, mock_prepare_occurrence_message
     ) -> None:
@@ -135,7 +116,6 @@ class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
     )
     @patch("sentry.issues.producer._occurrence_producer.produce")
     @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
-    @override_options({"issue_platform.use_kafka_partition_key.rollout": 1.0})
     def test_payload_sent_to_kafka_with_partition_key_no_fingerprint(
         self, mock_produce, mock_prepare_occurrence_message
     ) -> None:
@@ -155,7 +135,6 @@ class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
     )
     @patch("sentry.issues.producer._occurrence_producer.produce")
     @override_settings(SENTRY_EVENTSTREAM="sentry.eventstream.kafka.KafkaEventStream")
-    @override_options({"issue_platform.use_kafka_partition_key.rollout": 1.0})
     def test_payload_sent_to_kafka_with_partition_key_no_occurrence(
         self, mock_produce, mock_prepare_occurrence_message
     ) -> None:


### PR DESCRIPTION
Now that we've fully rolled out the `issue_platform.use_kafka_partition_key.rollout` option, we can remove the option from code and use the behavior where it is enabled.