### PR TITLE
feat(related_issues): Add button to open list of issues

### DIFF
--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -51,10 +51,10 @@ export type GroupListColumn =
 
 type Props = WithRouterProps & {
   api: Client;
+  endpointPath: string;
   orgSlug: string;
-  query: string; // Optional: `query` value to be passed to endpointPath
+  query: string;
   customStatsPeriod?: TimePeriodType;
-  endpointPath?: string; // It defaults to `/organizations/${orgSlug}/issues/`
   onFetchSuccess?: (
     groupListState: State,
     onCursor: (

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -51,10 +51,10 @@ export type GroupListColumn =
 
 type Props = WithRouterProps & {
   api: Client;
-  endpointPath: string;
   orgSlug: string;
-  query: string;
+  query: string; // Optional: `query` value to be passed to endpointPath
   customStatsPeriod?: TimePeriodType;
+  endpointPath?: string; // It defaults to `/organizations/${orgSlug}/issues/`
   onFetchSuccess?: (
     groupListState: State,
     onCursor: (

--- a/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
@@ -158,7 +158,7 @@ describe('Related Issues View', function () {
     expect(linkButton).toHaveAttribute(
       'href',
       // Opening in Issues needs to include the group we are currently viewing
-      `/issues/?query=issue.id:[${groupId},${group1},${group2}]`
+      `/organizations/org-slug/issues/?query=issue.id:[${groupId},${group1},${group2}]`
     );
   });
 
@@ -194,13 +194,13 @@ describe('Related Issues View', function () {
     const linkElement = screen.getByRole('link', {name: /this trace/i});
     expect(linkElement).toHaveAttribute(
       'href',
-      '/performance/trace/1234/?node=error-abcd'
+      '/organizations/org-slug/performance/trace/1234/?node=error-abcd'
     );
     const linkButton = screen.getByRole('button', {name: /open in issues/i});
+    // The Issue search supports using `trace` as a parameter
     expect(linkButton).toHaveAttribute(
       'href',
-      // Opening in Issues needs to include the group we are currently viewing
-      `/issues/?query=issue.id:[${groupId},${group1},${group2}]`
+      `/organizations/org-slug/issues/?query=trace:1234`
     );
   });
 });

--- a/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
@@ -16,7 +16,7 @@ describe('Related Issues View', function () {
   const group1 = '15';
   const group2 = '20';
   // query=issue.id:[15,20] -> query=issue.id%3A%5B15%2C20%5D
-  const orgIssuesEndpoint = `/organizations/${orgSlug}/issues/?limit=50&query=issue.id%3A%5B${group1}%2C${group2}%5D&sort=new`;
+  const orgIssuesEndpoint = `/organizations/${orgSlug}/issues/?query=issue.id%3A%5B${group1}%2C${group2}%5D`;
 
   const params = {groupId: groupId};
   const errorType = 'RuntimeError';

--- a/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
@@ -154,6 +154,12 @@ describe('Related Issues View', function () {
     expect(
       await screen.findByText('No trace-connected related issues were found.')
     ).toBeInTheDocument();
+    const linkButton = screen.getByRole('button', {name: /open in issues/i});
+    expect(linkButton).toHaveAttribute(
+      'href',
+      // Opening in Issues needs to include the group we are currently viewing
+      `/issues/?query=issue.id:[${groupId},${group1},${group2}]`
+    );
   });
 
   it('renders with trace connected issues', async function () {
@@ -189,6 +195,12 @@ describe('Related Issues View', function () {
     expect(linkElement).toHaveAttribute(
       'href',
       '/performance/trace/1234/?node=error-abcd'
+    );
+    const linkButton = screen.getByRole('button', {name: /open in issues/i});
+    expect(linkButton).toHaveAttribute(
+      'href',
+      // Opening in Issues needs to include the group we are currently viewing
+      `/issues/?query=issue.id:[${groupId},${group1},${group2}]`
     );
   });
 });

--- a/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.spec.tsx
@@ -16,7 +16,7 @@ describe('Related Issues View', function () {
   const group1 = '15';
   const group2 = '20';
   // query=issue.id:[15,20] -> query=issue.id%3A%5B15%2C20%5D
-  const orgIssuesEndpoint = `/organizations/${orgSlug}/issues/?query=issue.id%3A%5B${group1}%2C${group2}%5D`;
+  const orgIssuesEndpoint = `/organizations/${orgSlug}/issues/?limit=50&query=issue.id%3A%5B${group1}%2C${group2}%5D&sort=new`;
 
   const params = {groupId: groupId};
   const errorType = 'RuntimeError';

--- a/static/app/views/issueDetails/groupRelatedIssues/index.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.tsx
@@ -95,11 +95,10 @@ function GroupRelatedIssues({params}: Props) {
                 <Title>{t('Issues caused by the same root cause')}</Title>
                 {sameRootCauseIssues.length > 0 ? (
                   <GroupList
-                    endpointPath={`/organizations/${orgSlug}/issues/`}
                     orgSlug={orgSlug}
-                    queryParams={{query: `issue.id:[${sameRootCauseIssues}]`}}
-                    query=""
+                    query={`issue.id:[${sameRootCauseIssues}]`}
                     source="related-issues-tab"
+                    withColumns={['event', 'assignee']}
                   />
                 ) : (
                   <small>{t('No same-root-cause related issues were found.')}</small>
@@ -120,11 +119,10 @@ function GroupRelatedIssues({params}: Props) {
                       </Link>
                     </small>
                     <GroupList
-                      endpointPath={`/organizations/${orgSlug}/issues/`}
                       orgSlug={orgSlug}
-                      queryParams={{query: `issue.id:[${traceConnectedIssues}]`}}
-                      query=""
+                      query={`issue.id:[${traceConnectedIssues}]`}
                       source="related-issues-tab"
+                      withColumns={['event', 'assignee']}
                     />
                   </div>
                 ) : (

--- a/static/app/views/issueDetails/groupRelatedIssues/index.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.tsx
@@ -104,11 +104,11 @@ function GroupRelatedIssues({params}: Props) {
                       </LinkButton>
                     </TextButtonWrapper>
                     <GroupList
+                      endpointPath={`/organizations/${orgSlug}/issues/`}
                       orgSlug={orgSlug}
-                      // Exclude the current group from the list of related issues
-                      query={`issue.id:[${sameRootCauseIssues.filter(id => id !== groupId)}]`}
+                      queryParams={{query: `issue.id:[${sameRootCauseIssues}]`}}
+                      query=""
                       source="related-issues-tab"
-                      withColumns={['event', 'assignee']}
                     />
                   </div>
                 ) : (
@@ -139,11 +139,11 @@ function GroupRelatedIssues({params}: Props) {
                       </LinkButton>
                     </TextButtonWrapper>
                     <GroupList
+                      endpointPath={`/organizations/${orgSlug}/issues/`}
                       orgSlug={orgSlug}
-                      // Exclude the current group from the list of related issues
-                      query={`issue.id:[${traceConnectedIssues.filter(id => id !== groupId)}]`}
+                      queryParams={{query: `issue.id:[${traceConnectedIssues}]`}}
+                      query=""
                       source="related-issues-tab"
-                      withColumns={['event', 'assignee']}
                     />
                   </div>
                 ) : (

--- a/static/app/views/issueDetails/groupRelatedIssues/index.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.tsx
@@ -96,7 +96,7 @@ function GroupRelatedIssues({params}: Props) {
                     <TextButtonWrapper>
                       <div />
                       <LinkButton
-                        href={`/issues/?query=issue.id:[${groupId},${sameRootCauseIssues}]`}
+                        to={`/organizations/${orgSlug}/issues/?query=issue.id:[${groupId},${sameRootCauseIssues}]`}
                         size="xs"
                         external
                       >

--- a/static/app/views/issueDetails/groupRelatedIssues/index.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.tsx
@@ -98,7 +98,6 @@ function GroupRelatedIssues({params}: Props) {
                       <LinkButton
                         to={`/organizations/${orgSlug}/issues/?query=issue.id:[${groupId},${sameRootCauseIssues}]`}
                         size="xs"
-                        external
                       >
                         {t('Open in Issues')}
                       </LinkButton>
@@ -109,6 +108,8 @@ function GroupRelatedIssues({params}: Props) {
                       queryParams={{query: `issue.id:[${sameRootCauseIssues}]`}}
                       query=""
                       source="related-issues-tab"
+                      canSelectGroups={false}
+                      withChart={false}
                     />
                   </div>
                 ) : (
@@ -125,15 +126,14 @@ function GroupRelatedIssues({params}: Props) {
                       <small>
                         {t('These are the issues belonging to ')}
                         <Link
-                          to={`/performance/trace/${traceMeta.trace_id}/?node=error-${traceMeta.event_id}`}
+                          to={`/organizations/${orgSlug}/performance/trace/${traceMeta.trace_id}/?node=error-${traceMeta.event_id}`}
                         >
                           {t('this trace')}
                         </Link>
                       </small>
                       <LinkButton
-                        href={`/issues/?query=issue.id:[${groupId},${traceConnectedIssues}]`}
+                        to={`/organizations/${orgSlug}/issues/?query=trace:${traceMeta.trace_id}`}
                         size="xs"
-                        external
                       >
                         {t('Open in Issues')}
                       </LinkButton>
@@ -144,6 +144,8 @@ function GroupRelatedIssues({params}: Props) {
                       queryParams={{query: `issue.id:[${traceConnectedIssues}]`}}
                       query=""
                       source="related-issues-tab"
+                      canSelectGroups={false}
+                      withChart={false}
                     />
                   </div>
                 ) : (

--- a/static/app/views/issueDetails/groupRelatedIssues/index.tsx
+++ b/static/app/views/issueDetails/groupRelatedIssues/index.tsx
@@ -4,6 +4,7 @@ import type {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
+import {LinkButton} from 'sentry/components/button';
 import GroupList from 'sentry/components/issues/groupList';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Link from 'sentry/components/links/link';
@@ -61,10 +62,7 @@ function GroupRelatedIssues({params}: Props) {
       if (item.type === 'trace_connected') {
         traceMeta = {...item.meta};
       }
-      // If the group we're looking related issues for shows up in the table,
-      // it will trigger a bug in getGroupReprocessingStatus because activites would be empty,
-      // thus, we excude it from the list of related issues
-      const issuesList = item.data.filter(id => id.toString() !== groupId);
+      const issuesList = item.data;
       mapping[item.type] = issuesList;
       return mapping;
     },
@@ -94,12 +92,25 @@ function GroupRelatedIssues({params}: Props) {
               <HeaderWrapper>
                 <Title>{t('Issues caused by the same root cause')}</Title>
                 {sameRootCauseIssues.length > 0 ? (
-                  <GroupList
-                    orgSlug={orgSlug}
-                    query={`issue.id:[${sameRootCauseIssues}]`}
-                    source="related-issues-tab"
-                    withColumns={['event', 'assignee']}
-                  />
+                  <div>
+                    <TextButtonWrapper>
+                      <div />
+                      <LinkButton
+                        href={`/issues/?query=issue.id:[${groupId},${sameRootCauseIssues}]`}
+                        size="xs"
+                        external
+                      >
+                        {t('Open in Issues')}
+                      </LinkButton>
+                    </TextButtonWrapper>
+                    <GroupList
+                      orgSlug={orgSlug}
+                      // Exclude the current group from the list of related issues
+                      query={`issue.id:[${sameRootCauseIssues.filter(id => id !== groupId)}]`}
+                      source="related-issues-tab"
+                      withColumns={['event', 'assignee']}
+                    />
+                  </div>
                 ) : (
                   <small>{t('No same-root-cause related issues were found.')}</small>
                 )}
@@ -110,17 +121,27 @@ function GroupRelatedIssues({params}: Props) {
                 <Title>{t('Trace connected issues')}</Title>
                 {traceConnectedIssues.length > 0 ? (
                   <div>
-                    <small>
-                      {t('These are the issues belonging to ')}
-                      <Link
-                        to={`/performance/trace/${traceMeta.trace_id}/?node=error-${traceMeta.event_id}`}
+                    <TextButtonWrapper>
+                      <small>
+                        {t('These are the issues belonging to ')}
+                        <Link
+                          to={`/performance/trace/${traceMeta.trace_id}/?node=error-${traceMeta.event_id}`}
+                        >
+                          {t('this trace')}
+                        </Link>
+                      </small>
+                      <LinkButton
+                        href={`/issues/?query=issue.id:[${groupId},${traceConnectedIssues}]`}
+                        size="xs"
+                        external
                       >
-                        {t('this trace')}
-                      </Link>
-                    </small>
+                        {t('Open in Issues')}
+                      </LinkButton>
+                    </TextButtonWrapper>
                     <GroupList
                       orgSlug={orgSlug}
-                      query={`issue.id:[${traceConnectedIssues}]`}
+                      // Exclude the current group from the list of related issues
+                      query={`issue.id:[${traceConnectedIssues.filter(id => id !== groupId)}]`}
                       source="related-issues-tab"
                       withColumns={['event', 'assignee']}
                     />
@@ -159,4 +180,10 @@ const HeaderWrapper = styled('div')`
   small {
     color: ${p => p.theme.subText};
   }
+`;
+
+const TextButtonWrapper = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: ${space(1)};
 `;


### PR DESCRIPTION
Instead of adding the action bar to the `GroupList` component, we will add a button to open the list of issues in a new tab.

The developer can then take action on those issues if they wish to do so.
![image](https://github.com/getsentry/sentry/assets/44410/c57ed8be-8f5a-4847-98e1-d17fc28ad62a)

![image](https://github.com/getsentry/sentry/assets/44410/f07bd55d-6d3d-4808-8b8f-7ccce0c152c9)


