### PR TITLE
feat(highlights): Small fixes to highlights

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.tsx
@@ -186,6 +186,7 @@ export const TreeContainer = styled('div')<{columnCount: number}>`
   display: grid;
   grid-template-columns: repeat(${p => p.columnCount}, 1fr);
   align-items: start;
+  margin-left: -${space(1)};
 `;
 
 export const TreeColumn = styled('div')`

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -14,7 +14,7 @@ import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
-import {generateQueryWithTag, isUrl} from 'sentry/utils';
+import {generateQueryWithTag, isUrl, objectIsEmpty} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 
@@ -48,6 +48,7 @@ export default function EventTagsTreeRow({
   const tagMeta = content.meta?.value?.[''];
   const tagErrors = tagMeta?.err ?? [];
   const hasTagErrors = tagErrors.length > 0 && !config?.disableActions;
+  const hasStem = !isLast && objectIsEmpty(content.subtree);
 
   if (!originalTag) {
     return (
@@ -55,7 +56,7 @@ export default function EventTagsTreeRow({
         <TreeKeyTrunk spacerCount={spacerCount}>
           {spacerCount > 0 && (
             <Fragment>
-              <TreeSpacer spacerCount={spacerCount} isLast={isLast} />
+              <TreeSpacer spacerCount={spacerCount} hasStem={hasStem} />
               <TreeBranchIcon hasErrors={hasTagErrors} />
             </Fragment>
           )}
@@ -93,7 +94,7 @@ export default function EventTagsTreeRow({
       <TreeKeyTrunk spacerCount={spacerCount}>
         {spacerCount > 0 && (
           <Fragment>
-            <TreeSpacer spacerCount={spacerCount} isLast={isLast} />
+            <TreeSpacer spacerCount={spacerCount} hasStem={hasStem} />
             <TreeBranchIcon hasErrors={hasTagErrors} />
           </Fragment>
         )}
@@ -245,10 +246,10 @@ const TreeRow = styled('div')<{hasErrors: boolean}>`
     ${p => (p.hasErrors ? p.theme.alert.error.border : 'transparent')};
 `;
 
-const TreeSpacer = styled('div')<{isLast: boolean; spacerCount: number}>`
+const TreeSpacer = styled('div')<{hasStem: boolean; spacerCount: number}>`
   grid-column: span 1;
   /* Allows TreeBranchIcons to appear connected vertically */
-  border-right: 1px solid ${p => (!p.isLast ? p.theme.border : 'transparent')};
+  border-right: 1px solid ${p => (p.hasStem ? p.theme.border : 'transparent')};
   margin-right: -1px;
   height: 100%;
 `;

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -1,6 +1,6 @@
-import type {RefObject} from 'react';
+import {type RefObject, useCallback, useState} from 'react';
+import {useResizeObserver} from '@react-aria/utils';
 
