### PR TITLE
fix(api): Allow rule snooze to work with tokens

### DIFF
--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -48,7 +48,7 @@ def can_edit_alert_rule(organization, request):
     # Skip scope and user validation if using token authentication, excluding
     # user tokens.
     if request.auth and (isinstance(user, AnonymousUser) or user.is_sentry_app):
-        # Raise an exception if the user is anonymous, but the request is to mute for the user
+        # Raise an exception if the user is anonymous, but the request is to mute for the user.
         if mute_for_user:
             raise BadRequest(
                 {
@@ -217,5 +217,4 @@ class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint):
         "POST": ApiPublishStatus.UNKNOWN,
     }
     rule_model = AlertRule
-    rule_field = "alert_rule"
     rule_field = "alert_rule"

--- a/src/sentry/api/endpoints/rule_snooze.py
+++ b/src/sentry/api/endpoints/rule_snooze.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.contrib.auth.models import AnonymousUser
 from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -10,11 +11,13 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.exceptions import BadRequest
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 
@@ -38,8 +41,23 @@ class RuleSnoozeSerializer(Serializer):
         return result
 
 
-def can_edit_alert_rule(rule, organization, user_id, user):
-    # make sure user has 'alert:write' scope
+def can_edit_alert_rule(organization, request):
+    mute_for_user = request.data.get("target") == "me"
+    user = request.user
+
+    # Skip scope and user validation if using token authentication, excluding
+    # user tokens.
+    if request.auth and (isinstance(user, AnonymousUser) or user.is_sentry_app):
+        # Raise an exception if the user is anonymous, but the request is to mute for the user
+        if mute_for_user:
+            raise BadRequest(
+                {
+                    "detail": "Cannot mute for the request user because the user is anonymous.",
+                }
+            )
+        return True
+
+    # Ensure that the user has the 'alerts:write' scope.
     try:
         org_member = OrganizationMember.objects.get(organization=organization, user_id=user.id)
         if "alerts:write" not in org_member.get_scopes():
@@ -47,10 +65,8 @@ def can_edit_alert_rule(rule, organization, user_id, user):
     except OrganizationMember.DoesNotExist:
         pass
     # if the goal is to mute the rule just for the user, ensure they belong to the organization
-    if user_id:
-        if organization not in Organization.objects.get_for_user(user):
-            return False
-        return True
+    if mute_for_user:
+        return organization in Organization.objects.get_for_user(user)
     # if the rule is owned by a team, allow edit (same permission as delete)
     # if the rule is unassigned, anyone can edit it
     return True
@@ -68,7 +84,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
 
         return rule
 
