### PR TITLE
feat(cache): allow sorting on the miss rate field

### DIFF
--- a/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/starfish/components/tableCells/renderHeadCell.tsx
@@ -27,8 +27,15 @@ const DEFAULT_SORT_PARAMETER_NAME = 'sort';
 
 const {SPAN_SELF_TIME, HTTP_RESPONSE_CONTENT_LENGTH} = SpanMetricsField;
 const {RESPONSE_CODE, CACHE_ITEM_SIZE} = SpanIndexedField;
-const {TIME_SPENT_PERCENTAGE, SPS, SPM, HTTP_ERROR_COUNT, HTTP_RESPONSE_RATE} =
-  SpanFunction;
+const {
+  TIME_SPENT_PERCENTAGE,
+  SPS,
+  SPM,
+  HTTP_ERROR_COUNT,
+  HTTP_RESPONSE_RATE,
+  CACHE_HIT_RATE,
+  CACHE_MISS_RATE,
+} = SpanFunction;
 
 export const SORTABLE_FIELDS = new Set([
   `avg(${SPAN_SELF_TIME})`,
@@ -45,6 +52,8 @@ export const SORTABLE_FIELDS = new Set([
   `${HTTP_RESPONSE_RATE}(4)`,
   `${HTTP_RESPONSE_RATE}(5)`,
   `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
+  `${CACHE_HIT_RATE}()`,
+  `${CACHE_MISS_RATE}()`,
 ]);
 
 const NUMERIC_FIELDS = new Set([


### PR DESCRIPTION
Allows cache miss rate to be sorted in cache module. 🤔 In the future, I wonder if we can include `isSortable` as part of the discover response meta