### PR TITLE
ref: move TRANSITION_AFTER_DAYS constant to fix sentry.monitoring.queues cycle

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -23,6 +23,7 @@ from sentry.db.models.query import create_or_update
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.ignored import handle_archived_until_escalating, handle_ignored
 from sentry.issues.merge import handle_merge
+from sentry.issues.ongoing import TRANSITION_AFTER_DAYS
 from sentry.issues.priority import update_priority
 from sentry.issues.status_change import handle_status_update
 from sentry.issues.update_inbox import update_inbox
@@ -51,7 +52,6 @@ from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.services.hybrid_cloud.user_option import user_option_service
 from sentry.signals import issue_resolved
-from sentry.tasks.auto_ongoing_issues import TRANSITION_AFTER_DAYS
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.types.activity import ActivityType
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus, PriorityLevel

--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -10,6 +10,8 @@ from sentry.models.groupinbox import bulk_remove_groups_from_inbox
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 
+TRANSITION_AFTER_DAYS = 7
+
 
 def bulk_transition_group_to_ongoing(
     from_status: int,

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -6,7 +6,7 @@ import sentry_sdk
 from django.db.models import Max
 
 from sentry.conf.server import CELERY_ISSUE_STATES_QUEUE
-from sentry.issues.ongoing import bulk_transition_group_to_ongoing
+from sentry.issues.ongoing import TRANSITION_AFTER_DAYS, bulk_transition_group_to_ongoing
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus
 from sentry.monitoring.queues import backend
@@ -19,7 +19,6 @@ from sentry.utils.query import RangeQuerySetWrapper
 
 logger = logging.getLogger(__name__)
 
-TRANSITION_AFTER_DAYS = 7
 ITERATOR_CHUNK = 100
 CHILD_TASK_COUNT = 250
 

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -1,14 +1,12 @@
 from datetime import datetime, timedelta, timezone
 from unittest import mock
 
+from sentry.issues.ongoing import TRANSITION_AFTER_DAYS
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus, record_group_history
 from sentry.models.groupinbox import GroupInbox, GroupInboxReason, add_group_to_inbox
-from sentry.tasks.auto_ongoing_issues import (
-    TRANSITION_AFTER_DAYS,
-    schedule_auto_transition_to_ongoing,
-)
+from sentry.tasks.auto_ongoing_issues import schedule_auto_transition_to_ongoing
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.types.activity import ActivityType


### PR DESCRIPTION

```
src/sentry/monitoring/queues.py:110: error: Import cycle from Django settings module prevents type inference for 'CELERY_QUEUES'  [misc]
```

doesn't look like much here but it's a step towards django-stubs 5.x

will follow up with the one usage in `getsentry` -- though it will still work due to the import being preserved

<!-- Describe your PR here. -->