-    def post(self, request: Request, project, rule_id) -> Response:
+    def post(self, request: Request, project: Project, rule_id) -> Response:
         serializer = RuleSnoozeValidator(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -76,14 +92,14 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
         data = serializer.validated_data
         rule = self.get_rule(rule_id)
 
-        user_id = request.user.id if data.get("target") == "me" else None
-        if not can_edit_alert_rule(rule, project.organization, user_id, request.user):
+        if not can_edit_alert_rule(project.organization, request):
             raise PermissionDenied(
                 detail="Requesting user cannot mute this rule.", code=status.HTTP_403_FORBIDDEN
             )
 
         kwargs = {self.rule_field: rule}
 
+        user_id = request.user.id if data.get("target") == "me" else None
         rule_snooze, created = RuleSnooze.objects.get_or_create(
             user_id=user_id,
             defaults={
@@ -128,7 +144,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
             status=status.HTTP_201_CREATED,
         )
 
-    def delete(self, request: Request, project, rule_id) -> Response:
+    def delete(self, request: Request, project: Project, rule_id) -> Response:
         rule = self.get_rule(rule_id)
 
         # find if there is a mute for all that I can remove
@@ -141,7 +157,7 @@ class BaseRuleSnoozeEndpoint(ProjectEndpoint):
             pass
 
         # if user can edit then delete it
-        if shared_snooze and can_edit_alert_rule(rule, project.organization, None, request.user):
+        if shared_snooze and can_edit_alert_rule(project.organization, request):
             shared_snooze.delete()
             deletion_type = "everyone"
 
@@ -201,4 +217,5 @@ class MetricRuleSnoozeEndpoint(BaseRuleSnoozeEndpoint):
         "POST": ApiPublishStatus.UNKNOWN,
     }
     rule_model = AlertRule
+    rule_field = "alert_rule"
     rule_field = "alert_rule"

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -36,6 +36,12 @@ class SentryAPIException(APIException):
         self.detail = {"detail": detail}
 
 
+class BadRequest(SentryAPIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    code = "invalid-request"
+    message = "Invalid request"
+
+
 class ParameterValidationError(SentryAPIException):
     status_code = status.HTTP_400_BAD_REQUEST
     code = "parameter-validation-error"

--- a/tests/sentry/api/endpoints/test_rule_snooze.py
+++ b/tests/sentry/api/endpoints/test_rule_snooze.py
@@ -32,15 +32,14 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
 
     def test_mute_issue_alert_user_forever(self):
         """Test that a user can mute an issue alert rule for themselves forever"""
-        data = {"target": "me"}
-        response = self.get_response(
+        response = self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
-            **data,
+            target="me",
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
-        assert response.status_code == 201
         assert len(response.data) == 6
         assert response.data["ownerId"] == self.user.id
         assert response.data["userId"] == self.user.id
@@ -51,14 +50,14 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
     def test_mute_issue_alert_user_until(self):
         """Test that a user can mute an issue alert rule for themselves a period of time"""
         data = {"target": "me", "until": self.until}
-        response = self.get_response(
+        response = self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
-        assert response.status_code == 201
         assert len(response.data) == 6
         assert response.data["ownerId"] == self.user.id
         assert response.data["userId"] == self.user.id
@@ -68,16 +67,15 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
 
     def test_mute_issue_alert_everyone_forever(self):
         """Test that an issue alert rule can be muted for everyone forever"""
-        data = {"target": "everyone"}
         with outbox_runner():
-            response = self.get_response(
+            response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
                 self.issue_alert_rule.id,
-                **data,
+                target="everyone",
+                status_code=201,
             )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
-        assert response.status_code == 201
         assert len(response.data) == 6
         assert response.data["ownerId"] == self.user.id
         assert response.data["userId"] == "everyone"
@@ -96,14 +94,14 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
         """Test that an issue alert rule can be muted for everyone for a period of time"""
         data = {"target": "everyone", "until": self.until}
         with outbox_runner():
-            response = self.get_response(
+            response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
                 self.issue_alert_rule.id,
                 **data,
+                status_code=201,
             )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
-        assert response.status_code == 201
         assert len(response.data) == 6
         assert response.data["ownerId"] == self.user.id
         assert response.data["userId"] == "everyone"
@@ -121,78 +119,78 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
     def test_mute_issue_alert_user_then_everyone(self):
         """Test that a user can mute an issue alert for themselves and then the same alert can be muted for everyone"""
         data = {"target": "me", "until": self.until}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id, until=self.until
         ).exists()
-        assert response.status_code == 201
 
         everyone_until = datetime.now(timezone.utc) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
-        assert response.status_code == 201
 
     def test_mute_issue_alert_everyone_then_user(self):
         """Test that an issue alert can be muted for everyone and then a user can mute the same alert for themselves"""
         everyone_until = datetime.now(timezone.utc) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
-        assert response.status_code == 201
 
         data = {"target": "me", "until": self.until}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id, until=self.until
         ).exists()
-        assert response.status_code == 201
 
     def test_edit_issue_alert_mute(self):
         """Test that we throw an error if an issue alert rule has already been muted by a user"""
         data: dict[str, Any] = {"target": "me"}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
-        assert response.status_code == 201
 
         data = {"target": "me", "until": self.until}
-        response = self.get_response(
+        response = self.get_error_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
             **data,
+            status_code=410,
         )
         assert len(RuleSnooze.objects.all()) == 1
-        assert response.status_code == 410
         assert "RuleSnooze already exists for this rule and scope." in response.data["detail"]
 
     def test_mute_issue_alert_without_alert_write(self):
@@ -204,15 +202,45 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
         self.organization.update_option("sentry:alerts_member_write", False)
         self.login_as(member_user)
 
-        data = {"target": "me"}
-        response = self.get_response(
+        self.get_error_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
-            **data,
+            target="me",
+            status_code=403,
         )
         assert not RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
-        assert response.status_code == 403
+
+    def test_mute_issue_alert_using_internal_integration_token(self):
+        """Test that an integration token can mute an issue alert"""
+        integration_token = self.create_internal_integration_token(
+            user=self.user,
+            internal_integration=self.create_internal_integration(
+                organization=self.organization, scopes=["project:write"]
+            ),
+        )
+
+        self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            target="everyone",
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {integration_token.token}"},
+            status_code=201,
+        )
+        assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
+
+        # Using an internal integration token but requesting to snooze for self
+        # throws an error
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            self.issue_alert_rule.id,
+            target="me",
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {integration_token.token}"},
+            status_code=400,
+        )
+        assert RuleSnooze.objects.filter(rule=self.issue_alert_rule.id).exists()
 
     def test_user_can_mute_issue_alert_for_self(self):
         """Test that if a user doesn't belong to the team that can edit an issue alert rule, they can still mute it for just themselves."""
