### PR TITLE
feat(webhooks): Add a webhook for issue_unresolved

### DIFF
--- a/src/sentry/analytics/events/sentryapp_issue_webhooks.py
+++ b/src/sentry/analytics/events/sentryapp_issue_webhooks.py
@@ -27,7 +27,12 @@ class SentryAppIssueResolved(SentryAppIssueEvent):
     type = "sentry_app.issue.resolved"
 
 
+class SentryAppIssueUnresolved(SentryAppIssueEvent):
+    type = "sentry_app.issue.unresolved"
+
+
 analytics.register(SentryAppIssueCreated)
 analytics.register(SentryAppIssueAssigned)
 analytics.register(SentryAppIssueIgnored)
 analytics.register(SentryAppIssueResolved)
+analytics.register(SentryAppIssueUnresolved)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1956,6 +1956,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:user-feedback-spam-filter-ingest": False,
     # Enable User Feedback v2 UI
     "organizations:user-feedback-ui": False,
+    # Enabled unresolved issue webhook for organization
+    "organizations:webhooks-unresolved": False,
     # Enable view hierarchies options
     "organizations:view-hierarchies-options-dev": False,
     # Enable minimap in the widget viewer modal in dashboards

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2036,6 +2036,7 @@ def _handle_regression(group: Group, event: BaseEvent, release: Release | None) 
             group=group,
             transition_type="automatic",
             sender="handle_regression",