-import {useDimensions} from 'sentry/utils/useDimensions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -174,7 +174,16 @@ const ISSUE_DETAILS_COLUMN_BREAKPOINTS = [
  * accurately describe the available space.
  */
 export function useIssueDetailsColumnCount(elementRef: RefObject<HTMLElement>): number {
-  const {width} = useDimensions<HTMLElement>({elementRef});
+  const [width, setWidth] = useState(0);
+
+  const element = elementRef.current;
+
+  const onResize = useCallback(() => {
+    setWidth(element?.clientWidth || 0);
+  }, [element]);
+
+  useResizeObserver({ref: elementRef, onResize});
+
   const breakPoint = ISSUE_DETAILS_COLUMN_BREAKPOINTS.find(
     ({minWidth}) => width >= minWidth
   );

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -94,6 +94,11 @@ export const TagFilterData = {
     'url',
   ]),
   [TagFilter.OTHER]: new Set([
+    /* Monitors */
+    'monitor.slug',
+    'monitor.incident',
+    'monitor.id',
+    'monitor.status',
     /* SDK (maybe?) */
     'handled',
     'level',

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -179,18 +179,19 @@ const ISSUE_DETAILS_COLUMN_BREAKPOINTS = [
  * accurately describe the available space.
  */
 export function useIssueDetailsColumnCount(elementRef: RefObject<HTMLElement>): number {
-  const [width, setWidth] = useState(0);
+  const [columnCount, setColumnCount] = useState(1);
 
   const element = elementRef.current;
 
   const onResize = useCallback(() => {
-    setWidth(element?.clientWidth || 0);
+    const width = element?.clientWidth || 0;
+    const breakpoint = ISSUE_DETAILS_COLUMN_BREAKPOINTS.find(
+      ({minWidth}) => width >= minWidth
+    );
+    setColumnCount(breakpoint?.columnCount ?? 1);
   }, [element]);
 
   useResizeObserver({ref: elementRef, onResize});
 
-  const breakPoint = ISSUE_DETAILS_COLUMN_BREAKPOINTS.find(
-    ({minWidth}) => width >= minWidth
-  );
-  return breakPoint?.columnCount ?? 1;
+  return columnCount;
 }

--- a/static/app/components/events/highlights/editHighlightsModal.spec.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.spec.tsx
@@ -86,6 +86,7 @@ describe('EditHighlightsModal', function () {
     expect(screen.getByText('Edit Event Highlights')).toBeInTheDocument();
     expect(screen.getByTestId('highlights-preview-section')).toBeInTheDocument();
     expect(screen.getByTestId('highlights-empty-message')).toBeInTheDocument();
+    expect(screen.getByTestId('highlights-save-info')).toBeInTheDocument();
     expect(screen.getByTestId('highlights-tag-section')).toBeInTheDocument();
     expect(screen.getByTestId('highlights-context-section')).toBeInTheDocument();
 
@@ -106,7 +107,7 @@ describe('EditHighlightsModal', function () {
     // Reopen the modal to test cancel button
     jest.resetAllMocks();
     renderModal({highlightContext: {}, highlightTags: []});
-    const saveButton = screen.getByRole('button', {name: 'Save'});
+    const saveButton = screen.getByRole('button', {name: 'Apply to Project'});
     await userEvent.click(saveButton);
     expect(updateProjectMock).toHaveBeenCalled();
     expect(closeModal).toHaveBeenCalled();
@@ -150,7 +151,7 @@ describe('EditHighlightsModal', function () {
       expect(contextItem).not.toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Apply to Project'}));
     expect(updateProjectMock).toHaveBeenCalledWith(
       url,
       expect.objectContaining({
@@ -205,7 +206,7 @@ describe('EditHighlightsModal', function () {
     await Promise.all(tagTestPromises);
 
     // All event tags should be present now
-    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Apply to Project'}));
     expect(updateProjectMock).toHaveBeenCalledWith(
       url,
       expect.objectContaining({
@@ -281,7 +282,7 @@ describe('EditHighlightsModal', function () {
     });
 
     // All event tags should be present now
-    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Apply to Project'}));
     expect(updateProjectMock).toHaveBeenCalledWith(
       url,
       expect.objectContaining({

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -381,7 +381,7 @@ export default function EditHighlightsModal({
         />
       </Body>
       <Footer>
-        <FooterInfo>
+        <FooterInfo data-test-id="highlights-save-info">
           <IconInfo />
           <div>{t('Changes are applied to all issues for this project')}</div>
         </FooterInfo>

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -17,7 +17,7 @@ import {
   getHighlightContextData,
   getHighlightTagData,
 } from 'sentry/components/events/highlights/util';
-import {IconAdd, IconSubtract} from 'sentry/icons';
+import {IconAdd, IconInfo, IconSubtract} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Project} from 'sentry/types';
@@ -324,7 +324,7 @@ export default function EditHighlightsModal({
   const columnCount = 3;
   return (
     <Fragment>
-      <Header>
+      <Header closeButton>
         <Title>{t('Edit Event Highlights')}</Title>
       </Header>
       <Body>
@@ -374,6 +374,10 @@ export default function EditHighlightsModal({
         />
       </Body>
       <Footer>
+        <FooterInfo>
+          <IconInfo />
+          <div>{t('Changes are applied to all issues for this project')}</div>
+        </FooterInfo>
         <ButtonBar gap={1}>
           <Button onClick={closeModal} size="sm">
             {t('Cancel')}
@@ -395,7 +399,7 @@ export default function EditHighlightsModal({
             priority="primary"
             size="sm"
           >
-            {isLoading ? t('Saving...') : t('Save')}
+            {isLoading ? t('Saving...') : t('Apply to Project')}
           </Button>
         </ButtonBar>
       </Footer>
@@ -412,6 +416,14 @@ const Subtitle = styled('h4')`
   border-bottom: 1px solid ${p => p.theme.border};
   margin-bottom: ${space(1.5)};
   padding-bottom: ${space(0.5)};
+`;
+
+const FooterInfo = styled('div')`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  color: ${p => p.theme.subText};
+  gap: ${space(1)};
 `;
 
 const EditHighlightPreview = styled('div')<{columnCount: number}>`

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -21,6 +21,7 @@ import {IconAdd, IconInfo, IconSubtract} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Project} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
@@ -332,11 +333,13 @@ export default function EditHighlightsModal({
           event={event}
           highlightTags={highlightTags}
           highlightContext={highlightContext}
-          onRemoveTag={tagKey =>
-            setHighlightTags(highlightTags.filter(tag => tag !== tagKey))
-          }
+          onRemoveTag={tagKey => {
+            trackAnalytics('edit_highlights.remove_tag_key', {organization});
+            setHighlightTags(highlightTags.filter(tag => tag !== tagKey));
+          }}
           onRemoveContextKey={(contextType, contextKey) =>
             setHighlightContext(() => {
+              trackAnalytics('edit_highlights.remove_context_key', {organization});
               const {[contextType]: highlightContextKeys, ...newHighlightContext} =
                 highlightContext;
               const newHighlightContextKeys = (highlightContextKeys ?? []).filter(
@@ -357,19 +360,23 @@ export default function EditHighlightsModal({
           event={event}
           columnCount={columnCount}
           highlightTags={highlightTags}
-          onAddTag={tagKey => setHighlightTags([...highlightTags, tagKey])}
+          onAddTag={tagKey => {
+            trackAnalytics('edit_highlights.add_tag_key', {organization});
+            setHighlightTags([...highlightTags, tagKey]);
+          }}
           data-test-id="highlights-tag-section"
         />
         <EditContextHighlightSection
           event={event}
           columnCount={columnCount}
           highlightContext={highlightContext}
-          onAddContextKey={(contextType, contextKey) =>
+          onAddContextKey={(contextType, contextKey) => {
+            trackAnalytics('edit_highlights.add_context_key', {organization});
             setHighlightContext({
               ...highlightContext,
               [contextType]: [...(highlightContext[contextType] ?? []), contextKey],
-            })
-          }
+            });
+          }}
           data-test-id="highlights-context-section"
         />
       </Body>
@@ -379,12 +386,19 @@ export default function EditHighlightsModal({
           <div>{t('Changes are applied to all issues for this project')}</div>
         </FooterInfo>
         <ButtonBar gap={1}>
-          <Button onClick={closeModal} size="sm">
+          <Button
+            onClick={() => {
+              trackAnalytics('edit_highlights.cancel_clicked', {organization});
+              closeModal();
+            }}
+            size="sm"
+          >
             {t('Cancel')}
           </Button>
           {highlightPreset && (
             <Button
               onClick={() => {
+                trackAnalytics('edit_highlights.use_default_clicked', {organization});
                 setHighlightContext(highlightPreset.context);
                 setHighlightTags(highlightPreset.tags);
               }}
@@ -395,7 +409,10 @@ export default function EditHighlightsModal({
           )}
           <Button
             disabled={isLoading}
-            onClick={() => saveHighlights({highlightContext, highlightTags})}
+            onClick={() => {
+              trackAnalytics('edit_highlights.save_clicked', {organization});
+              saveHighlights({highlightContext, highlightTags});
+            }}
             priority="primary"
             size="sm"
           >

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -3,6 +3,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {ContextCardContent} from 'sentry/components/events/contexts/contextCard';
@@ -119,6 +120,11 @@ export default function HighlightsDataSection({
     );
   }
 
+  const isProjectAdmin = hasEveryAccess(['project:admin'], {
+    organization: organization,
+    project: detailedProject,
+  });
+
   function openEditHighlightsModal() {
     openModal(
       deps => (
@@ -135,6 +141,13 @@ export default function HighlightsDataSection({
     );
   }
 
+  const editProps = {
+    disabled: !isProjectAdmin,
+    title: !isProjectAdmin
+      ? t('You must be a Project Admin to edit highlights.')
+      : undefined,
+  };
+
   return (
     <EventDataSection
       title={t('Event Highlights')}
@@ -143,7 +156,12 @@ export default function HighlightsDataSection({
       actions={
         <ButtonBar gap={1}>
           {viewAllButton}
-          <Button size="xs" icon={<IconEdit />} onClick={openEditHighlightsModal}>
+          <Button
+            size="xs"
+            icon={<IconEdit />}
+            onClick={openEditHighlightsModal}
+            {...editProps}
+          >
             {t('Edit')}
           </Button>
         </ButtonBar>
@@ -158,7 +176,11 @@ export default function HighlightsDataSection({
           <EmptyHighlights>
             <EmptyHighlightsContent>
               {t("There's nothing here...")}
-              <AddHighlightsButton size="xs" onClick={openEditHighlightsModal}>
+              <AddHighlightsButton
+                size="xs"
+                onClick={openEditHighlightsModal}
+                {...editProps}
+              >
                 {t('Add Highlights')}
               </AddHighlightsButton>
             </EmptyHighlightsContent>

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -143,9 +143,7 @@ export default function HighlightsDataSection({
 
   const editProps = {
     disabled: !isProjectAdmin,
-    title: !isProjectAdmin
-      ? t('You must be a Project Admin to edit highlights.')
-      : undefined,
+    title: !isProjectAdmin ? t('Only Project Admins can edit highlights.') : undefined,
   };
 
   return (

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -28,6 +28,7 @@ import {IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event, Group, Project} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDetailedProject} from 'sentry/utils/useDetailedProject';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -66,7 +67,10 @@ export default function HighlightsDataSection({
 
   const viewAllButton = viewAllRef ? (
     <Button
-      onClick={() => viewAllRef?.current?.scrollIntoView({behavior: 'smooth'})}
+      onClick={() => {
+        trackAnalytics('highlights_section.view_all_clicked', {organization});
+        viewAllRef?.current?.scrollIntoView({behavior: 'smooth'});
+      }}
       size="xs"
     >
       {t('View All')}
@@ -126,6 +130,7 @@ export default function HighlightsDataSection({
   });
 
   function openEditHighlightsModal() {
+    trackAnalytics('highlights_section.edit_clicked', {organization});
     openModal(
       deps => (
         <EditHighlightsModal

--- a/static/app/components/events/highlights/highlightsSettingsForm.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.tsx
@@ -5,8 +5,14 @@ import Form, {type FormProps} from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
+import type {Project} from 'sentry/types';
 import {convertMultilineFieldValue, extractMultilineFields} from 'sentry/utils';
-import {useDetailedProject} from 'sentry/utils/useDetailedProject';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
+import {
+  makeDetailedProjectQueryKey,
+  useDetailedProject,
+} from 'sentry/utils/useDetailedProject';
 import useOrganization from 'sentry/utils/useOrganization';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
@@ -18,10 +24,11 @@ export default function HighlightsSettingsForm({
   projectSlug,
 }: HighlightsSettingsFormProps) {
   const organization = useOrganization();
-  const {data: project, refetch} = useDetailedProject({
+  const {data: project} = useDetailedProject({
     orgSlug: organization.slug,
     projectSlug,
   });
+  const queryClient = useQueryClient();
   if (!organization.features.includes('event-tags-tree-ui') || !project) {
     return null;
   }
@@ -35,8 +42,16 @@ export default function HighlightsSettingsForm({
     },
     apiMethod: 'PUT',
     apiEndpoint: `/projects/${organization.slug}/${projectSlug}/`,
-    onSubmitSuccess: () => {
-      refetch();
+    onSubmitSuccess: (updatedProject: Project) => {
+      setApiQueryData<Project>(
+        queryClient,
+        makeDetailedProjectQueryKey({
+          orgSlug: organization.slug,
+          projectSlug: project.slug,
+        }),
+        data => (updatedProject ? updatedProject : data)
+      );
+      trackAnalytics('project_settings.updated_highlights', {organization});
       addSuccessMessage(`Successfully updated highlights for '${project.name}'`);
     },
   };


### PR DESCRIPTION
Many small fixes to highlights feature:

- Add close button to header
<img width="142" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/0f2e9cd8-46d1-4784-bc19-2ba86eca3e09">

- Disable edit button when you lack sufficient permissions
<img width="278" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/6c177e5b-b037-475b-ac26-19ed9e7b9467">


- Fix nested branching UI bug
<img width="134" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/0d4eb83f-c8de-4fcb-ace6-047589608bb3">
<img width="142" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/b86ead62-eda2-4cea-8386-0a79692d6df3">

- Align highlights/tags with header 
<img width="63" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/76b77dd0-313c-41dc-bcde-ae5e3d1f9c6f"> 
<img width="66" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/e5c0576a-cee1-48ed-885c-ec6c7660ffb4">

- Add notice for applying changes to project
<img width="804" alt="image" src="https://github.com/getsentry/sentry/assets/35509934/4055ce65-f70d-4249-8a60-a95eafff09af">

- Add analytics for user interactions
- Add monitors to 'other' category
- Update project cache on highlights settings page
