### PR TITLE
fix(grouping): Remove `None` from `SimilarIssuesEmbeddingsResponse` type

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/api/endpoints/group_similar_issues_embeddings.py
@@ -107,7 +107,7 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
     }
 
     def get_formatted_results(
-        self, responses: Sequence[SimilarIssuesEmbeddingsData | None], user: User | AnonymousUser
+        self, responses: Sequence[SimilarIssuesEmbeddingsData], user: User | AnonymousUser
     ) -> Sequence[tuple[Mapping[str, Any], Mapping[str, Any]] | None]:
         """
         Format the responses using to be used by the frontend by changing the  field names and
@@ -115,13 +115,12 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         """
         group_data = {}
         for response in responses:
-            if response:
-                formatted_response: FormattedSimilarIssuesEmbeddingsData = {
-                    "message": 1 - response["message_distance"],
-                    "exception": 1 - response["stacktrace_distance"],
-                    "shouldBeGrouped": "Yes" if response["should_group"] else "No",
-                }
-                group_data.update({response["parent_group_id"]: formatted_response})
+            formatted_response: FormattedSimilarIssuesEmbeddingsData = {
+                "message": 1 - response["message_distance"],
+                "exception": 1 - response["stacktrace_distance"],
+                "shouldBeGrouped": "Yes" if response["should_group"] else "No",
+            }
+            group_data.update({response["parent_group_id"]: formatted_response})
 
         serialized_groups = {
             int(g["id"]): g

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -100,7 +100,7 @@ class SimilarIssuesEmbeddingsData(TypedDict):
 
 
 class SimilarIssuesEmbeddingsResponse(TypedDict):
-    responses: list[SimilarIssuesEmbeddingsData | None]
+    responses: list[SimilarIssuesEmbeddingsData]
 
 
 def get_similar_issues_embeddings(


### PR DESCRIPTION
When seer doesn't find any near-enough neighbors, it sends back an empty list rather than `None`, and when it sends back results, none of them are ever `None`. We therefore don't need the `None` in the seer response typing.