+            new_substatus=GroupSubStatus.REGRESSED,
         )
         if not options.get("groups.enable-post-update-signal"):
             post_save.send(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -258,6 +258,7 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
     manager.add("organizations:widget-viewer-modal-minimap", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+    manager.add("organizations:webhooks-unresolved", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.
 

--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -7,6 +7,7 @@ from django.db.models.signals import post_save
 from sentry import options
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupinbox import bulk_remove_groups_from_inbox
+from sentry.signals import issue_unresolved
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 
@@ -39,6 +40,15 @@ def bulk_transition_group_to_ongoing(
     for group in groups_to_transistion:
         group.status = GroupStatus.UNRESOLVED
         group.substatus = GroupSubStatus.ONGOING
+        if from_status != GroupStatus.UNRESOLVED:
+            issue_unresolved.send_robust(
+                project=group.project,
+                group=group,
+                user=None,
+                transition_type="automatic",
+                sender=bulk_transition_group_to_ongoing,
+                new_substatus=GroupSubStatus.ONGOING,
+            )
 
     with sentry_sdk.start_span(description="bulk_remove_groups_from_inbox"):
         bulk_remove_groups_from_inbox(groups_to_transistion)

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -62,7 +62,9 @@ def handle_status_update(
                     group=group,
                     transition_type="manual",
                     sender=sender,
+                    new_substatus=new_substatus,
                 )
+
     elif new_status == GroupStatus.IGNORED:
         ignore_duration = (
             status_details.pop("ignoreDuration", None) or status_details.pop("snoozeDuration", None)

--- a/src/sentry/models/integrations/sentry_app.py
+++ b/src/sentry/models/integrations/sentry_app.py
@@ -41,6 +41,7 @@ EVENT_EXPANSION = {
         "issue.resolved",
         "issue.ignored",
         "issue.assigned",
+        "issue.unresolved",
     ],
     "error": ["error.created"],
     "comment": ["comment.created", "comment.updated", "comment.deleted"],

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -7,6 +7,7 @@ from sentry import features
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.models.sentryfunction import SentryFunction
 from sentry.models.team import Team
 from sentry.models.user import User
@@ -21,9 +22,11 @@ from sentry.signals import (
     issue_assigned,
     issue_ignored,
     issue_resolved,
+    issue_unresolved,
 )
 from sentry.tasks.sentry_apps import build_comment_webhook, workflow_notification
 from sentry.tasks.sentry_functions import send_sentry_function_webhook
+from sentry.types.group import SUBSTATUS_TO_STR, GroupSubStatus
 
 
 @issue_assigned.connect(weak=False)
@@ -60,6 +63,27 @@ def send_issue_ignored_webhook(project, user, group_list, **kwargs):
     for issue in group_list:
         send_workflow_webhooks(project.organization, issue, user, "issue.ignored")
         send_workflow_webhooks(project.organization, issue, user, "issue.archived")
+
+
+@issue_unresolved.connect(weak=False)
+def send_issue_unresolved_webhook(
+    group: Group,
+    project: Project,
+    user: User | RpcUser | None = None,
+    new_substatus: GroupSubStatus | None = None,
+    **kwargs,
+):
+    organization = project.organization
+    if features.has("organizations:webhooks-unresolved", organization):
+        send_workflow_webhooks(
+            organization=organization,
+            issue=group,
+            user=user,
+            event="issue.unresolved",
+            data={
+                "substatus": SUBSTATUS_TO_STR[new_substatus if new_substatus else group.substatus]
+            },
+        )
 
 
 @comment_created.connect(weak=False)
@@ -100,7 +124,7 @@ def send_comment_webhooks(organization, issue, user, event, data=None):
 def send_workflow_webhooks(
     organization: Organization,
     issue: Group,
-    user: User | RpcUser,
+    user: User | RpcUser | None,
     event: str,
     data: Mapping[str, Any] | None = None,
 ) -> None:

--- a/tests/sentry/hybridcloud/test_hook_service.py
+++ b/tests/sentry/hybridcloud/test_hook_service.py
@@ -1,3 +1,4 @@
+from sentry.models.integrations.sentry_app import EVENT_EXPANSION
 from sentry.models.servicehook import ServiceHook
 from sentry.sentry_apps.apps import consolidate_events, expand_events
 from sentry.services.hybrid_cloud.hook import hook_service
@@ -40,21 +41,10 @@ class TestHookService(TestCase):
 
     def test_expands_resource_events_to_specific_events(self):
         service_hook = self.call_create_hook(events=["issue"])
-
-        assert set(service_hook.events) == {
-            "issue.created",
-            "issue.resolved",
-            "issue.ignored",
-            "issue.assigned",
-        }
+        assert set(service_hook.events) == set(EVENT_EXPANSION["issue"])
 
     def test_expand_events(self):
-        assert expand_events(["issue"]) == {
-            "issue.created",
-            "issue.resolved",
-            "issue.ignored",
-            "issue.assigned",
-        }
+        assert expand_events(["issue"]) == set(EVENT_EXPANSION["issue"])
 
     def test_consolidate_events(self):
         assert consolidate_events(["issue.created"]) == {"issue"}

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -6,8 +6,10 @@ from unittest.mock import patch
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import UserSerializer
 from sentry.constants import SentryAppInstallationStatus
+from sentry.issues.ongoing import bulk_transition_group_to_ongoing
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
+from sentry.models.group import GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.grouplink import GroupLink
 from sentry.models.release import Release
@@ -21,6 +23,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 # This testcase needs to be an APITestCase because all of the logic to resolve
 # Issues and kick off side effects are just chillin in the endpoint code -_-
 from sentry.types.activity import ActivityType
+from sentry.types.group import GroupSubStatus
 from sentry.utils import json
 
 
@@ -37,7 +40,9 @@ class TestIssueWorkflowNotifications(APITestCase):
     def setUp(self):
         self.issue = self.create_group(project=self.project)
 
-        self.sentry_app = self.create_sentry_app(events=["issue.resolved", "issue.ignored"])
+        self.sentry_app = self.create_sentry_app(
+            events=["issue.resolved", "issue.ignored", "issue.unresolved"]
+        )
 
         self.install = self.create_sentry_app_installation(
             organization=self.organization, slug=self.sentry_app.slug
@@ -51,6 +56,47 @@ class TestIssueWorkflowNotifications(APITestCase):
         data = {"status": "resolved"}
         data.update(_data or {})
         self.client.put(self.url, data=data, format="json")
+
+    @with_feature("organizations:webhooks-unresolved")
+    def test_notify_after_regress(self, delay):
+        # First we need to resolve the issue
+        self.update_issue({})
+        delay.assert_any_call(
+            installation_id=self.install.id,
+            issue_id=self.issue.id,
+            type="resolved",
+            user_id=self.user.id,
+            data={"resolution_type": "now"},
+        )
+
+        # Then marked it unresolved for regressed to make sense
+        self.update_issue({"status": "unresolved", "substatus": "regressed"})
+        delay.assert_any_call(
+            installation_id=self.install.id,
+            issue_id=self.issue.id,
+            type="unresolved",
+            user_id=self.user.id,
+            data={"substatus": "regressed"},
+        )
+        assert delay.call_count == 2
+
+    @with_feature("organizations:webhooks-unresolved")
+    def test_notify_after_bulk_ongoing(self, delay):
+        # First we need to have an ignored issue
+        self.update_issue({"status": "ignored", "substatus": "until_escalating"})
+        bulk_transition_group_to_ongoing(
+            from_status=GroupStatus.IGNORED,
+            from_substatus=GroupSubStatus.UNTIL_ESCALATING,
+            group_ids=[self.issue.id],
+        )
+        delay.assert_any_call(
+            installation_id=self.install.id,
+            issue_id=self.issue.id,
+            type="unresolved",
+            user_id=None,
+            data={"substatus": "ongoing"},
+        )
+        assert delay.call_count == 2
 
     def test_notify_after_basic_resolved(self, delay):
         self.update_issue()


### PR DESCRIPTION
issue_unresolved could mean the issue is regressed or ongoing. In this PR I'm using the existing unresolved signal and issue substatus to the data to be able to distinguish between regressed or escalated or others. Escalated will come in the next PR.