@@ -222,15 +250,14 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
             project=self.project,
             owner_team_id=other_team.id,
         )
-        data = {"target": "me"}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             other_issue_alert_rule.id,
-            **data,
+            target="me",
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
-        assert response.status_code == 201
 
     def test_user_can_mute_unassigned_issue_alert(self):
         """Test that if an issue alert rule's owner is unassigned, the user can mute it."""
@@ -238,20 +265,20 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
             label="test rule",
             project=self.project,
         )
-        data = {"target": "me"}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             other_issue_alert_rule.id,
-            **data,
+            target="me",
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(rule=other_issue_alert_rule.id).exists()
-        assert response.status_code == 201
 
     def test_no_issue_alert(self):
         """Test that we throw an error when an issue alert rule doesn't exist"""
-        data = {"target": "me"}
-        response = self.get_response(self.organization.slug, self.project.slug, 777, **data)
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, 777, target="me", status_code=400
+        )
         assert not RuleSnooze.objects.filter(alert_rule=self.issue_alert_rule.id).exists()
         assert response.status_code == 400
         assert "Rule does not exist" in response.data
@@ -259,14 +286,14 @@ class PostRuleSnoozeTest(BaseRuleSnoozeTest):
     def test_invalid_data_issue_alert(self):
         """Test that we throw an error when passed invalid data"""
         data = {"target": "me", "until": 123}
-        response = self.get_response(
+        response = self.get_error_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
             **data,
+            status_code=400,
         )
         assert not RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
-        assert response.status_code == 400
         assert "Datetime has wrong format." in response.data["until"][0]
 
 
@@ -277,32 +304,32 @@ class DeleteRuleSnoozeTest(BaseRuleSnoozeTest):
     def test_delete_issue_alert_rule_mute_myself(self):
         """Test that a user can unsnooze a rule they've snoozed for just themselves"""
         self.snooze_rule(user_id=self.user.id, owner_id=self.user.id, rule=self.issue_alert_rule)
-        data = {"target": "me"}
-        response = self.get_response(
+
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
-            **data,
+            target="me",
+            status_code=204,
         )
         assert not RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id
         ).exists()
-        assert response.status_code == 204
 
     def test_delete_issue_alert_rule_mute_everyone(self):
         """Test that a user can unsnooze a rule they've snoozed for everyone"""
         self.snooze_rule(owner_id=self.user.id, rule=self.issue_alert_rule)
-        data = {"target": "everyone"}
-        response = self.get_response(
+
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
-            **data,
+            target="everyone",
+            status_code=204,
         )
         assert not RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id
         ).exists()
-        assert response.status_code == 204
 
     def test_delete_issue_alert_rule_without_alert_write(self):
         """Test that a user without alerts:write access cannot unmute an issue alert rule"""
