### PR TITLE
perf(issues): bumping cache TTL for test_user_counts from 5m to 1h

### DIFF
--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -277,7 +277,7 @@ class GroupSnooze(Model):
 
         threshold = self.user_count + users_seen
 
-        CACHE_TTL = 300  # Redis TTL in seconds
+        CACHE_TTL = 3600  # Redis TTL in seconds
 
         value: int | float = float("inf")  # using +inf as a sentinel value
         try:

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -220,7 +220,7 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_distinct_counts_totals.call_count == 1
-            assert cache_spy.set.called_with(cache_key, 95, 3600)
+            cache_spy.set.assert_called_with(cache_key, 95, 3600)
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_distinct_counts_totals.call_count == 1
@@ -238,7 +238,7 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_distinct_counts_totals.call_count == 2
-            assert cache_spy.set.called_with(cache_key, 98, 3600)
+            cache_spy.set.assert_called_with(cache_key, 98, 3600)
             assert cache_spy.get(cache_key) == 98
 
             assert snooze.is_valid(test_rates=True)
@@ -269,21 +269,21 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_distinct_counts_totals.call_count == 1
-            assert cache_spy.set.called_with(cache_key, 98, 3600)
+            cache_spy.set.assert_called_with(cache_key, 98, 3600)
 
             # simulate cache expiration
             cache_spy.delete(cache_key)
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_distinct_counts_totals.call_count == 2
-            assert cache_spy.set.called_with(cache_key, 99, 3600)
+            cache_spy.set.assert_called_with(cache_key, 99, 3600)
 
             # simulate cache expiration
             cache_spy.delete(cache_key)
 
             assert not snooze.is_valid(test_rates=True)
             assert mocked_get_distinct_counts_totals.call_count == 3
-            assert cache_spy.set.called_with(cache_key, 100, 3600)
+            cache_spy.set.assert_called_with(cache_key, 100, 3600)
 
     def test_test_user_count_w_cache(self):
         snooze = GroupSnooze.objects.create(group=self.group, user_count=100)
@@ -306,7 +306,7 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_count_users_seen.call_count == 1
-            assert cache_spy.set.called_with(cache_key, 95, 300)
+            cache_spy.set.assert_called_with(cache_key, 95, 3600)
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_count_users_seen.call_count == 1
@@ -324,7 +324,7 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_count_users_seen.call_count == 2
-            assert cache_spy.set.called_with(cache_key, 98, 300)
+            cache_spy.set.assert_called_with(cache_key, 98, 3600)
             assert cache_spy.get(cache_key) == 98
 
             assert snooze.is_valid(test_rates=True)
@@ -342,7 +342,7 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
             mock.patch.object(
                 snooze.group,
                 "count_users_seen",
-                side_effect=[95, 98, 100],
+                side_effect=[98, 99, 100],
             ) as mocked_count_users_seen,
             mock.patch.object(
                 sentry.models.groupsnooze, "cache", wraps=sentry.models.groupsnooze.cache  # type: ignore[attr-defined]
@@ -353,21 +353,21 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_count_users_seen.call_count == 1
-            assert cache_spy.set.called_with(cache_key, 98, 300)
+            cache_spy.set.assert_called_with(cache_key, 98, 3600)
 
             # simulate cache expiration
             cache_spy.delete(cache_key)
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_count_users_seen.call_count == 2
-            assert cache_spy.set.called_with(cache_key, 99, 300)
+            cache_spy.set.assert_called_with(cache_key, 99, 3600)
 
             # simulate cache expiration
             cache_spy.delete(cache_key)
 
             assert not snooze.is_valid(test_rates=True)
             assert mocked_count_users_seen.call_count == 3
-            assert cache_spy.set.called_with(cache_key, 100, 300)
+            cache_spy.set.assert_called_with(cache_key, 100, 3600)
 
     def test_test_frequency_rates_w_cache(self):
         snooze = GroupSnooze.objects.create(group=self.group, count=100, window=60)
@@ -387,7 +387,7 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_sums.call_count == 1
-            assert cache_spy.set.called_with(cache_key, 95, 3600)
+            cache_spy.set.assert_called_with(cache_key, 95, 3600)
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_sums.call_count == 1
@@ -405,7 +405,7 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_sums.call_count == 2
-            assert cache_spy.set.called_with(cache_key, 98, 3600)
+            cache_spy.set.assert_called_with(cache_key, 98, 3600)
             assert cache_spy.get(cache_key) == 98
 
             assert snooze.is_valid(test_rates=True)
@@ -432,18 +432,18 @@ class GroupSnoozeWCacheTest(GroupSnoozeTest):
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_sums.call_count == 1
-            assert cache_spy.set.called_with(cache_key, 98, 3600)
+            cache_spy.set.assert_called_with(cache_key, 98, 3600)
 
             # simulate cache expiration
             cache_spy.delete(cache_key)
 
             assert snooze.is_valid(test_rates=True)
             assert mocked_get_sums.call_count == 2
-            assert cache_spy.set.called_with(cache_key, 99, 3600)
+            cache_spy.set.assert_called_with(cache_key, 99, 3600)
 
             # simulate cache expiration
             cache_spy.delete(cache_key)
 
             assert not snooze.is_valid(test_rates=True)
             assert mocked_get_sums.call_count == 3
-            assert cache_spy.set.called_with(cache_key, 100, 3600)
+            cache_spy.set.assert_called_with(cache_key, 100, 3600)


### PR DESCRIPTION
Bumping the cache TTL, based [on data](https://app.datadoghq.com/notebook/8072325/groupsnooze-pseudo-cache) that shows there's still room for improvement. 

Also, fixed asserts in tests. 