### PR TITLE
feat(webhooks):Add a webhook for issue.escalating

### DIFF
--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -522,6 +522,7 @@ def manage_issue_states(
                 event=event,
                 sender=manage_issue_states,
                 was_until_escalating=True if has_forecast else False,
+                new_substatus=GroupSubStatus.ESCALATING,
             )
             if data and activity_data and has_forecast:  # Redundant checks needed for typing
                 data.update(activity_data)


### PR DESCRIPTION
issue_escalating is already an existing analytics event that gets thrown but we don't have a webhook for it. So this PR maps a webhook to issue_escalating signal.