@@ -315,17 +342,16 @@ class DeleteRuleSnoozeTest(BaseRuleSnoozeTest):
         self.organization.update_option("sentry:alerts_member_write", False)
         self.login_as(member_user)
 
-        data = {"target": "me"}
-        response = self.get_response(
+        self.get_error_response(
             self.organization.slug,
             self.project.slug,
             self.issue_alert_rule.id,
-            **data,
+            target="me",
+            status_code=403,
         )
         assert RuleSnooze.objects.filter(
             rule=self.issue_alert_rule.id, user_id=self.user.id
         ).exists()
-        assert response.status_code == 403
 
 
 class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
@@ -334,15 +360,14 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
 
     def test_mute_metric_alert_user_forever(self):
         """Test that a user can mute a metric alert rule for themselves forever"""
-        data = {"target": "me"}
-        response = self.get_response(
+        response = self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
-            **data,
+            target="me",
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
-        assert response.status_code == 201
         assert len(response.data) == 6
         assert response.data["ownerId"] == self.user.id
         assert response.data["userId"] == self.user.id
@@ -353,14 +378,14 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
     def test_mute_metric_alert_user_until(self):
         """Test that a user can mute a metric alert rule for themselves a period of time"""
         data = {"target": "me", "until": self.until}
-        response = self.get_response(
+        response = self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
-        assert response.status_code == 201
         assert len(response.data) == 6
         assert response.data["ownerId"] == self.user.id
         assert response.data["userId"] == self.user.id
@@ -370,16 +395,15 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
 
     def test_mute_metric_alert_everyone_forever(self):
         """Test that a metric alert rule can be muted for everyone forever"""
-        data = {"target": "everyone"}
         with outbox_runner():
-            response = self.get_response(
+            response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
                 self.metric_alert_rule.id,
-                **data,
+                target="everyone",
+                status_code=201,
             )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
-        assert response.status_code == 201
         assert len(response.data) == 6
         assert response.data["ownerId"] == self.user.id
         assert response.data["userId"] == "everyone"
@@ -398,14 +422,14 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
         """Test that a metric alert rule can be muted for everyone for a period of time"""
         data = {"target": "everyone", "until": self.until}
         with outbox_runner():
-            response = self.get_response(
+            response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
                 self.metric_alert_rule.id,
                 **data,
+                status_code=201,
             )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
-        assert response.status_code == 201
         assert len(response.data) == 6
         assert response.data["ownerId"] == self.user.id
         assert response.data["userId"] == "everyone"
@@ -423,78 +447,78 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
     def test_mute_metric_alert_user_then_everyone(self):
         """Test that a user can mute a metric alert for themselves and then the same alert can be muted for everyone"""
         data = {"target": "me", "until": self.until}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id, until=self.until
         ).exists()
-        assert response.status_code == 201
 
         everyone_until = datetime.now(timezone.utc) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
-        assert response.status_code == 201
 
     def test_mute_metric_alert_everyone_then_user(self):
         """Test that a metric alert can be muted for everyone and then a user can mute the same alert for themselves"""
         everyone_until = datetime.now(timezone.utc) + timedelta(days=1)
         data = {"target": "everyone", "until": everyone_until}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=None, until=everyone_until
         ).exists()
-        assert response.status_code == 201
 
         data = {"target": "me", "until": self.until}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id, until=self.until
         ).exists()
-        assert response.status_code == 201
 
     def test_edit_metric_alert_mute(self):
         """Test that we throw an error if a metric alert rule has already been muted by a user"""
         data: dict[str, Any] = {"target": "me"}
-        response = self.get_response(
+        response = self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
             **data,
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
-        assert response.status_code == 201
 
         data = {"target": "me", "until": self.until}
-        response = self.get_response(
+        response = self.get_error_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
             **data,
+            status_code=410,
         )
         assert len(RuleSnooze.objects.all()) == 1
-        assert response.status_code == 410
         assert "RuleSnooze already exists for this rule and scope." in response.data["detail"]
 
     def test_mute_metric_alert_without_alert_write(self):
@@ -506,15 +530,14 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
         self.organization.update_option("sentry:alerts_member_write", False)
         self.login_as(member_user)
 
-        data = {"target": "me"}
-        response = self.get_response(
+        self.get_error_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
-            **data,
+            target="me",
+            status_code=403,
         )
         assert not RuleSnooze.objects.filter(rule=self.metric_alert_rule.id).exists()
-        assert response.status_code == 403
 
     def test_user_can_snooze_metric_alert_for_self(self):
         """Test that if a user doesn't belong to the team that can edit a metric alert rule, they are able to mute it for just themselves."""
@@ -524,37 +547,35 @@ class PostMetricRuleSnoozeTest(BaseRuleSnoozeTest):
             projects=[self.project],
             owner=ActorTuple.from_actor_identifier(f"team:{other_team.id}"),
         )
-        data = {"target": "me"}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             other_metric_alert_rule.id,
-            **data,
+            target="me",
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule).exists()
-        assert response.status_code == 201
 
     def test_user_can_mute_unassigned_metric_alert(self):
         """Test that if a metric alert rule's owner is unassigned, the user can mute it."""
         other_metric_alert_rule = self.create_alert_rule(
             organization=self.project.organization, projects=[self.project], owner=None
         )
-        data = {"target": "me"}
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             other_metric_alert_rule.id,
-            **data,
+            target="me",
+            status_code=201,
         )
         assert RuleSnooze.objects.filter(alert_rule=other_metric_alert_rule.id).exists()
-        assert response.status_code == 201
 
     def test_no_metric_alert(self):
         """Test that we throw an error when a metric alert rule doesn't exist"""
-        data = {"target": "me"}
-        response = self.get_response(self.organization.slug, self.project.slug, 777, **data)
+        response = self.get_error_response(
+            self.organization.slug, self.project.slug, 777, target="me", status_code=400
+        )
         assert not RuleSnooze.objects.filter(alert_rule=self.metric_alert_rule.id).exists()
-        assert response.status_code == 400
         assert "Rule does not exist" in response.data
 
 
@@ -567,26 +588,25 @@ class DeleteMetricRuleSnoozeTest(BaseRuleSnoozeTest):
         self.snooze_rule(
             user_id=self.user.id, owner_id=self.user.id, alert_rule=self.metric_alert_rule
         )
-        response = self.get_response(
-            self.organization.slug, self.project.slug, self.metric_alert_rule.id
+        self.get_success_response(
+            self.organization.slug, self.project.slug, self.metric_alert_rule.id, status_code=204
         )
         assert not RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id
         ).exists()
-        assert response.status_code == 204
 
     def test_delete_metric_alert_rule_mute_everyone(self):
         """Test that a user can unsnooze a metric rule they've snoozed for everyone"""
         self.snooze_rule(owner_id=self.user.id, alert_rule=self.metric_alert_rule)
-        response = self.get_response(
+        self.get_success_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
+            status_code=204,
         )
         assert not RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id
         ).exists()
-        assert response.status_code == 204
 
     def test_delete_metric_alert_rule_without_alert_write(self):
         """Test that a user without alerts:write access cannot unmute a metric alert rule"""
@@ -601,14 +621,13 @@ class DeleteMetricRuleSnoozeTest(BaseRuleSnoozeTest):
         self.organization.update_option("sentry:alerts_member_write", False)
         self.login_as(member_user)
 
-        data = {"target": "me"}
-        response = self.get_response(
+        self.get_error_response(
             self.organization.slug,
             self.project.slug,
             self.metric_alert_rule.id,
-            **data,
+            target="me",
+            status_code=403,
         )
         assert RuleSnooze.objects.filter(
             alert_rule=self.metric_alert_rule.id, user_id=self.user.id
         ).exists()
-        assert response.status_code == 403


### PR DESCRIPTION
Update permission checks added in https://github.com/getsentry/sentry/pull/47732 to be compatible with api tokens.

Fixes SENTRY-38K1